### PR TITLE
fix(api): reject non-canonical analytics queries

### DIFF
--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -447,14 +447,23 @@ describe("analytics routes (cold local D1)", () => {
     );
     assert.deepEqual(body.data.surfaces, []);
   });
-  test("incidents rejects unsupported query parameters", async () => {
-    for (const query of ["window=bogus", "window=7d&cacheBust=x"]) {
+  test("D1 analytics routes reject non-canonical query strings before D1", async () => {
+    const cases = [
+      ["/api/v1/subnets/7/health/percentiles?window=bogus", "window"],
+      ["/api/v1/subnets/7/health/incidents?window=7d&cacheBust=x", "cacheBust"],
+      ["/api/v1/subnets/7/health/incidents?window=7d&window=7d", "window"],
+      ["/api/v1/subnets/7/trajectory?x=random", "x"],
+      ["/api/v1/registry/leaderboards?limit=10&x=random", "x"],
+      ["/api/v1/registry/leaderboards?limit=10&limit=10", "limit"],
+    ];
+    for (const [path, parameter] of cases) {
       const { status, body } = await getJson(
-        `https://api.metagraph.sh/api/v1/subnets/7/health/incidents?${query}`,
+        `https://api.metagraph.sh${path}`,
         env,
       );
-      assert.equal(status, 400);
+      assert.equal(status, 400, path);
       assert.equal(body.error.code, "invalid_query");
+      assert.equal(body.meta.parameter, parameter);
     }
   });
   test("trajectory returns empty-but-valid", async () => {
@@ -496,9 +505,25 @@ describe("analytics routes (cold local D1)", () => {
     assert.deepEqual(bulkTrends.body.data.windows["7d"].subnets, []);
   });
   test("leaderboards returns most-complete from profiles even with cold D1", async () => {
+    const profileEnv = createLocalArtifactEnv({
+      METAGRAPH_ARCHIVE: {
+        get: async () => ({
+          json: async () => ({
+            profiles: [
+              {
+                netuid: 7,
+                slug: "sn-7",
+                name: "Subnet 7",
+                completeness_score: 88,
+              },
+            ],
+          }),
+        }),
+      },
+    });
     const { body } = await getJson(
       "https://api.metagraph.sh/api/v1/registry/leaderboards",
-      env,
+      profileEnv,
     );
     assert.equal(typeof body.data.boards, "object");
     assert.ok(body.data.boards["most-complete"].length > 0);

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -390,7 +390,12 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     }
     const trajectoryMatch = TRAJECTORY_PATH_PATTERN.exec(resolved.url.pathname);
     if (trajectoryMatch) {
-      return handleTrajectory(request, env, Number(trajectoryMatch[1]));
+      return handleTrajectory(
+        request,
+        env,
+        Number(trajectoryMatch[1]),
+        resolved.url,
+      );
     }
     const uptimeMatch = UPTIME_PATH_PATTERN.exec(resolved.url.pathname);
     if (uptimeMatch) {
@@ -1214,17 +1219,29 @@ async function handleHealthTrends(request, env, netuid) {
   );
 }
 
-function analyticsWindow(url) {
+function validateQueryParams(url, allowedParams) {
+  const seen = new Set();
   for (const key of url.searchParams.keys()) {
-    if (key !== ANALYTICS_WINDOW_PARAM) {
+    if (!allowedParams.includes(key)) {
       return {
-        error: {
-          parameter: key,
-          message: `${key} is not supported for this route.`,
-        },
+        parameter: key,
+        message: `${key} is not supported for this route.`,
       };
     }
+    if (seen.has(key)) {
+      return {
+        parameter: key,
+        message: `${key} may only be provided once.`,
+      };
+    }
+    seen.add(key);
   }
+  return null;
+}
+
+function analyticsWindow(url) {
+  const validationError = validateQueryParams(url, [ANALYTICS_WINDOW_PARAM]);
+  if (validationError) return { error: validationError };
 
   const requested = url.searchParams.get(ANALYTICS_WINDOW_PARAM);
   if (requested !== null && !ANALYTICS_WINDOWS[requested]) {
@@ -1481,7 +1498,9 @@ async function handleGlobalIncidents(request, env, url) {
 }
 
 // Week-over-week structural trajectory from daily snapshots.
-async function handleTrajectory(request, env, netuid) {
+async function handleTrajectory(request, env, netuid, url) {
+  const validationError = validateQueryParams(url, []);
+  if (validationError) return analyticsQueryError(validationError);
   // Keep the most-recent window (DESC) — formatTrajectory re-sorts ascending.
   // ASC + LIMIT would freeze on the oldest 400 days once history exceeds the cap.
   const rows = await d1All(
@@ -1513,6 +1532,8 @@ async function handleTrajectory(request, env, netuid) {
 // schema-stable empty payload when D1 is unbound/cold or no history has accrued
 // yet (mirrors the other D1-backed analytics routes).
 async function handleUptime(request, env, netuid, url) {
+  const validationError = validateQueryParams(url, ["window"]);
+  if (validationError) return analyticsQueryError(validationError);
   const windowParam = url.searchParams.get("window") || "90d";
   const days = UPTIME_WINDOWS[windowParam];
   if (!days) {
@@ -1617,6 +1638,8 @@ async function leaderboardProfilesProjection(env, now = Date.now()) {
 // Registry leaderboards: healthiest / fastest-rpc / most-complete /
 // fastest-growing. Combines live D1 status with registry projections.
 async function handleLeaderboards(request, env, url) {
+  const validationError = validateQueryParams(url, ["board", "limit"]);
+  if (validationError) return analyticsQueryError(validationError);
   const requestedBoard = url.searchParams.get("board");
   if (requestedBoard && !LEADERBOARD_BOARDS.includes(requestedBoard)) {
     return errorResponse(


### PR DESCRIPTION
### Motivation
- Live D1-backed analytics routes were special-cased and bypassed the normal route/query validation path, allowing unsupported or junk query parameters to reach D1 and enabling cache-busting cost-amplification attacks.
- Unknown or duplicated query parameters were silently accepted and canonicalized (e.g. invalid `window` defaulting to `7d`), causing distinct cache keys for identical work and driving unnecessary D1 queries.

### Description
- Add a `validateQueryParams(url, allowedParams)` guard and use it to reject unsupported or duplicate query parameters before any D1 work runs. 
- Integrate the guard into `analyticsWindow` and call `analyticsQueryError` on validation failures so routes return `400 invalid_query` rather than executing D1 queries.
- Pass the resolved URL into `handleTrajectory` and require that `trajectory` accept no query parameters, and apply the same validation to `handleUptime` and `handleLeaderboards` (rejecting unknown/duplicate `window`, `board`, and `limit`).
- Update `tests/analytics.test.mjs` to assert rejection of non-canonical/junk/duplicate query strings and inject a minimal `profiles.json` fixture for the cold-D1 leaderboards test.

### Testing
- Ran formatting with `npx prettier --write workers/api.mjs tests/analytics.test.mjs` and the files were formatted successfully. 
- Ran the analytics unit tests with `npx vitest run tests/analytics.test.mjs` and the modified analytics tests passed. 
- Ran `npm run validate:api` which failed due to a missing local `health/history/YYYY-MM-DD.json` artifact required by the validation script (environment/setup issue, not a patch regression). 
- Ran the full test suite with `npm test` which surfaced unrelated failures caused by missing generated public artifacts in the checkout (those failures are environmental and not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347867a3f4832c9d37e60f9884b8c9)