### PR TITLE
fix(registry): reject unsafe candidate URLs

### DIFF
--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -2,6 +2,7 @@ import path from "node:path";
 import {
   buildTimestamp,
   isBrandImpersonationUrl,
+  isCredentialedUrl,
   isLikelyExampleLink,
   isUnsafeResolvedUrl,
   isUnsafeUrl,
@@ -1143,7 +1144,12 @@ function normalizePublicUrl(value) {
 
   try {
     const url = new URL(candidate);
-    if (!["http:", "https:"].includes(url.protocol)) {
+    if (
+      !["http:", "https:"].includes(url.protocol) ||
+      url.username ||
+      url.password ||
+      isCredentialedUrl(url.toString())
+    ) {
       return null;
     }
     // SSRF pre-filter: literal private/loopback/link-local/metadata IPs +

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1010,6 +1010,7 @@ export function normalizePublicUrl(value) {
       !["http:", "https:", "ws:", "wss:"].includes(url.protocol) ||
       url.username ||
       url.password ||
+      isCredentialedUrl(url.toString()) ||
       isUnsafeUrl(url.toString())
     ) {
       return null;

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -574,7 +574,10 @@ function validateCandidate(candidate, nativeNetuids, providerIds) {
   assert(candidateStates.has(candidate.state), `${key}: invalid state`);
   assert(Boolean(candidate.name), `${key}: name is required`);
   assert(surfaceKinds.has(candidate.kind), `${key}: invalid kind`);
-  assert(isValidUrl(candidate.url), `${key}: url must be a URL`);
+  assert(
+    normalizePublicHttpUrl(candidate.url) && !isCredentialedUrl(candidate.url),
+    `${key}: url must be a public HTTP(S) URL without credentials`,
+  );
   assert(isValidUrl(candidate.source_url), `${key}: source_url must be a URL`);
   if (candidate.source_urls !== undefined) {
     assert(

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -3,7 +3,12 @@ import { execFileSync } from "node:child_process";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, test } from "vitest";
-import { isUnsafeResolvedUrl, isUnsafeUrl, repoRoot } from "../scripts/lib.mjs";
+import {
+  isUnsafeResolvedUrl,
+  isUnsafeUrl,
+  normalizePublicHttpUrl,
+  repoRoot,
+} from "../scripts/lib.mjs";
 
 const FIXTURE_DIR = path.join(repoRoot, "dist/metagraph-r2/metagraph/fixtures");
 const TEST_FIXTURE = "__public_safety_test__.json";
@@ -51,6 +56,25 @@ describe("public URL safety checks", () => {
     for (const url of unsafeUrls) {
       assert.equal(isUnsafeUrl(url), true, url);
     }
+  });
+
+  test("normalizes only public non-credentialed HTTP URLs", () => {
+    const unsafeUrls = [
+      "http://10.0.0.1/admin/",
+      "http://169.254.169.254/latest/meta-data/",
+      "http://[::1]/",
+      "https://user:pass@example.com/private/",
+      "https://example.com/private?token=secret",
+    ];
+
+    for (const url of unsafeUrls) {
+      assert.equal(normalizePublicHttpUrl(url), null, url);
+    }
+
+    assert.equal(
+      normalizePublicHttpUrl("example.com/docs/#intro"),
+      "https://example.com/docs",
+    );
   });
 
   test("blocks hostnames that resolve to private addresses", async () => {


### PR DESCRIPTION
### Motivation
- The discovery pipeline was normalizing and publishing attacker-controlled HTTP(S) URLs as `public_safe` without rejecting credentialed or private/link-local/loopback targets, allowing unverified unsafe URLs to be emitted into public artifacts.

### Description
- Reject credential-bearing URLs during discovery by using `isCredentialedUrl` in `normalizePublicUrl` so credentialed userinfo or token-like query parameters are refused (changes in `scripts/lib.mjs` and `scripts/discover-candidates.mjs`).
- Harden candidate validation so candidate `url` must normalize as a public HTTP(S) URL and must not contain credentials by asserting `normalizePublicHttpUrl(candidate.url) && !isCredentialedUrl(candidate.url)` in `scripts/validate.mjs`.
- Add a regression test that asserts `normalizePublicHttpUrl` rejects private, link-local, loopback IPv6, userinfo-credentialed, and credential-like query URLs and still normalizes valid public URLs in `tests/public-safety.test.mjs`.

### Testing
- Ran the focused unit test `tests/public-safety.test.mjs -t "normalizes only public non-credentialed HTTP URLs"`, which passed.
- Ran `npm run build:artifacts`, which completed and produced artifacts, and then `npm run validate`, which succeeded after addressing a transient R2 manifest artifact difference.
- Attempted the full test run via `npm test`, but the suite could not be completed in this environment (Vitest execution started and ultimately hung), so the full-suite run was stopped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478677c3c832c8bf69d66367b050d)