### PR TITLE
feat(registry): enrich SN64 Chutes — add GPU count history data artifact

### DIFF
--- a/registry/candidates/community/community-sn-64-data-artifact-api-chutes-ai.json
+++ b/registry/candidates/community/community-sn-64-data-artifact-api-chutes-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.chutes.ai/openapi.json",
       "source_urls": ["https://api.chutes.ai/openapi.json"],
       "state": "schema-valid",
-      "url": "https://api.chutes.ai/daily_revenue_summary"
+      "url": "https://api.chutes.ai/chutes/gpu_count_history"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.chutes.ai/chutes/gpu_count_history`.

Closes #959.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)