### PR TITLE
feat(registry): enrich SN56 Gradients — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-56-openapi-api-gradients-io.json
+++ b/registry/candidates/community/community-sn-56-openapi-api-gradients-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-56-openapi-api-gradients-io",
+      "kind": "openapi",
+      "name": "Gradients community openapi",
+      "netuid": 56,
+      "provider": "gradients",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.gradients.io/docs",
+      "source_urls": ["https://api.gradients.io/docs"],
+      "state": "schema-valid",
+      "url": "https://api.gradients.io/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.gradients.io/openapi.json`.

Closes #957.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)