### PR TITLE
feat(registry): enrich SN19 blockmachine — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-19-openapi-api-blockmachine-io.json
+++ b/registry/candidates/community/community-sn-19-openapi-api-blockmachine-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-19-openapi-api-blockmachine-io",
+      "kind": "openapi",
+      "name": "blockmachine community openapi",
+      "netuid": 19,
+      "provider": "blockmachine",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://blockmachine.io/",
+      "source_urls": ["https://blockmachine.io/"],
+      "state": "schema-valid",
+      "url": "https://api.blockmachine.io/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.blockmachine.io/openapi.json`.

Closes #690.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)