### PR TITLE
feat(api): stabilize endpoint ids

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -36,8 +36,8 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/profiles/{netuid}.json`: per-subnet public-safe profile detail. R2-backed.
 - `/metagraph/surfaces.json`: curated public surfaces only.
 - `/metagraph/surfaces/{netuid}.json`: curated public surfaces for one subnet. R2-backed.
-- `/metagraph/endpoints.json`: generalized endpoint/resource registry derived from curated surfaces and probe observations.
-- `/metagraph/endpoints/{netuid}.json`: generalized endpoint/resource registry for one subnet. R2-backed.
+- `/metagraph/endpoints.json`: generalized endpoint/resource registry derived from curated surfaces and probe observations. Endpoint `id` values derive from stable `surface_key` values; `surface_id` remains the human-readable surface alias.
+- `/metagraph/endpoints/{netuid}.json`: generalized endpoint/resource registry for one subnet. R2-backed. Endpoint `id` values derive from stable `surface_key` values; `surface_id` remains the human-readable surface alias.
 - `/metagraph/candidates.json`: unpromoted candidate surfaces from public discovery. R2-backed.
 - `/metagraph/candidates/{netuid}.json`: unpromoted candidate surfaces for one subnet. R2-backed.
 - `/metagraph/review-queue.json`: candidate surfaces queued for maintainer review. R2-backed.
@@ -66,8 +66,8 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/health/badges/{netuid}.json`: badge data for future metagraph.sh renderers. R2-backed.
 - `/metagraph/rpc-endpoints.json`: Bittensor base-layer RPC/WSS endpoint registry and probe status.
 - `/metagraph/rpc/pools.json`: endpoint pool scoring for future read-only routing.
