### PR TITLE
feat(registry): enrich SN103 Djinn — add health subnet API

### DIFF
--- a/registry/candidates/community/community-sn-103-subnet-api-api-djinn-ai.json
+++ b/registry/candidates/community/community-sn-103-subnet-api-api-djinn-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-103-subnet-api-api-djinn-ai",
+      "kind": "subnet-api",
+      "name": "Djinn community subnet-api",
+      "netuid": 103,
+      "provider": "djinn",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.djinn.ai/openapi.json",
+      "source_urls": ["https://api.djinn.ai/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.djinn.ai/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.djinn.ai/health`.

Closes #695.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)