### PR TITLE
feat(coverage): add depth scorecard

### DIFF
--- a/docs/all-subnet-registry.md
+++ b/docs/all-subnet-registry.md
@@ -89,6 +89,7 @@ Candidates are never treated as verified surfaces. They must pass verification a
 
 Generated artifacts expose review state through:
 
+- `/metagraph/coverage-depth.json`
 - `/metagraph/review/curation.json`
 - `/metagraph/review/gap-priorities.json`
 - `/metagraph/review/adapter-candidates.json`

--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -57,6 +57,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/evidence/{netuid}.json`: public evidence ledger claims for one subnet. R2-backed.
 - `/metagraph/overview/{netuid}.json`: composed per-subnet overview (profile + health + curation + gaps + counts). R2-backed.
 - `/metagraph/registry-summary.json`: registry-wide summary (completeness, top subnets, level counts, latest changes). R2-backed.
+- `/metagraph/coverage-depth.json`: machine-usable coverage depth scorecard with one row per subnet, blocker/gap summaries, and a ranked enrichment queue. R2-backed.
 - `/metagraph/lineage.json`: cross-network subnet lineage — maintainer-approved mainnet ↔ testnet pairs with reviewed match evidence, plus the testnet-only (deploying-soon) count.
 - `/metagraph/fixtures.json`: index of captured live request/response fixtures (which surfaces carry a sanitized sample).
 - `/metagraph/agent-resources.json`: machine index of every AI resource — the copyable agent, the MCP server + tools, the skill, llms.txt, OpenAPI, and the agent-facing APIs.
@@ -109,6 +110,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/api/v1/agent-catalog`: list subnets exposing callable services for AI agents (compact index: service kinds + callable count per subnet).
 - `/api/v1/agent-catalog/{netuid}`: fetch one subnet's agent capability catalog — each callable service with base URL, auth, machine-readable schema, and health/eligibility.
 - `/api/v1/registry/summary`: fetch the registry-wide summary (completeness, top subnets, level counts, latest changes).
+- `/api/v1/coverage-depth`: fetch the machine-usable scorecard and ranked enrichment queue for prioritizing schema, fixture, example, provenance, and review work.
 - `/api/v1/lineage`: fetch maintainer-approved cross-network subnet lineage (graduated subnets + the deploying-soon testnet pipeline).
 - `/api/v1/fixtures`: fetch the index of captured live request/response fixtures (per-surface samples are at `/metagraph/fixtures/{surface_id}.json`, also via the `get_fixture` MCP tool).
 - `/api/v1/agent-resources`: fetch the AI-resources index (the copyable agent at `/agent.md`, the MCP server + tools, the skill, llms.txt, OpenAPI, and the agent-facing APIs).

--- a/docs/curation-playbook.md
+++ b/docs/curation-playbook.md
@@ -32,6 +32,12 @@ The enrichment queue is also available through
 registry truth; it only prioritizes public-safe work derived from current
 artifacts.
 
+For the single maintainer/agent view of "which subnets should we enrich next
+and why?", use `/api/v1/coverage-depth`. It combines callable-service,
+schema, fixture, example/SDK, provenance, profile, and `agent_readiness`
+signals into one ranked queue while preserving separate missing-data,
+needs-review, and hard-blocker gap types.
+
 Contributor-ready targets are available through
 `/api/v1/review/enrichment-targets`. This route groups the queue into concrete
 surface-candidate, adapter-review, maintainer-review, and monitoring-followup

--- a/docs/integration-readiness.md
+++ b/docs/integration-readiness.md
@@ -78,6 +78,33 @@ The blocker model is not a second score. It is a deterministic explanation of
 the same readiness facts, shaped for agents and UI filters. Use it when a subnet
 is absent from the callable subset and the user asks why.
 
