### PR TITLE
fix(verify): reuse Worker DNS SSRF guard

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -12,7 +12,11 @@
 // R2/ASSETS resolution the REST routes use.
 import { PRIMARY_DOMAIN } from "./contracts.mjs";
 import { generateServiceSnippets } from "./integration-snippets.mjs";
-import { KV_HEALTH_RPC_POOL } from "./health-prober.mjs";
+import {
+  KV_HEALTH_RPC_POOL,
+  workerResolvedUrlSafetyGuard,
+  workerWebSocketConnector,
+} from "./health-prober.mjs";
 import {
   findSurface,
   primarySurfaceForNetuid,
@@ -1145,7 +1149,12 @@ export const MCP_TOOLS = [
           "Provide either surface_id or netuid.",
         );
       }
-      return await verifySurface(surface);
+      return await verifySurface(surface, {
+        isUnsafeUrl: workerResolvedUrlSafetyGuard({
+          fetchImpl: globalThis.fetch,
+        }),
+        connect: workerWebSocketConnector(globalThis.fetch),
+      });
     },
   },
 ];

--- a/tests/surface-verify.test.mjs
+++ b/tests/surface-verify.test.mjs
@@ -226,6 +226,40 @@ describe("surface verify-now endpoint (#358)", () => {
       assert.equal((await res2.json()).data.from_cache, true);
     });
   });
+
+  test("blocks catalogued hostnames that resolve to private addresses", async () => {
+    let surfaceFetches = 0;
+    await withGlobals(
+      {
+        fetchImpl: async (input) => {
+          const url = String(input);
+          if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+            return new Response(
+              JSON.stringify({
+                Answer: [{ type: 1, data: "127.0.0.1" }],
+              }),
+              { headers: { "content-type": "application/dns-json" } },
+            );
+          }
+          surfaceFetches += 1;
+          return okFetch();
+        },
+      },
+      async () => {
+        const res = await handleRequest(
+          req(SURFACE_ID),
+          createLocalArtifactEnv(),
+          {},
+        );
+        assert.equal(res.status, 200);
+        const body = await res.json();
+        assert.equal(body.data.callable, false);
+        assert.equal(body.data.classification, "unsafe");
+        assert.equal(body.data.error, "unsafe URL");
+      },
+    );
+    assert.equal(surfaceFetches, 0);
+  });
 });
 
 // --- MCP tool: verify_integration --------------------------------------------
@@ -283,6 +317,53 @@ describe("verify_integration MCP tool (#358)", () => {
     assert.equal(bySurface.structuredContent.surface_id, "x:api:1");
     const byNetuid = await call({ netuid: 5 });
     assert.equal(byNetuid.structuredContent.surface_id, "x:api:1");
+  });
+
+  test("blocks rebinding catalogued hostnames before probing", async () => {
+    let surfaceFetches = 0;
+    const of = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+        return new Response(
+          JSON.stringify({
+            Answer: [{ type: 1, data: "10.0.0.5" }],
+          }),
+          { headers: { "content-type": "application/dns-json" } },
+        );
+      }
+      surfaceFetches += 1;
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "verify_integration",
+              arguments: { surface_id: "x:api:1" },
+            },
+          }),
+        }),
+        {},
+        deps,
+      );
+      const result = (await response.json()).result;
+      assert.equal(result.isError, false);
+      assert.equal(result.structuredContent.callable, false);
+      assert.equal(result.structuredContent.classification, "unsafe");
+    } finally {
+      globalThis.fetch = of;
+    }
+    assert.equal(surfaceFetches, 0);
   });
 
   test("error paths require no probe", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -47,6 +47,8 @@ import {
   pruneHealthHistory,
   rollupDailyUptime,
   runHealthProber,
+  workerResolvedUrlSafetyGuard,
+  workerWebSocketConnector,
   writeSubnetSnapshot,
 } from "../src/health-prober.mjs";
 import { findSurface, verifySurface } from "../src/surface-verify.mjs";
@@ -1886,7 +1888,10 @@ async function handleSurfaceVerify(request, env, surfaceId, ctx = {}) {
     }
   }
 
-  const result = await verifySurface(surface);
+  const result = await verifySurface(surface, {
+    isUnsafeUrl: workerResolvedUrlSafetyGuard({ fetchImpl: globalThis.fetch }),
+    connect: workerWebSocketConnector(globalThis.fetch),
+  });
   if (cache) {
     const stored = new Response(JSON.stringify(result), {
       headers: {


### PR DESCRIPTION
### Motivation
- The public "verify-now" endpoint and the MCP `verify_integration` tool called `verifySurface` without the Cloudflare-DoH DNS-aware SSRF guard the cron prober uses, permitting DNS rebinding of catalogued hostnames to reach private addresses. 
- The change restores the stronger Worker-side protections so catalogued surfaces are vetted the same way the scheduled health prober does before any outbound fetch.

### Description
- Import and use `workerResolvedUrlSafetyGuard` and `workerWebSocketConnector` from `src/health-prober.mjs` in `workers/api.mjs` and `src/mcp-server.mjs`.
- Pass guarded probe options (`isUnsafeUrl: workerResolvedUrlSafetyGuard({ fetchImpl: globalThis.fetch })` and `connect: workerWebSocketConnector(globalThis.fetch)`) into `verifySurface(...)` for both the REST endpoint and the MCP tool.
- Add regression tests in `tests/surface-verify.test.mjs` asserting that private-address DNS answers cause classification `unsafe` and that no surface fetches occur when DoH indicates a private reply.

### Testing
- Ran the targeted test suite with `npm test -- --run tests/surface-verify.test.mjs` and all tests in that file passed.
- Ran lint with `npm run lint -- --quiet` and formatting checks with `npm run format:check`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b8c769f0832cba4544ad41b5480d)