### PR TITLE
fix: reject credentialed public URLs

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -775,6 +775,9 @@ export function isUnsafeUrl(value) {
     if (!["http:", "https:", "ws:", "wss:"].includes(url.protocol)) {
       return true;
     }
+    if (url.username || url.password) {
+      return true;
+    }
 
     const host = normalizeHostname(url.hostname);
     return isUnsafeHostname(host);

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -57,6 +57,18 @@ describe("public URL safety checks", () => {
     assert.equal(await isUnsafeResolvedUrl("http://localhost/"), true);
   });
 
+  test("blocks credentialed public URLs before DNS resolution", () => {
+    const credentialedUrls = [
+      "https://user:pass@example.com/api",
+      "http://peer1-api:8080,0xPeer2@http//peer2-api:8080",
+      "wss://token@example.com/socket",
+    ];
+
+    for (const url of credentialedUrls) {
+      assert.equal(isUnsafeUrl(url), true, url);
+    }
+  });
+
   test("allows syntactically valid public HTTP URLs before DNS resolution", () => {
     assert.equal(isUnsafeUrl("https://example.com/api"), false);
     assert.equal(isUnsafeUrl("http://8.8.8.8/dns-query"), false);


### PR DESCRIPTION
### Motivation
- A credentialed candidate URL containing userinfo was being published as `public_safe` because the shared URL safety guard only checked protocol and host and did not reject non-empty `username`/`password` fields, allowing credentialed URLs to appear in public artifacts.

### Description
- Treat URLs with embedded userinfo as unsafe by returning true if `url.username` or `url.password` is present in `isUnsafeUrl` in `scripts/lib.mjs`.
- Add a regression test that asserts credentialed HTTP and WebSocket URLs (including the reported malformed candidate shape) are blocked in `tests/public-safety.test.mjs`.
- Changes touch `scripts/lib.mjs` and `tests/public-safety.test.mjs` and are intentionally minimal to preserve existing behavior for non-credentialed URLs.

### Testing
- Quick runtime check using `node -e "import('./scripts/lib.mjs').then(({isUnsafeUrl})=>{...})"` confirmed the reported URL is now treated as unsafe (returned `true`).
- `npm run scan:public-safety` passed locally after the change.
- Targeted unit test run `npm test -- --run tests/script-utils.test.mjs tests/public-safety.test.mjs -t "blocks credentialed public URLs|script utilities"` passed the new regression assertion.
- Running the whole `tests/public-safety.test.mjs` suite showed an unrelated failure due to DNS resolution differences in this environment (the `https://example.com/` resolution), and `npm run validate` failed in this checkout because `public/metagraph/providers.json` is missing, both issues are environmental and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347868a548832ca2cd9efe58cf7b91)