### PR TITLE
feat(agent): expose readiness blockers

### DIFF
--- a/docs/integration-readiness.md
+++ b/docs/integration-readiness.md
@@ -60,6 +60,40 @@ score:
 | `identity-only` | neither of the above, but `has_source_repo` or `active_lifecycle` |
 | `dormant`       | none — no interface, no candidate, no docs, no repo, not active   |
 
+## Blocker reasons (`agent_readiness`)
+
+The agent catalog keeps its existing `subnets` array as the callable subset, and
+adds `blocked_subnets` for the rest of the registry. Each callable and blocked
+row carries an `agent_readiness` object:
+
+- `status`: `callable`, `base-layer`, `candidate`, `needs-evidence`, or
+  `blocked`.
+- `blocker_level`: `none`, `hard-blocked`, `needs-review`, or `missing-data`.
+- `blockers[]`: stable `{ code, severity, message, field, next_action }`
+  objects.
+- `missing_fields[]`: deduplicated fields/evidence families from
+  `missing-data` blockers.
+
+The blocker model is not a second score. It is a deterministic explanation of
+the same readiness facts, shaped for agents and UI filters. Use it when a subnet
+is absent from the callable subset and the user asks why.
+
+Common blocker codes:
+
+| Code                         | Meaning                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------ |
+| `base-layer-only`            | root/base-layer surfaces are not application-subnet APIs                 |
+| `inactive-lifecycle`         | the subnet is not marked active in the registry snapshot                 |
+| `missing-callable-service`   | no public-safe callable service is catalogued yet                        |
+| `service-not-callable`       | services exist, but none are structurally callable                       |
+| `candidate-api-needs-review` | an unpromoted candidate operational surface needs maintainer review      |
+| `no-candidate-api`           | no candidate API surface has been found                                  |
+| `missing-schema`             | callable services exist but no captured schema artifact is available     |
+| `unclear-auth`               | callable services exist but auth metadata is not machine-readable enough |
+| `missing-docs`               | no public documentation link is recorded                                 |
+| `missing-source-repo`        | no public source repository is recorded                                  |
+| `profile-incomplete`         | the subnet profile is below the completeness threshold                   |
+
 ## Live verification (`readiness.readiness_verified`)
 
 The numeric `score` is deliberately build-time and deterministic, so

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1045,9 +1045,29 @@ export interface components {
             [key: string]: unknown;
         });
         AgentCatalogArtifact: components["schemas"]["ArtifactBase"] & ({
+            blocked_subnet_count?: number;
+            blocked_subnets?: ({
+                agent_readiness: components["schemas"]["AgentReadinessStatus"];
+                callable_count?: number;
+                categories?: string[];
+                completeness_score?: number | null;
+                integration_readiness?: number;
+                name?: string;
+                netuid: number;
+                readiness_tier?: string;
+                service_count?: number;
+                slug?: string;
+                subnet_type?: string | null;
+            } & {
+                [key: string]: unknown;
+            })[];
+            blocker_summary?: {
+                [key: string]: unknown;
+            };
             callable_service_count?: number;
             subnet_count: number;
             subnets: ({
+                agent_readiness?: components["schemas"]["AgentReadinessStatus"];
                 base_url?: string | null;
                 callable_count?: number;
                 categories?: string[];
@@ -1069,6 +1089,7 @@ export interface components {
             [key: string]: unknown;
         });
         AgentCatalogSubnetArtifact: components["schemas"]["ArtifactBase"] & ({
+            agent_readiness?: components["schemas"]["AgentReadinessStatus"];
             categories?: string[];
             completeness_score?: number | null;
             integration_readiness?: number;
@@ -1103,6 +1124,27 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        /** @description Machine-readable reason a subnet is not immediately agent-ready, or a remaining data gap on a callable subnet. */
+        AgentReadinessBlocker: {
+            /** @description Stable blocker code, e.g. missing-callable-service or missing-schema. */
+            code: string;
+            /** @description Registry field, artifact family, or evidence surface that needs attention. */
+            field: string;
+            message: string;
+            /** @description Concrete maintainer/contributor action to clear or explain the blocker. */
+            next_action: string;
+            /** @enum {string} */
+            severity: "hard" | "missing-data" | "needs-review";
+        };
+        /** @description Agent-facing readiness status and blocker taxonomy for one subnet. */
+        AgentReadinessStatus: {
+            /** @enum {string} */
+            blocker_level: "none" | "hard-blocked" | "needs-review" | "missing-data";
+            blockers: components["schemas"]["AgentReadinessBlocker"][];
+            missing_fields: string[];
+            /** @enum {string} */
+            status: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
+        };
         AgentResourcesArtifact: components["schemas"]["ArtifactBase"] & ({
             content_hash?: string;
             copyable_agent: {
@@ -3882,6 +3924,29 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "blocked_subnet_count": 5000000,
+                     *         "blocked_subnets": [
+                     *           {
+                     *             "agent_readiness": {
+                     *               "blocker_level": "none",
+                     *               "blockers": [
+                     *                 {
+                     *                   "code": "example",
+                     *                   "field": "example",
+                     *                   "message": "example",
+                     *                   "next_action": "example",
+                     *                   "severity": "hard"
+                     *                 }
+                     *               ],
+                     *               "missing_fields": [
+                     *                 "example"
+                     *               ],
+                     *               "status": "callable"
+                     *             },
+                     *             "netuid": 7
+                     *           }
+                     *         ],
+                     *         "blocker_summary": {},
                      *         "callable_service_count": 1,
                      *         "contract_version": "2026-06-06.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
@@ -3995,6 +4060,22 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "agent_readiness": {
+                     *           "blocker_level": "none",
+                     *           "blockers": [
+                     *             {
+                     *               "code": "example",
+                     *               "field": "example",
+                     *               "message": "example",
+                     *               "next_action": "example",
+                     *               "severity": "hard"
+                     *             }
+                     *           ],
+                     *           "missing_fields": [
+                     *             "example"
+                     *           ],
+                     *           "status": "callable"
+                     *         },
                      *         "categories": [
                      *           "example"
                      *         ],

--- a/public/agent-workflows.md
+++ b/public/agent-workflows.md
@@ -276,6 +276,13 @@ Common blockers:
 - The subnet is parked, deprecated, candidate-only, or otherwise not suitable
   for an integration recommendation.
 
+For machine-readable explanations, read
+`GET https://api.metagraph.sh/api/v1/agent-catalog`. The `subnets` array is the
+callable subset. The `blocked_subnets` array contains the rest of the registry,
+each with `agent_readiness.status`, `agent_readiness.blocker_level`,
+`agent_readiness.blockers[]`, and `agent_readiness.missing_fields[]`. Use those
+fields when the user asks why a subnet is not agent-ready yet.
+
 ## Agent loop
 
 Use this loop for integration tasks:

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -70,6 +70,74 @@
           {
             "additionalProperties": true,
             "properties": {
+              "blocked_subnet_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "blocked_subnets": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "agent_readiness": {
+                      "$ref": "#/components/schemas/AgentReadinessStatus"
+                    },
+                    "callable_count": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "categories": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "completeness_score": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "integration_readiness": {
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "netuid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "readiness_tier": {
+                      "type": "string"
+                    },
+                    "service_count": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "subnet_type": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "netuid",
+                    "agent_readiness"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "blocker_summary": {
+                "additionalProperties": true,
+                "type": "object"
+              },
               "callable_service_count": {
                 "minimum": 0,
                 "type": "integer"
@@ -82,6 +150,9 @@
                 "items": {
                   "additionalProperties": true,
                   "properties": {
+                    "agent_readiness": {
+                      "$ref": "#/components/schemas/AgentReadinessStatus"
+                    },
                     "base_url": {
                       "type": [
                         "string",
@@ -171,6 +242,9 @@
           {
             "additionalProperties": true,
             "properties": {
+              "agent_readiness": {
+                "$ref": "#/components/schemas/AgentReadinessStatus"
+              },
               "categories": {
                 "items": {
                   "type": "string"
@@ -296,6 +370,87 @@
             "type": "object"
           }
         ]
+      },
+      "AgentReadinessBlocker": {
+        "additionalProperties": false,
+        "description": "Machine-readable reason a subnet is not immediately agent-ready, or a remaining data gap on a callable subnet.",
+        "properties": {
+          "code": {
+            "description": "Stable blocker code, e.g. missing-callable-service or missing-schema.",
+            "type": "string"
+          },
+          "field": {
+            "description": "Registry field, artifact family, or evidence surface that needs attention.",
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Concrete maintainer/contributor action to clear or explain the blocker.",
+            "type": "string"
+          },
+          "severity": {
+            "enum": [
+              "hard",
+              "missing-data",
+              "needs-review"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "severity",
+          "message",
+          "field",
+          "next_action"
+        ],
+        "type": "object"
+      },
+      "AgentReadinessStatus": {
+        "additionalProperties": false,
+        "description": "Agent-facing readiness status and blocker taxonomy for one subnet.",
+        "properties": {
+          "blocker_level": {
+            "enum": [
+              "none",
+              "hard-blocked",
+              "needs-review",
+              "missing-data"
+            ],
+            "type": "string"
+          },
+          "blockers": {
+            "items": {
+              "$ref": "#/components/schemas/AgentReadinessBlocker"
+            },
+            "type": "array"
+          },
+          "missing_fields": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "callable",
+              "base-layer",
+              "candidate",
+              "needs-evidence",
+              "blocked"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "blocker_level",
+          "blockers",
+          "missing_fields"
+        ],
+        "type": "object"
       },
       "AgentResourcesArtifact": {
         "allOf": [
@@ -10571,6 +10726,29 @@
               "application/json": {
                 "example": {
                   "data": {
+                    "blocked_subnet_count": 5000000,
+                    "blocked_subnets": [
+                      {
+                        "agent_readiness": {
+                          "blocker_level": "none",
+                          "blockers": [
+                            {
+                              "code": "example",
+                              "field": "example",
+                              "message": "example",
+                              "next_action": "example",
+                              "severity": "hard"
+                            }
+                          ],
+                          "missing_fields": [
+                            "example"
+                          ],
+                          "status": "callable"
+                        },
+                        "netuid": 7
+                      }
+                    ],
+                    "blocker_summary": {},
                     "callable_service_count": 1,
                     "contract_version": "2026-06-06.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
@@ -10711,6 +10889,22 @@
               "application/json": {
                 "example": {
                   "data": {
+                    "agent_readiness": {
+                      "blocker_level": "none",
+                      "blockers": [
+                        {
+                          "code": "example",
+                          "field": "example",
+                          "message": "example",
+                          "next_action": "example",
+                          "severity": "hard"
+                        }
+                      ],
+                      "missing_fields": [
+                        "example"
+                      ],
+                      "status": "callable"
+                    },
                     "categories": [
                       "example"
                     ],

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1045,9 +1045,29 @@ export interface components {
             [key: string]: unknown;
         });
         AgentCatalogArtifact: components["schemas"]["ArtifactBase"] & ({
+            blocked_subnet_count?: number;
+            blocked_subnets?: ({
+                agent_readiness: components["schemas"]["AgentReadinessStatus"];
+                callable_count?: number;
+                categories?: string[];
+                completeness_score?: number | null;
+                integration_readiness?: number;
+                name?: string;
+                netuid: number;
+                readiness_tier?: string;
+                service_count?: number;
+                slug?: string;
+                subnet_type?: string | null;
+            } & {
+                [key: string]: unknown;
+            })[];
+            blocker_summary?: {
+                [key: string]: unknown;
+            };
             callable_service_count?: number;
             subnet_count: number;
             subnets: ({
+                agent_readiness?: components["schemas"]["AgentReadinessStatus"];
                 base_url?: string | null;
                 callable_count?: number;
                 categories?: string[];
@@ -1069,6 +1089,7 @@ export interface components {
             [key: string]: unknown;
         });
         AgentCatalogSubnetArtifact: components["schemas"]["ArtifactBase"] & ({
+            agent_readiness?: components["schemas"]["AgentReadinessStatus"];
             categories?: string[];
             completeness_score?: number | null;
             integration_readiness?: number;
@@ -1103,6 +1124,27 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        /** @description Machine-readable reason a subnet is not immediately agent-ready, or a remaining data gap on a callable subnet. */
+        AgentReadinessBlocker: {
+            /** @description Stable blocker code, e.g. missing-callable-service or missing-schema. */
+            code: string;
+            /** @description Registry field, artifact family, or evidence surface that needs attention. */
+            field: string;
+            message: string;
+            /** @description Concrete maintainer/contributor action to clear or explain the blocker. */
+            next_action: string;
+            /** @enum {string} */
+            severity: "hard" | "missing-data" | "needs-review";
+        };
+        /** @description Agent-facing readiness status and blocker taxonomy for one subnet. */
+        AgentReadinessStatus: {
+            /** @enum {string} */
+            blocker_level: "none" | "hard-blocked" | "needs-review" | "missing-data";
+            blockers: components["schemas"]["AgentReadinessBlocker"][];
+            missing_fields: string[];
+            /** @enum {string} */
+            status: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
+        };
         AgentResourcesArtifact: components["schemas"]["ArtifactBase"] & ({
             content_hash?: string;
             copyable_agent: {
@@ -3882,6 +3924,29 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "blocked_subnet_count": 5000000,
+                     *         "blocked_subnets": [
+                     *           {
+                     *             "agent_readiness": {
+                     *               "blocker_level": "none",
+                     *               "blockers": [
+                     *                 {
+                     *                   "code": "example",
+                     *                   "field": "example",
+                     *                   "message": "example",
+                     *                   "next_action": "example",
+                     *                   "severity": "hard"
+                     *                 }
+                     *               ],
+                     *               "missing_fields": [
+                     *                 "example"
+                     *               ],
+                     *               "status": "callable"
+                     *             },
+                     *             "netuid": 7
+                     *           }
+                     *         ],
+                     *         "blocker_summary": {},
                      *         "callable_service_count": 1,
                      *         "contract_version": "2026-06-06.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
@@ -3995,6 +4060,22 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "agent_readiness": {
+                     *           "blocker_level": "none",
+                     *           "blockers": [
+                     *             {
+                     *               "code": "example",
+                     *               "field": "example",
+                     *               "message": "example",
+                     *               "next_action": "example",
+                     *               "severity": "hard"
+                     *             }
+                     *           ],
+                     *           "missing_fields": [
+                     *             "example"
+                     *           ],
+                     *           "status": "callable"
+                     *         },
                      *         "categories": [
                      *           "example"
                      *         ],

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -56,6 +56,74 @@
           {
             "additionalProperties": true,
             "properties": {
+              "blocked_subnet_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "blocked_subnets": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "agent_readiness": {
+                      "$ref": "#/components/schemas/AgentReadinessStatus"
+                    },
+                    "callable_count": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "categories": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "completeness_score": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "integration_readiness": {
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "netuid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "readiness_tier": {
+                      "type": "string"
+                    },
+                    "service_count": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "subnet_type": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "netuid",
+                    "agent_readiness"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "blocker_summary": {
+                "additionalProperties": true,
+                "type": "object"
+              },
               "callable_service_count": {
                 "minimum": 0,
                 "type": "integer"
@@ -68,6 +136,9 @@
                 "items": {
                   "additionalProperties": true,
                   "properties": {
+                    "agent_readiness": {
+                      "$ref": "#/components/schemas/AgentReadinessStatus"
+                    },
                     "base_url": {
                       "type": [
                         "string",
@@ -157,6 +228,9 @@
           {
             "additionalProperties": true,
             "properties": {
+              "agent_readiness": {
+                "$ref": "#/components/schemas/AgentReadinessStatus"
+              },
               "categories": {
                 "items": {
                   "type": "string"
@@ -282,6 +356,87 @@
             "type": "object"
           }
         ]
+      },
+      "AgentReadinessBlocker": {
+        "additionalProperties": false,
+        "description": "Machine-readable reason a subnet is not immediately agent-ready, or a remaining data gap on a callable subnet.",
+        "properties": {
+          "code": {
+            "description": "Stable blocker code, e.g. missing-callable-service or missing-schema.",
+            "type": "string"
+          },
+          "field": {
+            "description": "Registry field, artifact family, or evidence surface that needs attention.",
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "next_action": {
+            "description": "Concrete maintainer/contributor action to clear or explain the blocker.",
+            "type": "string"
+          },
+          "severity": {
+            "enum": [
+              "hard",
+              "missing-data",
+              "needs-review"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "severity",
+          "message",
+          "field",
+          "next_action"
+        ],
+        "type": "object"
+      },
+      "AgentReadinessStatus": {
+        "additionalProperties": false,
+        "description": "Agent-facing readiness status and blocker taxonomy for one subnet.",
+        "properties": {
+          "blocker_level": {
+            "enum": [
+              "none",
+              "hard-blocked",
+              "needs-review",
+              "missing-data"
+            ],
+            "type": "string"
+          },
+          "blockers": {
+            "items": {
+              "$ref": "#/components/schemas/AgentReadinessBlocker"
+            },
+            "type": "array"
+          },
+          "missing_fields": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "callable",
+              "base-layer",
+              "candidate",
+              "needs-evidence",
+              "blocked"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "blocker_level",
+          "blockers",
+          "missing_fields"
+        ],
+        "type": "object"
       },
       "AgentResourcesArtifact": {
         "allOf": [

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -793,6 +793,63 @@
           }
         }
       },
+      "AgentReadinessBlocker": {
+        "type": "object",
+        "description": "Machine-readable reason a subnet is not immediately agent-ready, or a remaining data gap on a callable subnet.",
+        "required": ["code", "severity", "message", "field", "next_action"],
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Stable blocker code, e.g. missing-callable-service or missing-schema."
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["hard", "missing-data", "needs-review"]
+          },
+          "message": { "type": "string" },
+          "field": {
+            "type": "string",
+            "description": "Registry field, artifact family, or evidence surface that needs attention."
+          },
+          "next_action": {
+            "type": "string",
+            "description": "Concrete maintainer/contributor action to clear or explain the blocker."
+          }
+        }
+      },
+      "AgentReadinessStatus": {
+        "type": "object",
+        "description": "Agent-facing readiness status and blocker taxonomy for one subnet.",
+        "required": ["status", "blocker_level", "blockers", "missing_fields"],
+        "additionalProperties": false,
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "callable",
+              "base-layer",
+              "candidate",
+              "needs-evidence",
+              "blocked"
+            ]
+          },
+          "blocker_level": {
+            "type": "string",
+            "enum": ["none", "hard-blocked", "needs-review", "missing-data"]
+          },
+          "blockers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentReadinessBlocker"
+            }
+          },
+          "missing_fields": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
       "AgentCatalogArtifact": {
         "allOf": [
           { "$ref": "#/components/schemas/ArtifactBase" },
@@ -802,7 +859,12 @@
             "properties": {
               "total_subnet_count": { "type": "integer", "minimum": 0 },
               "subnet_count": { "type": "integer", "minimum": 0 },
+              "blocked_subnet_count": { "type": "integer", "minimum": 0 },
               "callable_service_count": { "type": "integer", "minimum": 0 },
+              "blocker_summary": {
+                "type": "object",
+                "additionalProperties": true
+              },
               "subnets": {
                 "type": "array",
                 "items": {
@@ -826,6 +888,9 @@
                     "readiness": {
                       "$ref": "#/components/schemas/IntegrationReadiness"
                     },
+                    "agent_readiness": {
+                      "$ref": "#/components/schemas/AgentReadinessStatus"
+                    },
                     "service_count": { "type": "integer", "minimum": 0 },
                     "callable_count": { "type": "integer", "minimum": 0 },
                     "service_kinds": {
@@ -834,6 +899,36 @@
                     },
                     "base_url": { "type": ["string", "null"] },
                     "health": { "type": "string" }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "blocked_subnets": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["netuid", "agent_readiness"],
+                  "properties": {
+                    "netuid": { "type": "integer", "minimum": 0 },
+                    "slug": { "type": "string" },
+                    "name": { "type": "string" },
+                    "categories": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "subnet_type": { "type": ["string", "null"] },
+                    "completeness_score": { "type": ["number", "null"] },
+                    "integration_readiness": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 100
+                    },
+                    "readiness_tier": { "type": "string" },
+                    "service_count": { "type": "integer", "minimum": 0 },
+                    "callable_count": { "type": "integer", "minimum": 0 },
+                    "agent_readiness": {
+                      "$ref": "#/components/schemas/AgentReadinessStatus"
+                    }
                   },
                   "additionalProperties": true
                 }
@@ -901,6 +996,9 @@
               },
               "readiness": {
                 "$ref": "#/components/schemas/IntegrationReadiness"
+              },
+              "agent_readiness": {
+                "$ref": "#/components/schemas/AgentReadinessStatus"
               },
               "service_count": { "type": "integer", "minimum": 0 },
               "services": {

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1396,6 +1396,175 @@ function subnetIntegrationReadiness({
   };
 }
 
+function buildAgentReadiness({
+  subnet,
+  profile,
+  services,
+  readiness,
+  callableCount,
+}) {
+  const components = readiness?.components || {};
+  const subnetType = profile?.subnet_type || subnet.subnet_type || null;
+  const blockers = [];
+  const add = (code, severity, message, field, nextAction) => {
+    blockers.push({
+      code,
+      severity,
+      message,
+      field,
+      next_action: nextAction,
+    });
+  };
+
+  if (subnetType === "root") {
+    add(
+      "base-layer-only",
+      "hard",
+      "Root/base-layer surfaces are not application-subnet APIs.",
+      "subnet_type",
+      "Use get_best_rpc_endpoint or /api/v1/rpc/endpoints for chain RPC access.",
+    );
+  }
+  if (!components.active_lifecycle) {
+    add(
+      "inactive-lifecycle",
+      "hard",
+      "The subnet is not marked active in the registry snapshot.",
+      "lifecycle",
+      "Wait for an active mainnet subnet before recommending it for integrations.",
+    );
+  }
+  if ((services || []).length === 0) {
+    add(
+      "missing-callable-service",
+      "missing-data",
+      "No public-safe callable service is catalogued for this subnet yet.",
+      "surfaces",
+      "Find and verify an official subnet-api, OpenAPI, SSE, or data-artifact surface.",
+    );
+  } else if (callableCount === 0) {
+    add(
+      "service-not-callable",
+      "hard",
+      "Catalogued services exist, but none are structurally callable.",
+      "services.eligibility.callable",
+      "Review unsafe/dead service classifications before recommending this subnet.",
+    );
+  }
+  if (components.has_candidate_api && callableCount === 0) {
+    add(
+      "candidate-api-needs-review",
+      "needs-review",
+      "A candidate operational surface exists but has not been promoted into the callable catalog.",
+      "registry.candidates",
+      "Verify the candidate surface and promote it if it is public, safe, and subnet-owned.",
+    );
+  }
+  if (!components.has_candidate_api && callableCount === 0) {
+    add(
+      "no-candidate-api",
+      "missing-data",
+      "No candidate API surface has been found for this subnet.",
+      "registry.candidates",
+      "Search official docs, source repos, and project sites for a public integration surface.",
+    );
+  }
+  if (!components.documented && callableCount > 0) {
+    add(
+      "missing-schema",
+      "missing-data",
+      "At least one callable service exists, but no captured schema artifact is available.",
+      "schemas",
+      "Capture an official OpenAPI/Swagger/JSON Schema source or document that no schema exists.",
+    );
+  }
+  if (!components.auth_clarity && callableCount > 0) {
+    add(
+      "unclear-auth",
+      "missing-data",
+      "Callable services exist, but auth requirements are not fully machine-readable.",
+      "auth",
+      "Declare auth_required/auth_schemes or capture auth metadata from the service schema.",
+    );
+  }
+  if (!components.has_public_docs) {
+    add(
+      "missing-docs",
+      "missing-data",
+      "No public documentation link is recorded.",
+      "docs_url",
+      "Add an official docs URL or document that no public docs exist.",
+    );
+  }
+  if (!components.has_source_repo) {
+    add(
+      "missing-source-repo",
+      "missing-data",
+      "No public source repository is recorded.",
+      "source_repo",
+      "Add an official source repo or document that no public repo exists.",
+    );
+  }
+  if (!components.profile_complete) {
+    add(
+      "profile-incomplete",
+      "missing-data",
+      "The subnet profile is below the completeness threshold used by integration readiness.",
+      "completeness_score",
+      "Fill the missing required and operational registry fields for this subnet.",
+    );
+  }
+
+  const status =
+    callableCount > 0
+      ? "callable"
+      : subnetType === "root"
+        ? "base-layer"
+        : components.has_candidate_api
+          ? "candidate"
+          : components.has_public_docs || components.has_source_repo
+            ? "needs-evidence"
+            : "blocked";
+  const blockerLevel = blockers.some((blocker) => blocker.severity === "hard")
+    ? "hard-blocked"
+    : blockers.some((blocker) => blocker.severity === "needs-review")
+      ? "needs-review"
+      : blockers.length > 0
+        ? "missing-data"
+        : "none";
+
+  return {
+    status,
+    blocker_level: blockerLevel,
+    blockers,
+    missing_fields: [
+      ...new Set(
+        blockers
+          .filter((blocker) => blocker.severity === "missing-data")
+          .map((blocker) => blocker.field),
+      ),
+    ].sort(),
+  };
+}
+
+function summarizeAgentReadinessBlockers(blockedSubnets) {
+  const blockers = blockedSubnets.flatMap(
+    (subnet) => subnet.agent_readiness?.blockers || [],
+  );
+  return {
+    by_status: countBy(
+      blockedSubnets,
+      (subnet) => subnet.agent_readiness?.status || "unknown",
+    ),
+    by_level: countBy(
+      blockedSubnets,
+      (subnet) => subnet.agent_readiness?.blocker_level || "unknown",
+    ),
+    by_severity: countBy(blockers, "severity"),
+    by_code: countBy(blockers, "code"),
+  };
+}
+
 await fs.rm(r2ArtifactDir("agent-catalog"), { recursive: true, force: true });
 // #1008: code-examples (quickstarts / SDK snippets) per subnet, projected from
 // the curated `example`-kind surfaces. They are reference material, not callable
@@ -1414,6 +1583,7 @@ const subnetExamples = (netuid) =>
     authority: surface.authority || null,
   }));
 const agentCatalogIndex = [];
+const blockedAgentCatalogIndex = [];
 let callableServiceCount = 0;
 for (const subnet of mergedSubnets) {
   const profile = profileArtifacts.byNetuid.get(subnet.netuid) || null;
@@ -1421,6 +1591,14 @@ for (const subnet of mergedSubnets) {
   const examples = subnetExamples(subnet.netuid);
   // Reuse the readiness computed once above for the index/profile surfaces.
   const readiness = readinessByNetuid.get(subnet.netuid);
+  const callable = services.filter((s) => s.eligibility.callable).length;
+  const agentReadiness = buildAgentReadiness({
+    subnet,
+    profile,
+    services,
+    readiness,
+    callableCount: callable,
+  });
   await writeJson(artifactFile(`agent-catalog/${subnet.netuid}.json`), {
     schema_version: 1,
     contract_version: contractVersion,
@@ -1433,14 +1611,14 @@ for (const subnet of mergedSubnets) {
     completeness_score: profile?.completeness_score ?? null,
     integration_readiness: readiness.score,
     readiness,
+    agent_readiness: agentReadiness,
     service_count: services.length,
     services,
     example_count: examples.length,
     examples,
   });
-  if (services.length > 0) {
-    const callable = services.filter((s) => s.eligibility.callable).length;
-    callableServiceCount += callable;
+  callableServiceCount += callable;
+  if (callable > 0) {
     // Primary callable surface (first callable, else first overall) — gives the
     // index a "where do I call this + is it up" rollup so single-read consumers
     // (e.g. the /ask RAG join) don't have to fan out to per-subnet detail files.
@@ -1457,6 +1635,7 @@ for (const subnet of mergedSubnets) {
       completeness_score: profile?.completeness_score ?? null,
       integration_readiness: readiness.score,
       readiness,
+      agent_readiness: agentReadiness,
       service_count: services.length,
       callable_count: callable,
       service_kinds: [...new Set(services.map((s) => s.kind))].sort(),
@@ -1465,11 +1644,37 @@ for (const subnet of mergedSubnets) {
       // Live-only: overlaid from KV/D1 on read; `unknown` when the store is cold.
       health: "unknown",
     });
+  } else {
+    blockedAgentCatalogIndex.push({
+      netuid: subnet.netuid,
+      slug: subnet.slug,
+      name: subnet.name,
+      categories: Array.isArray(profile?.categories) ? profile.categories : [],
+      subnet_type: profile?.subnet_type || null,
+      completeness_score: profile?.completeness_score ?? null,
+      integration_readiness: readiness.score,
+      readiness_tier: readiness.readiness_tier,
+      service_count: services.length,
+      callable_count: callable,
+      agent_readiness: agentReadiness,
+    });
   }
 }
 const agentCatalogSubnets = agentCatalogIndex.sort(
   (a, b) => a.netuid - b.netuid,
 );
+const blockedAgentCatalogSubnets = blockedAgentCatalogIndex.sort(
+  (a, b) => a.netuid - b.netuid,
+);
+const agentCatalogContent = {
+  total_subnet_count: mergedSubnets.length,
+  subnet_count: agentCatalogIndex.length,
+  blocked_subnet_count: blockedAgentCatalogIndex.length,
+  callable_service_count: callableServiceCount,
+  blocker_summary: summarizeAgentReadinessBlockers(blockedAgentCatalogSubnets),
+  subnets: agentCatalogSubnets,
+  blocked_subnets: blockedAgentCatalogSubnets,
+};
 await writeJson(artifactFile("agent-catalog.json"), {
   schema_version: 1,
   contract_version: contractVersion,
@@ -1479,11 +1684,8 @@ await writeJson(artifactFile("agent-catalog.json"), {
   // discerning agent reads honest freshness, not a 1970 stamp (issue #349).
   generated_at: generatedAt,
   published_at: publishedAt(),
-  content_hash: hashJson(agentCatalogSubnets),
-  total_subnet_count: mergedSubnets.length,
-  subnet_count: agentCatalogIndex.length,
-  callable_service_count: callableServiceCount,
-  subnets: agentCatalogSubnets,
+  content_hash: hashJson(agentCatalogContent),
+  ...agentCatalogContent,
 });
 
 // --- llms.txt / llms-full.txt (LLM + agent discoverability) ------------------

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -748,6 +748,58 @@ test("public artifacts are internally consistent", () => {
     "agent-catalog must carry a deterministic content_hash",
   );
   assert.ok(agentCatalog.content_hash.length >= 16);
+  assert.equal(
+    agentCatalog.total_subnet_count,
+    agentCatalog.subnet_count + agentCatalog.blocked_subnet_count,
+    "agent-catalog callable + blocked counts must cover every subnet",
+  );
+  assert.ok(
+    Array.isArray(agentCatalog.blocked_subnets) &&
+      agentCatalog.blocked_subnets.length > 0,
+    "agent-catalog must explain blocked/non-callable subnets",
+  );
+  assert.equal(
+    agentCatalog.blocked_subnet_count,
+    agentCatalog.blocked_subnets.length,
+    "blocked_subnet_count must match blocked_subnets length",
+  );
+  assert.ok(
+    agentCatalog.subnets.every(
+      (entry) => entry.agent_readiness?.status === "callable",
+    ),
+    "callable agent-catalog entries must carry callable readiness status",
+  );
+  const blockedRecall = agentCatalog.blocked_subnets.find(
+    (entry) => entry.netuid === 31,
+  );
+  assert.ok(blockedRecall, "SN31 should be represented as a blocked subnet");
+  assert.equal(blockedRecall.agent_readiness.status, "blocked");
+  assert.ok(
+    blockedRecall.agent_readiness.blockers.some(
+      (blocker) => blocker.code === "missing-callable-service",
+    ),
+    "blocked subnets must explain the missing callable service",
+  );
+  const rootBlocker = agentCatalog.blocked_subnets.find(
+    (entry) => entry.netuid === 0,
+  );
+  assert.equal(rootBlocker.agent_readiness.status, "base-layer");
+  assert.ok(
+    rootBlocker.agent_readiness.blockers.some(
+      (blocker) => blocker.code === "base-layer-only",
+    ),
+    "root subnet must explain the base-layer-only boundary",
+  );
+  assert.ok(
+    agentCatalog.blocker_summary.by_code["missing-callable-service"] > 0,
+    "blocker summary must count missing callable service blockers",
+  );
+  const catalog31 = readArtifact("agent-catalog/31.json");
+  assert.equal(catalog31.agent_readiness.status, "blocked");
+  assert.ok(
+    catalog31.agent_readiness.missing_fields.includes("surfaces"),
+    "per-subnet detail must expose blocker missing_fields",
+  );
 
   // Cross-network lineage (issue #353): mainnet ↔ testnet mapping, with the
   // profile's lineage reconciled against the standalone artifact.


### PR DESCRIPTION
## Summary
- Add machine-readable readiness blockers to the agent catalog so callers can explain why a subnet is not agent-ready yet.
- Keep the existing callable `subnets` array intact while adding `blocked_subnets`, `blocked_subnet_count`, and `blocker_summary`.

## What changed
- Added deterministic `agent_readiness` status, blocker level, blocker list, and missing field families for callable and non-callable subnets.
- Added global blocked subnet coverage and summary counts to `agent-catalog.json`.
- Added per-subnet `agent_readiness` details to `agent-catalog/{netuid}.json`.
- Updated schemas, OpenAPI/types artifacts, docs, and artifact tests for the new fields.

## Why
Agents, SDKs, and UI surfaces need a public-safe way to answer “why is this subnet not callable?” without reading registry source files or guessing from score components.

Closes #1142

## Validation
- `npm run build`
- `npm run format:check`
- `npm test -- tests/artifacts.test.mjs`
- `npm run validate:mcp`
- `npm run validate:schemas`
- `npm run validate:api`
- `npm run validate:openapi`
- `npm run validate:openapi-examples`
- `npm run validate:types`
- `npm run validate:contract-drift`
- `npm run lint`
- `npm run validate`
- `npm run validate:docs`
- `npm run validate:artifact-budgets` (expected size warnings for `openapi.json`, `profiles.json`, and `testnet/subnets.json`)
- `npm run validate:generated-client`
- `npm run validate:readme-catalog`
- `npm run validate:intake`
- `npm run validate:workflows`
- `npm run scan:public-safety`
- `npm run validate:private-boundary`
- `npm run worker:test`
- `npm run worker:deploy:dry-run`
- `npm run test:coverage`
- `npm run r2:manifest`
- `npm run r2:manifest:dry-run`
- `git diff --check`

## Notes
- `public/metagraph/r2-manifest.json` is intentionally not committed; CI/publish regenerates the volatile byte totals.