### PR TITLE
feat(registry): enrich SN98 ForeverMoney — add health subnet API

### DIFF
--- a/registry/candidates/community/community-sn-98-subnet-api-api-forevermoney-ai.json
+++ b/registry/candidates/community/community-sn-98-subnet-api-api-forevermoney-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-98-subnet-api-api-forevermoney-ai",
+      "kind": "subnet-api",
+      "name": "ForeverMoney community subnet-api",
+      "netuid": 98,
+      "provider": "forevermoney",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.forevermoney.ai/openapi.json",
+      "source_urls": ["https://api.forevermoney.ai/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.forevermoney.ai/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.forevermoney.ai/health`.

Closes #700.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)