### PR TITLE
feat(registry): enrich SN11 TrajectoryRL — add health subnet API

### DIFF
--- a/registry/candidates/community/community-sn-11-subnet-api-api-trajrl-com.json
+++ b/registry/candidates/community/community-sn-11-subnet-api-api-trajrl-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-11-subnet-api-api-trajrl-com",
+      "kind": "subnet-api",
+      "name": "TrajectoryRL community subnet-api",
+      "netuid": 11,
+      "provider": "trajectoryrl",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.trajrl.com/openapi.json",
+      "source_urls": ["https://api.trajrl.com/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.trajrl.com/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.trajrl.com/health`.

Closes #712.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)