### PR TITLE
feat(registry): enrich SN82 Compelle — add health subnet API

### DIFF
--- a/registry/candidates/community/community-sn-82-subnet-api-compelle-ai.json
+++ b/registry/candidates/community/community-sn-82-subnet-api-compelle-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-82-subnet-api-compelle-ai",
+      "kind": "subnet-api",
+      "name": "Compelle community subnet-api",
+      "netuid": 82,
+      "provider": "compelle",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://compelle.ai/openapi.json",
+      "source_urls": ["https://compelle.ai/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://compelle.ai/api/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://compelle.ai/api/health`.

Closes #685.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)