### PR TITLE
fix(test): artifact-tier assertions after data-index R2 move

### DIFF
--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -640,15 +640,28 @@ describe("script utility contracts", () => {
       isR2PreferredDualArtifactPath("/metagraph/subnets.json"),
       true,
     );
-    // The agent-catalog/agent-resources discovery indexes are R2-preferred too so
-    // MCP discovery reflects the refreshed callable set.
+    // The agent-catalog/agent-resources/lineage/operational-surfaces indexes
+    // moved to plain R2-only (#1003, ADR-0006) — live-data/registry-derived
+    // indexes, not the committed contract, so they're R2-only and NOT dual.
     assert.equal(
-      isR2PreferredDualArtifactPath("/metagraph/agent-catalog.json"),
-      true,
+      artifactStorageTierForRelativePath("agent-catalog.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
     );
     assert.equal(
-      isR2PreferredDualArtifactPath("/metagraph/agent-resources.json"),
-      true,
+      isR2PreferredDualArtifactPath("/metagraph/agent-catalog.json"),
+      false,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("agent-resources.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("lineage.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("operational-surfaces.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
     );
     // Other dual artifacts stay committed-first; R2-only artifacts are not "dual".
     assert.equal(


### PR DESCRIPTION
Forward-fix for main's red `test` job. `script-utils.test.mjs` asserted agent-catalog/agent-resources were R2-preferred-dual; the ADR-0006 migration ([#1017](https://github.com/JSONbored/metagraphed/pull/1017)) moved them — plus lineage + operational-surfaces — to plain R2-only. Assertions updated to the new tiers. Full local suite green (1123 tests). Part of #999, #1003.