### PR TITLE
fix(ci): validate ignored R2 manifest byte totals

### DIFF
--- a/scripts/ci-verify-submitted-artifacts.mjs
+++ b/scripts/ci-verify-submitted-artifacts.mjs
@@ -125,17 +125,26 @@ export function canonicalArtifactJson(artifactPath, value) {
     // The committed compact manifest is a publish lockfile, but its full/R2-only
     // byte totals can vary slightly across otherwise-equivalent rebuilds. Keep
     // the dual artifact entries strict while ignoring the known unstable R2
-    // aggregate byte counters.
-    delete normalized.full_artifact_size_bytes;
+    // aggregate byte counters only when they are valid byte totals; otherwise
+    // committed public manifest tampering must remain visible to the verifier.
+    if (isValidByteTotal(normalized.full_artifact_size_bytes)) {
+      delete normalized.full_artifact_size_bytes;
+    }
     if (
       normalized.storage_tier_size_bytes &&
       typeof normalized.storage_tier_size_bytes === "object" &&
       !Array.isArray(normalized.storage_tier_size_bytes)
     ) {
-      delete normalized.storage_tier_size_bytes.r2;
+      if (isValidByteTotal(normalized.storage_tier_size_bytes.r2)) {
+        delete normalized.storage_tier_size_bytes.r2;
+      }
     }
   }
   return JSON.stringify(normalized);
+}
+
+function isValidByteTotal(value) {
+  return Number.isSafeInteger(value) && value >= 0;
 }
 
 function normalizeForComparison(value) {

--- a/tests/ci-artifact-verifier.test.mjs
+++ b/tests/ci-artifact-verifier.test.mjs
@@ -49,3 +49,24 @@ test("R2 manifest comparison ignores only R2 aggregate byte drift", () => {
     }),
   );
 });
+
+test("R2 manifest comparison rejects invalid ignored byte totals", () => {
+  const rebuilt = {
+    artifact_count: 1,
+    artifact_size_bytes: 10,
+    full_artifact_count: 3,
+    full_artifact_size_bytes: 30,
+    artifacts: [{ path: "/metagraph/types.d.ts", size_bytes: 10 }],
+    storage_tier_size_bytes: { dual: 10, r2: 20 },
+  };
+  const committed = {
+    ...rebuilt,
+    full_artifact_size_bytes: "30",
+    storage_tier_size_bytes: { dual: 10, r2: { bytes: 20 } },
+  };
+
+  assert.notEqual(
+    canonicalArtifactJson("public/metagraph/r2-manifest.json", committed),
+    canonicalArtifactJson("public/metagraph/r2-manifest.json", rebuilt),
+  );
+});


### PR DESCRIPTION
### Motivation
- The artifact verifier unconditionally removed `full_artifact_size_bytes` and `storage_tier_size_bytes.r2` from `public/metagraph/r2-manifest.json` before comparison, which allowed non-numeric or tampered committed values to bypass reproducibility checks.
- The goal is to preserve the existing tolerance for small numeric byte-drift while ensuring committed manifest tampering remains visible when the ignored fields are not valid byte totals.

### Description
- Update `canonicalArtifactJson` in `scripts/ci-verify-submitted-artifacts.mjs` to only delete `full_artifact_size_bytes` and `storage_tier_size_bytes.r2` when they pass `isValidByteTotal` validation.
- Add `isValidByteTotal` helper that returns `Number.isSafeInteger(value) && value >= 0` to enforce nonnegative safe-integer byte totals.
- Add a regression test `tests/ci-artifact-verifier.test.mjs` that asserts non-numeric/tampered ignored fields no longer canonicalize as equivalent to a valid rebuilt manifest.

### Testing
- Ran `npm test -- tests/ci-artifact-verifier.test.mjs` and the test file passed.
- Ran `npm test -- tests/script-utils.test.mjs` and the suite passed.
- Ran formatting and lint checks with `npx prettier --write` and `npm run lint` and they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b325d040832c81a884e0d1c30659)