### PR TITLE
feat(registry): enrich SN61 RedTeam — add health subnet API

### DIFF
--- a/registry/candidates/community/community-sn-61-subnet-api-api-redteamsubnet-com.json
+++ b/registry/candidates/community/community-sn-61-subnet-api-api-redteamsubnet-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-61-subnet-api-api-redteamsubnet-com",
+      "kind": "subnet-api",
+      "name": "RedTeam community subnet-api",
+      "netuid": 61,
+      "provider": "redteam",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.redteamsubnet.com/openapi.json",
+      "source_urls": ["https://api.redteamsubnet.com/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.redteamsubnet.com/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.redteamsubnet.com/health`.

Closes #716.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)