### PR TITLE
fix(worker): route dynamic OG image before assets

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -28,6 +28,8 @@
       "/.well-known/api-catalog",
       "/.well-known/mcp/server-card.json",
       "/.well-known/agent-tools/*",
+      "/og.png",
+      "/og",
       "/api/*",
       "/rpc/*",
       "/metagraph/*",


### PR DESCRIPTION
### Motivation
- The dynamic Open Graph image handler at `/og.png` and `/og` is implemented in the Worker but those top-level paths were not included in the Cloudflare assets `run_worker_first` allowlist, which can cause the asset layer to intercept requests and return a 404 instead of invoking the Worker.

### Description
- Add `/og.png` and `/og` to the `assets.run_worker_first` list in `wrangler.jsonc` so requests for the advertised Open Graph image reach the Worker before static asset handling.

### Testing
- Ran `npm test -- tests/og-image.test.mjs` (all tests passed) and `npx prettier --check wrangler.jsonc` (format check passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b324eb34832c81ebe89b60940772)