### PR TITLE
fix: redact common fixture credential keys

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -906,7 +906,7 @@ export function redactCredentialedUrls(value) {
 // might echo back. Match common separator-delimited, camelCase, and compact
 // spellings so live fixtures do not publish token/session-like fields.
 const FIXTURE_SENSITIVE_KEY =
-  /(?:^|[_-])(?:token|secret|api[_-]?key|apikey|password|passwd|pwd|authorization|auth|cookie|session|credential|private[_-]?key|mnemonic|seed[_-]?phrase|bearer|access[_-]?key|refresh[_-]?token|csrf[_-]?token|jwt)(?:[_-]|$)|(?:access|refresh|csrf|session|cookie|password|private|seed)(?:Token|Key|Id|Value|Hash|Phrase)\b|(?:apiKey|passwordHash|cookieValue|sessionId|csrfToken|accessToken|refreshToken|privateKey|seedPhrase|jwt)\b/i;
+  /(?:^|[_-])(?:token|secret|api[_-]?key|apikey|password|passwd|pwd|authorization|auth|cookie|session|credential|private[_-]?key|mnemonic|seed[_-]?phrase|bearer|access[_-]?key|refresh[_-]?token|csrf[_-]?token|jwt)(?:[_-]|$)|(?:access|refresh|csrf|session|cookie|password|private|seed|id|auth|client|secret)(?:Token|Key|Id|Secret|Value|Hash|Phrase)\b|(?:apiKey|passwordHash|cookieValue|sessionId|csrfToken|accessToken|refreshToken|authToken|idToken|clientSecret|secretKey|privateKey|seedPhrase|jwt)\b/i;
 
 // Sanitize an arbitrary parsed JSON response from a third-party subnet API so a
 // single live sample can be committed as a fixture (issue #352). Redacts

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -1001,6 +1001,10 @@ describe("sanitizeFixtureBody (#352)", () => {
   test("redacts common compact and camelCase sensitive keys", () => {
     const out = sanitizeFixtureBody({
       accessToken: "access-token",
+      idToken: "id-token",
+      authToken: "auth-token",
+      clientSecret: "client-secret",
+      secretKey: "secret-key",
       sessionId: "session-id",
       cookieValue: "cookie-value",
       passwordHash: "password-hash",
@@ -1011,6 +1015,10 @@ describe("sanitizeFixtureBody (#352)", () => {
     });
 
     assert.equal(out.accessToken, "[redacted]");
+    assert.equal(out.idToken, "[redacted]");
+    assert.equal(out.authToken, "[redacted]");
+    assert.equal(out.clientSecret, "[redacted]");
+    assert.equal(out.secretKey, "[redacted]");
     assert.equal(out.sessionId, "[redacted]");
     assert.equal(out.cookieValue, "[redacted]");
     assert.equal(out.passwordHash, "[redacted]");


### PR DESCRIPTION
### Motivation
- The fixture sanitizer missed common camelCase and compact credential keys (e.g. `idToken`, `authToken`, `clientSecret`, `secretKey`), allowing sampled third‑party JSON responses to persist secrets into public fixtures.

### Description
- Broadened the `FIXTURE_SENSITIVE_KEY` matcher in `scripts/lib.mjs` to cover additional camelCase/compact variants and token/secret name components so such keys are recognized and redacted.  
- Added regression coverage in `tests/lib-helpers.test.mjs` to include `idToken`, `authToken`, `clientSecret`, and `secretKey` in the `sanitizeFixtureBody` test and assert they are redacted.  
- Preserved existing sanitizer behavior for credentialed URLs and bounding (depth/array/string/key limits) while only expanding the sensitive-key detection.

### Testing
- Ran `npm test -- tests/lib-helpers.test.mjs` and the `sanitizeFixtureBody` tests passed.  
- Ran `npm test` (full test suite) which failed due to missing generated public artifacts such as `public/metagraph/providers.json` and `public/metagraph/build-summary.json`, causing unrelated ENOENT/404 test failures.  
- Attempted `npm test -- --runInBand` which is unsupported by Vitest and failed due to the extra flag, not due to the sanitizer change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347868388c832ca919e8225edd2467)