### PR TITLE
feat(readme): auto-generated subnet catalog (#1020)

### DIFF
--- a/.github/workflows/readme-catalog-refresh.yml
+++ b/.github/workflows/readme-catalog-refresh.yml
@@ -1,0 +1,62 @@
+name: README catalog refresh
+
+# Regenerate the README subnet catalog (#1020) from the curated overlays whenever
+# they change on main, and open a PR if it drifted. Normally a no-op: PRs that
+# touch an overlay are gated by `validate:readme-catalog`, so the catalog is
+# already fresh at merge. This is the safety net for admin-merges/direct pushes
+# that bypass the gate — the catalog is NOT regenerated on the 6h data refresh.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "registry/subnets/**"
+      - "scripts/generate-registry-readme-section.mjs"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: readme-catalog-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22.22.3
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Regenerate README catalog
+        run: npm run readme:catalog
+
+      - name: Open catalog refresh PR (no-op if unchanged)
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/readme-catalog
+          delete-branch: true
+          add-paths: README.md
+          title: "docs(readme): refresh subnet catalog (#1020)"
+          commit-message: "docs(readme): refresh subnet catalog (#1020)"
+          body: |
+            Auto-regenerated the README subnet catalog from the curated overlays
+            in `registry/subnets/` (`npm run readme:catalog`, #1020). Opened
+            because the committed catalog drifted from the overlays.
+          labels: |
+            docs
+            automation

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -216,6 +216,10 @@ jobs:
         if: steps.route.outputs.mode == 'full'
         run: npm run validate:docs
 
+      - name: Validate README subnet catalog (#1020)
+        if: steps.route.outputs.mode == 'full'
+        run: npm run validate:readme-catalog
+
       - name: Validate intake templates
         if: steps.route.outputs.mode == 'full'
         run: npm run validate:intake

--- a/README.md
+++ b/README.md
@@ -95,6 +95,110 @@ Issues are labeled `good first issue` and `help wanted` — start there.
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`docs/submission-gate.md`](docs/submission-gate.md).
 
+## Subnet catalog
+
+<!-- BEGIN:REGISTRY-CATALOG -->
+
+**91 curated subnets** — 79 with a site, 44 with docs, 78 with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](https://metagraph.sh)**; per-subnet JSON at `https://api.metagraph.sh/api/v1/subnets/{netuid}`.
+
+**Focus areas:** `data` 7 · `compute` 6 · `inference` 5 · `defi` 4 · `data-artifact` 2 · `decentralized-training` 2 · `depin` 2 · `finance` 2 · `language-models` 2 · `mcp` 2 · `prediction-market` 2 · `quantum` 2
+
+- **[root](https://metagraph.sh/subnets/0)** `SN0` — `chain-rpc` · [site](https://bittensor.com) · [docs](https://docs.learnbittensor.org/concepts/bittensor-networks) · [repo](https://github.com/opentensor/subtensor)
+- **[Apex](https://metagraph.sh/subnets/1)** `SN1` · [site](https://apex.macrocosmos.ai/) · [docs](https://docs.macrocosmos.ai/subnets/subnet-1-apex) · [repo](https://github.com/macrocosm-os/apex)
+- **[DSperse](https://metagraph.sh/subnets/2)** `SN2` — `verifiable-oracles` `zkml` · [site](https://subnet2.inferencelabs.com/) · [docs](https://sn2-docs.inferencelabs.com/) · [repo](https://github.com/inference-labs-inc/subnet-2)
+- **[Templar](https://metagraph.sh/subnets/3)** `SN3` — `decentralized-training` · [site](https://www.tplr.ai/) · [docs](https://docs.tplr.ai/) · [repo](https://github.com/one-covenant/templar)
+- **[Targon](https://metagraph.sh/subnets/4)** `SN4` · [site](https://targon.com/) · [docs](https://docs.targon.com/) · [repo](https://github.com/manifold-inc/targon)
+- **[Hone](https://metagraph.sh/subnets/5)** `SN5` · [site](https://www.hone.training/) · [repo](https://github.com/manifold-inc/hone)
+- **[Numinous](https://metagraph.sh/subnets/6)** `SN6` — `forecasting` `openapi` `subnet-api` · [site](https://numinouslabs.io/) · [docs](https://api.numinouslabs.io/api/docs) · [repo](https://github.com/numinouslabs/numinous)
+- **[Allways](https://metagraph.sh/subnets/7)** `SN7` — `bitcoin` `subnet-api` · [site](https://all-ways.io/) · [docs](https://docs.all-ways.io/how-it-works.html) · [repo](https://github.com/entrius/allways)
+- **[Vanta](https://metagraph.sh/subnets/8)** `SN8` · [site](https://www.vantanetwork.io/) · [repo](https://github.com/taoshidev/vanta-network)
+- **[iota](https://metagraph.sh/subnets/9)** `SN9` · [site](https://iota.macrocosmos.ai/) · [repo](https://github.com/macrocosm-os/iota)
+- **[Swap](https://metagraph.sh/subnets/10)** `SN10` · [site](https://www.taofi.com/pool) · [docs](https://docs.taofi.com/) · [repo](https://github.com/Swap-Subnet/swap-subnet)
+- **[TrajectoryRL](https://metagraph.sh/subnets/11)** `SN11` · [site](https://trajrl.com/) · [docs](https://trajrl.com/docs) · [repo](https://github.com/trajectoryRL/trajectoryRL)
+- **[Compute Horde](https://metagraph.sh/subnets/12)** `SN12` — `compute` `dashboard` · [site](https://computehorde.io/) · [repo](https://github.com/backend-developers-ltd/ComputeHorde)
+- **[Data Universe](https://metagraph.sh/subnets/13)** `SN13` — `data` `mcp` · [site](https://datauniverse.macrocosmos.ai/) · [docs](https://docs.macrocosmos.ai/product-and-services/gravity) · [repo](https://github.com/macrocosm-os/data-universe)
+- **[Cacheon](https://metagraph.sh/subnets/14)** `SN14` — `inference` · [site](https://cacheon.ai/) · [docs](https://cacheon.ai/docs) · [repo](https://github.com/latent-to/cacheon)
+- **[ORO](https://metagraph.sh/subnets/15)** `SN15` · [site](https://oroagents.com/) · [docs](https://docs.oroagents.com/docs/miners/quick-start) · [repo](https://github.com/ORO-AI/oro)
+- **[BitAds](https://metagraph.sh/subnets/16)** `SN16` · [site](https://bitads.ai/) · [docs](https://bitads.ai/docs) · [repo](https://github.com/FirstTensorLabs/BitAds)
+- **[blockmachine](https://metagraph.sh/subnets/19)** `SN19` · [site](https://blockmachine.io/) · [docs](https://blockmachine.io/whitepaper) · [repo](https://github.com/taostat/blockmachine)
+- **[GroundLayer](https://metagraph.sh/subnets/20)** `SN20` — `capital-markets` · [site](https://www.groundlayer.xyz/) · [repo](https://github.com/RogueTensor/comingsoon)
+- **[AdTAO](https://metagraph.sh/subnets/21)** `SN21` — `advertising` · [site](https://adtao.io/) · [repo](https://github.com/ippcteam/SN21-adtao)
+- **[Desearch](https://metagraph.sh/subnets/22)** `SN22` — `search` `social-data` · [site](https://www.desearch.ai/) · [docs](https://www.desearch.ai/docs) · [repo](https://github.com/Desearch-ai/subnet-22)
+- **[Trishool](https://metagraph.sh/subnets/23)** `SN23` — `subnet-api-observed` · [site](https://trishool.ai/) · [repo](https://github.com/TrishoolAI/trishool-phase2)
+- **[Quasar](https://metagraph.sh/subnets/24)** `SN24` — `language-models` `model-artifacts` · [site](https://silxinc.com/) · [docs](https://github.com/SILX-LABS/QUASAR-SUBNET/blob/main/README.md) · [repo](https://github.com/SILX-LABS/QUASAR-SUBNET)
+- **[Mainframe](https://metagraph.sh/subnets/25)** `SN25` — `compute` · [site](https://macrocosmos.ai/sn25) · [repo](https://github.com/macrocosm-os/mainframe)
+- **[Nodexo](https://metagraph.sh/subnets/27)** `SN27` — `compute` `gpu` · [site](https://nodexo.ai/) · [docs](https://docs.nodexo.ai/)
+- **[gm](https://metagraph.sh/subnets/28)** `SN28` — `llm-inference` `marketplace` `tee` · [site](https://saygm.com/)
+- **[Coldint](https://metagraph.sh/subnets/29)** `SN29` — `data` `distributed-training` · [site](https://coldint.io/) · [docs](https://github.com/coldint/coldint_validator/blob/main/README.md) · [repo](https://github.com/coldint/coldint_validator)
+- **[Endure Network](https://metagraph.sh/subnets/30)** `SN30` — `defi` `risk-intelligence` · [site](https://endure.network/) · [docs](https://docs.endure.network/)
+- **[Recall](https://metagraph.sh/subnets/31)** `SN31` — `rag` `retrieval`
+- **[ItsAI](https://metagraph.sh/subnets/32)** `SN32` · [site](https://its-ai.org/en) · [repo](https://github.com/It-s-AI/llm-detection)
+- **[ReadyAI](https://metagraph.sh/subnets/33)** `SN33` — `conversation-data` `data` · [site](https://readyai.ai/) · [docs](https://github.com/afterpartyai/bittensor-conversation-genome-project/blob/main/README.md) · [repo](https://github.com/afterpartyai/bittensor-conversation-genome-project)
+- **[BitMind](https://metagraph.sh/subnets/34)** `SN34` — `deepfake-detection` · [site](https://bitmind.ai/) · [docs](https://docs.bitmind.ai/) · [repo](https://github.com/BitMind-AI/bitmind-subnet)
+- **[colosseum](https://metagraph.sh/subnets/38)** `SN38` — `stale-source-cleanup` · [repo](https://github.com/TAO-Colosseum/tao-colosseum-subnet)
+- **[Basilica](https://metagraph.sh/subnets/39)** `SN39` — `compute` · [site](https://www.basilica.ai/) · [repo](https://github.com/one-covenant/basilica)
+- **[Chunking](https://metagraph.sh/subnets/40)** `SN40` — `data-pipeline` `rag` · [site](https://subnet.chunking.com/)
+- **[Gopher](https://metagraph.sh/subnets/42)** `SN42` — `data` `tee` · [site](https://developers.gopher-ai.com/) · [docs](https://developers.gopher-ai.com/docs/subnet/intro) · [repo](https://github.com/gopher-lab/subnet-42)
+- **[Graphite](https://metagraph.sh/subnets/43)** `SN43` — `optimization` `research` · [site](https://graphite-ai.net/) · [repo](https://github.com/GraphiteAI/Graphite-Subnet)
+- **[Talisman AI](https://metagraph.sh/subnets/45)** `SN45` · [site](https://ai.talisman.xyz/) · [repo](https://github.com/Team-Rizzo/talisman-ai)
+- **[EvolAI](https://metagraph.sh/subnets/47)** `SN47` — `data` · [repo](https://github.com/openevolai/evolai)
+- **[Quantum Compute](https://metagraph.sh/subnets/48)** `SN48` — `compute` `quantum` · [site](https://www.qbittensorlabs.com/) · [repo](https://github.com/qbittensor-labs/quantum-compute)
+- **[Nepher Robotics](https://metagraph.sh/subnets/49)** `SN49` — `robotics` `tournament` · [site](https://nepher.ai) · [docs](https://docs.nepher.ai/) · [repo](https://github.com/nepher-ai/nepher-subnet)
+- **[Dojo](https://metagraph.sh/subnets/52)** `SN52` — `tensorplex` · [site](https://www.tensorplex.ai/) · [docs](https://docs.tensorplex.ai/tensorplex-docs/tensorplex-dojo-bittensor-subnet/subnet-mechanism) · [repo](https://github.com/tensorplex-labs/dojo)
+- **[EfficientFrontier](https://metagraph.sh/subnets/53)** `SN53` — `defi` `financial-trading` `trading-strategies` · [site](https://www.signalplus.com/) · [repo](https://github.com/EfficientFrontier-SignalPlus/EfficientFrontier)
+- **[Gradients](https://metagraph.sh/subnets/56)** `SN56` — `ai-training` `operational-interface` · [site](https://www.gradients.io/) · [docs](https://api.gradients.io/docs) · [repo](https://github.com/gradients-ai/G.O.D)
+- **[Sparket](https://metagraph.sh/subnets/57)** `SN57` — `prediction-market` `sports` · [site](https://sparket.ai/) · [repo](https://github.com/sparket-ai/sparket-ai)
+- **[Handshake58](https://metagraph.sh/subnets/58)** `SN58` — `ai-marketplace` `payments` · [site](https://handshake58.com) · [docs](https://handshake58.com/skill.md) · [repo](https://github.com/Handshake58/HS58-subnet)
+- **[RedTeam](https://metagraph.sh/subnets/61)** `SN61` — `cybersecurity` · [site](https://www.theredteam.io/) · [docs](https://docs.theredteam.io/) · [repo](https://github.com/RedTeamSubnet/RedTeam)
+- **[Ridges](https://metagraph.sh/subnets/62)** `SN62` — `agents` · [site](https://www.ridges.ai/) · [repo](https://github.com/ridgesai/ridges)
+- **[Enigma](https://metagraph.sh/subnets/63)** `SN63` — `quantum` · [site](https://www.qbittensorlabs.com/) · [repo](https://github.com/qbittensor-labs/enigma)
+- **[Chutes](https://metagraph.sh/subnets/64)** `SN64` — `compute` `inference` · [site](https://chutes.ai/) · [docs](https://chutes.ai/docs) · [repo](https://github.com/chutesai/chutes)
+- **[ninja](https://metagraph.sh/subnets/66)** `SN66` — `software-engineering` `workflow` · [site](https://ninja.arbos.life/) · [docs](https://github.com/unarbos/tau/blob/main/README.md) · [repo](https://github.com/unarbos/tau)
+- **[ain](https://metagraph.sh/subnets/69)** `SN69`
+- **[StreetVision by NATIX](https://metagraph.sh/subnets/72)** `SN72` — `computer-vision` `data` `depin` · [site](https://www.natix.network/) · [docs](https://docs.natix.network/whitepaper) · [repo](https://github.com/natixnetwork/streetvision-subnet)
+- **[MetaHash](https://metagraph.sh/subnets/73)** `SN73` — `defi` `otc` `treasury`
+- **[Gittensor](https://metagraph.sh/subnets/74)** `SN74` — `developer-tools` `repositories` · [site](https://gittensor.io/) · [docs](https://docs.gittensor.io/) · [repo](https://github.com/entrius/gittensor)
+- **[Hippius](https://metagraph.sh/subnets/75)** `SN75` — `depin` `storage` · [site](https://hippius.com/) · [docs](https://docs.hippius.com/) · [repo](https://github.com/thenervelab/hippius-validator)
+- **[Byzantium](https://metagraph.sh/subnets/76)** `SN76` · [site](https://www.byzantiumai.net/)
+- **[MVTRX](https://metagraph.sh/subnets/79)** `SN79` · [site](https://taos.im/) · [docs](https://simulate.trading/taos-im-paper) · [repo](https://github.com/taos-im/sn-79)
+- **[Grail](https://metagraph.sh/subnets/81)** `SN81` — `decentralized-training` · [docs](https://github.com/one-covenant/grail/tree/main/docs) · [repo](https://github.com/one-covenant/grail)
+- **[Compelle](https://metagraph.sh/subnets/82)** `SN82` · [site](https://compelle.com/) · [repo](https://github.com/compelle/compelle-validator)
+- **[ansuz](https://metagraph.sh/subnets/84)** `SN84` — `chip-design` `hardware` · [site](https://www.chipforge.io/) · [docs](https://docs.chipforge.io/) · [repo](https://github.com/TatsuProject/ChipForge_SN84)
+- **[Vidaio](https://metagraph.sh/subnets/85)** `SN85` · [site](https://vidaio.io/) · [repo](https://github.com/vidaio-subnet/vidaio-subnet)
+- **[Subnet 86](https://metagraph.sh/subnets/86)** `SN86`
+- **[Luminar Network](https://metagraph.sh/subnets/87)** `SN87` — `video-intelligence` `vision` · [site](https://luminar.network/) · [docs](https://docs.luminar.network/)
+- **[Investing](https://metagraph.sh/subnets/88)** `SN88` — `data-artifact` `finance` · [site](https://investing88.ai/) · [repo](https://github.com/mobiusfund/investing)
+- **[InfiniteHash](https://metagraph.sh/subnets/89)** `SN89` · [site](https://infinitehash.xyz/) · [docs](https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md) · [repo](https://github.com/backend-developers-ltd/InfiniteHash)
+- **[DegenBrain](https://metagraph.sh/subnets/90)** `SN90` — `prediction-markets` `verification` · [site](https://subnet90.com/)
+- **[Bitstarter #1](https://metagraph.sh/subnets/91)** `SN91` · [site](https://bitstarter.ai/) · [repo](https://github.com/AlphaCoreBittensor/alphacore)
+- **[Tensorclaw](https://metagraph.sh/subnets/92)** `SN92` — `inference` `stale-source-restored` · [site](https://www.tensorclaw.ai/) · [repo](https://github.com/tensorclaw/tensorclaw)
+- **[Actual](https://metagraph.sh/subnets/95)** `SN95` — `inference` `model-registry` · [site](https://actual.inc/) · [repo](https://github.com/actual-computer/actual-subnet-95)
+- **[Verathos](https://metagraph.sh/subnets/96)** `SN96` — `inference` `language-models` · [site](https://verathos.ai/) · [docs](https://verathos.ai/docs) · [repo](https://github.com/verathos-ai/verathos)
+- **[ForeverMoney](https://metagraph.sh/subnets/98)** `SN98` — `finance` · [site](https://forevermoney.ai/) · [repo](https://github.com/SN98-ForeverMoney/forever-money)
+- **[Plaτform](https://metagraph.sh/subnets/100)** `SN100` — `ai-research` · [site](https://www.platform.network/) · [docs](https://www.platform.network/docs) · [repo](https://github.com/PlatformNetwork/platform)
+- **[eni](https://metagraph.sh/subnets/101)** `SN101` · [site](http://tag101.ai/) · [repo](https://github.com/tag101-ai/tag101)
+- **[ConnitoAI](https://metagraph.sh/subnets/102)** `SN102` · [site](https://connito.ai/) · [repo](https://github.com/Connito-AI/Connito)
+- **[Djinn](https://metagraph.sh/subnets/103)** `SN103` · [site](https://www.djinn.gg/) · [repo](https://github.com/Djinn-Inc/djinn)
+- **[for sale (burn to uid1)](https://metagraph.sh/subnets/104)** `SN104` — `no-public-project-surface`
+- **[Academia](https://metagraph.sh/subnets/109)** `SN109` — `data-artifact` · [repo](https://github.com/fx-integral/academia)
+- **[Green Compute](https://metagraph.sh/subnets/110)** `SN110` — `model-directory` · [site](https://www.green-compute.com/) · [docs](https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_110/index.mdx) · [repo](https://github.com/Rich-Kids-of-TAO/rkt-subnet)
+- **[oneoneone](https://metagraph.sh/subnets/111)** `SN111` — `data` `ugc` · [site](https://oneoneone.io/) · [repo](https://github.com/oneoneone-io/subnet-111)
+- **[TensorUSD](https://metagraph.sh/subnets/113)** `SN113` — `stablecoin` · [site](https://tensorusd.com/) · [docs](https://docs.tensorusd.com/components/subnet) · [repo](https://github.com/TensorUSD/subnet)
+- **[SOMA](https://metagraph.sh/subnets/114)** `SN114` — `mcp` · [site](https://thesoma.ai/) · [repo](https://github.com/DendriteHQ/SOMA)
+- **[HashiChain](https://metagraph.sh/subnets/115)** `SN115` · [repo](https://github.com/hashi115/hashichain)
+- **[TaoLend](https://metagraph.sh/subnets/116)** `SN116` — `defi` `lending` · [site](https://taolend.io/)
+- **[BrainPlay](https://metagraph.sh/subnets/117)** `SN117` · [site](https://play.shiftlayer.ai/) · [repo](https://github.com/shiftlayer-llc/brainplay-subnet)
+- **[Ditto](https://metagraph.sh/subnets/118)** `SN118` — `agent-memory` · [site](https://heyditto.ai/) · [docs](https://heyditto.ai/docs/) · [repo](https://github.com/orgs/ditto-assistant/repositories)
+- **[Satori](https://metagraph.sh/subnets/119)** `SN119` — `virtual-world` · [repo](https://github.com/Satori119/Satori)
+- **[sundae_bar](https://metagraph.sh/subnets/121)** `SN121` · [site](https://www.sundaebar.ai/) · [repo](https://github.com/sundae-bar/bittensor-subnet)
+- **[Bitrecs](https://metagraph.sh/subnets/122)** `SN122` — `recommendations` · [site](https://www.bitrecs.ai/) · [docs](https://bitrecs.gitbook.io/bitrecs-docs/) · [repo](https://github.com/bitrecs/bitrecs-subnet)
+- **[MANTIS](https://metagraph.sh/subnets/123)** `SN123` — `sdk` · [repo](https://github.com/Barbariandev/MANTIS)
+- **[8 Ball](https://metagraph.sh/subnets/125)** `SN125` — `prediction-market` · [site](https://8ball125.com/) · [docs](https://github.com/Barbariandev/8Ball_miner#readme) · [repo](https://github.com/Barbariandev/8Ball_miner)
+
+<sub>Auto-generated from the curated overlays in `registry/subnets/` by `scripts/generate-registry-readme-section.mjs` — enrich a subnet (one PR) and it appears here. Not the live list; browse + monitor everything at [metagraph.sh](https://metagraph.sh).</sub>
+
+<!-- END:REGISTRY-CATALOG -->
+
 ## Related
 
 - **Frontend** — [JSONbored/metagraphed-ui](https://github.com/JSONbored/metagraphed-ui): the web app at [metagraph.sh](https://metagraph.sh). Vite + React 19 + TanStack Start, deployed as a Cloudflare Worker. Holds no subnet data — it renders what this backend serves.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "contract:summary": "node scripts/contract-change-summary.mjs",
     "validate:artifact-budgets": "node scripts/validate-artifact-budgets.mjs",
     "validate:docs": "node scripts/validate-docs.mjs",
+    "validate:readme-catalog": "node scripts/generate-registry-readme-section.mjs --check",
+    "readme:catalog": "node scripts/generate-registry-readme-section.mjs",
     "validate:adapters": "node scripts/validate-adapters.mjs",
     "assert:probe-health": "node scripts/assert-published-probe-health.mjs",
     "validate:intake": "node scripts/validate-intake.mjs",

--- a/scripts/generate-registry-readme-section.mjs
+++ b/scripts/generate-registry-readme-section.mjs
@@ -1,0 +1,147 @@
+// Awesome-list-style subnet catalog for the README (#1020).
+//
+// Renders a categorized, link-rich catalog of the CURATED subnets and injects it
+// between the <!-- BEGIN:REGISTRY-CATALOG --> / <!-- END:REGISTRY-CATALOG -->
+// markers in README.md.
+//
+// Source = the COMMITTED curated overlays (registry/subnets/*.json), which change
+// only on human contributions — NOT the 6h live data refresh. So the README never
+// churns on a data publish; it regenerates only when an overlay changes (the
+// gittensor flywheel: an enriched subnet shows up in the catalog → visibility →
+// more contributions). Live health/readiness links out to the profile rather than
+// being inlined, so there are no per-view badge requests baked into git.
+//
+//   node scripts/generate-registry-readme-section.mjs           # write README.md
+//   node scripts/generate-registry-readme-section.mjs --check    # verify up-to-date
+
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { repoRoot } from "./lib.mjs";
+
+const BEGIN = "<!-- BEGIN:REGISTRY-CATALOG -->";
+const END = "<!-- END:REGISTRY-CATALOG -->";
+const README_PATH = path.join(repoRoot, "README.md");
+const OVERLAYS_DIR = path.join(repoRoot, "registry/subnets");
+const SITE = "https://metagraph.sh";
+const API = "https://api.metagraph.sh";
+
+// Provenance / process tags (how an entry was curated) are noise in a catalog —
+// keep only the use-case "focus" tags. Prefix-matched so new official-*/baseline-*
+// tags are filtered automatically.
+const PROVENANCE_PREFIX = /^(official|baseline|identity)-/;
+const PROVENANCE_EXACT = new Set([
+  "pilot",
+  "root",
+  "system",
+  "native-only",
+  "macrocosmos",
+]);
+
+function loadOverlays() {
+  return readdirSync(OVERLAYS_DIR)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) =>
+      JSON.parse(readFileSync(path.join(OVERLAYS_DIR, file), "utf8")),
+    )
+    .filter((overlay) => Number.isInteger(overlay?.netuid))
+    .sort((a, b) => a.netuid - b.netuid);
+}
+
+function focusTags(overlay) {
+  return (overlay.categories || [])
+    .filter((tag) => !PROVENANCE_PREFIX.test(tag) && !PROVENANCE_EXACT.has(tag))
+    .sort();
+}
+
+function links(overlay) {
+  const out = [];
+  if (overlay.website_url) out.push(`[site](${overlay.website_url})`);
+  if (overlay.docs_url) out.push(`[docs](${overlay.docs_url})`);
+  if (overlay.source_repo) out.push(`[repo](${overlay.source_repo})`);
+  return out.join(" · ") || "—";
+}
+
+function renderCatalog(overlays) {
+  const focusCounts = new Map();
+  for (const overlay of overlays) {
+    for (const tag of focusTags(overlay)) {
+      focusCounts.set(tag, (focusCounts.get(tag) || 0) + 1);
+    }
+  }
+  const topFocus = [...focusCounts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 12)
+    .map(([tag, count]) => `\`${tag}\` ${count}`)
+    .join(" · ");
+
+  const withSite = overlays.filter((o) => o.website_url).length;
+  const withDocs = overlays.filter((o) => o.docs_url).length;
+  const withRepo = overlays.filter((o) => o.source_repo).length;
+
+  // A bulleted list (not a markdown table): Prettier pads table cells to the
+  // widest column, which at ~90 rows of long URLs explodes the diff — a list
+  // stays Prettier-stable and renders just as cleanly on GitHub.
+  const items = overlays.map((overlay) => {
+    const name = overlay.name || `Subnet ${overlay.netuid}`;
+    const focus = focusTags(overlay)
+      .map((tag) => `\`${tag}\``)
+      .join(" ");
+    const linkStr = links(overlay);
+    return (
+      `- **[${name}](${SITE}/subnets/${overlay.netuid})** \`SN${overlay.netuid}\`` +
+      (focus ? ` — ${focus}` : "") +
+      (linkStr !== "—" ? ` · ${linkStr}` : "")
+    );
+  });
+
+  return [
+    `**${overlays.length} curated subnets** — ${withSite} with a site, ${withDocs} with docs, ${withRepo} with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](${SITE})**; per-subnet JSON at \`${API}/api/v1/subnets/{netuid}\`.`,
+    "",
+    `**Focus areas:** ${topFocus}`,
+    "",
+    ...items,
+    "",
+    `<sub>Auto-generated from the curated overlays in \`registry/subnets/\` by \`scripts/generate-registry-readme-section.mjs\` — enrich a subnet (one PR) and it appears here. Not the live list; browse + monitor everything at [metagraph.sh](${SITE}).</sub>`,
+  ].join("\n");
+}
+
+function injectedReadme(readme, catalog) {
+  const beginAt = readme.indexOf(BEGIN);
+  const endAt = readme.indexOf(END);
+  if (beginAt === -1 || endAt === -1 || endAt < beginAt) {
+    throw new Error(
+      `README.md is missing the ${BEGIN} / ${END} markers (add them where the catalog should render).`,
+    );
+  }
+  const before = readme.slice(0, beginAt + BEGIN.length);
+  const after = readme.slice(endAt);
+  return `${before}\n\n${catalog}\n\n${after}`;
+}
+
+function main() {
+  const check = process.argv.includes("--check");
+  const overlays = loadOverlays();
+  const catalog = renderCatalog(overlays);
+  const current = readFileSync(README_PATH, "utf8");
+  const next = injectedReadme(current, catalog);
+
+  if (check) {
+    if (next !== current) {
+      console.error(
+        "README catalog is stale. Run `npm run readme:catalog` and commit README.md.",
+      );
+      process.exit(1);
+    }
+    console.log(
+      `README catalog up to date (${overlays.length} curated subnets).`,
+    );
+    return;
+  }
+
+  writeFileSync(README_PATH, next);
+  console.log(
+    `Wrote README catalog: ${overlays.length} curated subnets injected.`,
+  );
+}
+
+main();


### PR DESCRIPTION
Closes #1020 — an awesome-list-style subnet catalog in the README, for repo traffic + SEO + the gittensor flywheel.

## How
- **`scripts/generate-registry-readme-section.mjs`** renders a categorized, link-rich list (name + `SN{netuid}` + focus tags + site/docs/repo links) plus a focus-area summary, injected between `<!-- BEGIN/END:REGISTRY-CATALOG -->` markers.
- **Source = committed curated overlays** (`registry/subnets/*.json`) — *not* the 6h live data. So the README never churns on a data publish (respects ADR-0006); it changes only when a subnet is enriched. Live health/search links out to metagraph.sh rather than inlining ~90 per-view badge requests.
- Bulleted list (not a markdown table) so Prettier stays stable across ~90 entries instead of column-padding the diff.
- `npm run readme:catalog` writes it; **`npm run validate:readme-catalog`** (`--check`) gates freshness, wired into the **Validate** workflow.
- **`readme-catalog-refresh.yml`** regenerates + opens a PR on `registry/subnets/**` changes (safety net for admin-merges that bypass the gate).

Renders **91 curated subnets** today (79 with a site, 44 docs, 78 repos).

> Provenance/process tags (`official-*`, `baseline-*`) are filtered out of the per-entry "focus" tags so only use-case tags (`data`, `compute`, `inference`, `zkml`…) show.