### PR TITLE
fix(ci): run validation router from trusted checkout

### DIFF
--- a/.github/actions/classify-validation-route/action.yml
+++ b/.github/actions/classify-validation-route/action.yml
@@ -53,4 +53,4 @@ runs:
     - name: Classify validation route
       id: route
       shell: bash
-      run: python3 scripts/classify-validation-route.py
+      run: python3 "${{ github.action_path }}/../../../scripts/classify-validation-route.py"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,9 +36,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout trusted validation router
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: .ci-trusted
+          fetch-depth: 1
+
       - name: Classify validation route
         id: route
-        uses: ./.github/actions/classify-validation-route
+        uses: ./.ci-trusted/.github/actions/classify-validation-route
 
       - name: Setup Node
         if: steps.route.outputs.mode == 'full'
@@ -86,9 +93,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout trusted validation router
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: .ci-trusted
+          fetch-depth: 1
+
       - name: Classify validation route
         id: route
-        uses: ./.github/actions/classify-validation-route
+        uses: ./.ci-trusted/.github/actions/classify-validation-route
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -131,6 +131,25 @@ for (const workflow of workflows) {
       "classify-validation-route action must keep PR routing diffs unfiltered and filter deletions only for submitted-artifact verification",
     );
     check(
+      content.includes("Checkout trusted validation router") &&
+        content.includes("path: .ci-trusted") &&
+        content.includes(
+          "ref: ${{ github.event.pull_request.base.sha || github.sha }}",
+        ) &&
+        content.includes(
+          "uses: ./.ci-trusted/.github/actions/classify-validation-route",
+        ),
+      workflow,
+      "validate workflow must run the validation router from trusted base code",
+    );
+    check(
+      routeAction.includes(
+        "${{ github.action_path }}/../../../scripts/classify-validation-route.py",
+      ),
+      workflow,
+      "classify-validation-route action must execute its own trusted classifier script",
+    );
+    check(
       content.includes("--changed-files submitted-artifact-files.txt"),
       workflow,
       "validate workflow must verify submitted artifacts from the deletion-filtered list",


### PR DESCRIPTION
### Motivation
- The route classifier used by the `validate` workflow was executed from the checked-out PR workspace, allowing a malicious PR to modify the classifier and force `mode=ugc` to skip full validation and tests.
- The change restores the router trust boundary by running the classifier from a trusted base checkout so PR-controlled files cannot gate CI behavior.

### Description
- In `validate` jobs, `test` and `checks` now `checkout` the trusted base revision into `.ci-trusted` before running the classifier, and the workflow invokes the action from `.ci-trusted` instead of the PR workspace (`.ci-trusted/.github/actions/classify-validation-route`).
- The composite action was changed to execute its bundled classifier script via `github.action_path` so the classifier resolves to the action bundle rather than a PR-modified workspace script (`python3 "${{ github.action_path }}/../../../scripts/classify-validation-route.py"`).
- `scripts/validate-workflows.mjs` was extended to assert the presence of the trusted checkout and the trusted classifier invocation to prevent regressions.
- Files changed: `/.github/workflows/validate.yml`, `/.github/actions/classify-validation-route/action.yml`, and `/scripts/validate-workflows.mjs`; behavior of the classifier logic itself is unchanged and still produces the same `mode`/`scope` outputs when run from trusted code.

### Testing
- Ran `npm run validate:workflows` and it completed successfully with all workflow validations passing. 
- Ran `npm run format:check` after applying formatting and it reported no style issues. 
- Ran `npm run lint` and the linter passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b3252014832c9f7d6f51e4b46e80)