### PR TITLE
feat(api): add bulk health trends endpoint

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -71,6 +71,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/operational-surfaces.json`: operational surfaces (RPC/WSS/subnet-api/SSE/data-artifact) probed live by the 2-minute Cloudflare cron health prober; the prober's input list, served from the committed assets.
 - `/metagraph/agent-catalog.json`: compact index of subnets exposing callable services for AI agents (per subnet: service kinds + callable count). Committed.
 - `/metagraph/agent-catalog/{netuid}.json`: per-subnet agent capability catalog — each callable service with base URL, auth, machine-readable schema, and build-time health/eligibility. R2-backed.
+- `/metagraph/health/trends.json`: schema for the compact all-subnet 7d/30d daily uptime + latency trend matrix served live from D1 at `GET /api/v1/health/trends` (no static file is written).
 - `/metagraph/health/trends/{netuid}.json`: schema for the computed 7d/30d uptime + latency trends served live from D1 at `GET /api/v1/subnets/{netuid}/health/trends` (no static file is written).
 - `/metagraph/health/percentiles/{netuid}.json`: schema for per-surface latency percentiles (p50/p95/p99) served live from D1 at `GET /api/v1/subnets/{netuid}/health/percentiles` (no static file).
 - `/metagraph/health/incidents/{netuid}.json`: schema for per-surface SLA + reconstructed downtime incidents served live from D1 at `GET /api/v1/subnets/{netuid}/health/incidents` (no static file).
@@ -138,6 +139,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/api/v1/health`: fetch global health summary.
 - `/api/v1/health/history/{date}`: fetch compact daily health history.
 - `/api/v1/subnets/{netuid}/health`: fetch health detail for one subnet.
+- `/api/v1/health/trends`: fetch compact all-subnet 7d/30d daily uptime and latency trends (live from D1).
 - `/api/v1/freshness`: fetch freshness and staleness state.
 - `/api/v1/source-health`: fetch upstream source health.
 - `/api/v1/evidence`: fetch public evidence ledger.

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -361,6 +361,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/health/trends": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch compact 7d/30d daily uptime and latency trends for all subnets (computed live from D1). */
+        get: operations["healthTrendsBulk"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/incidents": {
         parameters: {
             query?: never;
@@ -1222,6 +1239,31 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        BulkHealthTrendsArtifact: {
+            observed_at?: string | null;
+            schema_version: number;
+            source: string;
+            windows: {
+                [key: string]: {
+                    days: number;
+                    /** @enum {string} */
+                    granularity: "1d";
+                    subnet_count: number;
+                    subnets: {
+                        avg_latency_ms: number | null;
+                        netuid: number;
+                        points: {
+                            avg_latency_ms: number | null;
+                            date: string;
+                            samples: number;
+                            uptime_ratio: number | null;
+                        }[];
+                        samples: number;
+                        uptime_ratio: number | null;
+                    }[];
+                };
+            };
+        };
         /** @enum {unknown} */
         CacheProfile: "short" | "standard" | "static";
         CandidatesArtifact: components["schemas"]["ArtifactBase"] & ({
@@ -6222,6 +6264,130 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthHistoryArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    healthTrendsBulk: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "windows": {
+                     *           "example": {
+                     *             "days": 1,
+                     *             "granularity": "1d",
+                     *             "subnet_count": 1,
+                     *             "subnets": [
+                     *               {
+                     *                 "avg_latency_ms": 120,
+                     *                 "netuid": 7,
+                     *                 "points": [
+                     *                   {
+                     *                     "avg_latency_ms": 120,
+                     *                     "date": "2026-06-01",
+                     *                     "samples": 1,
+                     *                     "uptime_ratio": 0.9966
+                     *                   }
+                     *                 ],
+                     *                 "samples": 1,
+                     *                 "uptime_ratio": 0.9966
+                     *               }
+                     *             ]
+                     *           }
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["BulkHealthTrendsArtifact"];
                     };
                 };
             };

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -201,6 +201,7 @@ Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1
 - `GET /api/v1/health` — Fetch global health summary.
 - `GET /api/v1/health/history/{date}` — Fetch compact daily health history.
 - `GET /api/v1/subnets/{netuid}/health` — Fetch health detail for one subnet.
+- `GET /api/v1/health/trends` — Fetch compact 7d/30d daily uptime and latency trends for all subnets (computed live from D1).
 - `GET /api/v1/subnets/{netuid}/health/trends` — Fetch 7d/30d uptime and latency trends for one subnet's operational surfaces (computed live from D1).
 - `GET /api/v1/subnets/{netuid}/health/percentiles` — Fetch latency percentiles (p50/p95/p99) per operational surface for one subnet over a 7d or 30d window (computed live from D1).
 - `GET /api/v1/subnets/{netuid}/health/incidents` — Fetch SLA (uptime ratio) and reconstructed downtime incidents per operational surface for one subnet over a 7d or 30d window (computed live from D1).

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -310,6 +310,13 @@
     },
     {
       "contract_version": "2026-06-06.1",
+      "id": "health-trends-bulk",
+      "path": "/metagraph/health/trends.json",
+      "schema_ref": "#/components/schemas/BulkHealthTrendsArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "contract_version": "2026-06-06.1",
       "id": "health-percentiles",
       "path": "/metagraph/health/percentiles/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthPercentilesArtifact",
@@ -3367,6 +3374,18 @@
           }
         }
       ]
