### PR TITLE
feat(brand): dynamic OG card for the api.metagraph.sh landing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "metagraphed",
       "version": "0.1.0-beta.0",
       "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "workers-og": "^0.0.27"
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@vitest/coverage-v8": "^4.1.8",
@@ -1575,6 +1578,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/@resvg/resvg-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.4.0.tgz",
+      "integrity": "sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -1838,6 +1850,22 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
@@ -2177,6 +2205,15 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -2197,6 +2234,15 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2212,6 +2258,12 @@
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
       "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -2257,6 +2309,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.16.tgz",
+      "integrity": "sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2290,6 +2383,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/error-stack-parser-es": {
@@ -2350,6 +2452,12 @@
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2619,6 +2727,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2706,6 +2820,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/html-escaper": {
@@ -2890,6 +3016,12 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/just-camel-case": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-camel-case/-/just-camel-case-6.2.0.tgz",
+      "integrity": "sha512-ICenRLXwkQYLk3UyvLQZ+uKuwFVJ3JHFYFn7F2782G2Mv2hW8WPePqgdhpnjGaqkYtSVWnyCESZhGXUmY3/bEg==",
       "license": "MIT"
     },
     "node_modules/keyv": {
@@ -3187,6 +3319,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3409,6 +3551,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
+      }
+    },
     "node_modules/parse-json": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
@@ -3520,6 +3678,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3598,6 +3762,28 @@
         "@rolldown/binding-wasm32-wasi": "1.0.3",
         "@rolldown/binding-win32-arm64-msvc": "1.0.3",
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/satori": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.15.2.tgz",
+      "integrity": "sha512-vu/49vdc8MzV5jUchs3TIRDCOkOvMc1iJ11MrZvhg9tE4ziKIEIBjBZvies6a9sfM2vQ2gc3dXeu6rCK7AztHA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.16",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-wasm-web": "^0.3.3"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/semver": {
@@ -3712,6 +3898,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3724,6 +3916,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -3836,6 +4034,16 @@
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
       }
     },
     "node_modules/uri-js": {
@@ -4087,6 +4295,17 @@
         "@cloudflare/workerd-windows-64": "1.20260611.1"
       }
     },
+    "node_modules/workers-og": {
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/workers-og/-/workers-og-0.0.27.tgz",
+      "integrity": "sha512-QvwptQ0twmouQHiITUi3kYxEPCLdueC/U4msQ2xMz2iktd+iseSs7zlREw3T1dAsPxPw73FQlw8cXFsfANZPlw==",
+      "dependencies": {
+        "@resvg/resvg-wasm": "2.4.0",
+        "just-camel-case": "^6.2.0",
+        "satori": "^0.15.2",
+        "yoga-wasm-web": "0.3.3"
+      }
+    },
     "node_modules/wrangler": {
       "version": "4.100.0",
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.100.0.tgz",
@@ -4174,6 +4393,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-wasm-web": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz",
+      "integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==",
+      "license": "MIT"
     },
     "node_modules/youch": {
       "version": "4.1.0-beta.10",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,9 @@
     "endpoint:brief": "node scripts/endpoint-ops-brief.mjs",
     "endpoint:ops:brief": "node scripts/endpoint-ops-brief.mjs"
   },
