### PR TITLE
feat(registry): per-field provenance — last_verified_at + freshness TTL on surfaces (#1006)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -3337,6 +3337,8 @@ export interface components {
             /** @description Stable surface identity (#1005): a hash of netuid|kind|url, invariant across display-name/slug renames. Prefer this over the hand-authored id for durable references; D1 history + endpoint links re-key onto it. */
             key?: string;
             kind: components["schemas"]["SurfaceKind"];
+            /** @description Per-field provenance (#1006): the as-of timestamp this surface was last verified — a per-surface verification when present, otherwise the subnet curation's verified_at. null when unverified. Agents reason about how fresh the value is and cache-bust on it. */
+            last_verified_at?: string | null;
             name?: string;
             netuid: number;
             notes?: string;
@@ -3376,6 +3378,8 @@ export interface components {
             /** Format: uri */
             schema_url?: string;
             source_urls?: string[];
+            /** @description Freshness TTL (#1006): true when last_verified_at is older than the per-kind window (callable surfaces ~30d, identity surfaces ~90-120d), measured against the dataset's native-snapshot captured_at. false when fresh or unverified. */
+            stale?: boolean;
             status?: components["schemas"]["HealthStatus"];
             subnet_name?: string;
             subnet_slug?: string;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9302,6 +9302,13 @@
           "kind": {
             "$ref": "#/components/schemas/SurfaceKind"
           },
+          "last_verified_at": {
+            "description": "Per-field provenance (#1006): the as-of timestamp this surface was last verified — a per-surface verification when present, otherwise the subnet curation's verified_at. null when unverified. Agents reason about how fresh the value is and cache-bust on it.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "name": {
             "type": "string"
           },
@@ -9413,6 +9420,10 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "stale": {
+            "description": "Freshness TTL (#1006): true when last_verified_at is older than the per-kind window (callable surfaces ~30d, identity surfaces ~90-120d), measured against the dataset's native-snapshot captured_at. false when fresh or unverified.",
+            "type": "boolean"
           },
           "status": {
             "$ref": "#/components/schemas/HealthStatus"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -3337,6 +3337,8 @@ export interface components {
             /** @description Stable surface identity (#1005): a hash of netuid|kind|url, invariant across display-name/slug renames. Prefer this over the hand-authored id for durable references; D1 history + endpoint links re-key onto it. */
             key?: string;
             kind: components["schemas"]["SurfaceKind"];
+            /** @description Per-field provenance (#1006): the as-of timestamp this surface was last verified — a per-surface verification when present, otherwise the subnet curation's verified_at. null when unverified. Agents reason about how fresh the value is and cache-bust on it. */
+            last_verified_at?: string | null;
             name?: string;
             netuid: number;
             notes?: string;
@@ -3376,6 +3378,8 @@ export interface components {
             /** Format: uri */
             schema_url?: string;
             source_urls?: string[];
+            /** @description Freshness TTL (#1006): true when last_verified_at is older than the per-kind window (callable surfaces ~30d, identity surfaces ~90-120d), measured against the dataset's native-snapshot captured_at. false when fresh or unverified. */
+            stale?: boolean;
             status?: components["schemas"]["HealthStatus"];
             subnet_name?: string;
             subnet_slug?: string;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -9280,6 +9280,13 @@
           "kind": {
             "$ref": "#/components/schemas/SurfaceKind"
           },
+          "last_verified_at": {
+            "description": "Per-field provenance (#1006): the as-of timestamp this surface was last verified — a per-surface verification when present, otherwise the subnet curation's verified_at. null when unverified. Agents reason about how fresh the value is and cache-bust on it.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "name": {
             "type": "string"
           },
@@ -9391,6 +9398,10 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "stale": {
+            "description": "Freshness TTL (#1006): true when last_verified_at is older than the per-kind window (callable surfaces ~30d, identity surfaces ~90-120d), measured against the dataset's native-snapshot captured_at. false when fresh or unverified.",
+            "type": "boolean"
           },
           "status": {
             "$ref": "#/components/schemas/HealthStatus"

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -198,6 +198,14 @@
             "type": "string",
             "description": "Stable surface identity (#1005): a hash of netuid|kind|url, invariant across display-name/slug renames. Prefer this over the hand-authored id for durable references; D1 history + endpoint links re-key onto it."
           },
+          "last_verified_at": {
+            "type": ["string", "null"],
+            "description": "Per-field provenance (#1006): the as-of timestamp this surface was last verified — a per-surface verification when present, otherwise the subnet curation's verified_at. null when unverified. Agents reason about how fresh the value is and cache-bust on it."
+          },
+          "stale": {
+            "type": "boolean",
+            "description": "Freshness TTL (#1006): true when last_verified_at is older than the per-kind window (callable surfaces ~30d, identity surfaces ~90-120d), measured against the dataset's native-snapshot captured_at. false when fresh or unverified."
+          },
           "name": {
             "type": "string"
           },

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -22,6 +22,7 @@ import {
   stripUrls,
   buildRpcEndpointArtifact,
   flattenSurfaces,
+  withSurfaceFreshness,
   formatLlmMarkdownText,
   hashJson,
   listJsonFilesRecursive,
@@ -115,7 +116,13 @@ const activeOverlayNetuids = new Set(
 const activeOverlays = overlays.filter((overlay) =>
   activeOverlayNetuids.has(overlay.netuid),
 );
-const surfaces = flattenSurfaces(activeOverlays);
+// #1006: stamp the per-surface `stale` flag against the committed native-snapshot
+// captured_at — a deterministic reference (never wall-clock), so the flag stays
+// reproducible across builds. `last_verified_at` is added inside flattenSurfaces.
+const surfaces = withSurfaceFreshness(
+  flattenSurfaces(activeOverlays),
+  Date.parse(nativeSnapshot.captured_at),
+);
 // #1002: dedup candidate ↔ curated surface. A candidate that shares a curated
 // surface's (netuid | kind | normalized-url) identity is the same thing already
 // promoted to the registry — flag it `superseded_by` the surface (stamped onto

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -464,10 +464,69 @@ export function flattenSurfaces(subnets) {
         };
         // #1005: a stable identity decoupled from the hand-authored display id.
         flattened.key = surfaceStableKey(flattened);
+        // #1006: the as-of timestamp every served surface should carry. A
+        // per-surface verification wins; otherwise the subnet's curation
+        // verified_at (when a maintainer last vetted the overlay). null when
+        // neither exists — the agent then sees the surface is unverified.
+        flattened.last_verified_at =
+          surface.verification?.verified_at ??
+          subnet.curation?.verified_at ??
+          null;
         return flattened;
       }),
     )
     .sort((a, b) => a.netuid - b.netuid || a.id.localeCompare(b.id));
+}
+
+// #1006: per-kind verification-freshness TTL (days). `last_verified_at` is the
+// curator's as-of; a surface is `stale` once it hasn't been re-verified within
+// its kind's window. Callable/operational surfaces drift fast (short window);
+// static identity surfaces are stable (long window). Any kind not listed uses
+// SURFACE_FRESHNESS_DEFAULT_TTL_DAYS. Fixed (not env-gated) so the build and the
+// validate reproduction compute byte-identical `stale` values.
+export const SURFACE_FRESHNESS_DEFAULT_TTL_DAYS = 90;
+export const SURFACE_FRESHNESS_TTL_DAYS = {
+  "subnet-api": 30,
+  openapi: 30,
+  sse: 30,
+  "data-artifact": 30,
+  "subtensor-rpc": 30,
+  "subtensor-wss": 30,
+  dashboard: 60,
+  website: 90,
+  docs: 90,
+  archive: 120,
+  example: 120,
+  sdk: 120,
+  "source-repo": 120,
+  "repo-registry": 120,
+};
+
+export function surfaceFreshnessTtlDays(kind) {
+  return SURFACE_FRESHNESS_TTL_DAYS[kind] ?? SURFACE_FRESHNESS_DEFAULT_TTL_DAYS;
+}
+
+// True when a surface's verification is older than its kind's TTL, measured
+// against `nowMs` (the dataset's native-snapshot captured_at, a committed +
+// deterministic reference — never wall-clock — so the flag is reproducible). A
+// surface with no last_verified_at is NOT stale: that's "unverified", a distinct
+// state the null timestamp already signals.
+export function isSurfaceStale(lastVerifiedAt, kind, nowMs) {
+  if (!lastVerifiedAt) return false;
+  const verifiedMs = Date.parse(lastVerifiedAt);
+  if (!Number.isFinite(verifiedMs) || !Number.isFinite(nowMs)) return false;
+  return nowMs - verifiedMs > surfaceFreshnessTtlDays(kind) * 86_400_000;
+}
+
+// Stamp the serve-time `stale` flag onto a flattened-surface list (the companion
+// to flattenSurfaces' static `last_verified_at`). Kept separate because `stale`
+// needs the `nowMs` reference flattenSurfaces does not carry; build + validate
+// both call this with the same captured_at so per-subnet artifacts reproduce.
+export function withSurfaceFreshness(surfaces, nowMs) {
+  return surfaces.map((surface) => ({
+    ...surface,
+    stale: isSurfaceStale(surface.last_verified_at, surface.kind, nowMs),
+  }));
 }
 
 // Stable surface identity (#1005): a short hash of the netuid|kind|url key, so a

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -6,6 +6,7 @@ import {
   socialAccounts,
   subnetContact,
   flattenSurfaces,
+  withSurfaceFreshness,
   loadCandidates,
   loadVerification,
   loadNativeSnapshot,
@@ -905,7 +906,13 @@ async function validateGeneratedArtifacts(
   const activeOverlays = overlays.filter((overlay) =>
     activeNetuids.has(overlay.netuid),
   );
-  const surfaces = flattenSurfaces(activeOverlays);
+  // #1006: mirror the build's per-surface freshness stamp (last_verified_at is
+  // added inside flattenSurfaces; `stale` is computed against the same committed
+  // captured_at) so the per-subnet detail artifact stays reproducible.
+  const surfaces = withSurfaceFreshness(
+    flattenSurfaces(activeOverlays),
+    Date.parse(nativeSnapshot.captured_at),
+  );
   // #1002: mirror the build's candidate ↔ curated-surface dedup. A candidate
   // sharing a curated surface's registrySurfaceKey is already promoted, so the
   // per-subnet detail artifact counts/lists only the non-superseded candidates.

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -25,6 +25,7 @@ import {
   publicMetagraphRoot,
   r2StagingRoot,
   registrySurfaceKey,
+  isSurfaceStale,
 } from "../scripts/lib.mjs";
 import { handleRequest } from "../workers/api.mjs";
 
@@ -959,6 +960,33 @@ test("public artifacts are internally consistent", () => {
   assert.equal(
     healthHistory.surfaces.every((surface) => !Object.hasOwn(surface, "url")),
     true,
+  );
+  // #1006: per-field provenance. Every served surface exposes last_verified_at
+  // (string|null) + a `stale` boolean, and `stale` is reproducible from the
+  // helper against the committed native-snapshot captured_at.
+  const surfaceNowMs = Date.parse(native.captured_at);
+  for (const surface of surfaces.surfaces) {
+    assert.ok(
+      surface.last_verified_at === null ||
+        typeof surface.last_verified_at === "string",
+      `surface ${surface.id} last_verified_at must be a string or null`,
+    );
+    assert.equal(
+      typeof surface.stale,
+      "boolean",
+      `surface ${surface.id} must carry a boolean stale flag`,
+    );
+    assert.equal(
+      surface.stale,
+      isSurfaceStale(surface.last_verified_at, surface.kind, surfaceNowMs),
+      `surface ${surface.id} stale flag must match the freshness helper`,
+    );
+  }
+  // The curation→surface verified_at join must actually populate timestamps, not
+  // leave every surface unverified (guard against a silent no-op).
+  assert.ok(
+    surfaces.surfaces.some((surface) => surface.last_verified_at !== null),
+    "expected at least one surface to carry a last_verified_at timestamp",
   );
   assert.equal(coverage.chain_subnet_count, native.subnets.length);
   assert.equal(coverage.curated_overlay_count, native.subnets.length);

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -25,6 +25,10 @@ import {
   formatRepositoryJson,
   hashJson,
   isCredentialedUrl,
+  isSurfaceStale,
+  surfaceFreshnessTtlDays,
+  withSurfaceFreshness,
+  SURFACE_FRESHNESS_DEFAULT_TTL_DAYS,
   isHtmlContentType,
   isJsonContentType,
   isUnsafeResolvedUrl,
@@ -1235,6 +1239,56 @@ describe("script utility contracts", () => {
       "7|docs|https://docs.all-ways.io/",
     );
     assert.equal(slugify("TAO / Metagraph: Build"), "tao-metagraph-build");
+  });
+
+  test("surface freshness TTL + staleness flag (#1006)", () => {
+    // Per-kind TTL map with a default fallback for unlisted kinds.
+    assert.equal(surfaceFreshnessTtlDays("subnet-api"), 30);
+    assert.equal(surfaceFreshnessTtlDays("source-repo"), 120);
+    assert.equal(
+      surfaceFreshnessTtlDays("totally-unknown-kind"),
+      SURFACE_FRESHNESS_DEFAULT_TTL_DAYS,
+    );
+
+    const now = Date.parse("2026-06-14T00:00:00.000Z");
+    const daysAgo = (n) => new Date(now - n * 86_400_000).toISOString();
+
+    // Unverified surfaces are NOT stale — null is a distinct state the agent reads.
+    assert.equal(isSurfaceStale(null, "subnet-api", now), false);
+    assert.equal(isSurfaceStale(undefined, "docs", now), false);
+    // Unparseable inputs never throw and never flag stale.
+    assert.equal(isSurfaceStale("not-a-date", "docs", now), false);
+    assert.equal(isSurfaceStale(daysAgo(999), "docs", Number.NaN), false);
+    // Fresh: age below the kind TTL.
+    assert.equal(isSurfaceStale(daysAgo(10), "subnet-api", now), false);
+    // Boundary: exactly at the TTL is still fresh (strict greater-than).
+    assert.equal(isSurfaceStale(daysAgo(30), "subnet-api", now), false);
+    // Just over the TTL flips stale.
+    assert.equal(isSurfaceStale(daysAgo(31), "subnet-api", now), true);
+    // The window is per-kind: the same age is stale for a callable surface but
+    // fresh for a long-lived identity surface.
+    assert.equal(isSurfaceStale(daysAgo(45), "openapi", now), true);
+    assert.equal(isSurfaceStale(daysAgo(45), "source-repo", now), false);
+
+    // withSurfaceFreshness stamps `stale` from last_verified_at + kind, leaving
+    // the other surface fields intact.
+    const stamped = withSurfaceFreshness(
+      [
+        { id: "a", kind: "openapi", last_verified_at: daysAgo(45) },
+        { id: "b", kind: "source-repo", last_verified_at: daysAgo(45) },
+        { id: "c", kind: "docs", last_verified_at: null },
+      ],
+      now,
+    );
+    assert.deepEqual(
+      stamped.map((s) => [s.id, s.stale]),
+      [
+        ["a", true],
+        ["b", false],
+        ["c", false],
+      ],
+    );
+    assert.equal(stamped[0].kind, "openapi");
   });
 
   test("resolves hostnames before treating probe URLs as safe", async () => {


### PR DESCRIPTION
Part of #999 (data-integrity epic) · closes #1006.

## What
Agents could see an API surface but not reason about *how fresh* its verification is. Every served surface now exposes:
- **`last_verified_at`** — the as-of timestamp it was last verified: a per-surface verification when present, otherwise the subnet curation's `verified_at`, `null` when unverified. Added in `flattenSurfaces` (`lib.mjs`), so it flows to every surface-bearing artifact (`surfaces`, `subnets/{netuid}`, `profiles`).
- **`stale`** — `true` when `last_verified_at` is older than the kind's freshness TTL.

## Freshness model
- Per-kind TTL map (`SURFACE_FRESHNESS_TTL_DAYS`): callable/operational surfaces drift fast (~30d), static identity surfaces are stable (~90–120d); unlisted kinds use the 90-day default. `isSurfaceStale` + `withSurfaceFreshness` are pure helpers in `lib.mjs` (codecov scope), unit-tested at the TTL boundary.
- **Determinism:** `stale` is computed against the committed native-snapshot `captured_at` — a deterministic reference, *never* wall-clock (`buildTimestamp()` is the 1970 placeholder in deterministic builds). So the flag reproduces across builds, the per-subnet detail artifact stays drift-clean, and `validate.mjs` mirrors the same stamp.
- A surface with no `last_verified_at` is **not** stale — `null` is a distinct "unverified" state the agent reads directly.

## Schema / contract
`Surface` gains optional `last_verified_at` + `stale` (additive; `additionalProperties:false` honored). Regenerated the contract subset: `api-components.schema.json`, `openapi.json`, `types.d.ts`, `generated/metagraphed-api.d.ts`.

## Live effect
784 / 1160 surfaces carry a `last_verified_at`; none are currently stale (recent bulk re-curation), so the flag is a forward-looking trust signal. The unit boundary test covers the `stale=true` path.

## Verification
- Full `npm test` green (49 files / 1149 tests).
- Full `validate:*` sweep green (incl. contract-drift, types, generated-client, schemas, openapi-examples).
- Deterministic build leaves `git diff public/` clean except the two regenerated contract files (`openapi.json`, `types.d.ts`).