### PR TITLE
feat(registry): enrich SN8 Vanta — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-8-openapi-api-vantanetwork-io.json
+++ b/registry/candidates/community/community-sn-8-openapi-api-vantanetwork-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-8-openapi-api-vantanetwork-io",
+      "kind": "openapi",
+      "name": "Vanta community openapi",
+      "netuid": 8,
+      "provider": "vanta",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://www.vantanetwork.io/",
+      "source_urls": ["https://www.vantanetwork.io/"],
+      "state": "schema-valid",
+      "url": "https://api.vantanetwork.io/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.vantanetwork.io/openapi.json`.

Closes #715.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)