### PR TITLE
fix(build): exclude hidden files from artifact size/digest walk (#1028)

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -5693,6 +5693,13 @@ async function walkIfExists(dirPath, onFile) {
     throw error;
   }
   for (const entry of entries) {
+    // #1028: skip hidden files (macOS .DS_Store, AppleDouble ._*). They are not
+    // artifacts and their bytes vary, which polluted r2-manifest size/digest
+    // sums non-deterministically. Hidden directories (e.g. .well-known) are
+    // still walked — they hold real artifacts.
+    if (entry.isFile() && entry.name.startsWith(".")) {
+      continue;
+    }
     const entryPath = path.join(dirPath, entry.name);
     if (entry.isDirectory()) {
       await walkIfExists(entryPath, onFile);

--- a/scripts/refresh-build-summary.mjs
+++ b/scripts/refresh-build-summary.mjs
@@ -105,6 +105,12 @@ async function walk(dirPath, onFile) {
   }
 
   for (const entry of entries) {
+    // #1028: skip hidden files (macOS .DS_Store, AppleDouble ._*) — not
+    // artifacts; their bytes vary and would pollute size sums. Hidden
+    // directories (e.g. .well-known) still hold real artifacts, so walk them.
+    if (entry.isFile() && entry.name.startsWith(".")) {
+      continue;
+    }
     const entryPath = path.join(dirPath, entry.name);
     if (entry.isDirectory()) {
       await walk(entryPath, onFile);


### PR DESCRIPTION
Addresses the root cause in #1028.

## Problem
The build's artifact-size + digest collection (`collectArtifactFiles` → `walkIfExists`, and `refresh-build-summary`'s `walk`) enumerated **every** file under the `public/` + R2 staging trees — including macOS `.DS_Store` / AppleDouble `._*` files. Those aren't artifacts, and their bytes vary, so they polluted `r2-manifest`'s `*_artifact_size_bytes` totals non-deterministically (`.DS_Store` was the *only* file that re-drifted on a local rebuild — the real `.json` artifacts are byte-stable).

## Fix
Skip hidden **files** in both walkers. Hidden **directories** (e.g. `.well-known`, which holds `llms.txt` + `mcp/server-card.json`) are still walked.

**Verified:** planted two differing `.DS_Store` files in the staging tree, built twice → `r2-manifest` byte-identical (was the sole drift source).

## Scope
Env-independent code fix. On CI (Linux, no `.DS_Store`) it is a no-op, so artifacts are unchanged. **Dropping the `r2-manifest` exclusion from the #1025 drift gate is deferred** — that needs a fresh `r2-manifest` committed from a clean build environment; tracked on #1028.