### PR TITLE
fix(ci): preserve __proto__ keys in artifact canonicalization

### DIFF
--- a/scripts/ci-verify-submitted-artifacts.mjs
+++ b/scripts/ci-verify-submitted-artifacts.mjs
@@ -143,7 +143,7 @@ function normalizeForComparison(value) {
     return value.map(normalizeForComparison);
   }
   if (value && typeof value === "object") {
-    const out = {};
+    const out = Object.create(null);
     for (const key of Object.keys(value).sort()) {
       out[key] = normalizeForComparison(value[key]);
     }

--- a/tests/ci-artifact-verifier.test.mjs
+++ b/tests/ci-artifact-verifier.test.mjs
@@ -19,6 +19,16 @@ test("artifact canonical JSON preserves semantic array order", () => {
   );
 });
 
+test("artifact canonical JSON preserves __proto__ data properties", () => {
+  const withProtoKey = JSON.parse('{"x":1,"__proto__":{"polluted":true}}');
+
+  assert.notEqual(canonicalJson(withProtoKey), canonicalJson({ x: 1 }));
+  assert.equal(
+    canonicalJson(withProtoKey),
+    '{"__proto__":{"polluted":true},"x":1}',
+  );
+});
+
 test("R2 manifest comparison ignores only R2 aggregate byte drift", () => {
   const committed = {
     artifact_count: 1,


### PR DESCRIPTION
### Motivation
- The artifact canonicalizer previously copied object properties into a plain `{}` which invoked the inherited `__proto__` setter and omitted any own `__proto__` data properties, weakening the CI reproducibility check and enabling prototype-pollution payloads to go undetected.

### Description
- Use a null-prototype accumulator (`Object.create(null)`) in `normalizeForComparison` so own `__proto__` keys are preserved as data instead of setting the prototype. (`scripts/ci-verify-submitted-artifacts.mjs`)
- Add a regression test that verifies an object with an own `__proto__` property canonicalizes differently than the same object without that property. (`tests/ci-artifact-verifier.test.mjs`)
- Leave array handling unchanged (preserves semantic array order) and retain the existing R2-manifest special-casing behavior.

### Testing
- Ran `npx vitest run tests/ci-artifact-verifier.test.mjs` and the targeted verifier tests passed (4 tests, 0 failures).
- Ran `npm run lint -- scripts/ci-verify-submitted-artifacts.mjs tests/ci-artifact-verifier.test.mjs` and linting passed without errors.
- Ran `npm test` and the full test suite failed due to missing generated public artifact fixtures in this checkout (e.g. `public/metagraph/providers.json`, `public/metagraph/build-summary.json`), which is unrelated to this targeted fix.
- Attempting `npm test -- --runInBand` failed because Vitest does not accept the Jest-style `--runInBand` option; this is an environment/CLI mismatch, not a regression from these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478677198832c979a9cf2924b6117)