### PR TITLE
fix(ci): block mixed deletion+edits UGC preflight bypass

### DIFF
--- a/scripts/submission-pr.mjs
+++ b/scripts/submission-pr.mjs
@@ -35,9 +35,10 @@ const changedFiles = normalizeChangedFiles(
 );
 // A delete-only direct submission REMOVES the candidate/provider file — it's absent from the working
 // tree. A removal is a registry DELETION, not a content submission to validate; reading the missing file
-// ENOENT-ed the whole preflight and false-failed maintainer cleanup #944. Drop removed direct files so a
-// pure removal routes as a normal/non-submission PR (and passes); the review gate + maintainer authorize
-// the deletion separately. (#candidate-deletion)
+// ENOENT-ed the whole preflight and false-failed maintainer cleanup #944. Drop removed direct files only
+// when every changed file is such a deletion, so pure removals route as normal/non-submission PRs. Mixed
+// deletion PRs must keep the removed paths in the policy input; otherwise the UGC preflight can disagree
+// with the workflow router and skip the full CI gates for unrelated edits. (#candidate-deletion)
 // Use the broad community-dir prefix (matching classifyPrScope's touchedCommunity* check), not just the
 // strict DIRECT_*_PATTERN, so ANY removed candidate/provider file is recognized as a deletion.
 const isRemovedDirectFile = (file) =>
@@ -46,19 +47,20 @@ const isRemovedDirectFile = (file) =>
   file.endsWith(".json") &&
   !existsSync(path.join(inputRoot, file));
 const removedDirectFiles = changedFiles.filter(isRemovedDirectFile);
-const effectiveChangedFiles = changedFiles.filter(
-  (file) => !isRemovedDirectFile(file),
-);
-if (removedDirectFiles.length > 0) {
+const deletionOnlyDirectPr =
+  removedDirectFiles.length > 0 &&
+  removedDirectFiles.length === changedFiles.length;
+const effectiveChangedFiles = deletionOnlyDirectPr ? [] : changedFiles;
+if (deletionOnlyDirectPr) {
   console.log(
     `Submission preflight: ${removedDirectFiles.length} removed direct file(s) treated as registry deletion(s): ${removedDirectFiles.join(", ")}`,
   );
 }
-const directCandidateFile = effectiveChangedFiles.find((file) =>
-  DIRECT_CANDIDATE_PATTERN.test(file),
+const directCandidateFile = effectiveChangedFiles.find(
+  (file) => DIRECT_CANDIDATE_PATTERN.test(file) && !isRemovedDirectFile(file),
 );
-const directProviderFile = effectiveChangedFiles.find((file) =>
-  DIRECT_PROVIDER_PATTERN.test(file),
+const directProviderFile = effectiveChangedFiles.find(
+  (file) => DIRECT_PROVIDER_PATTERN.test(file) && !isRemovedDirectFile(file),
 );
 const candidateDocument = directCandidateFile
   ? await readJson(path.join(inputRoot, directCandidateFile))

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -195,6 +195,87 @@ describe("Metagraphed submission gate policy", () => {
     }
   });
 
+  test("blocks mixed candidate deletion and unrelated edits in the preflight", () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), "metagraphed-del-mixed-"));
+    try {
+      const changedFilesPath = path.join(tmp, "changed-files.txt");
+      const outputPath = path.join(tmp, "report.json");
+      writeFileSync(
+        changedFilesPath,
+        [
+          "registry/candidates/community/removed-candidate.json",
+          "README.md",
+        ].join("\n"),
+      );
+
+      assert.throws(() =>
+        execFileSync(
+          process.execPath,
+          [
+            "scripts/submission-pr.mjs",
+            "--changed-files",
+            changedFilesPath,
+            "--out",
+            outputPath,
+            "--submitter",
+            "JSONbored",
+          ],
+          { stdio: "pipe" },
+        ),
+      );
+      const report = JSON.parse(readFileSync(outputPath, "utf8"));
+      assert.equal(report.blocking, true);
+      assert.equal(report.state, "schema-invalid");
+      assert.deepEqual(report.changed_files, [
+        "README.md",
+        "registry/candidates/community/removed-candidate.json",
+      ]);
+      assert.equal(
+        report.error_categories.includes("generated-artifact-tampering"),
+        true,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("blocks direct submissions mixed with deleted direct files", () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), "metagraphed-del-submit-"));
+    try {
+      const changedFilesPath = path.join(tmp, "changed-files.txt");
+      const outputPath = path.join(tmp, "report.json");
+      writeFileSync(
+        changedFilesPath,
+        [
+          "registry/candidates/community/removed-candidate.json",
+          "registry/candidates/community/community-sn-7-subnet-api-api-all-ways-io.json",
+        ].join("\n"),
+      );
+
+      assert.throws(() =>
+        execFileSync(
+          process.execPath,
+          [
+            "scripts/submission-pr.mjs",
+            "--changed-files",
+            changedFilesPath,
+            "--out",
+            outputPath,
+            "--submitter",
+            "JSONbored",
+          ],
+          { stdio: "pipe" },
+        ),
+      );
+      const report = JSON.parse(readFileSync(outputPath, "utf8"));
+      assert.equal(report.blocking, true);
+      assert.equal(report.state, "schema-invalid");
+      assert.equal(report.error_categories.includes("unsupported-shape"), true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   test("routes mixed direct candidate PRs through the UGC gate", () => {
     const tmp = mkdtempSync(path.join(tmpdir(), "metagraphed-route-"));
     try {


### PR DESCRIPTION
### Motivation
- The submission preflight previously stripped absent `registry/*/community/*.json` paths unconditionally, allowing a PR that deletes a community JSON and also changes unrelated files to be routed to UGC mode while the preflight saw only the unrelated edits and allowed the lightweight checks to pass.
- This created a router/preflight mismatch that could skip full CI gates for mixed-deletion PRs and bypass the direct-submission anti-tamper policy.

### Description
- In `scripts/submission-pr.mjs` add `deletionOnlyDirectPr` and only drop removed community candidate/provider JSON paths when the PR is a pure deletion of direct files, preserving removed paths for mixed PRs so the policy sees them.
- Ensure direct submission documents are only read when their paths still exist in the working tree to avoid `ENOENT` for pure deletion PRs while keeping mixed PRs blocking.
- Update selection of `directCandidateFile` and `directProviderFile` so files recognized as removed are not treated as present in the preflight input.
- Add regression tests in `tests/submission-gate.test.mjs` covering mixed deletion+unrelated edits and deletion+direct-submission cases to prevent regressions.

### Testing
- Ran `node --check scripts/submission-pr.mjs` with no syntax errors (success).
- Ran targeted tests with `npm test -- --run tests/submission-gate.test.mjs -t "candidate deletion|deleted direct"` and the new regression tests passed (success).
- Attempted full `npm test -- --run tests/submission-gate.test.mjs`, but unrelated submitted-artifact tests fail in this checkout due to a missing `public/metagraph/build-summary.json`; the changes are limited to submission preflight logic and relevant targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b325b220832cb310c2304981f9bd)