### PR TITLE
feat(registry): enrich SN21 AdTAO — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-21-openapi-api-adtao-io.json
+++ b/registry/candidates/community/community-sn-21-openapi-api-adtao-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-21-openapi-api-adtao-io",
+      "kind": "openapi",
+      "name": "AdTAO community openapi",
+      "netuid": 21,
+      "provider": "adtao",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://adtao.io/",
+      "source_urls": ["https://adtao.io/"],
+      "state": "schema-valid",
+      "url": "https://api.adtao.io/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.adtao.io/openapi.json`.

Closes #693.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)