### PR TITLE
feat(api): serve-time contract-version staleness signal (#1001)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -2196,6 +2196,13 @@ export interface components {
              */
             published_at?: string | null;
             source?: string;
+            /** @description Present ONLY when the served artifact was built under an older contract than the live one (serve-time drift, #1001) — the body may predate a schema change. Mirrored on the x-metagraph-stale-contract response header for monitoring. */
+            stale_contract?: {
+                /** @description Contract version the served artifact was built under. */
+                built_under: string;
+                /** @description Current (live) contract version the Worker is running. */
+                live: string;
+            };
         } & {
             [key: string]: unknown;
         };
@@ -3531,7 +3538,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -3638,7 +3649,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -3745,7 +3760,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -3869,7 +3888,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -3996,7 +4019,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4110,7 +4137,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4232,7 +4263,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4362,7 +4397,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4475,7 +4514,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4606,7 +4649,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4736,7 +4783,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4880,7 +4931,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5043,7 +5098,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5192,7 +5251,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5308,7 +5371,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5414,7 +5481,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5546,7 +5617,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5672,7 +5747,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5791,7 +5870,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5920,7 +6003,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6038,7 +6125,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6152,7 +6243,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6254,7 +6349,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6504,7 +6603,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6620,7 +6723,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6743,7 +6850,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6899,7 +7010,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7005,7 +7120,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7124,7 +7243,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7272,7 +7395,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7424,7 +7551,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7625,7 +7756,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7839,7 +7974,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7962,7 +8101,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8152,7 +8295,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8285,7 +8432,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8441,7 +8592,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8566,7 +8721,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8673,7 +8832,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8789,7 +8952,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8910,7 +9077,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -9032,7 +9203,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -9163,7 +9338,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -9414,7 +9593,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -9537,7 +9720,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -9690,7 +9877,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -9808,7 +9999,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -10007,7 +10202,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -10143,7 +10342,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -10263,7 +10466,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -10373,7 +10580,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -10487,7 +10698,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -10776,7 +10991,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -11143,7 +11362,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -11262,7 +11485,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -11369,7 +11596,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -11498,7 +11729,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -11616,7 +11851,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -4494,6 +4494,25 @@
           },
           "source": {
             "type": "string"
+          },
+          "stale_contract": {
+            "additionalProperties": false,
+            "description": "Present ONLY when the served artifact was built under an older contract than the live one (serve-time drift, #1001) — the body may predate a schema change. Mirrored on the x-metagraph-stale-contract response header for monitoring.",
+            "properties": {
+              "built_under": {
+                "description": "Contract version the served artifact was built under.",
+                "type": "string"
+              },
+              "live": {
+                "description": "Current (live) contract version the Worker is running.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "built_under",
+              "live"
+            ],
+            "type": "object"
           }
         },
         "required": [
@@ -9758,7 +9777,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -9891,7 +9914,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -10016,7 +10043,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -10167,7 +10198,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -10313,7 +10348,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -10445,7 +10484,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -10681,7 +10724,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -10829,7 +10876,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -10960,7 +11011,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -11109,7 +11164,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -11317,7 +11376,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -11598,7 +11661,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -11839,7 +11906,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -12142,7 +12213,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -12323,7 +12398,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -12447,7 +12526,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -12598,7 +12681,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -12817,7 +12904,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -13022,7 +13113,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -13293,7 +13388,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -13440,7 +13539,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -13573,7 +13676,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -13694,7 +13801,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -14081,7 +14192,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -14290,7 +14405,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -14439,7 +14558,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -14749,7 +14872,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -14897,7 +15024,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -15035,7 +15166,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -15334,7 +15469,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -15636,7 +15775,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -16067,7 +16210,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -16538,7 +16685,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -16754,7 +16905,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -17095,7 +17250,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -17384,7 +17543,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -17558,7 +17721,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -17712,7 +17879,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -17839,7 +18010,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -18020,7 +18195,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -18159,7 +18338,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -18346,7 +18529,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -18631,7 +18818,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -18908,7 +19099,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -19144,7 +19339,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -19451,7 +19650,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -19642,7 +19845,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -19932,7 +20139,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -20204,7 +20415,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -20361,7 +20576,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -20509,7 +20728,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -20651,7 +20874,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -20967,7 +21194,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -21362,7 +21593,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -21578,7 +21813,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -21712,7 +21951,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -21878,7 +22121,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1
@@ -22095,7 +22342,11 @@
                       "total": 1
                     },
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "source": "live-cron-prober"
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
                   },
                   "ok": true,
                   "schema_version": 1

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2196,6 +2196,13 @@ export interface components {
              */
             published_at?: string | null;
             source?: string;
+            /** @description Present ONLY when the served artifact was built under an older contract than the live one (serve-time drift, #1001) — the body may predate a schema change. Mirrored on the x-metagraph-stale-contract response header for monitoring. */
+            stale_contract?: {
+                /** @description Contract version the served artifact was built under. */
+                built_under: string;
+                /** @description Current (live) contract version the Worker is running. */
+                live: string;
+            };
         } & {
             [key: string]: unknown;
         };
