### PR TITLE
fix(security): reject .local and bare local hostnames in URL sanitizer

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -819,7 +819,13 @@ export async function isUnsafeResolvedUrl(value, resolver = lookup) {
 }
 
 function isUnsafeHostname(host) {
-  if (!host || host === "localhost" || host.endsWith(".localhost")) {
+  if (
+    !host ||
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "local" ||
+    host.endsWith(".local")
+  ) {
     return true;
   }
 

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -610,6 +610,10 @@ describe("backfilledIdentityUrl", () => {
       backfilledIdentityUrl(undefined, "github.com/username/repo"),
       null,
     );
+    assert.equal(
+      backfilledIdentityUrl(undefined, "https://glyph.testnet.local"),
+      null,
+    );
     assert.equal(backfilledIdentityUrl(undefined, null), null);
     assert.equal(backfilledIdentityUrl(undefined, "not a url"), null);
   });

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -1229,6 +1229,8 @@ describe("script utility contracts", () => {
     assert.equal(isValidUrl("not a url"), false);
     assert.equal(isUnsafeUrl("http://127.0.0.1:9944"), true);
     assert.equal(isUnsafeUrl("http://metadata.localhost"), true);
+    assert.equal(isUnsafeUrl("https://taochat.testnet.local"), true);
+    assert.equal(isUnsafeUrl("https://local"), true);
     assert.equal(isUnsafeUrl("ftp://metagraph.sh"), true);
     assert.equal(isUnsafeUrl("http://100.64.0.1"), true);
     assert.equal(isUnsafeUrl("http://172.16.0.1"), true);


### PR DESCRIPTION
### Motivation
- The testnet registry builder was publishing on-chain identity URLs like `https://*.testnet.local` into public artifacts, and the shared hostname sanitizer did not treat `.local`/`local` as unsafe which could lead to client-side private-network requests.

### Description
- Extend the unsafe-hostname guard in `isUnsafeHostname` so bare `local` and `*.local` hostnames are treated as unsafe and will be rejected by `isUnsafeUrl`/`normalizePublicUrl`.
- Add regression coverage so `backfilledIdentityUrl` rejects `.local` chain identity URLs and add direct `isUnsafeUrl` assertions for `.local` and `local` hostnames in tests.
- Files changed: `scripts/lib.mjs`, `tests/lib-helpers.test.mjs`, and `tests/script-utils.test.mjs`.

### Testing
- Ran the unit tests with `npm test -- tests/script-utils.test.mjs tests/lib-helpers.test.mjs`, and the targeted test files passed (Test Files 2 passed; Tests 141 passed).
- Ran the registry builder with `node scripts/build-network-registry.mjs` and inspected `dist/metagraph-r2/metagraph/testnet/subnets/*` to confirm `.local` identity URLs are dropped (resulting `website_url`/`logo_url` are `null` for the previously affected netuids).
- Ran the public-safety scan with `npm run scan:public-safety`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478690b00832cbe37be741195ace9)