### PR TITLE
fix(client): hash ETag header cache keys

### DIFF
--- a/generated/metagraphed-client.ts
+++ b/generated/metagraphed-client.ts
@@ -471,15 +471,37 @@ function mergeRequestHeaders(
   return merged;
 }
 
+function hashCacheKeyPart(value: string): string {
+  let high = 0xdeadbeef;
+  let low = 0x41c6ce57;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    high = Math.imul(high ^ code, 2654435761);
+    low = Math.imul(low ^ code, 1597334677);
+  }
+  high =
+    Math.imul(high ^ (high >>> 16), 2246822507) ^
+    Math.imul(low ^ (low >>> 13), 3266489909);
+  low =
+    Math.imul(low ^ (low >>> 16), 2246822507) ^
+    Math.imul(high ^ (high >>> 13), 3266489909);
+  return (
+    (low >>> 0).toString(16).padStart(8, "0") +
+    (high >>> 0).toString(16).padStart(8, "0")
+  );
+}
+
 function buildEtagCacheKey(
   url: URL,
   requestHeaders: Record<string, string>,
 ): string {
-  const headerKey = Object.entries(requestHeaders)
-    .filter(([key]) => key !== "if-none-match")
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, value]) => key + ":" + value)
-    .join("\n");
+  const headerKey = hashCacheKeyPart(
+    Object.entries(requestHeaders)
+      .filter(([key]) => key !== "if-none-match")
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => key + ":" + value)
+      .join("\n"),
+  );
   return url.toString() + "\n" + headerKey;
 }
 

--- a/scripts/generate-client.mjs
+++ b/scripts/generate-client.mjs
@@ -491,15 +491,37 @@ function mergeRequestHeaders(
   return merged;
 }
 
+function hashCacheKeyPart(value: string): string {
+  let high = 0xdeadbeef;
+  let low = 0x41c6ce57;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    high = Math.imul(high ^ code, 2654435761);
+    low = Math.imul(low ^ code, 1597334677);
+  }
+  high =
+    Math.imul(high ^ (high >>> 16), 2246822507) ^
+    Math.imul(low ^ (low >>> 13), 3266489909);
+  low =
+    Math.imul(low ^ (low >>> 16), 2246822507) ^
+    Math.imul(high ^ (high >>> 13), 3266489909);
+  return (
+    (low >>> 0).toString(16).padStart(8, "0") +
+    (high >>> 0).toString(16).padStart(8, "0")
+  );
+}
+
 function buildEtagCacheKey(
   url: URL,
   requestHeaders: Record<string, string>,
 ): string {
-  const headerKey = Object.entries(requestHeaders)
-    .filter(([key]) => key !== "if-none-match")
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, value]) => key + ":" + value)
-    .join("\\n");
+  const headerKey = hashCacheKeyPart(
+    Object.entries(requestHeaders)
+      .filter(([key]) => key !== "if-none-match")
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => key + ":" + value)
+      .join("\\n"),
+  );
   return url.toString() + "\\n" + headerKey;
 }
 

--- a/tests/client-sdk.test.ts
+++ b/tests/client-sdk.test.ts
@@ -351,6 +351,47 @@ describe("createMetagraphedClient", () => {
     });
   });
 
+  test("ETag cache keys do not expose raw request header values", async () => {
+    const observedKeys: string[] = [];
+    const cache = {
+      get(key: string) {
+        observedKeys.push(key);
+        return undefined;
+      },
+      set(key: string) {
+        observedKeys.push(key);
+      },
+    };
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, data: { v: 1 }, meta: {} }), {
+          status: 200,
+          headers: { etag: 'W/"secret-safe"' },
+        }),
+    );
+    const client = createMetagraphedClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      headers: {
+        authorization: "Bearer SECRET_TOKEN_123",
+        cookie: "sid=SECRET_COOKIE_456",
+      },
+      cache,
+    });
+
+    await client.health({ headers: { "x-api-key": "SECRET_API_KEY_789" } });
+
+    expect(observedKeys).toHaveLength(2);
+    for (const key of observedKeys) {
+      expect(key).toContain("https://api.metagraph.sh/api/v1/health");
+      expect(key).not.toContain("SECRET_TOKEN_123");
+      expect(key).not.toContain("SECRET_COOKIE_456");
+      expect(key).not.toContain("SECRET_API_KEY_789");
+      expect(key).not.toContain("authorization:");
+      expect(key).not.toContain("cookie:");
+      expect(key).not.toContain("x-api-key:");
+    }
+  });
+
   test("fetchAll collects data rows across cursor pages", async () => {
     const pages = [
       {


### PR DESCRIPTION
### Motivation
- Prevent secret-bearing request headers from being embedded in ETag cache keys and handed to pluggable/custom stores, which could leak credentials via cache backends, logs, or error traces.
- The prior change made the ETag key header-aware but concatenated raw header names/values, so this replaces the plaintext inclusion with a safe canonical hash.

### Description
- Add a `hashCacheKeyPart` helper and use it in `buildEtagCacheKey` to hash the canonical header block instead of concatenating raw header names/values in both the generator (`scripts/generate-client.mjs`) and the regenerated client (`generated/metagraphed-client.ts`).
- Regenerate the client source so the runtime client uses the new hashed header component for ETag keys (`buildEtagCacheKey` now incorporates `hashCacheKeyPart(...)`).
- Add a regression test `ETag cache keys do not expose raw request header values` to `tests/client-sdk.test.ts` that provides secret-bearing `Authorization`, `Cookie`, and `X-API-Key` headers and asserts those raw values and header names do not appear in cache keys observed by a custom `EtagCache`.

### Testing
- Ran `npm test -- tests/client-sdk.test.ts`, which executed the suite and reported all tests passed (25 tests passed).
- Ran `npm run validate:generated-client`, which confirmed the generated client helper is current.
- Ran code formatting (`prettier`) and the tests as part of the change workflow; the added test passed and the repository validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347868d4bc832c90d5038cbfdadbea)