### PR TITLE
Reject unsupported query params on health trends endpoints to prevent D1 amplification

### DIFF
--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -457,6 +457,32 @@ describe("analytics routes (cold local D1)", () => {
       assert.equal(body.error.code, "invalid_query");
     }
   });
+  test("trends rejects unsupported query parameters before D1", async () => {
+    let d1Calls = 0;
+    const countingEnv = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          d1Calls += 1;
+          return {
+            bind: () => ({ all: () => Promise.resolve({ results: [] }) }),
+          };
+        },
+      },
+    };
+    for (const path of [
+      "/api/v1/subnets/7/health/trends?r=nonce",
+      "/api/v1/health/trends?cacheBust=x",
+    ]) {
+      const { status, body } = await getJson(
+        `https://api.metagraph.sh${path}`,
+        countingEnv,
+      );
+      assert.equal(status, 400);
+      assert.equal(body.error.code, "invalid_query");
+    }
+    assert.equal(d1Calls, 0);
+  });
   test("trajectory returns empty-but-valid", async () => {
     const { body } = await getJson(
       "https://api.metagraph.sh/api/v1/subnets/7/trajectory",

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -362,11 +362,16 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       resolved.url.pathname,
     );
     if (bulkTrendsMatch) {
-      return handleBulkHealthTrends(request, env);
+      return handleBulkHealthTrends(request, env, resolved.url);
     }
     const trendsMatch = TRENDS_PATH_PATTERN.exec(resolved.url.pathname);
     if (trendsMatch) {
-      return handleHealthTrends(request, env, Number(trendsMatch[1]));
+      return handleHealthTrends(
+        request,
+        env,
+        Number(trendsMatch[1]),
+        resolved.url,
+      );
     }
     const percentilesMatch = PERCENTILES_PATH_PATTERN.exec(
       resolved.url.pathname,
@@ -1091,7 +1096,11 @@ async function handleApiRequest(
 // D1-backed 7d/30d daily uptime + latency trends across all subnets. This is a
 // compact matrix feed for UI dashboards and agents, so it groups by netuid/day
 // instead of returning every surface series.
-async function handleBulkHealthTrends(request, env) {
+async function handleBulkHealthTrends(request, env, url) {
+  const queryError = noQueryParamsError(url);
+  if (queryError) {
+    return analyticsQueryError(queryError);
+  }
   const db = env.METAGRAPH_HEALTH_DB;
   const nowMs = Date.now();
   const windows = {};
@@ -1153,7 +1162,11 @@ async function handleBulkHealthTrends(request, env) {
 // D1-backed 7d/30d uptime + latency trends for one subnet's operational
 // surfaces. Returns a schema-stable empty payload when D1 is unbound/cold so it
 // never errors (mirrors the live-overlay fall-back philosophy).
-async function handleHealthTrends(request, env, netuid) {
+async function handleHealthTrends(request, env, netuid, url) {
+  const queryError = noQueryParamsError(url);
+  if (queryError) {
+    return analyticsQueryError(queryError);
+  }
   const db = env.METAGRAPH_HEALTH_DB;
   const nowMs = Date.now();
   const windows = {};
@@ -1212,6 +1225,16 @@ async function handleHealthTrends(request, env, netuid) {
     },
     "short",
   );
+}
+
+function noQueryParamsError(url) {
+  for (const key of url.searchParams.keys()) {
+    return {
+      parameter: key,
+      message: `${key} is not supported for this route.`,
+    };
+  }
+  return null;
 }
 
 function analyticsWindow(url) {


### PR DESCRIPTION
### Motivation
- The public D1-backed trends endpoints were executing expensive 7d/30d aggregate queries for every request without validating or canonicalizing query parameters, enabling cache-busting requests to amplify D1 load and cost. 
- Rejecting unsupported query parameters early prevents unnecessary D1 work and preserves existing behaviour for documented query parameters.

### Description
- Thread the resolved request `url` into both trends handlers so validation runs after slug→netuid resolution and before any D1 queries (`handleBulkHealthTrends` and `handleHealthTrends` now accept `url`).
- Add `noQueryParamsError(url)` and call it at the top of the trends handlers to reject any undocumented query parameters with a `400 invalid_query` response before executing D1 aggregates. 
- Wire the calling sites to pass `resolved.url` into the handlers so the validation has access to the parsed search params. 
- Add a regression test that sends cache-busting query parameters to both `/api/v1/subnets/{netuid}/health/trends` and `/api/v1/health/trends`, asserts an `invalid_query` response, and verifies no D1 prepare calls occurred.

### Testing
- Ran the targeted analytics regression: `npm test -- --run tests/analytics.test.mjs -t "trends rejects unsupported query parameters before D1"` which passed. 
- Ran the health trends tests: `npm test -- --run tests/health-serving.test.mjs -t "health/trends"` which passed. 
- Formatting and lint checks `npx prettier --check workers/api.mjs tests/analytics.test.mjs` and `npm run lint -- --quiet` succeeded. 
- A full run of `npm test -- --run tests/analytics.test.mjs` still exposes an unrelated existing cold-D1 assertion failure in leaderboards (`most-complete` empty), which is outside the scope of this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347867de90832ca7a5a90d0360b798)