### PR TITLE
feat(registry): enrich SN118 Ditto — add Genie Claw SDK candidate

### DIFF
--- a/registry/candidates/community/community-sn-118-sdk-github-com.json
+++ b/registry/candidates/community/community-sn-118-sdk-github-com.json
@@ -14,10 +14,12 @@
       "schema_version": 1,
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",
-      "source_url": "https://heyditto.ai/docs/mcp-server",
-      "source_urls": ["https://heyditto.ai/docs/mcp-server"],
+      "source_url": "https://github.com/Geniepod/genie-claw/blob/main/README.md",
+      "source_urls": [
+        "https://github.com/Geniepod/genie-claw/blob/main/README.md"
+      ],
       "state": "schema-valid",
-      "url": "https://github.com/ditto-assistant/ditto-mcp"
+      "url": "https://github.com/Geniepod/genie-claw"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://github.com/Geniepod/genie-claw`.

Closes #718.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)