### PR TITLE
feat(registry): enrich SN25 Mainframe — add health subnet API

### DIFF
--- a/registry/candidates/community/community-sn-25-subnet-api-api-macrocosmos-ai.json
+++ b/registry/candidates/community/community-sn-25-subnet-api-api-macrocosmos-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-25-subnet-api-api-macrocosmos-ai",
+      "kind": "subnet-api",
+      "name": "Mainframe community subnet-api",
+      "netuid": 25,
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.macrocosmos.ai/openapi.json",
+      "source_urls": ["https://api.macrocosmos.ai/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.macrocosmos.ai/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.macrocosmos.ai/health`.

Closes #691.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)