### PR TITLE
feat(registry): enrich SN5 Hone — add health subnet API

### DIFF
--- a/registry/candidates/community/community-sn-5-subnet-api-api-hone-training.json
+++ b/registry/candidates/community/community-sn-5-subnet-api-api-hone-training.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-5-subnet-api-api-hone-training",
+      "kind": "subnet-api",
+      "name": "Hone community subnet-api",
+      "netuid": 5,
+      "provider": "hone",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.hone.training/openapi.json",
+      "source_urls": ["https://api.hone.training/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.hone.training/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.hone.training/health`.

Closes #713.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)