### PR TITLE
fix(ci): keep validation scratch files in runner temp

### DIFF
--- a/.github/actions/classify-validation-route/action.yml
+++ b/.github/actions/classify-validation-route/action.yml
@@ -3,7 +3,7 @@ description: >-
   Compute this PR's changed files with a merge-base (three-dot) diff and classify
   the validation route as "ugc" (a single community candidate/provider submission)
   or "full" (everything else). Writes changed-files.txt + submitted-artifact-files.txt
-  to the workspace and exposes mode/scope as outputs. Shared by the parallel test +
+  to trusted runner temp storage and exposes mode/scope plus file paths as outputs. Shared by the parallel test +
   checks jobs so the stale-base-safe diff and the classifier live in one place.
 outputs:
   mode:
@@ -12,9 +12,26 @@ outputs:
   scope:
     description: PR scope — "normal-pr", "direct-candidate", or "direct-provider".
     value: ${{ steps.route.outputs.scope }}
+  changed-files:
+    description: Path to the trusted temporary changed-files list.
+    value: ${{ steps.paths.outputs.changed-files }}
+  submitted-artifact-files:
+    description: Path to the trusted temporary deletion-filtered submitted artifact list.
+    value: ${{ steps.paths.outputs.submitted-artifact-files }}
 runs:
   using: composite
   steps:
+    - name: Prepare trusted scratch paths
+      id: paths
+      shell: bash
+      run: |
+        scratch_dir="$RUNNER_TEMP/metagraphed-validation-route"
+        rm -rf "$scratch_dir"
+        mkdir -p "$scratch_dir"
+        echo "changed-files=$scratch_dir/changed-files.txt" >> "$GITHUB_OUTPUT"
+        echo "submitted-artifact-files=$scratch_dir/submitted-artifact-files.txt" >> "$GITHUB_OUTPUT"
+        echo "route-report=$scratch_dir/validate-route.json" >> "$GITHUB_OUTPUT"
+
     - name: Capture changed files
       if: github.event_name == 'pull_request'
       shell: bash
@@ -35,22 +52,25 @@ runs:
         # deletion-filtered (removing a public artifact — e.g. moving it R2-only
         # per ADR 0001 — is not a submitted artifact).
         if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
-          git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
-          git diff --name-only --diff-filter=d "$BASE_SHA"..."$HEAD_SHA" > submitted-artifact-files.txt
+          git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > "${{ steps.paths.outputs.changed-files }}"
+          git diff --name-only --diff-filter=d "$BASE_SHA"..."$HEAD_SHA" > "${{ steps.paths.outputs.submitted-artifact-files }}"
         else
           git fetch origin "$BASE_REF"
-          git diff --name-only "origin/$BASE_REF"...HEAD > changed-files.txt
-          git diff --name-only --diff-filter=d "origin/$BASE_REF"...HEAD > submitted-artifact-files.txt
+          git diff --name-only "origin/$BASE_REF"...HEAD > "${{ steps.paths.outputs.changed-files }}"
+          git diff --name-only --diff-filter=d "origin/$BASE_REF"...HEAD > "${{ steps.paths.outputs.submitted-artifact-files }}"
         fi
 
     - name: Capture changed files for full validation
       if: github.event_name != 'pull_request'
       shell: bash
       run: |
-        : > changed-files.txt
-        : > submitted-artifact-files.txt
+        : > "${{ steps.paths.outputs.changed-files }}"
+        : > "${{ steps.paths.outputs.submitted-artifact-files }}"
 
     - name: Classify validation route
       id: route
       shell: bash
+      env:
+        CHANGED_FILES_PATH: ${{ steps.paths.outputs.changed-files }}
+        ROUTE_REPORT_PATH: ${{ steps.paths.outputs.route-report }}
       run: python3 scripts/classify-validation-route.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -105,7 +105,7 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: npm run submission:pr -- --changed-files changed-files.txt --out submission-report.json --submitter "$PR_AUTHOR"
+        run: npm run submission:pr -- --changed-files "${{ steps.route.outputs.changed-files }}" --out "$RUNNER_TEMP/submission-report.json" --submitter "$PR_AUTHOR"
 
       - name: Validate UGC intake templates
         if: steps.route.outputs.mode == 'ugc'
@@ -148,7 +148,7 @@ jobs:
 
       - name: Verify submitted public artifacts are reproducible
         if: steps.route.outputs.mode == 'full' && github.event_name == 'pull_request'
-        run: node scripts/ci-verify-submitted-artifacts.mjs --changed-files submitted-artifact-files.txt
+        run: node scripts/ci-verify-submitted-artifacts.mjs --changed-files "${{ steps.route.outputs.submitted-artifact-files }}"
 
       - name: Validate registry
         if: steps.route.outputs.mode == 'full'

--- a/scripts/classify-validation-route.py
+++ b/scripts/classify-validation-route.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Classify a PR's validation route for CI (UGC submission vs full validation).
 
