### PR TITLE
feat(registry): enrich SN4 Targon — add health subnet API

### DIFF
--- a/registry/candidates/community/community-sn-4-subnet-api-api-targon-com.json
+++ b/registry/candidates/community/community-sn-4-subnet-api-api-targon-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-4-subnet-api-api-targon-com",
+      "kind": "subnet-api",
+      "name": "Targon community subnet-api",
+      "netuid": 4,
+      "provider": "targon",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.targon.com/openapi.json",
+      "source_urls": ["https://api.targon.com/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.targon.com/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.targon.com/health`.

Closes #682.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)