### PR TITLE
fix(security): scan private-boundary symlink targets

### DIFF
--- a/scripts/validate-private-boundary.mjs
+++ b/scripts/validate-private-boundary.mjs
@@ -69,7 +69,34 @@ for (const file of trackedFiles) {
     continue;
   }
 
-  if (stat.isSymbolicLink() || !stat.isFile()) {
+  if (stat.isSymbolicLink()) {
+    let linkTarget;
+    try {
+      linkTarget = await fs.readlink(absolutePath);
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        continue;
+      }
+      console.warn(`Skipping unreadable symlink ${file}: ${error.message}`);
+      continue;
+    }
+
+    for (const pattern of contentPatterns) {
+      if (!pattern.regex.test(linkTarget)) {
+        continue;
+      }
+      if (
+        pattern.name !== "real Discord webhook URL" &&
+        allowedContentMentions.has(file)
+      ) {
+        continue;
+      }
+      findings.push(`${file}: symlink target: ${pattern.name}`);
+    }
+    continue;
+  }
+
+  if (!stat.isFile()) {
     continue;
   }
 


### PR DESCRIPTION
### Motivation
- The private-boundary validator previously skipped tracked symlinks, which allowed sensitive patterns (e.g. real Discord webhook URLs or provider-specific routing strings) to evade detection in symlink targets and risk being published.

### Description
- When a tracked path is a symbolic link, the script now reads the symlink target with `fs.readlink` and scans the target text against the existing `contentPatterns` set.
- Matches on symlink targets are reported as findings using the same allowed-content exceptions as regular files (except the real Discord webhook check), and unreadable symlinks are logged and skipped.
- The streaming scan behavior for regular tracked files is preserved and unchanged.

### Testing
- Ran `npm run validate:private-boundary` with no issues present and it exited reporting `Private-boundary validation passed.`
- Created a tracked symlink whose link target contained a Discord webhook-shaped URL and verified the validator fails and reports `symlink target: real Discord webhook URL`.
- Created a tracked large (>1 MiB) text file containing a Discord webhook-shaped URL and verified the validator fails and reports the matching line as an issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478683e8c832ca1aef975bb9b9c3c)