+    },
+    {
+      "artifact_path": "/metagraph/health/trends.json",
+      "cache": "short",
+      "description": "Fetch compact 7d/30d daily uptime and latency trends for all subnets (computed live from D1).",
+      "id": "health-trends-bulk",
+      "method": "GET",
+      "path": "/api/v1/health/trends",
+      "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
+      "query_parameters": []
     },
     {
       "artifact_path": "/metagraph/health/trends/{netuid}.json",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -399,6 +399,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
+      "description": "Compact all-subnet 7d/30d daily uptime + latency trend matrix. Served live from D1 at /api/v1/health/trends (no static file).",
+      "id": "health-trends-bulk",
+      "path": "/metagraph/health/trends.json",
+      "schema_ref": "#/components/schemas/BulkHealthTrendsArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-06-06.1",
       "description": "Latency percentiles (p50/p95/p99 + avg/min/max) per operational surface for one subnet, computed live from D1 at /api/v1/subnets/{netuid}/health/percentiles (no static file).",
       "id": "health-percentiles",
       "path": "/metagraph/health/percentiles/{netuid}.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -767,6 +767,135 @@
           }
         ]
       },
+      "BulkHealthTrendsArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "observed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "source": {
+            "type": "string"
+          },
+          "windows": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "days": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "granularity": {
+                  "enum": [
+                    "1d"
+                  ],
+                  "type": "string"
+                },
+                "subnet_count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "subnets": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "avg_latency_ms": {
+                        "minimum": 0,
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "netuid": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "points": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "avg_latency_ms": {
+                              "minimum": 0,
+                              "type": [
+                                "integer",
+                                "null"
+                              ]
+                            },
+                            "date": {
+                              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                              "type": "string"
+                            },
+                            "samples": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "uptime_ratio": {
+                              "maximum": 1,
+                              "minimum": 0,
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "date",
+                            "samples",
+                            "uptime_ratio",
+                            "avg_latency_ms"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "samples": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "uptime_ratio": {
+                        "maximum": 1,
+                        "minimum": 0,
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "netuid",
+                      "samples",
+                      "uptime_ratio",
+                      "avg_latency_ms",
+                      "points"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "days",
+                "granularity",
+                "subnet_count",
+                "subnets"
+              ],
+              "type": "object"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "schema_version",
+          "source",
+          "windows"
+        ],
+        "type": "object"
+      },
       "CacheProfile": {
         "enum": [
           "short",
@@ -13902,6 +14031,149 @@
         "summary": "Fetch compact daily health history.",
         "tags": [
           "health"
+        ]
+      }
+    },
+    "/api/v1/health/trends": {
+      "get": {
+        "operationId": "healthTrendsBulk",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "observed_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1,
+                    "source": "live-cron-prober",
+                    "windows": {
+                      "example": {
+                        "days": 1,
+                        "granularity": "1d",
+                        "subnet_count": 1,
+                        "subnets": [
+                          {
+                            "avg_latency_ms": 120,
+                            "netuid": 7,
+                            "points": [
+                              {
+                                "avg_latency_ms": 120,
+                                "date": "2026-06-01",
+                                "samples": 1,
+                                "uptime_ratio": 0.9966
+                              }
+                            ],
+                            "samples": 1,
+                            "uptime_ratio": 0.9966
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/BulkHealthTrendsArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch compact 7d/30d daily uptime and latency trends for all subnets (computed live from D1).",
+        "tags": [
+          "health",
+          "analytics"
         ]
       }
     },

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,14 +1,14 @@
 {
   "artifact_count": 5,
-  "artifact_size_bytes": 1364865,
+  "artifact_size_bytes": 1381414,
   "artifacts": [
     {
       "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "28e8bd44e57c14f905ff89e15e52e925b82b1ded71cc748c785abdfc1d212bee",
-      "size_bytes": 104808,
+      "sha256": "bdc778393c95d6749664627157f242e9a849f74b2aa9dc861184a90686e3e897",
+      "size_bytes": 105462,
       "storage_tier": "dual"
     },
     {
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/contracts.json",
       "latest_key": "latest/contracts.json",
       "path": "/metagraph/contracts.json",
-      "sha256": "ecdf5ba0f16166837814d0456dc622b31aba65bf5fced7cd94834d51d5636579",
-      "size_bytes": 27673,
+      "sha256": "2d439f45b7d1c49f82d84ddacc6ea8b07f2db707d72b476254db1ed8a125d583",
+      "size_bytes": 28097,
       "storage_tier": "dual"
     },
     {
@@ -25,8 +25,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "4cc549c8bf9981142af1efc9220a3052ac1860dddb3b2882eb169ed197e79f24",
-      "size_bytes": 688380,
+      "sha256": "5ba46f53d80a07509bd96c1859cfd1f26126ea91fd73167b3c08b8e903b204fb",
+      "size_bytes": 697294,
       "storage_tier": "dual"
     },
     {
@@ -43,8 +43,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "d531c9862d1103e5d286e665a9d30f65d44a2551ffbf08c054c4644090da874a",
-      "size_bytes": 520039,
+      "sha256": "2108e047b6bb0bd6fcfccd7700e2ae70f56fe67b0eb51c67199239ef6f3e8a24",
+      "size_bytes": 526596,
       "storage_tier": "dual"
     }
   ],
@@ -52,7 +52,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 2183,
-  "full_artifact_size_bytes": 38215225,
+  "full_artifact_size_bytes": 38232178,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -74,7 +74,7 @@
     "r2": 2178
   },
   "storage_tier_size_bytes": {
-    "dual": 1364865,
-    "r2": 36850360
+    "dual": 1381414,
+    "r2": 36850764
   }
 }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -361,6 +361,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/health/trends": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch compact 7d/30d daily uptime and latency trends for all subnets (computed live from D1). */
+        get: operations["healthTrendsBulk"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/incidents": {
         parameters: {
             query?: never;
@@ -1222,6 +1239,31 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        BulkHealthTrendsArtifact: {
+            observed_at?: string | null;
+            schema_version: number;
+            source: string;
+            windows: {
+                [key: string]: {
+                    days: number;
+                    /** @enum {string} */
+                    granularity: "1d";
+                    subnet_count: number;
+                    subnets: {
+                        avg_latency_ms: number | null;
+                        netuid: number;
+                        points: {
+                            avg_latency_ms: number | null;
+                            date: string;
+                            samples: number;
+                            uptime_ratio: number | null;
+                        }[];
+                        samples: number;
+                        uptime_ratio: number | null;
+                    }[];
+                };
+            };
+        };
         /** @enum {unknown} */
         CacheProfile: "short" | "standard" | "static";
         CandidatesArtifact: components["schemas"]["ArtifactBase"] & ({
@@ -6222,6 +6264,130 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthHistoryArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    healthTrendsBulk: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "windows": {
+                     *           "example": {
+                     *             "days": 1,
+                     *             "granularity": "1d",
+                     *             "subnet_count": 1,
+                     *             "subnets": [
+                     *               {
+                     *                 "avg_latency_ms": 120,
+                     *                 "netuid": 7,
+                     *                 "points": [
+                     *                   {
+                     *                     "avg_latency_ms": 120,
+                     *                     "date": "2026-06-01",
+                     *                     "samples": 1,
+                     *                     "uptime_ratio": 0.9966
+                     *                   }
+                     *                 ],
+                     *                 "samples": 1,
+                     *                 "uptime_ratio": 0.9966
+                     *               }
+                     *             ]
+                     *           }
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["BulkHealthTrendsArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -753,6 +753,135 @@
           }
         ]
       },
+      "BulkHealthTrendsArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "observed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "source": {
+            "type": "string"
+          },
+          "windows": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "days": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "granularity": {
+                  "enum": [
+                    "1d"
+                  ],
+                  "type": "string"
+                },
+                "subnet_count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "subnets": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "avg_latency_ms": {
+                        "minimum": 0,
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "netuid": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "points": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "avg_latency_ms": {
+                              "minimum": 0,
+                              "type": [
+                                "integer",
+                                "null"
+                              ]
+                            },
+                            "date": {
+                              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                              "type": "string"
+                            },
+                            "samples": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "uptime_ratio": {
+                              "maximum": 1,
+                              "minimum": 0,
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "date",
+                            "samples",
+                            "uptime_ratio",
+                            "avg_latency_ms"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "samples": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "uptime_ratio": {
+                        "maximum": 1,
+                        "minimum": 0,
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "netuid",
+                      "samples",
+                      "uptime_ratio",
+                      "avg_latency_ms",
+                      "points"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "days",
+                "granularity",
+                "subnet_count",
+                "subnets"
+              ],
+              "type": "object"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "schema_version",
+          "source",
+          "windows"
+        ],
+        "type": "object"
+      },
       "CacheProfile": {
         "enum": [
           "short",

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -450,6 +450,85 @@
         },
         "additionalProperties": true
       },
+      "BulkHealthTrendsArtifact": {
+        "type": "object",
+        "required": ["schema_version", "source", "windows"],
+        "properties": {
+          "schema_version": { "type": "integer" },
+          "observed_at": { "type": ["string", "null"] },
+          "source": { "type": "string" },
+          "windows": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "required": ["days", "granularity", "subnet_count", "subnets"],
+              "properties": {
+                "days": { "type": "integer", "minimum": 0 },
+                "granularity": { "type": "string", "enum": ["1d"] },
+                "subnet_count": { "type": "integer", "minimum": 0 },
+                "subnets": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "netuid",
+                      "samples",
+                      "uptime_ratio",
+                      "avg_latency_ms",
+                      "points"
+                    ],
+                    "properties": {
+                      "netuid": { "type": "integer", "minimum": 0 },
+                      "samples": { "type": "integer", "minimum": 0 },
+                      "uptime_ratio": {
+                        "type": ["number", "null"],
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "avg_latency_ms": {
+                        "type": ["integer", "null"],
+                        "minimum": 0
+                      },
+                      "points": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "date",
+                            "samples",
+                            "uptime_ratio",
+                            "avg_latency_ms"
+                          ],
+                          "properties": {
+                            "date": {
+                              "type": "string",
+                              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                            },
+                            "samples": { "type": "integer", "minimum": 0 },
+                            "uptime_ratio": {
+                              "type": ["number", "null"],
+                              "minimum": 0,
+                              "maximum": 1
+                            },
+                            "avg_latency_ms": {
+                              "type": ["integer", "null"],
+                              "minimum": 0
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "HealthPercentilesArtifact": {
         "type": "object",
         "required": ["schema_version", "netuid", "source", "surfaces"],

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -48,6 +48,15 @@ const checks = [
     },
   ],
   [
+    "/api/v1/health/trends",
+    (body) => {
+      assert.equal(body.data.source, "live-cron-prober");
+      assert.equal(typeof body.data.windows, "object");
+      assert.equal(Array.isArray(body.data.windows["7d"].subnets), true);
+      assert.equal(typeof body.data.windows["7d"].subnet_count, "number");
+    },
+  ],
+  [
     "/api/v1/subnets/7/health/percentiles",
     (body) => {
       assert.equal(body.data.netuid, 7);

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -22,6 +22,7 @@ import {
 // per-route response validation, not by validating files here.
 const COMPUTED_ARTIFACTS = new Set([
   "health-trends",
+  "health-trends-bulk",
   "health-percentiles",
   "health-incidents",
   "subnet-trajectory",

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -27,6 +27,7 @@ const R2_ONLY_PATTERNS = [
   // Health trends are computed live from D1 by the Worker, never written as a
   // file. Marked R2-only so the contract maps a schema to the route without the
   // build expecting a committed/staged artifact.
+  /^health\/trends\.json$/,
   /^health\/trends\/(?:\d+|\{netuid\})\.json$/,
   // AI-4 analytics: also computed live from D1, never written as files.
   /^health\/percentiles\/(?:\d+|\{netuid\})\.json$/,

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -793,6 +793,12 @@ export const PUBLIC_ARTIFACTS = [
     "HealthTrendsArtifact",
   ),
   artifact(
+    "health-trends-bulk",
+    "/metagraph/health/trends.json",
+    "Compact all-subnet 7d/30d daily uptime + latency trend matrix. Served live from D1 at /api/v1/health/trends (no static file).",
+    "BulkHealthTrendsArtifact",
+  ),
+  artifact(
     "health-percentiles",
     "/metagraph/health/percentiles/{netuid}.json",
     "Latency percentiles (p50/p95/p99 + avg/min/max) per operational surface for one subnet, computed live from D1 at /api/v1/subnets/{netuid}/health/percentiles (no static file).",
@@ -1327,6 +1333,15 @@ export const API_ROUTES = [
     ["health", "subnets"],
     listQuery("health-surfaces", { exclude: ["netuid"] }),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
+  ),
+  route(
+    "health-trends-bulk",
+    "GET",
+    "/api/v1/health/trends",
+    "/metagraph/health/trends.json",
+    "Fetch compact 7d/30d daily uptime and latency trends for all subnets (computed live from D1).",
+    "short",
+    ["health", "analytics"],
   ),
   route(
     "subnet-health-trends",

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -309,6 +309,91 @@ export function formatTrends({ netuid, observedAt, windows }) {
   };
 }
 
+// Format all-subnet daily aggregates for the matrix UI. This intentionally
+// keeps the bulk contract subnet-level instead of per-surface to bound payload
+// size while still exposing enough data for sparklines and uptime sorting.
+export function formatBulkTrends({ observedAt, windows, windowDays = {} }) {
+  const formatWindow = (rows, days) => {
+    const bySubnet = new Map();
+    for (const row of rows || []) {
+      const netuid = Number(row.netuid);
+      const date = String(row.date || "");
+      if (
+        !Number.isInteger(netuid) ||
+        netuid < 0 ||
+        !/^\d{4}-\d{2}-\d{2}$/.test(date)
+      ) {
+        continue;
+      }
+      const samples = Math.max(0, Number(row.total) || 0);
+      const okCount = Math.max(0, Number(row.ok_count) || 0);
+      const latencyRaw =
+        row.avg_latency_ms == null ? null : Number(row.avg_latency_ms);
+      const avgLatency = Number.isFinite(latencyRaw)
+        ? Math.round(latencyRaw)
+        : null;
+
+      let entry = bySubnet.get(netuid);
+      if (!entry) {
+        entry = {
+          netuid,
+          samples: 0,
+          okCount: 0,
+          latencyTotal: 0,
+          latencySamples: 0,
+          points: [],
+        };
+        bySubnet.set(netuid, entry);
+      }
+
+      entry.samples += samples;
+      entry.okCount += okCount;
+      if (Number.isFinite(latencyRaw) && samples > 0) {
+        entry.latencyTotal += latencyRaw * samples;
+        entry.latencySamples += samples;
+      }
+      entry.points.push({
+        date,
+        samples,
+        uptime_ratio: samples ? round4(okCount / samples) : null,
+        avg_latency_ms: avgLatency,
+      });
+    }
+
+    const subnets = [...bySubnet.values()]
+      .map((entry) => ({
+        netuid: entry.netuid,
+        samples: entry.samples,
+        uptime_ratio: entry.samples
+          ? round4(entry.okCount / entry.samples)
+          : null,
+        avg_latency_ms: entry.latencySamples
+          ? Math.round(entry.latencyTotal / entry.latencySamples)
+          : null,
+        points: entry.points.sort((a, b) => a.date.localeCompare(b.date)),
+      }))
+      .sort((a, b) => a.netuid - b.netuid);
+
+    return {
+      days: Number(days) || 0,
+      granularity: "1d",
+      subnet_count: subnets.length,
+      subnets,
+    };
+  };
+
+  const windowsOut = {};
+  for (const [label, rows] of Object.entries(windows || {})) {
+    windowsOut[label] = formatWindow(rows, windowDays[label]);
+  }
+  return {
+    schema_version: 1,
+    observed_at: observedAt || null,
+    source: "live-cron-prober",
+    windows: windowsOut,
+  };
+}
+
 // --- AI-4 historical analytics (pure transforms over D1 query rows) ---------
 
 // A gap larger than this between consecutive failing checks (probe cadence is

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -471,6 +471,12 @@ describe("analytics routes (cold local D1)", () => {
       hungEnv,
     );
     assert.equal(trends.status, 200);
+    const bulkTrends = await getJson(
+      "https://api.metagraph.sh/api/v1/health/trends",
+      hungEnv,
+    );
+    assert.equal(bulkTrends.status, 200);
+    assert.deepEqual(bulkTrends.body.data.windows["7d"].subnets, []);
   });
   test("leaderboards returns most-complete from profiles even with cold D1", async () => {
     const { body } = await getJson(

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1071,6 +1071,52 @@ describe("health trends D1 error handling", () => {
     assert.equal(body.data.netuid, 0);
     assert.equal(body.data.windows["7d"].uptime_ratio, null);
   });
+
+  test("bulk route returns a schema-stable empty payload when D1 throws", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  throw new Error("d1 down");
+                },
+              };
+            },
+          };
+        },
+      },
+    });
+    const res = await handleRequest(req("/api/v1/health/trends"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.windows["7d"].subnet_count, 0);
+    assert.deepEqual(body.data.windows["7d"].subnets, []);
+  });
+
+  test("bulk route treats a D1 response without results as empty", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  return {};
+                },
+              };
+            },
+          };
+        },
+      },
+    });
+    const res = await handleRequest(req("/api/v1/health/trends"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.windows["7d"].subnet_count, 0);
+    assert.deepEqual(body.data.windows["30d"].subnets, []);
+  });
 });
 
 // --- readAsset with no ASSETS binding ----------------------------------------

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -3,6 +3,7 @@ import { describe, test } from "vitest";
 import {
   OPERATIONAL_KINDS,
   buildGlobalHealth,
+  formatBulkTrends,
   formatGlobalIncidents,
   formatTrends,
   mergeFreshness,
@@ -674,6 +675,118 @@ describe("formatTrends (additional paths)", () => {
   });
 });
 