-- `/metagraph/endpoint-pools.json`: generalized endpoint pool scoring for future read-only routing.
-- `/metagraph/endpoint-incidents.json`: probe-derived endpoint incident summary and active endpoint failures.
+- `/metagraph/endpoint-pools.json`: generalized endpoint pool scoring for future read-only routing; pool entries include `surface_id` and `surface_key` when backed by catalogued surfaces.
+- `/metagraph/endpoint-incidents.json`: probe-derived endpoint incident summary and active endpoint failures; incidents include the human `surface_id` alias plus stable `surface_key`.
 - `/metagraph/operational-surfaces.json`: operational surfaces (RPC/WSS/subnet-api/SSE/data-artifact) probed live by the 2-minute Cloudflare cron health prober; the prober's input list, served from the committed assets.
 - `/metagraph/agent-catalog.json`: compact index of subnets exposing callable services for AI agents (per subnet: service kinds + callable count). Committed.
 - `/metagraph/agent-catalog/{netuid}.json`: per-subnet agent capability catalog — each callable service with base URL, auth, machine-readable schema, and build-time health/eligibility. R2-backed.

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1520,6 +1520,8 @@ export interface components {
             subnet_name?: string;
             subnet_slug?: string;
             surface_id: string;
+            /** @description Stable surface identity (#1005): hash of netuid|kind|url for the affected surface. */
+            surface_key: string;
             user_reported: boolean;
         };
         EndpointIncidentsArtifact: components["schemas"]["ArtifactBase"] & ({
@@ -1603,6 +1605,8 @@ export interface components {
             subnet_name?: string;
             subnet_slug?: string;
             surface_id: string;
+            /** @description Stable surface identity (#1005): hash of netuid|kind|url. Endpoint ids derive from this value so display slug renames do not break endpoint links. */
+            surface_key: string;
             /** Format: uri */
             url: string;
         };
@@ -2697,6 +2701,10 @@ export interface components {
             score: number;
             score_reasons?: components["schemas"]["EndpointScoreReason"][];
             status: components["schemas"]["HealthStatus"];
+            /** @description Human-readable surface alias retained for display/back-compat. */
+            surface_id?: string;
+            /** @description Stable surface identity (#1005) when the pool endpoint came from a catalogued surface. */
+            surface_key?: string;
             /** Format: uri */
             url: string;
         };
@@ -5158,6 +5166,7 @@ export interface operations {
                      *             "state": "active",
                      *             "status": "ok",
                      *             "surface_id": "example",
+                     *             "surface_key": "example",
                      *             "user_reported": false
                      *           }
                      *         ],
@@ -5476,6 +5485,7 @@ export interface operations {
                      *             "score": 100,
                      *             "status": "ok",
                      *             "surface_id": "example",
+                     *             "surface_key": "example",
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
@@ -7361,6 +7371,7 @@ export interface operations {
                      *             "score": 100,
                      *             "status": "ok",
                      *             "surface_id": "example",
+                     *             "surface_key": "example",
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
@@ -9877,6 +9888,7 @@ export interface operations {
                      *             "score": 100,
                      *             "status": "ok",
                      *             "surface_id": "example",
+                     *             "surface_key": "example",
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
@@ -10240,6 +10252,7 @@ export interface operations {
                      *             "score": 100,
                      *             "status": "ok",
                      *             "surface_id": "example",
+                     *             "surface_key": "example",
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
@@ -11515,6 +11528,7 @@ export interface operations {
                      *             "score": 100,
                      *             "status": "ok",
                      *             "surface_id": "example",
+                     *             "surface_key": "example",
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1836,6 +1836,10 @@
           "surface_id": {
             "type": "string"
           },
+          "surface_key": {
+            "description": "Stable surface identity (#1005): hash of netuid|kind|url for the affected surface.",
+            "type": "string"
+          },
           "user_reported": {
             "type": "boolean"
           }
@@ -1844,6 +1848,7 @@
           "id",
           "endpoint_id",
           "surface_id",
+          "surface_key",
           "netuid",
           "layer",
           "kind",
@@ -2217,6 +2222,10 @@
           "surface_id": {
             "type": "string"
           },
+          "surface_key": {
+            "description": "Stable surface identity (#1005): hash of netuid|kind|url. Endpoint ids derive from this value so display slug renames do not break endpoint links.",
+            "type": "string"
+          },
           "url": {
             "format": "uri",
             "type": "string"
@@ -2225,6 +2234,7 @@
         "required": [
           "id",
           "surface_id",
+          "surface_key",
           "netuid",
           "layer",
           "kind",
@@ -6706,6 +6716,14 @@
           },
           "status": {
             "$ref": "#/components/schemas/HealthStatus"
+          },
+          "surface_id": {
+            "description": "Human-readable surface alias retained for display/back-compat.",
+            "type": "string"
+          },
+          "surface_key": {
+            "description": "Stable surface identity (#1005) when the pool endpoint came from a catalogued surface.",
+            "type": "string"
           },
           "url": {
             "format": "uri",
@@ -12227,6 +12245,7 @@
                         "state": "active",
                         "status": "ok",
                         "surface_id": "example",
+                        "surface_key": "example",
                         "user_reported": false
                       }
                     ],
@@ -12777,6 +12796,7 @@
                         "score": 100,
                         "status": "ok",
                         "surface_id": "example",
+                        "surface_key": "example",
                         "url": "https://api.metagraph.sh/example"
                       }
                     ],
@@ -15581,6 +15601,7 @@
                         "score": 100,
                         "status": "ok",
                         "surface_id": "example",
+                        "surface_key": "example",
                         "url": "https://api.metagraph.sh/example"
                       }
                     ],
@@ -19741,6 +19762,7 @@
                         "score": 100,
                         "status": "ok",
                         "surface_id": "example",
+                        "surface_key": "example",
                         "url": "https://api.metagraph.sh/example"
                       }
                     ],
@@ -20371,6 +20393,7 @@
                         "score": 100,
                         "status": "ok",
                         "surface_id": "example",
+                        "surface_key": "example",
                         "url": "https://api.metagraph.sh/example"
                       }
                     ],
