### PR TITLE
feat(registry): enrich SN15 ORO — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-15-openapi-api-oroagents-com.json
+++ b/registry/candidates/community/community-sn-15-openapi-api-oroagents-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-15-openapi-api-oroagents-com",
+      "kind": "openapi",
+      "name": "ORO community openapi",
+      "netuid": 15,
+      "provider": "oro",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://oroagents.com/",
+      "source_urls": ["https://oroagents.com/"],
+      "state": "schema-valid",
+      "url": "https://api.oroagents.com/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.oroagents.com/openapi.json`.

Closes #699.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)