### PR TITLE
fix(ci): restore trusted submission gate workflow

### DIFF
--- a/.github/workflows/submission-gate.yml
+++ b/.github/workflows/submission-gate.yml
@@ -1,0 +1,65 @@
+name: Submission Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: submission-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  metagraphed-submission-gate:
+    name: metagraphed-submission-gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR input worktree
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          path: pr
+          fetch-depth: 0
+
+      - name: Checkout trusted base worktree
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          path: trusted
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Capture PR changed files
+        working-directory: pr
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22.22.3
+          cache: npm
+          cache-dependency-path: trusted/package-lock.json
+
+      - name: Install trusted dependencies
+        working-directory: trusted
+        run: npm ci
+
+      - name: Classify PR submission route with trusted code
+        id: route
+        working-directory: trusted
+        run: node scripts/ci-validate-route.mjs --changed-files ../pr/changed-files.txt --out ../pr/submission-route.json
+
+      - name: Run trusted UGC submission preflight against PR input
+        if: steps.route.outputs.mode == 'ugc'
+        working-directory: trusted
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: node scripts/submission-pr.mjs --changed-files ../pr/changed-files.txt --input-root ../pr --out ../pr/submission-report.json --submitter "$PR_AUTHOR"
+
+      - name: Skip non-submission PRs
+        if: steps.route.outputs.mode != 'ugc'
+        run: echo "No direct community submission detected; full validation remains authoritative for this PR."


### PR DESCRIPTION
### Motivation
- Reinstate a tamper-resistant submission preflight that was removed, because the single-checkout `validate` workflow can run PR-controlled npm scripts and allow mixed community submissions to bypass UGC safety gates. 
- Ensure classification and preflight logic are executed from the trusted base commit and trusted dependencies to prevent malicious PRs from altering validation behavior. 

### Description
- Add a dedicated pull-request workflow `/.github/workflows/submission-gate.yml` that checks out the PR input into `pr/` and a trusted base worktree into `trusted/` so validation code and deps are read from the base commit. 
- Install dependencies in the `trusted` worktree and run the trusted route classifier (`node scripts/ci-validate-route.mjs`) and the trusted UGC submission preflight (`node scripts/submission-pr.mjs`) against the PR input tree. 
- Use read-only repository `permissions` and a concurrency guard to limit the workflow scope and prevent it from publishing or merging.

### Testing
- Ran `npm run validate:workflows` and it completed successfully validating workflow rules. 
- Simulated classification with `python3 scripts/classify-validation-route.py` against a `changed-files.txt` containing a community candidate plus an unrelated file and confirmed the trusted classifier/preflight path is exercised as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478683dc8832cb196d41da47b6795)