### PR TITLE
fix(publish): re-stamp r2-manifest after changelog:publish (unblock R2 upload)

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -269,6 +269,16 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      # changelog:publish overwrote the staged changelog.json with the real diff,
+      # but the r2-manifest still records the build-time PLACEHOLDER changelog's
+      # hash — so r2:upload's per-artifact verification fails ("local artifact
+      # hash mismatch for /metagraph/changelog.json"). Re-stamp the manifest from
+      # the now-final staged artifacts before upload. Gated identically (dry-runs
+      # skip changelog:publish, so the manifest already matches the placeholder).
+      - name: Re-stamp R2 manifest after changelog
+        if: steps.cloudflare-secrets.outputs.publish == 'true' && steps.cloudflare-secrets.outputs.dry_run != 'true'
+        run: npm run r2:manifest
+
       - name: Upload artifact history to R2
         if: steps.cloudflare-secrets.outputs.publish == 'true' && steps.cloudflare-secrets.outputs.dry_run != 'true'
         run: npm run r2:upload


### PR DESCRIPTION
**Third** production-publish blocker, exposed once the OpenAPI-discovery fixes ([#1100](https://github.com/JSONbored/metagraphed/pull/1100), [#1101](https://github.com/JSONbored/metagraphed/pull/1101)) let the publish reach the R2 **upload** step (which the dry-run skips, so the dry-run was green):

```
Error: local artifact hash mismatch for /metagraph/changelog.json:
  expected 59bf5c… (manifest), got 9e377d… (file)
  at verifyLocalArtifact (scripts/r2-upload.mjs)
```

## Cause
`changelog:publish` (`build-changelog.mjs`, from #1003) overwrites the staged `changelog.json` with the real "diff vs previous R2 publish" **after** the build already wrote the `r2-manifest` recording the *placeholder* changelog's hash. `r2:upload` then verifies each artifact against that stale manifest and aborts. Latent since #1003; never reached in ~15h because the publish failed earlier at `Validate registry`.

## Fix
Re-run `r2:manifest` after `changelog:publish` and before `r2:upload`, so the manifest reflects the final staged artifacts. Gated identically to `changelog:publish` (real publish only; dry-runs skip both).

## Verified locally
Built artifacts, edited the staged `changelog.json` to reproduce the mismatch, then confirmed `npm run r2:manifest` re-stamps the manifest's changelog entry to match the file (so `r2:upload`'s per-artifact check passes). `validate:workflows` green.

This is the last of three blockers; the refresh + build + validate + public-safety stages already pass. Merging + a real publish should restore R2/KV and revive the 14h-down prober.