### PR TITLE
feat(registry): enrich SN82 Compelle — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-82-openapi-compelle-ai.json
+++ b/registry/candidates/community/community-sn-82-openapi-compelle-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-82-openapi-compelle-ai",
+      "kind": "openapi",
+      "name": "Compelle community openapi",
+      "netuid": 82,
+      "provider": "compelle",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://compelle.ai/",
+      "source_urls": ["https://compelle.ai/"],
+      "state": "schema-valid",
+      "url": "https://compelle.ai/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://compelle.ai/openapi.json`.

Closes #685.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)