### PR TITLE
feat(registry): enrich SN16 BitAds — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-16-openapi-api-bitads-ai.json
+++ b/registry/candidates/community/community-sn-16-openapi-api-bitads-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-16-openapi-api-bitads-ai",
+      "kind": "openapi",
+      "name": "BitAds community openapi",
+      "netuid": 16,
+      "provider": "bitads",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://bitads.ai/docs",
+      "source_urls": ["https://bitads.ai/docs"],
+      "state": "schema-valid",
+      "url": "https://api.bitads.ai/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.bitads.ai/openapi.json`.

Closes #720.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)