### PR TITLE
fix(ci): detect regenerated untracked public artifacts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -176,8 +176,10 @@ jobs:
       - name: Verify committed derived artifacts are fresh
         if: steps.route.outputs.mode == 'full'
         run: |
-          if ! git diff --quiet -- public/ ':(exclude)public/metagraph/r2-manifest.json'; then
-            echo "::error::Committed derived artifacts under public/ are stale (a fresh build changed them). Run 'npm run build' and commit the result."
+          status=$(git status --porcelain --untracked-files=all -- public/ ':(exclude)public/metagraph/r2-manifest.json')
+          if [ -n "$status" ]; then
+            echo "::error::Committed derived artifacts under public/ are stale (a fresh build changed, deleted, or recreated them). Run 'npm run build' and commit the result."
+            printf '%s\n' "$status"
             git diff --name-only -- public/ ':(exclude)public/metagraph/r2-manifest.json'
             git diff --stat -- public/ ':(exclude)public/metagraph/r2-manifest.json'
             exit 1

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -135,6 +135,14 @@ for (const workflow of workflows) {
       workflow,
       "validate workflow must verify submitted artifacts from the deletion-filtered list",
     );
+    check(
+      content.includes(
+        "git status --porcelain --untracked-files=all -- public/",
+      ) &&
+        content.includes("Committed derived artifacts under public/ are stale"),
+      workflow,
+      "validate workflow must detect rebuilt-but-untracked public artifacts after build",
+    );
   }
   if (workflow === "submission-gate.yml") {
     check(


### PR DESCRIPTION
### Motivation
- Prevent a CI bypass where a PR that deletes a committed `public/metagraph/*` artifact could recreate it during the build and have the regenerated file be untracked, which `git diff` ignores allowing the deletion/tamper to slip through.

### Description
- Replace the diff-only freshness check with a porcelain status check by running `git status --porcelain --untracked-files=all -- public/ ':(exclude)public/metagraph/r2-manifest.json'` in `.github/workflows/validate.yml` and erroring if any status lines are present.
- Preserve the existing diagnostic outputs by printing the porcelain status and still running `git diff --name-only` and `git diff --stat` for tracked mismatches.
- Add an assertion to `scripts/validate-workflows.mjs` to ensure the workflow contains the new `git status --porcelain --untracked-files=all` check to prevent regressions.

### Testing
- Ran `npm run validate:workflows` and it validated the workflows (11 files) successfully.
- Ran `npm run format:check` after applying `prettier --write` to fix style and it passed formatting checks.
- Ran `npm run lint` which completed with no reported errors.
- Verified the new status-based check via a local `git status --porcelain --untracked-files=all -- public/ ':(exclude)public/metagraph/r2-manifest.json'` invocation and ensured the CI validation logic would now detect rebuilt-but-untracked artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34786815e0832c8c464b4410de4016)