### PR TITLE
feat(registry): enrich SN49 Nepher Robotics — add active tournament list data artifact

### DIFF
--- a/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
+++ b/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://tournament-api.nepher.ai/openapi.json",
       "source_urls": ["https://tournament-api.nepher.ai/openapi.json"],
       "state": "schema-valid",
-      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active/id"
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active/list"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://tournament-api.nepher.ai/api/v1/tournaments/active/list`.

Closes #962.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)