+  "dependencies": {
+    "workers-og": "^0.0.27"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@vitest/coverage-v8": "^4.1.8",

--- a/src/og-image.mjs
+++ b/src/og-image.mjs
@@ -1,0 +1,180 @@
+// Edge-rendered Open Graph card for the api.metagraph.sh landing page
+// (GET /og.png, alias /og). Renders a branded 1200x630 PNG via workers-og
+// (satori + resvg-wasm) with LIVE registry stats, so link unfurls show a real,
+// data-driven card instead of a frozen hand-made banner. Mirrors the
+// metagraphed-ui /og pattern (loadGoogleFont, no bundled font file).
+//
+// workers-og is DYNAMIC-imported inside the handler so its wasm only evaluates
+// when this low-traffic route is actually hit — the agent/API hot path (every
+// other request) never pays the parse/instantiate cost. The whole render is
+// fail-soft: any failure (artifact miss, font fetch, wasm, satori) returns a
+// tiny valid PNG instead of a 500, keeping the public endpoint cheap and the
+// crawler happy. workers-og + fonts + caches are injectable for unit tests.
+
+// Brand palette (brand kit BRAND.md): Mint accent on an Ink surface; Ink-text
+// reads AAA on mint. The landing page currently ships the static mint OG banner,
+// so this dynamic card keeps the same mint-on-ink identity.
+const MINT = "#30FFC0";
+const INK = "#0B1F1A";
+const INK_TEXT = "#08110E";
+
+const OG_PATHS = new Set(["/og.png", "/og"]);
+// Stats refresh on the 6h publish; an hour of edge cache + a long
+// stale-while-revalidate keeps render cost near-zero without serving stale art.
+const CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400";
+const SUBTITLE = "The Bittensor subnet integration registry";
+const HEADLINE = "Every subnet, metagraphed.";
+const EYEBROW = "api.metagraph.sh";
+
+// A tiny valid 1x1 PNG returned when any render dependency fails.
+const FALLBACK_PNG = new Uint8Array([
+  137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0,
+  0, 0, 1, 8, 6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 13, 73, 68, 65, 84, 120,
+  156, 99, 248, 255, 255, 255, 127, 0, 9, 251, 3, 253, 5, 67, 69, 202, 0, 0, 0,
+  0, 73, 69, 78, 68, 174, 66, 96, 130,
+]);
+
+function fallbackResponse(status = 200) {
+  return new Response(FALLBACK_PNG, {
+    status,
+    headers: { "cache-control": CACHE_CONTROL, "content-type": "image/png" },
+  });
+}
+
+function imageHeaders(extra) {
+  const headers = new Headers(extra);
+  headers.set("cache-control", CACHE_CONTROL);
+  headers.set("content-type", "image/png");
+  return headers;
+}
+
+function formatCount(value) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value.toLocaleString("en-US")
+    : null;
+}
+
+// Pull the live counts off registry-summary.json. Returns a human stat line, or
+// the subtitle as a graceful fallback when the artifact is cold/unavailable.
+async function loadStatLine(env, readArtifact) {
+  try {
+    if (typeof readArtifact !== "function") return null;
+    const result = await readArtifact(env, "/metagraph/registry-summary.json");
+    if (!result?.ok || !result.data) return null;
+    const data = result.data;
+    const parts = [];
+    const subnets = formatCount(data.subnet_count);
+    if (subnets) parts.push(`${subnets} subnets`);
+    const endpoints = formatCount(data.counts?.endpoints);
+    if (endpoints) parts.push(`${endpoints} endpoints`);
+    const providers = formatCount(data.counts?.providers);
+    if (providers) parts.push(`${providers} providers`);
+    const coverage = data.coverage?.average_score;
+    if (typeof coverage === "number" && Number.isFinite(coverage)) {
+      parts.push(`${coverage}% avg coverage`);
+    }
+    return parts.length ? parts.join("  ·  ") : null;
+  } catch {
+    return null;
+  }
+}
+
+function renderMarkup(statLine) {
+  // satori is strict: any element with >1 child needs display:flex + a direction;
+  // text lives in leaf divs. An ink tile with a mint "M" mirrors the brand's
+  // icon-mint-on-ink lockup without risking inline-SVG rendering quirks.
+  return `
+    <div style="display:flex;flex-direction:column;justify-content:space-between;width:100%;height:100%;padding:72px 80px;background:${MINT};color:${INK_TEXT};font-family:'Space Grotesk';">
+      <div style="display:flex;align-items:center;">
+        <div style="display:flex;align-items:center;justify-content:center;width:64px;height:64px;background:${INK};border-radius:14px;">
+          <div style="display:flex;font-size:40px;font-weight:700;color:${MINT};">M</div>
+        </div>
+        <div style="display:flex;margin-left:22px;font-size:31px;font-weight:500;letter-spacing:1px;">${EYEBROW}</div>
+      </div>
+      <div style="display:flex;flex-direction:column;">
+        <div style="display:flex;font-size:88px;font-weight:700;line-height:1.0;max-width:1000px;">${HEADLINE}</div>
+        <div style="display:flex;margin-top:20px;font-size:35px;font-weight:500;color:${INK};opacity:0.78;">${SUBTITLE}</div>
+      </div>
+      <div style="display:flex;flex-direction:column;">
+        <div style="display:flex;width:100%;height:3px;background:${INK};opacity:0.22;margin-bottom:26px;"></div>
+        <div style="display:flex;font-size:31px;font-weight:500;">${statLine}</div>
+      </div>
+    </div>`;
+}
+
+// Returns a Response for the OG route, or null when the path doesn't match (so
+// the caller can fall through). deps: { readArtifact, og, cache } — og defaults
+// to a dynamic import of workers-og; cache to the edge cache.
+export async function handleOgImage(request, env, url, deps = {}) {
+  if (!OG_PATHS.has(url.pathname)) return null;
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { allow: "GET, HEAD" },
+    });
+  }
+
+  // Cache on a canonical /og.png key so /og and /og.png share one cached render.
+  const cache =
+    deps.cache !== undefined
+      ? deps.cache
+      : (globalThis.caches?.default ?? null);
+  const cacheKey = new Request(new URL("/og.png", url).toString(), {
+    method: "GET",
+  });
+  const cached = await cache?.match(cacheKey);
+  if (cached) {
+    return request.method === "HEAD" ? new Response(null, cached) : cached;
+  }
+
+  if (request.method === "HEAD") {
+    return new Response(null, { headers: imageHeaders() });
+  }
+
+  const statLine = (await loadStatLine(env, deps.readArtifact)) ?? SUBTITLE;
+
+  let ImageResponse;
+  let loadGoogleFont;
+  try {
+    ({ ImageResponse, loadGoogleFont } =
+      deps.og || (await import("workers-og")));
+  } catch (error) {
+    console.error("og: workers-og unavailable", error);
+    return fallbackResponse();
+  }
+
+  // Subset both weights to only the glyphs we render (faster, smaller fetch).
+  // Includes digits/comma/percent/middot so any live stat-line variant resolves.
+  const glyphs = `${EYEBROW}${HEADLINE}${SUBTITLE}${statLine}M0123456789,.%· `;
+  let bold;
+  let medium;
+  try {
+    [bold, medium] = await Promise.all([
+      loadGoogleFont({ family: "Space Grotesk", weight: 700, text: glyphs }),
+      loadGoogleFont({ family: "Space Grotesk", weight: 500, text: glyphs }),
+    ]);
+  } catch (error) {
+    console.error("og: font load failed", error);
+    return fallbackResponse();
+  }
+
+  try {
+    const image = new ImageResponse(renderMarkup(statLine), {
+      width: 1200,
+      height: 630,
+      fonts: [
+        { name: "Space Grotesk", data: bold, weight: 700, style: "normal" },
+        { name: "Space Grotesk", data: medium, weight: 500, style: "normal" },
+      ],
+    });
+    const response = new Response(image.body, {
+      status: image.status,
+      headers: imageHeaders(image.headers),
+    });
+    if (cache) await cache.put(cacheKey, response.clone());
+    return response;
+  } catch (error) {
+    console.error("og: render failed", error);
+    return fallbackResponse();
+  }
+}

