### PR TITLE
fix(submissions): preserve short multi-tenant owner tokens

### DIFF
--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -1,6 +1,7 @@
 import {
   clusterDomainFromUrl,
   flattenSurfaces,
+  MULTI_TENANT_HOST_SUFFIXES,
   normalizePublicHttpUrl,
   normalizePublicUrl,
   registrySurfaceKey,
@@ -970,10 +971,15 @@ const normIdentToken = (value) =>
   String(value || "")
     .toLowerCase()
     .replace(/[^a-z0-9]/g, "");
+const isMultiTenantClusterDomain = (domain) =>
+  typeof domain === "string" &&
+  [...MULTI_TENANT_HOST_SUFFIXES].some((suffix) =>
+    domain.toLowerCase().endsWith(`.${suffix}`),
+  );
 
 /** Owner token(s) a URL claims — a code host (github/gitlab/bitbucket) contributes its ORG; any other
- *  host contributes its registrable-domain label. Normalized to alnum, ≥4 chars (a 1-3 char slug
- *  matches anywhere). */
+ *  host contributes its registrable-domain label. Normalized to alnum, ≥4 chars except short
+ *  multi-tenant labels, which are still tenant-controlled owner claims and must not disappear. */
 export function urlOwnerTokens(value) {
   if (typeof value !== "string" || !value) return [];
   let url;
@@ -986,12 +992,18 @@ export function urlOwnerTokens(value) {
   const out = [];
   if (CODE_HOST_RE.test(host)) {
     const org = url.pathname.replace(/^\/+/, "").split("/")[0];
-    if (org) out.push(normIdentToken(org));
+    const token = normIdentToken(org);
+    if (token.length >= 4) out.push(token);
   } else {
     const domain = clusterDomainFromUrl(value);
-    if (domain) out.push(normIdentToken(domain.split(".")[0]));
+    if (domain) {
+      const token = normIdentToken(domain.split(".")[0]);
+      if (token.length >= 4 || isMultiTenantClusterDomain(domain)) {
+        out.push(token);
+      }
+    }
   }
-  return out.filter((token) => token.length >= 4);
+  return out.filter(Boolean);
 }
 
 /** Identity tokens for a candidate's declared provider — its name, id, and the owner tokens of its

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -1285,6 +1285,7 @@ describe("submission-policy owner-identity + placeholder helpers", () => {
     assert.deepEqual(urlOwnerTokens("https://attacker.uc.r.appspot.com/api"), [
       "attacker",
     ]);
+    assert.deepEqual(urlOwnerTokens("https://abc.gitlab.io/api"), ["abc"]);
     assert.deepEqual(urlOwnerTokens("not a url"), []);
     assert.deepEqual(urlOwnerTokens(42), []);
     // a sub-4-char org is filtered out
@@ -1322,6 +1323,33 @@ describe("submission-policy owner-identity + placeholder helpers", () => {
     assert.equal(
       ownerTokensMatch(["safescanai"], ["byzantium", "byzantiumai"]),
       false,
+    );
+  });
+
+  test("short multi-tenant URL owners still trigger owner mismatch review", () => {
+    const document = structuredClone(validCandidateDocument);
+    document.candidates[0].kind = "subnet-api";
+    document.candidates[0].url = "https://abc.gitlab.io/api";
+    document.candidates[0].source_url =
+      "https://docs.all-ways.io/how-it-works.html";
+    document.candidates[0].source_urls = [
+      "https://docs.all-ways.io/how-it-works.html",
+    ];
+
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/abc-gitlab-api.json"],
+      candidateDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "JSONbored",
+    });
+
+    assert.equal(
+      report.manual_reasons.includes(
+        "candidate url owner does not match its registered provider's identity — needs review to confirm it is the subnet's own surface",
+      ),
+      true,
     );
   });
 


### PR DESCRIPTION
### Motivation
- Recent multi-tenant cluster suffixes (e.g. `gitlab.io`, `azurewebsites.net`) caused tenant-scoped cluster domains like `abc.gitlab.io` to be normalized away by the existing ≥4-char filter, producing an empty claim-token set and suppressing the owner-mismatch manual-review reason.

### Description
- Preserve short tenant labels for configured multi-tenant cluster domains by importing `MULTI_TENANT_HOST_SUFFIXES` and adding `isMultiTenantClusterDomain(domain)` to detect those clusters in `scripts/submission-policy.mjs`.
- Change `urlOwnerTokens()` to still return short tokens when the derived cluster domain belongs to a multi-tenant host, while keeping the existing >=4 character requirement for code-host org tokens and non-multi-tenant domains.
- Normalize code-host org extraction to apply the same token-length filter consistently.
- Add regression tests in `tests/submission-gate.test.mjs` to assert `urlOwnerTokens("https://abc.gitlab.io/api")` yields `"abc"` and to verify an ownership-sensitive candidate using a short multi-tenant tenant triggers the owner-mismatch manual-review reason.
- Files changed: `scripts/submission-policy.mjs`, `tests/submission-gate.test.mjs`.

### Testing
- Ran targeted test subset: `npm test -- --run tests/submission-gate.test.mjs -t "owner-identity|short multi-tenant|urlOwnerTokens"` and all targeted tests passed.
- Ran linter: `npm run lint` and it completed with no errors.
- Attempted full `npm test -- --run tests/submission-gate.test.mjs`; this run failed on unrelated artifact verification tests in this workspace due to a missing `public/metagraph/build-summary.json` file (environment/test setup issue), not due to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347867adfc832c9c20872925beedff)