-Reads ``changed-files.txt`` (one path per line, produced by the merge-base diff in
-the classify-validation-route composite action) and decides:
+Reads ``$CHANGED_FILES_PATH`` (or ``changed-files.txt`` when unset; one path per
+line, produced by the merge-base diff in the classify-validation-route composite
+action) and decides:
 
   * ``mode=ugc``   — the PR is a single community candidate/provider submission
                      (registry/{candidates,providers}/community/<slug>.json). The
@@ -22,11 +23,12 @@ import os
 import pathlib
 import re
 
+changed_files_path = pathlib.Path(os.environ.get("CHANGED_FILES_PATH", "changed-files.txt"))
+route_report_path = pathlib.Path(os.environ.get("ROUTE_REPORT_PATH", "validate-route.json"))
+
 changed_files = sorted(
     file.strip().replace("\\", "/").removeprefix("./")
-    for file in pathlib.Path("changed-files.txt")
-    .read_text(encoding="utf-8")
-    .splitlines()
+    for file in changed_files_path.read_text(encoding="utf-8").splitlines()
     if file.strip()
 )
 candidate_pattern = re.compile(r"^registry/candidates/community/[a-z0-9][a-z0-9-]*\.json$")
@@ -74,9 +76,7 @@ report = {
     "provider_files": provider_files,
     "errors": errors,
 }
-pathlib.Path("validate-route.json").write_text(
-    json.dumps(report, indent=2) + "\n", encoding="utf-8"
-)
+route_report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
 output_path = os.environ.get("GITHUB_OUTPUT")
 if output_path:
     with open(output_path, "a", encoding="utf-8") as output:

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -124,14 +124,19 @@ for (const workflow of workflows) {
     );
     check(
       routeAction.includes("git diff --name-only ") &&
-        routeAction.includes("> changed-files.txt") &&
+        routeAction.includes("$RUNNER_TEMP/metagraphed-validation-route") &&
+        routeAction.includes("> \"${{ steps.paths.outputs.changed-files }}\"") &&
         routeAction.includes("--diff-filter=d") &&
-        routeAction.includes("> submitted-artifact-files.txt"),
+        routeAction.includes(
+          "> \"${{ steps.paths.outputs.submitted-artifact-files }}\"",
+        ),
       workflow,
       "classify-validation-route action must keep PR routing diffs unfiltered and filter deletions only for submitted-artifact verification",
     );
     check(
-      content.includes("--changed-files submitted-artifact-files.txt"),
+      content.includes(
+        '--changed-files "${{ steps.route.outputs.submitted-artifact-files }}"',
+      ),
       workflow,
       "validate workflow must verify submitted artifacts from the deletion-filtered list",
     );


### PR DESCRIPTION
### Motivation
- The classify-validation-route composite action previously wrote `changed-files.txt` and related outputs into the PR worktree, allowing a malicious PR to create symlinks that could clobber trusted files in the adjacent `trusted/` checkout and lead to code execution in CI.
- The intent is to preserve the trusted/base boundary by ensuring scratch outputs are created in a runner-controlled temp directory so PR-controlled paths cannot overwrite trusted artifacts.

### Description
- Add a `Prepare trusted scratch paths` step to the `classify-validation-route` composite action which creates a trusted directory under `$RUNNER_TEMP/metagraphed-validation-route` and exposes `changed-files` and `submitted-artifact-files` as step outputs.
- Change the composite action's diff steps to write the git diff outputs to the trusted temp paths (`${{ steps.paths.outputs.changed-files }}` and `${{ steps.paths.outputs.submitted-artifact-files }}`).
- Teach the Python classifier `scripts/classify-validation-route.py` to read the changed-files path and write its report via `CHANGED_FILES_PATH` / `ROUTE_REPORT_PATH` environment variables while preserving defaults for local runs.
- Update `validate.yml` to consume the composite action's trusted temp-file outputs for the UGC preflight and submitted-artifact verification, and update `scripts/validate-workflows.mjs` checks to enforce the new trusted-temp pattern.

### Testing
- Ran `npm run validate:workflows` and the workflow validations succeeded. (passed)
- Ran `npm run lint` and linting completed successfully. (passed)
- Performed an end-to-end local classifier invocation with `CHANGED_FILES_PATH` / `ROUTE_REPORT_PATH` to confirm the Python classifier reads/writes the configured paths. (passed)
- Ran `npx vitest run tests/submission-gate.test.mjs` which exercised the submission-gate tests; 45/47 tests passed and 2 failed due to missing `public/metagraph/build-summary.json` in this checkout unrelated to the scratch-file fix. (partial)
- Attempted `npm test -- --runInBand` but the test runner rejected the unsupported `--runInBand` flag; this is an unrelated test runner argument issue. (not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347867a784832c8e59ebc37a38d5fd)