### PR TITLE
fix(api): bound subnet CSV filter parsing

### DIFF
--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -592,7 +592,8 @@
         {
           "name": "netuids",
           "schema": {
-            "pattern": "^\\d+(,\\d+)*$",
+            "maxLength": 767,
+            "pattern": "^\\d{1,5}(,\\d{1,5}){0,127}$",
             "type": "string"
           }
         },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -20838,7 +20838,8 @@
             "name": "netuids",
             "required": false,
             "schema": {
-              "pattern": "^\\d+(,\\d+)*$",
+              "maxLength": 767,
+              "pattern": "^\\d{1,5}(,\\d{1,5}){0,127}$",
               "type": "string"
             }
           },

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -540,7 +540,11 @@ export const API_QUERY_COLLECTIONS = {
     arrayFilters: { domain: ["categories", "derived_categories"] },
     filters: {
       netuid: integerSchema,
-      netuids: { type: "string", pattern: "^\\d+(,\\d+)*$" },
+      netuids: {
+        type: "string",
+        maxLength: 767,
+        pattern: "^\\d{1,5}(,\\d{1,5}){0,127}$",
+      },
       coverage_level: enumSchema(QUERY_ENUMS.coverageLevel),
       curation_level: enumSchema(QUERY_ENUMS.curationLevel),
       domain: enumSchema(DOMAIN_TAGS),

--- a/tests/batch-ratelimit.test.mjs
+++ b/tests/batch-ratelimit.test.mjs
@@ -31,6 +31,19 @@ describe("batch subnet lookups (?netuids=)", () => {
     assert.equal((await res.json()).error.code, "invalid_query");
   });
 
+  test("rejects an oversized netuids list with 400 invalid_query", async () => {
+    const netuids = Array.from({ length: 129 }, (_, i) => i).join(",");
+    const res = await get(`/api/v1/subnets?netuids=${netuids}`);
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "invalid_query");
+  });
+
+  test("rejects oversized netuid members with 400 invalid_query", async () => {
+    const res = await get("/api/v1/subnets?netuids=100000");
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "invalid_query");
+  });
+
   test("the single netuid filter still works alongside", async () => {
     const res = await get("/api/v1/subnets?netuid=7");
     assert.equal(res.status, 200);

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -33,6 +33,12 @@ export function applyQueryFilters(
 }
 
 function filterRows(rows, params, keys, csvFilters = {}, arrayFilters = {}) {
+  const csvWantedByKey = new Map(
+    Object.keys(csvFilters)
+      .filter((key) => params.has(key))
+      .map((key) => [key, new Set(params.get(key).split(","))]),
+  );
+
   return rows.filter((row) =>
     keys.every((key) => {
       if (!params.has(key)) {
@@ -42,13 +48,7 @@ function filterRows(rows, params, keys, csvFilters = {}, arrayFilters = {}) {
       // CSV membership filter (e.g. ?netuids=1,7,74 -> match row.netuid).
       const csvField = csvFilters[key];
       if (csvField) {
-        const wanted = new Set(
-          expected
-            .split(",")
-            .map((value) => value.trim())
-            .filter(Boolean),
-        );
-        return wanted.has(String(row[csvField]));
+        return csvWantedByKey.get(key)?.has(String(row[csvField])) ?? false;
       }
       // Array-membership filter over the UNION of one or more array fields
       // (e.g. ?domain=inference -> match row.categories or row.derived_categories).
@@ -220,6 +220,12 @@ function validateListQuery(params, config) {
       return {
         parameter: key,
         message: `${key} is not supported for this route.`,
+      };
+    }
+    if (schema.maxLength && value.length > schema.maxLength) {
+      return {
+        parameter: key,
+        message: `${key} is too long.`,
       };
     }
     if (schema.pattern && !new RegExp(schema.pattern).test(value)) {


### PR DESCRIPTION
### Motivation

- The public `/api/v1/subnets` CSV filter `?netuids=` accepted arbitrarily long digit lists and reparsed the CSV once per row, allowing unauthenticated requests to amplify CPU and memory usage.  
- The intent is to limit attack surface by bounding input size and avoid per-row CSV reallocation while preserving the batch lookup feature.

### Description

- Constrain the `netuids` query parameter schema with a `maxLength` and a stricter `pattern` to limit digits per item and maximum item count at the contract level (`src/contracts.mjs`).  
- Parse CSV membership filters once per request and cache `Set`s by parameter instead of splitting/allocating inside the per-row callback (`workers/list-query.mjs`).  
- Add early `maxLength` validation in `validateListQuery` so overly long patterned string filters are rejected before regex matching (`workers/list-query.mjs`).  
- Add regression tests covering oversized `netuids` lists and oversized numeric members, and regenerate the public API artifacts so `api-index.json` and `openapi.json` reflect the new bounds (`tests/batch-ratelimit.test.mjs`, `public/metagraph/*`).

### Testing

- Ran `npm test -- tests/batch-ratelimit.test.mjs`, and all tests in that file passed.  
- Ran `npm run format:check` and the Prettier check passed.  
- Ran `npm run lint` and ESLint reported no problems.  
- Ran `npm run validate:contract-drift` and contract drift validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347867774c832c9e2b269756d5ce55)