### PR TITLE
fix(r2): read build-summary.json from R2 staging (unblocks production publish)

### DIFF
--- a/scripts/r2-upload.mjs
+++ b/scripts/r2-upload.mjs
@@ -254,7 +254,15 @@ function buildControlArtifacts(manifest) {
       content_type: "application/json; charset=utf-8",
       key: `${manifest.run_prefix}build-summary.json`,
       latest_key: "latest/build-summary.json",
-      local_path: path.join(repoRoot, "public/metagraph/build-summary.json"),
+      // build-summary.json is R2-only (#1003): the build writes it to the R2
+      // staging tier, not public/metagraph/. Read it from staging like the full
+      // r2-manifest.json above — the old public/ path was left stale by #1003
+      // and broke every publish at the control-artifact upload step.
+      local_path: path.join(
+        repoRoot,
+        R2_STAGING_RELATIVE_ROOT,
+        "build-summary.json",
+      ),
       path: "/metagraph/build-summary.json",
     },
   ];


### PR DESCRIPTION
## Problem

Every scheduled `publish-cloudflare` run since **#1003 (ebcad7e5, merged 08:49 UTC today)** fails. #1003 made `build-summary.json` R2-only and **deleted** `public/metagraph/build-summary.json`, but never updated `scripts/r2-upload.mjs` — its control-artifact upload still read the now-missing `public/` path.

Symptom in the publish log: all 4444 data objects upload successfully (so production data *is* fresh), then the run dies on the trailing control artifact:
```
The file ".../public/metagraph/build-summary.json" does not exist.
```
That failure fails the publish job and **skips `kv:publish`**.

## Fix

Repoint the `build-summary.json` control artifact's `local_path` at the R2 staging tier (`R2_STAGING_RELATIVE_ROOT`), matching the full `r2-manifest.json` control artifact immediately above it. One-line behavioral change.

## Verification

- Deterministic build writes `build-summary.json` to `dist/metagraph-r2/metagraph/`; the fixed `local_path` resolves there (`exists: true`).
- `node scripts/validate.mjs` passes; `tests/artifacts.test.mjs` green after a fresh build+manifest.
- prettier + eslint clean.

The 06:27 UTC baseline publish succeeded because it ran *before* #1003 merged; this restores publish health for all subsequent runs.