### PR TITLE
fix(validate): reject future freshness timestamps

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1410,6 +1410,10 @@ function validateFreshnessForPublish(freshnessArtifact) {
       failures.push(`${source.id} has invalid as_of timestamp`);
       continue;
     }
+    if (observedAt > now) {
+      failures.push(`${source.id} as_of timestamp is in the future`);
+      continue;
+    }
     const ageHours = (now - observedAt) / 3_600_000;
     if (ageHours > source.stale_after_hours) {
       failures.push(


### PR DESCRIPTION
### Motivation
- Prevent publish freshness gate bypasses where `as_of` timestamps in the future are treated as fresh and therefore allow stale or missing operational data to pass publishing checks.

### Description
- Update `validateFreshnessForPublish` in `scripts/validate.mjs` to explicitly reject sources whose parsed `as_of` (`observedAt`) is later than `now` before computing age and stale-window checks.

### Testing
- Ran `npm run lint -- scripts/validate.mjs`, which succeeded.
- Ran `npm test -- tests/raw-artifact-freshness.test.mjs`, which reported 1 failing assertion in that test file (existing test expecting a published header returned `null`).
- Ran `METAGRAPH_REQUIRE_FRESHNESS=1 node scripts/validate.mjs`, which exited with an error due to missing local generated artifacts (e.g., `public/metagraph/providers.json`) in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478675b00832c831ef271b7c9c2e5)