### PR TITLE
fix(datasets): include exported CSV content in manifest content_hash

### DIFF
--- a/public/datasets/index.json
+++ b/public/datasets/index.json
@@ -1,5 +1,5 @@
 {
-  "content_hash": "ea04e0e4d4fd835cc622a094e202bb0631cafe6f31372c79a9e7e71cb97f2b95",
+  "content_hash": "efefe964da0d837095d5bdfbf91b9e704448589c4163c740ab88c42d39fe5791",
   "contract_version": "2026-06-06.1",
   "dataset_count": 3,
   "datasets": [

--- a/scripts/datasets.mjs
+++ b/scripts/datasets.mjs
@@ -169,6 +169,15 @@ export function buildDatasetExports({
     });
   }
 
+  const contentFingerprint = {
+    datasets,
+    files: files.map(({ relativePath, contentType, body }) => ({
+      relativePath,
+      contentType,
+      body,
+    })),
+  };
+
   return {
     files,
     manifest: {
@@ -178,7 +187,7 @@ export function buildDatasetExports({
       // generated_at stays the deterministic build stamp.
       generated_at: generatedAt,
       published_at: publishedAt,
-      content_hash: hashJson ? hashJson(datasets) : null,
+      content_hash: hashJson ? hashJson(contentFingerprint) : null,
       dataset_count: datasets.length,
       datasets,
     },

--- a/tests/datasets.test.mjs
+++ b/tests/datasets.test.mjs
@@ -97,19 +97,37 @@ describe("buildDatasetExports", () => {
   });
 
   test("carries published_at + a deterministic content_hash (#349)", () => {
-    const hashJson = (value) => JSON.stringify(value).length.toString(16);
+    const hashJson = (value) => JSON.stringify(value);
     const a = buildDatasetExports({
       ...input,
       publishedAt: "2026-06-12T10:00:00.000Z",
       hashJson,
     });
     assert.equal(a.manifest.published_at, "2026-06-12T10:00:00.000Z");
-    assert.equal(a.manifest.content_hash, hashJson(a.manifest.datasets));
+    assert.equal(
+      a.manifest.content_hash,
+      hashJson({
+        datasets: a.manifest.datasets,
+        files: a.files.map(({ relativePath, contentType, body }) => ({
+          relativePath,
+          contentType,
+          body,
+        })),
+      }),
+    );
     // generated_at stays the deterministic stamp, independent of published_at
     assert.equal(a.manifest.generated_at, input.generatedAt);
     // content_hash ignores published_at — same content, same hash
     const b = buildDatasetExports({ ...input, publishedAt: null, hashJson });
     assert.equal(a.manifest.content_hash, b.manifest.content_hash);
+
+    // content_hash includes exported CSV content, not just dataset metadata
+    const changed = buildDatasetExports({
+      ...input,
+      subnets: [{ ...input.subnets[0], name: "Changed" }],
+      hashJson,
+    });
+    assert.notEqual(a.manifest.content_hash, changed.manifest.content_hash);
   });
 
   test("published_at + content_hash default to null without injection", () => {


### PR DESCRIPTION
### Motivation

- The manifest `content_hash` previously hashed only dataset metadata, so changes to exported CSV bodies (row values) could occur without the manifest hash changing and consumers could miss content updates.

### Description

- Compute a stronger deterministic fingerprint by including both `datasets` metadata and the exported `files` (CSV `body`, `relativePath`, and `contentType`) in a `contentFingerprint` and hash that instead of `datasets` alone (`scripts/datasets.mjs`).
- Update the datasets test to expect the new hash input and add a regression assertion that mutating a projected row value changes `manifest.content_hash` (`tests/datasets.test.mjs`).
- Regenerate and commit the updated `public/datasets/index.json` `content_hash` to match the stronger fingerprint.

### Testing

- Ran `npm test -- --run tests/datasets.test.mjs` and the modified tests passed.
- Ran `npm run build:artifacts` which completed successfully and produced the artifacts used to regenerate the public dataset manifest.
- Ran `npx prettier --check` on the changed files and formatting checks passed.
- Attempted `npm test -- --run tests/artifacts.test.mjs` but stopped because the run invoked the R2 upload path in this environment and was aborted (no assertions were left failing in the focused tests run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478683a38832c80b94337ac63a155)