### PR TITLE
feat(agent): expose fixture coverage

### DIFF
--- a/docs/integration-readiness.md
+++ b/docs/integration-readiness.md
@@ -112,6 +112,22 @@ generation. Treat `same-origin-openapi` as a strong pointer to the canonical
 API contract, then inspect the schema artifact before claiming a specific path
 or request shape is supported.
 
+## Fixture status (`fixture_status`)
+
+Agent-catalog services expose fixture availability separately from schemas:
+
+| Status             | Meaning                                                   |
+| ------------------ | --------------------------------------------------------- |
+| `available`        | a sanitized request/response fixture exists               |
+| `missing`          | no fixture has been captured yet                          |
+| `capture-failed`   | the capture run tried the service and could not save JSON |
+| `auth-required`    | capture is skipped because credentials are required       |
+| `non-get`          | capture is skipped because the probe is disabled/non-GET  |
+| `unsupported-kind` | capture is skipped because the service kind is not JSON   |
+
+Use `fixture_status` to explain absence. Use `fixture.artifact_path` only when
+the status is `available`.
+
 ## Live verification (`readiness.readiness_verified`)
 
 The numeric `score` is deliberately build-time and deterministic, so

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1107,6 +1107,7 @@ export interface components {
                     [key: string]: unknown;
                 };
                 fixture?: components["schemas"]["SurfaceFixtureReference"];
+                fixture_status?: components["schemas"]["AgentServiceFixtureStatus"];
                 health?: {
                     [key: string]: unknown;
                 };
