### PR TITLE
fix(lineage): surface broken cross-network links instead of silently dropping (#1012)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1933,6 +1933,13 @@ export interface components {
             [key: string]: unknown;
         };
         LineageArtifact: components["schemas"]["ArtifactBase"] & ({
+            broken_link_count?: number;
+            broken_links?: {
+                /** @enum {unknown} */
+                reason: "invalid-approval" | "source-netuid-missing" | "target-netuid-missing";
+                source_netuid: number | null;
+                target_netuid: number | null;
+            }[];
             graduated_subnet_count?: number;
             link_count: number;
             links: ({
@@ -6206,6 +6213,14 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "broken_link_count": 1,
+                     *         "broken_links": [
+                     *           {
+                     *             "reason": "invalid-approval",
+                     *             "source_netuid": 7,
+                     *             "target_netuid": 7
+                     *           }
+                     *         ],
                      *         "contract_version": "2026-06-06.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "graduated_subnet_count": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3612,6 +3612,45 @@
           {
             "additionalProperties": true,
             "properties": {
+              "broken_link_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broken_links": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "reason": {
+                      "enum": [
+                        "invalid-approval",
+                        "source-netuid-missing",
+                        "target-netuid-missing"
+                      ]
+                    },
+                    "source_netuid": {
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "target_netuid": {
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "source_netuid",
+                    "target_netuid",
+                    "reason"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
               "graduated_subnet_count": {
                 "minimum": 0,
                 "type": "integer"
@@ -13642,6 +13681,14 @@
               "application/json": {
                 "example": {
                   "data": {
+                    "broken_link_count": 1,
+                    "broken_links": [
+                      {
+                        "reason": "invalid-approval",
+                        "source_netuid": 7,
+                        "target_netuid": 7
+                      }
+                    ],
                     "contract_version": "2026-06-06.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "graduated_subnet_count": 1,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1933,6 +1933,13 @@ export interface components {
             [key: string]: unknown;
         };
         LineageArtifact: components["schemas"]["ArtifactBase"] & ({
+            broken_link_count?: number;
+            broken_links?: {
+                /** @enum {unknown} */
+                reason: "invalid-approval" | "source-netuid-missing" | "target-netuid-missing";
+                source_netuid: number | null;
+                target_netuid: number | null;
+            }[];
             graduated_subnet_count?: number;
             link_count: number;
             links: ({
@@ -6206,6 +6213,14 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "broken_link_count": 1,
+                     *         "broken_links": [
+                     *           {
+                     *             "reason": "invalid-approval",
+                     *             "source_netuid": 7,
+                     *             "target_netuid": 7
+                     *           }
+                     *         ],
                      *         "contract_version": "2026-06-06.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "graduated_subnet_count": 1,

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3590,6 +3590,45 @@
           {
             "additionalProperties": true,
             "properties": {
+              "broken_link_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broken_links": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "reason": {
+                      "enum": [
+                        "invalid-approval",
+                        "source-netuid-missing",
+                        "target-netuid-missing"
+                      ]
+                    },
+                    "source_netuid": {
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "target_netuid": {
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "source_netuid",
+                    "target_netuid",
+                    "reason"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
               "graduated_subnet_count": {
                 "minimum": 0,
                 "type": "integer"

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1612,6 +1612,32 @@
                 "additionalProperties": { "type": "integer", "minimum": 0 }
               },
               "testnet_only_count": { "type": "integer", "minimum": 0 },
+              "broken_link_count": { "type": "integer", "minimum": 0 },
+              "broken_links": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["source_netuid", "target_netuid", "reason"],
+                  "properties": {
+                    "source_netuid": {
+                      "type": ["integer", "null"],
+                      "minimum": 0
+                    },
+                    "target_netuid": {
+                      "type": ["integer", "null"],
+                      "minimum": 0
+                    },
+                    "reason": {
+                      "enum": [
+                        "invalid-approval",
+                        "source-netuid-missing",
+                        "target-netuid-missing"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
               "links": {
                 "type": "array",
                 "items": {

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -267,11 +267,19 @@ const mergedByNetuid = new Map(
 const lineageApprovals = await readOptionalJson(
   path.join(repoRoot, "registry/lineage.json"),
 );
+const lineageBrokenLinks = [];
 const lineageLinks = buildSubnetLineageLinks(
   chainSubnets,
   testnetSubnets,
   lineageApprovals?.links || [],
+  lineageBrokenLinks,
 );
+if (lineageBrokenLinks.length > 0) {
+  // #1012: don't silently drop — warn + surface in lineage.json.broken_links.
+  console.warn(
+    `lineage: ${lineageBrokenLinks.length} approved link(s) reference a missing/invalid netuid — surfaced in lineage.json broken_links instead of silently dropped: ${JSON.stringify(lineageBrokenLinks)}`,
+  );
+}
 const lineageEntries = lineageLinks.map((link) => ({
   mainnet_netuid: link.source_netuid,
   mainnet_name: mergedByNetuid.get(link.source_netuid)?.name || null,
@@ -859,6 +867,10 @@ await writeJson(artifactFile("lineage.json"), {
   matched_by_counts: countBy(lineageEntries, (entry) => entry.matched_by),
   testnet_only_count: testnetSubnets.length - matchedTestnetNetuids.size,
   links: lineageEntries,
+  // #1012: approved links that reference a netuid no longer present on its
+  // network (or a malformed approval) — surfaced, not silently dropped.
+  broken_link_count: lineageBrokenLinks.length,
+  broken_links: lineageBrokenLinks,
 });
 
 await fs.rm(r2ArtifactDir("subnets"), { recursive: true, force: true });

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1250,6 +1250,7 @@ export function buildSubnetLineageLinks(
   sourceSubnets,
   targetSubnets,
   approvedLinks = [],
+  brokenLinks = [],
 ) {
   const sourcesByNetuid = new Map(
     (sourceSubnets || []).map((source) => [source.netuid, source]),
@@ -1267,11 +1268,26 @@ export function buildSubnetLineageLinks(
       !Number.isInteger(targetNetuid) ||
       !LINEAGE_MATCH_TYPES.has(approval?.matched_by)
     ) {
+      // #1012: don't silently drop — record the malformed approval so it's fixable.
+      brokenLinks.push({
+        source_netuid: Number.isInteger(sourceNetuid) ? sourceNetuid : null,
+        target_netuid: Number.isInteger(targetNetuid) ? targetNetuid : null,
+        reason: "invalid-approval",
+      });
       continue;
     }
     const source = sourcesByNetuid.get(sourceNetuid);
     const target = targetsByNetuid.get(targetNetuid);
-    if (!source || !target) continue;
+    if (!source || !target) {
+      // #1012: an approval referencing a netuid that no longer exists on its
+      // network — surface it instead of silently dropping the lineage link.
+      brokenLinks.push({
+        source_netuid: sourceNetuid,
+        target_netuid: targetNetuid,
+        reason: !source ? "source-netuid-missing" : "target-netuid-missing",
+      });
+      continue;
+    }
     const key = `${sourceNetuid}:${targetNetuid}`;
     if (seen.has(key)) continue;
     seen.add(key);

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -661,6 +661,44 @@ describe("buildSubnetLineageLinks", () => {
     );
   });
 
+  test("#1012: surfaces broken approvals instead of silently dropping them", () => {
+    const mainnet = [
+      sub(24, "Quasar", "https://github.com/silx-labs/quasar-subnet"),
+    ];
+    const testnet = [
+      sub(383, "quasar-test", "https://github.com/silx-labs/quasar-subnet"),
+    ];
+    const broken = [];
+    const links = buildSubnetLineageLinks(
+      mainnet,
+      testnet,
+      [
+        { source_netuid: 24, target_netuid: 383, matched_by: "github_repo" },
+        { source_netuid: 24, target_netuid: 999, matched_by: "github_repo" },
+        { source_netuid: 24, target_netuid: 383, matched_by: "unreviewed" },
+      ],
+      broken,
+    );
+    // The valid link is still returned …
+    assert.deepEqual(links, [
+      { source_netuid: 24, target_netuid: 383, matched_by: "github_repo" },
+    ]);
+    // … and the missing-netuid + invalid-match approvals are surfaced, not dropped.
+    assert.equal(broken.length, 2);
+    assert.deepEqual(broken.map((entry) => entry.reason).sort(), [
+      "invalid-approval",
+      "target-netuid-missing",
+    ]);
+    assert.deepEqual(
+      broken.find((entry) => entry.reason === "target-netuid-missing"),
+      {
+        source_netuid: 24,
+        target_netuid: 999,
+        reason: "target-netuid-missing",
+      },
+    );
+  });
+
   test("returns [] for empty inputs", () => {
     assert.deepEqual(buildSubnetLineageLinks([], []), []);
     assert.deepEqual(buildSubnetLineageLinks(undefined, undefined), []);


### PR DESCRIPTION
Closes #1012 · Part of #999.

`buildSubnetLineageLinks()` silently `continue`d on approvals referencing a netuid that no longer exists on its network (or a malformed approval) — a dead lineage link just **vanished**, with no way to notice or fix it.

## Fix
- `scripts/lib.mjs`: optional `brokenLinks` collector — pushes `{source_netuid, target_netuid, reason}` (`source-netuid-missing` / `target-netuid-missing` / `invalid-approval`) instead of a bare `continue`. Opt-in, so the validator + other callers are unchanged.
- `scripts/build-artifacts.mjs`: passes the collector, **warns** if non-empty, surfaces it on `lineage.json` as `broken_links` + `broken_link_count`.
- Schema: `broken_links`/`broken_link_count` declared on `LineageArtifact` (served at `/api/v1/lineage`).

## Verification
- New unit test: an approval with a missing netuid + an invalid match type → both surfaced (`target-netuid-missing` + `invalid-approval`), valid link still returned.
- Full suite **1124/1124**; `validate:schemas`/`:api`/`:contract-drift`/`:types` pass; eslint + prettier clean; contract regen reproducible (ci-verify).
- Current data: `broken_link_count: 0` (all 43 approvals valid) — guard in place for when one breaks.