### PR TITLE
fix(adapter-snapshots): cap OpenAPI schema fetch size

### DIFF
--- a/scripts/snapshot-adapters.mjs
+++ b/scripts/snapshot-adapters.mjs
@@ -17,6 +17,7 @@ const shouldWrite = args.has("--write");
 const dryRun = args.has("--dry-run") || !shouldWrite;
 const generatedAt = buildTimestamp();
 const contractVersion = "2026-06-06.1";
+const MAX_OPENAPI_SCHEMA_BYTES = 2 * 1024 * 1024;
 const outputRoot = path.join(repoRoot, "registry/adapters/latest");
 // GitHub token plumbing: accept either env name (the project convention used by
 // discover-candidates and the CI workflows) and ignore accidental whitespace.
@@ -441,6 +442,42 @@ async function fetchJsonSummary(url) {
   };
 }
 
+function parseContentLength(value) {
+  if (value === null) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+async function readResponseText(response, maxBytes) {
+  if (!response.body) {
+    return { ok: true, text: "" };
+  }
+  const reader = response.body.getReader();
+  const chunks = [];
+  let totalBytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    totalBytes += value.byteLength;
+    if (totalBytes > maxBytes) {
+      await reader.cancel();
+      return { ok: false };
+    }
+    chunks.push(value);
+  }
+  const bodyBytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bodyBytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { ok: true, text: new TextDecoder().decode(bodyBytes) };
+}
+
 export async function fetchJson(url, redirectCount = 0) {
   if (await isUnsafeResolvedUrl(url)) {
     return {
@@ -486,7 +523,23 @@ export async function fetchJson(url, redirectCount = 0) {
       return fetchJson(redirectTarget, redirectCount + 1);
     }
     const contentType = response.headers.get("content-type") || "";
-    const text = await response.text();
+    const contentLength = parseContentLength(
+      response.headers.get("content-length"),
+    );
+    if (contentLength !== null && contentLength > MAX_OPENAPI_SCHEMA_BYTES) {
+      await response.body?.cancel();
+      return {
+        ok: false,
+        status: "too-large",
+        error: `response exceeded ${MAX_OPENAPI_SCHEMA_BYTES} bytes`,
+        status_code: response.status,
+        content_type: contentType || null,
+        content_length: contentLength,
+        max_bytes: MAX_OPENAPI_SCHEMA_BYTES,
+        latency_ms: Math.round(performance.now() - started),
+        captured_at: new Date().toISOString(),
+      };
+    }
     if (!response.ok) {
       return {
         ok: false,
@@ -503,6 +556,24 @@ export async function fetchJson(url, redirectCount = 0) {
         captured_at: new Date().toISOString(),
       };
     }
+    const limitedBody = await readResponseText(
+      response,
+      MAX_OPENAPI_SCHEMA_BYTES,
+    );
+    if (!limitedBody.ok) {
+      return {
+        ok: false,
+        status: "too-large",
+        error: `response exceeded ${MAX_OPENAPI_SCHEMA_BYTES} bytes`,
+        status_code: response.status,
+        content_type: contentType || null,
+        content_length: contentLength,
+        max_bytes: MAX_OPENAPI_SCHEMA_BYTES,
+        latency_ms: Math.round(performance.now() - started),
+        captured_at: new Date().toISOString(),
+      };
+    }
+    const text = limitedBody.text;
     let body = null;
     try {
       body = text ? JSON.parse(text) : null;

--- a/tests/adapter-snapshot-security.test.mjs
+++ b/tests/adapter-snapshot-security.test.mjs
@@ -57,3 +57,47 @@ describe("adapter snapshot fetch redirect safety", () => {
     );
   });
 });
+
+describe("adapter snapshot fetch body limits", () => {
+  test("rejects OpenAPI responses with oversized content-length", async () => {
+    let bodyCanceled = false;
+    globalThis.fetch = async () =>
+      new Response("{}", {
+        status: 200,
+        headers: {
+          "content-length": String(2 * 1024 * 1024 + 1),
+          "content-type": "application/json",
+        },
+      });
+
+    const response = await globalThis.fetch();
+    const originalCancel = response.body.cancel.bind(response.body);
+    response.body.cancel = async () => {
+      bodyCanceled = true;
+      return originalCancel();
+    };
+    globalThis.fetch = async () => response;
+
+    const result = await fetchJson("http://1.1.1.1/openapi.json");
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, "too-large");
+    assert.equal(result.content_length, 2 * 1024 * 1024 + 1);
+    assert.equal(result.max_bytes, 2 * 1024 * 1024);
+    assert.equal(bodyCanceled, true);
+  });
+
+  test("rejects OpenAPI responses that stream beyond the byte cap", async () => {
+    globalThis.fetch = async () =>
+      new Response(`{"padding":"${"x".repeat(2 * 1024 * 1024)}"}`, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+
+    const result = await fetchJson("http://1.1.1.1/openapi.json");
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, "too-large");
+    assert.equal(result.max_bytes, 2 * 1024 * 1024);
+  });
+});


### PR DESCRIPTION
### Motivation
- The production publish path began re-running the adapter snapshotter which fetched third-party OpenAPI schemas without any byte cap, allowing large or streaming responses to exhaust memory and crash the build process. 
- This poses an availability/DoS risk for the publish pipeline because attacker-controlled or compromised catalogued endpoints can return very large JSON payloads. 
- A minimal runtime guard is needed so snapshots remain useful but cannot OOM the build worker. 

### Description
- Introduce a configurable byte cap `MAX_OPENAPI_SCHEMA_BYTES` (set to 2 MiB) and add a `parseContentLength` helper to interpret `Content-Length` headers. 
- Add a `readResponseText(response, maxBytes)` reader that consumes the response stream while counting bytes and cancels the body if the cap is exceeded. 
- Wire pre-checks into `fetchJson` to reject responses whose `Content-Length` exceeds the cap and to use the capped stream reader instead of unbounded `response.text()` before `JSON.parse()`. 
- Add regression tests in `tests/adapter-snapshot-security.test.mjs` covering oversized `Content-Length` and streaming responses that exceed the byte cap. 

### Testing
- Ran the focused test file with `npx vitest run tests/adapter-snapshot-security.test.mjs` and the tests passed. 
- Ran linting with `npm run lint` and it completed without errors. 
- The change is a minimal protection that preserves existing behavior for normal-sized OpenAPI schemas while preventing unbounded memory use.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347867a2c8832caca2fe92cccfce7a)