### PR TITLE
fix(uptime): validate uptime window using Object.hasOwn to block prototype keys

### DIFF
--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -1886,13 +1886,15 @@ describe("worker /api/v1/subnets/{netuid}/uptime route", () => {
 
   test("rejects an invalid window with 400", async () => {
     const env = createLocalArtifactEnv();
-    const res = await handleRequest(
-      req("/api/v1/subnets/7/uptime?window=5y"),
-      env,
-      {},
-    );
-    assert.equal(res.status, 400);
-    assert.equal((await res.json()).error.code, "invalid_query");
+    for (const windowParam of ["5y", "constructor", "__proto__"]) {
+      const res = await handleRequest(
+        req(`/api/v1/subnets/7/uptime?window=${windowParam}`),
+        env,
+        {},
+      );
+      assert.equal(res.status, 400);
+      assert.equal((await res.json()).error.code, "invalid_query");
+    }
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1514,8 +1514,7 @@ async function handleTrajectory(request, env, netuid) {
 // yet (mirrors the other D1-backed analytics routes).
 async function handleUptime(request, env, netuid, url) {
   const windowParam = url.searchParams.get("window") || "90d";
-  const days = UPTIME_WINDOWS[windowParam];
-  if (!days) {
+  if (!Object.hasOwn(UPTIME_WINDOWS, windowParam)) {
     return errorResponse(
       "invalid_query",
       "Query parameter `window` must be one of: 90d, 1y.",
@@ -1523,6 +1522,7 @@ async function handleUptime(request, env, netuid, url) {
       { parameter: "window" },
     );
   }
+  const days = UPTIME_WINDOWS[windowParam];
   const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
     .toISOString()
     .slice(0, 10);


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated requests from crashing the uptime endpoint by treating inherited prototype keys (e.g. `constructor`, `__proto__`) as valid window values which led to `RangeError` and a 500 from `toISOString()`.

### Description
- Validate the `window` query parameter with `Object.hasOwn(UPTIME_WINDOWS, windowParam)` before reading `UPTIME_WINDOWS[windowParam]` in `handleUptime` to ensure only explicit keys are accepted.
- Extend the uptime route test to assert that `window` values `"5y"`, `"constructor"`, and `"__proto__"` all return a `400` `invalid_query` response, ensuring prototype keys are rejected.

### Testing
- Ran the targeted tests for the uptime route with `vitest` (`npm test -- tests/health-serving.test.mjs -t "uptime route"`) and the uptime-related tests passed.
- Ran `npm run lint` and the linter succeeded with no errors.
- Ran the full `tests/health-serving.test.mjs` file; the uptime tests passed but there remain two unrelated pre-existing failures in composed overview behavior (these failures are not caused by the uptime change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347867d69c832cac9a6498b4ca68c8)