+## Coverage depth scorecard
+
+`GET /api/v1/coverage-depth` publishes the registry-wide prioritization view.
+It is generated from the same public-safe build data as `agent-catalog`,
+`fixtures.json`, schema snapshots, profiles, candidates, and surface authority.
+
+Use it when the question is "what should we enrich next and why?". It provides:
+
+- `summary`: row counts, tier counts, blocker-level counts, severity counts,
+  and gap-code counts.
+- `rows[]`: one row per subnet, sorted by `netuid`, with a deterministic
+  `score`, `tier`, `dimensions`, `top_gaps`, and `recommended_next_action`.
+- `ranked_queue[]`: the highest-priority actionable rows, sorted by
+  `priority_score`, then lower score, then `netuid`.
+
+The scorecard intentionally separates three classes of work:
+
+- `missing-data`: data we should add or explicitly mark absent, such as schemas,
+  fixtures, examples, docs, source repos, or profile fields.
+- `needs-review`: evidence exists, but a maintainer needs to verify authority or
+  promote a candidate surface.
+- `hard`: the subnet should not be recommended for application integration in
+  its current state, such as root/base-layer-only or inactive lifecycle.
+
+The score is deterministic and build-time only. Live up/down remains the health
+overlay and should not be inferred from `coverage-depth`.
+
 Common blocker codes:
 
 | Code                         | Meaning                                                                  |

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -174,6 +174,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/coverage-depth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch the machine-usable coverage depth scorecard and ranked enrichment queue. */
+        get: operations["coverageDepth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/curation": {
         parameters: {
             query?: never;
@@ -1513,6 +1530,100 @@ export interface components {
             after: number;
             before: number;
             delta: number;
+        };
+        CoverageDepthArtifact: components["schemas"]["ArtifactBase"] & ({
+            coverage_depth_version: number;
+            ranked_queue: components["schemas"]["CoverageDepthQueueEntry"][];
+            rows: components["schemas"]["CoverageDepthRow"][];
+            scoring: {
+                methodology: string;
+                weights: {
+                    [key: string]: number;
+                };
+            } & {
+                [key: string]: unknown;
+            };
+            subnet_count: number;
+            summary: {
+                agent_ready_count: number;
+                average_score: number;
+                blocked_subnet_count: number;
+                blocker_level_counts: {
+                    [key: string]: number;
+                };
+                callable_subnet_count: number;
+                gap_code_counts: {
+                    [key: string]: number;
+                };
+                queue_count: number;
+                row_count: number;
+                severity_counts: {
+                    [key: string]: number;
+                };
+                tier_counts: {
+                    [key: string]: number;
+                };
+            };
+        } & {
+            [key: string]: unknown;
+        });
+        CoverageDepthQueueEntry: {
+            name: string;
+            netuid: number;
+            priority_score: number;
+            rank: number;
+            recommended_next_action: string;
+            score: number;
+            /** @enum {string} */
+            severity: "hard" | "missing-data" | "needs-review";
+            slug: string;
+            tier: string;
+            top_gap_codes: string[];
+        };
+        CoverageDepthRow: {
+            /** @enum {string} */
+            agent_status: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
+            /** @enum {string} */
+            blocker_level: "none" | "hard-blocked" | "needs-review" | "missing-data";
+            completeness_score?: number | null;
+            curation_level?: string | null;
+            dimensions: {
+                callable_service_count: number;
+                candidate_count: number;
+                candidate_operational_count: number;
+                data_artifact_count: number;
+                docs_url_present: boolean;
+                example_count: number;
+                fixture_available_count: number;
+                fixture_status_counts: {
+                    [key: string]: number;
+                };
+                official_surface_count: number;
+                provider_claimed_surface_count: number;
+                registry_observed_surface_count: number;
+                schema_missing_count: number;
+                schema_service_count: number;
+                sdk_count: number;
+                service_count: number;
+                service_kinds: string[];
+                source_repo_present: boolean;
+                surface_count: number;
+            } & {
+                [key: string]: unknown;
+            };
+            name: string;
+            netuid: number;
+            priority_score: number;
+            profile_level?: string | null;
+            readiness_score: number;
+            recommended_next_action: string | null;
+            score: number;
+            slug: string;
+            subnet_type?: string | null;
+            /** @enum {string} */
+            tier: "agent-ready" | "machine-usable" | "candidate-review" | "needs-evidence" | "hard-blocked" | "missing-interface";
+            top_gap_codes: string[];
+            top_gaps: components["schemas"]["AgentReadinessBlocker"][];
         };
         /**
          * @description How much of a subnet's interface metagraphed has observed, low→high: native-only (chain identity only) · manifested (declared surfaces) · probed (surfaces confirmed live by the health prober).
@@ -4943,6 +5054,200 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["CoverageArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    coverageDepth: {
+        parameters: {
+            query?: {
+                netuid?: number;
+                tier?: "agent-ready" | "machine-usable" | "candidate-review" | "needs-evidence" | "hard-blocked" | "missing-interface";
+                agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
+                blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
+                q?: string;
+                limit?: number;
+                cursor?: number;
+                sort?: "agent_status" | "blocker_level" | "name" | "netuid" | "priority_score" | "score" | "tier";
+                order?: "asc" | "desc";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "coverage_depth_version": 1,
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "ranked_queue": [
+                     *           {
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "priority_score": 100,
+                     *             "rank": 1,
+                     *             "recommended_next_action": "2026-06-01T00:00:00.000Z",
+                     *             "score": 100,
+                     *             "severity": "hard",
+                     *             "slug": "example-subnet",
+                     *             "tier": "example",
+                     *             "top_gap_codes": [
+                     *               "example"
+                     *             ]
+                     *           }
+                     *         ],
+                     *         "rows": [
+                     *           {
+                     *             "agent_status": "callable",
+                     *             "blocker_level": "none",
+                     *             "dimensions": {
+                     *               "callable_service_count": 1,
+                     *               "candidate_count": 1,
+                     *               "candidate_operational_count": 1,
+                     *               "data_artifact_count": 1,
+                     *               "docs_url_present": false,
+                     *               "example_count": 1,
+                     *               "fixture_available_count": 1,
+                     *               "fixture_status_counts": {},
+                     *               "official_surface_count": 1,
+                     *               "provider_claimed_surface_count": 1,
+                     *               "registry_observed_surface_count": 1,
+                     *               "schema_missing_count": 1,
+                     *               "schema_service_count": 1,
+                     *               "sdk_count": 1,
+                     *               "service_count": 1,
+                     *               "service_kinds": [
+                     *                 "example"
+                     *               ],
+                     *               "source_repo_present": false,
+                     *               "surface_count": 1
+                     *             },
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "priority_score": 100,
+                     *             "readiness_score": 100,
+                     *             "recommended_next_action": "2026-06-01T00:00:00.000Z",
+                     *             "score": 100,
+                     *             "slug": "example-subnet",
+                     *             "tier": "agent-ready",
+                     *             "top_gap_codes": [
+                     *               "example"
+                     *             ],
+                     *             "top_gaps": [
+                     *               {
+                     *                 "code": "example",
+                     *                 "field": "example",
+                     *                 "message": "example",
+                     *                 "next_action": "example",
+                     *                 "severity": "hard"
+                     *               }
+                     *             ]
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "scoring": {
+                     *           "methodology": "GET",
+                     *           "weights": {}
+                     *         },
+                     *         "subnet_count": 1,
+                     *         "summary": {
+                     *           "agent_ready_count": 1,
+                     *           "average_score": 100,
+                     *           "blocked_subnet_count": 5000000,
+                     *           "blocker_level_counts": {},
+                     *           "callable_subnet_count": 1,
+                     *           "gap_code_counts": {},
+                     *           "queue_count": 1,
+                     *           "row_count": 1,
+                     *           "severity_counts": {},
+                     *           "tier_counts": {}
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["CoverageDepthArtifact"];
                     };
                 };
             };

--- a/public/.well-known/llms.txt
+++ b/public/.well-known/llms.txt
@@ -9,6 +9,7 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 ## Machine entrypoints
 - [OpenAPI 3.1](https://api.metagraph.sh/metagraph/openapi.json): full machine contract for all routes
 - [Agent capability catalog](https://api.metagraph.sh/api/v1/agent-catalog): per-subnet callable services + their schemas + health
+- [Coverage depth scorecard](https://api.metagraph.sh/api/v1/coverage-depth): one ranked view of which subnets are machine-usable, what is missing, and which enrichment actions should happen next
 - [Copyable AI agent](https://api.metagraph.sh/agent.md): paste-ready system prompt that turns any agent into a metagraphed-powered Bittensor integration agent. Every AI resource indexed at [/api/v1/agent-resources](https://api.metagraph.sh/api/v1/agent-resources).
 - [Agent workflows](https://api.metagraph.sh/agent-workflows.md): task-oriented REST, MCP, npm, and Python examples for finding and calling subnets
 - [MCP server](https://api.metagraph.sh/mcp): Model Context Protocol endpoint — agents query the registry as tools. Install: `claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp`

--- a/public/agent-workflows.md
+++ b/public/agent-workflows.md
@@ -283,6 +283,13 @@ each with `agent_readiness.status`, `agent_readiness.blocker_level`,
 `agent_readiness.blockers[]`, and `agent_readiness.missing_fields[]`. Use those
 fields when the user asks why a subnet is not agent-ready yet.
 
+For prioritization across the whole registry, read
+`GET https://api.metagraph.sh/api/v1/coverage-depth`. It has one row per subnet
+plus a `ranked_queue` of concrete enrichment actions. Use `top_gaps[]` and
+`recommended_next_action` to explain whether a subnet needs missing data,
+maintainer review, or is hard-blocked. Do not infer live uptime from this
+artifact; use health routes for that.
+
 When a service has a schema, `schema_artifact` points at the captured contract
 and `schema_source` explains how it was attached. `surface-id` and `schema-url`
 matches are exact. `same-origin-openapi` means Metagraphed found a captured

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -9,6 +9,7 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 ## Machine entrypoints
 - [OpenAPI 3.1](https://api.metagraph.sh/metagraph/openapi.json): full machine contract for all routes
 - [Agent capability catalog](https://api.metagraph.sh/api/v1/agent-catalog): per-subnet callable services + their schemas + health
+- [Coverage depth scorecard](https://api.metagraph.sh/api/v1/coverage-depth): one ranked view of which subnets are machine-usable, what is missing, and which enrichment actions should happen next
 - [Copyable AI agent](https://api.metagraph.sh/agent.md): paste-ready system prompt that turns any agent into a metagraphed-powered Bittensor integration agent. Every AI resource indexed at [/api/v1/agent-resources](https://api.metagraph.sh/api/v1/agent-resources).
 - [Agent workflows](https://api.metagraph.sh/agent-workflows.md): task-oriented REST, MCP, npm, and Python examples for finding and calling subnets
 - [MCP server](https://api.metagraph.sh/mcp): Model Context Protocol endpoint — agents query the registry as tools. Install: `claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp`
@@ -185,6 +186,7 @@ Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1
 - `GET /api/v1/providers/{slug}` — Fetch per-provider detail.
 - `GET /api/v1/providers/{slug}/endpoints` — List endpoint resources for one provider or operator.
 - `GET /api/v1/coverage` — Fetch registry coverage summary.
+- `GET /api/v1/coverage-depth` — Fetch the machine-usable coverage depth scorecard and ranked enrichment queue.
 - `GET /api/v1/economics` — List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share), ordered by emission share.
 - `GET /api/v1/registry/summary` — Fetch the registry-wide summary (completeness, top subnets, level counts, latest changes).
 - `GET /api/v1/lineage` — Fetch maintainer-approved cross-network subnet lineage (graduated subnets + the deploying-soon testnet pipeline).

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,6 +9,7 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 ## Machine entrypoints
 - [OpenAPI 3.1](https://api.metagraph.sh/metagraph/openapi.json): full machine contract for all routes
 - [Agent capability catalog](https://api.metagraph.sh/api/v1/agent-catalog): per-subnet callable services + their schemas + health
+- [Coverage depth scorecard](https://api.metagraph.sh/api/v1/coverage-depth): one ranked view of which subnets are machine-usable, what is missing, and which enrichment actions should happen next
 - [Copyable AI agent](https://api.metagraph.sh/agent.md): paste-ready system prompt that turns any agent into a metagraphed-powered Bittensor integration agent. Every AI resource indexed at [/api/v1/agent-resources](https://api.metagraph.sh/api/v1/agent-resources).
 - [Agent workflows](https://api.metagraph.sh/agent-workflows.md): task-oriented REST, MCP, npm, and Python examples for finding and calling subnets
 - [MCP server](https://api.metagraph.sh/mcp): Model Context Protocol endpoint — agents query the registry as tools. Install: `claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp`

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -170,6 +170,13 @@
     },
     {
       "contract_version": "2026-06-06.1",
+      "id": "coverage-depth",
+      "path": "/metagraph/coverage-depth.json",
+      "schema_ref": "#/components/schemas/CoverageDepthArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "contract_version": "2026-06-06.1",
       "id": "economics",
       "path": "/metagraph/economics.json",
       "schema_ref": "#/components/schemas/EconomicsArtifact",
@@ -1794,6 +1801,115 @@
       "query_collection": null,
       "query_filter_names": [],
       "query_parameters": []
+    },
+    {
+      "artifact_path": "/metagraph/coverage-depth.json",
+      "cache": "standard",
+      "description": "Fetch the machine-usable coverage depth scorecard and ranked enrichment queue.",
+      "id": "coverage-depth",
+      "method": "GET",
+      "path": "/api/v1/coverage-depth",
+      "public": true,
+      "query_collection": "coverage-depth",
+      "query_filter_names": [
+        "netuid",
+        "tier",
+        "agent_status",
+        "blocker_level"
+      ],
+      "query_parameters": [
+        {
+          "name": "netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "tier",
+          "schema": {
+            "enum": [
+              "agent-ready",
+              "machine-usable",
+              "candidate-review",
+              "needs-evidence",
+              "hard-blocked",
+              "missing-interface"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "agent_status",
+          "schema": {
+            "enum": [
+              "callable",
+              "base-layer",
+              "candidate",
+              "needs-evidence",
+              "blocked"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "blocker_level",
+          "schema": {
+            "enum": [
+              "none",
+              "hard-blocked",
+              "needs-review",
+              "missing-data"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "q",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "cursor",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "sort",
+          "schema": {
+            "enum": [
+              "agent_status",
+              "blocker_level",
+              "name",
+              "netuid",
+              "priority_score",
+              "score",
+              "tier"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "order",
+          "schema": {
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/economics.json",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -219,6 +219,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
+      "description": "Machine-usable coverage depth scorecard with per-subnet readiness dimensions and a ranked enrichment queue.",
+      "id": "coverage-depth",
+      "path": "/metagraph/coverage-depth.json",
+      "schema_ref": "#/components/schemas/CoverageDepthArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-06-06.1",
       "description": "Per-subnet validator and economic metrics from the chain: validator/miner counts, total + max stake, registration cost, alpha price, and derived price-weighted emission share.",
       "id": "economics",
       "path": "/metagraph/economics.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1803,6 +1803,420 @@
         ],
         "type": "object"
       },
+      "CoverageDepthArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "coverage_depth_version": {
+                "minimum": 1,
+                "type": "integer"
+              },
+              "ranked_queue": {
+                "items": {
+                  "$ref": "#/components/schemas/CoverageDepthQueueEntry"
+                },
+                "type": "array"
+              },
+              "rows": {
+                "items": {
+                  "$ref": "#/components/schemas/CoverageDepthRow"
+                },
+                "type": "array"
+              },
+              "scoring": {
+                "additionalProperties": true,
+                "properties": {
+                  "methodology": {
+                    "type": "string"
+                  },
+                  "weights": {
+                    "additionalProperties": {
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "methodology",
+                  "weights"
+                ],
+                "type": "object"
+              },
+              "subnet_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "summary": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_ready_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "average_score": {
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "blocked_subnet_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "blocker_level_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "callable_subnet_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "gap_code_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "queue_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "row_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "severity_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "tier_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "row_count",
+                  "agent_ready_count",
+                  "callable_subnet_count",
+                  "blocked_subnet_count",
+                  "queue_count",
+                  "average_score",
+                  "tier_counts",
+                  "blocker_level_counts",
+                  "severity_counts",
+                  "gap_code_counts"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "coverage_depth_version",
+              "subnet_count",
+              "summary",
+              "scoring",
+              "rows",
+              "ranked_queue"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "CoverageDepthQueueEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "priority_score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "rank": {
+            "minimum": 1,
+            "type": "integer"
+          },
+          "recommended_next_action": {
+            "type": "string"
+          },
+          "score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "severity": {
+            "enum": [
+              "hard",
+              "missing-data",
+              "needs-review"
+            ],
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "tier": {
+            "type": "string"
+          },
+          "top_gap_codes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "rank",
+          "netuid",
+          "slug",
+          "name",
+          "tier",
+          "score",
+          "priority_score",
+          "severity",
+          "top_gap_codes",
+          "recommended_next_action"
+        ],
+        "type": "object"
+      },
+      "CoverageDepthRow": {
+        "additionalProperties": false,
+        "properties": {
+          "agent_status": {
+            "enum": [
+              "callable",
+              "base-layer",
+              "candidate",
+              "needs-evidence",
+              "blocked"
+            ],
+            "type": "string"
+          },
+          "blocker_level": {
+            "enum": [
+              "none",
+              "hard-blocked",
+              "needs-review",
+              "missing-data"
+            ],
+            "type": "string"
+          },
+          "completeness_score": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "curation_level": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "dimensions": {
+            "additionalProperties": true,
+            "properties": {
+              "callable_service_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "candidate_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "candidate_operational_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "data_artifact_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "docs_url_present": {
+                "type": "boolean"
+              },
+              "example_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "fixture_available_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "fixture_status_counts": {
+                "additionalProperties": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "object"
+              },
+              "official_surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "provider_claimed_surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "registry_observed_surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "schema_missing_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "schema_service_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "sdk_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "service_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "service_kinds": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "source_repo_present": {
+                "type": "boolean"
+              },
+              "surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "surface_count",
+              "official_surface_count",
+              "registry_observed_surface_count",
+              "provider_claimed_surface_count",
+              "service_count",
+              "callable_service_count",
+              "service_kinds",
+              "schema_service_count",
+              "schema_missing_count",
+              "fixture_available_count",
+              "fixture_status_counts",
+              "example_count",
+              "sdk_count",
+              "candidate_count",
+              "candidate_operational_count",
+              "data_artifact_count",
+              "source_repo_present",
+              "docs_url_present"
+            ],
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "priority_score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "profile_level": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "readiness_score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "recommended_next_action": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "subnet_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "tier": {
+            "enum": [
+              "agent-ready",
+              "machine-usable",
+              "candidate-review",
+              "needs-evidence",
+              "hard-blocked",
+              "missing-interface"
+            ],
+            "type": "string"
+          },
+          "top_gap_codes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "top_gaps": {
+            "items": {
+              "$ref": "#/components/schemas/AgentReadinessBlocker"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "netuid",
+          "slug",
+          "name",
+          "score",
+          "tier",
+          "priority_score",
+          "agent_status",
+          "blocker_level",
+          "readiness_score",
+          "dimensions",
+          "top_gaps",
+          "top_gap_codes",
+          "recommended_next_action"
+        ],
+        "type": "object"
+      },
       "CoverageLevel": {
         "description": "How much of a subnet's interface metagraphed has observed, low→high: native-only (chain identity only) · manifested (declared surfaces) · probed (surfaces confirmed live by the health prober).",
         "enum": [
@@ -12198,6 +12612,320 @@
         "summary": "Fetch registry coverage summary.",
         "tags": [
           "registry"
+        ]
+      }
+    },
+    "/api/v1/coverage-depth": {
+      "get": {
+        "operationId": "coverageDepth",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tier",
+            "required": false,
+            "schema": {
+              "enum": [
+                "agent-ready",
+                "machine-usable",
+                "candidate-review",
+                "needs-evidence",
+                "hard-blocked",
+                "missing-interface"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "callable",
+                "base-layer",
+                "candidate",
+                "needs-evidence",
+                "blocked"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "blocker_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "none",
+                "hard-blocked",
+                "needs-review",
+                "missing-data"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "agent_status",
+                "blocker_level",
+                "name",
+                "netuid",
+                "priority_score",
+                "score",
+                "tier"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "coverage_depth_version": 1,
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "ranked_queue": [
+                      {
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "priority_score": 100,
+                        "rank": 1,
+                        "recommended_next_action": "2026-06-01T00:00:00.000Z",
+                        "score": 100,
+                        "severity": "hard",
+                        "slug": "example-subnet",
+                        "tier": "example",
+                        "top_gap_codes": [
+                          "example"
+                        ]
+                      }
+                    ],
+                    "rows": [
+                      {
+                        "agent_status": "callable",
+                        "blocker_level": "none",
+                        "dimensions": {
+                          "callable_service_count": 1,
+                          "candidate_count": 1,
+                          "candidate_operational_count": 1,
+                          "data_artifact_count": 1,
+                          "docs_url_present": false,
+                          "example_count": 1,
+                          "fixture_available_count": 1,
+                          "fixture_status_counts": {},
+                          "official_surface_count": 1,
+                          "provider_claimed_surface_count": 1,
+                          "registry_observed_surface_count": 1,
+                          "schema_missing_count": 1,
+                          "schema_service_count": 1,
+                          "sdk_count": 1,
+                          "service_count": 1,
+                          "service_kinds": [
+                            "example"
+                          ],
+                          "source_repo_present": false,
+                          "surface_count": 1
+                        },
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "priority_score": 100,
+                        "readiness_score": 100,
+                        "recommended_next_action": "2026-06-01T00:00:00.000Z",
+                        "score": 100,
+                        "slug": "example-subnet",
+                        "tier": "agent-ready",
+                        "top_gap_codes": [
+                          "example"
+                        ],
+                        "top_gaps": [
+                          {
+                            "code": "example",
+                            "field": "example",
+                            "message": "example",
+                            "next_action": "example",
+                            "severity": "hard"
+                          }
+                        ]
+                      }
+                    ],
+                    "schema_version": 1,
+                    "scoring": {
+                      "methodology": "GET",
+                      "weights": {}
+                    },
+                    "subnet_count": 1,
+                    "summary": {
+                      "agent_ready_count": 1,
+                      "average_score": 100,
+                      "blocked_subnet_count": 5000000,
+                      "blocker_level_counts": {},
+                      "callable_subnet_count": 1,
+                      "gap_code_counts": {},
+                      "queue_count": 1,
+                      "row_count": 1,
+                      "severity_counts": {},
+                      "tier_counts": {}
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/CoverageDepthArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch the machine-usable coverage depth scorecard and ranked enrichment queue.",
+        "tags": [
+          "registry",
+          "review",
+          "api-dx"
         ]
       }
     },

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,14 +1,14 @@
 {
   "artifact_count": 5,
-  "artifact_size_bytes": 1389980,
+  "artifact_size_bytes": 1447130,
   "artifacts": [
     {
       "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "b2ede11e893e02fb39ac5d2f4ff30bf69dd0314d6d17f1e42bf38ac7bcda4a1e",
-      "size_bytes": 105714,
+      "sha256": "e5fedda9bf605c220c44838f948ea264ca87f93d883aa63becc7c0acc48b9ceb",
+      "size_bytes": 108394,
       "storage_tier": "dual"
     },
     {
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/contracts.json",
       "latest_key": "latest/contracts.json",
       "path": "/metagraph/contracts.json",
-      "sha256": "fce5de31f4df1d9d3d077ef569b5635f5be90dc3dc47c0086a3b74936cbbfcc1",
-      "size_bytes": 28508,
+      "sha256": "f07e9a28c4f5423f758972faa90ff995f117b2fb77b42ced9b5f94ffb248e254",
+      "size_bytes": 28908,
       "storage_tier": "dual"
     },
     {
@@ -25,8 +25,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "f0d845c30b60260d44668e9291caab84033ece9bb16e0fe58c88e8f1efd1135d",
-      "size_bytes": 702691,
+      "sha256": "349172da94ee1fe601ff52abb7847a76d8b973bdf1063ff06cbca0223ff02ea4",
+      "size_bytes": 736643,
       "storage_tier": "dual"
     },
     {
@@ -43,16 +43,16 @@
       "key": "runs/1970-01-01T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "f6f47bbfe2609d3248ec9da050389014f01324f1810e37526f4eabb5fcad94e4",
-      "size_bytes": 529102,
+      "sha256": "4a146c4beb691649d38602d0bc3fd8b572075392204d9f98da90f7def2e94106",
+      "size_bytes": 549220,
       "storage_tier": "dual"
     }
   ],
   "bucket_binding": "METAGRAPH_ARCHIVE",
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
-  "full_artifact_count": 2184,
-  "full_artifact_size_bytes": 37271583,
+  "full_artifact_count": 2185,
+  "full_artifact_size_bytes": 38136812,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -71,10 +71,10 @@
   "schema_version": 1,
   "storage_tier_counts": {
     "dual": 5,
-    "r2": 2179
+    "r2": 2180
   },
   "storage_tier_size_bytes": {
-    "dual": 1389980,
-    "r2": 35881603
+    "dual": 1447130,
+    "r2": 36689682
   }
 }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -174,6 +174,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/coverage-depth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch the machine-usable coverage depth scorecard and ranked enrichment queue. */
+        get: operations["coverageDepth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/curation": {
         parameters: {
             query?: never;
@@ -1513,6 +1530,100 @@ export interface components {
             after: number;
             before: number;
             delta: number;
+        };
+        CoverageDepthArtifact: components["schemas"]["ArtifactBase"] & ({
+            coverage_depth_version: number;
+            ranked_queue: components["schemas"]["CoverageDepthQueueEntry"][];
+            rows: components["schemas"]["CoverageDepthRow"][];
+            scoring: {
+                methodology: string;
+                weights: {
+                    [key: string]: number;
+                };
+            } & {
+                [key: string]: unknown;
+            };
+            subnet_count: number;
+            summary: {
+                agent_ready_count: number;
+                average_score: number;
+                blocked_subnet_count: number;
+                blocker_level_counts: {
+                    [key: string]: number;
+                };
+                callable_subnet_count: number;
+                gap_code_counts: {
+                    [key: string]: number;
+                };
+                queue_count: number;
+                row_count: number;
+                severity_counts: {
+                    [key: string]: number;
+                };
+                tier_counts: {
+                    [key: string]: number;
+                };
+            };
+        } & {
+            [key: string]: unknown;
+        });
+        CoverageDepthQueueEntry: {
+            name: string;
+            netuid: number;
+            priority_score: number;
+            rank: number;
+            recommended_next_action: string;
+            score: number;
+            /** @enum {string} */
+            severity: "hard" | "missing-data" | "needs-review";
+            slug: string;
+            tier: string;
+            top_gap_codes: string[];
+        };
+        CoverageDepthRow: {
+            /** @enum {string} */
+            agent_status: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
+            /** @enum {string} */
+            blocker_level: "none" | "hard-blocked" | "needs-review" | "missing-data";
+            completeness_score?: number | null;
+            curation_level?: string | null;
+            dimensions: {
+                callable_service_count: number;
+                candidate_count: number;
+                candidate_operational_count: number;
+                data_artifact_count: number;
+                docs_url_present: boolean;
+                example_count: number;
+                fixture_available_count: number;
+                fixture_status_counts: {
+                    [key: string]: number;
+                };
+                official_surface_count: number;
+                provider_claimed_surface_count: number;
+                registry_observed_surface_count: number;
+                schema_missing_count: number;
+                schema_service_count: number;
+                sdk_count: number;
+                service_count: number;
+                service_kinds: string[];
+                source_repo_present: boolean;
+                surface_count: number;
+            } & {
+                [key: string]: unknown;
+            };
+            name: string;
+            netuid: number;
+            priority_score: number;
+            profile_level?: string | null;
+            readiness_score: number;
+            recommended_next_action: string | null;
+            score: number;
+            slug: string;
+            subnet_type?: string | null;
+            /** @enum {string} */
+            tier: "agent-ready" | "machine-usable" | "candidate-review" | "needs-evidence" | "hard-blocked" | "missing-interface";
+            top_gap_codes: string[];
+            top_gaps: components["schemas"]["AgentReadinessBlocker"][];
         };
         /**
          * @description How much of a subnet's interface metagraphed has observed, low→high: native-only (chain identity only) · manifested (declared surfaces) · probed (surfaces confirmed live by the health prober).
@@ -4943,6 +5054,200 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["CoverageArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    coverageDepth: {
+        parameters: {
+            query?: {
+                netuid?: number;
+                tier?: "agent-ready" | "machine-usable" | "candidate-review" | "needs-evidence" | "hard-blocked" | "missing-interface";
+                agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
+                blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
+                q?: string;
+                limit?: number;
+                cursor?: number;
+                sort?: "agent_status" | "blocker_level" | "name" | "netuid" | "priority_score" | "score" | "tier";
+                order?: "asc" | "desc";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "coverage_depth_version": 1,
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "ranked_queue": [
+                     *           {
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "priority_score": 100,
+                     *             "rank": 1,
+                     *             "recommended_next_action": "2026-06-01T00:00:00.000Z",
+                     *             "score": 100,
+                     *             "severity": "hard",
+                     *             "slug": "example-subnet",
+                     *             "tier": "example",
+                     *             "top_gap_codes": [
+                     *               "example"
+                     *             ]
+                     *           }
+                     *         ],
+                     *         "rows": [
+                     *           {
+                     *             "agent_status": "callable",
+                     *             "blocker_level": "none",
+                     *             "dimensions": {
+                     *               "callable_service_count": 1,
+                     *               "candidate_count": 1,
+                     *               "candidate_operational_count": 1,
+                     *               "data_artifact_count": 1,
+                     *               "docs_url_present": false,
+                     *               "example_count": 1,
+                     *               "fixture_available_count": 1,
+                     *               "fixture_status_counts": {},
+                     *               "official_surface_count": 1,
+                     *               "provider_claimed_surface_count": 1,
+                     *               "registry_observed_surface_count": 1,
+                     *               "schema_missing_count": 1,
+                     *               "schema_service_count": 1,
+                     *               "sdk_count": 1,
+                     *               "service_count": 1,
+                     *               "service_kinds": [
+                     *                 "example"
+                     *               ],
+                     *               "source_repo_present": false,
+                     *               "surface_count": 1
+                     *             },
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "priority_score": 100,
+                     *             "readiness_score": 100,
+                     *             "recommended_next_action": "2026-06-01T00:00:00.000Z",
+                     *             "score": 100,
+                     *             "slug": "example-subnet",
+                     *             "tier": "agent-ready",
+                     *             "top_gap_codes": [
+                     *               "example"
+                     *             ],
+                     *             "top_gaps": [
+                     *               {
+                     *                 "code": "example",
+                     *                 "field": "example",
+                     *                 "message": "example",
+                     *                 "next_action": "example",
+                     *                 "severity": "hard"
+                     *               }
+                     *             ]
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "scoring": {
+                     *           "methodology": "GET",
+                     *           "weights": {}
+                     *         },
+                     *         "subnet_count": 1,
+                     *         "summary": {
+                     *           "agent_ready_count": 1,
+                     *           "average_score": 100,
+                     *           "blocked_subnet_count": 5000000,
+                     *           "blocker_level_counts": {},
+                     *           "callable_subnet_count": 1,
+                     *           "gap_code_counts": {},
+                     *           "queue_count": 1,
+                     *           "row_count": 1,
+                     *           "severity_counts": {},
+                     *           "tier_counts": {}
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["CoverageDepthArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -1789,6 +1789,420 @@
         ],
         "type": "object"
       },
+      "CoverageDepthArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "coverage_depth_version": {
+                "minimum": 1,
+                "type": "integer"
+              },
+              "ranked_queue": {
+                "items": {
+                  "$ref": "#/components/schemas/CoverageDepthQueueEntry"
+                },
+                "type": "array"
+              },
+              "rows": {
+                "items": {
+                  "$ref": "#/components/schemas/CoverageDepthRow"
+                },
+                "type": "array"
+              },
+              "scoring": {
+                "additionalProperties": true,
+                "properties": {
+                  "methodology": {
+                    "type": "string"
+                  },
+                  "weights": {
+                    "additionalProperties": {
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "methodology",
+                  "weights"
+                ],
+                "type": "object"
+              },
+              "subnet_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "summary": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_ready_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "average_score": {
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "blocked_subnet_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "blocker_level_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "callable_subnet_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "gap_code_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "queue_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "row_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "severity_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "tier_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "row_count",
+                  "agent_ready_count",
+                  "callable_subnet_count",
+                  "blocked_subnet_count",
+                  "queue_count",
+                  "average_score",
+                  "tier_counts",
+                  "blocker_level_counts",
+                  "severity_counts",
+                  "gap_code_counts"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "coverage_depth_version",
+              "subnet_count",
+              "summary",
+              "scoring",
+              "rows",
+              "ranked_queue"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "CoverageDepthQueueEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "priority_score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "rank": {
+            "minimum": 1,
+            "type": "integer"
+          },
+          "recommended_next_action": {
+            "type": "string"
+          },
+          "score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "severity": {
+            "enum": [
+              "hard",
+              "missing-data",
+              "needs-review"
+            ],
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "tier": {
+            "type": "string"
+          },
+          "top_gap_codes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "rank",
+          "netuid",
+          "slug",
+          "name",
+          "tier",
+          "score",
+          "priority_score",
+          "severity",
+          "top_gap_codes",
+          "recommended_next_action"
+        ],
+        "type": "object"
+      },
+      "CoverageDepthRow": {
+        "additionalProperties": false,
+        "properties": {
+          "agent_status": {
+            "enum": [
+              "callable",
+              "base-layer",
+              "candidate",
+              "needs-evidence",
+              "blocked"
+            ],
+            "type": "string"
+          },
+          "blocker_level": {
+            "enum": [
+              "none",
+              "hard-blocked",
+              "needs-review",
+              "missing-data"
+            ],
+            "type": "string"
+          },
+          "completeness_score": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "curation_level": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "dimensions": {
+            "additionalProperties": true,
+            "properties": {
+              "callable_service_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "candidate_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "candidate_operational_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "data_artifact_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "docs_url_present": {
+                "type": "boolean"
+              },
+              "example_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "fixture_available_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "fixture_status_counts": {
+                "additionalProperties": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "object"
+              },
+              "official_surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "provider_claimed_surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "registry_observed_surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "schema_missing_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "schema_service_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "sdk_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "service_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "service_kinds": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "source_repo_present": {
+                "type": "boolean"
+              },
+              "surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "surface_count",
+              "official_surface_count",
+              "registry_observed_surface_count",
+              "provider_claimed_surface_count",
+              "service_count",
+              "callable_service_count",
+              "service_kinds",
+              "schema_service_count",
+              "schema_missing_count",
+              "fixture_available_count",
+              "fixture_status_counts",
+              "example_count",
+              "sdk_count",
+              "candidate_count",
+              "candidate_operational_count",
+              "data_artifact_count",
+              "source_repo_present",
+              "docs_url_present"
+            ],
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "priority_score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "profile_level": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "readiness_score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "recommended_next_action": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "subnet_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "tier": {
+            "enum": [
+              "agent-ready",
+              "machine-usable",
+              "candidate-review",
+              "needs-evidence",
+              "hard-blocked",
+              "missing-interface"
+            ],
+            "type": "string"
+          },
+          "top_gap_codes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "top_gaps": {
+            "items": {
+              "$ref": "#/components/schemas/AgentReadinessBlocker"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "netuid",
+          "slug",
+          "name",
+          "score",
+          "tier",
+          "priority_score",
+          "agent_status",
+          "blocker_level",
+          "readiness_score",
+          "dimensions",
+          "top_gaps",
+          "top_gap_codes",
+          "recommended_next_action"
+        ],
+        "type": "object"
+      },
       "CoverageLevel": {
         "description": "How much of a subnet's interface metagraphed has observed, low→high: native-only (chain identity only) · manifested (declared surfaces) · probed (surfaces confirmed live by the health prober).",
         "enum": [

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1417,6 +1417,294 @@
           }
         ]
       },
+      "CoverageDepthArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "type": "object",
+            "required": [
+              "coverage_depth_version",
+              "subnet_count",
+              "summary",
+              "scoring",
+              "rows",
+              "ranked_queue"
+            ],
+            "properties": {
+              "coverage_depth_version": { "type": "integer", "minimum": 1 },
+              "subnet_count": { "type": "integer", "minimum": 0 },
+              "summary": {
+                "type": "object",
+                "required": [
+                  "row_count",
+                  "agent_ready_count",
+                  "callable_subnet_count",
+                  "blocked_subnet_count",
+                  "queue_count",
+                  "average_score",
+                  "tier_counts",
+                  "blocker_level_counts",
+                  "severity_counts",
+                  "gap_code_counts"
+                ],
+                "properties": {
+                  "row_count": { "type": "integer", "minimum": 0 },
+                  "agent_ready_count": { "type": "integer", "minimum": 0 },
+                  "callable_subnet_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "blocked_subnet_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "queue_count": { "type": "integer", "minimum": 0 },
+                  "average_score": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100
+                  },
+                  "tier_counts": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  },
+                  "blocker_level_counts": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  },
+                  "severity_counts": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  },
+                  "gap_code_counts": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "scoring": {
+                "type": "object",
+                "required": ["methodology", "weights"],
+                "properties": {
+                  "methodology": { "type": "string" },
+                  "weights": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 100
+                    }
+                  }
+                },
+                "additionalProperties": true
+              },
+              "rows": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CoverageDepthRow"
+                }
+              },
+              "ranked_queue": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CoverageDepthQueueEntry"
+                }
+              }
+            },
+            "additionalProperties": true
+          }
+        ]
+      },
+      "CoverageDepthRow": {
+        "type": "object",
+        "required": [
+          "netuid",
+          "slug",
+          "name",
+          "score",
+          "tier",
+          "priority_score",
+          "agent_status",
+          "blocker_level",
+          "readiness_score",
+          "dimensions",
+          "top_gaps",
+          "top_gap_codes",
+          "recommended_next_action"
+        ],
+        "properties": {
+          "netuid": { "type": "integer", "minimum": 0 },
+          "slug": { "type": "string" },
+          "name": { "type": "string" },
+          "subnet_type": { "type": ["string", "null"] },
+          "curation_level": { "type": ["string", "null"] },
+          "profile_level": { "type": ["string", "null"] },
+          "score": { "type": "integer", "minimum": 0, "maximum": 100 },
+          "tier": {
+            "type": "string",
+            "enum": [
+              "agent-ready",
+              "machine-usable",
+              "candidate-review",
+              "needs-evidence",
+              "hard-blocked",
+              "missing-interface"
+            ]
+          },
+          "priority_score": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "agent_status": {
+            "type": "string",
+            "enum": [
+              "callable",
+              "base-layer",
+              "candidate",
+              "needs-evidence",
+              "blocked"
+            ]
+          },
+          "blocker_level": {
+            "type": "string",
+            "enum": ["none", "hard-blocked", "needs-review", "missing-data"]
+          },
+          "readiness_score": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "completeness_score": { "type": ["number", "null"] },
+          "dimensions": {
+            "type": "object",
+            "required": [
+              "surface_count",
+              "official_surface_count",
+              "registry_observed_surface_count",
+              "provider_claimed_surface_count",
+              "service_count",
+              "callable_service_count",
+              "service_kinds",
+              "schema_service_count",
+              "schema_missing_count",
+              "fixture_available_count",
+              "fixture_status_counts",
+              "example_count",
+              "sdk_count",
+              "candidate_count",
+              "candidate_operational_count",
+              "data_artifact_count",
+              "source_repo_present",
+              "docs_url_present"
+            ],
+            "properties": {
+              "surface_count": { "type": "integer", "minimum": 0 },
+              "official_surface_count": { "type": "integer", "minimum": 0 },
+              "registry_observed_surface_count": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "provider_claimed_surface_count": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "service_count": { "type": "integer", "minimum": 0 },
+              "callable_service_count": { "type": "integer", "minimum": 0 },
+              "service_kinds": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "schema_service_count": { "type": "integer", "minimum": 0 },
+              "schema_missing_count": { "type": "integer", "minimum": 0 },
+              "fixture_available_count": { "type": "integer", "minimum": 0 },
+              "fixture_status_counts": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "example_count": { "type": "integer", "minimum": 0 },
+              "sdk_count": { "type": "integer", "minimum": 0 },
+              "candidate_count": { "type": "integer", "minimum": 0 },
+              "candidate_operational_count": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "data_artifact_count": { "type": "integer", "minimum": 0 },
+              "source_repo_present": { "type": "boolean" },
+              "docs_url_present": { "type": "boolean" }
+            },
+            "additionalProperties": true
+          },
+          "top_gaps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentReadinessBlocker"
+            }
+          },
+          "top_gap_codes": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "recommended_next_action": { "type": ["string", "null"] }
+        },
+        "additionalProperties": false
+      },
+      "CoverageDepthQueueEntry": {
+        "type": "object",
+        "required": [
+          "rank",
+          "netuid",
+          "slug",
+          "name",
+          "tier",
+          "score",
+          "priority_score",
+          "severity",
+          "top_gap_codes",
+          "recommended_next_action"
+        ],
+        "properties": {
+          "rank": { "type": "integer", "minimum": 1 },
+          "netuid": { "type": "integer", "minimum": 0 },
+          "slug": { "type": "string" },
+          "name": { "type": "string" },
+          "tier": { "type": "string" },
+          "score": { "type": "integer", "minimum": 0, "maximum": 100 },
+          "priority_score": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["hard", "missing-data", "needs-review"]
+          },
+          "top_gap_codes": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "recommended_next_action": { "type": "string" }
+        },
+        "additionalProperties": false
+      },
       "CoverageDelta": {
         "type": "object",
         "required": ["after", "before", "delta"],

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1788,6 +1788,404 @@ function summarizeAgentReadinessBlockers(blockedSubnets) {
   };
 }
 
+const COVERAGE_DEPTH_VERSION = 1;
+const COVERAGE_DEPTH_WEIGHTS = {
+  callable_service: 25,
+  schema_availability: 15,
+  fixture_state: 10,
+  examples_or_sdk: 10,
+  provenance: 15,
+  readiness_blockers: 15,
+  profile_completeness: 10,
+};
+const COVERAGE_DEPTH_QUEUE_LIMIT = 100;
+const COVERAGE_DEPTH_SEVERITY_RANK = {
+  hard: 0,
+  "needs-review": 1,
+  "missing-data": 2,
+};
+
+function coverageDepthTier({ agentReadiness, dimensions, gaps, score }) {
+  if (agentReadiness?.blocker_level === "hard-blocked") {
+    return "hard-blocked";
+  }
+  if (
+    dimensions.callable_service_count > 0 &&
+    agentReadiness?.blocker_level === "none" &&
+    gaps.length === 0 &&
+    score >= 80
+  ) {
+    return "agent-ready";
+  }
+  if (dimensions.callable_service_count > 0) {
+    return "machine-usable";
+  }
+  if (
+    agentReadiness?.status === "candidate" ||
+    dimensions.candidate_operational_count > 0
+  ) {
+    return "candidate-review";
+  }
+  if (agentReadiness?.status === "needs-evidence") {
+    return "needs-evidence";
+  }
+  return "missing-interface";
+}
+
+function addCoverageDepthGap(gaps, seenCodes, gap) {
+  if (seenCodes.has(gap.code)) return;
+  seenCodes.add(gap.code);
+  gaps.push(gap);
+}
+
+function sortCoverageDepthGaps(gaps) {
+  return [...gaps].sort((a, b) => {
+    const severityDelta =
+      (COVERAGE_DEPTH_SEVERITY_RANK[a.severity] ?? 9) -
+      (COVERAGE_DEPTH_SEVERITY_RANK[b.severity] ?? 9);
+    if (severityDelta !== 0) return severityDelta;
+    return a.code.localeCompare(b.code);
+  });
+}
+
+function scoreCoverageDepthDimensions({
+  dimensions,
+  agentReadiness,
+  completenessScore,
+}) {
+  const callableCoverage =
+    dimensions.callable_service_count > 0
+      ? 1
+      : dimensions.candidate_operational_count > 0
+        ? 0.3
+        : 0;
+  const schemaCoverage =
+    dimensions.callable_service_count > 0
+      ? dimensions.schema_service_count / dimensions.callable_service_count
+      : 0;
+  const explicitFixtureAbsenceCount = Object.values(
+    dimensions.fixture_status_counts,
+  ).reduce((sum, count) => sum + count, 0);
+  const fixtureCoverage =
+    dimensions.callable_service_count > 0
+      ? dimensions.fixture_available_count > 0
+        ? dimensions.fixture_available_count / dimensions.callable_service_count
+        : explicitFixtureAbsenceCount > 0
+          ? 0.4
+          : 0
+      : 0;
+  const exampleSdkCoverage =
+    dimensions.example_count + dimensions.sdk_count > 0 ? 1 : 0;
+  const provenanceCoverage =
+    dimensions.official_surface_count > 0
+      ? 1
+      : dimensions.provider_claimed_surface_count > 0
+        ? 0.6
+        : dimensions.registry_observed_surface_count > 0
+          ? 0.35
+          : 0;
+  const readinessCoverage =
+    agentReadiness?.blocker_level === "none"
+      ? 1
+      : agentReadiness?.blocker_level === "missing-data"
+        ? 0.65
+        : agentReadiness?.blocker_level === "needs-review"
+          ? 0.45
+          : 0;
+  const profileCoverage = Math.max(
+    0,
+    Math.min(1, Number(completenessScore || 0) / 100),
+  );
+
+  return Math.round(
+    COVERAGE_DEPTH_WEIGHTS.callable_service * callableCoverage +
+      COVERAGE_DEPTH_WEIGHTS.schema_availability * schemaCoverage +
+      COVERAGE_DEPTH_WEIGHTS.fixture_state * fixtureCoverage +
+      COVERAGE_DEPTH_WEIGHTS.examples_or_sdk * exampleSdkCoverage +
+      COVERAGE_DEPTH_WEIGHTS.provenance * provenanceCoverage +
+      COVERAGE_DEPTH_WEIGHTS.readiness_blockers * readinessCoverage +
+      COVERAGE_DEPTH_WEIGHTS.profile_completeness * profileCoverage,
+  );
+}
+
+function coverageDepthPriorityScore({ row, gaps }) {
+  const actionableGaps = gaps.filter((gap) => gap.severity !== "hard");
+  if (row.subnet_type === "root" || actionableGaps.length === 0) {
+    return 0;
+  }
+  const severityWeight = actionableGaps.reduce((sum, gap) => {
+    if (gap.severity === "needs-review") return sum + 18;
+    return sum + 12;
+  }, 0);
+  const base =
+    row.dimensions.callable_service_count > 0
+      ? 42
+      : row.dimensions.candidate_operational_count > 0
+        ? 30
+        : 14;
+  const deficitWeight = Math.round((100 - row.score) * 0.25);
+  const reviewWeight = row.curation_level === "maintainer-reviewed" ? 0 : 6;
+  const hardBlockerPenalty = row.blocker_level === "hard-blocked" ? 35 : 0;
+  return Math.max(
+    0,
+    Math.min(
+      100,
+      base +
+        Math.min(32, severityWeight) +
+        deficitWeight +
+        reviewWeight -
+        hardBlockerPenalty,
+    ),
+  );
+}
+
+function buildCoverageDepthArtifact({
+  subnets,
+  profileByNetuid,
+  surfacesByNetuid,
+  servicesByNetuid,
+  candidatesByNetuid,
+  readinessByNetuid,
+  agentReadinessByNetuid,
+  examplesByNetuid,
+  generatedAt,
+  contractVersion,
+}) {
+  const rows = subnets
+    .map((subnet) => {
+      const profile = profileByNetuid.get(subnet.netuid) || null;
+      const subnetSurfaces = surfacesByNetuid.get(subnet.netuid) || [];
+      const services = servicesByNetuid.get(subnet.netuid) || [];
+      const callableServices = services.filter(
+        (service) => service.eligibility?.callable,
+      );
+      const candidatesForSubnet = candidatesByNetuid.get(subnet.netuid) || [];
+      const agentReadiness = agentReadinessByNetuid.get(subnet.netuid) || {
+        status: "blocked",
+        blocker_level: "missing-data",
+        blockers: [],
+        missing_fields: [],
+      };
+      const readiness = readinessByNetuid.get(subnet.netuid) || {
+        score: 0,
+      };
+      const examples = examplesByNetuid.get(subnet.netuid) || [];
+      const sdkCount = subnetSurfaces.filter(
+        (surface) => surface.kind === "sdk",
+      ).length;
+      const fixtureStatusCounts = countBy(
+        callableServices,
+        (service) => service.fixture_status?.status || "missing",
+      );
+      const dimensions = {
+        surface_count: subnetSurfaces.length,
+        official_surface_count: subnetSurfaces.filter(
+          (surface) => surface.authority === "official",
+        ).length,
+        registry_observed_surface_count: subnetSurfaces.filter(
+          (surface) => surface.authority === "registry-observed",
+        ).length,
+        provider_claimed_surface_count: subnetSurfaces.filter(
+          (surface) => surface.authority === "provider-claimed",
+        ).length,
+        service_count: services.length,
+        callable_service_count: callableServices.length,
+        service_kinds: [
+          ...new Set(callableServices.map((service) => service.kind)),
+        ].sort(),
+        schema_service_count: callableServices.filter(
+          (service) => service.schema_artifact,
+        ).length,
+        schema_missing_count: callableServices.filter(
+          (service) => !service.schema_artifact,
+        ).length,
+        fixture_available_count: callableServices.filter(
+          (service) => service.fixture_status?.status === "available",
+        ).length,
+        fixture_status_counts: fixtureStatusCounts,
+        example_count: examples.length,
+        sdk_count: sdkCount,
+        candidate_count: candidatesForSubnet.length,
+        candidate_operational_count: candidatesForSubnet.filter((candidate) =>
+          OPERATIONAL_SURFACE_KINDS.includes(candidate.kind),
+        ).length,
+        data_artifact_count: callableServices.filter(
+          (service) => service.kind === "data-artifact",
+        ).length,
+        source_repo_present: Boolean(subnet.source_repo),
+        docs_url_present: Boolean(subnet.docs_url),
+      };
+      const score = scoreCoverageDepthDimensions({
+        dimensions,
+        agentReadiness,
+        completenessScore: profile?.completeness_score,
+      });
+      const gaps = [];
+      const seenGapCodes = new Set();
+      for (const blocker of agentReadiness.blockers || []) {
+        addCoverageDepthGap(gaps, seenGapCodes, blocker);
+      }
+      if (
+        dimensions.callable_service_count > 0 &&
+        dimensions.schema_missing_count > 0 &&
+        dimensions.schema_service_count > 0
+      ) {
+        addCoverageDepthGap(gaps, seenGapCodes, {
+          code: "partial-schema-coverage",
+          severity: "missing-data",
+          message:
+            "Some callable services have captured schemas, but at least one callable service is still schema-less.",
+          field: "schemas",
+          next_action:
+            "Capture or explicitly mark schema absence for the remaining callable services.",
+        });
+      }
+      if (
+        dimensions.callable_service_count > 0 &&
+        dimensions.fixture_available_count === 0 &&
+        ((dimensions.fixture_status_counts.missing || 0) > 0 ||
+          (dimensions.fixture_status_counts["capture-failed"] || 0) > 0)
+      ) {
+        addCoverageDepthGap(gaps, seenGapCodes, {
+          code: "missing-fixture",
+          severity: "missing-data",
+          message:
+            "Callable services exist, but no sanitized request/response fixture is available.",
+          field: "fixtures",
+          next_action:
+            "Run fixture capture in write mode or document why the callable surface cannot publish a public sample.",
+        });
+      }
+      if (
+        dimensions.callable_service_count > 0 &&
+        dimensions.example_count + dimensions.sdk_count === 0
+      ) {
+        addCoverageDepthGap(gaps, seenGapCodes, {
+          code: "missing-example-or-sdk",
+          severity: "missing-data",
+          message:
+            "Callable services exist, but no example or SDK surface is recorded.",
+          field: "examples",
+          next_action:
+            "Add an official quickstart, SDK, or minimal code example for this subnet.",
+        });
+      }
+      if (
+        dimensions.surface_count > 0 &&
+        dimensions.official_surface_count === 0
+      ) {
+        addCoverageDepthGap(gaps, seenGapCodes, {
+          code: "missing-official-provenance",
+          severity: "needs-review",
+          message:
+            "Surfaces are catalogued, but none are marked operator-official.",
+          field: "authority",
+          next_action:
+            "Verify whether any recorded surface is first-party, or add official evidence.",
+        });
+      }
+      const sortedGaps = sortCoverageDepthGaps(gaps);
+      const row = {
+        netuid: subnet.netuid,
+        slug: subnet.slug,
+        name: subnet.name,
+        subnet_type: profile?.subnet_type || subnet.subnet_type || null,
+        curation_level: profile?.curation_level || null,
+        profile_level: profile?.profile_level || null,
+        score,
+        tier: coverageDepthTier({
+          agentReadiness,
+          dimensions,
+          gaps: sortedGaps,
+          score,
+        }),
+        priority_score: 0,
+        agent_status: agentReadiness.status,
+        blocker_level: agentReadiness.blocker_level,
+        readiness_score: readiness.score,
+        completeness_score: profile?.completeness_score ?? null,
+        dimensions,
+        top_gaps: sortedGaps.slice(0, 6),
+        top_gap_codes: sortedGaps.slice(0, 6).map((gap) => gap.code),
+        recommended_next_action:
+          sortedGaps.find((gap) => gap.severity !== "hard")?.next_action ||
+          sortedGaps[0]?.next_action ||
+          null,
+      };
+      row.priority_score = coverageDepthPriorityScore({
+        row,
+        gaps: sortedGaps,
+      });
+      return row;
+    })
+    .sort((a, b) => a.netuid - b.netuid);
+
+  const rankedQueue = rows
+    .filter((row) => row.priority_score > 0 && row.top_gaps.length > 0)
+    .sort((a, b) => {
+      const priorityDelta = b.priority_score - a.priority_score;
+      if (priorityDelta !== 0) return priorityDelta;
+      const scoreDelta = a.score - b.score;
+      if (scoreDelta !== 0) return scoreDelta;
+      return a.netuid - b.netuid;
+    })
+    .slice(0, COVERAGE_DEPTH_QUEUE_LIMIT)
+    .map((row, index) => {
+      const primaryGap =
+        row.top_gaps.find((gap) => gap.severity !== "hard") || row.top_gaps[0];
+      return {
+        rank: index + 1,
+        netuid: row.netuid,
+        slug: row.slug,
+        name: row.name,
+        tier: row.tier,
+        score: row.score,
+        priority_score: row.priority_score,
+        severity: primaryGap.severity,
+        top_gap_codes: row.top_gap_codes,
+        recommended_next_action:
+          row.recommended_next_action || primaryGap.next_action,
+      };
+    });
+  const allTopGaps = rows.flatMap((row) => row.top_gaps);
+  return {
+    schema_version: 1,
+    contract_version: contractVersion,
+    generated_at: generatedAt,
+    coverage_depth_version: COVERAGE_DEPTH_VERSION,
+    subnet_count: rows.length,
+    summary: {
+      row_count: rows.length,
+      agent_ready_count: rows.filter((row) => row.tier === "agent-ready")
+        .length,
+      callable_subnet_count: rows.filter(
+        (row) => row.dimensions.callable_service_count > 0,
+      ).length,
+      blocked_subnet_count: rows.filter(
+        (row) => row.blocker_level === "hard-blocked",
+      ).length,
+      queue_count: rankedQueue.length,
+      average_score:
+        rows.length === 0
+          ? 0
+          : Math.round(
+              rows.reduce((sum, row) => sum + row.score, 0) / rows.length,
+            ),
+      tier_counts: countBy(rows, "tier"),
+      blocker_level_counts: countBy(rows, "blocker_level"),
+      severity_counts: countBy(allTopGaps, "severity"),
+      gap_code_counts: countBy(allTopGaps, "code"),
+    },
+    scoring: {
+      methodology:
+        "Deterministic build-time score over callable services, schema coverage, fixture state, examples/SDKs, provenance, readiness blockers, and profile completeness. Live health is intentionally separate.",
+      weights: COVERAGE_DEPTH_WEIGHTS,
+    },
+    rows,
+    ranked_queue: rankedQueue,
+  };
+}
+
 await fs.rm(r2ArtifactDir("agent-catalog"), { recursive: true, force: true });
 // #1008: code-examples (quickstarts / SDK snippets) per subnet, projected from
 // the curated `example`-kind surfaces. They are reference material, not callable
@@ -1807,6 +2205,7 @@ const subnetExamples = (netuid) =>
   }));
 const agentCatalogIndex = [];
 const blockedAgentCatalogIndex = [];
+const agentReadinessByNetuid = new Map();
 let callableServiceCount = 0;
 for (const subnet of mergedSubnets) {
   const profile = profileArtifacts.byNetuid.get(subnet.netuid) || null;
@@ -1822,6 +2221,7 @@ for (const subnet of mergedSubnets) {
     readiness,
     callableCount: callable,
   });
+  agentReadinessByNetuid.set(subnet.netuid, agentReadiness);
   await writeJson(artifactFile(`agent-catalog/${subnet.netuid}.json`), {
     schema_version: 1,
     contract_version: contractVersion,
@@ -1911,6 +2311,20 @@ await writeJson(artifactFile("agent-catalog.json"), {
   ...agentCatalogContent,
 });
 
+const coverageDepthArtifact = buildCoverageDepthArtifact({
+  subnets: mergedSubnets,
+  profileByNetuid: profileArtifacts.byNetuid,
+  surfacesByNetuid: overviewSurfacesByNetuid,
+  servicesByNetuid,
+  candidatesByNetuid: activeCandidatesByNetuid,
+  readinessByNetuid,
+  agentReadinessByNetuid,
+  examplesByNetuid: exampleSurfacesByNetuid,
+  generatedAt,
+  contractVersion,
+});
+await writeJson(artifactFile("coverage-depth.json"), coverageDepthArtifact);
+
 // --- llms.txt / llms-full.txt (LLM + agent discoverability) ------------------
 // The emerging standard for making a site/API legible to LLMs. Served from the
 // public/ root (and /.well-known) by the ASSETS handler at api.metagraph.sh.
@@ -1927,6 +2341,7 @@ const llmsHeader = [
   "## Machine entrypoints",
   `- [OpenAPI 3.1](${llmsApiBase}/metagraph/openapi.json): full machine contract for all routes`,
   `- [Agent capability catalog](${llmsApiBase}/api/v1/agent-catalog): per-subnet callable services + their schemas + health`,
+  `- [Coverage depth scorecard](${llmsApiBase}/api/v1/coverage-depth): one ranked view of which subnets are machine-usable, what is missing, and which enrichment actions should happen next`,
   `- [Copyable AI agent](${llmsApiBase}/agent.md): paste-ready system prompt that turns any agent into a metagraphed-powered Bittensor integration agent. Every AI resource indexed at [/api/v1/agent-resources](${llmsApiBase}/api/v1/agent-resources).`,
   `- [Agent workflows](${llmsApiBase}/agent-workflows.md): task-oriented REST, MCP, npm, and Python examples for finding and calling subnets`,
   `- [MCP server](${llmsApiBase}/mcp): Model Context Protocol endpoint — agents query the registry as tools. Install: \`claude mcp add --transport http metagraphed ${llmsApiBase}/mcp\``,
@@ -2216,6 +2631,12 @@ const agentResourcesContent = {
       title: "Agent capability catalog",
       kind: "api",
       url: `${llmsApiBase}/api/v1/agent-catalog`,
+    },
+    {
+      id: "coverage-depth",
+      title: "Coverage depth scorecard",
+      kind: "api",
+      url: `${llmsApiBase}/api/v1/coverage-depth`,
     },
     {
       id: "semantic-search",

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -230,6 +230,19 @@ const checks = [
       assert.equal(Number.isInteger(body.data.chain_subnet_count), true),
   ],
   [
+    "/api/v1/coverage-depth?tier=machine-usable&limit=3",
+    (body) => {
+      assert.equal(Number.isInteger(body.data.subnet_count), true);
+      assert.equal(Array.isArray(body.data.rows), true);
+      assert.equal(body.data.rows.length <= 3, true);
+      assert.equal(
+        body.data.rows.every((row) => row.tier === "machine-usable"),
+        true,
+      );
+      assert.equal(Array.isArray(body.data.ranked_queue), true);
+    },
+  ],
+  [
     "/api/v1/economics",
     (body) => {
       assert.equal(Array.isArray(body.data.subnets), true);

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -94,6 +94,7 @@ const R2_ONLY_PATTERNS = [
   // (scripts/build-changelog.mjs), not a committed baseline.
   /^subnets\.json$/,
   /^coverage\.json$/,
+  /^coverage-depth\.json$/,
   // #1009: per-subnet validator/economic entity. Pure chain-state (stake,
   // emission share, registration cost) that changes every block — republished
   // each sync, never a committed seed.

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -84,6 +84,22 @@ export const QUERY_ENUMS = {
     "disabled",
     "rejected",
   ],
+  coverageDepthTier: [
+    "agent-ready",
+    "machine-usable",
+    "candidate-review",
+    "needs-evidence",
+    "hard-blocked",
+    "missing-interface",
+  ],
+  agentReadinessStatus: [
+    "callable",
+    "base-layer",
+    "candidate",
+    "needs-evidence",
+    "blocked",
+  ],
+  agentBlockerLevel: ["none", "hard-blocked", "needs-review", "missing-data"],
   endpointIncidentSeverity: ["critical", "warning", "info"],
   endpointIncidentState: ["active", "resolved"],
   recommendedAdapterKind: [
@@ -133,6 +149,24 @@ export const API_QUERY_COLLECTIONS = {
       coverage_level: enumSchema(QUERY_ENUMS.coverageLevel),
     },
     sort: ["coverage_level", "curation_level", "name", "netuid"],
+  }),
+  "coverage-depth": queryCollection("rows", {
+    filters: {
+      netuid: integerSchema,
+      tier: enumSchema(QUERY_ENUMS.coverageDepthTier),
+      agent_status: enumSchema(QUERY_ENUMS.agentReadinessStatus),
+      blocker_level: enumSchema(QUERY_ENUMS.agentBlockerLevel),
+    },
+    search: ["name", "slug", "top_gap_codes", "recommended_next_action"],
+    sort: [
+      "agent_status",
+      "blocker_level",
+      "name",
+      "netuid",
+      "priority_score",
+      "score",
+      "tier",
+    ],
   }),
   "curated-surfaces": queryCollection("surfaces", {
     filters: {
@@ -673,6 +707,12 @@ export const PUBLIC_ARTIFACTS = [
     "CoverageArtifact",
   ),
   artifact(
+    "coverage-depth",
+    "/metagraph/coverage-depth.json",
+    "Machine-usable coverage depth scorecard with per-subnet readiness dimensions and a ranked enrichment queue.",
+    "CoverageDepthArtifact",
+  ),
+  artifact(
     "economics",
     "/metagraph/economics.json",
     "Per-subnet validator and economic metrics from the chain: validator/miner counts, total + max stake, registration cost, alpha price, and derived price-weighted emission share.",
@@ -1166,6 +1206,16 @@ export const API_ROUTES = [
     "Fetch registry coverage summary.",
     "standard",
     ["registry"],
+  ),
+  route(
+    "coverage-depth",
+    "GET",
+    "/api/v1/coverage-depth",
+    "/metagraph/coverage-depth.json",
+    "Fetch the machine-usable coverage depth scorecard and ranked enrichment queue.",
+    "standard",
+    ["registry", "review", "api-dx"],
+    listQuery("coverage-depth"),
   ),
   route(
     "economics",

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -458,6 +458,7 @@ test("public artifacts are internally consistent", () => {
   const subnetProfile = readArtifact("profiles/7.json");
   const subnetEndpoints = readArtifact("endpoints/7.json");
   const coverage = readArtifact("coverage.json");
+  const coverageDepth = readArtifact("coverage-depth.json");
   const economics = readArtifact("economics.json");
   const contracts = readArtifact("contracts.json");
   const apiIndex = readArtifact("api-index.json");
@@ -793,6 +794,85 @@ test("public artifacts are internally consistent", () => {
   assert.ok(
     agentCatalog.blocker_summary.by_code["missing-callable-service"] > 0,
     "blocker summary must count missing callable service blockers",
+  );
+  assert.equal(
+    coverageDepth.subnet_count,
+    subnets.subnets.length,
+    "coverage-depth must score every subnet",
+  );
+  assert.equal(
+    coverageDepth.summary.row_count,
+    coverageDepth.rows.length,
+    "coverage-depth row summary must match rows",
+  );
+  assert.ok(
+    coverageDepth.rows.every(
+      (row, index, rows) => index === 0 || rows[index - 1].netuid < row.netuid,
+    ),
+    "coverage-depth rows must be sorted by netuid",
+  );
+  assert.equal(
+    Object.values(coverageDepth.summary.tier_counts).reduce(
+      (sum, count) => sum + count,
+      0,
+    ),
+    coverageDepth.rows.length,
+    "coverage-depth tier counts must cover every row",
+  );
+  assert.equal(
+    coverageDepth.summary.queue_count,
+    coverageDepth.ranked_queue.length,
+    "coverage-depth queue_count must match the ranked queue",
+  );
+  assert.ok(
+    coverageDepth.ranked_queue.every(
+      (entry, index, rows) =>
+        index === 0 ||
+        rows[index - 1].priority_score > entry.priority_score ||
+        (rows[index - 1].priority_score === entry.priority_score &&
+          (rows[index - 1].score < entry.score ||
+            (rows[index - 1].score === entry.score &&
+              rows[index - 1].netuid < entry.netuid))),
+    ),
+    "coverage-depth ranked_queue must have deterministic priority order",
+  );
+  assert.ok(
+    coverageDepth.summary.severity_counts["missing-data"] > 0,
+    "coverage-depth must summarize missing-data gaps",
+  );
+  assert.ok(
+    coverageDepth.summary.tier_counts["hard-blocked"] > 0,
+    "coverage-depth must separate hard-blocked subnets",
+  );
+  const coverageDepthAllways = coverageDepth.rows.find(
+    (entry) => entry.netuid === 7,
+  );
+  assert.ok(coverageDepthAllways, "SN7 must have a coverage-depth row");
+  assert.equal(coverageDepthAllways.agent_status, "callable");
+  assert.ok(
+    coverageDepthAllways.dimensions.callable_service_count > 0,
+    "SN7 coverage-depth row must count callable services",
+  );
+  assert.ok(
+    coverageDepthAllways.top_gap_codes.includes("missing-fixture"),
+    "SN7 coverage-depth row must expose deterministic fixture absence",
+  );
+  const coverageDepthRecall = coverageDepth.rows.find(
+    (entry) => entry.netuid === 31,
+  );
+  assert.equal(coverageDepthRecall.agent_status, "blocked");
+  assert.ok(
+    coverageDepthRecall.top_gap_codes.includes("missing-callable-service"),
+    "SN31 coverage-depth row must carry missing callable-service blocker",
+  );
+  assert.ok(
+    coverageDepth.ranked_queue.some(
+      (entry) =>
+        entry.top_gap_codes.includes("missing-fixture") ||
+        entry.top_gap_codes.includes("missing-schema") ||
+        entry.top_gap_codes.includes("candidate-api-needs-review"),
+    ),
+    "coverage-depth queue must contain actionable enrichment gaps",
   );
   const catalog31 = readArtifact("agent-catalog/31.json");
   assert.equal(catalog31.agent_readiness.status, "blocked");

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -645,6 +645,10 @@ describe("script utility contracts", () => {
       ARTIFACT_STORAGE_TIERS.r2,
     );
     assert.equal(
+      artifactStorageTierForRelativePath("coverage-depth.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+    assert.equal(
       isR2PreferredDualArtifactPath("/metagraph/coverage.json"),
       false,
     );


### PR DESCRIPTION
## Summary
- Adds `/metagraph/coverage-depth.json` and `/api/v1/coverage-depth` as the machine-usable scorecard for subnet enrichment prioritization.
- Closes #1149.

## What changed
- Generates one coverage-depth row per subnet with deterministic score, tier, readiness dimensions, top gaps, and next action.
- Adds a ranked queue for actionable enrichment work across schema, fixture, example/SDK, provenance, profile, and review gaps.
- Separates `missing-data`, `needs-review`, and `hard` blockers while keeping live up/down health out of the score.
- Adds contract/schema/OpenAPI/type/client updates and R2 storage-tier classification.
- Documents the new scorecard in readiness, agent workflow, backend artifact, registry, and curation docs.
- Adds artifact, storage-tier, and API validation coverage.

## Why
Maintainers and agents had callable-service, schema, fixture, readiness, and review signals in separate places, but no single generated view for “which subnets should we enrich next and why?” This scorecard makes that prioritization explicit without creating a competing source of truth.

## Validation
- `npm run build`
- `npm test -- tests/artifacts.test.mjs`
- `npm test -- tests/script-utils.test.mjs`
- `npm run format:check`
- `npm run validate:schemas`
- `npm run validate:api`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:contract-drift`
- `npm run validate:mcp`
- `npm run validate:docs`
- `npm run validate:generated-client`
- `npm run validate:openapi-examples`
- `npm run validate:artifact-budgets`
- `npm run scan:public-safety`
- `npm run validate:private-boundary`
- `npm run lint`
- `npm run validate`
- `npm run worker:test`
- `npm run worker:deploy:dry-run`
- `npm run test:coverage`
- `npm run validate:schema-enums`
- `npm run validate:committed-seed`
- `npm run validate:readme-catalog`
- `npm run validate:ai`
- `npm run validate:workflows`
- `npm run validate:intake`
- `npm run validate:adapters`
- `npm run validate:candidate`
- `git diff --check`

## Notes
- `validate:artifact-budgets` passed with warnings for `coverage-depth.json`, `openapi.json`, `profiles.json`, and `testnet/subnets.json`; no budget gate failed.
- `coverage-depth.json` is R2-only like other high-churn registry-derived artifacts. The committed contract, OpenAPI, types, API index, and R2 manifest are updated.
