### PR TITLE
feat(registry): dedup candidate ↔ curated surface via superseded_by (#1002)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1275,6 +1275,8 @@ export interface components {
             source_urls?: string[];
             state: components["schemas"]["CandidateState"];
             subnet_name?: string | null;
+            /** @description When set, the id of a curated registry surface that shares this candidate's (netuid, kind, normalized-url) identity. The candidate is a duplicate of an already-verified surface and is excluded from the review/enrichment queue. Null when the candidate is not yet covered by any surface. */
+            superseded_by?: string | null;
             /** Format: uri */
             url: string;
             verification?: components["schemas"]["VerificationResult"] | null;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -962,6 +962,13 @@
               "null"
             ]
           },
+          "superseded_by": {
+            "description": "When set, the id of a curated registry surface that shares this candidate's (netuid, kind, normalized-url) identity. The candidate is a duplicate of an already-verified surface and is excluded from the review/enrichment queue. Null when the candidate is not yet covered by any surface.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "url": {
             "format": "uri",
             "type": "string"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1275,6 +1275,8 @@ export interface components {
             source_urls?: string[];
             state: components["schemas"]["CandidateState"];
             subnet_name?: string | null;
+            /** @description When set, the id of a curated registry surface that shares this candidate's (netuid, kind, normalized-url) identity. The candidate is a duplicate of an already-verified surface and is excluded from the review/enrichment queue. Null when the candidate is not yet covered by any surface. */
+            superseded_by?: string | null;
             /** Format: uri */
             url: string;
             verification?: components["schemas"]["VerificationResult"] | null;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -948,6 +948,13 @@
               "null"
             ]
           },
