### PR TITLE
feat(registry): enrich SN57 Sparket — add health subnet API

### DIFF
--- a/registry/candidates/community/community-sn-57-subnet-api-api-sparket-ai.json
+++ b/registry/candidates/community/community-sn-57-subnet-api-api-sparket-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-57-subnet-api-api-sparket-ai",
+      "kind": "subnet-api",
+      "name": "gaia community subnet-api",
+      "netuid": 57,
+      "provider": "sparket",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.sparket.ai/openapi.json",
+      "source_urls": ["https://api.sparket.ai/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.sparket.ai/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.sparket.ai/health`.

Closes #730.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)