### PR TITLE
feat(registry): enrich SN16 BitAds — add health subnet API

### DIFF
--- a/registry/candidates/community/community-sn-16-subnet-api-api-bitads-ai.json
+++ b/registry/candidates/community/community-sn-16-subnet-api-api-bitads-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-16-subnet-api-api-bitads-ai",
+      "kind": "subnet-api",
+      "name": "BitAds community subnet-api",
+      "netuid": 16,
+      "provider": "bitads",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.bitads.ai/openapi.json",
+      "source_urls": ["https://api.bitads.ai/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.bitads.ai/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.bitads.ai/health`.

Closes #720.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)