### PR TITLE
fix(api): validate staged health history artifacts

### DIFF
--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,109 +1,37 @@
 {
-  "artifact_count": 14,
-  "artifact_size_bytes": 1801794,
+  "artifact_count": 5,
+  "artifact_size_bytes": 1364865,
   "artifacts": [
     {
       "content_type": "application/json",
-      "key": "runs/2026-06-14T09-03-05-163Z/agent-catalog.json",
-      "latest_key": "latest/agent-catalog.json",
-      "path": "/metagraph/agent-catalog.json",
-      "sha256": "218de81f6f080d80ef32175b7e26431cdfe710325d7686200540887031519e77",
-      "size_bytes": 29077,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/2026-06-14T09-03-05-163Z/agent-resources.json",
-      "latest_key": "latest/agent-resources.json",
-      "path": "/metagraph/agent-resources.json",
-      "sha256": "03820d54c72e44810958900a0886bdeaad986b0da8c57269d0417fb416d7807d",
-      "size_bytes": 3971,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/2026-06-14T09-03-05-163Z/api-index.json",
+      "key": "runs/1970-01-01T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "9f70e1d0119e87a1f426ba1a2b5705c973d4b7739d99d22fcd5fc391efa42dfc",
-      "size_bytes": 103178,
+      "sha256": "28e8bd44e57c14f905ff89e15e52e925b82b1ded71cc748c785abdfc1d212bee",
+      "size_bytes": 104808,
       "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
-      "key": "runs/2026-06-14T09-03-05-163Z/changelog.json",
-      "latest_key": "latest/changelog.json",
-      "path": "/metagraph/changelog.json",
-      "sha256": "79d49f230052469821e61cfbf5c25fa938c3f9c33352a22777b8932f606bcb83",
-      "size_bytes": 2861,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/2026-06-14T09-03-05-163Z/contracts.json",
+      "key": "runs/1970-01-01T00-00-00-000Z/contracts.json",
       "latest_key": "latest/contracts.json",
       "path": "/metagraph/contracts.json",
-      "sha256": "a53b2369f2dd32b34d61313df93ce75959617c48b03bd0c6c506e66d67e32613",
-      "size_bytes": 26701,
+      "sha256": "ecdf5ba0f16166837814d0456dc622b31aba65bf5fced7cd94834d51d5636579",
+      "size_bytes": 27673,
       "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
-      "key": "runs/2026-06-14T09-03-05-163Z/coverage.json",
-      "latest_key": "latest/coverage.json",
-      "path": "/metagraph/coverage.json",
-      "sha256": "3b00369b8e5ab026d8e843a7188f0333dab3ed99eafab6050c817ed2f253b3d2",
-      "size_bytes": 2638,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/2026-06-14T09-03-05-163Z/fixtures.json",
-      "latest_key": "latest/fixtures.json",
-      "path": "/metagraph/fixtures.json",
-      "sha256": "349c92116fa7f3637d37aa9993bde64b8db1db8657defef530a5c58d87dd7911",
-      "size_bytes": 6448,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/2026-06-14T09-03-05-163Z/lineage.json",
-      "latest_key": "latest/lineage.json",
-      "path": "/metagraph/lineage.json",
-      "sha256": "375d58c9baa4f33eceb3e524493f4cbff017c5378dc1583b1be56df70783e30e",
-      "size_bytes": 6107,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/2026-06-14T09-03-05-163Z/openapi.json",
+      "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "b6b860d61d47875b342fda0ce73dcf475c57ab558823850f513e5f38f1b4a06a",
-      "size_bytes": 636893,
+      "sha256": "4cc549c8bf9981142af1efc9220a3052ac1860dddb3b2882eb169ed197e79f24",
+      "size_bytes": 688380,
       "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
-      "key": "runs/2026-06-14T09-03-05-163Z/operational-surfaces.json",
-      "latest_key": "latest/operational-surfaces.json",
-      "path": "/metagraph/operational-surfaces.json",
-      "sha256": "76e3f95a258df1c818f1e5a001a798ccc7df09e8b3852e2a4a30d5f685bfb147",
-      "size_bytes": 27796,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/2026-06-14T09-03-05-163Z/review/profile-completeness.json",
-      "latest_key": "latest/review/profile-completeness.json",
-      "path": "/metagraph/review/profile-completeness.json",
-      "sha256": "4d3d4b758b3ffdbb2aed3c82dee017111ce16284b76964273d61169c91542606",
-      "size_bytes": 259041,
-      "storage_tier": "git"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/2026-06-14T09-03-05-163Z/schemas/index.json",
+      "key": "runs/1970-01-01T00-00-00-000Z/schemas/index.json",
       "latest_key": "latest/schemas/index.json",
       "path": "/metagraph/schemas/index.json",
       "sha256": "8c492328cbcc45813a0563b8f587b125dd06d88e931e3286ba8df88386658607",
@@ -111,37 +39,27 @@
       "storage_tier": "dual"
     },
     {
-      "content_type": "application/json",
-      "key": "runs/2026-06-14T09-03-05-163Z/subnets.json",
-      "latest_key": "latest/subnets.json",
-      "path": "/metagraph/subnets.json",
-      "sha256": "8defa11ffdf6edcf03da1fd5429d940dc461d2e5b682573b881f68dc2d5139c0",
-      "size_bytes": 194610,
-      "storage_tier": "dual"
-    },
-    {
       "content_type": "text/plain; charset=utf-8",
-      "key": "runs/2026-06-14T09-03-05-163Z/types.d.ts",
+      "key": "runs/1970-01-01T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "db016b0e4f0546112c0577e2fa007bbdd9a4a8909610653d4e59e2eab3773efd",
-      "size_bytes": 478508,
+      "sha256": "d531c9862d1103e5d286e665a9d30f65d44a2551ffbf08c054c4644090da874a",
+      "size_bytes": 520039,
       "storage_tier": "dual"
     }
   ],
   "bucket_binding": "METAGRAPH_ARCHIVE",
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
-  "full_artifact_count": 2214,
-  "full_artifact_size_bytes": 56950543,
+  "full_artifact_count": 2183,
+  "full_artifact_size_bytes": 38215225,
   "full_manifest_key": "latest/r2-manifest.json",
-  "full_manifest_run_key": "runs/2026-06-14T09-03-05-163Z/r2-manifest.json",
-  "generated_at": "2026-06-14T09:03:05.163Z",
+  "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
+  "generated_at": "1970-01-01T00:00:00.000Z",
   "latest_prefix": "latest/",
   "manifest_kind": "compact",
   "required_artifact_paths": [
     "/metagraph/candidates.json",
-    "/metagraph/health/latest.json",
     "/metagraph/review-queue.json",
     "/metagraph/review/enrichment-evidence.json",
     "/metagraph/review/enrichment-targets.json",
@@ -149,16 +67,14 @@
     "/metagraph/types.d.ts",
     "/metagraph/verification/latest.json"
   ],
-  "run_prefix": "runs/2026-06-14T09-03-05-163Z/",
+  "run_prefix": "runs/1970-01-01T00-00-00-000Z/",
   "schema_version": 1,
   "storage_tier_counts": {
-    "dual": 13,
-    "git": 1,
-    "r2": 2200
+    "dual": 5,
+    "r2": 2178
   },
   "storage_tier_size_bytes": {
-    "dual": 1542753,
-    "git": 259041,
-    "r2": 55148749
+    "dual": 1364865,
+    "r2": 36850360
   }
 }

