### PR TITLE
feat(registry): enrich SN72 StreetVision by NATIX — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-72-openapi-natix-network.json
+++ b/registry/candidates/community/community-sn-72-openapi-natix-network.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-72-openapi-natix-network",
+      "kind": "openapi",
+      "name": "StreetVision by NATIX community openapi",
+      "netuid": 72,
+      "provider": "natix",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://natix.network/",
+      "source_urls": ["https://natix.network/"],
+      "state": "schema-valid",
+      "url": "https://natix.network/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://natix.network/openapi.json`.

Closes #681.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)