### PR TITLE
feat(api): add rpc usage buckets

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -79,7 +79,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/subnets/{netuid}/uptime.json`: schema for the long-term daily uptime history per operational surface (90d/1y window), served live from the `surface_uptime_daily` D1 rollup at `GET /api/v1/subnets/{netuid}/uptime` (no static file).
 - `/metagraph/incidents.json`: schema for recent cross-subnet downtime incidents reconstructed from probe history, served live from D1 at `GET /api/v1/incidents` (no static file).
 - `/metagraph/registry/leaderboards.json`: schema for the registry leaderboards served live from D1 + registry projections at `GET /api/v1/registry/leaderboards` (no static file).
-- `/metagraph/rpc/usage.json`: schema for RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution), served live from the `rpc_proxy_events` D1 telemetry at `GET /api/v1/rpc/usage` (no static file).
+- `/metagraph/rpc/usage.json`: schema for RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets), served live from the `rpc_proxy_events` D1 telemetry at `GET /api/v1/rpc/usage` (no static file). `7d` uses 1-hour buckets; `30d` uses 6-hour buckets.
 - `/metagraph/schema-drift.json`: OpenAPI snapshot/drift status.
 - `/metagraph/schemas/index.json`: captured machine-readable schema index.
 - `/metagraph/schemas/{surface_id}.json`: captured machine-readable OpenAPI/Swagger schema snapshot detail. R2-backed.
@@ -115,7 +115,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/api/v1/subnets/{netuid}/trajectory`: fetch the week-over-week structural trajectory (completeness + counts) from daily snapshots (live from D1).
 - `/api/v1/subnets/{netuid}/uptime`: fetch long-term daily uptime history per operational surface over a 90d/1y window (live from the `surface_uptime_daily` D1 rollup).
 - `/api/v1/registry/leaderboards`: fetch registry leaderboards (`board=healthiest|fastest-rpc|most-complete|fastest-growing`, or omit for all).
-- `/api/v1/rpc/usage`: fetch RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution) over a 7d/30d window (live from the `rpc_proxy_events` D1 telemetry).
+- `/api/v1/rpc/usage`: fetch RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets) over a 7d/30d window (live from the `rpc_proxy_events` D1 telemetry). `7d` uses 1-hour buckets; `30d` uses 6-hour buckets.
 - `/api/v1/surfaces`: list curated public surfaces.
 - `/api/v1/subnets/{netuid}/surfaces`: list curated public surfaces for one subnet.
 - `/api/v1/endpoints`: list generalized endpoint resources and monitored public surfaces.

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -674,7 +674,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, and the per-endpoint request distribution — over a 7d or 30d window (computed live from D1 telemetry). */
+        /** Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets for heatmaps — over a 7d or 30d window (computed live from D1 telemetry). */
         get: operations["rpcUsage"];
         put?: never;
         post?: never;