+describe("formatBulkTrends", () => {
+  test("groups daily rows by subnet and sorts subnets/points", () => {
+    const out = formatBulkTrends({
+      observedAt: "2026-06-11T00:00:00.000Z",
+      windowDays: { "7d": 7, "30d": 30 },
+      windows: {
+        "7d": [
+          {
+            netuid: 8,
+            date: "2026-06-10",
+            total: 4,
+            ok_count: 2,
+            avg_latency_ms: 10.2,
+          },
+          {
+            netuid: 7,
+            date: "2026-06-11",
+            total: 10,
+            ok_count: 9,
+            avg_latency_ms: 50.4,
+          },
+          {
+            netuid: 7,
+            date: "2026-06-10",
+            total: 5,
+            ok_count: 5,
+            avg_latency_ms: 30,
+          },
+        ],
+        "30d": [],
+      },
+    });
+
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.source, "live-cron-prober");
+    assert.equal(out.windows["7d"].days, 7);
+    assert.equal(out.windows["7d"].granularity, "1d");
+    assert.equal(out.windows["7d"].subnet_count, 2);
+    assert.deepEqual(
+      out.windows["7d"].subnets.map((entry) => entry.netuid),
+      [7, 8],
+    );
+
+    const sn7 = out.windows["7d"].subnets[0];
+    assert.equal(sn7.samples, 15);
+    assert.equal(sn7.uptime_ratio, Number((14 / 15).toFixed(4)));
+    assert.equal(sn7.avg_latency_ms, 44);
+    assert.deepEqual(
+      sn7.points.map((point) => point.date),
+      ["2026-06-10", "2026-06-11"],
+    );
+    assert.equal(sn7.points[1].uptime_ratio, 0.9);
+    assert.equal(sn7.points[1].avg_latency_ms, 50);
+    assert.equal(out.windows["30d"].subnet_count, 0);
+  });
+
+  test("empty or invalid rows keep the schema-stable cold shape", () => {
+    const out = formatBulkTrends({
+      windows: {
+        "7d": [
+          { netuid: -1, date: "2026-06-10", total: 1, ok_count: 1 },
+          { netuid: 7, date: "not-a-date", total: 1, ok_count: 1 },
+        ],
+      },
+      windowDays: { "7d": 7 },
+    });
+    assert.equal(out.observed_at, null);
+    assert.equal(out.windows["7d"].days, 7);
+    assert.equal(out.windows["7d"].subnet_count, 0);
+    assert.deepEqual(out.windows["7d"].subnets, []);
+  });
+
+  test("covers zero-sample and omitted-window fallback branches", () => {
+    const empty = formatBulkTrends({});
+    assert.deepEqual(empty.windows, {});
+
+    const out = formatBulkTrends({
+      windows: {
+        "7d": null,
+        cold: [
+          {
+            netuid: 7,
+            date: "2026-06-10",
+            total: 0,
+            ok_count: undefined,
+            avg_latency_ms: null,
+          },
+          {
+            netuid: 7,
+            date: "2026-06-11",
+            total: undefined,
+            ok_count: undefined,
+            avg_latency_ms: "not-a-number",
+          },
+          { netuid: "bad", date: "2026-06-10", total: 1, ok_count: 1 },
+          { netuid: 9, total: 1, ok_count: 1 },
+        ],
+      },
+    });
+
+    assert.equal(out.windows["7d"].days, 0);
+    assert.equal(out.windows["7d"].subnet_count, 0);
+    const sn7 = out.windows.cold.subnets[0];
+    assert.equal(sn7.samples, 0);
+    assert.equal(sn7.uptime_ratio, null);
+    assert.equal(sn7.avg_latency_ms, null);
+    assert.equal(sn7.points[0].uptime_ratio, null);
+    assert.equal(sn7.points[0].avg_latency_ms, null);
+    assert.equal(sn7.points[1].avg_latency_ms, null);
+  });
+});
+
 // --- Worker integration: the LIVE path (mock KV + D1) -------------------------
 function kvWith(entries) {
   return {
@@ -744,6 +857,44 @@ describe("worker live health serving", () => {
     assert.equal(body.data.netuid, 0);
     assert.equal(body.data.windows["7d"].uptime_ratio, 0.99);
     assert.equal(body.data.source, "live-cron-prober");
+  });
+
+  test("/api/v1/health/trends queries compact all-subnet D1 rows", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_HEALTH_DB: d1With([
+        {
+          netuid: 8,
+          date: "2026-06-10",
+          total: 10,
+          ok_count: 8,
+          avg_latency_ms: 30,
+        },
+        {
+          netuid: 7,
+          date: "2026-06-10",
+          total: 5,
+          ok_count: 5,
+          avg_latency_ms: 20,
+        },
+      ]),
+      METAGRAPH_CONTROL: kvWith({
+        "health:meta": { last_run_at: "2026-06-11T00:00:00.000Z" },
+      }),
+    });
+    const res = await handleRequest(req("/api/v1/health/trends"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.meta.artifact_path, "/metagraph/health/trends.json");
+    assert.equal(body.data.observed_at, "2026-06-11T00:00:00.000Z");
+    assert.equal(body.data.windows["7d"].days, 7);
+    assert.deepEqual(
+      body.data.windows["7d"].subnets.map((entry) => entry.netuid),
+      [7, 8],
+    );
+    assert.equal(
+      body.data.windows["7d"].subnets[1].points[0].uptime_ratio,
+      0.8,
+    );
   });
 });
 