--- a/tests/og-image.test.mjs
+++ b/tests/og-image.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleOgImage } from "../src/og-image.mjs";
+
+// A fake workers-og module: records the markup + fonts it was handed, and can be
+// told to fail font loading or rendering to exercise the fail-soft paths.
+function fakeOg({ failFont = false, failRender = false } = {}) {
+  const calls = { fontTexts: [], fontWeights: [], markup: null, fonts: null };
+  return {
+    calls,
+    og: {
+      loadGoogleFont: async ({ weight, text }) => {
+        calls.fontTexts.push(text);
+        calls.fontWeights.push(weight);
+        if (failFont) throw new Error("font fetch failed");
+        return new ArrayBuffer(8);
+      },
+      ImageResponse: class {
+        constructor(markup, opts) {
+          calls.markup = markup;
+          calls.fonts = opts.fonts;
+          if (failRender) throw new Error("satori blew up");
+          this.body = "PNG-BODY";
+          this.status = 200;
+          this.headers = new Headers({ "x-render": "ok" });
+        }
+      },
+    },
+  };
+}
+
+function fakeCache(hit = null) {
+  const puts = [];
+  return {
+    puts,
+    cache: { match: async () => hit, put: async (key) => void puts.push(key) },
+  };
+}
+
+const readSummaryOk = async () => ({
+  ok: true,
+  data: {
+    subnet_count: 129,
+    counts: { endpoints: 1198, providers: 92 },
+    coverage: { average_score: 57 },
+  },
+});
+const readSummaryMiss = async () => ({ ok: false, status: 404 });
+
+function req(method, path = "/og.png") {
+  return new Request(`https://api.metagraph.sh${path}`, { method });
+}
+const urlFor = (path = "/og.png") => new URL(`https://api.metagraph.sh${path}`);
+
+describe("handleOgImage", () => {
+  test("returns null for a non-OG path so routing falls through", async () => {
+    const result = await handleOgImage(req("GET", "/foo"), {}, urlFor("/foo"));
+    assert.equal(result, null);
+  });
+
+  test("rejects non-GET/HEAD methods with 405", async () => {
+    const res = await handleOgImage(req("POST"), {}, urlFor(), { cache: null });
+    assert.equal(res.status, 405);
+    assert.equal(res.headers.get("allow"), "GET, HEAD");
+  });
+
+  test("HEAD returns image headers and no body", async () => {
+    const res = await handleOgImage(req("HEAD"), {}, urlFor(), { cache: null });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "image/png");
+    assert.match(res.headers.get("cache-control"), /max-age=3600/);
+    assert.equal(await res.text(), "");
+  });
+
+  test("renders a PNG card embedding live registry stats", async () => {
+    const og = fakeOg();
+    const { cache, puts } = fakeCache();
+    const res = await handleOgImage(req("GET"), {}, urlFor(), {
+      readArtifact: readSummaryOk,
+      og: og.og,
+      cache,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "image/png");
+    assert.match(res.headers.get("cache-control"), /stale-while-revalidate/);
+    // live counts are formatted into the card markup
+    assert.match(og.calls.markup, /129 subnets/);
+    assert.match(og.calls.markup, /1,198 endpoints/);
+    assert.match(og.calls.markup, /92 providers/);
+    assert.match(og.calls.markup, /57% avg coverage/);
+    // both Space Grotesk weights loaded, subset to the rendered glyphs
+    assert.deepEqual(og.calls.fontWeights.sort(), [500, 700]);
+    assert.match(og.calls.fontTexts[0], /129 subnets/);
+    // successful renders are cached
+    assert.equal(puts.length, 1);
+  });
+
+  test("falls back to the subtitle when registry-summary is unavailable", async () => {
+    const og = fakeOg();
+    const res = await handleOgImage(req("GET"), {}, urlFor(), {
+      readArtifact: readSummaryMiss,
+      og: og.og,
+      cache: null,
+    });
+    assert.equal(res.status, 200);
+    // no stat counts rendered; the subtitle stands in for the stat line
+    assert.doesNotMatch(og.calls.markup, /subnets ·/);
+    assert.match(og.calls.markup, /The Bittensor subnet integration registry/);
+  });
+
+  test("returns the fallback PNG (not a 500) when font loading fails", async () => {
+    const og = fakeOg({ failFont: true });
+    const { cache, puts } = fakeCache();
+    const res = await handleOgImage(req("GET"), {}, urlFor(), {
+      readArtifact: readSummaryOk,
+      og: og.og,
+      cache,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "image/png");
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    assert.ok(bytes.length > 0 && bytes.length < 200); // tiny fallback PNG
+    assert.equal(puts.length, 0); // a failed render is never cached
+  });
+
+  test("returns the fallback PNG when satori rendering throws", async () => {
+    const og = fakeOg({ failRender: true });
+    const res = await handleOgImage(req("GET"), {}, urlFor(), {
+      readArtifact: readSummaryOk,
+      og: og.og,
+      cache: null,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "image/png");
+  });
+
+  test("serves a cached render on hit without re-rendering", async () => {
+    let rendered = false;
+    const og = {
+      loadGoogleFont: async () => {
+        rendered = true;
+        return new ArrayBuffer(8);
+      },
+      ImageResponse: class {
+        constructor() {
+          rendered = true;
+        }
+      },
+    };
+    const cachedResponse = new Response("CACHED-PNG", {
+      headers: { "content-type": "image/png" },
+    });
+    const res = await handleOgImage(req("GET"), {}, urlFor(), {
+      readArtifact: readSummaryOk,
+      og,
+      cache: { match: async () => cachedResponse, put: async () => {} },
+    });
+    assert.equal(await res.text(), "CACHED-PNG");
+    assert.equal(rendered, false);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -76,6 +76,7 @@ import {
 import { handleMcpRequest } from "../src/mcp-server.mjs";
 import { handleFeedRequest } from "../src/feeds.mjs";
 import { handleBadgeRequest } from "../src/badge.mjs";
+import { handleOgImage } from "../src/og-image.mjs";
 import {
   aiEnabled,
   askQuestion,
@@ -262,6 +263,13 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     /^\/api\/v1\/(?:subnets|providers)\/[^/]+\/badge\.svg$/.test(url.pathname)
   ) {
     return handleBadgeRequest(request, env, url, { readArtifact });
+  }
+
+  // Dynamic Open Graph card (/og.png, alias /og) for the landing page's
+  // link-unfurl. Worker-computed PNG with live registry counts; workers-og's
+  // wasm is lazy-loaded inside the handler so this never weighs on other routes.
+  if (url.pathname === "/og.png" || url.pathname === "/og") {
+    return handleOgImage(request, env, url, { readArtifact });
   }
 
   // Agent/AI discovery surfaces. The homepage advertises the machine resources

--- a/workers/request-handlers/discovery.mjs
+++ b/workers/request-handlers/discovery.mjs
@@ -166,11 +166,12 @@ const HOMEPAGE_HTML = `<!doctype html>
 <meta property="og:title" content="metagraphed API — Bittensor subnet operational registry">
 <meta property="og:description" content="Machine-readable operational + integration registry for Bittensor subnets: what each subnet exposes, whether it's healthy, and how to call it.">
 <meta property="og:url" content="https://${PRIMARY_DOMAIN}/">
-<meta property="og:image" content="https://${PRIMARY_DOMAIN}/brand/banner-og-social-mint.png">
+<meta property="og:image" content="https://${PRIMARY_DOMAIN}/og.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:alt" content="Metagraphed — Bittensor subnet operational layer · data hub · API">
 <meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://${PRIMARY_DOMAIN}/og.png">
 <link rel="api-catalog" href="/.well-known/api-catalog" type="application/linkset+json">
 <link rel="service-desc" href="/metagraph/openapi.json" type="application/json">
 <link rel="service-doc" href="/llms.txt" type="text/plain">


### PR DESCRIPTION
## What

A worker-computed Open Graph image at **`GET /og.png`** (alias `/og`) — a 1200×630 PNG rendered on the edge via `workers-og` (satori + resvg-wasm) with **live registry stats** baked in:

> **129 subnets · 1,198 endpoints · 92 providers · 57% avg coverage**

This replaces the static `banner-og-social-mint.png` the landing page linked (#1104). The card refreshes itself as the registry grows — no more hand-made banner drift. Mint-on-ink identity per the brand kit (`#30FFC0` / `#0B1F1A` / `#08110E`), Space Grotesk via `loadGoogleFont`.

## Why it's safe on the lean API worker
- `workers-og` is **dynamic-imported inside the handler**, so its ~1.3 MB resvg wasm only evaluates when this low-traffic route is actually hit. Every other (agent/API) request is untouched.
- Bundle measured at **774 KiB gzipped** — far under Cloudflare's 10 MB limit. Verified it bundles via `worker:deploy:dry-run`.
- **Fail-soft**: any failure (registry-summary cold, font fetch, wasm, satori) returns a tiny valid PNG, never a 500. Edge-cached 1h (stats only change on the 6h publish).

## Changes
- `src/og-image.mjs` — the handler (renderer/fonts/cache injectable for tests).
- `workers/api.mjs` — route dispatch after the badge route.
- `workers/request-handlers/discovery.mjs` — `og:image` + new `twitter:image` → `/og.png`.
- `package.json` / lock — `workers-og@^0.0.27` (first runtime dep).

## Tests
- `tests/og-image.test.mjs` — 8 tests: routing fall-through, 405, HEAD, the live-stats render, subtitle fallback when registry-summary is cold, both fail-soft paths, and cache-hit short-circuit.
- Full suite green; lint + format + `worker:deploy:dry-run` pass.

## Note
`/og.png` is a worker-computed asset like `badge.svg` — not an `/api/v1` contract route, so no OpenAPI/contract machinery. Visual output verified post-deploy by curling `/og.png` (the wasm render path can't run in Node/CI; the handler logic is unit-tested with an injected renderer).