### PR TITLE
fix(subnets): tighten contact email sanitizer

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1147,7 +1147,12 @@ const CONTACT_JUNK_VALUES = new Set([
   "-",
   "null",
 ]);
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+const EMAIL_ATOM = "[A-Z0-9!#$%&\\'*+/=?^_`{|}~-]+";
+const EMAIL_RE = new RegExp(
+  `^${EMAIL_ATOM}(?:\\.${EMAIL_ATOM})*@` +
+    "(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\\.)+[A-Z]{2,63}$",
+  "i",
+);
 export function subnetContact(overlayContact) {
   if (typeof overlayContact !== "string") return null;
   const value = overlayContact.trim();

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -1386,6 +1386,10 @@ describe("subnetContact", () => {
     assert.equal(subnetContact("None"), null);
     assert.equal(subnetContact("deprecated@gmail.com"), null); // junk local-part
     assert.equal(subnetContact("not an email"), null);
+    assert.equal(subnetContact("javascript:alert(1)@example.com"), null);
+    assert.equal(subnetContact("<|system|>@example.com"), null);
+    assert.equal(subnetContact("https://evil.com@127.0.0.1/x"), null);
+    assert.equal(subnetContact("mailto:javascript:alert(1)@example.com"), null);
     assert.equal(subnetContact("http://127.0.0.1/x"), null); // not public
     assert.equal(subnetContact(""), null);
     assert.equal(subnetContact(null), null);


### PR DESCRIPTION
### Motivation
- Prevent URI-like, markup-like, and control-token-like strings from being accepted as "emails" by the `subnetContact()` sanitizer so unsafe payloads cannot bypass URL safety checks and be published as the public `contact` field.

### Description
- Replace the permissive `EMAIL_RE` with a stricter dot-atom style email pattern constructed from `EMAIL_ATOM` and `RegExp` in `scripts/lib.mjs`, preserving the existing `mailto:` trim and URL fallback behavior.
- Keep the fallback to `normalizePublicHttpUrl()` for non-email inputs and still reject placeholder identity URLs via `isPlaceholderIdentityUrl()`.
- Add regression coverage in `tests/lib-helpers.test.mjs` asserting that inputs like `javascript:alert(1)@example.com`, `<|system|>@example.com`, `https://evil.com@127.0.0.1/x`, and `mailto:javascript:alert(1)@example.com` are rejected.

### Testing
- Ran `npm test -- tests/lib-helpers.test.mjs` and the focused test file passed (`103 tests` passed). 
- Ran `npm run lint -- scripts/lib.mjs tests/lib-helpers.test.mjs` and `npm run format:check -- scripts/lib.mjs tests/lib-helpers.test.mjs`, both succeeded. 
- Ran the full test suite with `npm test`; it failed due to unrelated missing generated public artifacts (e.g. `public/metagraph/providers.json` and `public/metagraph/build-summary.json`) in this environment, producing broad ENOENT/404 failures that are not related to this sanitizer change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478675d6c832c8b80eb7bf623196d)