### PR TITLE
feat(registry): enrich SN121 sundae_bar — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-121-openapi-sundaebar-ai.json
+++ b/registry/candidates/community/community-sn-121-openapi-sundaebar-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-121-openapi-sundaebar-ai",
+      "kind": "openapi",
+      "name": "sundae_bar community openapi",
+      "netuid": 121,
+      "provider": "sundae-bar",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://sundaebar.ai/",
+      "source_urls": ["https://sundaebar.ai/"],
+      "state": "schema-valid",
+      "url": "https://sundaebar.ai/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://sundaebar.ai/openapi.json`.

Closes #697.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)