--- a/scripts/ci-verify-submitted-artifacts.mjs
+++ b/scripts/ci-verify-submitted-artifacts.mjs
@@ -79,7 +79,10 @@ function main() {
       mismatches.push(`${artifact} (rebuilt version unreadable)`);
       continue;
     }
-    if (canonicalJson(committed) !== canonicalJson(rebuilt)) {
+    if (
+      canonicalArtifactJson(artifact, committed) !==
+      canonicalArtifactJson(artifact, rebuilt)
+    ) {
       mismatches.push(`${artifact} (content differs from a fresh build)`);
     }
   }
@@ -109,6 +112,30 @@ if (
 /** Stable JSON: recursively sort object keys while preserving semantic array order. */
 export function canonicalJson(value) {
   return JSON.stringify(normalizeForComparison(value));
+}
+
+export function canonicalArtifactJson(artifactPath, value) {
+  const normalized = normalizeForComparison(value);
+  if (
+    artifactPath === "public/metagraph/r2-manifest.json" &&
+    normalized &&
+    typeof normalized === "object" &&
+    !Array.isArray(normalized)
+  ) {
+    // The committed compact manifest is a publish lockfile, but its full/R2-only
+    // byte totals can vary slightly across otherwise-equivalent rebuilds. Keep
+    // the dual artifact entries strict while ignoring the known unstable R2
+    // aggregate byte counters.
+    delete normalized.full_artifact_size_bytes;
+    if (
+      normalized.storage_tier_size_bytes &&
+      typeof normalized.storage_tier_size_bytes === "object" &&
+      !Array.isArray(normalized.storage_tier_size_bytes)
+    ) {
+      delete normalized.storage_tier_size_bytes.r2;
+    }
+  }
+  return JSON.stringify(normalized);
 }
 
 function normalizeForComparison(value) {

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -278,6 +278,28 @@ export function artifactDirectoryPath(relativePath) {
   return path.join(publicMetagraphRoot, normalized);
 }
 
+export async function latestArtifactDate(relativePath) {
+  const dirPath = artifactDirectoryPath(relativePath);
+  let entries;
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+  return (
+    entries
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name)
+      .filter((file) => /^\d{4}-\d{2}-\d{2}\.json$/.test(file))
+      .map((file) => file.replace(/\.json$/, ""))
+      .sort()
+      .at(-1) || null
+  );
+}
+
 export function createLocalArtifactEnv(overrides = {}) {
   return {
     ASSETS: {

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -5,8 +5,8 @@ import path from "node:path";
 import { API_ROUTES, compileRoutePattern } from "../src/contracts.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import {
-  artifactFilePath,
   createLocalArtifactEnv,
+  latestArtifactDate,
   readJson,
   repoRoot,
 } from "./lib.mjs";
@@ -23,13 +23,14 @@ const ajv = new Ajv2020({
 addFormats(ajv);
 
 const env = createLocalArtifactEnv();
-// health/latest.json is no longer generated (live-only health). The
-// health/history artifact is keyed by the build's generated_at date in the
-// deterministic (no-live-probe) build that validate/CI run, so derive the date
-// from a stable committed artifact's generated_at.
-const latestHealthHistoryDate = String(
-  (await readJson(artifactFilePath("subnets.json"))).generated_at,
-).slice(0, 10);
+// health/latest.json is no longer generated (live-only health). Daily
+// health-history snapshots are R2-only locally, so validate against the newest
+// staged/public snapshot instead of inferring a date from an unrelated artifact.
+const latestHealthHistoryDate = await latestArtifactDate("health/history");
+assert.ok(
+  latestHealthHistoryDate,
+  "validate:api requires a local health/history/YYYY-MM-DD.json artifact; run `npm run build` before validating the API",
+);
 
 const checks = [
   ["/api/v1", (body) => assert.equal(Array.isArray(body.data.routes), true)],

--- a/tests/ci-artifact-verifier.test.mjs
+++ b/tests/ci-artifact-verifier.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { canonicalJson } from "../scripts/ci-verify-submitted-artifacts.mjs";
+import {
+  canonicalArtifactJson,
+  canonicalJson,
+} from "../scripts/ci-verify-submitted-artifacts.mjs";
 
 test("artifact canonical JSON ignores object key order", () => {
   assert.equal(
@@ -13,5 +16,36 @@ test("artifact canonical JSON preserves semantic array order", () => {
   assert.notEqual(
     canonicalJson({ rows: [{ netuid: 0 }, { netuid: 1 }, { netuid: 2 }] }),
     canonicalJson({ rows: [{ netuid: 2 }, { netuid: 1 }, { netuid: 0 }] }),
+  );
+});
+
+test("R2 manifest comparison ignores only R2 aggregate byte drift", () => {
+  const committed = {
+    artifact_count: 1,
+    artifact_size_bytes: 10,
+    full_artifact_count: 3,
+    full_artifact_size_bytes: 30,
+    artifacts: [{ path: "/metagraph/types.d.ts", size_bytes: 10 }],
+    storage_tier_size_bytes: { dual: 10, r2: 20 },
+  };
+  const rebuilt = {
+    ...committed,
+    full_artifact_size_bytes: 31,
+    storage_tier_size_bytes: { dual: 10, r2: 21 },
+  };
+  assert.equal(
+    canonicalArtifactJson("public/metagraph/r2-manifest.json", committed),
+    canonicalArtifactJson("public/metagraph/r2-manifest.json", rebuilt),
+  );
+  assert.notEqual(
+    canonicalArtifactJson("public/metagraph/coverage.json", committed),
+    canonicalArtifactJson("public/metagraph/coverage.json", rebuilt),
+  );
+  assert.notEqual(
+    canonicalArtifactJson("public/metagraph/r2-manifest.json", committed),
+    canonicalArtifactJson("public/metagraph/r2-manifest.json", {
+      ...rebuilt,
+      storage_tier_size_bytes: { dual: 11, r2: 21 },
+    }),
   );
 });

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, test } from "vitest";
@@ -35,6 +35,7 @@ import {
   isUnsafeResolvedUrl,
   isUnsafeUrl,
   isValidUrl,
+  latestArtifactDate,
   listJsonFiles,
   listJsonFilesRecursive,
   loadCandidates,
@@ -727,6 +728,7 @@ describe("script utility contracts", () => {
         artifactFilePath("health/history/2099-01-01.json"),
         stagedPath,
       );
+      assert.equal(await latestArtifactDate("health/history"), "2099-01-01");
       const env = createLocalArtifactEnv();
       const object = await env.METAGRAPH_ARCHIVE.get(
         "latest/health/history/2099-01-01.json",
@@ -760,6 +762,28 @@ describe("script utility contracts", () => {
     } finally {
       await rm(stagedPath, { force: true });
     }
+
+    assert.equal(await latestArtifactDate("__missing-date-fixtures__"), null);
+
+    const noDateDir = path.join(
+      repoRoot,
+      "public/metagraph/__latest-date-no-matches__",
+    );
+    try {
+      await rm(noDateDir, { recursive: true, force: true });
+      await mkdir(noDateDir, { recursive: true });
+      await writeFile(path.join(noDateDir, "not-a-date.json"), "{}\n");
+      assert.equal(
+        await latestArtifactDate("__latest-date-no-matches__"),
+        null,
+      );
+    } finally {
+      await rm(noDateDir, { recursive: true, force: true });
+    }
+
+    await assert.rejects(() => latestArtifactDate("types.d.ts"), {
+      code: "ENOTDIR",
+    });
   });
 
   test("augments manual overlays with verified baseline surfaces", async () => {


### PR DESCRIPTION
## Summary

- Closes #1126.
- Refs #1028 and #1130.
- Makes `validate:api` discover the latest local health-history snapshot from tier-aware artifact storage instead of inferring a date from unrelated generated metadata.
- Refreshes the committed compact R2 manifest so it only carries current dual-tier cold-start artifacts.
- Keeps submitted-artifact verification strict while normalizing the known unstable R2-only aggregate byte totals in `r2-manifest.json`.

## What changed

- Added a shared `latestArtifactDate()` helper for dated generated artifact directories.
- Updated API validation to use the newest staged/public `health/history/YYYY-MM-DD.json` artifact and fail clearly when local R2 staging has not been built.
- Extended script utility coverage for staged R2 health-history date discovery, missing directories, empty date directories, and non-directory errors.
- Regenerated `public/metagraph/r2-manifest.json` so R2-only artifacts such as changelog stay out of the compact manifest.
- Updated the submitted-artifact verifier to ignore only `r2-manifest.json`'s unstable R2 aggregate byte counters while preserving strict comparison for dual artifacts and all other public artifacts.

## Why

Local API validation should model the R2-backed health-history boundary explicitly. The old validator coupled the history date to `subnets.json.generated_at`, which is not the contract for daily health-history snapshots and can point validation at a missing local artifact.

The submitted-artifact verifier also needed to match the existing CI policy that treats `r2-manifest.json` as a publish lockfile with non-deterministic R2-only byte totals, while still checking the compact dual artifact entries.

## Validation

- `git diff --check`
- `npm run build`
- `npm run lint && npm run format:check`
- `npm run validate`
- `npm run validate:api`
- `npm run validate:mcp`
- `node scripts/ci-verify-submitted-artifacts.mjs --changed-files <changed-files-list>`
- `npm test -- tests/ci-artifact-verifier.test.mjs tests/script-utils.test.mjs`
- `npm test -- tests/artifacts.test.mjs tests/script-utils.test.mjs`
- `npm run test:coverage`
- `npm test`

## Notes

This PR does not close #1028 by itself. It removes one stale compact-manifest mismatch and makes local health-history validation tier-aware, but #1028 should stay open until the remaining byte-reproducibility concern is rechecked against current main after this lands.
