### PR TITLE
fix(health): re-key live health rows by surface key

### DIFF
--- a/docs/cloudflare-backend.md
+++ b/docs/cloudflare-backend.md
@@ -51,6 +51,7 @@ Worker responses include CORS, cache-control, ETags, and `x-metagraph-contract-v
 - Static assets binding: `ASSETS`
 - Optional KV binding: `METAGRAPH_CONTROL`
 - KV keys: `metagraph:latest`, `metagraph:feature-flags`, `metagraph:endpoint-pools`, `metagraph:source-freshness`
+- D1 health migrations live in `migrations/`. `0006_surface_key_rekey.sql` must be applied before deploying the prober cutover that upserts `surface_status` and `surface_uptime_daily` by stable `surface_key`.
 
 If no KV binding is configured, the Worker falls back to `METAGRAPH_R2_LATEST_PREFIX` for R2 reads. R2-tier artifacts are read from R2 first; static fallback is only allowed when `METAGRAPH_ALLOW_R2_STATIC_FALLBACK=true` is set for local migration/testing.
 

--- a/migrations/0006_surface_key_rekey.sql
+++ b/migrations/0006_surface_key_rekey.sql
@@ -1,0 +1,218 @@
+-- Re-key live health latest/daily rows onto stable surface_key (#1005 PR2).
+--
+-- Apply after 0005_surface_key.sql and before deploying prober code that uses
+-- ON CONFLICT(surface_key). This migration is intentionally idempotent over the
+-- current operational-surface map: it backfills known current ids, collapses any
+-- same-key duplicates, then adds unique partial indexes for the new upsert
+-- targets. surface_id remains the display/back-compat alias.
+
+UPDATE surface_checks
+SET surface_key = CASE surface_id
+    WHEN 'allways-api-health' THEN 'srf-e81528d66302ee51'
+    WHEN 'allways-crown' THEN 'srf-b4011f2dcaf520b8'
+    WHEN 'allways-events-latest' THEN 'srf-cc1a1ad8cf1170b7'
+    WHEN 'allways-miners' THEN 'srf-d4a66107344a3f28'
+    WHEN 'allways-miners-leaderboard' THEN 'srf-611e6482fd15f376'
+    WHEN 'allways-miners-reliability' THEN 'srf-7f553de2b7ed71ea'
+    WHEN 'allways-network-overview' THEN 'srf-3517b995dfdb719a'
+    WHEN 'allways-protocol-chain-state' THEN 'srf-117ca13385677b0a'
+    WHEN 'allways-protocol-constants' THEN 'srf-cc58e48f67eab560'
+    WHEN 'allways-sse' THEN 'srf-9a3013f8b54338b4'
+    WHEN 'community-sn-14-subnet-api-api-cacheon-ai' THEN 'srf-08ad6da0db95e254'
+    WHEN 'community-sn-7-subnet-api-api-all-ways-io' THEN 'srf-7ae24ec1e4ae7d50'
+    WHEN 'gittensor-master-repositories' THEN 'srf-150f1f0ade50ced8'
+    WHEN 'gittensory-contribution-interface' THEN 'srf-cc923091819b9bf0'
+    WHEN 'onfinality-finney-rpc' THEN 'srf-dece284ea80ec36c'
+    WHEN 'onfinality-finney-wss' THEN 'srf-09438235257fa944'
+    WHEN 'opentensor-archive-rpc' THEN 'srf-d6ad3703dbed701f'
+    WHEN 'opentensor-archive-wss' THEN 'srf-62a01e9d17dc2ac8'
+    WHEN 'opentensor-finney-rpc' THEN 'srf-3ffcb1a074d13547'
+    WHEN 'opentensor-finney-wss' THEN 'srf-f216252c5e5b341f'
+    WHEN 'opentensor-lite-rpc' THEN 'srf-2d3306d2cfa2223e'
+    WHEN 'opentensor-lite-wss' THEN 'srf-dcf48d017826dc4b'
+    WHEN 'sn-107-github-readme-minos-protocol-minos-subnet-subnet-api-1' THEN 'srf-3462824e2b9e0eed'
+    WHEN 'sn-109-academia-archives' THEN 'srf-0070df9e44e7d65b'
+    WHEN 'sn-110-green-compute-models' THEN 'srf-8fa47d05ebfe89b1'
+    WHEN 'sn-110-website-link-www-green-compute-com-data-artifact-10' THEN 'srf-4956e665c57320f3'
+    WHEN 'sn-110-website-link-www-green-compute-com-data-artifact-9' THEN 'srf-ae90870b3452e032'
+    WHEN 'sn-114-soma-mcp' THEN 'srf-71dfb5eb3db2406d'
+    WHEN 'sn-118-website-link-heyditto-ai-data-artifact-3' THEN 'srf-eeeec504a19120d3'
+    WHEN 'sn-23-trishool-api-root' THEN 'srf-b98c53721003635a'
+    WHEN 'sn-24-quasar-base-model' THEN 'srf-2e8a77e8b3404e86'
+    WHEN 'sn-24-quasar-launch-teacher' THEN 'srf-840a2605f8fb23c0'
+    WHEN 'sn-24-website-link-silxinc-com-data-artifact-3' THEN 'srf-319b61d8ff50a870'
+    WHEN 'sn-29-coldint-fineweb-dataset' THEN 'srf-f51c73d17f954447'
+    WHEN 'sn-33-readyai-hf-dataset' THEN 'srf-1e2a3e1a34a5a2b9'
+    WHEN 'sn-33-readyai-llms-data-repo' THEN 'srf-369814c5b1cde9c3'
+    WHEN 'sn-47-evolai-universal-qa-dataset' THEN 'srf-aa5d5d31a0f78307'
+    WHEN 'sn-51-website-common-api' THEN 'srf-c27814da8fc343a3'
+    WHEN 'sn-56-gradients-last-boss-battle' THEN 'srf-c0245306b1d6177a'
+    WHEN 'sn-56-gradients-latest-tournament-weights' THEN 'srf-2e2ae1882c93c037'
+    WHEN 'sn-56-gradients-models' THEN 'srf-8d4249cf3cefb4cc'
+    WHEN 'sn-56-gradients-weight-projection-static' THEN 'srf-5aa367d8193a4a6a'
+    WHEN 'sn-58-github-readme-handshake58-hs58-subnet-api-2' THEN 'srf-71a5fb1f52db86ad'
+    WHEN 'sn-58-handshake58-provider-directory-api' THEN 'srf-1c93ab1da6a59c50'
+    WHEN 'sn-58-handshake58-skills-api' THEN 'srf-fdcb03337cc44e64'
+    WHEN 'sn-59-github-readme-babelbit-babelbit-subnet-subnet-api-1' THEN 'srf-4a5f786ffee0dd5f'
+    WHEN 'sn-6-numinous-api-health' THEN 'srf-4d92fe6304cbb843'
+    WHEN 'sn-6-numinous-leaderboard' THEN 'srf-1e61c2a2b07ebb24'
+    WHEN 'sn-64-chutes-pricing-api' THEN 'srf-a452646cd344d1a2'
+    WHEN 'sn-64-website-link-chutes-ai-data-artifact-5' THEN 'srf-9e534fe113c5b86a'
+    WHEN 'sn-64-website-link-chutes-ai-data-artifact-6' THEN 'srf-dea1477f513710c8'
+    WHEN 'sn-68-website-link-www-metanova-labs-ai-data-artifact-4' THEN 'srf-1216a921c8908de5'
+    WHEN 'sn-70-website-link-nexisgen-ai-data-artifact-5' THEN 'srf-009a5089d0e13e24'
+    WHEN 'sn-72-natix-huggingface' THEN 'srf-f58da177e29ec502'
+    WHEN 'sn-79-mvtrx-paper' THEN 'srf-0c31e228973cafd3'
+    WHEN 'sn-88-investing-assets' THEN 'srf-3d79d0526c25e5cc'
+    WHEN 'sn-95-actual-model-registry' THEN 'srf-5a99159ed1a9bd15'
+    WHEN 'sn-96-verathos-models-api' THEN 'srf-4f803cf3db704548'
+  END
+WHERE surface_key IS NULL
+  AND surface_id IN (
+    'allways-api-health', 'allways-crown', 'allways-events-latest',
+    'allways-miners', 'allways-miners-leaderboard',
+    'allways-miners-reliability', 'allways-network-overview',
+    'allways-protocol-chain-state', 'allways-protocol-constants',
+    'allways-sse', 'community-sn-14-subnet-api-api-cacheon-ai',
+    'community-sn-7-subnet-api-api-all-ways-io',
+    'gittensor-master-repositories', 'gittensory-contribution-interface',
+    'onfinality-finney-rpc', 'onfinality-finney-wss',
+    'opentensor-archive-rpc', 'opentensor-archive-wss',
+    'opentensor-finney-rpc', 'opentensor-finney-wss',
+    'opentensor-lite-rpc', 'opentensor-lite-wss',
+    'sn-107-github-readme-minos-protocol-minos-subnet-subnet-api-1',
+    'sn-109-academia-archives', 'sn-110-green-compute-models',
+    'sn-110-website-link-www-green-compute-com-data-artifact-10',
+    'sn-110-website-link-www-green-compute-com-data-artifact-9',
+    'sn-114-soma-mcp', 'sn-118-website-link-heyditto-ai-data-artifact-3',
+    'sn-23-trishool-api-root', 'sn-24-quasar-base-model',
+    'sn-24-quasar-launch-teacher',
+    'sn-24-website-link-silxinc-com-data-artifact-3',
+    'sn-29-coldint-fineweb-dataset', 'sn-33-readyai-hf-dataset',
+    'sn-33-readyai-llms-data-repo', 'sn-47-evolai-universal-qa-dataset',
+    'sn-51-website-common-api', 'sn-56-gradients-last-boss-battle',
+    'sn-56-gradients-latest-tournament-weights', 'sn-56-gradients-models',
+    'sn-56-gradients-weight-projection-static',
+    'sn-58-github-readme-handshake58-hs58-subnet-api-2',
+    'sn-58-handshake58-provider-directory-api',
+    'sn-58-handshake58-skills-api',
+    'sn-59-github-readme-babelbit-babelbit-subnet-subnet-api-1',
+    'sn-6-numinous-api-health', 'sn-6-numinous-leaderboard',
+    'sn-64-chutes-pricing-api',
+    'sn-64-website-link-chutes-ai-data-artifact-5',
+    'sn-64-website-link-chutes-ai-data-artifact-6',
+    'sn-68-website-link-www-metanova-labs-ai-data-artifact-4',
+    'sn-70-website-link-nexisgen-ai-data-artifact-5',
+    'sn-72-natix-huggingface', 'sn-79-mvtrx-paper',
+    'sn-88-investing-assets', 'sn-95-actual-model-registry',
+    'sn-96-verathos-models-api'
+  );
+
+UPDATE surface_status
+SET surface_key = (
+  SELECT surface_key
+  FROM surface_checks
+  WHERE surface_checks.surface_id = surface_status.surface_id
+    AND surface_checks.surface_key IS NOT NULL
+  ORDER BY checked_at DESC
+  LIMIT 1
+)
+WHERE surface_key IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM surface_checks
+    WHERE surface_checks.surface_id = surface_status.surface_id
+      AND surface_checks.surface_key IS NOT NULL
+  );
+
+UPDATE surface_uptime_daily
+SET surface_key = (
+  SELECT surface_key
+  FROM surface_checks
+  WHERE surface_checks.surface_id = surface_uptime_daily.surface_id
+    AND surface_checks.surface_key IS NOT NULL
+  ORDER BY checked_at DESC
+  LIMIT 1
+)
+WHERE surface_key IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM surface_checks
+    WHERE surface_checks.surface_id = surface_uptime_daily.surface_id
+      AND surface_checks.surface_key IS NOT NULL
+  );
+
+DELETE FROM surface_status
+WHERE surface_key IS NOT NULL
+  AND rowid NOT IN (
+    SELECT rowid
+    FROM (
+      SELECT
+        rowid,
+        ROW_NUMBER() OVER (
+          PARTITION BY surface_key
+          ORDER BY updated_at DESC, last_checked DESC, surface_id DESC
+        ) AS rn
+      FROM surface_status
+      WHERE surface_key IS NOT NULL
+    )
+    WHERE rn = 1
+  );
+
+DROP TABLE IF EXISTS _surface_uptime_daily_rekey;
+
+CREATE TABLE _surface_uptime_daily_rekey AS
+SELECT
+  MAX(surface_id) AS surface_id,
+  surface_key,
+  MAX(netuid) AS netuid,
+  day,
+  SUM(samples) AS samples,
+  SUM(ok_count) AS ok_count,
+  CASE
+    WHEN SUM(samples) > 0 THEN ROUND(CAST(SUM(ok_count) AS REAL) / SUM(samples), 4)
+    ELSE NULL
+  END AS uptime_ratio,
+  CASE
+    WHEN SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN samples ELSE 0 END) > 0
+      THEN CAST(ROUND(
+        SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN avg_latency_ms * samples ELSE 0 END) /
+        SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN samples ELSE 0 END)
+      ) AS INTEGER)
+    ELSE NULL
+  END AS avg_latency_ms,
+  CASE
+    WHEN SUM(ok_count) = SUM(samples) THEN 'ok'
+    WHEN SUM(ok_count) = 0 THEN 'failed'
+    ELSE 'degraded'
+  END AS status,
+  MAX(updated_at) AS updated_at
+FROM surface_uptime_daily
+WHERE surface_key IS NOT NULL
+GROUP BY surface_key, day
+HAVING COUNT(*) > 1;
+
+DELETE FROM surface_uptime_daily
+WHERE surface_key IS NOT NULL
+  AND (surface_key, day) IN (
+    SELECT surface_key, day FROM _surface_uptime_daily_rekey
+  );
+
+INSERT INTO surface_uptime_daily (
+  surface_id, surface_key, netuid, day, samples, ok_count, uptime_ratio,
+  avg_latency_ms, status, updated_at
+)
+SELECT
+  surface_id, surface_key, netuid, day, samples, ok_count, uptime_ratio,
+  avg_latency_ms, status, updated_at
+FROM _surface_uptime_daily_rekey;
+
+DROP TABLE _surface_uptime_daily_rekey;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_surface_status_surface_key_unique
+  ON surface_status (surface_key)
+  WHERE surface_key IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_surface_uptime_daily_surface_key_day_unique
+  ON surface_uptime_daily (surface_key, day)
+  WHERE surface_key IS NOT NULL;

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -360,15 +360,22 @@ export async function runHealthProber(env, ctx, overrides = {}) {
   const priorStatus = new Map();
   if (db) {
     try {
+      const keys = surfaces.map((s) => s.surface_key || s.surface_id);
       const ids = surfaces.map((s) => s.surface_id);
-      const placeholders = ids.map(() => "?").join(",");
+      const keyPlaceholders = keys.map(() => "?").join(",");
+      const idPlaceholders = ids.map(() => "?").join(",");
       const { results } = await db
         .prepare(
-          `SELECT surface_id, last_ok, consecutive_failures FROM surface_status WHERE surface_id IN (${placeholders})`,
+          `SELECT surface_id, surface_key, last_ok, consecutive_failures
+           FROM surface_status
+           WHERE surface_key IN (${keyPlaceholders})
+              OR surface_id IN (${idPlaceholders})`,
         )
-        .bind(...ids)
+        .bind(...keys, ...ids)
         .all();
-      for (const row of results || []) priorStatus.set(row.surface_id, row);
+      for (const row of results || []) {
+        priorStatus.set(row.surface_key || row.surface_id, row);
+      }
     } catch {
       // First run / cold table — treat all as having no prior state.
     }
@@ -401,7 +408,8 @@ export async function runHealthProber(env, ctx, overrides = {}) {
       };
     }
     const ok = base.status === "ok";
-    const prior = priorStatus.get(surface.surface_id);
+    const stableLookupKey = surface.surface_key || surface.surface_id;
+    const prior = priorStatus.get(stableLookupKey);
     const lastOkMs = ok ? runAt : (prior?.last_ok ?? null);
     const consecutiveFailures = ok ? 0 : (prior?.consecutive_failures ?? 0) + 1;
     return {
@@ -448,17 +456,15 @@ async function persistToD1(db, probed, runAt) {
        (surface_id, surface_key, netuid, kind, status, classification, latency_ms, status_code, ok, checked_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
-    // #1005: surface_key is written alongside surface_id and back-filled onto the
-    // existing latest row via the ON CONFLICT(surface_id) UPDATE — so once every
-    // surface has been probed once post-migration, surface_status carries the
-    // stable key the serving cutover (PR3) joins on. Conflict target stays
-    // surface_id (unchanged behavior); PR3 owns the key-based read path.
+    // #1005: surface_status now keys latest rows on surface_key, so a display
+    // id/slug rename updates the alias in-place instead of creating a new latest
+    // row and resetting breaker continuity.
     const statusStmt = db.prepare(
       `INSERT INTO surface_status
        (surface_id, surface_key, netuid, kind, url, provider, status, classification, latency_ms, status_code, last_checked, last_ok, consecutive_failures, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(surface_id) DO UPDATE SET
-         surface_key=excluded.surface_key,
+       ON CONFLICT(surface_key) WHERE surface_key IS NOT NULL DO UPDATE SET
+         surface_id=excluded.surface_id,
          netuid=excluded.netuid, kind=excluded.kind, url=excluded.url,
          provider=excluded.provider, status=excluded.status,
          classification=excluded.classification, latency_ms=excluded.latency_ms,
@@ -617,10 +623,8 @@ export async function rollupDailyUptime(env, overrides = {}) {
        (surface_id, surface_key, netuid, day, samples, ok_count, uptime_ratio,
         avg_latency_ms, status, updated_at)
      SELECT
-       surface_id,
-       -- #1005: surface_key is functionally dependent on surface_id within the
-       -- raw checks, so MAX() picks it deterministically per group.
-       MAX(surface_key) AS surface_key,
+       MAX(surface_id) AS surface_id,
+       COALESCE(surface_key, surface_id) AS surface_key,
        netuid,
        ? AS day,
        COUNT(*) AS samples,
@@ -635,9 +639,9 @@ export async function rollupDailyUptime(env, overrides = {}) {
        ? AS updated_at
      FROM surface_checks
      WHERE checked_at >= ? AND checked_at < ?
-     GROUP BY surface_id, netuid
-     ON CONFLICT(surface_id, day) DO UPDATE SET
-       surface_key = excluded.surface_key,
+     GROUP BY COALESCE(surface_key, surface_id), netuid
+     ON CONFLICT(surface_key, day) WHERE surface_key IS NOT NULL DO UPDATE SET
+       surface_id = excluded.surface_id,
        netuid = excluded.netuid,
        samples = excluded.samples,
        ok_count = excluded.ok_count,

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -124,7 +124,7 @@ function makeDb({ priorStatus = [] } = {}) {
     binds,
     async all() {
       calls.selects.push({ sql, binds });
-      if (/FROM surface_status WHERE surface_id IN/.test(sql)) {
+      if (/FROM surface_status/.test(sql)) {
         return { results: priorStatus };
       }
       return { results: [] };
@@ -258,7 +258,12 @@ describe("runHealthProber", () => {
   test("writes D1 batch + the three KV snapshots with correct shapes", async () => {
     const db = makeDb({
       priorStatus: [
-        { surface_id: "sn7-api", last_ok: 1000, consecutive_failures: 2 },
+        {
+          surface_id: "sn7-api-old",
+          surface_key: "srf-sn7apikey000000",
+          last_ok: 1000,
+          consecutive_failures: 2,
+        },
       ],
     });
     const kv = makeKv();
@@ -291,6 +296,16 @@ describe("runHealthProber", () => {
     // #1005: both the append-only time-series and the latest-row upsert carry the
     // stable surface_key (binds[1]) so D1 history re-keys onto the rename-stable
     // identity. surface_checks binds: [surface_id, surface_key, netuid, ...].
+    assert.match(
+      db.calls.selects[0].sql,
+      /WHERE surface_key IN \(\?,\?\)\s+OR surface_id IN \(\?,\?\)/,
+    );
+    assert.deepEqual(db.calls.selects[0].binds, [
+      "srf-sn7apikey000000",
+      "srf-rootrpckey00000",
+      "sn7-api",
+      "opentensor-finney-rpc",
+    ]);
     const checkInsert = db.calls.batches[0].find(
       (s) =>
         /INSERT INTO surface_checks/.test(s.sql) && s.binds[0] === "sn7-api",
@@ -392,7 +407,12 @@ describe("runHealthProber", () => {
   test("bumps consecutive_failures from prior state for the breaker", async () => {
     const db = makeDb({
       priorStatus: [
-        { surface_id: "sn7-api", last_ok: 1000, consecutive_failures: 2 },
+        {
+          surface_id: "sn7-api-before-rename",
+          surface_key: "srf-sn7apikey000000",
+          last_ok: 1000,
+          consecutive_failures: 2,
+        },
       ],
     });
     await runHealthProber(
@@ -415,6 +435,10 @@ describe("runHealthProber", () => {
     // binds: [surface_id, surface_key, netuid, kind, url, provider, status,
     //   classification, latency_ms, status_code, last_checked, last_ok, consec,
     //   updated_at] — #1005 added surface_key at index 1, shifting the rest by 1.
+    assert.match(
+      apiUpsert.sql,
+      /ON CONFLICT\(surface_key\) WHERE surface_key IS NOT NULL/,
+    );
     assert.equal(apiUpsert.binds[1], "srf-sn7apikey000000");
     assert.equal(apiUpsert.binds[12], 3);
   });
@@ -1342,7 +1366,14 @@ describe("rollupDailyUptime (durable daily history)", () => {
     const stmts = db.calls.batches[0];
     assert.equal(stmts.length, 2);
     assert.match(stmts[0].sql, /INSERT INTO surface_uptime_daily/);
-    assert.match(stmts[0].sql, /ON CONFLICT\(surface_id, day\)/);
+    assert.match(
+      stmts[0].sql,
+      /GROUP BY COALESCE\(surface_key, surface_id\), netuid/,
+    );
+    assert.match(
+      stmts[0].sql,
+      /ON CONFLICT\(surface_key, day\) WHERE surface_key IS NOT NULL/,
+    );
     // binds: [day, updated_at, dayStart, dayEnd]
     assert.deepEqual(stmts[0].binds, [
       "2026-06-13",


### PR DESCRIPTION
## Summary
- add `0006_surface_key_rekey.sql` to backfill live-health rows onto stable `surface_key`
- preserve prober breaker continuity by looking up prior status by `surface_key` with `surface_id` fallback
- upsert latest health rows and daily uptime rollups by stable key so display id renames stop creating fresh history rows

## What changed
- `runHealthProber` reads prior `surface_status` rows by stable key first and uses the key to keep `last_ok` / `consecutive_failures` across display slug renames.
- `surface_status` writes now update the current human `surface_id` alias on stable-key conflict.
- `surface_uptime_daily` rollups group by `COALESCE(surface_key, surface_id)` and update the display alias on conflict.
- Migration `0006_surface_key_rekey.sql` backfills the current operational surface map, collapses duplicate latest/daily rows by stable key, and creates unique partial indexes for the new D1 upsert targets.
- Cloudflare backend docs now call out the deploy order for this D1 migration.

## Why
This is the D1 re-key slice of #1005. The additive artifact work is merged, but live health history still depended on mutable display ids. This moves the live latest-row and daily-rollup storage path to stable surface keys while keeping `surface_id` as the readable alias.

## Validation
- `npm test -- tests/health-prober.test.mjs`
- SQLite migration smoke: apply `0001`, `0003`, `0005`, seed duplicate rows, apply `0006`, verify merged stable-key rows
- SQLite idempotency smoke: apply `0006` twice against the same seeded database
- `npm run validate`
- `npm test`
- `npm run test:coverage`
- `npm run validate:api`
- `npm run validate:schemas`
- `npm run worker:test`
- `npm run worker:deploy:dry-run`
- `npm run validate:private-boundary`
- `npm run scan:public-safety`
- `npm run lint`
- `npm run format:check`
- `npm run validate:docs`
- `git diff --check`

## Notes
- Ref #1005.
- Apply `migrations/0006_surface_key_rekey.sql` to the metagraphed health D1 database before deploying this Worker code.
- This PR does not add deprecated-id serve-time alias resolution for external callers; keep that as the next #1005 PR.