@@ -1192,6 +1193,14 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        /** @description Fixture availability or absence reason for an agent-catalog service. */
+        AgentServiceFixtureStatus: {
+            artifact_path: string | null;
+            captured_at: string | null;
+            reason: string | null;
+            /** @enum {string} */
+            status: "available" | "missing" | "capture-failed" | "auth-required" | "non-get" | "unsupported-kind";
+        };
         /** @description Source metadata for the schema artifact associated with an agent-catalog service. */
         AgentServiceSchemaSource: {
             /** @description Metagraphed schema artifact path. */
@@ -1723,6 +1732,21 @@ export interface components {
             [key: string]: unknown;
         });
         FixturesIndexArtifact: components["schemas"]["ArtifactBase"] & ({
+            candidate_count?: number;
+            coverage?: ({
+                artifact_path?: string | null;
+                captured_at?: string | null;
+                kind?: string;
+                netuid: number;
+                reason?: string | null;
+                response_status?: number | null;
+                /** @enum {string} */
+                status: "available" | "missing" | "capture-failed";
+                subnet_slug?: string | null;
+                surface_id: string;
+            } & {
+                [key: string]: unknown;
+            })[];
             fixture_count: number;
             fixtures: ({
                 captured_at?: string | null;
@@ -1734,7 +1758,11 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
+            missing_count?: number;
             published_at?: string | null;
+            status_counts?: {
+                [key: string]: number;
+            };
         } & {
             [key: string]: unknown;
         });
@@ -5843,7 +5871,15 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "candidate_count": 1,
                      *         "contract_version": "2026-06-06.1",
+                     *         "coverage": [
+                     *           {
+                     *             "netuid": 7,
+                     *             "status": "available",
+                     *             "surface_id": "example"
+                     *           }
+                     *         ],
                      *         "fixture_count": 1,
                      *         "fixtures": [
                      *           {
@@ -5852,9 +5888,13 @@ export interface operations {
                      *           }
                      *         ],
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "missing_count": 1,
                      *         "notes": "Example description.",
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "schema_version": 1
+                     *         "schema_version": 1,
+                     *         "status_counts": {
+                     *           "example": 1
+                     *         }
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/public/agent-workflows.md
+++ b/public/agent-workflows.md
@@ -290,6 +290,15 @@ OpenAPI surface for the same subnet and origin; inspect the schema artifact
 before generating endpoint-specific request bodies. For MCP, pass
 `schema_source.surface_id` to `get_api_schema` when it is present.
 
+Fixtures are separate from schemas. Each service has `fixture_status` so agents
+can distinguish `available`, `missing`, `capture-failed`, `auth-required`,
+`non-get`, and `unsupported-kind` cases. When `fixture_status.status` is
+`available`, the service also carries `fixture.artifact_path`; fetch it through
+REST (`GET /metagraph/fixtures/{surface_id}.json`) or MCP (`get_fixture`) before
+showing a response example. The global fixture index is available at
+`GET https://api.metagraph.sh/api/v1/fixtures` and includes coverage rows for
+no-auth GET capture candidates.
+
 ## Agent loop
 
 Use this loop for integration tasks:

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -308,6 +308,9 @@
                     "fixture": {
                       "$ref": "#/components/schemas/SurfaceFixtureReference"
                     },
+                    "fixture_status": {
+                      "$ref": "#/components/schemas/AgentServiceFixtureStatus"
+                    },
                     "health": {
                       "additionalProperties": true,
                       "type": "object"
@@ -595,6 +598,48 @@
             "type": "object"
           }
         ]
+      },
+      "AgentServiceFixtureStatus": {
+        "additionalProperties": false,
+        "description": "Fixture availability or absence reason for an agent-catalog service.",
+        "properties": {
+          "artifact_path": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "captured_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "enum": [
+              "available",
+              "missing",
+              "capture-failed",
+              "auth-required",
+              "non-get",
+              "unsupported-kind"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "reason",
+          "artifact_path",
+          "captured_at"
+        ],
+        "type": "object"
       },
       "AgentServiceSchemaSource": {
         "additionalProperties": false,
@@ -2683,6 +2728,72 @@
           {
             "additionalProperties": true,
             "properties": {
+              "candidate_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "coverage": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "artifact_path": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "captured_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "netuid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "reason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "response_status": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "status": {
+                      "enum": [
+                        "available",
+                        "missing",
+                        "capture-failed"
+                      ],
+                      "type": "string"
+                    },
+                    "subnet_slug": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "surface_id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "surface_id",
+                    "netuid",
+                    "status"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
               "fixture_count": {
                 "minimum": 0,
                 "type": "integer"
@@ -2728,11 +2839,22 @@
                 },
                 "type": "array"
               },
+              "missing_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
               "published_at": {
                 "type": [
                   "string",
                   "null"
                 ]
+              },
+              "status_counts": {
+                "additionalProperties": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "object"
               }
             },
             "required": [
@@ -13478,7 +13600,15 @@
               "application/json": {
                 "example": {
                   "data": {
+                    "candidate_count": 1,
                     "contract_version": "2026-06-06.1",
+                    "coverage": [
+                      {
+                        "netuid": 7,
+                        "status": "available",
+                        "surface_id": "example"
+                      }
+                    ],
                     "fixture_count": 1,
                     "fixtures": [
                       {
@@ -13487,9 +13617,13 @@
                       }
                     ],
                     "generated_at": "2026-06-01T00:00:00.000Z",
+                    "missing_count": 1,
                     "notes": "Example description.",
                     "published_at": "2026-06-01T00:00:00.000Z",
-                    "schema_version": 1
+                    "schema_version": 1,
+                    "status_counts": {
+                      "example": 1
+                    }
                   },
                   "meta": {
                     "artifact_path": "example",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1107,6 +1107,7 @@ export interface components {
                     [key: string]: unknown;
                 };
                 fixture?: components["schemas"]["SurfaceFixtureReference"];
+                fixture_status?: components["schemas"]["AgentServiceFixtureStatus"];
                 health?: {
                     [key: string]: unknown;
                 };
@@ -1192,6 +1193,14 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        /** @description Fixture availability or absence reason for an agent-catalog service. */
+        AgentServiceFixtureStatus: {
+            artifact_path: string | null;
+            captured_at: string | null;
+            reason: string | null;
+            /** @enum {string} */
+            status: "available" | "missing" | "capture-failed" | "auth-required" | "non-get" | "unsupported-kind";
+        };
         /** @description Source metadata for the schema artifact associated with an agent-catalog service. */
         AgentServiceSchemaSource: {
             /** @description Metagraphed schema artifact path. */
@@ -1723,6 +1732,21 @@ export interface components {
             [key: string]: unknown;
         });
         FixturesIndexArtifact: components["schemas"]["ArtifactBase"] & ({
+            candidate_count?: number;
+            coverage?: ({
+                artifact_path?: string | null;
+                captured_at?: string | null;
+                kind?: string;
+                netuid: number;
+                reason?: string | null;
+                response_status?: number | null;
+                /** @enum {string} */
+                status: "available" | "missing" | "capture-failed";
+                subnet_slug?: string | null;
+                surface_id: string;
+            } & {
+                [key: string]: unknown;
+            })[];
             fixture_count: number;
             fixtures: ({
                 captured_at?: string | null;
@@ -1734,7 +1758,11 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
+            missing_count?: number;
             published_at?: string | null;
+            status_counts?: {
+                [key: string]: number;
+            };
         } & {
             [key: string]: unknown;
         });
@@ -5843,7 +5871,15 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "candidate_count": 1,
                      *         "contract_version": "2026-06-06.1",
+                     *         "coverage": [
+                     *           {
+                     *             "netuid": 7,
+                     *             "status": "available",
+                     *             "surface_id": "example"
+                     *           }
+                     *         ],
                      *         "fixture_count": 1,
                      *         "fixtures": [
                      *           {
@@ -5852,9 +5888,13 @@ export interface operations {
                      *           }
                      *         ],
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "missing_count": 1,
                      *         "notes": "Example description.",
                      *         "published_at": "2026-06-01T00:00:00.000Z",
-                     *         "schema_version": 1
+                     *         "schema_version": 1,
+                     *         "status_counts": {
+                     *           "example": 1
+                     *         }
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -294,6 +294,9 @@
                     "fixture": {
                       "$ref": "#/components/schemas/SurfaceFixtureReference"
                     },
+                    "fixture_status": {
+                      "$ref": "#/components/schemas/AgentServiceFixtureStatus"
+                    },
                     "health": {
                       "additionalProperties": true,
                       "type": "object"
@@ -581,6 +584,48 @@
             "type": "object"
           }
         ]
+      },
+      "AgentServiceFixtureStatus": {
+        "additionalProperties": false,
+        "description": "Fixture availability or absence reason for an agent-catalog service.",
+        "properties": {
+          "artifact_path": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "captured_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "enum": [
+              "available",
+              "missing",
+              "capture-failed",
+              "auth-required",
+              "non-get",
+              "unsupported-kind"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "reason",
+          "artifact_path",
+          "captured_at"
+        ],
+        "type": "object"
       },
       "AgentServiceSchemaSource": {
         "additionalProperties": false,
@@ -2669,6 +2714,72 @@
           {
             "additionalProperties": true,
             "properties": {
+              "candidate_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "coverage": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "artifact_path": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "captured_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "netuid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "reason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "response_status": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "status": {
+                      "enum": [
+                        "available",
+                        "missing",
+                        "capture-failed"
+                      ],
+                      "type": "string"
+                    },
+                    "subnet_slug": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "surface_id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "surface_id",
+                    "netuid",
+                    "status"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
               "fixture_count": {
                 "minimum": 0,
                 "type": "integer"
@@ -2714,11 +2825,22 @@
                 },
                 "type": "array"
               },
+              "missing_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
               "published_at": {
                 "type": [
                   "string",
                   "null"
                 ]
+              },
+              "status_counts": {
+                "additionalProperties": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "object"
               }
             },
             "required": [

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -895,6 +895,28 @@
           }
         }
       },
+      "AgentServiceFixtureStatus": {
+        "type": "object",
+        "description": "Fixture availability or absence reason for an agent-catalog service.",
+        "required": ["status", "reason", "artifact_path", "captured_at"],
+        "additionalProperties": false,
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "available",
+              "missing",
+              "capture-failed",
+              "auth-required",
+              "non-get",
+              "unsupported-kind"
+            ]
+          },
+          "reason": { "type": ["string", "null"] },
+          "artifact_path": { "type": ["string", "null"] },
+          "captured_at": { "type": ["string", "null"] }
+        }
+      },
       "AgentCatalogArtifact": {
         "allOf": [
           { "$ref": "#/components/schemas/ArtifactBase" },
@@ -1081,6 +1103,9 @@
                     },
                     "fixture": {
                       "$ref": "#/components/schemas/SurfaceFixtureReference"
+                    },
+                    "fixture_status": {
+                      "$ref": "#/components/schemas/AgentServiceFixtureStatus"
                     }
                   },
                   "additionalProperties": true

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1840,7 +1840,35 @@
             "required": ["fixture_count", "fixtures"],
             "properties": {
               "published_at": { "type": ["string", "null"] },
+              "candidate_count": { "type": "integer", "minimum": 0 },
               "fixture_count": { "type": "integer", "minimum": 0 },
+              "missing_count": { "type": "integer", "minimum": 0 },
+              "status_counts": {
+                "type": "object",
+                "additionalProperties": { "type": "integer", "minimum": 0 }
+              },
+              "coverage": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["surface_id", "netuid", "status"],
+                  "properties": {
+                    "surface_id": { "type": "string" },
+                    "netuid": { "type": "integer", "minimum": 0 },
+                    "subnet_slug": { "type": ["string", "null"] },
+                    "kind": { "type": "string" },
+                    "status": {
+                      "type": "string",
+                      "enum": ["available", "missing", "capture-failed"]
+                    },
+                    "reason": { "type": ["string", "null"] },
+                    "captured_at": { "type": ["string", "null"] },
+                    "response_status": { "type": ["integer", "null"] },
+                    "artifact_path": { "type": ["string", "null"] }
+                  },
+                  "additionalProperties": true
+                }
+              },
               "fixtures": {
                 "type": "array",
                 "items": {

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -224,10 +224,11 @@ const capturedSchemaDocuments = new Map();
 
 // Captured live request/response fixtures (issue #352), written to R2 staging by
 // the network capture:fixtures step. Preserve them across the wipe so the build
-// can re-serve fixtures/{surface_id}.json + index them in the committed
-// fixtures.json. Absent on a pure deterministic build (no capture run) → an
-// empty index, populated on the next refresh (same model as schemas).
+// can re-serve fixtures/{surface_id}.json + index them in R2 fixtures.json.
+// Absent on a pure deterministic build (no capture run) → an empty index,
+// populated on the next refresh (same model as schemas).
 const capturedFixtures = new Map();
+let capturedFixtureReport = null;
 {
   const fixturesDir = path.join(r2OutputRoot, "fixtures");
   let fixtureFiles;
@@ -239,6 +240,10 @@ const capturedFixtures = new Map();
   for (const file of fixtureFiles) {
     if (!file.endsWith(".json") || file === "index.json") continue;
     const existing = await readOptionalJson(path.join(fixturesDir, file));
+    if (file === "_capture-report.json") {
+      capturedFixtureReport = existing;
+      continue;
+    }
     if (existing?.surface_id) {
       capturedFixtures.set(existing.surface_id, existing);
     }
@@ -685,6 +690,11 @@ const AGENT_SERVICE_KINDS = new Set([
   "sse",
   "data-artifact",
 ]);
+const FIXTURE_SERVICE_KINDS = new Set([
+  "subnet-api",
+  "openapi",
+  "data-artifact",
+]);
 const overviewSurfacesByNetuid = groupByNetuid(surfaces);
 const agentSchemaBySurfaceId = new Map(
   (schemaIndexArtifact.schemas || []).map((entry) => [entry.surface_id, entry]),
@@ -714,6 +724,11 @@ const agentEndpointBySurfaceId = new Map(
   endpointResources.endpoints
     .filter((endpoint) => endpoint.surface_id)
     .map((endpoint) => [endpoint.surface_id, endpoint]),
+);
+const capturedFixtureStatusBySurfaceId = new Map(
+  (capturedFixtureReport?.surfaces || [])
+    .filter((entry) => entry?.surface_id)
+    .map((entry) => [entry.surface_id, entry]),
 );
 
 // Integration readiness (objective 0-100) for EVERY subnet — surfaced inline on
@@ -1343,6 +1358,110 @@ function serviceSchemaSource(schemaResolution) {
   };
 }
 
+function fixtureProbeMethod(surface) {
+  return (surface.probe?.method || "GET").toUpperCase();
+}
+
+function isFixtureCaptureCandidateSurface(surface) {
+  return (
+    FIXTURE_SERVICE_KINDS.has(surface.kind) &&
+    surface.public_safe &&
+    !surface.auth_required &&
+    surface.probe?.enabled !== false &&
+    fixtureProbeMethod(surface) === "GET"
+  );
+}
+
+function fixtureCoverageEntry(surface) {
+  const fixtureRef = surfaceFixtureReference(
+    surface.id,
+    capturedFixtures.get(surface.id),
+  );
+  const report = capturedFixtureStatusBySurfaceId.get(surface.id);
+  const status = fixtureRef
+    ? "available"
+    : report && report.status !== "captured"
+      ? "capture-failed"
+      : "missing";
+  return {
+    surface_id: surface.id,
+    netuid: surface.netuid,
+    subnet_slug: surface.subnet_slug || null,
+    kind: surface.kind,
+    status,
+    reason:
+      status === "capture-failed"
+        ? report.reason || "capture failed"
+        : status === "missing"
+          ? "no captured fixture available"
+          : null,
+    captured_at: fixtureRef?.captured_at || null,
+    response_status:
+      fixtureRef?.response?.status ?? report?.response_status ?? null,
+    artifact_path: fixtureRef?.artifact_path || null,
+  };
+}
+
+function fixtureCoverageEntries(surfacesForFixtures) {
+  return surfacesForFixtures
+    .filter(isFixtureCaptureCandidateSurface)
+    .map(fixtureCoverageEntry)
+    .sort((a, b) => String(a.surface_id).localeCompare(String(b.surface_id)));
+}
+
+function serviceFixtureStatus(surface, fixtureRef, authRequired) {
+  if (fixtureRef) {
+    return {
+      status: "available",
+      reason: null,
+      artifact_path: fixtureRef.artifact_path,
+      captured_at: fixtureRef.captured_at,
+    };
+  }
+  if (authRequired) {
+    return {
+      status: "auth-required",
+      reason: "fixture capture skips credentialed services",
+      artifact_path: null,
+      captured_at: null,
+    };
+  }
+  if (!FIXTURE_SERVICE_KINDS.has(surface.kind)) {
+    return {
+      status: "unsupported-kind",
+      reason: "fixture capture only samples JSON-returning service kinds",
+      artifact_path: null,
+      captured_at: null,
+    };
+  }
+  if (
+    surface.probe?.enabled === false ||
+    fixtureProbeMethod(surface) !== "GET"
+  ) {
+    return {
+      status: "non-get",
+      reason: "fixture capture only samples enabled GET probes",
+      artifact_path: null,
+      captured_at: null,
+    };
+  }
+  const report = capturedFixtureStatusBySurfaceId.get(surface.id);
+  if (report && report.status !== "captured") {
+    return {
+      status: "capture-failed",
+      reason: report.reason || "capture failed",
+      artifact_path: null,
+      captured_at: null,
+    };
+  }
+  return {
+    status: "missing",
+    reason: "no captured fixture available",
+    artifact_path: null,
+    captured_at: null,
+  };
+}
+
 function buildSubnetServices(netuid) {
   return (overviewSurfacesByNetuid.get(netuid) || [])
     .filter(
@@ -1368,6 +1487,11 @@ function buildSubnetServices(netuid) {
         surface.id,
         capturedFixtures.get(surface.id),
       );
+      const fixtureStatus = serviceFixtureStatus(
+        surface,
+        fixtureRef,
+        authRequired,
+      );
       return {
         surface_id: surface.id,
         kind: surface.kind,
@@ -1391,6 +1515,7 @@ function buildSubnetServices(netuid) {
           auth: authDetail,
         }),
         ...(fixtureRef ? { fixture: fixtureRef } : {}),
+        fixture_status: fixtureStatus,
         schema_url: surface.schema_url || schema?.schema_url || null,
         schema_status:
           surface.schema_status || (schema ? "machine-readable" : null),
@@ -2409,14 +2534,26 @@ const fixtureIndexEntries = [...capturedFixtures.values()]
     response_status: fixture.response?.status ?? null,
   }))
   .sort((a, b) => String(a.surface_id).localeCompare(String(b.surface_id)));
+const fixtureCoverage = fixtureCoverageEntries(surfaces);
 for (const fixture of capturedFixtures.values()) {
   await writeJson(artifactFile(`fixtures/${fixture.surface_id}.json`), fixture);
+}
+if (capturedFixtureReport) {
+  await writeJson(artifactFile("fixtures/_capture-report.json"), {
+    ...capturedFixtureReport,
+    mode: capturedFixtureReport.mode || "write",
+  });
 }
 await writeJson(artifactFile("fixtures.json"), {
   schema_version: 1,
   generated_at: generatedAt,
   published_at: publishedAt(),
+  candidate_count: fixtureCoverage.length,
   fixture_count: fixtureIndexEntries.length,
+  missing_count: fixtureCoverage.filter((entry) => entry.status !== "available")
+    .length,
+  status_counts: countBy(fixtureCoverage, "status"),
+  coverage: fixtureCoverage,
   fixtures: fixtureIndexEntries,
 });
 

--- a/scripts/capture-fixtures.mjs
+++ b/scripts/capture-fixtures.mjs
@@ -169,9 +169,22 @@ const candidates = flattenSurfaces(subnets).filter(
 );
 
 const captured = [];
+const statuses = [];
 await mapLimit(candidates, CONCURRENCY, async (surface) => {
   const result = await fetchSample(surface.url);
-  if (!result.ok) return;
+  if (!result.ok) {
+    statuses.push({
+      surface_id: surface.id,
+      netuid: surface.netuid,
+      subnet_slug: surface.subnet_slug || null,
+      kind: surface.kind,
+      status: "capture-failed",
+      reason: result.error || "capture failed",
+      response_status: result.status ?? null,
+      error_class: result.error_class || null,
+    });
+    return;
+  }
   const fixture = {
     schema_version: 1,
     generated_at: generatedAt,
@@ -190,15 +203,62 @@ await mapLimit(candidates, CONCURRENCY, async (surface) => {
     },
   };
   captured.push(fixture);
+  statuses.push({
+    surface_id: surface.id,
+    netuid: surface.netuid,
+    subnet_slug: surface.subnet_slug || null,
+    kind: surface.kind,
+    status: "captured",
+    reason: null,
+    response_status: result.status,
+    error_class: null,
+    captured_at: observedAt,
+  });
   if (shouldWrite) {
     await writeJson(artifactOutputPath(`fixtures/${surface.id}.json`), fixture);
   }
 });
 
+const statusCounts = Object.fromEntries(
+  Object.entries(
+    statuses.reduce((acc, entry) => {
+      acc[entry.status] = (acc[entry.status] || 0) + 1;
+      return acc;
+    }, {}),
+  ).sort(),
+);
+const captureReport = {
+  schema_version: 1,
+  generated_at: generatedAt,
+  captured_at: observedAt,
+  mode: dryRun ? "dry-run" : "write",
+  candidate_count: candidates.length,
+  captured_count: captured.length,
+  status_counts: statusCounts,
+  surfaces: statuses.sort((a, b) =>
+    String(a.surface_id).localeCompare(String(b.surface_id)),
+  ),
+};
+if (shouldWrite) {
+  await writeJson(artifactOutputPath("fixtures/_capture-report.json"), {
+    ...captureReport,
+    mode: "write",
+  });
+}
+
 const summary = {
   mode: dryRun ? "dry-run" : "write",
   candidate_count: candidates.length,
   captured_count: captured.length,
+  status_counts: statusCounts,
   surface_ids: captured.map((fixture) => fixture.surface_id).sort(),
+  failures: statuses
+    .filter((entry) => entry.status !== "captured")
+    .map((entry) => ({
+      surface_id: entry.surface_id,
+      reason: entry.reason,
+      response_status: entry.response_status,
+      error_class: entry.error_class,
+    })),
 };
 console.log(JSON.stringify(summary, null, 2));

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -1069,6 +1069,21 @@ export const MCP_TOOLS = [
               schema_url: s.schema_url || null,
             }
           : { available: false, schema_url: s.schema_url || null },
+        fixture: s.fixture
+          ? {
+              available: true,
+              fetch_with: `get_fixture with surface_id ${s.surface_id}`,
+              artifact_path: s.fixture.artifact_path,
+              captured_at: s.fixture.captured_at,
+              response_status: s.fixture.response?.status ?? null,
+              content_type: s.fixture.response?.content_type ?? null,
+            }
+          : {
+              available: false,
+              status: s.fixture_status?.status || "missing",
+              reason:
+                s.fixture_status?.reason || "no captured fixture available",
+            },
         health: {
           status: s.health?.status ?? "unknown",
           stale: s.health?.stale ?? false,
@@ -1077,6 +1092,7 @@ export const MCP_TOOLS = [
       }));
       const isCallable = callable.length > 0;
       const schemaStep = steps.find((s) => s.schema.available);
+      const fixtureStep = steps.find((s) => s.fixture.available);
       return {
         netuid,
         name: detail.name,
@@ -1094,6 +1110,7 @@ export const MCP_TOOLS = [
           ? [
               `get_subnet_health with netuid ${netuid} for live status`,
               ...(schemaStep ? [schemaStep.schema.fetch_with] : []),
+              ...(fixtureStep ? [fixtureStep.fixture.fetch_with] : []),
             ]
           : [`get_subnet with netuid ${netuid}`],
       };

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -903,6 +903,41 @@ test("public artifacts are internally consistent", () => {
   assert.equal(typeof fixturesIndex.fixture_count, "number");
   assert.equal(Array.isArray(fixturesIndex.fixtures), true);
   assert.equal(fixturesIndex.fixture_count, fixturesIndex.fixtures.length);
+  assert.equal(
+    fixturesIndex.candidate_count,
+    fixturesIndex.coverage.length,
+    "fixture candidate_count must match coverage rows",
+  );
+  assert.equal(
+    fixturesIndex.missing_count,
+    fixturesIndex.coverage.filter((entry) => entry.status !== "available")
+      .length,
+    "fixture missing_count must summarize non-available coverage rows",
+  );
+  assert.equal(
+    fixturesIndex.status_counts.missing,
+    fixturesIndex.candidate_count,
+    "deterministic no-capture builds should classify fixture candidates as missing",
+  );
+  const allwaysFixtureCandidate = fixturesIndex.coverage.find(
+    (entry) => entry.surface_id === "allways-api-health",
+  );
+  assert.equal(allwaysFixtureCandidate.status, "missing");
+  const allwaysFixtureService = readArtifact(
+    "agent-catalog/7.json",
+  ).services.find((service) => service.surface_id === "allways-api-health");
+  assert.equal(allwaysFixtureService.fixture_status.status, "missing");
+  const allwaysSseFixtureService = readArtifact(
+    "agent-catalog/7.json",
+  ).services.find((service) => service.surface_id === "allways-sse");
+  assert.equal(
+    allwaysSseFixtureService.fixture_status.status,
+    "unsupported-kind",
+  );
+  const allwaysHistoryFixtureService = readArtifact(
+    "agent-catalog/7.json",
+  ).services.find((service) => service.surface_id === "allways-crown-history");
+  assert.equal(allwaysHistoryFixtureService.fixture_status.status, "non-get");
 
   // AI-resources index: the copyable agent + the live MCP tool list + resources.
   assert.match(agentResources.copyable_agent.url, /\/agent\.md$/);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1426,6 +1426,8 @@ describe("MCP goal-shaped tools (find_subnet_for_task + how_do_i_call)", () => {
     assert.deepEqual(out.services[0].auth.schemes, ["apiKey"]);
     assert.equal(out.services[0].schema.available, true);
     assert.match(out.services[0].schema.fetch_with, /get_api_schema/);
+    assert.equal(out.services[0].fixture.available, false);
+    assert.equal(out.services[0].fixture.status, "missing");
     // ready-to-run snippets (#351): curl/python/typescript for a first call
     assert.ok(out.services[0].snippets, "expected integration snippets");
     assert.match(
@@ -1436,6 +1438,38 @@ describe("MCP goal-shaped tools (find_subnet_for_task + how_do_i_call)", () => {
     assert.match(out.services[0].snippets.python, /import requests/);
     assert.match(out.services[0].snippets.typescript, /await fetch/);
     assert.ok(out.next_steps.some((s) => /get_subnet_health/.test(s)));
+  });
+
+  test("how_do_i_call surfaces fixture fetch instructions when available", async () => {
+    const fixtureDetail = structuredClone(callDetail);
+    const service =
+      fixtureDetail["/metagraph/agent-catalog/7.json"].services[0];
+    service.fixture = {
+      captured_at: "2026-06-18T00:00:00.000Z",
+      request: { method: "GET", url: "https://api.data.io" },
+      response: { status: 200, content_type: "application/json" },
+      artifact_path: "/metagraph/fixtures/sn-7-api.json",
+    };
+    service.fixture_status = {
+      status: "available",
+      reason: null,
+      artifact_path: "/metagraph/fixtures/sn-7-api.json",
+      captured_at: "2026-06-18T00:00:00.000Z",
+    };
+
+    const res = await callTool(
+      "how_do_i_call",
+      { netuid: 7 },
+      { deps: makeDeps(fixtureDetail) },
+    );
+
+    const out = res.body.result.structuredContent;
+    assert.equal(out.services[0].fixture.available, true);
+    assert.equal(
+      out.services[0].fixture.fetch_with,
+      "get_fixture with surface_id sn-7-api",
+    );
+    assert.ok(out.next_steps.some((s) => /get_fixture/.test(s)));
   });
 
   test("how_do_i_call regenerates snippets without cleartext credentials", async () => {


### PR DESCRIPTION
## Summary
- Add machine-readable fixture availability/absence status to agent-catalog service rows.
- Extend fixture capture dry-runs/write runs with status counts, failure reasons, and an R2-only capture report.
- Expand `fixtures.json` into a coverage index for no-auth GET fixture candidates.
- Surface fixture fetch instructions through MCP `how_do_i_call` when a fixture is available.

## What changed
- Added `fixture_status` with `available`, `missing`, `capture-failed`, `auth-required`, `non-get`, and `unsupported-kind` states.
- Added fixture coverage metadata: `candidate_count`, `missing_count`, `status_counts`, and `coverage` rows.
- Updated docs for fixture status and fixture-backed workflows.
- Updated generated schemas/OpenAPI/types for the new fixture fields.
- Added artifact and MCP tests for fixture coverage, absence reasons, and `get_fixture` guidance.

## Fixture coverage
- Deterministic no-capture build: 35 fixture candidates, 0 fixtures, 35 `missing` coverage rows.
- Live dry-run from this branch: 35 candidates, 28 capturable samples, 7 capture failures with public-safe reasons.
- Fixture bodies remain R2-only. Write-mode capture stores sanitized bodies under `fixtures/{surface_id}.json` and the capture report under `fixtures/_capture-report.json` for the build to index.

## Why
Before this, agents could only infer fixture absence from a missing `fixture` field. That is weak UX for users and tools: absence could mean missing, unsafe, credentialed, non-GET, or just failed capture. The new status model makes the next action explicit without publishing unsafe data.

Closes #1144

## Validation
- `npm run build`
- `npm run capture:fixtures:dry-run`
- `npm test -- tests/artifacts.test.mjs`
- `npm test -- tests/mcp-server.test.mjs`
- `npm run scan:public-safety`
- `npm run validate:mcp`
- `npm run format:check`
- `npm run validate:schemas`
- `npm run validate:api`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:contract-drift`
- `npm run lint`
- `npm run validate`
- `npm run validate:openapi-examples`
- `npm run validate:generated-client`
- `npm run validate:docs`
- `npm run validate:artifact-budgets` (expected size warnings for `openapi.json` and `profiles.json`)
- `npm run validate:workflows`
- `npm run validate:private-boundary`
- `npm run worker:test`
- `npm run worker:deploy:dry-run`
- `npm run validate:readme-catalog`
- `npm run validate:intake`
- `npm run validate:ai`
- `npm run test:coverage`
- `git diff --check`

## Notes
- `public/metagraph/r2-manifest.json` was intentionally restored because it only contains volatile byte totals regenerated by publish/CI.
- No fixture bodies are committed; they are generated by the capture pipeline and served from R2.