### PR TITLE
feat(registry): enrich SN122 Bitrecs — add source repository candidate

### DIFF
--- a/registry/candidates/community/community-sn-122-source-repo-github-com.json
+++ b/registry/candidates/community/community-sn-122-source-repo-github-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-122-source-repo-github-com",
+      "kind": "source-repo",
+      "name": "gamma_small community source-repo",
+      "netuid": 122,
+      "provider": "bitrecs",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/bitrecs/subnet-122",
+      "source_urls": ["https://github.com/bitrecs/subnet-122"],
+      "state": "schema-valid",
+      "url": "https://github.com/bitrecs/subnet-122"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://github.com/bitrecs/subnet-122`.

Closes #733.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)