### PR TITLE
feat(surfaces): stable surface key decoupled from display id (#1005 PR1)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -3187,6 +3187,8 @@ export interface components {
         });
         SubnetProfileSurfaceSummary: {
             id: string;
+            /** @description Stable surface identity (#1005): hash of netuid|kind|url, invariant across renames. */
+            key?: string;
             kind: components["schemas"]["SurfaceKind"];
             name: string;
             provider: string;
@@ -3275,6 +3277,8 @@ export interface components {
             authority: components["schemas"]["Authority"];
             classification?: components["schemas"]["Classification"];
             id: string;
+            /** @description Stable surface identity (#1005): a hash of netuid|kind|url, invariant across display-name/slug renames. Prefer this over the hand-authored id for durable references; D1 history + endpoint links re-key onto it. */
+            key?: string;
             kind: components["schemas"]["SurfaceKind"];
             name?: string;
             netuid: number;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -8823,6 +8823,10 @@
           "id": {
             "type": "string"
           },
+          "key": {
+            "description": "Stable surface identity (#1005): hash of netuid|kind|url, invariant across renames.",
+            "type": "string"
+          },
           "kind": {
             "$ref": "#/components/schemas/SurfaceKind"
           },
@@ -9075,6 +9079,10 @@
             "$ref": "#/components/schemas/Classification"
           },
           "id": {
+            "type": "string"
+          },
+          "key": {
+            "description": "Stable surface identity (#1005): a hash of netuid|kind|url, invariant across display-name/slug renames. Prefer this over the hand-authored id for durable references; D1 history + endpoint links re-key onto it.",
             "type": "string"
           },
           "kind": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -3187,6 +3187,8 @@ export interface components {
         });
         SubnetProfileSurfaceSummary: {
             id: string;
+            /** @description Stable surface identity (#1005): hash of netuid|kind|url, invariant across renames. */
+            key?: string;
             kind: components["schemas"]["SurfaceKind"];
             name: string;
             provider: string;
@@ -3275,6 +3277,8 @@ export interface components {
             authority: components["schemas"]["Authority"];
             classification?: components["schemas"]["Classification"];
             id: string;
+            /** @description Stable surface identity (#1005): a hash of netuid|kind|url, invariant across display-name/slug renames. Prefer this over the hand-authored id for durable references; D1 history + endpoint links re-key onto it. */
+            key?: string;
             kind: components["schemas"]["SurfaceKind"];
             name?: string;
             netuid: number;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -8801,6 +8801,10 @@
           "id": {
             "type": "string"
           },
+          "key": {
+            "description": "Stable surface identity (#1005): hash of netuid|kind|url, invariant across renames.",
+            "type": "string"
+          },
           "kind": {
             "$ref": "#/components/schemas/SurfaceKind"
           },
@@ -9053,6 +9057,10 @@
             "$ref": "#/components/schemas/Classification"
           },
           "id": {
+            "type": "string"
+          },
+          "key": {
+            "description": "Stable surface identity (#1005): a hash of netuid|kind|url, invariant across display-name/slug renames. Prefer this over the hand-authored id for durable references; D1 history + endpoint links re-key onto it.",
             "type": "string"
           },
           "kind": {

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -194,6 +194,10 @@
           "id": {
             "type": "string"
           },
+          "key": {
+            "type": "string",
+            "description": "Stable surface identity (#1005): a hash of netuid|kind|url, invariant across display-name/slug renames. Prefer this over the hand-authored id for durable references; D1 history + endpoint links re-key onto it."
+          },
           "name": {
             "type": "string"
           },

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -470,6 +470,10 @@
           "id": {
             "type": "string"
           },
+          "key": {
+            "type": "string",
+            "description": "Stable surface identity (#1005): hash of netuid|kind|url, invariant across renames."
+          },
           "kind": {
             "$ref": "#/components/schemas/SurfaceKind"
           },

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -455,14 +455,28 @@ export async function loadDetailedVerification() {
 export function flattenSurfaces(subnets) {
   return subnets
     .flatMap((subnet) =>
-      subnet.surfaces.map((surface) => ({
-        ...surface,
-        netuid: subnet.netuid,
-        subnet_slug: subnet.slug,
-        subnet_name: subnet.name,
-      })),
+      subnet.surfaces.map((surface) => {
+        const flattened = {
+          ...surface,
+          netuid: subnet.netuid,
+          subnet_slug: subnet.slug,
+          subnet_name: subnet.name,
+        };
+        // #1005: a stable identity decoupled from the hand-authored display id.
+        flattened.key = surfaceStableKey(flattened);
+        return flattened;
+      }),
     )
     .sort((a, b) => a.netuid - b.netuid || a.id.localeCompare(b.id));
+}
+
+// Stable surface identity (#1005): a short hash of the netuid|kind|url key, so a
+// surface keeps the same `key` across display-name/slug renames (the `id` is
+// author-controlled and changes on rename, which orphans D1 history + breaks the
+// derived endpoint link). PR1 surfaces this `key`; later PRs re-key D1 history +
+// endpoint links onto it. A URL change is intentionally a new identity.
+export function surfaceStableKey(entry) {
+  return `srf-${sha256Hex(registrySurfaceKey(entry)).slice(0, 16)}`;
 }
 
 export function stableStringify(value) {

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -32,6 +32,7 @@ import {
   deriveDescriptionFromNotes,
   clusterDomainFromUrl,
   buildSubnetLineageLinks,
+  surfaceStableKey,
   sanitizeFixtureBody,
   surfaceFixtureReference,
   writeJson,
@@ -702,6 +703,59 @@ describe("buildSubnetLineageLinks", () => {
   test("returns [] for empty inputs", () => {
     assert.deepEqual(buildSubnetLineageLinks([], []), []);
     assert.deepEqual(buildSubnetLineageLinks(undefined, undefined), []);
+  });
+});
+
+describe("surfaceStableKey (#1005)", () => {
+  test("is stable across display-name/slug renames (same netuid|kind|url)", () => {
+    const before = surfaceStableKey({
+      netuid: 7,
+      kind: "openapi",
+      url: "https://api.example.io/openapi.json",
+      id: "sn-7-old-slug-openapi",
+      name: "Old Name",
+    });
+    const afterRename = surfaceStableKey({
+      netuid: 7,
+      kind: "openapi",
+      url: "https://api.example.io/openapi.json",
+      id: "sn-7-new-slug-openapi",
+      name: "New Name",
+    });
+    assert.equal(before, afterRename);
+    assert.match(before, /^srf-[0-9a-f]{16}$/);
+  });
+
+  test("changes when the url, kind, or netuid changes (a different identity)", () => {
+    const base = surfaceStableKey({
+      netuid: 7,
+      kind: "openapi",
+      url: "https://api.example.io/openapi.json",
+    });
+    assert.notEqual(
+      base,
+      surfaceStableKey({
+        netuid: 7,
+        kind: "openapi",
+        url: "https://api.other.io/openapi.json",
+      }),
+    );
+    assert.notEqual(
+      base,
+      surfaceStableKey({
+        netuid: 8,
+        kind: "openapi",
+        url: "https://api.example.io/openapi.json",
+      }),
+    );
+    assert.notEqual(
+      base,
+      surfaceStableKey({
+        netuid: 7,
+        kind: "subnet-api",
+        url: "https://api.example.io/openapi.json",
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
Part of #999 · advances #1005 (PR1 of the stable-ID migration — the additive foundation).

`surface.id` is hand-authored (`sn-{netuid}-{slug}-{kind}`), so an author renaming a surface changes its id — **orphaning** its D1 health/incident/uptime history (keyed on `surface_id`) and breaking the derived `endpoint.id`.

## This PR (additive, no D1 change)
- Adds a **stable `key`** = `srf-{16-hex hash of netuid|kind|url}` (reusing the existing `registrySurfaceKey`), attached in `flattenSurfaces`. Invariant across display-name/slug renames; changes only when url/kind/netuid changes (a genuinely different surface).
- Declared on `Surface` + `SubnetProfileSurfaceSummary` → served wherever surfaces appear (`/api/v1/surfaces`, subnet profiles).
- **Nothing else changes** — `id`, `endpoint.id`, and the D1 keying are untouched.

## Next (not this PR)
PR2 re-keys D1 history + endpoint links onto `key` (the deploy-critical live-D1 migration, idempotent/reversible); PR3 adds the `deprecated_id → key` remap + serve-time alias. Full plan on #1005.

## Verification
- New unit tests: `surfaceStableKey` stable across slug/name renames; changes with url/kind/netuid.
- Full suite **1126/1126**; `validate:schemas`/`:api`/`:committed-seed`/`:contract-drift`/`:types`/`:mcp` pass; eslint + prettier clean; contract regen reproducible (ci-verify).