### PR TITLE
fix(fixtures): redact private/loopback URLs in captured bodies (unbreak prod publish)

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -898,7 +898,11 @@ export function sanitizeFixtureBody(
   const walk = (node, depth) => {
     if (depth > maxDepth) return "[truncated: max depth]";
     if (typeof node === "string") {
-      const redacted = redactCredentialedUrl(node);
+      // Redact credentials AND private/loopback URLs. A captured spec can carry a
+      // servers[].url pointing at localhost / 10.x / 192.168.x (operators leave
+      // dev servers in their public OpenAPI); the publish public-safety scan
+      // rejects those, so mirror the schema-snapshot sanitizer here too.
+      const redacted = sanitizeSchemaText(redactCredentialedUrl(node));
       return redacted.length > maxString
         ? `${redacted.slice(0, maxString)}…[truncated]`
         : redacted;

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -50,6 +50,7 @@ import {
   registrySurfaceKey,
   repoRoot,
   isReviewableReadmeLink,
+  sanitizeFixtureBody,
   selectReviewableReadmeLinks,
   sha256Hex,
   slugify,
@@ -1324,6 +1325,32 @@ describe("script utility contracts", () => {
     assert.equal(isLikelyExampleLink("documentation site /docs/intro"), false);
     assert.equal(isLikelyExampleLink(""), false);
     assert.equal(isLikelyExampleLink(undefined), false);
+  });
+
+  test("sanitizeFixtureBody redacts private/loopback URLs in captured bodies", () => {
+    // A captured OpenAPI spec can carry dev servers (localhost / private IPs) the
+    // publish public-safety scan rejects; the fixture sanitizer must strip them.
+    const out = sanitizeFixtureBody({
+      openapi: "3.0.0",
+      servers: [
+        { url: "https://api.example.com" },
+        { url: "http://10.0.0.5:8000" },
+        { url: "http://localhost:3000/v1" },
+        { url: "http://192.168.1.4/api" },
+      ],
+      note: "callbacks hit http://127.0.0.1:9000/cb internally",
+    });
+    const json = JSON.stringify(out);
+    assert.equal(
+      /https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|10\.|192\.168\.|172\.(?:1[6-9]|2\d|3[01])\.)/i.test(
+        json,
+      ),
+      false,
+      "no private/loopback URL may survive in a captured fixture body",
+    );
+    // Public server URLs are preserved.
+    assert.equal(out.servers[0].url, "https://api.example.com");
+    assert.equal(out.servers[1].url, "[redacted-unsafe-url]");
   });
 
   test("resolves hostnames before treating probe URLs as safe", async () => {


### PR DESCRIPTION
Second publish blocker from the OpenAPI auto-discovery (#1026), exposed once [#1100](https://github.com/JSONbored/metagraphed/pull/1100) let the publish past `Validate registry`. The `Public-safety scan` step then failed:

```
dist/.../fixtures/sn-51-openapi-probe-lium-io.json:response.body.servers[1].url: private or loopback URL
```

## Cause
The lium.io OpenAPI spec lists a **dev server** (private/loopback URL) in its `servers`, which the probe captures verbatim into the fixture. The *schema snapshot* already strips these (`sanitizeSchemaServer` → `sanitizeSchemaUrlString` → `isUnsafeUrl`), but the *fixture* sanitizer (`sanitizeFixtureBody`) only redacted credentials — not private/loopback hosts. So the publish's public-safety scan rejected the artifact.

## Fix
`sanitizeFixtureBody` now runs captured strings through `sanitizeSchemaText` (after `redactCredentialedUrl`), so any private/loopback URL anywhere in a captured body becomes `[redacted-unsafe-url]` while public URLs are preserved. **Class-level** — covers every fixture, not just lium. Unit-tested.

## Context
This is the 2nd of (so far) two production-publish blockers from #1026's live OpenAPI discovery (both masked behind the prior failure). The publish — and the connected 14h live-prober outage (it reads R2-only `operational-surfaces.json`, which no successful publish has refreshed) — should clear once a publish runs green. Verifying with a fresh dry-run after merge.