### PR TITLE
feat(registry): enrich SN110 Green Compute — add SSE stream

### DIFF
--- a/registry/candidates/community/community-sn-110-sse-api-greencompute-ai.json
+++ b/registry/candidates/community/community-sn-110-sse-api-greencompute-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-110-sse-api-greencompute-ai",
+      "kind": "sse",
+      "name": "Green Compute community sse",
+      "netuid": 110,
+      "provider": "green-compute",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://greencompute.ai/",
+      "source_urls": ["https://greencompute.ai/"],
+      "state": "schema-valid",
+      "url": "https://api.greencompute.ai/events"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.greencompute.ai/events`.

Closes #678.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)