### PR TITLE
docs(agent): add callable subnet workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Bittensor subnet integration registry. For every subnet it answers: **what d
 [![PyPI](https://img.shields.io/pypi/v/metagraphed?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/metagraphed/)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue)](./LICENSE)
 
-**[Website](https://metagraph.sh)** &nbsp;·&nbsp; [API](https://api.metagraph.sh) &nbsp;·&nbsp; [OpenAPI](https://api.metagraph.sh/metagraph/openapi.json) &nbsp;·&nbsp; [MCP](https://api.metagraph.sh/mcp) &nbsp;·&nbsp; [Agent docs](https://api.metagraph.sh/llms.txt) &nbsp;·&nbsp; [Feeds](https://api.metagraph.sh/api/v1/feeds/registry) &nbsp;·&nbsp; [npm](https://www.npmjs.com/package/@jsonbored/metagraphed) &nbsp;·&nbsp; [PyPI](https://pypi.org/project/metagraphed/)
+**[Website](https://metagraph.sh)** &nbsp;·&nbsp; [API](https://api.metagraph.sh) &nbsp;·&nbsp; [OpenAPI](https://api.metagraph.sh/metagraph/openapi.json) &nbsp;·&nbsp; [MCP](https://api.metagraph.sh/mcp) &nbsp;·&nbsp; [Agent docs](https://api.metagraph.sh/llms.txt) &nbsp;·&nbsp; [Agent workflows](https://api.metagraph.sh/agent-workflows.md) &nbsp;·&nbsp; [Feeds](https://api.metagraph.sh/api/v1/feeds/registry) &nbsp;·&nbsp; [npm](https://www.npmjs.com/package/@jsonbored/metagraphed) &nbsp;·&nbsp; [PyPI](https://pypi.org/project/metagraphed/)
 
 </div>
 
@@ -32,7 +32,7 @@ Three ways to use Metagraphed. Pick one.
 
 #### 🤖 AI agent (MCP)
 
-Agent-native, public, read-only, Streamable-HTTP. 14 tools to discover a subnet, check if it's up, and learn how to call it.
+Agent-native, public, read-only, Streamable-HTTP. 16 tools to discover a subnet, check if it's up, and learn how to call it.
 
 ```bash
 claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp
@@ -40,7 +40,7 @@ claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp
 
 > Cursor / other clients: add an MCP server with url `https://api.metagraph.sh/mcp`, transport `streamable-http`.
 >
-> Tools: `search_subnets` · `find_subnets_by_capability` · `get_subnet` · `get_subnet_health` · `list_subnet_apis` · `get_api_schema` · `get_fixture` · `get_agent_catalog` · `get_best_rpc_endpoint` · `registry_summary` · `semantic_search` · `ask` · `find_subnet_for_task` · `how_do_i_call`
+> Tools: `search_subnets` · `list_subnets` · `find_subnets_by_capability` · `get_subnet` · `get_subnet_health` · `list_subnet_apis` · `get_api_schema` · `get_fixture` · `get_agent_catalog` · `get_best_rpc_endpoint` · `registry_summary` · `semantic_search` · `ask` · `find_subnet_for_task` · `how_do_i_call` · `verify_integration`
 
 #### 📦 Typed client
 
@@ -64,6 +64,7 @@ curl https://api.metagraph.sh/api/v1/subnets
 | Resource              | URL                                                                                                                                                                                   |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Copyable agent prompt | [`/agent.md`](https://api.metagraph.sh/agent.md)                                                                                                                                      |
+| Agent workflows       | [`/agent-workflows.md`](https://api.metagraph.sh/agent-workflows.md)                                                                                                                  |
 | Machine index         | [`/llms.txt`](https://api.metagraph.sh/llms.txt)                                                                                                                                      |
 | Drop-in skill         | [`/skills/bittensor/SKILL.md`](https://api.metagraph.sh/skills/bittensor/SKILL.md)                                                                                                    |
 | Resources index       | [`/metagraph/agent-resources.json`](https://api.metagraph.sh/metagraph/agent-resources.json)                                                                                          |

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -17,6 +17,10 @@ of `{ type: "function", function: {...} }`; the Anthropic document is a bare
 array of `{ name, description, input_schema }`. Each is dropped directly into the
 respective SDK's `tools` parameter.
 
+For the end-to-end path from "find a callable subnet" to a working REST, MCP,
+npm, or Python call, use the public workflow guide at
+`https://api.metagraph.sh/agent-workflows.md`.
+
 ## Executing a tool call
 
 The specs declare the tool _shape_; execution is uniform — forward the model's

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -3,7 +3,7 @@
   "skills": [
     {
       "description": "Use when a developer asks what a Bittensor subnet does, whether it's up right now, or how to call/integrate its API — e.g. \"which subnet does image generation\", \"is subnet 7 healthy\", \"how do I call the Chutes API\", \"build on a Bittensor subnet\". Backed by metagraphed (api.metagraph.sh), the live operational + integration registry for ~129 subnets.",
-      "digest": "sha256:bb4ef97a109fa1898221ac0d69ef4d28f4b5a7031f0638c3bfa78bde1deadd42",
+      "digest": "sha256:5dca3a1fbb05d00600cb262f21516893fef5a45d797d8bf8b1a9f00c03cb673c",
       "name": "bittensor",
       "type": "skill-md",
       "url": "https://api.metagraph.sh/skills/bittensor/SKILL.md"

--- a/public/.well-known/llms.txt
+++ b/public/.well-known/llms.txt
@@ -10,6 +10,7 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 - [OpenAPI 3.1](https://api.metagraph.sh/metagraph/openapi.json): full machine contract for all routes
 - [Agent capability catalog](https://api.metagraph.sh/api/v1/agent-catalog): per-subnet callable services + their schemas + health
 - [Copyable AI agent](https://api.metagraph.sh/agent.md): paste-ready system prompt that turns any agent into a metagraphed-powered Bittensor integration agent. Every AI resource indexed at [/api/v1/agent-resources](https://api.metagraph.sh/api/v1/agent-resources).
+- [Agent workflows](https://api.metagraph.sh/agent-workflows.md): task-oriented REST, MCP, npm, and Python examples for finding and calling subnets
 - [MCP server](https://api.metagraph.sh/mcp): Model Context Protocol endpoint — agents query the registry as tools. Install: `claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp`
 - [MCP server card](https://api.metagraph.sh/.well-known/mcp/server-card.json): machine-readable server descriptor (tools, transport, protocol versions)
 - [Content feeds](https://api.metagraph.sh/api/v1/feeds/registry): RSS 2.0 / Atom 1.0 / JSON Feed 1.1 of registry changes + incidents (per-subnet at /api/v1/feeds/subnets/{netuid}). Content-negotiated via Accept, or append .rss/.atom/.json.

--- a/public/agent-workflows.md
+++ b/public/agent-workflows.md
@@ -1,0 +1,292 @@
+# Agent workflows for callable subnet discovery
+
+This is the practical path from "I want to build on a Bittensor subnet" to a
+working call. Use this when you need task-oriented guidance instead of a raw
+endpoint list.
+
+Everything below is public, read-only, and served from
+`https://api.metagraph.sh`. REST responses use the envelope
+`{ ok, schema_version, data, meta }`; read `data`.
+
+## Choose an interface
+
+Use the interface that matches your environment:
+
+- MCP: best for Claude, Cursor, ChatGPT Apps, and agent frameworks that can call
+  tools. Connect `https://api.metagraph.sh/mcp`.
+- REST: best for shell scripts, browser apps, and quick inspection.
+- npm: best for TypeScript apps that want typed API paths.
+- Python: best for notebooks, crawlers, and backend jobs.
+
+All four paths read the same registry truth. MCP gives the most guided workflow;
+REST and SDKs give you the same data directly.
+
+## 1. Find callable subnet candidates
+
+Start with the agent catalog. It is the subset of subnets with at least one
+catalogued public integration surface.
+
+REST:
+
+```bash
+curl -sS 'https://api.metagraph.sh/api/v1/agent-catalog?limit=10'
+```
+
+MCP:
+
+```bash
+curl -sS 'https://api.metagraph.sh/mcp' \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"find_subnet_for_task","arguments":{"task":"bitcoin yield or routing API","limit":5}}}'
+```
+
+npm:
+
+```ts
+import { metagraphedFetch } from "@jsonbored/metagraphed";
+
+const catalog = await metagraphedFetch("/api/v1/agent-catalog", {
+  query: { limit: 10 },
+});
+
+for (const subnet of catalog.data.subnets) {
+  console.log(
+    subnet.netuid,
+    subnet.name,
+    subnet.callable_count,
+    subnet.service_kinds,
+  );
+}
+```
+
+Python:
+
+```python
+from metagraphed import MetagraphedClient
+
+client = MetagraphedClient()
+catalog = client.fetch("/api/v1/agent-catalog", query={"limit": 10})
+
+for subnet in catalog["data"]["subnets"]:
+    print(
+        subnet["netuid"],
+        subnet["name"],
+        subnet.get("callable_count"),
+        subnet.get("service_kinds"),
+    )
+```
+
+If the user's request is vague, ask the registry rather than guessing:
+
+```bash
+curl -sS 'https://api.metagraph.sh/api/v1/ask' \
+  -H 'content-type: application/json' \
+  -d '{"question":"Which Bittensor subnets expose public APIs for inference or developer tooling, and how should I call them?"}'
+```
+
+## 2. Inspect one subnet before calling it
+
+Use SN7 as a concrete example. Swap `7` for any netuid from the catalog.
+
+REST:
+
+```bash
+curl -sS 'https://api.metagraph.sh/api/v1/agent-catalog/7'
+curl -sS 'https://api.metagraph.sh/api/v1/subnets/7/health'
+```
+
+MCP:
+
+```bash
+curl -sS 'https://api.metagraph.sh/mcp' \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"how_do_i_call","arguments":{"netuid":7}}}'
+```
+
+npm:
+
+```ts
+import { metagraphedFetch } from "@jsonbored/metagraphed";
+
+const catalog = await metagraphedFetch("/api/v1/agent-catalog/{netuid}", {
+  pathParams: { netuid: 7 },
+});
+
+const callable = catalog.data.services.filter(
+  (service) => service.eligibility?.callable,
+);
+
+for (const service of callable) {
+  console.log({
+    surface_id: service.surface_id,
+    base_url: service.base_url,
+    auth_required: service.auth_required,
+    health: service.health?.status,
+    snippets: service.snippets,
+  });
+}
+```
+
+Python:
+
+```python
+from metagraphed import MetagraphedClient
+
+client = MetagraphedClient()
+catalog = client.agent_catalog(7)
+
+callable_services = [
+    service
+    for service in (catalog.services or [])
+    if service.get("eligibility", {}).get("callable")
+]
+
+for service in callable_services:
+    print(
+        service["surface_id"],
+        service["base_url"],
+        service.get("auth_required"),
+        service.get("health", {}).get("status"),
+        service.get("snippets"),
+    )
+```
+
+Do not treat a catalogued surface as production-ready just because it exists.
+Check `eligibility.callable`, `auth_required`, `auth_schemes`, schema
+availability, and the live `health` block first.
+
+To live-probe one catalogued surface on demand, use the service's `surface_id`
+or stable `surface_key`:
+
+```bash
+curl -sS 'https://api.metagraph.sh/api/v1/surfaces/allways-api-health/verify'
+```
+
+MCP equivalent:
+
+```bash
+curl -sS 'https://api.metagraph.sh/mcp' \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"verify_integration","arguments":{"surface_id":"allways-api-health"}}}'
+```
+
+This is a catalog-resolved probe, not arbitrary URL fetching. It verifies the
+curated URL already known to metagraphed and is cached briefly to avoid fan-out.
+
+## 3. Fetch schema and fixture examples
+
+The agent catalog tells you which service to call. If a service has
+`schema_artifact`, fetch the captured machine-readable contract:
+
+```bash
+curl -sS 'https://api.metagraph.sh/metagraph/schemas/{surface_id}.json'
+```
+
+For no-auth GET surfaces with captured samples, use fixtures:
+
+```bash
+curl -sS 'https://api.metagraph.sh/metagraph/fixtures/{surface_id}.json'
+```
+
+MCP equivalents:
+
+```bash
+curl -sS 'https://api.metagraph.sh/mcp' \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_api_schema","arguments":{"surface_id":"allways-api-health"}}}'
+
+curl -sS 'https://api.metagraph.sh/mcp' \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_fixture","arguments":{"surface_id":"allways-api-health"}}}'
+```
+
+If the schema or fixture is absent, say that plainly and fall back to the
+service's `base_url`, `auth` metadata, and generated snippets. Do not invent a
+request shape.
+
+## 4. Make the first call
+
+Prefer the snippets already carried by the agent catalog or returned by
+`how_do_i_call`. They are generated from the curated `base_url` and auth
+metadata.
+
+REST inspection:
+
+```bash
+curl -sS 'https://api.metagraph.sh/api/v1/agent-catalog/7'
+```
+
+Then read:
+
+- `data.services[].snippets.curl`
+- `data.services[].snippets.python`
+- `data.services[].snippets.typescript`
+
+If `auth_required` is `true`, the user needs a credential from that subnet's
+team. Metagraphed tells you which scheme is required; it does not provide,
+broker, or guess secrets.
+
+## 5. Ask semantic questions with provenance
+
+Use `/api/v1/ask` when the user wants an answer, not a raw list:
+
+```bash
+curl -sS 'https://api.metagraph.sh/api/v1/ask' \
+  -H 'content-type: application/json' \
+  -d '{"question":"Which callable subnets have public developer-tooling APIs, and what evidence supports that?"}'
+```
+
+Use `/api/v1/search/semantic` when the user wants candidate rows:
+
+```bash
+curl -sS 'https://api.metagraph.sh/api/v1/search/semantic?q=developer%20tooling%20api'
+```
+
+The AI routes are grounded in the registry. They can still be unavailable if the
+AI layer is down or rate-limited, so a robust agent should fall back to
+`/api/v1/agent-catalog`, `/api/v1/subnets`, and MCP keyword tools.
+
+## Readiness criteria
+
+A subnet is agent-ready only when a developer or agent can decide what to call
+and how to call it without guessing.
+
+Included in the agent catalog:
+
+- The subnet has at least one public-safe, catalogued integration surface.
+- At least one service is marked `eligibility.callable`.
+- The service has a concrete `base_url`.
+- Auth is explicitly declared as none or described through `auth_required` and
+  `auth_schemes`.
+- The surface is not private, unsafe, parked-only, deprecated-only, or purely a
+  Bittensor base-layer endpoint.
+- Health, schema, fixture, and snippet data are included when available, with
+  absence represented as absence rather than fabricated detail.
+
+Common blockers:
+
+- No public API, docs, repo, or operator-owned surface has been found.
+- The only known surface is a marketing page, dashboard, Discord, X profile, or
+  generic repo with no callable interface.
+- Auth is required but the scheme or onboarding path is unclear.
+- There is no stable base URL.
+- The schema is missing, stale, or not machine-readable.
+- The surface failed public-safety checks or points at private/internal
+  infrastructure.
+- The subnet is parked, deprecated, candidate-only, or otherwise not suitable
+  for an integration recommendation.
+
+## Agent loop
+
+Use this loop for integration tasks:
+
+1. Call `find_subnet_for_task` or `GET /api/v1/agent-catalog`.
+2. Pick a subnet with `callable_count > 0` and relevant `service_kinds`.
+3. Call `how_do_i_call` or `GET /api/v1/agent-catalog/{netuid}`.
+4. Check `auth_required`, `auth_schemes`, `health.status`, and schema/fixture
+   availability.
+5. Use `verify_integration` or `/api/v1/surfaces/{surface_id}/verify` when the
+   user needs "callable right now" before wiring an integration.
+6. Use the returned snippet as the first call.
+7. If required data is missing, explain the blocker and link the missing field
+   back to the catalog instead of guessing.

--- a/public/agent.md
+++ b/public/agent.md
@@ -12,7 +12,8 @@ claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp
 ```
 
 No MCP host? Everything is also a plain `GET`/`POST` over HTTPS — see "REST
-fallback" at the bottom.
+fallback" at the bottom. For copyable REST/npm/Python/MCP examples, use
+`https://api.metagraph.sh/agent-workflows.md`.
 
 ---
 
@@ -41,9 +42,12 @@ Ground rules:
 Your tools (metagraphed MCP server):
 
 - `find_subnet_for_task` — natural-language → the best-fit subnets for a goal.
+- `list_subnets` — compact registry index when you need every subnet.
 - `find_subnets_by_capability` / `search_subnets` — discover by capability/keyword.
 - `how_do_i_call` — concrete call instructions for one subnet: each callable
   service's base_url, auth, schema availability, and live health.
+- `verify_integration` — live-probe one catalogued surface or a subnet's primary
+  surface before wiring.
 - `get_fixture` — a real, sanitized request/response sample for a no-auth GET
   service (what it actually returns, not just what the schema claims).
 - `get_api_schema` — the captured OpenAPI/Swagger spec for a surface.
@@ -89,6 +93,7 @@ meta }` envelope — read `data`:
   to mainnet.
 
 Machine entrypoints: `https://api.metagraph.sh/llms.txt` (index),
+`/agent-workflows.md` (task-oriented REST/npm/Python/MCP examples),
 `/metagraph/openapi.json` (full contract), `/api/v1/agent-resources` (this
 file's machine index — every AI resource in one JSON), `/skills/bittensor/SKILL.md`
 (drop-in skill).

--- a/public/auth.md
+++ b/public/auth.md
@@ -24,6 +24,7 @@ Anonymous abuse-control limits apply per client IP (no key raises them):
 ## Discovery
 
 - Machine index: https://api.metagraph.sh/llms.txt
+- Agent workflows: https://api.metagraph.sh/agent-workflows.md
 - API catalog (RFC 9727): https://api.metagraph.sh/.well-known/api-catalog
 - OpenAPI 3.1: https://api.metagraph.sh/metagraph/openapi.json
 - MCP server card: https://api.metagraph.sh/.well-known/mcp/server-card.json

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -10,6 +10,7 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 - [OpenAPI 3.1](https://api.metagraph.sh/metagraph/openapi.json): full machine contract for all routes
 - [Agent capability catalog](https://api.metagraph.sh/api/v1/agent-catalog): per-subnet callable services + their schemas + health
 - [Copyable AI agent](https://api.metagraph.sh/agent.md): paste-ready system prompt that turns any agent into a metagraphed-powered Bittensor integration agent. Every AI resource indexed at [/api/v1/agent-resources](https://api.metagraph.sh/api/v1/agent-resources).
+- [Agent workflows](https://api.metagraph.sh/agent-workflows.md): task-oriented REST, MCP, npm, and Python examples for finding and calling subnets
 - [MCP server](https://api.metagraph.sh/mcp): Model Context Protocol endpoint — agents query the registry as tools. Install: `claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp`
 - [MCP server card](https://api.metagraph.sh/.well-known/mcp/server-card.json): machine-readable server descriptor (tools, transport, protocol versions)
 - [Content feeds](https://api.metagraph.sh/api/v1/feeds/registry): RSS 2.0 / Atom 1.0 / JSON Feed 1.1 of registry changes + incidents (per-subnet at /api/v1/feeds/subnets/{netuid}). Content-negotiated via Accept, or append .rss/.atom/.json.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -10,6 +10,7 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 - [OpenAPI 3.1](https://api.metagraph.sh/metagraph/openapi.json): full machine contract for all routes
 - [Agent capability catalog](https://api.metagraph.sh/api/v1/agent-catalog): per-subnet callable services + their schemas + health
 - [Copyable AI agent](https://api.metagraph.sh/agent.md): paste-ready system prompt that turns any agent into a metagraphed-powered Bittensor integration agent. Every AI resource indexed at [/api/v1/agent-resources](https://api.metagraph.sh/api/v1/agent-resources).
+- [Agent workflows](https://api.metagraph.sh/agent-workflows.md): task-oriented REST, MCP, npm, and Python examples for finding and calling subnets
 - [MCP server](https://api.metagraph.sh/mcp): Model Context Protocol endpoint — agents query the registry as tools. Install: `claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp`
 - [MCP server card](https://api.metagraph.sh/.well-known/mcp/server-card.json): machine-readable server descriptor (tools, transport, protocol versions)
 - [Content feeds](https://api.metagraph.sh/api/v1/feeds/registry): RSS 2.0 / Atom 1.0 / JSON Feed 1.1 of registry changes + incidents (per-subnet at /api/v1/feeds/subnets/{netuid}). Content-negotiated via Accept, or append .rss/.atom/.json.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -4,6 +4,7 @@
   <url><loc>https://api.metagraph.sh/llms.txt</loc></url>
   <url><loc>https://api.metagraph.sh/llms-full.txt</loc></url>
   <url><loc>https://api.metagraph.sh/agent.md</loc></url>
+  <url><loc>https://api.metagraph.sh/agent-workflows.md</loc></url>
   <url><loc>https://api.metagraph.sh/auth.md</loc></url>
   <url><loc>https://api.metagraph.sh/metagraph/openapi.json</loc></url>
   <url><loc>https://api.metagraph.sh/.well-known/api-catalog</loc></url>

--- a/public/skills/bittensor/SKILL.md
+++ b/public/skills/bittensor/SKILL.md
@@ -98,5 +98,6 @@ the SDK, so code written against localnet runs unchanged on testnet and mainnet.
 ## More
 
 - Machine index: `https://api.metagraph.sh/llms.txt` (and `/llms-full.txt`)
+- Agent workflows: `https://api.metagraph.sh/agent-workflows.md`
 - OpenAPI 3.1: `https://api.metagraph.sh/metagraph/openapi.json`
 - Source: `https://github.com/JSONbored/metagraphed`

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1503,6 +1503,7 @@ const llmsHeader = [
   `- [OpenAPI 3.1](${llmsApiBase}/metagraph/openapi.json): full machine contract for all routes`,
   `- [Agent capability catalog](${llmsApiBase}/api/v1/agent-catalog): per-subnet callable services + their schemas + health`,
   `- [Copyable AI agent](${llmsApiBase}/agent.md): paste-ready system prompt that turns any agent into a metagraphed-powered Bittensor integration agent. Every AI resource indexed at [/api/v1/agent-resources](${llmsApiBase}/api/v1/agent-resources).`,
+  `- [Agent workflows](${llmsApiBase}/agent-workflows.md): task-oriented REST, MCP, npm, and Python examples for finding and calling subnets`,
   `- [MCP server](${llmsApiBase}/mcp): Model Context Protocol endpoint — agents query the registry as tools. Install: \`claude mcp add --transport http metagraphed ${llmsApiBase}/mcp\``,
   `- [MCP server card](${llmsApiBase}/.well-known/mcp/server-card.json): machine-readable server descriptor (tools, transport, protocol versions)`,
   `- [Content feeds](${llmsApiBase}/api/v1/feeds/registry): RSS 2.0 / Atom 1.0 / JSON Feed 1.1 of registry changes + incidents (per-subnet at /api/v1/feeds/subnets/{netuid}). Content-negotiated via Accept, or append .rss/.atom/.json.`,
@@ -1756,6 +1757,12 @@ const agentResourcesContent = {
       url: `${llmsApiBase}/agent.md`,
     },
     {
+      id: "agent-workflows",
+      title: "Agent workflows",
+      kind: "guide",
+      url: `${llmsApiBase}/agent-workflows.md`,
+    },
+    {
       id: "skill",
       title: "Bittensor skill",
       kind: "skill",
@@ -1868,6 +1875,7 @@ const sitemapUrls = [
   `${llmsApiBase}/llms.txt`,
   `${llmsApiBase}/llms-full.txt`,
   `${llmsApiBase}/agent.md`,
+  `${llmsApiBase}/agent-workflows.md`,
   `${llmsApiBase}/auth.md`,
   `${llmsApiBase}/metagraph/openapi.json`,
   `${llmsApiBase}/.well-known/api-catalog`,
@@ -1925,6 +1933,7 @@ Anonymous abuse-control limits apply per client IP (no key raises them):
 ## Discovery
 
 - Machine index: ${llmsApiBase}/llms.txt
+- Agent workflows: ${llmsApiBase}/agent-workflows.md
 - API catalog (RFC 9727): ${llmsApiBase}/.well-known/api-catalog
 - OpenAPI 3.1: ${llmsApiBase}/metagraph/openapi.json
 - MCP server card: ${llmsApiBase}/.well-known/mcp/server-card.json

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -784,6 +784,10 @@ test("public artifacts are internally consistent", () => {
     agentResources.resources.some((r) => r.id === "agent"),
     "resources must include the copyable agent",
   );
+  assert.ok(
+    agentResources.resources.some((r) => r.id === "agent-workflows"),
+    "resources must include the public agent workflow guide",
+  );
   assert.ok(agentResources.resources.every((r) => r.id && r.title && r.url));
   // every profile that claims to have graduated appears in the lineage artifact
   for (const profile of profiles.profiles) {

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1552,6 +1552,11 @@ describe("Agent discovery surfaces", () => {
       context["service-doc"][0].href,
       "https://api.metagraph.sh/llms.txt",
     );
+    assert.ok(
+      context["service-doc"].some(
+        (entry) => entry.href === "https://api.metagraph.sh/agent-workflows.md",
+      ),
+    );
     assert.equal(context.status[0].href, "https://api.metagraph.sh/health");
   });
 

--- a/workers/request-handlers/discovery.mjs
+++ b/workers/request-handlers/discovery.mjs
@@ -143,6 +143,7 @@ const DISCOVERY_LINK_HEADER = [
   `<${DISCOVERY_LINK_BASE}/metagraph/openapi.json>; rel="service-desc"; type="application/json"`,
   `<${DISCOVERY_LINK_BASE}/llms.txt>; rel="service-doc"; type="text/plain"`,
   `<${DISCOVERY_LINK_BASE}/agent.md>; rel="service-doc"; type="text/markdown"`,
+  `<${DISCOVERY_LINK_BASE}/agent-workflows.md>; rel="service-doc"; type="text/markdown"`,
   `<${DISCOVERY_LINK_BASE}/health>; rel="status"; type="application/json"`,
   `<${DISCOVERY_LINK_BASE}/.well-known/mcp/server-card.json>; rel="describedby"; type="application/json"`,
   // Content feeds (#741) — registry changes, content-negotiated (json/rss/atom).
@@ -176,6 +177,7 @@ const HOMEPAGE_HTML = `<!doctype html>
 <link rel="service-desc" href="/metagraph/openapi.json" type="application/json">
 <link rel="service-doc" href="/llms.txt" type="text/plain">
 <link rel="service-doc" href="/agent.md" type="text/markdown">
+<link rel="service-doc" href="/agent-workflows.md" type="text/markdown">
 <link rel="status" href="/health" type="application/json">
 <link rel="describedby" href="/.well-known/mcp/server-card.json" type="application/json">
 <link rel="alternate" href="/api/v1/feeds/registry.rss" type="application/rss+xml" title="metagraphed registry changes">
@@ -188,6 +190,7 @@ const HOMEPAGE_HTML = `<!doctype html>
 <ul>
 <li><a href="/llms.txt">llms.txt</a> — LLM/agent discovery index</li>
 <li><a href="/agent.md">agent.md</a> — copyable agent system prompt</li>
+<li><a href="/agent-workflows.md">agent-workflows.md</a> — REST, MCP, npm, and Python workflows</li>
 <li><a href="/metagraph/openapi.json">OpenAPI 3.1 contract</a></li>
 <li><a href="/.well-known/api-catalog">API catalog</a> (RFC 9727 linkset)</li>
 <li><a href="/.well-known/mcp/server-card.json">MCP server card</a> — <code>POST /mcp</code></li>
@@ -244,6 +247,7 @@ export function apiCatalogResponse(request) {
         "service-doc": [
           { href: `${base}/llms.txt`, type: "text/plain" },
           { href: `${base}/agent.md`, type: "text/markdown" },
+          { href: `${base}/agent-workflows.md`, type: "text/markdown" },
         ],
         status: [{ href: `${base}/health`, type: "application/json" }],
         describedby: [


### PR DESCRIPTION
## Summary
- Add a public agent workflow guide that takes users from callable subnet discovery to REST, MCP, npm, and Python examples.
- Wire the guide into README, `/agent.md`, the Bittensor skill, `llms.txt`, `auth.md`, sitemap, agent resources, and API discovery surfaces.
- Correct the MCP quickstart docs to reflect the current 16-tool server surface.

## What changed
- Added `public/agent-workflows.md` with task-oriented workflows for discovery, readiness checks, schema/fixture lookup, live verification, snippets, and grounded Q&A.
- Advertised the workflow guide from the Link header, homepage discovery HTML, RFC API catalog, generated `llms` outputs, sitemap, and agent resource generation.
- Added tests that keep the workflow guide discoverable from generated agent resources and the API catalog.
- Created child issues for the top agent-readiness follow-up gaps: #1142, #1143, and #1144.

## Why
The existing surfaces were useful but too implicit: agents could find endpoint lists, but a new user still had to infer the path from “what subnet should I call?” to a runnable REST/MCP/SDK example. This makes that path explicit and keeps the machine-discovery surfaces aligned.

Addresses #1129.

## Validation
- `npm run build`
- `npm run format:check`
- `npm run lint`
- `npm test -- tests/artifacts.test.mjs tests/worker-runtime.test.mjs`
- `npm run test:coverage` (51 files, 1179 tests; expected public-safety fixture warnings from test fixtures)
- `npm run validate:contract-drift`
- `npm run validate:schema-enums`
- `npm run validate:openapi-examples`
- `npm run validate:generated-client`
- `npm run validate:committed-seed`
- `npm run validate`
- `npm run validate:schemas`
- `npm run validate:api`
- `npm run validate:mcp`
- `npm run validate:ai`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:artifact-budgets`
- `npm run validate:docs`
- `npm run validate:readme-catalog`
- `npm run validate:intake`
- `npm run validate:workflows`
- `npm run cloudflare:verify:dry-run` (passed; local account/KV identifiers were not configured, so live account resource checks were skipped)
- `npm run r2:manifest`
- `npm run r2:manifest:dry-run`
- `npm run r2:download:dry-run`
- `npm run kv:publish:dry-run`
- `npm run worker:deploy:dry-run`
- `npm run scan:public-safety`
- `npm run validate:private-boundary`
- `npm run worker:test`
- `git diff --check`

## Notes
- `public/metagraph/r2-manifest.json` was intentionally not committed; its R2 byte totals are non-deterministic and the CI freshness gate excludes it for that reason.
- #1129 should stay open until the merged docs are published on the public API surface.