@@ -22104,6 +22127,7 @@
                         "score": 100,
                         "status": "ok",
                         "surface_id": "example",
+                        "surface_key": "example",
                         "url": "https://api.metagraph.sh/example"
                       }
                     ],

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 5,
-  "artifact_size_bytes": 1383613,
+  "artifact_size_bytes": 1385745,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -25,8 +25,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "6d01686ae6746f15b53e71d544a4db777af3d0550247480e94734bf9c1e7fc69",
-      "size_bytes": 698690,
+      "sha256": "9ef7f79924145a8be00f2860def10be707412c86f2c44d9dae4afb117356af60",
+      "size_bytes": 699815,
       "storage_tier": "dual"
     },
     {
@@ -43,8 +43,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "23aaa99e95f1d04c6ab99a1b0d8fd38e49feeaaa84a26e8b8c6d5ed6ebbc935b",
-      "size_bytes": 527350,
+      "sha256": "853057dfdfe8d2e472ac7e167069f04fa55dd89b572cf57522cfe44571e27005",
+      "size_bytes": 528357,
       "storage_tier": "dual"
     }
   ],
@@ -52,7 +52,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 2183,
-  "full_artifact_size_bytes": 38234377,
+  "full_artifact_size_bytes": 37266740,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -74,7 +74,7 @@
     "r2": 2178
   },
   "storage_tier_size_bytes": {
-    "dual": 1383613,
-    "r2": 36850764
+    "dual": 1385745,
+    "r2": 35880995
   }
 }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1520,6 +1520,8 @@ export interface components {
             subnet_name?: string;
             subnet_slug?: string;
             surface_id: string;
+            /** @description Stable surface identity (#1005): hash of netuid|kind|url for the affected surface. */
+            surface_key: string;
             user_reported: boolean;
         };
         EndpointIncidentsArtifact: components["schemas"]["ArtifactBase"] & ({
@@ -1603,6 +1605,8 @@ export interface components {
             subnet_name?: string;
             subnet_slug?: string;
             surface_id: string;
+            /** @description Stable surface identity (#1005): hash of netuid|kind|url. Endpoint ids derive from this value so display slug renames do not break endpoint links. */
+            surface_key: string;
             /** Format: uri */
             url: string;
         };
@@ -2697,6 +2701,10 @@ export interface components {
             score: number;
             score_reasons?: components["schemas"]["EndpointScoreReason"][];
             status: components["schemas"]["HealthStatus"];
+            /** @description Human-readable surface alias retained for display/back-compat. */
+            surface_id?: string;
+            /** @description Stable surface identity (#1005) when the pool endpoint came from a catalogued surface. */
+            surface_key?: string;
             /** Format: uri */
             url: string;
         };
@@ -5158,6 +5166,7 @@ export interface operations {
                      *             "state": "active",
                      *             "status": "ok",
                      *             "surface_id": "example",
+                     *             "surface_key": "example",
                      *             "user_reported": false
                      *           }
                      *         ],
@@ -5476,6 +5485,7 @@ export interface operations {
                      *             "score": 100,
                      *             "status": "ok",
                      *             "surface_id": "example",
+                     *             "surface_key": "example",
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
@@ -7361,6 +7371,7 @@ export interface operations {
                      *             "score": 100,
                      *             "status": "ok",
                      *             "surface_id": "example",
+                     *             "surface_key": "example",
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
@@ -9877,6 +9888,7 @@ export interface operations {
                      *             "score": 100,
                      *             "status": "ok",
                      *             "surface_id": "example",
+                     *             "surface_key": "example",
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
@@ -10240,6 +10252,7 @@ export interface operations {
                      *             "score": 100,
                      *             "status": "ok",
                      *             "surface_id": "example",
+                     *             "surface_key": "example",
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
@@ -11515,6 +11528,7 @@ export interface operations {
                      *             "score": 100,
                      *             "status": "ok",
                      *             "surface_id": "example",
+                     *             "surface_key": "example",
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -1822,6 +1822,10 @@
           "surface_id": {
             "type": "string"
           },
+          "surface_key": {
+            "description": "Stable surface identity (#1005): hash of netuid|kind|url for the affected surface.",
+            "type": "string"
+          },
           "user_reported": {
             "type": "boolean"
           }
@@ -1830,6 +1834,7 @@
           "id",
           "endpoint_id",
           "surface_id",
+          "surface_key",
           "netuid",
           "layer",
           "kind",
@@ -2203,6 +2208,10 @@
           "surface_id": {
             "type": "string"
           },
+          "surface_key": {
+            "description": "Stable surface identity (#1005): hash of netuid|kind|url. Endpoint ids derive from this value so display slug renames do not break endpoint links.",
+            "type": "string"
+          },
           "url": {
             "format": "uri",
             "type": "string"
@@ -2211,6 +2220,7 @@
         "required": [
           "id",
           "surface_id",
+          "surface_key",
           "netuid",
           "layer",
           "kind",
@@ -6684,6 +6694,14 @@
           },
           "status": {
             "$ref": "#/components/schemas/HealthStatus"
+          },
+          "surface_id": {
+            "description": "Human-readable surface alias retained for display/back-compat.",
+            "type": "string"
+          },
+          "surface_key": {
+            "description": "Stable surface identity (#1005) when the pool endpoint came from a catalogued surface.",
+            "type": "string"
           },
           "url": {
             "format": "uri",

--- a/schemas/components/07-endpoints-rpc.schema.json
+++ b/schemas/components/07-endpoints-rpc.schema.json
@@ -188,6 +188,14 @@
           "id": {
             "type": "string"
           },
+          "surface_id": {
+            "type": "string",
+            "description": "Human-readable surface alias retained for display/back-compat."
+          },
+          "surface_key": {
+            "type": "string",
+            "description": "Stable surface identity (#1005) when the pool endpoint came from a catalogued surface."
+          },
           "kind": {
             "$ref": "#/components/schemas/SurfaceKind"
           },
@@ -276,6 +284,7 @@
         "required": [
           "id",
           "surface_id",
+          "surface_key",
           "netuid",
           "layer",
           "kind",
@@ -301,6 +310,10 @@
           },
           "surface_id": {
             "type": "string"
+          },
+          "surface_key": {
+            "type": "string",
+            "description": "Stable surface identity (#1005): hash of netuid|kind|url. Endpoint ids derive from this value so display slug renames do not break endpoint links."
           },
           "netuid": {
             "type": "integer",
@@ -520,6 +533,7 @@
           "id",
           "endpoint_id",
           "surface_id",
+          "surface_key",
           "netuid",
           "layer",
           "kind",
@@ -549,6 +563,10 @@
           },
           "surface_id": {
             "type": "string"
+          },
+          "surface_key": {
+            "type": "string",
+            "description": "Stable surface identity (#1005): hash of netuid|kind|url for the affected surface."
           },
           "netuid": {
             "type": "integer",

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -2212,6 +2212,7 @@ export function buildEndpointResourceArtifact({
     healthSurfaces.map((surface) => [surface.surface_id, surface]),
   );
   const endpoints = surfaces.map((surface) => {
+    const surfaceKey = surface.key || surfaceStableKey(surface);
     const health = healthBySurface.get(surface.id) || {};
     const monitored = surface.probe?.enabled === true && surface.public_safe;
     const healthMeta = endpointHealthMetadata({
@@ -2229,8 +2230,9 @@ export function buildEndpointResourceArtifact({
     });
 
     return {
-      id: `endpoint-${surface.id}`,
+      id: `endpoint-${surfaceKey}`,
       surface_id: surface.id,
+      surface_key: surfaceKey,
       netuid: surface.netuid,
       subnet_slug: surface.subnet_slug,
       subnet_name: surface.subnet_name,
@@ -2425,6 +2427,8 @@ function endpointPool(id, kind, endpoints) {
     endpoints: poolEndpoints.map((endpoint) => ({
       archive_support: endpoint.archive_support,
       id: endpoint.id,
+      surface_id: endpoint.surface_id,
+      surface_key: endpoint.surface_key,
       kind: endpoint.kind,
       layer: endpoint.layer || endpointLayer(endpoint.kind),
       health_source: endpoint.health_source || "missing-probe",
@@ -2477,6 +2481,7 @@ export function buildEndpointIncidentArtifact({
         id: `incident-${endpoint.id}`,
         endpoint_id: endpoint.id,
         surface_id: endpoint.surface_id,
+        surface_key: endpoint.surface_key,
         netuid: endpoint.netuid,
         subnet_slug: endpoint.subnet_slug,
         subnet_name: endpoint.subnet_name,

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -1573,6 +1573,14 @@ describe("script utility contracts", () => {
       source: "fixture",
     });
     assert.equal(endpointResources.summary.endpoint_count, 7);
+    const rootRpcSurface = surfaces.find(
+      (surface) => surface.id === "root-rpc",
+    );
+    const rootRpcEndpoint = endpointResources.endpoints.find(
+      (endpoint) => endpoint.surface_id === "root-rpc",
+    );
+    assert.equal(rootRpcEndpoint.surface_key, rootRpcSurface.key);
+    assert.equal(rootRpcEndpoint.id, `endpoint-${rootRpcSurface.key}`);
     assert.equal(
       endpointResources.endpoints.find(
         (endpoint) => endpoint.surface_id === "root-docs",
@@ -1690,6 +1698,13 @@ describe("script utility contracts", () => {
       ),
       true,
     );
+    assert.equal(
+      generalizedPools.pools
+        .find((pool) => pool.id === "finney-rpc")
+        .endpoints.find((endpoint) => endpoint.surface_id === "root-rpc")
+        .surface_key,
+      rootRpcSurface.key,
+    );
 
     const incidents = buildEndpointIncidentArtifact({
       endpointArtifact: endpointResources,
@@ -1697,14 +1712,21 @@ describe("script utility contracts", () => {
       contractVersion: "test",
     });
     assert.equal(incidents.summary.incident_count, 2);
+    const failedEndpoint = endpointResources.endpoints.find(
+      (endpoint) => endpoint.surface_id === "root-failed-rpc",
+    );
+    const degradedEndpoint = endpointResources.endpoints.find(
+      (endpoint) => endpoint.surface_id === "root-degraded-rpc",
+    );
+    assert.equal(incidents.incidents[0].endpoint_id, failedEndpoint.id);
     assert.equal(
-      incidents.incidents[0].endpoint_id,
-      "endpoint-root-failed-rpc",
+      incidents.incidents[0].surface_key,
+      failedEndpoint.surface_key,
     );
     assert.equal(incidents.incidents[0].severity, "critical");
     assert.equal(
       incidents.incidents.find(
-        (incident) => incident.endpoint_id === "endpoint-root-degraded-rpc",
+        (incident) => incident.endpoint_id === degradedEndpoint.id,
       ).severity,
       "warning",
     );
@@ -1714,6 +1736,70 @@ describe("script utility contracts", () => {
     assert.equal(
       incidents.incidents[0].observed_at,
       "1970-01-01T00:00:00.000Z",
+    );
+  });
+
+  test("endpoint resources keep stable ids across display slug renames", () => {
+    const buildRenamedEndpoint = (surfaceId) =>
+      buildEndpointResourceArtifact({
+        surfaces: flattenSurfaces([
+          {
+            netuid: 7,
+            slug: "allways",
+            name: "Allways",
+            surfaces: [
+              {
+                id: surfaceId,
+                kind: "subnet-api",
+                url: "https://api.allways.example.com/v1",
+                provider: "allways",
+                authority: "official",
+                auth_required: false,
+                public_safe: true,
+                probe: { enabled: true, method: "GET", expect: "json" },
+              },
+            ],
+          },
+        ]),
+        generatedAt: "1970-01-01T00:00:00.000Z",
+        contractVersion: "test",
+        source: "fixture",
+      }).endpoints[0];
+
+    const before = buildRenamedEndpoint("sn-7-allways-api");
+    const afterRename = buildRenamedEndpoint("sn-7-allways-public-api");
+
+    assert.equal(before.surface_id, "sn-7-allways-api");
+    assert.equal(afterRename.surface_id, "sn-7-allways-public-api");
+    assert.equal(before.surface_key, afterRename.surface_key);
+    assert.equal(before.id, afterRename.id);
+    assert.match(before.id, /^endpoint-srf-[a-f0-9]{16}$/);
+
+    const rawSurfaceEndpoint = buildEndpointResourceArtifact({
+      surfaces: [
+        {
+          id: "sn-7-raw-api",
+          netuid: 7,
+          subnet_slug: "allways",
+          subnet_name: "Allways",
+          kind: "subnet-api",
+          url: "https://api.allways.example.com/v1",
+          provider: "allways",
+          authority: "official",
+          auth_required: false,
+          public_safe: true,
+          probe: { enabled: true, method: "GET", expect: "json" },
+        },
+      ],
+      generatedAt: "1970-01-01T00:00:00.000Z",
+      contractVersion: "test",
+      source: "fixture",
+    }).endpoints[0];
+
+    assert.match(rawSurfaceEndpoint.surface_key, /^srf-[a-f0-9]{16}$/);
+    assert.equal(
+      rawSurfaceEndpoint.id,
+      `endpoint-${rawSurfaceEndpoint.surface_key}`,
     );
   });
 


### PR DESCRIPTION
## Summary
- derive generalized endpoint ids from stable `surface_key` instead of the hand-authored `surface_id`
- carry both `surface_id` and `surface_key` through endpoint resources, endpoint pools, and endpoint incidents
- regenerate OpenAPI/types/manifest artifacts and document the new identity semantics

## What changed
- `buildEndpointResourceArtifact` now emits `endpoint-${surface_key}` and derives a fallback stable key for raw surface inputs.
- Endpoint pool rows and incidents expose `surface_id` for display/back-compat plus `surface_key` for durable joins.
- Endpoint resource and incident schemas require `surface_key`; pool entries allow it when backed by catalogued surfaces.
- Added regression coverage proving display slug renames keep the same endpoint id.

## Why
This is the additive endpoint-link part of #1005. Surface display ids can change on rename, so deriving endpoint ids from them breaks links and contributes to orphaned health history. The stable key keeps endpoint identity tied to `netuid|kind|normalized-url` while preserving the readable surface alias for callers.

## Validation
- `npm run build`
- `npm test -- tests/script-utils.test.mjs`
- `npm run validate`
- `npm test`
- `npm run test:coverage`
- `npm run validate:api`
- `npm run validate:schemas`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:openapi-examples`
- `npm run validate:generated-client`
- `npm run validate:docs`
- `npm run validate:contract-drift`
- `npm run validate:artifact-budgets` (passed with existing size warnings)
- `npm run lint`
- `npm run format:check`
- `git diff --check`
- `npm run schemas:bundle:check`
- `npm run openapi:generate:dry-run`
- `npm run r2:manifest:dry-run`
- `npm run validate:schema-enums`
- `npm run validate:intake`
- `npm run validate:workflows`
- `npm run worker:test`
- `npm run worker:deploy:dry-run`
- `npm run scan:public-safety`
- `npm run validate:private-boundary`

## Notes
- Ref #1005. This does not perform the live D1 re-key or serve-time deprecated-id alias resolution; those should remain separate PRs.
- `npm run check` was attempted, but its `sync:subnets:dry-run` substep stayed silent for several minutes. The deterministic substeps relevant to this change were run directly above.
