### PR TITLE
feat(registry): enrich SN21 AdTAO — add health subnet API

### DIFF
--- a/registry/candidates/community/community-sn-21-subnet-api-api-adtao-io.json
+++ b/registry/candidates/community/community-sn-21-subnet-api-api-adtao-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-21-subnet-api-api-adtao-io",
+      "kind": "subnet-api",
+      "name": "AdTAO community subnet-api",
+      "netuid": 21,
+      "provider": "adtao",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.adtao.io/openapi.json",
+      "source_urls": ["https://api.adtao.io/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.adtao.io/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.adtao.io/health`.

Closes #693.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)