### PR TITLE
ci: keep validation routing in trusted workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,7 +38,83 @@ jobs:
 
       - name: Classify validation route
         id: route
-        uses: ./.github/actions/classify-validation-route
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+        run: |
+          # Keep route classification in the trusted workflow instead of a
+          # checkout-local action/script. Pull request contents are untrusted and
+          # must not be able to force the reduced UGC lane.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
+              git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
+              git diff --name-only --diff-filter=d "$BASE_SHA"..."$HEAD_SHA" > submitted-artifact-files.txt
+            else
+              git fetch origin "$BASE_REF"
+              git diff --name-only "origin/$BASE_REF"...HEAD > changed-files.txt
+              git diff --name-only --diff-filter=d "origin/$BASE_REF"...HEAD > submitted-artifact-files.txt
+            fi
+          else
+            : > changed-files.txt
+            : > submitted-artifact-files.txt
+          fi
+
+          python3 - <<'PY_ROUTE'
+          import json
+          import os
+          import pathlib
+          import re
+
+          changed_files = sorted(
+              file.strip().replace("\\", "/").removeprefix("./")
+              for file in pathlib.Path("changed-files.txt").read_text(encoding="utf-8").splitlines()
+              if file.strip()
+          )
+          candidate_pattern = re.compile(r"^registry/candidates/community/[a-z0-9][a-z0-9-]*\.json$")
+          provider_pattern = re.compile(r"^registry/providers/community/[a-z0-9][a-z0-9-]*\.json$")
+          candidate_files = [file for file in changed_files if candidate_pattern.fullmatch(file)]
+          provider_files = [file for file in changed_files if provider_pattern.fullmatch(file)]
+          touched_community = [
+              file
+              for file in changed_files
+              if file.startswith("registry/candidates/community/")
+              or file.startswith("registry/providers/community/")
+          ]
+          errors = []
+          submission_files = candidate_files + provider_files
+          if not submission_files and not touched_community:
+              scope = "normal-pr"
+          else:
+              scope = "direct-provider" if len(provider_files) == 1 else "direct-candidate"
+              if len(submission_files) != 1:
+                  errors.append({"category": "unsupported-shape"})
+              unrelated = [
+                  file
+                  for file in changed_files
+                  if not candidate_pattern.fullmatch(file) and not provider_pattern.fullmatch(file)
+              ]
+              if unrelated:
+                  errors.append({"category": "generated-artifact-tampering"})
+          mode = "ugc" if scope in {"direct-candidate", "direct-provider"} and not errors else "full"
+          report = {
+              "schema_version": 1,
+              "mode": mode,
+              "scope": scope,
+              "changed_files": changed_files,
+              "candidate_files": candidate_files,
+              "provider_files": provider_files,
+              "errors": errors,
+          }
+          pathlib.Path("validate-route.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+          output_path = os.environ.get("GITHUB_OUTPUT")
+          if output_path:
+              with open(output_path, "a", encoding="utf-8") as output:
+                  output.write(f"mode={mode}\n")
+                  output.write(f"scope={scope}\n")
+          print(json.dumps(report, indent=2))
+          PY_ROUTE
 
       - name: Setup Node
         if: steps.route.outputs.mode == 'full'
@@ -88,7 +164,83 @@ jobs:
 
       - name: Classify validation route
         id: route
-        uses: ./.github/actions/classify-validation-route
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+        run: |
+          # Keep route classification in the trusted workflow instead of a
+          # checkout-local action/script. Pull request contents are untrusted and
+          # must not be able to force the reduced UGC lane.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
+              git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
+              git diff --name-only --diff-filter=d "$BASE_SHA"..."$HEAD_SHA" > submitted-artifact-files.txt
+            else
+              git fetch origin "$BASE_REF"
+              git diff --name-only "origin/$BASE_REF"...HEAD > changed-files.txt
+              git diff --name-only --diff-filter=d "origin/$BASE_REF"...HEAD > submitted-artifact-files.txt
+            fi
+          else
+            : > changed-files.txt
+            : > submitted-artifact-files.txt
+          fi
+
+          python3 - <<'PY_ROUTE'
+          import json
+          import os
+          import pathlib
+          import re
+
+          changed_files = sorted(
+              file.strip().replace("\\", "/").removeprefix("./")
+              for file in pathlib.Path("changed-files.txt").read_text(encoding="utf-8").splitlines()
+              if file.strip()
+          )
+          candidate_pattern = re.compile(r"^registry/candidates/community/[a-z0-9][a-z0-9-]*\.json$")
+          provider_pattern = re.compile(r"^registry/providers/community/[a-z0-9][a-z0-9-]*\.json$")
+          candidate_files = [file for file in changed_files if candidate_pattern.fullmatch(file)]
+          provider_files = [file for file in changed_files if provider_pattern.fullmatch(file)]
+          touched_community = [
+              file
+              for file in changed_files
+              if file.startswith("registry/candidates/community/")
+              or file.startswith("registry/providers/community/")
+          ]
+          errors = []
+          submission_files = candidate_files + provider_files
+          if not submission_files and not touched_community:
+              scope = "normal-pr"
+          else:
+              scope = "direct-provider" if len(provider_files) == 1 else "direct-candidate"
+              if len(submission_files) != 1:
+                  errors.append({"category": "unsupported-shape"})
+              unrelated = [
+                  file
+                  for file in changed_files
+                  if not candidate_pattern.fullmatch(file) and not provider_pattern.fullmatch(file)
+              ]
+              if unrelated:
+                  errors.append({"category": "generated-artifact-tampering"})
+          mode = "ugc" if scope in {"direct-candidate", "direct-provider"} and not errors else "full"
+          report = {
+              "schema_version": 1,
+              "mode": mode,
+              "scope": scope,
+              "changed_files": changed_files,
+              "candidate_files": candidate_files,
+              "provider_files": provider_files,
+              "errors": errors,
+          }
+          pathlib.Path("validate-route.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+          output_path = os.environ.get("GITHUB_OUTPUT")
+          if output_path:
+              with open(output_path, "a", encoding="utf-8") as output:
+                  output.write(f"mode={mode}\n")
+                  output.write(f"scope={scope}\n")
+          print(json.dumps(report, indent=2))
+          PY_ROUTE
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -112,23 +112,23 @@ for (const workflow of workflows) {
     );
   }
   if (workflow === "validate.yml") {
-    // The routing diff lives in the classify-validation-route composite action
-    // (shared by the parallel test + checks jobs); the deletion-filtered
-    // verification is consumed back in this workflow.
-    const routeAction = await fs.readFile(
-      path.join(
-        repoRoot,
-        ".github/actions/classify-validation-route/action.yml",
-      ),
-      "utf8",
+    // Route classification must stay in this trusted workflow. Running a
+    // checkout-local action/script would let pull requests forge `mode=ugc` and
+    // skip full validation. The deletion-filtered verification is consumed back
+    // in this workflow.
+    check(
+      !content.includes("uses: ./.github/actions/classify-validation-route"),
+      workflow,
+      "validate workflow must not route CI through PR-controlled local actions",
     );
     check(
-      routeAction.includes("git diff --name-only ") &&
-        routeAction.includes("> changed-files.txt") &&
-        routeAction.includes("--diff-filter=d") &&
-        routeAction.includes("> submitted-artifact-files.txt"),
+      content.includes("git diff --name-only ") &&
+        content.includes("> changed-files.txt") &&
+        content.includes("--diff-filter=d") &&
+        content.includes("> submitted-artifact-files.txt") &&
+        content.includes("python3 - <<'PY_ROUTE'"),
       workflow,
-      "classify-validation-route action must keep PR routing diffs unfiltered and filter deletions only for submitted-artifact verification",
+      "validate workflow must compute routing diffs and classify the route inline from trusted workflow code",
     );
     check(
       content.includes("--changed-files submitted-artifact-files.txt"),


### PR DESCRIPTION
### Motivation
- Prevent pull requests from forging the CI routing decision by running a PR-controlled local action or npm script that could emit `mode=ugc` and skip the full validation matrix.
- Ensure the validation route (UGC vs full) is computed from trusted workflow code rather than code in the checked-out PR.

### Description
- Moved route classification inline into `.github/workflows/validate.yml` for both the `test` and `checks` jobs so the workflow computes `changed-files.txt`/`submitted-artifact-files.txt` and classifies mode from trusted workflow code instead of using the checkout-local action `./.github/actions/classify-validation-route`.
- The inline classifier reproduces the previous classification logic and still writes `validate-route.json` and appends `mode`/`scope` to `$GITHUB_OUTPUT` for downstream `if:` gating.
- Updated `scripts/validate-workflows.mjs` to require the trusted inline classification and to forbid routing CI through the PR-controlled local action, enforcing the new required pattern.
- The changes touch `.github/workflows/validate.yml` and `scripts/validate-workflows.mjs` and preserve existing changed-files and deletion-filtered submitted-artifact generation.

### Testing
- Ran `npm run validate:workflows` which reported success and validated workflow rules after the changes.
- Ran `npm run format:check` which succeeded (Prettier checks passed) and `npm run lint` which completed without errors.
- Performed a syntax check of the inline route script with `bash -n` and executed the inline route script via `GITHUB_OUTPUT=/tmp/validate-route-output bash /tmp/validate-route-inline.sh` which produced `mode=full` and a JSON route report as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347867a174832cb8548cba7d0dfc28)