### PR TITLE
feat(registry): enrich SN12 Compute Horde — add health subnet API

### DIFF
--- a/registry/candidates/community/community-sn-12-subnet-api-api-computehorde-io.json
+++ b/registry/candidates/community/community-sn-12-subnet-api-api-computehorde-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-12-subnet-api-api-computehorde-io",
+      "kind": "subnet-api",
+      "name": "Compute Horde community subnet-api",
+      "netuid": 12,
+      "provider": "compute-horde",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.computehorde.io/openapi.json",
+      "source_urls": ["https://api.computehorde.io/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.computehorde.io/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.computehorde.io/health`.

Closes #726.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)