### PR TITLE
feat(registry): enrich SN62 Ridges — add health subnet API

### DIFF
--- a/registry/candidates/community/community-sn-62-subnet-api-api-ridges-ai.json
+++ b/registry/candidates/community/community-sn-62-subnet-api-api-ridges-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-62-subnet-api-api-ridges-ai",
+      "kind": "subnet-api",
+      "name": "Ridges community subnet-api",
+      "netuid": 62,
+      "provider": "ridges",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.ridges.ai/openapi.json",
+      "source_urls": ["https://api.ridges.ai/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.ridges.ai/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.ridges.ai/health`.

Closes #722.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)