### PR TITLE
fix: sanitize fixture capture errors

### DIFF
--- a/scripts/capture-fixtures.mjs
+++ b/scripts/capture-fixtures.mjs
@@ -7,6 +7,7 @@
 import {
   artifactOutputPath,
   buildTimestamp,
+  fixtureCaptureFailureReason,
   flattenSurfaces,
   isJsonContentType,
   isUnsafeResolvedUrl,
@@ -108,7 +109,11 @@ async function fetchSample(url, redirectCount = 0) {
       body: JSON.parse(raw),
     };
   } catch (error) {
-    return { ok: false, error: error.message, error_class: error.name };
+    return {
+      ok: false,
+      error: fixtureCaptureFailureReason(error),
+      error_class: error.name,
+    };
   } finally {
     clearTimeout(timer);
   }

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -960,6 +960,23 @@ export function sanitizeFixtureBody(
 // body itself is NOT inlined — captured bodies can be ~1 MB — so service detail
 // stays lean and the one already-sanitized copy is served from a single place.
 // Returns null when there is no fixture, so callers omit the field entirely.
+export function fixtureCaptureFailureReason(error) {
+  const name = error?.name || null;
+  if (name === "SyntaxError") {
+    return "invalid json response";
+  }
+  if (name === "AbortError") {
+    return "request timed out";
+  }
+  if (name === "FixtureCaptureLimitError") {
+    return "response exceeds byte limit";
+  }
+  if (name === "TypeError") {
+    return "request failed";
+  }
+  return "capture failed";
+}
+
 export function surfaceFixtureReference(surfaceId, fixture) {
   if (!surfaceId || !fixture || typeof fixture !== "object") {
     return null;

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -22,6 +22,7 @@ import {
   createLocalArtifactEnv,
   flattenSurfaces,
   formatLlmMarkdownText,
+  fixtureCaptureFailureReason,
   formatRepositoryJson,
   hashJson,
   isCredentialedUrl,
@@ -109,6 +110,18 @@ const native = {
 const providers = [{ id: "allways" }, { id: "gittensor" }];
 
 describe("script utility contracts", () => {
+  test("uses public-safe fixture capture parse failure reasons", () => {
+    const error = new SyntaxError(
+      `Unexpected token 'T', "TOKEN=abc" is not valid JSON`,
+    );
+
+    assert.equal(fixtureCaptureFailureReason(error), "invalid json response");
+    assert.equal(
+      fixtureCaptureFailureReason(error).includes("TOKEN=abc"),
+      false,
+    );
+  });
+
   test("classifies redirect-limit probes as unsupported", () => {
     assert.equal(
       classifyHttpProbe(


### PR DESCRIPTION
### Motivation
- Prevent persisting raw upstream response bytes coming from `JSON.parse` exception messages into public fixture metadata and indexes by replacing free-form error messages with safe, deterministic reason strings.

### Description
- Added `fixtureCaptureFailureReason(error)` in `scripts/lib.mjs` to map exception classes to public-safe reason strings (e.g. `SyntaxError` -> `invalid json response`).
- Replaced the previous use of `error.message` in `fetchSample` (`scripts/capture-fixtures.mjs`) with `fixtureCaptureFailureReason(error)` and preserved `error.name` in `error_class`.
- Exported/imported the helper where needed and updated `scripts/capture-fixtures.mjs` imports accordingly.
- Added a regression test in `tests/script-utils.test.mjs` asserting that a `SyntaxError`-style parse message is reduced to the safe string and does not include the raw response snippet.

### Testing
- Ran `npm run lint` and the linter completed successfully.
- Ran `npm run format:check` (after formatting) and code style checks passed.
- Ran the unit tests for the change with `npm test -- --run tests/script-utils.test.mjs` and the test file passed (`1 passed`, `39 tests passed` overall in that run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3476c7d2cc832c8bcb19a2c27fc1c1)