@@ -3531,7 +3538,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -3638,7 +3649,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -3745,7 +3760,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -3869,7 +3888,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -3996,7 +4019,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4110,7 +4137,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4232,7 +4263,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4362,7 +4397,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4475,7 +4514,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4606,7 +4649,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4736,7 +4783,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -4880,7 +4931,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5043,7 +5098,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5192,7 +5251,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5308,7 +5371,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5414,7 +5481,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5546,7 +5617,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5672,7 +5747,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5791,7 +5870,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -5920,7 +6003,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6038,7 +6125,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6152,7 +6243,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6254,7 +6349,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6504,7 +6603,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6620,7 +6723,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6743,7 +6850,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -6899,7 +7010,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7005,7 +7120,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7124,7 +7243,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7272,7 +7395,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7424,7 +7551,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7625,7 +7756,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7839,7 +7974,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -7962,7 +8101,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8152,7 +8295,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8285,7 +8432,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8441,7 +8592,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8566,7 +8721,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8673,7 +8832,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8789,7 +8952,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -8910,7 +9077,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -9032,7 +9203,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -9163,7 +9338,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -9414,7 +9593,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -9537,7 +9720,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -9690,7 +9877,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -9808,7 +9999,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -10007,7 +10202,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -10143,7 +10342,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -10263,7 +10466,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -10373,7 +10580,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -10487,7 +10698,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -10776,7 +10991,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -11143,7 +11362,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -11262,7 +11485,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -11369,7 +11596,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -11498,7 +11729,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1
@@ -11616,7 +11851,11 @@ export interface operations {
                      *           "total": 1
                      *         },
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "source": "live-cron-prober"
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
                      *       },
                      *       "ok": true,
                      *       "schema_version": 1

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -4472,6 +4472,25 @@
           },
           "source": {
             "type": "string"
+          },
+          "stale_contract": {
+            "additionalProperties": false,
+            "description": "Present ONLY when the served artifact was built under an older contract than the live one (serve-time drift, #1001) — the body may predate a schema change. Mirrored on the x-metagraph-stale-contract response header for monitoring.",
+            "properties": {
+              "built_under": {
+                "description": "Contract version the served artifact was built under.",
+                "type": "string"
+              },
+              "live": {
+                "description": "Current (live) contract version the Worker is running.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "built_under",
+              "live"
+            ],
+            "type": "object"
           }
         },
         "required": [

--- a/schemas/components/02-envelopes.schema.json
+++ b/schemas/components/02-envelopes.schema.json
@@ -84,6 +84,22 @@
           },
           "source": {
             "type": "string"
+          },
+          "stale_contract": {
+            "type": "object",
+            "required": ["built_under", "live"],
+            "properties": {
+              "built_under": {
+                "type": "string",
+                "description": "Contract version the served artifact was built under."
+              },
+              "live": {
+                "type": "string",
+                "description": "Current (live) contract version the Worker is running."
+              }
+            },
+            "additionalProperties": false,
+            "description": "Present ONLY when the served artifact was built under an older contract than the live one (serve-time drift, #1001) — the body may predate a schema change. Mirrored on the x-metagraph-stale-contract response header for monitoring."
           }
         },
         "additionalProperties": true

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -827,6 +827,9 @@ for (const provider of enrichedProviders) {
 
 await writeJson(artifactFile("subnets.json"), {
   schema_version: 1,
+  // Stamp the build's contract version so the Worker can flag serve-time drift
+  // when this artifact lags a contract deploy (#1001).
+  contract_version: contractVersion,
   generated_at: generatedAt,
   network: nativeSnapshot.network,
   source: nativeSnapshot.source,
@@ -845,6 +848,7 @@ const matchedTestnetNetuids = new Set(
 );
 await writeJson(artifactFile("lineage.json"), {
   schema_version: 1,
+  contract_version: contractVersion,
   generated_at: generatedAt,
   published_at: publishedAt(),
   source_network: "mainnet",
@@ -1077,6 +1081,7 @@ coverage.completeness = buildCompletenessSummary(
   profileArtifacts.profiles,
   subnetIndex,
 );
+coverage.contract_version = contractVersion;
 await writeJson(artifactFile("coverage.json"), coverage);
 // Per-subnet overview (R2-tier): one call composes a subnet's profile + health +
 // curation + gaps + counts so the UI renders a subnet page without 6 round-trips.
@@ -1677,6 +1682,7 @@ const agentResourcesContent = {
 };
 await writeJson(artifactFile("agent-resources.json"), {
   schema_version: 1,
+  contract_version: contractVersion,
   generated_at: generatedAt,
   published_at: publishedAt(),
   content_hash: hashJson(agentResourcesContent),

--- a/tests/contract-staleness.test.mjs
+++ b/tests/contract-staleness.test.mjs
@@ -1,0 +1,64 @@
+// #1001 — serve-time contract-version enforcement. When the Worker serves a
+// stored artifact built under an OLDER contract than the live one (the silent
+// drift that ships when a deploy bumps the contract but R2/committed data hasn't
+// been rebuilt yet), it must surface meta.stale_contract + the
+// x-metagraph-stale-contract header. We simulate the drift by pinning a FUTURE
+// live contract version, so every current artifact lags it.
+
+import { describe, expect, it } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+import { contractStaleness } from "../workers/responses.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+const ARTIFACT_ROUTE = "https://metagraph.sh/api/v1/subnets";
+
+describe("serve-time contract staleness (#1001)", () => {
+  it("surfaces stale_contract on meta + header when the artifact lags the live contract", async () => {
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_CONTRACT_VERSION: "2099-01-01.1",
+    };
+    const res = await handleRequest(new Request(ARTIFACT_ROUTE), env, {});
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.meta.stale_contract).toBeTruthy();
+    expect(body.meta.stale_contract.live).toBe("2099-01-01.1");
+    expect(typeof body.meta.stale_contract.built_under).toBe("string");
+    expect(body.meta.stale_contract.built_under).not.toBe("2099-01-01.1");
+    // The header mirrors meta for monitoring/CDN alarms.
+    expect(res.headers.get("x-metagraph-stale-contract")).toBe(
+      body.meta.stale_contract.built_under,
+    );
+  });
+
+  it("omits stale_contract when the artifact matches the live contract", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(new Request(ARTIFACT_ROUTE), env, {});
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.meta.stale_contract).toBeUndefined();
+    expect(res.headers.get("x-metagraph-stale-contract")).toBeNull();
+  });
+
+  it("orders contract versions by date then numeric revision", () => {
+    const live = (v) => ({ METAGRAPH_CONTRACT_VERSION: v });
+    // older date -> stale
+    expect(contractStaleness(live("2026-06-07.1"), "2026-06-06.9")).toEqual({
+      built_under: "2026-06-06.9",
+      live: "2026-06-07.1",
+    });
+    // same date, lower revision -> stale (numeric, not lexicographic: .2 < .10)
+    expect(contractStaleness(live("2026-06-06.10"), "2026-06-06.2")).toEqual({
+      built_under: "2026-06-06.2",
+      live: "2026-06-06.10",
+    });
+    // equal -> not stale
+    expect(contractStaleness(live("2026-06-06.1"), "2026-06-06.1")).toBeNull();
+    // newer artifact than live -> not flagged
+    expect(contractStaleness(live("2026-06-06.1"), "2026-06-07.1")).toBeNull();
+    // missing -> not flagged
+    expect(contractStaleness(live("2026-06-06.1"), undefined)).toBeNull();
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -15,6 +15,7 @@ import {
   withTimeout,
 } from "./storage.mjs";
 import {
+  contractStaleness,
   contractVersion,
   dataResponse,
   envelopeResponse,
@@ -980,6 +981,22 @@ async function handleApiRequest(
     ? baseData?.health_source || "live-cron-prober"
     : artifact.source;
 
+  // Serve-time contract drift (#1001): when serving a STORED artifact (not a
+  // live overlay) that was built under an older contract than the live one, the
+  // body may predate a schema change. Surface it on meta + the
+  // x-metagraph-stale-contract header (in envelopeResponse) + a warn log so the
+  // otherwise-silent drift is observable.
+  const staleContract = live
+    ? null
+    : contractStaleness(env, artifact.data?.contract_version);
+  if (staleContract) {
+    logEvent(env, "warn", "stale_contract_served", {
+      artifact_path: artifactPath,
+      built_under: staleContract.built_under,
+      live: staleContract.live,
+    });
+  }
+
   const transformed = applyQueryFilters(
     baseData,
     url,
@@ -1024,6 +1041,7 @@ async function handleApiRequest(
         generated_at: baseData?.generated_at || null,
         published_at: pub,
         source: baseSource,
+        ...(staleContract ? { stale_contract: staleContract } : {}),
         ...(baseData?.operational_observed_at
           ? { operational_observed_at: baseData.operational_observed_at }
           : {}),

--- a/workers/responses.mjs
+++ b/workers/responses.mjs
@@ -11,6 +11,30 @@ export function contractVersion(env) {
   return env.METAGRAPH_CONTRACT_VERSION || CONTRACT_VERSION;
 }
 
+// Contract versions are "YYYY-MM-DD.N": the ISO date sorts lexicographically,
+// the revision N numerically. Returns <0 if a precedes b, 0 if equal, >0 after.
+function compareContractVersions(a, b) {
+  const parse = (value) => {
+    const [date = "", rev = "0"] = String(value).split(".");
+    return [date, Number.parseInt(rev, 10) || 0];
+  };
+  const [dateA, revA] = parse(a);
+  const [dateB, revB] = parse(b);
+  if (dateA !== dateB) return dateA < dateB ? -1 : 1;
+  return revA - revB;
+}
+
+// A served artifact built under an OLDER contract than the live one may predate
+// a schema change — the silent serve-time drift #1001 makes observable. Returns
+// { built_under, live } when the artifact lags the live contract, else null.
+export function contractStaleness(env, builtUnderVersion) {
+  if (!builtUnderVersion) return null;
+  const live = contractVersion(env);
+  return compareContractVersions(builtUnderVersion, live) < 0
+    ? { built_under: String(builtUnderVersion), live }
+    : null;
+}
+
 // Published-at is read from the latest-pointer KV (warmed on publish), so this
 // only touches KV on origin misses. Returns null when KV is unbound or the
 // pointer predates published_at support.
@@ -54,6 +78,14 @@ export async function envelopeResponse(request, payload, cacheProfile) {
     "x-metagraph-contract-version",
     payload.meta.contract_version || CONTRACT_VERSION,
   );
+  // Serve-time drift signal (#1001): mirror meta.stale_contract on a header so
+  // monitoring/CDN can alarm on a served artifact that lags the live contract.
+  if (payload.meta.stale_contract?.built_under) {
+    headers.set(
+      "x-metagraph-stale-contract",
+      payload.meta.stale_contract.built_under,
+    );
+  }
   if (request.headers.get("if-none-match") === etag) {
     return new Response(null, {
       status: 304,


### PR DESCRIPTION
Closes #1001 · Part of #999 (Phase 1 — stop silent drift).

## Problem
Production serves static R2 artifacts that are never re-checked against the live contract. If a deploy bumps `CONTRACT_VERSION` but the 6h R2 refresh hasn't run yet, the Worker serves data built under the OLD contract — **silently**. The highest-severity reliability gap in the data audit.

## Fix — a serve-time staleness signal
- **`responses.mjs`**: `contractStaleness()` compares an artifact's built-under `contract_version` against the live one (date lexicographic, revision numeric so `.2 < .10`); `envelopeResponse` mirrors it on the `x-metagraph-stale-contract` header.
- **`api.mjs`**: `handleApiRequest` adds `meta.stale_contract: {built_under, live}` and logs a `stale_contract_served` warn when serving a stored artifact that lags the live contract. Live overlays (health/analytics) are exempt — computed fresh.
- **`build-artifacts.mjs`**: stamp `contract_version` on the 4 served seeds that lacked it (subnets/coverage/lineage/agent-resources) so coverage is **universal** — the other 7 already carried it, including `agent-catalog` (the #356/#998 drift case).
- **Schema**: `ResponseMeta.stale_contract` declared (optional; present only on drift) + contract regenerated.

## Verification
- New hermetic test (`tests/contract-staleness.test.mjs`): with a pinned future live contract, every artifact route surfaces `meta.stale_contract` + the header; a matching contract omits it; the comparator orders date-then-revision (`.2 < .10`).
- `validate:api` (58), `validate:schemas`, `validate:contract-drift`, `validate:types`, `validate:generated-client`, `validate:committed-seed` pass; 119 tests (incl. artifacts/worker-runtime/api-coverage) green; eslint + prettier clean.
- ci-verify: the regenerated `openapi.json`/`types.d.ts` are content-equivalent to a fresh build (reproducible).

## Notes
The committed seeds for subnets/coverage/agent-resources carry live-refresh data (not locally reproducible), so this PR changes only the build *code* to stamp them; their committed copies + R2 pick up `contract_version` on the next scheduled refresh. Cold-start drift on those routes is already gated at build by #1000 (the committed-seed gate).