### PR TITLE
fix(health): correct cron prober R2 key — revives 17h-frozen live health

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -280,7 +280,13 @@ export async function loadOperationalSurfaces(env) {
   try {
     if (env.METAGRAPH_ARCHIVE?.get) {
       const prefix = env.METAGRAPH_R2_LATEST_PREFIX || "latest/";
-      const key = `${prefix}metagraph/operational-surfaces.json`;
+      // R2 artifact keys are FLAT under the prefix (latest/<file>.json), NOT
+      // latest/metagraph/<file>.json — the manifest's latest_key is
+      // "latest/operational-surfaces.json". The "/metagraph/" segment is only
+      // the public HTTP path, not the R2 key. This fallback went unexercised
+      // until #1017 made operational-surfaces.json R2-only; the stray
+      // "metagraph/" segment then 404'd every read and silently froze the prober.
+      const key = `${prefix}operational-surfaces.json`;
       const object = await env.METAGRAPH_ARCHIVE.get(key);
       if (object) {
         const body = JSON.parse(await object.text());

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -708,7 +708,7 @@ describe("loadOperationalSurfaces", () => {
       METAGRAPH_R2_LATEST_PREFIX: "live/",
       METAGRAPH_ARCHIVE: {
         get: async (key) => {
-          assert.equal(key, "live/metagraph/operational-surfaces.json");
+          assert.equal(key, "live/operational-surfaces.json");
           return { text: async () => JSON.stringify(surfacesBody) };
         },
       },
@@ -721,7 +721,7 @@ describe("loadOperationalSurfaces", () => {
     const env = {
       METAGRAPH_ARCHIVE: {
         get: async (key) => {
-          assert.equal(key, "latest/metagraph/operational-surfaces.json");
+          assert.equal(key, "latest/operational-surfaces.json");
           return { text: async () => JSON.stringify(surfacesBody) };
         },
       },


### PR DESCRIPTION
## Impact (production)

The 2-minute cron health prober **stopped writing to D1 at 07:46:58 UTC** and has been dead ~17h. `surface_checks` (265k rows, ~6 days) and `surface_status` (60 rows) both froze at the exact same instant. Live endpoint health, RPC pool eligibility, and uptime have been stale since.

## Root cause

`loadOperationalSurfaces()` reads ASSETS first, then falls back to R2. The R2 key was built as:
```
${prefix}metagraph/operational-surfaces.json   →  latest/metagraph/operational-surfaces.json  ❌
```
But R2 artifact keys are **flat** under the prefix — the manifest `latest_key` is `latest/operational-surfaces.json`. The `/metagraph/` part is only the public HTTP path, not the R2 key. Verified live:
```
wrangler r2 object get .../latest/operational-surfaces.json          → returns data ✓
wrangler r2 object get .../latest/metagraph/operational-surfaces.json → key does not exist ✗
```

This fallback was **never exercised** until **#1017 (de38d054, deployed 07:48 UTC)** made `operational-surfaces.json` R2-only, removing it from ASSETS. From that deploy on, every tick: ASSETS 404 → broken R2 key 404 → empty list → `no-operational-surfaces` no-op (writes nothing). The 07:48 deploy lines up with the 07:46:58 freeze.

## Fix

Drop the phantom `metagraph/` segment: `${prefix}operational-surfaces.json`. A pre-existing test **asserted the buggy key**, so it never caught this — corrected both assertions.

## Verification
- `tests/health-prober.test.mjs`: 62/62 pass; prettier + eslint clean.
- Real key confirmed from the r2-manifest `latest_key` and live `wrangler r2 object get`.

After this deploys (Workers Builds on merge), the prober should resume on its next 2-min tick — I'll confirm D1 advances + `surface_key` populates (the #1005 column). **Deploy-critical.**