### PR TITLE
Fix Cacheon community candidate URL

### DIFF
--- a/registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json
+++ b/registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://cacheon.ai/docs/miners/api-contract",
       "source_urls": ["https://cacheon.ai/docs/miners/api-contract"],
       "state": "schema-valid",
-      "url": "https://api.cacheon.ai/api/container-logs"
+      "url": "https://api.cacheon.ai/api/evaluations"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
### Motivation
- Remove a potentially sensitive container-logs endpoint from public candidate artifacts by reverting the candidate URL to a less sensitive evaluations endpoint so the registry does not advertise an unauthenticated logs surface.

### Description
- Updated the candidate entry in `registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json` to change the `url` from `https://api.cacheon.ai/api/container-logs` to `https://api.cacheon.ai/api/evaluations`, leaving all other metadata intact.

### Testing
- Ran `node scripts/validate-candidate.mjs registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json`, `npm run build:artifacts`, and `git diff --check`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b0c8cde4832cb77031cb5f576893)