### PR TITLE
feat(registry): enrich SN10 Swap — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-10-openapi-api-taofi-com.json
+++ b/registry/candidates/community/community-sn-10-openapi-api-taofi-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-10-openapi-api-taofi-com",
+      "kind": "openapi",
+      "name": "Swap community openapi",
+      "netuid": 10,
+      "provider": "taofi",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://www.taofi.com/",
+      "source_urls": ["https://www.taofi.com/"],
+      "state": "schema-valid",
+      "url": "https://api.taofi.com/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.taofi.com/openapi.json`.

Closes #719.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)