### PR TITLE
feat(registry): enrich SN96 Verathos — add SSE stream

### DIFF
--- a/registry/candidates/community/community-sn-96-sse-api-verathos-ai.json
+++ b/registry/candidates/community/community-sn-96-sse-api-verathos-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-96-sse-api-verathos-ai",
+      "kind": "sse",
+      "name": "Verathos community sse",
+      "netuid": 96,
+      "provider": "verathos",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://verathos.ai/openapi.json",
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.verathos.ai/v1/streams"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.verathos.ai/v1/streams`.

Closes #736.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `errors: []`, `manual_reasons: []`)