### PR TITLE
feat(registry): enrich SN5 Hone — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-5-openapi-api-hone-training.json
+++ b/registry/candidates/community/community-sn-5-openapi-api-hone-training.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-5-openapi-api-hone-training",
+      "kind": "openapi",
+      "name": "Hone community openapi",
+      "netuid": 5,
+      "provider": "hone",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://www.hone.training/",
+      "source_urls": ["https://www.hone.training/"],
+      "state": "schema-valid",
+      "url": "https://api.hone.training/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.hone.training/openapi.json`.

Closes #713.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)