### PR TITLE
fix(discovery): reserve committed community candidate locators (unbreak prod publish)

### DIFF
--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -5,6 +5,7 @@ import {
   isLikelyExampleLink,
   isUnsafeResolvedUrl,
   isUnsafeUrl,
+  listJsonFilesRecursive,
   loadNativeSnapshot,
   loadProviders,
   loadSubnets,
@@ -71,6 +72,27 @@ const candidatesByKey = new Map();
 const candidateIds = new Set();
 const warnings = [];
 const existingGeneratedCandidates = await loadExistingGeneratedCandidates();
+// A committed community/curated candidate already pins a locator that the live
+// OpenAPI/website probes can rediscover under a different id — which trips
+// validate's candidate-locator uniqueness in the production publish (#1026
+// follow-up). CI builds from committed data only, so it never sees the live
+// collision; that's why the publish failed while every PR's CI stayed green.
+// Reserve every committed community candidate's locator (same key format as
+// addCandidate, with the LOCAL normalizePublicUrl) so the discovery never emits
+// a duplicate of one — the committed candidate stands.
+const reservedCandidateLocators = new Set();
+for (const file of await listJsonFilesRecursive(
+  path.join(repoRoot, "registry/candidates/community"),
+)) {
+  const document = await readJson(file);
+  for (const candidate of document.candidates || []) {
+    const normalizedUrl = normalizePublicUrl(candidate.url);
+    if (!normalizedUrl) continue;
+    reservedCandidateLocators.add(
+      `${candidate.netuid}:${candidate.kind}:${normalizedUrl.toLowerCase()}`,
+    );
+  }
+}
 const restoredProviders = new Set();
 const TAOPEDIA_ARTICLE_PROBE_MAX_BYTES = 64 * 1024;
 
@@ -1021,6 +1043,12 @@ function addCandidate(candidate) {
   }
 
   const key = `${candidate.netuid}:${candidate.kind}:${normalizedUrl.toLowerCase()}`;
+  // A committed community candidate already pins this locator — re-emitting it as
+  // a generated candidate breaks the publish's candidate-locator uniqueness check
+  // (#1026 follow-up). Skip; the committed candidate stands.
+  if (reservedCandidateLocators.has(key)) {
+    return;
+  }
   const sourceUrl = normalizePublicUrl(candidate.source_url);
   if (!sourceUrl) {
     return;


### PR DESCRIPTION
## Production publish is broken — R2/KV going stale
The **Publish Cloudflare Backend** workflow has failed its **Validate registry** step on every run since the OpenAPI auto-discovery landed ([#1026](https://github.com/JSONbored/metagraphed/pull/1026), ~04:29 today), so the R2/KV data refresh has not shipped since:

```
Validation failed with 1 issue(s):
- sn-14-openapi-probe-api-cacheon-ai: duplicate candidate locator
  14|openapi|https://api.cacheon.ai/openapi.json
```

## Root cause
The live OpenAPI probe rediscovers `api.cacheon.ai/openapi.json` and emits it as a generated candidate (`sn-14-openapi-probe-...`), but a committed **community** candidate (`community-sn-14-openapi-api-cacheon-ai`, submitted by @kiannidev) already pins that exact `(netuid, kind, url)` locator. `validate` enforces candidate-locator uniqueness across the whole set → two candidates, one locator → fail.

**Why CI stayed green:** CI builds from committed data only. The collision exists solely in the *live* discovery output the publish regenerates — so every PR's `Validate` workflow passed while the publish broke. Pre-existing; not caused by the recent #999 work.

## Fix
At discovery startup, reserve every committed community candidate's locator (same key format as `addCandidate`, using the local `normalizePublicUrl`); `addCandidate` skips any reserved locator — the committed candidate stands, the discovery never emits a duplicate of it. General fix for any community-vs-discovery collision, not just cacheon.

- Touches only `scripts/discover-candidates.mjs`. The deterministic build/validate (CI path) is unaffected.
- The contributor's candidate file is left intact (no contributor-file edit).

## Verification
- Reserved set built deterministically from the 38 community candidates includes the cacheon locator (confirmed); `addCandidate`'s skip uses the identical key, so the probe is dropped.
- `eslint`/`prettier` clean; deterministic build + `validate` pass; no `public/` churn.
- A live `discover:candidates --dry-run` was run as an end-to-end check.
- The definitive confirmation is the post-merge publish succeeding — I'll watch it.