### PR TITLE
feat(registry): enrich SN34 BitMind — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-34-openapi-api-bitmind-ai.json
+++ b/registry/candidates/community/community-sn-34-openapi-api-bitmind-ai.json
@@ -14,8 +14,8 @@
       "schema_version": 1,
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",
-      "source_url": "https://api.bitmind.ai/openapi.json",
-      "source_urls": ["https://api.bitmind.ai/openapi.json"],
+      "source_url": "https://bitmind.ai/docs",
+      "source_urls": ["https://bitmind.ai/docs"],
       "state": "schema-valid",
       "url": "https://api.bitmind.ai/openapi.json"
     }


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.bitmind.ai/openapi.json`.

Closes #961.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)