### PR TITLE
feat(api): add list field projection

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -4597,6 +4597,7 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "confidence" | "id" | "kind" | "name" | "netuid" | "provider" | "state";
@@ -5110,6 +5111,7 @@ export interface operations {
                 agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
                 blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "agent_status" | "blocker_level" | "name" | "netuid" | "priority_score" | "score" | "tier";
@@ -5301,6 +5303,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "coverage_level" | "curation_level" | "name" | "netuid";
@@ -5574,6 +5577,7 @@ export interface operations {
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 severity?: "critical" | "warning" | "info";
                 state?: "active" | "resolved";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "detected_at" | "endpoint_id" | "kind" | "last_checked" | "netuid" | "provider" | "severity" | "state" | "status";
@@ -5719,6 +5723,7 @@ export interface operations {
             query?: {
                 id?: string;
                 kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "eligible_count" | "endpoint_count" | "id" | "kind";
@@ -5891,6 +5896,7 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -6039,6 +6045,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "claim" | "source_url" | "subject" | "verified_at";
@@ -6419,6 +6426,7 @@ export interface operations {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "coverage_level" | "curation_level" | "gap_count" | "name" | "netuid";
@@ -6548,6 +6556,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "avg_latency_ms" | "degraded_count" | "failed_count" | "last_checked" | "last_ok" | "name" | "netuid" | "ok_count" | "status" | "surface_count" | "unknown_count";
@@ -6674,6 +6683,7 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "classification" | "kind" | "last_checked" | "last_ok" | "latency_ms" | "netuid" | "provider" | "status" | "status_code" | "surface_id" | "verified_at";
@@ -7287,6 +7297,7 @@ export interface operations {
                 confidence?: "low" | "medium" | "high";
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "candidate_count" | "completeness_score" | "curation_level" | "interface_count" | "missing_critical_count" | "name" | "netuid" | "operational_interface_count" | "profile_level" | "review_state";
@@ -7537,6 +7548,7 @@ export interface operations {
                 id?: string;
                 kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
                 authority?: "community" | "official" | "provider-claimed" | "registry-observed";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "authority" | "id" | "kind" | "name";
@@ -7787,6 +7799,7 @@ export interface operations {
                 pool_eligible?: "true" | "false";
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -8181,6 +8194,7 @@ export interface operations {
                 operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 reason_codes?: string;
                 recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "candidate_api_count" | "candidate_api_kinds" | "curation_level" | "name" | "netuid" | "operational_kinds" | "operational_surface_count" | "priority_score" | "recommended_adapter_kind";
@@ -8333,6 +8347,7 @@ export interface operations {
                 missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 netuid?: number;
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "evidence_action" | "lane" | "name" | "netuid" | "priority_score";
@@ -8495,6 +8510,7 @@ export interface operations {
                 review_state?: string;
                 manual_review_required?: "true" | "false";
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "adapter_score" | "candidate_count" | "completeness_score" | "curation_level" | "endpoint_count" | "evidence_action" | "identity_level" | "identity_surface_count" | "lane" | "name" | "netuid" | "operational_interface_count" | "priority_score" | "profile_level" | "review_state" | "stale_candidate_count" | "surface_count" | "verified_candidate_count";
@@ -8702,6 +8718,7 @@ export interface operations {
                 target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 target_type?: "surface-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "auto_review_candidate" | "evidence_action" | "identity_level" | "kind" | "lane" | "manual_review_required" | "name" | "netuid" | "priority_score" | "profile_level" | "submission_route" | "target_action" | "target_type";
@@ -8909,6 +8926,7 @@ export interface operations {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "candidate_count" | "curation_level" | "missing_kinds" | "name" | "netuid" | "priority_score" | "surface_count" | "verified_candidate_count";
@@ -9039,6 +9057,7 @@ export interface operations {
                 identity_level?: "none" | "directory" | "partial" | "complete";
                 identity_promotion_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 native_name_quality?: "chain" | "placeholder" | "empty";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "candidate_count" | "completeness_score" | "identity_level" | "identity_promotion_kind_count" | "identity_surface_count" | "live_identity_candidate_kind_count" | "missing_critical_count" | "name" | "native_identity_signal_count" | "native_name_quality" | "netuid" | "priority_score" | "profile_level" | "stale_identity_candidate_kind_count";
@@ -9234,6 +9253,7 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -9774,6 +9794,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "kind" | "netuid" | "slug" | "title";
@@ -10019,6 +10040,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "id" | "kind" | "path" | "record_count";
@@ -10151,6 +10173,7 @@ export interface operations {
                 domain?: "agents" | "compute" | "data" | "finance" | "inference" | "media" | "prediction" | "privacy" | "robotics" | "science" | "search" | "security" | "storage" | "training";
                 status?: "active" | "inactive";
                 subnet_type?: "root" | "application";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
@@ -10538,6 +10561,7 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "confidence" | "id" | "kind" | "name" | "netuid" | "provider" | "state";
@@ -10668,6 +10692,7 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -10821,6 +10846,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "claim" | "source_url" | "subject" | "verified_at";
@@ -10944,6 +10970,7 @@ export interface operations {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "candidate_count" | "curation_level" | "missing_kinds" | "name" | "netuid" | "priority_score" | "surface_count" | "verified_candidate_count";
@@ -11149,6 +11176,7 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "classification" | "kind" | "last_checked" | "last_ok" | "latency_ms" | "netuid" | "provider" | "status" | "status_code" | "surface_id" | "verified_at";
@@ -12308,6 +12336,7 @@ export interface operations {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "id" | "kind" | "name" | "netuid" | "provider";
@@ -12676,6 +12705,7 @@ export interface operations {
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "id" | "kind" | "name" | "netuid" | "provider";

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -663,6 +663,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -802,6 +809,13 @@
         {
           "name": "q",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },
@@ -948,6 +962,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -1025,6 +1046,13 @@
         {
           "name": "provider",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },
@@ -1170,6 +1198,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -1308,6 +1343,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -1417,6 +1459,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -1515,6 +1564,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -1598,6 +1654,13 @@
               "provider-claimed",
               "registry-observed"
             ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },
@@ -1747,6 +1810,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -1867,6 +1937,13 @@
         {
           "name": "q",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },
@@ -2004,6 +2081,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -2088,6 +2172,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -2168,6 +2259,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -2239,6 +2337,13 @@
         {
           "name": "review_state",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },
@@ -2375,6 +2480,13 @@
               "placeholder",
               "empty"
             ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },
@@ -2523,6 +2635,13 @@
               "generic-openapi-or-custom",
               "stream-adapter"
             ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },
@@ -2737,6 +2856,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -2886,6 +3012,13 @@
         {
           "name": "q",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },
@@ -3128,6 +3261,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -3204,6 +3344,13 @@
               "failed",
               "unknown"
             ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },
@@ -3335,6 +3482,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -3450,6 +3604,13 @@
               "unsupported",
               "unsafe"
             ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },
@@ -3702,6 +3863,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -3753,6 +3921,13 @@
         {
           "name": "q",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },
@@ -3820,6 +3995,13 @@
         {
           "name": "q",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },
@@ -3964,6 +4146,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -4047,6 +4236,13 @@
               "subtensor-wss",
               "archive"
             ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },
@@ -4175,6 +4371,13 @@
           }
         },
         {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
           "name": "limit",
           "schema": {
             "maximum": 1000,
@@ -4278,6 +4481,13 @@
         {
           "name": "q",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
             "type": "string"
           }
         },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -11998,6 +11998,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -12683,6 +12692,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -12952,6 +12970,15 @@
                 "manifested",
                 "probed"
               ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -13380,6 +13407,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -13603,6 +13639,15 @@
                 "subtensor-wss",
                 "archive"
               ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -13928,6 +13973,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -14142,6 +14196,15 @@
             "name": "q",
             "required": false,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -14656,6 +14719,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -14860,6 +14932,15 @@
                 "failed",
                 "unknown"
               ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -15130,6 +15211,15 @@
                 "unsupported",
                 "unsafe"
               ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -15970,6 +16060,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -16314,6 +16413,15 @@
                 "provider-claimed",
                 "registry-observed"
               ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -16740,6 +16848,15 @@
                 "failed",
                 "unknown"
               ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -17350,6 +17467,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -17651,6 +17777,15 @@
             "name": "q",
             "required": false,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -18030,6 +18165,15 @@
             "name": "q",
             "required": false,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -18504,6 +18648,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -18809,6 +18962,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -19079,6 +19241,15 @@
                 "placeholder",
                 "empty"
               ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -19434,6 +19605,15 @@
                 "failed",
                 "unknown"
               ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -20117,6 +20297,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -20445,6 +20634,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -20717,6 +20915,15 @@
                 "root",
                 "application"
               ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -21256,6 +21463,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -21537,6 +21753,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -21769,6 +21994,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -21974,6 +22208,15 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -22312,6 +22555,15 @@
                 "unsupported",
                 "unsafe"
               ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },
@@ -23737,6 +23989,15 @@
           },
           {
             "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -24261,6 +24522,15 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
               "type": "string"
             }
           },

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,14 +1,14 @@
 {
   "artifact_count": 5,
-  "artifact_size_bytes": 1447130,
+  "artifact_size_bytes": 1461620,
   "artifacts": [
     {
       "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "e5fedda9bf605c220c44838f948ea264ca87f93d883aa63becc7c0acc48b9ceb",
-      "size_bytes": 108394,
+      "sha256": "3a730ab97210f043c4abc401f19295c29d322ffc78e6eed9f2a684766dddbff1",
+      "size_bytes": 114064,
       "storage_tier": "dual"
     },
     {
@@ -25,8 +25,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "349172da94ee1fe601ff52abb7847a76d8b973bdf1063ff06cbca0223ff02ea4",
-      "size_bytes": 736643,
+      "sha256": "719e737d1a0c51751651d657ee3a3f44def223b78b3c623426d39a63ceafa12a",
+      "size_bytes": 744473,
       "storage_tier": "dual"
     },
     {
@@ -43,8 +43,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "4a146c4beb691649d38602d0bc3fd8b572075392204d9f98da90f7def2e94106",
-      "size_bytes": 549220,
+      "sha256": "a4d4c221e7fc842e8e74fee8dfe7ed98dfe15616e8f38bdda587f5a9c3418804",
+      "size_bytes": 550210,
       "storage_tier": "dual"
     }
   ],
@@ -52,7 +52,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 2185,
-  "full_artifact_size_bytes": 38136518,
+  "full_artifact_size_bytes": 38151278,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -74,7 +74,7 @@
     "r2": 2180
   },
   "storage_tier_size_bytes": {
-    "dual": 1447130,
-    "r2": 36689388
+    "dual": 1461620,
+    "r2": 36689658
   }
 }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4597,6 +4597,7 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "confidence" | "id" | "kind" | "name" | "netuid" | "provider" | "state";
@@ -5110,6 +5111,7 @@ export interface operations {
                 agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
                 blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "agent_status" | "blocker_level" | "name" | "netuid" | "priority_score" | "score" | "tier";
@@ -5301,6 +5303,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "coverage_level" | "curation_level" | "name" | "netuid";
@@ -5574,6 +5577,7 @@ export interface operations {
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 severity?: "critical" | "warning" | "info";
                 state?: "active" | "resolved";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "detected_at" | "endpoint_id" | "kind" | "last_checked" | "netuid" | "provider" | "severity" | "state" | "status";
@@ -5719,6 +5723,7 @@ export interface operations {
             query?: {
                 id?: string;
                 kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "eligible_count" | "endpoint_count" | "id" | "kind";
@@ -5891,6 +5896,7 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -6039,6 +6045,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "claim" | "source_url" | "subject" | "verified_at";
@@ -6419,6 +6426,7 @@ export interface operations {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "coverage_level" | "curation_level" | "gap_count" | "name" | "netuid";
@@ -6548,6 +6556,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "avg_latency_ms" | "degraded_count" | "failed_count" | "last_checked" | "last_ok" | "name" | "netuid" | "ok_count" | "status" | "surface_count" | "unknown_count";
@@ -6674,6 +6683,7 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "classification" | "kind" | "last_checked" | "last_ok" | "latency_ms" | "netuid" | "provider" | "status" | "status_code" | "surface_id" | "verified_at";
@@ -7287,6 +7297,7 @@ export interface operations {
                 confidence?: "low" | "medium" | "high";
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "candidate_count" | "completeness_score" | "curation_level" | "interface_count" | "missing_critical_count" | "name" | "netuid" | "operational_interface_count" | "profile_level" | "review_state";
@@ -7537,6 +7548,7 @@ export interface operations {
                 id?: string;
                 kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
                 authority?: "community" | "official" | "provider-claimed" | "registry-observed";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "authority" | "id" | "kind" | "name";
@@ -7787,6 +7799,7 @@ export interface operations {
                 pool_eligible?: "true" | "false";
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -8181,6 +8194,7 @@ export interface operations {
                 operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 reason_codes?: string;
                 recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "candidate_api_count" | "candidate_api_kinds" | "curation_level" | "name" | "netuid" | "operational_kinds" | "operational_surface_count" | "priority_score" | "recommended_adapter_kind";
@@ -8333,6 +8347,7 @@ export interface operations {
                 missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 netuid?: number;
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "evidence_action" | "lane" | "name" | "netuid" | "priority_score";
@@ -8495,6 +8510,7 @@ export interface operations {
                 review_state?: string;
                 manual_review_required?: "true" | "false";
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "adapter_score" | "candidate_count" | "completeness_score" | "curation_level" | "endpoint_count" | "evidence_action" | "identity_level" | "identity_surface_count" | "lane" | "name" | "netuid" | "operational_interface_count" | "priority_score" | "profile_level" | "review_state" | "stale_candidate_count" | "surface_count" | "verified_candidate_count";
@@ -8702,6 +8718,7 @@ export interface operations {
                 target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 target_type?: "surface-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "auto_review_candidate" | "evidence_action" | "identity_level" | "kind" | "lane" | "manual_review_required" | "name" | "netuid" | "priority_score" | "profile_level" | "submission_route" | "target_action" | "target_type";
@@ -8909,6 +8926,7 @@ export interface operations {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "candidate_count" | "curation_level" | "missing_kinds" | "name" | "netuid" | "priority_score" | "surface_count" | "verified_candidate_count";
@@ -9039,6 +9057,7 @@ export interface operations {
                 identity_level?: "none" | "directory" | "partial" | "complete";
                 identity_promotion_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 native_name_quality?: "chain" | "placeholder" | "empty";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "candidate_count" | "completeness_score" | "identity_level" | "identity_promotion_kind_count" | "identity_surface_count" | "live_identity_candidate_kind_count" | "missing_critical_count" | "name" | "native_identity_signal_count" | "native_name_quality" | "netuid" | "priority_score" | "profile_level" | "stale_identity_candidate_kind_count";
@@ -9234,6 +9253,7 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -9774,6 +9794,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "kind" | "netuid" | "slug" | "title";
@@ -10019,6 +10040,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "id" | "kind" | "path" | "record_count";
@@ -10151,6 +10173,7 @@ export interface operations {
                 domain?: "agents" | "compute" | "data" | "finance" | "inference" | "media" | "prediction" | "privacy" | "robotics" | "science" | "search" | "security" | "storage" | "training";
                 status?: "active" | "inactive";
                 subnet_type?: "root" | "application";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
@@ -10538,6 +10561,7 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "confidence" | "id" | "kind" | "name" | "netuid" | "provider" | "state";
@@ -10668,6 +10692,7 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "kind" | "last_checked" | "latency_ms" | "layer" | "netuid" | "pool_eligible" | "provider" | "publication_state" | "score" | "status";
@@ -10821,6 +10846,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "claim" | "source_url" | "subject" | "verified_at";
@@ -10944,6 +10970,7 @@ export interface operations {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "candidate_count" | "curation_level" | "missing_kinds" | "name" | "netuid" | "priority_score" | "surface_count" | "verified_candidate_count";
@@ -11149,6 +11176,7 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe";
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "classification" | "kind" | "last_checked" | "last_ok" | "latency_ms" | "netuid" | "provider" | "status" | "status_code" | "surface_id" | "verified_at";
@@ -12308,6 +12336,7 @@ export interface operations {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "id" | "kind" | "name" | "netuid" | "provider";
@@ -12676,6 +12705,7 @@ export interface operations {
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                fields?: string;
                 limit?: number;
                 cursor?: number;
                 sort?: "id" | "kind" | "name" | "netuid" | "provider";

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -128,6 +128,10 @@ export const QUERY_ENUMS = {
 
 const integerSchema = { type: "integer", minimum: 0 };
 const textSchema = { type: "string" };
+const fieldListSchema = {
+  type: "string",
+  pattern: "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+};
 
 export const API_QUERY_COLLECTIONS = {
   candidates: queryCollection("candidates", {
@@ -1983,6 +1987,10 @@ function listQuery(collection, options = {}) {
     parameters: [
       ...filterParameters,
       ...searchParameters,
+      {
+        name: "fields",
+        schema: fieldListSchema,
+      },
       {
         name: "limit",
         schema: { type: "integer", minimum: 1, maximum: 1000 },

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -539,6 +539,18 @@ describe("invalid query handling", () => {
     assert.equal((await res.json()).meta.parameter, "order");
   });
 
+  test("400 invalid_query for an unsupported projected field", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets?fields=netuid,not_a_field"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "fields");
+  });
+
   test("paginates with cursor + limit and reports next_cursor", async () => {
     const res = await handleRequest(
       req("/api/v1/subnets?limit=2&cursor=0&sort=netuid"),

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -120,6 +120,12 @@ describe("public contract registry", () => {
     );
     assert.equal(
       apiIndex.routes
+        .find((route) => route.id === "subnets")
+        .query_parameters.some((parameter) => parameter.name === "fields"),
+      true,
+    );
+    assert.equal(
+      apiIndex.routes
         .find((route) => route.id === "subnet-surfaces")
         .query_parameters.some((parameter) => parameter.name === "netuid"),
       false,
@@ -141,6 +147,11 @@ describe("public contract registry", () => {
     assert.equal(openapi["x-metagraphed"].generated_at, generatedAt);
 
     const subnetParameters = openapi.paths["/api/v1/subnets"].get.parameters;
+    assert.equal(
+      subnetParameters.find((parameter) => parameter.name === "fields").schema
+        .pattern,
+      "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+    );
     assert.deepEqual(
       subnetParameters.find((parameter) => parameter.name === "sort").schema
         .enum,

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { applyQueryFilters } from "../workers/list-query.mjs";
+
+function query(path) {
+  return new URL(`https://api.metagraph.sh${path}`);
+}
+
+describe("list-query field projection", () => {
+  test("rejects malformed field lists", () => {
+    const result = applyQueryFilters(
+      { subnets: [{ netuid: 7, name: "Allways", slug: "allways" }] },
+      query("/api/v1/subnets?fields=netuid,,name"),
+      "subnets",
+    );
+
+    assert.equal(result.error.parameter, "fields");
+    assert.match(result.error.message, /comma-separated/);
+  });
+
+  test("deduplicates projected fields and leaves malformed rows untouched", () => {
+    const result = applyQueryFilters(
+      {
+        subnets: [
+          null,
+          ["malformed"],
+          { netuid: 7, name: "Allways", slug: "allways" },
+        ],
+      },
+      query("/api/v1/subnets?fields=netuid,netuid,slug"),
+      "subnets",
+    );
+
+    assert.deepEqual(result.meta.projection.fields, ["netuid", "slug"]);
+    assert.deepEqual(result.data.subnets, [
+      null,
+      ["malformed"],
+      { netuid: 7, slug: "allways" },
+    ]);
+  });
+});

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -550,6 +550,7 @@ describe("Worker runtime", () => {
       ["/api/v1/subnets?cursor=nope", "cursor"],
       ["/api/v1/subnets?order=sideways", "order"],
       ["/api/v1/subnets?sort=nope", "sort"],
+      ["/api/v1/subnets?fields=netuid,nope", "fields"],
       ["/api/v1/subnets?netuid=nope", "netuid"],
       ["/api/v1/subnets?subnet_type=nope", "subnet_type"],
     ];
@@ -578,6 +579,29 @@ describe("Worker runtime", () => {
     assert.equal(body.meta.pagination.collection, "subnets");
     assert.equal(body.meta.pagination.limit, 1);
     assert.equal(body.meta.pagination.sort, "netuid");
+  });
+
+  test("projects list rows with ?fields while preserving pagination and filters", async () => {
+    const response = await handleRequest(
+      new Request(
+        "https://metagraph.sh/api/v1/subnets?domain=inference&fields=netuid,name,slug&limit=2&sort=netuid",
+      ),
+      env,
+      {},
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.meta.pagination.collection, "subnets");
+    assert.ok(body.meta.pagination.returned > 0);
+    assert.ok(body.meta.pagination.returned <= 2);
+    assert.deepEqual(body.meta.projection.fields, ["netuid", "name", "slug"]);
+    assert.equal(body.data.subnets.length, body.meta.pagination.returned);
+    assert.deepEqual(Object.keys(body.data.subnets[0]).sort(), [
+      "name",
+      "netuid",
+      "slug",
+    ]);
+    assert.equal("categories" in body.data.subnets[0], false);
   });
 
   test("returns deterministic API errors", async () => {
@@ -1362,6 +1386,7 @@ describe("Worker runtime", () => {
       "https://metagraph.sh/api/v1/subnets?cursor=-1",
       "https://metagraph.sh/api/v1/subnets?order=sideways",
       "https://metagraph.sh/api/v1/subnets?sort=unknown_field",
+      "https://metagraph.sh/api/v1/subnets?fields=netuid,unknown_field",
       "https://metagraph.sh/api/v1/subnets?netuid=not-a-number",
       "https://metagraph.sh/api/v1/subnets?coverage_level=fake",
       "https://metagraph.sh/api/v1/candidates?state=approved",

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -5,6 +5,8 @@
 // `applyQueryFilters` is the single public entry; the rest are internal helpers.
 import { API_QUERY_COLLECTIONS } from "../src/contracts.mjs";
 
+const FIELD_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 export function applyQueryFilters(
   data,
   url,
@@ -73,6 +75,10 @@ function applyListTransform(data, params, config) {
     return { error: queryError };
   }
   const key = config.data_key;
+  const projection = parseProjection(params, data[key], key);
+  if (projection.error) {
+    return { error: projection.error };
+  }
   const filterKeys = Object.keys(config.filters);
   const filtered = filterRows(
     searchRows(data[key], params, config.search_keys),
@@ -86,7 +92,7 @@ function applyListTransform(data, params, config) {
   return {
     data: {
       ...data,
-      [key]: paginated.rows,
+      [key]: projectRows(paginated.rows, projection.fields),
     },
     meta: {
       pagination: {
@@ -99,6 +105,9 @@ function applyListTransform(data, params, config) {
         sort: paginated.sort,
         order: paginated.order,
       },
+      ...(projection.fields
+        ? { projection: { fields: projection.fields } }
+        : {}),
     },
   };
 }
@@ -222,6 +231,61 @@ function validateListQuery(params, config) {
   }
 
   return null;
+}
+
+function parseProjection(params, rows, dataKey) {
+  if (!params.has("fields")) {
+    return { fields: null };
+  }
+  const requested = params.get("fields").split(",");
+  if (
+    requested.length === 0 ||
+    requested.some((field) => !FIELD_NAME_PATTERN.test(field))
+  ) {
+    return {
+      error: {
+        parameter: "fields",
+        message:
+          "fields must be a comma-separated list of row field names, e.g. netuid,name,slug.",
+      },
+    };
+  }
+
+  const knownFields = new Set(
+    rows.flatMap((row) =>
+      row && typeof row === "object" && !Array.isArray(row)
+        ? Object.keys(row)
+        : [],
+    ),
+  );
+  const fields = [...new Set(requested)];
+  const unknown = fields.filter((field) => !knownFields.has(field));
+  if (unknown.length > 0) {
+    return {
+      error: {
+        parameter: "fields",
+        message: `fields includes unsupported field${unknown.length === 1 ? "" : "s"} for ${dataKey}: ${unknown.join(", ")}.`,
+      },
+    };
+  }
+
+  return { fields };
+}
+
+function projectRows(rows, fields) {
+  if (!fields) {
+    return rows;
+  }
+  return rows.map((row) => {
+    if (!row || typeof row !== "object" || Array.isArray(row)) {
+      return row;
+    }
+    return Object.fromEntries(
+      fields
+        .filter((field) => Object.hasOwn(row, field))
+        .map((field) => [field, row[field]]),
+    );
+  });
 }
 
 function integerParam(value) {


### PR DESCRIPTION
## Summary
Adds `?fields=` projection to artifact-backed list routes so frontend, SDK, and agent clients can request cheap index-shaped payloads without losing the normal envelope or pagination metadata.

## What changed
- Added shared worker support for `?fields=netuid,name,slug` style row projection after filtering, sorting, and pagination.
- Validates requested fields against the actual row keys in the backing artifact and returns the existing `invalid_query` envelope for unsupported fields.
- Advertises `fields` through the list-query route contract, generated API index, OpenAPI spec, and generated TypeScript client/types.
- Added runtime, API, contract, and direct list-query tests for projection success, invalid field handling, and defensive row handling.

## Why
#601 was originally held until an agent/SDK use case made cheap enumeration useful. The MCP and coverage-depth workflows now create that use case: agents and UI modules can ask for compact list rows instead of fetching full collection payloads when they only need identifiers and labels.

Closes #601.

## Validation
- `npm run build`
- `npm test -- tests/worker-runtime.test.mjs`
- `npm test -- tests/api-coverage.test.mjs`
- `npm test -- tests/contracts.test.mjs`
- `npm test -- tests/list-query.test.mjs tests/worker-runtime.test.mjs tests/api-coverage.test.mjs tests/contracts.test.mjs`
- `npm run validate:api`
- `npm run validate:openapi`
- `npm run validate:contract-drift`
- `npm run validate:types`
- `npm run validate:generated-client`
- `npm run validate:openapi-examples`
- `npm run validate:schemas`
- `npm run validate:schema-enums`
- `npm run format:check`
- `npm run lint`
- `npm run validate`
- `npm run worker:test`
- `npm test`
- `npm run scan:public-safety`
- `npm run validate:private-boundary`
- `npm run worker:deploy:dry-run`
- `git diff --check`
- `npm run validate:artifact-budgets`
- `npm run validate:docs`
- `npm run validate:committed-seed`
- `npm run validate:mcp`
- `npm run validate:ai`
- `npm run validate:workflows`
- `npm run validate:intake`
- `npm run validate:adapters`
- `npm run validate:candidate`
- `npm run validate:readme-catalog`
- `npm run test:coverage`

`npm run validate:artifact-budgets` passed with warnings for `coverage-depth.json`, `openapi.json`, `profiles.json`, and `testnet/subnets.json`. Coverage passed: 52 files, 1187 tests, 97.64% statements, 90% branches.