### PR TITLE
feat(registry): enrich SN103 Djinn — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-103-openapi-api-djinn-ai.json
+++ b/registry/candidates/community/community-sn-103-openapi-api-djinn-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-103-openapi-api-djinn-ai",
+      "kind": "openapi",
+      "name": "Djinn community openapi",
+      "netuid": 103,
+      "provider": "djinn",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://djinn.ai/docs",
+      "source_urls": ["https://djinn.ai/docs"],
+      "state": "schema-valid",
+      "url": "https://api.djinn.ai/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.djinn.ai/openapi.json`.

Closes #695.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)