### PR TITLE
feat(registry): add SN7 Allways network overview data-artifact

### DIFF
--- a/registry/candidates/community/community-sn-7-data-artifact-network-overview-all-ways-io.json
+++ b/registry/candidates/community/community-sn-7-data-artifact-network-overview-all-ways-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-7-data-artifact-api-all-ways-io",
+      "kind": "data-artifact",
+      "name": "Allways community data-artifact",
+      "netuid": 7,
+      "provider": "allways",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.all-ways.io/swagger-json",
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
+      "state": "schema-valid",
+      "url": "https://api.all-ways.io/network/overview"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jaso0n0818",
+    "submitted_by_url": "https://github.com/jaso0n0818"
+  }
+}


### PR DESCRIPTION
Community candidate for the public network overview JSON at `https://api.all-ways.io/network/overview`.

Validated with:
```bash
npm run validate:candidate -- registry/candidates/community/community-sn-7-data-artifact-network-overview-all-ways-io.json
```