### PR TITLE
feat(health): re-key D1 health history onto the stable surface_key (#1005 PR2)

### DIFF
--- a/migrations/0005_surface_key.sql
+++ b/migrations/0005_surface_key.sql
@@ -1,0 +1,26 @@
+-- Stable surface key on the live-health tables (#1005 PR2).
+--
+-- `surface.key` (srf-<hash of netuid|kind|url>) is invariant across display-name
+-- / slug renames; the hand-authored `surface_id` is author-controlled, so a
+-- rename changes it and ORPHANS the surface's D1 probe history (history is keyed
+-- on surface_id). This adds `surface_key` as an additive column (+ indexes) on
+-- all three live-health tables. The prober backfills it on every write
+-- (surface_status' ON CONFLICT(surface_id) UPDATE SET surface_key=...); the
+-- serving cutover to JOIN on surface_key (so renames preserve history) lands in
+-- PR3.
+--
+-- ALTER TABLE ... ADD COLUMN is non-destructive in SQLite (no table rebuild, no
+-- data loss, no default backfill cost). Apply to the prod metagraphed-health D1
+-- BEFORE the prober code that writes the column deploys, so a missing column can
+-- never make the (try/catch-wrapped) write path silently drop health rows.
+
+ALTER TABLE surface_checks ADD COLUMN surface_key TEXT;
+ALTER TABLE surface_status ADD COLUMN surface_key TEXT;
+ALTER TABLE surface_uptime_daily ADD COLUMN surface_key TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_surface_checks_key_time
+  ON surface_checks (surface_key, checked_at);
+CREATE INDEX IF NOT EXISTS idx_surface_status_key
+  ON surface_status (surface_key);
+CREATE INDEX IF NOT EXISTS idx_surface_uptime_daily_key_day
+  ON surface_uptime_daily (surface_key, day);

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -2238,6 +2238,11 @@ const operationalSurfaces = surfaces
   )
   .map((surface) => ({
     surface_id: surface.id,
+    // #1005: the stable identity (srf-<hash of netuid|kind|url>) the prober
+    // re-keys D1 health history onto, so a display-name/slug rename no longer
+    // orphans the surface's probe history. The hand-authored surface_id stays
+    // for back-compat + display.
+    surface_key: surface.key,
     netuid: surface.netuid,
     subnet_slug: surface.subnet_slug,
     subnet_name: surface.subnet_name,

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -400,6 +400,8 @@ export async function runHealthProber(env, ctx, overrides = {}) {
     const consecutiveFailures = ok ? 0 : (prior?.consecutive_failures ?? 0) + 1;
     return {
       surface_id: surface.surface_id,
+      // #1005: stable key re-keyed onto D1 history; null for pre-#1005 artifacts.
+      surface_key: surface.surface_key ?? null,
       netuid: surface.netuid,
       kind: surface.kind,
       provider: surface.provider || null,
@@ -437,14 +439,20 @@ async function persistToD1(db, probed, runAt) {
   try {
     const checkStmt = db.prepare(
       `INSERT INTO surface_checks
-       (surface_id, netuid, kind, status, classification, latency_ms, status_code, ok, checked_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       (surface_id, surface_key, netuid, kind, status, classification, latency_ms, status_code, ok, checked_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
+    // #1005: surface_key is written alongside surface_id and back-filled onto the
+    // existing latest row via the ON CONFLICT(surface_id) UPDATE — so once every
+    // surface has been probed once post-migration, surface_status carries the
+    // stable key the serving cutover (PR3) joins on. Conflict target stays
+    // surface_id (unchanged behavior); PR3 owns the key-based read path.
     const statusStmt = db.prepare(
       `INSERT INTO surface_status
-       (surface_id, netuid, kind, url, provider, status, classification, latency_ms, status_code, last_checked, last_ok, consecutive_failures, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       (surface_id, surface_key, netuid, kind, url, provider, status, classification, latency_ms, status_code, last_checked, last_ok, consecutive_failures, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(surface_id) DO UPDATE SET
+         surface_key=excluded.surface_key,
          netuid=excluded.netuid, kind=excluded.kind, url=excluded.url,
          provider=excluded.provider, status=excluded.status,
          classification=excluded.classification, latency_ms=excluded.latency_ms,
@@ -457,6 +465,7 @@ async function persistToD1(db, probed, runAt) {
       statements.push(
         checkStmt.bind(
           row.surface_id,
+          row.surface_key,
           row.netuid,
           row.kind,
           row.status,
@@ -468,6 +477,7 @@ async function persistToD1(db, probed, runAt) {
         ),
         statusStmt.bind(
           row.surface_id,
+          row.surface_key,
           row.netuid,
           row.kind,
           row.url,
@@ -598,10 +608,13 @@ export async function rollupDailyUptime(env, overrides = {}) {
   const days = [utcDayBounds(runAt), utcDayBounds(runAt - 24 * 60 * 60 * 1000)];
   const stmt = db.prepare(
     `INSERT INTO surface_uptime_daily
-       (surface_id, netuid, day, samples, ok_count, uptime_ratio,
+       (surface_id, surface_key, netuid, day, samples, ok_count, uptime_ratio,
         avg_latency_ms, status, updated_at)
      SELECT
        surface_id,
+       -- #1005: surface_key is functionally dependent on surface_id within the
+       -- raw checks, so MAX() picks it deterministically per group.
+       MAX(surface_key) AS surface_key,
        netuid,
        ? AS day,
        COUNT(*) AS samples,
@@ -618,6 +631,7 @@ export async function rollupDailyUptime(env, overrides = {}) {
      WHERE checked_at >= ? AND checked_at < ?
      GROUP BY surface_id, netuid
      ON CONFLICT(surface_id, day) DO UPDATE SET
+       surface_key = excluded.surface_key,
        netuid = excluded.netuid,
        samples = excluded.samples,
        ok_count = excluded.ok_count,

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -209,6 +209,7 @@ const RPC_CALLS = [
 const SURFACES = [
   {
     surface_id: "sn7-api",
+    surface_key: "srf-sn7apikey000000",
     netuid: 7,
     kind: "subnet-api",
     url: "https://api.example.dev",
@@ -222,6 +223,7 @@ const SURFACES = [
   },
   {
     surface_id: "opentensor-finney-rpc",
+    surface_key: "srf-rootrpckey00000",
     netuid: 0,
     kind: "subtensor-rpc",
     url: "https://entrypoint-finney.opentensor.ai",
@@ -285,6 +287,15 @@ describe("runHealthProber", () => {
     // One batch with 4 statements (2 surfaces × {check insert, status upsert}).
     assert.equal(db.calls.batches.length, 1);
     assert.equal(db.calls.batches[0].length, 4);
+
+    // #1005: both the append-only time-series and the latest-row upsert carry the
+    // stable surface_key (binds[1]) so D1 history re-keys onto the rename-stable
+    // identity. surface_checks binds: [surface_id, surface_key, netuid, ...].
+    const checkInsert = db.calls.batches[0].find(
+      (s) =>
+        /INSERT INTO surface_checks/.test(s.sql) && s.binds[0] === "sn7-api",
+    );
+    assert.equal(checkInsert.binds[1], "srf-sn7apikey000000");
 
     const current = kv.json(KV_HEALTH_CURRENT);
     assert.equal(current.summary.surface_count, 2);
@@ -401,9 +412,11 @@ describe("runHealthProber", () => {
       /INSERT INTO surface_status/.test(s.sql),
     );
     const apiUpsert = upserts.find((s) => s.binds[0] === "sn7-api");
-    // binds: [surface_id, netuid, kind, url, provider, status, classification,
-    //         latency_ms, status_code, last_checked, last_ok, consec, updated_at]
-    assert.equal(apiUpsert.binds[11], 3);
+    // binds: [surface_id, surface_key, netuid, kind, url, provider, status,
+    //   classification, latency_ms, status_code, last_checked, last_ok, consec,
+    //   updated_at] — #1005 added surface_key at index 1, shifting the rest by 1.
+    assert.equal(apiUpsert.binds[1], "srf-sn7apikey000000");
+    assert.equal(apiUpsert.binds[12], 3);
   });
 
   test("no-ops cleanly when there are no operational surfaces", async () => {


### PR DESCRIPTION
Part of #999 (data-integrity epic) · #1005 **PR2 of 2** (PR3 = serving cutover + rename test).

## Context
[#1005 PR1](https://github.com/JSONbored/metagraphed/pull/1023) gave every surface a stable `key` (`srf-<hash of netuid|kind|url>`), invariant across display-name/slug renames. The live-health D1 tables still key on the hand-authored `surface_id`, so renaming a surface **orphans** its probe history.

## PR2 — additive write-side re-key (no read-side behavior change)
- **`migrations/0005_surface_key.sql`**: `ALTER TABLE ... ADD COLUMN surface_key` on `surface_checks`, `surface_status`, `surface_uptime_daily` + supporting indexes. Non-destructive in SQLite (no table rebuild, no data loss).
- **`operational-surfaces.json`** carries `surface_key` (projected from `surface.key`) so the prober knows each surface's stable key. R2-only artifact → no committed churn.
- **Prober** writes `surface_key` into all three tables: the append-only `surface_checks` time-series, the `surface_status` latest-row upsert (also **back-filling existing rows** via the `ON CONFLICT(surface_id)` UPDATE), and the `surface_uptime_daily` rollup (`MAX(surface_key)` per group). **Conflict targets stay `surface_id`** — behavior is unchanged; the `surface_key`-based serving cutover that actually preserves history across a rename (+ its rename test) lands in PR3.

## Deploy sequencing (handled by me, out-of-band)
The additive migration is applied to the prod `metagraphed-health` D1 via the Cloudflare API **before this code merges/deploys**, so the (try/catch-wrapped) prober write path can never reference a missing column. The old deployed prober ignores the new column, so the pre-merge window is safe.

## Verification
- Migration applied cleanly to a local SQLite (`0001`+`0003`+`0005`): all three `surface_key` columns + indexes present, prober insert round-trips.
- Full `npm test` green (49 files / 1150 tests); the prober suite asserts `surface_key` is bound on the check insert + status upsert (binds shifted +1).
- Full `validate:*` sweep green; no committed `public/` churn (operational-surfaces is R2-only).