+          "superseded_by": {
+            "description": "When set, the id of a curated registry surface that shares this candidate's (netuid, kind, normalized-url) identity. The candidate is a duplicate of an already-verified surface and is excluded from the review/enrichment queue. Null when the candidate is not yet covered by any surface.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "url": {
             "format": "uri",
             "type": "string"

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -575,6 +575,10 @@
           "subnet_name": {
             "type": ["string", "null"]
           },
+          "superseded_by": {
+            "type": ["string", "null"],
+            "description": "When set, the id of a curated registry surface that shares this candidate's (netuid, kind, normalized-url) identity. The candidate is a duplicate of an already-verified surface and is excluded from the review/enrichment queue. Null when the candidate is not yet covered by any surface."
+          },
           "verification": {
             "oneOf": [
               {

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -39,6 +39,7 @@ import {
   normalizePublicUrl,
   publishedAt,
   readJson,
+  registrySurfaceKey,
   clusterDomainFromUrl,
   redactCredentialedUrls,
   sanitizeOpenApiDocument,
@@ -572,8 +573,19 @@ const coverage = {
   ),
 };
 
+// #1002: dedup candidate ↔ curated surface. A candidate that shares a curated
+// surface's (netuid | kind | normalized-url) identity is the same thing already
+// promoted to the registry — flag it `superseded_by` the surface so it is not
+// presented or queued for enrichment as a separate, unverified duplicate.
+// Keyed on registrySurfaceKey (same key flattenSurfaces hashes into surface.id).
+const curatedSurfaceIdByRegistryKey = new Map(
+  surfaces.map((surface) => [registrySurfaceKey(surface), surface.id]),
+);
+const supersededBySurfaceId = (candidate) =>
+  curatedSurfaceIdByRegistryKey.get(registrySurfaceKey(candidate)) ?? null;
 const candidateIndex = candidates.map((candidate) => ({
   ...candidate,
+  superseded_by: supersededBySurfaceId(candidate),
   verification:
     fullVerificationByCandidate.get(candidate.id) ||
     fullVerificationResultOrNull(candidate.verification),
@@ -583,6 +595,7 @@ const candidateIndex = candidates.map((candidate) => ({
 }));
 const canonicalCandidateIndex = candidates.map((candidate) => ({
   ...candidate,
+  superseded_by: supersededBySurfaceId(candidate),
   verification:
     canonicalVerificationByCandidate.get(candidate.id) ||
     fullVerificationResultOrNull(candidate.verification),
@@ -698,8 +711,12 @@ const enrichmentArtifacts = buildEnrichmentQueueArtifacts({
 });
 const enrichmentQueue = enrichmentArtifacts.queueArtifact;
 
-const reviewQueue = candidateIndex.filter((candidate) =>
-  ["schema-valid", "maintainer-review", "stale"].includes(candidate.state),
+const reviewQueue = candidateIndex.filter(
+  (candidate) =>
+    // #1002: a candidate already covered by a curated surface is not a review
+    // target — it is the same surface, already verified.
+    !candidate.superseded_by &&
+    ["schema-valid", "maintainer-review", "stale"].includes(candidate.state),
 );
 
 const curationIndex = mergedSubnets.map((subnet) => ({

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -24,6 +24,7 @@ import {
   deriveDomainTags,
   publicMetagraphRoot,
   r2StagingRoot,
+  registrySurfaceKey,
 } from "../scripts/lib.mjs";
 import { handleRequest } from "../workers/api.mjs";
 
@@ -998,6 +999,45 @@ test("public artifacts are internally consistent", () => {
     true,
   );
   assert.equal(reviewQueue.count, reviewQueue.candidates.length);
+  // #1002: candidate ↔ curated-surface dedup. Every candidate carries a
+  // superseded_by field; when set it points to the curated surface that shares
+  // its (netuid, kind, normalized-url) identity, and such candidates are
+  // excluded from the review/enrichment queue so duplicates are not re-targeted.
+  const surfaceIdByRegistryKey = new Map(
+    surfaces.surfaces.map((surface) => [
+      registrySurfaceKey(surface),
+      surface.id,
+    ]),
+  );
+  for (const candidate of candidates.candidates) {
+    assert.ok(
+      "superseded_by" in candidate,
+      `candidate ${candidate.id} is missing the superseded_by field`,
+    );
+    if (candidate.superseded_by) {
+      assert.equal(
+        candidate.superseded_by,
+        surfaceIdByRegistryKey.get(registrySurfaceKey(candidate)),
+        `candidate ${candidate.id} superseded_by must equal the curated surface sharing its identity`,
+      );
+    } else {
+      assert.equal(
+        surfaceIdByRegistryKey.has(registrySurfaceKey(candidate)),
+        false,
+        `candidate ${candidate.id} has no superseded_by yet a curated surface shares its identity`,
+      );
+    }
+  }
+  assert.equal(
+    reviewQueue.candidates.some((candidate) => candidate.superseded_by),
+    false,
+    "review queue must not contain candidates superseded by a curated surface",
+  );
+  // Guard against a no-op: the dedup must actually fire on real registry data.
+  assert.ok(
+    candidates.candidates.some((candidate) => candidate.superseded_by),
+    "expected at least one candidate to be superseded by a curated surface",
+  );
   assert.equal(contracts.primary_domain, "api.metagraph.sh");
   assert.equal(contracts.status_domain, null);
   assert.equal(


### PR DESCRIPTION
Closes part of #1002 (epic #999).

## Problem
A discovered candidate and an already-curated registry surface can describe the **same** integration point — same `(netuid, kind, normalized-url)`. Today both ship in served output: the surface as verified, the candidate as an unverified duplicate that the enrichment flywheel keeps re-targeting. On current data **1001 of 2073 candidates** are such duplicates.

## Change (bounded, build-time)
- Every candidate now carries `superseded_by`. When the candidate's `registrySurfaceKey` (`netuid | kind | normalized-url`, lowercased) matches a curated surface, it is set to that surface's `id`; otherwise `null`.
- Reuses `registrySurfaceKey` — the exact key `flattenSurfaces` hashes into `surface.id` (#1005) — so candidate↔surface identity is computed one way.
- Superseded candidates are excluded from the **review/enrichment queue** (`reviewQueue`) so duplicates aren't re-targeted.
- Candidates are kept (flagged), not dropped — transparent, no data loss.

## Not tautological (the #1011 lesson)
The key discriminates on real data: `backprop-dashboard` candidates are 129/129 superseded (all curated), while `taostats-metagraph-dashboard` candidates are 129/129 **not** superseded (no curated taostats surfaces exist). Superseded candidates come from genuine external discovery (`taopedia-article`, `community-pr-intake`, `subtensor-subnet-identities-v3`, …), not from surfaces.

## Deferred (follow-up on #1002)
Count propagation — `candidate_count` / `coverage_level` / `gaps` excluding superseded candidates — touches coverage, leaderboards, profiles, and their full test sweep. Deferred to keep this a low-risk additive pass (same PR1/PR2 discipline as #1005).

## Test
`tests/artifacts.test.mjs`: asserts the field exists on every candidate, `superseded_by` points to the surface sharing its key, the inverse (no flag ⟹ no matching surface), the review queue excludes superseded, and a non-trivial guard that the dedup actually fires.

## Verification
- `npm test` — 1126 pass
- `validate:schemas`, `validate:api`, `validate:contract-drift` — pass; contract regenerated (`superseded_by` additive on `CandidateSurface`)
- lint clean