### PR TITLE
fix(health): handle legacy surface id upserts

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -470,6 +470,14 @@ async function persistToD1(db, probed, runAt) {
          classification=excluded.classification, latency_ms=excluded.latency_ms,
          status_code=excluded.status_code, last_checked=excluded.last_checked,
          last_ok=excluded.last_ok, consecutive_failures=excluded.consecutive_failures,
+         updated_at=excluded.updated_at
+       ON CONFLICT(surface_id) DO UPDATE SET
+         surface_key=excluded.surface_key,
+         netuid=excluded.netuid, kind=excluded.kind, url=excluded.url,
+         provider=excluded.provider, status=excluded.status,
+         classification=excluded.classification, latency_ms=excluded.latency_ms,
+         status_code=excluded.status_code, last_checked=excluded.last_checked,
+         last_ok=excluded.last_ok, consecutive_failures=excluded.consecutive_failures,
          updated_at=excluded.updated_at`,
     );
     const statements = [];
@@ -643,6 +651,15 @@ export async function rollupDailyUptime(env, overrides = {}) {
      GROUP BY COALESCE(surface_key, surface_id), netuid
      ON CONFLICT(surface_key, day) WHERE surface_key IS NOT NULL DO UPDATE SET
        surface_id = excluded.surface_id,
+       netuid = excluded.netuid,
+       samples = excluded.samples,
+       ok_count = excluded.ok_count,
+       uptime_ratio = excluded.uptime_ratio,
+       avg_latency_ms = excluded.avg_latency_ms,
+       status = excluded.status,
+       updated_at = excluded.updated_at
+     ON CONFLICT(surface_id, day) DO UPDATE SET
+       surface_key = excluded.surface_key,
        netuid = excluded.netuid,
        samples = excluded.samples,
        ok_count = excluded.ok_count,

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -439,6 +439,7 @@ describe("runHealthProber", () => {
       apiUpsert.sql,
       /ON CONFLICT\(surface_key\) WHERE surface_key IS NOT NULL/,
     );
+    assert.match(apiUpsert.sql, /ON CONFLICT\(surface_id\) DO UPDATE SET/);
     assert.equal(apiUpsert.binds[1], "srf-sn7apikey000000");
     assert.equal(apiUpsert.binds[12], 3);
   });
@@ -1374,6 +1375,7 @@ describe("rollupDailyUptime (durable daily history)", () => {
       stmts[0].sql,
       /ON CONFLICT\(surface_key, day\) WHERE surface_key IS NOT NULL/,
     );
+    assert.match(stmts[0].sql, /ON CONFLICT\(surface_id, day\) DO UPDATE SET/);
     // binds: [day, updated_at, dayStart, dayEnd]
     assert.deepEqual(stmts[0].binds, [
       "2026-06-13",


### PR DESCRIPTION
### Motivation
- The prober still persisted `surface_key = NULL` for pre-#1005 artifacts while D1 upserts only handled conflicts on non-null `surface_key`, which can produce primary-key `surface_id` UNIQUE conflicts and leave D1 health rows stale.
- The caught-and-swallowed D1 batch error made the failure silent so KV advanced while durable D1 state did not, breaking continuity for legacy rows.

### Description
- Add a fallback `ON CONFLICT(surface_id) DO UPDATE SET ...` clause to the `surface_status` upsert so legacy rows keyed by `surface_id` are updated instead of causing primary-key conflicts.
- Add a fallback `ON CONFLICT(surface_id, day) DO UPDATE SET ...` clause to the `surface_uptime_daily` rollup insert so legacy daily rows are refreshed when rollups emit non-null `surface_key` values.
- Update `tests/health-prober.test.mjs` to assert both the stable `surface_key` conflict path and the legacy `surface_id` conflict path are present for status and daily rollups.
- Preserve existing behavior for non-legacy (non-null `surface_key`) rows and keep the partial-index stable-key upsert semantics intact.

### Testing
- Ran the focused test file with `npm test -- --run tests/health-prober.test.mjs` and all tests passed (1 file, 62 tests passed). 
- Ran lint with `npm run lint` and it completed successfully. 
- The modified tests assert the presence of both conflict handlers and succeeded under the test harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478684c04832c900b4c96d62ca268)