@@ -2729,8 +2729,17 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
-        /** @description RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, and the per-endpoint request distribution. Computed live from the rpc_proxy_events telemetry (no static file). */
+        /** @description RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, per-endpoint request distribution, and bounded time buckets for heatmaps. Computed live from the rpc_proxy_events telemetry (no static file). */
         RpcUsageArtifact: {
+            bucket_granularity?: string | null;
+            buckets: ({
+                avg_latency_ms: number | null;
+                errors: number;
+                requests: number;
+                ts: number;
+            } & {
+                [key: string]: unknown;
+            })[];
             endpoints: ({
                 avg_latency_ms?: number | null;
                 endpoint_id: string | null;
@@ -9056,6 +9065,15 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "bucket_granularity": "example",
+                     *         "buckets": [
+                     *           {
+                     *             "avg_latency_ms": 120,
+                     *             "errors": 1,
+                     *             "requests": 1,
+                     *             "ts": 1
+                     *           }
+                     *         ],
                      *         "endpoints": [
                      *           {
                      *             "endpoint_id": "https://api.metagraph.sh/example",

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -208,7 +208,7 @@ Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1
 - `GET /api/v1/subnets/{netuid}/trajectory` — Fetch the week-over-week structural trajectory (completeness + surface/endpoint counts) for one subnet from daily snapshots (computed live from D1).
 - `GET /api/v1/subnets/{netuid}/uptime` — Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup).
 - `GET /api/v1/registry/leaderboards` — Fetch registry leaderboards (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing) computed live from D1 + registry projections. Omit `board` for all boards.
-- `GET /api/v1/rpc/usage` — Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, and the per-endpoint request distribution — over a 7d or 30d window (computed live from D1 telemetry).
+- `GET /api/v1/rpc/usage` — Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets for heatmaps — over a 7d or 30d window (computed live from D1 telemetry).
 - `GET /api/v1/freshness` — Fetch freshness and staleness state.
 - `GET /api/v1/source-health` — Fetch upstream source health.
 - `GET /api/v1/evidence` — Fetch public evidence ledger.

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -3517,7 +3517,7 @@
     {
       "artifact_path": "/metagraph/rpc/usage.json",
       "cache": "short",
-      "description": "Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, and the per-endpoint request distribution — over a 7d or 30d window (computed live from D1 telemetry).",
+      "description": "Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets for heatmaps — over a 7d or 30d window (computed live from D1 telemetry).",
       "id": "rpc-usage",
       "method": "GET",
       "path": "/api/v1/rpc/usage",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -462,7 +462,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
-      "description": "RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution) over a 7d/30d window, computed live from the rpc_proxy_events telemetry at /api/v1/rpc/usage (no static file).",
+      "description": "RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets) over a 7d/30d window, computed live from the rpc_proxy_events telemetry at /api/v1/rpc/usage (no static file).",
       "id": "rpc-usage",
       "path": "/metagraph/rpc/usage.json",
       "schema_ref": "#/components/schemas/RpcUsageArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -6818,8 +6818,47 @@
       },
       "RpcUsageArtifact": {
         "additionalProperties": true,
-        "description": "RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, and the per-endpoint request distribution. Computed live from the rpc_proxy_events telemetry (no static file).",
+        "description": "RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, per-endpoint request distribution, and bounded time buckets for heatmaps. Computed live from the rpc_proxy_events telemetry (no static file).",
         "properties": {
+          "bucket_granularity": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "buckets": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "avg_latency_ms": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "errors": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "requests": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "ts": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "ts",
+                "requests",
+                "errors",
+                "avg_latency_ms"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "endpoints": {
             "items": {
               "additionalProperties": true,
@@ -6998,7 +7037,8 @@
           "source",
           "summary",
           "endpoints",
-          "networks"
+          "networks",
+          "buckets"
         ],
         "type": "object"
       },
@@ -18541,6 +18581,15 @@
               "application/json": {
                 "example": {
                   "data": {
+                    "bucket_granularity": "example",
+                    "buckets": [
+                      {
+                        "avg_latency_ms": 120,
+                        "errors": 1,
+                        "requests": 1,
+                        "ts": 1
+                      }
+                    ],
                     "endpoints": [
                       {
                         "endpoint_id": "https://api.metagraph.sh/example",
@@ -18670,7 +18719,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, and the per-endpoint request distribution — over a 7d or 30d window (computed live from D1 telemetry).",
+        "summary": "Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets for heatmaps — over a 7d or 30d window (computed live from D1 telemetry).",
         "tags": [
           "rpc",
           "analytics",

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,14 +1,14 @@
 {
   "artifact_count": 5,
-  "artifact_size_bytes": 1381414,
+  "artifact_size_bytes": 1383613,
   "artifacts": [
     {
       "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "bdc778393c95d6749664627157f242e9a849f74b2aa9dc861184a90686e3e897",
-      "size_bytes": 105462,
+      "sha256": "37f97653da967dda33000b191c509047ab68b682d3b4990d0228bbfdf8dcffcc",
+      "size_bytes": 105485,
       "storage_tier": "dual"
     },
     {
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/contracts.json",
       "latest_key": "latest/contracts.json",
       "path": "/metagraph/contracts.json",
-      "sha256": "2d439f45b7d1c49f82d84ddacc6ea8b07f2db707d72b476254db1ed8a125d583",
-      "size_bytes": 28097,
+      "sha256": "4da0dd81e945038f95966681c8cd2f97a0ba0947c1b1fd6e7c9c27c4db7e2013",
+      "size_bytes": 28123,
       "storage_tier": "dual"
     },
     {
@@ -25,8 +25,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "5ba46f53d80a07509bd96c1859cfd1f26126ea91fd73167b3c08b8e903b204fb",
-      "size_bytes": 697294,
+      "sha256": "6d01686ae6746f15b53e71d544a4db777af3d0550247480e94734bf9c1e7fc69",
+      "size_bytes": 698690,
       "storage_tier": "dual"
     },
     {
@@ -43,8 +43,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "2108e047b6bb0bd6fcfccd7700e2ae70f56fe67b0eb51c67199239ef6f3e8a24",
-      "size_bytes": 526596,
+      "sha256": "23aaa99e95f1d04c6ab99a1b0d8fd38e49feeaaa84a26e8b8c6d5ed6ebbc935b",
+      "size_bytes": 527350,
       "storage_tier": "dual"
     }
   ],
@@ -52,7 +52,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 2183,
-  "full_artifact_size_bytes": 38232178,
+  "full_artifact_size_bytes": 38234377,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -74,7 +74,7 @@
     "r2": 2178
   },
   "storage_tier_size_bytes": {
-    "dual": 1381414,
+    "dual": 1383613,
     "r2": 36850764
   }
 }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -674,7 +674,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, and the per-endpoint request distribution — over a 7d or 30d window (computed live from D1 telemetry). */
+        /** Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets for heatmaps — over a 7d or 30d window (computed live from D1 telemetry). */
         get: operations["rpcUsage"];
         put?: never;
         post?: never;
@@ -2729,8 +2729,17 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
-        /** @description RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, and the per-endpoint request distribution. Computed live from the rpc_proxy_events telemetry (no static file). */
+        /** @description RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, per-endpoint request distribution, and bounded time buckets for heatmaps. Computed live from the rpc_proxy_events telemetry (no static file). */
         RpcUsageArtifact: {
+            bucket_granularity?: string | null;
+            buckets: ({
+                avg_latency_ms: number | null;
+                errors: number;
+                requests: number;
+                ts: number;
+            } & {
+                [key: string]: unknown;
+            })[];
             endpoints: ({
                 avg_latency_ms?: number | null;
                 endpoint_id: string | null;
@@ -9056,6 +9065,15 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "bucket_granularity": "example",
+                     *         "buckets": [
+                     *           {
+                     *             "avg_latency_ms": 120,
+                     *             "errors": 1,
+                     *             "requests": 1,
+                     *             "ts": 1
+                     *           }
+                     *         ],
                      *         "endpoints": [
                      *           {
                      *             "endpoint_id": "https://api.metagraph.sh/example",

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -6796,8 +6796,47 @@
       },
       "RpcUsageArtifact": {
         "additionalProperties": true,
-        "description": "RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, and the per-endpoint request distribution. Computed live from the rpc_proxy_events telemetry (no static file).",
+        "description": "RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, per-endpoint request distribution, and bounded time buckets for heatmaps. Computed live from the rpc_proxy_events telemetry (no static file).",
         "properties": {
+          "bucket_granularity": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "buckets": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "avg_latency_ms": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "errors": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "requests": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "ts": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "ts",
+                "requests",
+                "errors",
+                "avg_latency_ms"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "endpoints": {
             "items": {
               "additionalProperties": true,
@@ -6976,7 +7015,8 @@
           "source",
           "summary",
           "endpoints",
-          "networks"
+          "networks",
+          "buckets"
         ],
         "type": "object"
       },

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -711,17 +711,19 @@
       },
       "RpcUsageArtifact": {
         "type": "object",
-        "description": "RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, and the per-endpoint request distribution. Computed live from the rpc_proxy_events telemetry (no static file).",
+        "description": "RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, per-endpoint request distribution, and bounded time buckets for heatmaps. Computed live from the rpc_proxy_events telemetry (no static file).",
         "required": [
           "schema_version",
           "source",
           "summary",
           "endpoints",
-          "networks"
+          "networks",
+          "buckets"
         ],
         "properties": {
           "schema_version": { "type": "integer" },
           "window": { "type": ["string", "null"] },
+          "bucket_granularity": { "type": ["string", "null"] },
           "observed_at": { "type": ["string", "null"] },
           "source": { "type": "string" },
           "summary": {
@@ -775,6 +777,20 @@
                 "requests": { "type": "integer", "minimum": 0 },
                 "ok_requests": { "type": "integer", "minimum": 0 },
                 "error_rate": { "type": ["number", "null"] }
+              },
+              "additionalProperties": true
+            }
+          },
+          "buckets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["ts", "requests", "errors", "avg_latency_ms"],
+              "properties": {
+                "ts": { "type": "integer", "minimum": 0 },
+                "requests": { "type": "integer", "minimum": 0 },
+                "errors": { "type": "integer", "minimum": 0 },
+                "avg_latency_ms": { "type": ["integer", "null"] }
               },
               "additionalProperties": true
             }

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -98,6 +98,8 @@ const checks = [
     (body) => {
       assert.equal(body.data.source, "rpc-proxy");
       assert.equal(typeof body.data.summary.total_requests, "number");
+      assert.equal(typeof body.data.bucket_granularity, "string");
+      assert.equal(Array.isArray(body.data.buckets), true);
       assert.equal(Array.isArray(body.data.endpoints), true);
       assert.equal(Array.isArray(body.data.networks), true);
     },

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -837,7 +837,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "rpc-usage",
     "/metagraph/rpc/usage.json",
-    "RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution) over a 7d/30d window, computed live from the rpc_proxy_events telemetry at /api/v1/rpc/usage (no static file).",
+    "RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets) over a 7d/30d window, computed live from the rpc_proxy_events telemetry at /api/v1/rpc/usage (no static file).",
     "RpcUsageArtifact",
   ),
   artifact(
@@ -1429,7 +1429,7 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/rpc/usage",
     "/metagraph/rpc/usage.json",
-    "Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, and the per-endpoint request distribution — over a 7d or 30d window (computed live from D1 telemetry).",
+    "Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets for heatmaps — over a 7d or 30d window (computed live from D1 telemetry).",
     "short",
     ["rpc", "analytics", "operations"],
     [{ name: "window", schema: { type: "string", enum: ["7d", "30d"] } }],

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -449,8 +449,9 @@ export function formatPercentiles({ netuid, window, observedAt, rows }) {
 // `totals`: one aggregate row { total, ok_count, failover_count, cache_hits,
 // avg_latency_ms }. `latency`: one row { p50, p95 } (window percentiles).
 // `endpointRows`/`networkRows`: per-endpoint / per-network breakdowns ordered by
-// request volume. Cold/unmigrated D1 yields a schema-stable zeroed payload (every
-// arg may be empty/undefined), so the route never errors before the table exists.
+// request volume. `bucketRows`: bounded time buckets for heatmaps. Cold/
+// unmigrated D1 yields a schema-stable zeroed payload (every arg may be
+// empty/undefined), so the route never errors before the table exists.
 export function formatRpcUsage({
   window,
   observedAt,
@@ -458,6 +459,8 @@ export function formatRpcUsage({
   latency,
   endpointRows,
   networkRows,
+  bucketRows,
+  bucketGranularity,
 }) {
   const total = Number(totals?.total) || 0;
   const okCount = Number(totals?.ok_count) || 0;
@@ -469,6 +472,7 @@ export function formatRpcUsage({
   return {
     schema_version: 1,
     window: window || null,
+    bucket_granularity: bucketGranularity || null,
     observed_at: observedAt || null,
     source: "rpc-proxy",
     summary: {
@@ -509,6 +513,18 @@ export function formatRpcUsage({
         error_rate: ratioOf(requests - ok, requests),
       };
     }),
+    buckets: (bucketRows || [])
+      .map((row) => {
+        const ts = Number(row.ts);
+        if (!Number.isFinite(ts)) return null;
+        return {
+          ts: Math.trunc(ts),
+          requests: Number(row.requests) || 0,
+          errors: Math.max(0, Number(row.errors) || 0),
+          avg_latency_ms: roundInt(row.avg_latency_ms),
+        };
+      })
+      .filter(Boolean),
   };
 }
 

--- a/tests/rpc-usage.test.mjs
+++ b/tests/rpc-usage.test.mjs
@@ -16,13 +16,16 @@ describe("formatRpcUsage", () => {
     assert.equal(out.summary.error_rate, null); // no requests → undefined rate
     assert.equal(out.summary.cache_hit_rate, null);
     assert.equal(out.summary.latency_ms.p50, null);
+    assert.equal(out.bucket_granularity, null);
+    assert.deepEqual(out.buckets, []);
     assert.deepEqual(out.endpoints, []);
     assert.deepEqual(out.networks, []);
   });
 
-  test("computes rates, ranks endpoints, and rounds latency", () => {
+  test("computes rates, ranks endpoints, and rounds latency/buckets", () => {
     const out = formatRpcUsage({
       window: "30d",
+      bucketGranularity: "6h",
       observedAt: "2026-06-14T00:00:00Z",
       totals: {
         total: 1000,
@@ -52,7 +55,28 @@ describe("formatRpcUsage", () => {
         { network: "finney", requests: 900, ok_count: 870 },
         { network: "test", requests: 100, ok_count: 80 },
       ],
+      bucketRows: [
+        {
+          ts: 1_718_323_200_000,
+          requests: 100,
+          errors: 3,
+          avg_latency_ms: 120.4,
+        },
+        {
+          ts: 1_718_344_800_000,
+          requests: undefined,
+          errors: undefined,
+          avg_latency_ms: null,
+        },
+        {
+          ts: "bad",
+          requests: 10,
+          errors: 10,
+          avg_latency_ms: 999,
+        },
+      ],
     });
+    assert.equal(out.bucket_granularity, "6h");
     assert.equal(out.summary.error_requests, 50);
     assert.equal(out.summary.error_rate, 0.05);
     assert.equal(out.summary.failover_rate, 0.04);
@@ -70,6 +94,20 @@ describe("formatRpcUsage", () => {
     assert.equal(out.endpoints[1].avg_latency_ms, 221);
     assert.equal(out.networks[1].network, "test");
     assert.equal(out.networks[1].error_rate, 0.2);
+    assert.deepEqual(out.buckets, [
+      {
+        ts: 1_718_323_200_000,
+        requests: 100,
+        errors: 3,
+        avg_latency_ms: 120,
+      },
+      {
+        ts: 1_718_344_800_000,
+        requests: 0,
+        errors: 0,
+        avg_latency_ms: null,
+      },
+    ]);
   });
 
   test("a zero-request endpoint/network row reports a null rate (no divide-by-zero)", () => {
@@ -155,6 +193,18 @@ describe("/api/v1/rpc/usage route", () => {
                 results: [{ network: "finney", requests: 500, ok_count: 480 }],
               };
             }
+            if (sql.includes("GROUP BY ts")) {
+              return {
+                results: [
+                  {
+                    ts: 1_718_323_200_000,
+                    requests: 120,
+                    errors: 5,
+                    avg_latency_ms: 155.6,
+                  },
+                ],
+              };
+            }
             return { results: [] };
           },
         }),
@@ -172,6 +222,41 @@ describe("/api/v1/rpc/usage route", () => {
     assert.equal(body.data.summary.latency_ms.p95, 430);
     assert.equal(body.data.endpoints[0].endpoint_id, "fx");
     assert.equal(body.data.networks[0].network, "finney");
+    assert.equal(body.data.bucket_granularity, "6h");
+    assert.deepEqual(body.data.buckets, [
+      {
+        ts: 1_718_323_200_000,
+        requests: 120,
+        errors: 5,
+        avg_latency_ms: 156,
+      },
+    ]);
+  });
+
+  test("uses bounded bucket params per window", async () => {
+    const calls = [];
+    const usageDb = {
+      prepare: (sql) => ({
+        bind: (...params) => ({
+          async all() {
+            calls.push({ sql, params });
+            return { results: [] };
+          },
+        }),
+      }),
+    };
+    const env = { ...createLocalArtifactEnv(), METAGRAPH_HEALTH_DB: usageDb };
+    const { status, body } = await getJson(
+      "https://api.metagraph.sh/api/v1/rpc/usage",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.bucket_granularity, "1h");
+    const bucketCall = calls.find((call) => call.sql.includes("GROUP BY ts"));
+    assert.ok(bucketCall);
+    assert.equal(bucketCall.params[0], 60 * 60 * 1000);
+    assert.equal(bucketCall.params[1], 60 * 60 * 1000);
+    assert.equal(bucketCall.params[3], 7 * 24);
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -104,6 +104,7 @@ import {
   MAX_WEBHOOK_BODY_BYTES,
   PERCENTILES_PATH_PATTERN,
   RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN,
+  RPC_USAGE_BUCKETS,
   SAFE_RPC_METHODS,
   TRAJECTORY_PATH_PATTERN,
   TRENDS_PATH_PATTERN,
@@ -1714,7 +1715,8 @@ async function handleRpcUsage(request, env, url) {
   const { label, days, error } = analyticsWindow(url);
   if (error) return analyticsQueryError(error);
   const since = Date.now() - days * DAY_MS;
-  const [totalsRows, latencyRows, endpointRows, networkRows] =
+  const bucketConfig = RPC_USAGE_BUCKETS[label];
+  const [totalsRows, latencyRows, endpointRows, networkRows, bucketRows] =
     await Promise.all([
       d1All(
         env,
@@ -1765,6 +1767,24 @@ async function handleRpcUsage(request, env, url) {
          ORDER BY requests DESC`,
         [since],
       ),
+      d1All(
+        env,
+        `SELECT CAST(observed_at / ? AS INTEGER) * ? AS ts,
+                COUNT(*) AS requests,
+                SUM(CASE WHEN ok = 1 THEN 0 ELSE 1 END) AS errors,
+                AVG(latency_ms) AS avg_latency_ms
+         FROM rpc_proxy_events
+         WHERE observed_at >= ?
+         GROUP BY ts
+         ORDER BY ts ASC
+         LIMIT ?`,
+        [
+          bucketConfig.bucketMs,
+          bucketConfig.bucketMs,
+          since,
+          bucketConfig.maxBuckets,
+        ],
+      ),
     ]);
   const meta = await readHealthKv(env, KV_HEALTH_META);
   const data = formatRpcUsage({
@@ -1774,6 +1794,8 @@ async function handleRpcUsage(request, env, url) {
     latency: latencyRows[0],
     endpointRows,
     networkRows,
+    bucketRows,
+    bucketGranularity: bucketConfig.granularity,
   });
   return envelopeResponse(
     request,

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -31,6 +31,14 @@ export const UPTIME_WINDOWS = { "90d": 90, "1y": 365 };
 export const MAX_UPTIME_ROWS = 10000;
 export const ANALYTICS_WINDOWS = { "7d": 7, "30d": 30 };
 export const ANALYTICS_WINDOW_PARAM = "window";
+export const RPC_USAGE_BUCKETS = {
+  "7d": { granularity: "1h", bucketMs: 60 * 60 * 1000, maxBuckets: 7 * 24 },
+  "30d": {
+    granularity: "6h",
+    bucketMs: 6 * 60 * 60 * 1000,
+    maxBuckets: 30 * 4,
+  },
+};
 export const MAX_INCIDENT_ROWS = 1000;
 export const MAX_GLOBAL_INCIDENT_SOURCE_ROWS = 5000;
 export const DAY_MS = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary
- Adds bounded time buckets to `GET /api/v1/rpc/usage` for UI heatmaps.
- Exposes `bucket_granularity` and `buckets[]` in the RPC usage contract, schema, OpenAPI, generated types, API index, llms text, and backend docs.
- Adds formatter and route tests for bucket output, invalid bucket filtering, and bounded D1 query params.

## What changed
- `7d` usage responses use 1-hour buckets with a 168-bucket cap.
- `30d` usage responses use 6-hour buckets with a 120-bucket cap.
- Bucket rows include `{ ts, requests, errors, avg_latency_ms }` and are computed live from `rpc_proxy_events`.

## Why
- Closes #1123.
- Gives the frontend and agent/API consumers a bounded time-series feed without broad client-side polling or unbounded D1 responses.

## Validation
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `npm run validate`
- `npm run validate:api`
- `npm run validate:schemas`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:openapi-examples`
- `npm run validate:generated-client`
- `npm run validate:docs`
- `npm run validate:contract-drift`
- `npm run validate:artifact-budgets`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
