### PR TITLE
fix(python): strip custom headers on cross-origin redirects

### DIFF
--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -14,7 +14,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from importlib.metadata import PackageNotFoundError, version as _package_version
-from typing import Any, Iterator, List, Mapping, Optional, Sequence
+from typing import Any, Iterator, List, Mapping, Optional, Sequence, Tuple
 
 from .models import AgentCatalogSubnet, Endpoint, Provider, Subnet, Surface
 
@@ -40,6 +40,40 @@ DEFAULT_USER_AGENT = (
     f"metagraphed-python/{__version__} (+https://github.com/JSONbored/metagraphed)"
 )
 _PATH_PARAM = re.compile(r"\{([^{}]+)\}")
+
+
+def _url_origin(url: str) -> Tuple[str, str, Optional[int]]:
+    parsed = urllib.parse.urlsplit(url)
+    port = parsed.port
+    if port is None and parsed.scheme == "http":
+        port = 80
+    elif port is None and parsed.scheme == "https":
+        port = 443
+    return (parsed.scheme.lower(), (parsed.hostname or "").lower(), port)
+
+
+class _CrossOriginSafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Redirect handler that does not forward custom headers cross-origin."""
+
+    _CROSS_ORIGIN_HEADER_ALLOWLIST = frozenset({"Accept", "User-agent"})
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        redirected = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if redirected is None:
+            return None
+        if _url_origin(req.full_url) != _url_origin(newurl):
+            for key in list(redirected.headers):
+                if key not in self._CROSS_ORIGIN_HEADER_ALLOWLIST:
+                    redirected.remove_header(key)
+            for key in list(redirected.unredirected_hdrs):
+                if key not in self._CROSS_ORIGIN_HEADER_ALLOWLIST:
+                    redirected.remove_header(key)
+        return redirected
+
+
+def _open_request(request: urllib.request.Request, timeout: float):
+    opener = urllib.request.build_opener(_CrossOriginSafeRedirectHandler())
+    return opener.open(request, timeout=timeout)
 
 
 class MetagraphedError(Exception):
@@ -101,7 +135,7 @@ def metagraphed_fetch(
     attempt = 0
     while True:
         try:
-            with urllib.request.urlopen(request, timeout=timeout) as response:
+            with _open_request(request, timeout=timeout) as response:
                 body = response.read().decode("utf-8")
             break
         except urllib.error.HTTPError as error:
@@ -276,7 +310,7 @@ def metagraphed_rpc(
         request.add_header(key, value)
 
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
+        with _open_request(request, timeout=timeout) as response:
             body = response.read().decode("utf-8")
     except urllib.error.HTTPError as error:
         raise MetagraphedError(

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -3,7 +3,10 @@
 import json
 import unittest
 import urllib.error
+import urllib.request
 from unittest import mock
+
+import metagraphed.client as client
 
 from metagraphed import (
     MetagraphedClient,
@@ -40,7 +43,7 @@ class ClientTest(unittest.TestCase):
             captured["accept"] = request.get_header("Accept")
             return _FakeResponse({"ok": True, "data": {"netuid": 7}})
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
             out = metagraphed_fetch(
                 "/api/v1/subnets/{netuid}", path_params={"netuid": 7}
             )
@@ -60,7 +63,7 @@ class ClientTest(unittest.TestCase):
             captured["url"] = request.full_url
             return _FakeResponse({"ok": True})
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
             metagraphed_fetch(
                 "/api/v1/search",
                 query={"q": "image gen", "cursor": None, "limit": 5},
@@ -77,7 +80,7 @@ class ClientTest(unittest.TestCase):
             captured["url"] = request.full_url
             return _FakeResponse({"ok": True})
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
             MetagraphedClient(base_url="https://metagraph.sh").fetch("/api/v1/health")
 
         self.assertTrue(
@@ -88,7 +91,7 @@ class ClientTest(unittest.TestCase):
         def fake_urlopen(request, timeout=None):
             raise urllib.error.HTTPError(request.full_url, 404, "Not Found", {}, None)
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
             with self.assertRaises(MetagraphedError) as ctx:
                 metagraphed_fetch("/api/v1/subnets/{netuid}", path_params={"netuid": 9999})
         self.assertEqual(ctx.exception.status, 404)
@@ -102,7 +105,7 @@ class ClientTest(unittest.TestCase):
             captured["ua"] = request.get_header("User-agent")
             return _FakeResponse({"ok": True})
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
             metagraphed_fetch("/api/v1/health")
 
         self.assertIsNotNone(captured["ua"])
@@ -115,10 +118,36 @@ class ClientTest(unittest.TestCase):
             captured["ua"] = request.get_header("User-agent")
             return _FakeResponse({"ok": True})
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
             metagraphed_fetch("/api/v1/health", headers={"User-Agent": "my-app/1.0"})
 
         self.assertEqual(captured["ua"], "my-app/1.0")
+
+    def test_cross_origin_redirect_strips_custom_headers(self):
+        request = urllib.request.Request("https://api.example.test/v1", method="GET")
+        request.add_header("Accept", "application/json")
+        request.add_header("User-Agent", "metagraphed-python/test")
+        request.add_header("Authorization", "Bearer SECRET")
+        request.add_header("X-Api-Key", "SECRET")
+        request.add_header("Cookie", "session=SECRET")
+
+        redirected = client._CrossOriginSafeRedirectHandler().redirect_request(
+            request,
+            None,
+            302,
+            "Found",
+            {},
+            "https://attacker.example.test/collect",
+        )
+
+        self.assertIsNotNone(redirected)
+        self.assertEqual(redirected.get_header("Accept"), "application/json")
+        self.assertEqual(
+            redirected.get_header("User-agent"), "metagraphed-python/test"
+        )
+        self.assertIsNone(redirected.get_header("Authorization"))
+        self.assertIsNone(redirected.get_header("X-api-key"))
+        self.assertIsNone(redirected.get_header("Cookie"))
 
     def test_http_error_surfaces_api_error_envelope(self):
         import io
@@ -134,7 +163,7 @@ class ClientTest(unittest.TestCase):
             )
             raise urllib.error.HTTPError(request.full_url, 404, "Not Found", {}, body)
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
             with self.assertRaises(MetagraphedError) as ctx:
                 metagraphed_fetch(
                     "/api/v1/subnets/{netuid}", path_params={"netuid": 9999}
@@ -156,7 +185,7 @@ class ClientTest(unittest.TestCase):
             )
             raise urllib.error.HTTPError(request.full_url, 502, "Bad Gateway", {}, body)
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
             with self.assertRaises(MetagraphedError) as ctx:
                 metagraphed_fetch("/api/v1/health")
         self.assertEqual(ctx.exception.status, 502)
@@ -168,7 +197,8 @@ class ClientTest(unittest.TestCase):
                 self._body = b"<html>not json</html>"
 
         with mock.patch(
-            "urllib.request.urlopen", lambda request, timeout=None: _BadResponse()
+            "metagraphed.client._open_request",
+            lambda request, timeout=None: _BadResponse(),
         ):
             with self.assertRaises(MetagraphedError):
                 metagraphed_fetch("/api/v1/health")
@@ -182,7 +212,7 @@ class ClientTest(unittest.TestCase):
                 raise urllib.error.HTTPError(request.full_url, 503, "busy", {}, None)
             return _FakeResponse({"ok": True, "data": {"healthy": True}})
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
             out = metagraphed_fetch("/api/v1/health", retries=1, backoff=0)
 
         self.assertEqual(calls["n"], 2)
@@ -212,7 +242,7 @@ class ClientTest(unittest.TestCase):
                 )
             return _FakeResponse({"ok": True})
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen), mock.patch(
+        with mock.patch("metagraphed.client._open_request", fake_urlopen), mock.patch(
             "time.sleep", lambda seconds: sleeps.append(seconds)
         ):
             out = metagraphed_fetch("/api/v1/health", retries=2, backoff=0)
@@ -224,7 +254,7 @@ class ClientTest(unittest.TestCase):
         def fake_urlopen(request, timeout=None):
             raise urllib.error.HTTPError(request.full_url, 503, "busy", {}, None)
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
             with self.assertRaises(MetagraphedError) as ctx:
                 metagraphed_fetch("/api/v1/health", retries=2, backoff=0)
         self.assertEqual(ctx.exception.status, 503)
@@ -243,7 +273,7 @@ class ClientTest(unittest.TestCase):
             state["i"] += 1
             return _FakeResponse(page)
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
             seen = [
                 page["data"][0]
                 for page in metagraphed_paginate("/api/v1/subnets", query={"limit": 1})
@@ -261,7 +291,7 @@ class ClientTest(unittest.TestCase):
             captured["body"] = request.data
             return _FakeResponse({"jsonrpc": "2.0", "id": 1, "result": {"peers": 40}})
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
             result = metagraphed_rpc("finney", "system_health")
 
         self.assertEqual(result, {"peers": 40})
@@ -279,7 +309,7 @@ class ClientTest(unittest.TestCase):
                 }
             )
 
-        with mock.patch("urllib.request.urlopen", fake_urlopen):
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
             with self.assertRaises(MetagraphedError) as ctx:
                 metagraphed_rpc("finney", "nope")
         self.assertIn("Method not found", str(ctx.exception))
@@ -292,7 +322,7 @@ class FetchAllAndModelsTest(unittest.TestCase):
         def fake_urlopen(request, timeout=None):
             return next(responses)
 
-        return mock.patch("urllib.request.urlopen", fake_urlopen)
+        return mock.patch("metagraphed.client._open_request", fake_urlopen)
 
     def test_fetch_all_flattens_pages_following_cursor(self):
         pages = [


### PR DESCRIPTION
### Motivation
- The sync Python client attached caller-provided headers to `urllib.request.Request` and used `urllib.request.urlopen` with default redirect handling, which can forward sensitive headers across origins on HTTP redirects.

### Description
- Add `_CrossOriginSafeRedirectHandler` that compares scheme/host/port origins and removes non-allowlisted headers on cross-origin redirects, preserving normal redirect behavior otherwise in `python/src/metagraphed/client.py`.
- Add helper `_open_request` that builds an opener with the safe redirect handler and use it from `metagraphed_fetch` and `metagraphed_rpc` so GET and RPC flows use the safe opener instead of `urllib.request.urlopen`.
- Update tests in `python/tests/test_client.py` to patch the new `_open_request` helper and add `test_cross_origin_redirect_strips_custom_headers` that verifies `Authorization`, `X-Api-Key`, and `Cookie` are stripped while `Accept` and `User-Agent` are preserved.

### Testing
- Ran unit tests with `PYTHONPATH=python/src python -m unittest discover -s python/tests` and all tests passed (`OK`, 29 tests run, 7 skipped).
- Ran `git diff --check` to validate formatting and whitespace and it reported no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478676ebc832c8d325f23f1f8b69e)