### PR TITLE
feat(registry): add SN42 Gopher subnet API candidate

### DIFF
--- a/registry/candidates/community/community-sn-42-subnet-api-data-gopher-ai-com.json
+++ b/registry/candidates/community/community-sn-42-subnet-api-data-gopher-ai-com.json
@@ -1,0 +1,31 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-42-subnet-api-data-gopher-ai-com",
+      "kind": "subnet-api",
+      "name": "Gopher community subnet-api",
+      "netuid": 42,
+      "provider": "gopher",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://developers.gopher-ai.com/docs/data/intro",
+      "source_urls": [
+        "https://developers.gopher-ai.com/docs/data/intro",
+        "https://github.com/gopher-lab/sn42-datasets"
+      ],
+      "state": "schema-valid",
+      "url": "https://data.gopher-ai.com/api"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "prakashiitp",
+    "submitted_by_url": "https://github.com/prakashiitp"
+  }
+}


### PR DESCRIPTION
## Summary

* Adds a community `subnet-api` candidate for SN42 (Gopher).
* Documents a publicly discoverable API surface associated with Gopher.
* Adds a single candidate file under `registry/candidates/community/`.

## Template Used

* Direct subnet/interface candidate

## Evidence

* Official documentation: https://developers.gopher-ai.com/docs/data/intro
* Official repository: https://github.com/gopher-lab/sn42-datasets

## Candidate

* NetUID: 42
* Provider: gopher
* Kind: subnet-api
* URL: https://data.gopher-ai.com/api

Closes #734