--- a/tests/network-routing.test.mjs
+++ b/tests/network-routing.test.mjs
@@ -91,6 +91,7 @@ describe("multi-network routing prefix (Phase 1)", () => {
 
     for (const route of [
       "/api/v1/registry/leaderboards",
+      "/api/v1/health/trends",
       "/api/v1/subnets/7/health/trends",
     ]) {
       const bare = await get(env, route);
@@ -237,7 +238,11 @@ describe("multi-network routing prefix (Phase 1)", () => {
     );
     assert.equal(leaderboards.res.status, 404);
 
-    // Numeric per-subnet dynamic route (D1-backed) is mainnet-only too.
+    // D1-backed health trend routes are mainnet-only too.
+    const bulkTrends = await get(env, "/api/v1/testnet/health/trends");
+    assert.equal(bulkTrends.res.status, 404);
+    assert.equal(bulkTrends.body.meta.network, "testnet");
+
     const trends = await get(env, "/api/v1/testnet/subnets/7/health/trends");
     assert.equal(trends.res.status, 404);
     assert.equal(trends.body.meta.network, "testnet");

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -52,6 +52,7 @@ import {
 import { findSurface, verifySurface } from "../src/surface-verify.mjs";
 import {
   buildGlobalHealth,
+  formatBulkTrends,
   formatGlobalIncidents,
   formatIncidents,
   formatLeaderboards,
@@ -87,6 +88,7 @@ import {
 import {
   ANALYTICS_WINDOW_PARAM,
   ANALYTICS_WINDOWS,
+  BULK_TRENDS_PATH_PATTERN,
   DAY_MS,
   DENIED_RPC_PREFIXES,
   EMBEDDING_SYNC_CRON,
@@ -352,6 +354,12 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     }
     // D1-backed health trends (slug-aware after resolution). Special-handled
     // rather than artifact-backed, like /api/v1/events.
+    const bulkTrendsMatch = BULK_TRENDS_PATH_PATTERN.exec(
+      resolved.url.pathname,
+    );
+    if (bulkTrendsMatch) {
+      return handleBulkHealthTrends(request, env);
+    }
     const trendsMatch = TRENDS_PATH_PATTERN.exec(resolved.url.pathname);
     if (trendsMatch) {
       return handleHealthTrends(request, env, Number(trendsMatch[1]));
@@ -422,6 +430,7 @@ function isMainnetOnlyApiPath(pathname) {
     pathname === "/api/v1/search/semantic" ||
     pathname === "/api/v1/registry/leaderboards" ||
     pathname.startsWith("/api/v1/webhooks/") ||
+    BULK_TRENDS_PATH_PATTERN.test(pathname) ||
     TRENDS_PATH_PATTERN.test(pathname) ||
     PERCENTILES_PATH_PATTERN.test(pathname) ||
     INCIDENTS_PATH_PATTERN.test(pathname) ||
@@ -1073,6 +1082,68 @@ async function handleApiRequest(
     ctx?.waitUntil?.(overlayCache.put(overlayCacheKey, response.clone()));
   }
   return response;
+}
+
+// D1-backed 7d/30d daily uptime + latency trends across all subnets. This is a
+// compact matrix feed for UI dashboards and agents, so it groups by netuid/day
+// instead of returning every surface series.
+async function handleBulkHealthTrends(request, env) {
+  const db = env.METAGRAPH_HEALTH_DB;
+  const nowMs = Date.now();
+  const windows = {};
+  const windowRows = await Promise.all(
+    Object.entries(HEALTH_TREND_WINDOWS).map(async ([label, days]) => {
+      if (!db?.prepare) {
+        return [label, []];
+      }
+      try {
+        const result = await withTimeout(
+          db
+            .prepare(
+              `SELECT netuid,
+                    date(checked_at / 1000, 'unixepoch') AS date,
+                    COUNT(*) AS total,
+                    SUM(ok) AS ok_count,
+                    AVG(latency_ms) AS avg_latency_ms
+             FROM surface_checks
+             WHERE checked_at >= ?
+             GROUP BY netuid, date
+             ORDER BY netuid, date`,
+            )
+            .bind(nowMs - days * DAY_MS)
+            .all(),
+          d1TimeoutMs(env),
+        );
+        return [label, result?.results || []];
+      } catch {
+        return [label, []];
+      }
+    }),
+  );
+  for (const [label, rows] of windowRows) {
+    windows[label] = rows;
+  }
+  const meta = await readHealthKv(env, KV_HEALTH_META);
+  const data = formatBulkTrends({
+    observedAt: meta?.last_run_at || null,
+    windows,
+    windowDays: HEALTH_TREND_WINDOWS,
+  });
+  return envelopeResponse(
+    request,
+    {
+      data,
+      meta: {
+        artifact_path: "/metagraph/health/trends.json",
+        cache: "short",
+        contract_version: contractVersion(env),
+        generated_at: data.observed_at,
+        published_at: await publishedAt(env),
+        source: "live-cron-prober",
+      },
+    },
+    "short",
+  );
 }
 
 // D1-backed 7d/30d uptime + latency trends for one subnet's operational

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -12,10 +12,12 @@ export const HEALTH_PRUNE_CRON = "0 * * * *";
 // Distinct minute (odd) so it never collides with the 2-minute probe or the
 // top-of-hour prune. Must match a wrangler.jsonc `triggers.crons` entry.
 export const EMBEDDING_SYNC_CRON = "37 3 * * *";
-// Trend windows for /api/v1/subnets/{netuid}/health/trends.
+// Trend windows for /api/v1/subnets/{netuid}/health/trends and
+// /api/v1/health/trends.
 export const RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN =
   /^\/metagraph\/health\/(?:latest\.json|summary\.json|subnets\/\d+\.json)$/;
 export const HEALTH_TREND_WINDOWS = { "7d": 7, "30d": 30 };
+export const BULK_TRENDS_PATH_PATTERN = /^\/api\/v1\/health\/trends$/;
 export const TRENDS_PATH_PATTERN =
   /^\/api\/v1\/subnets\/(\d+)\/health\/trends$/;
 export const PERCENTILES_PATH_PATTERN =


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/health/trends` for compact all-subnet 7d/30d daily uptime and latency trends.
- Registers the `BulkHealthTrendsArtifact` contract, OpenAPI schema, generated TypeScript types, API index, R2 manifest, and backend contract docs.
- Adds formatter, worker, D1 error/timeout, API smoke, network-prefix, and coverage-targeted fallback tests.

## What changed
- Queries D1 once per trend window and groups rows by `netuid` + day.
- Returns bounded subnet-level daily points instead of per-surface series.
- Keeps cold/unbound/throwing D1 behavior schema-stable with empty windows.
- Gates the route as mainnet-only under network prefixes.

## Why
- Closes #1121.
- Gives the frontend and agent/API consumers one bounded health trend matrix endpoint instead of requiring broad per-subnet fanout.

## Validation
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `npm run validate`
- `npm run validate:api`
- `npm run validate:schemas`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:openapi-examples`
- `npm run validate:generated-client`
- `npm run validate:docs`
- `npm run validate:contract-drift`
- `npm run validate:artifact-budgets`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## Notes
- `npm run pipeline:check` was started and passed local R2 staging, but was interrupted during the upstream `sync-subnets --dry-run` phase after several minutes without output. The deterministic local checks above were run separately after rebuilding.