### PR TITLE
fix(brand): OG stat separators render as brand dots, not tofu

### DIFF
--- a/src/og-image.mjs
+++ b/src/og-image.mjs
@@ -25,6 +25,9 @@ const CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400";
 const SUBTITLE = "The Bittensor subnet integration registry";
 const HEADLINE = "Every subnet, metagraphed.";
 const EYEBROW = "api.metagraph.sh";
+// Shown in the stat row only when registry-summary is cold (rare, transient).
+// ASCII-only on purpose — see the glyph note in handleOgImage.
+const FALLBACK_STAT = "Live health, schemas, and discovery for every subnet";
 
 // A tiny valid 1x1 PNG returned when any render dependency fails.
 const FALLBACK_PNG = new Uint8Array([
@@ -73,13 +76,24 @@ async function loadStatLine(env, readArtifact) {
     if (typeof coverage === "number" && Number.isFinite(coverage)) {
       parts.push(`${coverage}% avg coverage`);
     }
-    return parts.length ? parts.join("  ·  ") : null;
+    return parts.length ? parts : null;
   } catch {
     return null;
   }
 }
 
-function renderMarkup(statLine) {
+// Build the bottom stat row: each stat in its own leaf div, joined by a small
+// ink dot (a div, not a glyph — the "·" character doesn't survive loadGoogleFont
+// subsetting and renders as tofu). When stats are cold, show the ASCII fallback.
+function renderStatRow(statParts) {
+  const items = statParts && statParts.length ? statParts : [FALLBACK_STAT];
+  const dot = `<div style="display:flex;width:9px;height:9px;border-radius:5px;background:${INK};opacity:0.5;margin:0 18px;"></div>`;
+  return items
+    .map((part) => `<div style="display:flex;">${part}</div>`)
+    .join(dot);
+}
+
+function renderMarkup(statParts) {
   // satori is strict: any element with >1 child needs display:flex + a direction;
   // text lives in leaf divs. An ink tile with a mint "M" mirrors the brand's
   // icon-mint-on-ink lockup without risking inline-SVG rendering quirks.
@@ -97,7 +111,7 @@ function renderMarkup(statLine) {
       </div>
       <div style="display:flex;flex-direction:column;">
         <div style="display:flex;width:100%;height:3px;background:${INK};opacity:0.22;margin-bottom:26px;"></div>
-        <div style="display:flex;font-size:31px;font-weight:500;">${statLine}</div>
+        <div style="display:flex;align-items:center;font-size:31px;font-weight:500;">${renderStatRow(statParts)}</div>
       </div>
     </div>`;
 }
@@ -131,7 +145,7 @@ export async function handleOgImage(request, env, url, deps = {}) {
     return new Response(null, { headers: imageHeaders() });
   }
 
-  const statLine = (await loadStatLine(env, deps.readArtifact)) ?? SUBTITLE;
+  const statParts = await loadStatLine(env, deps.readArtifact);
 
   let ImageResponse;
   let loadGoogleFont;
@@ -144,8 +158,11 @@ export async function handleOgImage(request, env, url, deps = {}) {
   }
 
   // Subset both weights to only the glyphs we render (faster, smaller fetch).
-  // Includes digits/comma/percent/middot so any live stat-line variant resolves.
-  const glyphs = `${EYEBROW}${HEADLINE}${SUBTITLE}${statLine}M0123456789,.%· `;
+  // ASCII-only: loadGoogleFont's Google Fonts subset request drops non-ASCII
+  // glyphs (e.g. U+00B7 "·"), which then render as tofu — so the stat separator
+  // is a styled div, not a character (see renderStatRow).
+  const statText = (statParts ?? [FALLBACK_STAT]).join(" ");
+  const glyphs = `${EYEBROW}${HEADLINE}${SUBTITLE}${statText}M0123456789,.% `;
   let bold;
   let medium;
   try {
@@ -159,7 +176,7 @@ export async function handleOgImage(request, env, url, deps = {}) {
   }
 
   try {
-    const image = new ImageResponse(renderMarkup(statLine), {
+    const image = new ImageResponse(renderMarkup(statParts), {
       width: 1200,
       height: 630,
       fonts: [

--- a/tests/og-image.test.mjs
+++ b/tests/og-image.test.mjs
@@ -88,6 +88,10 @@ describe("handleOgImage", () => {
     assert.match(og.calls.markup, /1,198 endpoints/);
     assert.match(og.calls.markup, /92 providers/);
     assert.match(og.calls.markup, /57% avg coverage/);
+    // no non-ASCII glyphs in the rendered text -- the stat-row
+    // separator is a styled div, not a character (which would tofu)
+    assert.doesNotMatch(og.calls.markup, /[\u0080-\uffff]/);
+    assert.doesNotMatch(og.calls.fontTexts[0], /[\u0080-\uffff]/);
     // both Space Grotesk weights loaded, subset to the rendered glyphs
     assert.deepEqual(og.calls.fontWeights.sort(), [500, 700]);
     assert.match(og.calls.fontTexts[0], /129 subnets/);
@@ -95,7 +99,7 @@ describe("handleOgImage", () => {
     assert.equal(puts.length, 1);
   });
 
-  test("falls back to the subtitle when registry-summary is unavailable", async () => {
+  test("falls back to a generic stat line when registry-summary is unavailable", async () => {
     const og = fakeOg();
     const res = await handleOgImage(req("GET"), {}, urlFor(), {
       readArtifact: readSummaryMiss,
@@ -103,9 +107,9 @@ describe("handleOgImage", () => {
       cache: null,
     });
     assert.equal(res.status, 200);
-    // no stat counts rendered; the subtitle stands in for the stat line
-    assert.doesNotMatch(og.calls.markup, /subnets ·/);
-    assert.match(og.calls.markup, /The Bittensor subnet integration registry/);
+    // no live counts rendered; the ASCII fallback stat line stands in
+    assert.doesNotMatch(og.calls.markup, /\d+ subnets/);
+    assert.match(og.calls.markup, /Live health, schemas, and discovery/);
   });
 
   test("returns the fallback PNG (not a 500) when font loading fails", async () => {


### PR DESCRIPTION
Follow-up to #1108. The deployed `/og.png` rendered the `·` stat separators as missing-glyph boxes — `loadGoogleFont`'s Google Fonts subset request drops non-ASCII glyphs (U+00B7), so satori had no `·` in the font data.

**Fix:** render each separator as a small ink dot (a styled `div`) instead of a character, and keep all rendered text ASCII-only. The stat row is now an array of parts joined by dot divs; the cold-start fallback is an ASCII line.

Verified: 8 OG unit tests pass (incl. a new regression assertion that the rendered markup contains no non-ASCII glyphs), prettier + eslint clean, `worker:deploy:dry-run` passes. Will confirm the live render after deploy.