### PR TITLE
fix(client): bound uncached 304 retry

### DIFF
--- a/generated/metagraphed-client.ts
+++ b/generated/metagraphed-client.ts
@@ -580,13 +580,16 @@ export function createMetagraphedClient(
       query as Record<string, unknown> | undefined,
     );
     let attempt = 0;
-    let skipConditional = false;
+    let retriedUncachedNotModified = false;
     for (;;) {
       const requestHeaders = mergeRequestHeaders(clientOptions.headers, headers);
       const key = buildEtagCacheKey(url, requestHeaders);
-      const cached = !skipConditional && store ? store.get(key) : undefined;
+      const cached = !retriedUncachedNotModified && store ? store.get(key) : undefined;
       if (cached) {
         requestHeaders["if-none-match"] = cached.etag;
+      } else if (retriedUncachedNotModified) {
+        delete requestHeaders["if-none-match"];
+        delete requestHeaders["if-modified-since"];
       }
       let response: Response;
       try {
@@ -615,9 +618,15 @@ export function createMetagraphedClient(
           return cached.body as JsonResponse<Path>;
         }
         // Not Modified, but the store no longer has the entry (a shared/evicting
-        // store can drop it between send and receipt). Re-issue once without the
-        // conditional header to get a full body instead of throwing on the 304.
-        skipConditional = true;
+        // store can drop it between send and receipt). Re-issue once without
+        // conditional headers to get a full body, but never loop on repeated 304s.
+        if (retriedUncachedNotModified) {
+          throw new MetagraphedError(
+            "GET " + url.pathname + " returned 304 without a cached response",
+            response.status,
+          );
+        }
+        retriedUncachedNotModified = true;
         continue;
       }
       if (

--- a/scripts/generate-client.mjs
+++ b/scripts/generate-client.mjs
@@ -600,13 +600,16 @@ export function createMetagraphedClient(
       query as Record<string, unknown> | undefined,
     );
     let attempt = 0;
-    let skipConditional = false;
+    let retriedUncachedNotModified = false;
     for (;;) {
       const requestHeaders = mergeRequestHeaders(clientOptions.headers, headers);
       const key = buildEtagCacheKey(url, requestHeaders);
-      const cached = !skipConditional && store ? store.get(key) : undefined;
+      const cached = !retriedUncachedNotModified && store ? store.get(key) : undefined;
       if (cached) {
         requestHeaders["if-none-match"] = cached.etag;
+      } else if (retriedUncachedNotModified) {
+        delete requestHeaders["if-none-match"];
+        delete requestHeaders["if-modified-since"];
       }
       let response: Response;
       try {
@@ -635,9 +638,15 @@ export function createMetagraphedClient(
           return cached.body as JsonResponse<Path>;
         }
         // Not Modified, but the store no longer has the entry (a shared/evicting
-        // store can drop it between send and receipt). Re-issue once without the
-        // conditional header to get a full body instead of throwing on the 304.
-        skipConditional = true;
+        // store can drop it between send and receipt). Re-issue once without
+        // conditional headers to get a full body, but never loop on repeated 304s.
+        if (retriedUncachedNotModified) {
+          throw new MetagraphedError(
+            "GET " + url.pathname + " returned 304 without a cached response",
+            response.status,
+          );
+        }
+        retriedUncachedNotModified = true;
         continue;
       }
       if (

--- a/tests/client-sdk.test.ts
+++ b/tests/client-sdk.test.ts
@@ -439,6 +439,29 @@ describe("createMetagraphedClient", () => {
     expect((out as { data: unknown }).data).toEqual({ fresh: true });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  test("throws instead of looping on repeated 304 responses without a cache entry", async () => {
+    const fetchMock = vi.fn(async (_url: URL, init: RequestInit) => {
+      if (fetchMock.mock.calls.length === 2) {
+        expect(
+          (init.headers as Record<string, string>)["if-none-match"],
+        ).toBeUndefined();
+      }
+      return new Response(null, { status: 304 });
+    });
+    const client = createMetagraphedClient({
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await expect(
+      client.health({ headers: { "if-none-match": 'W/"caller-stale"' } }),
+    ).rejects.toMatchObject({
+      name: "MetagraphedError",
+      status: 304,
+      message: "GET /api/v1/health returned 304 without a cached response",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("createLruEtagCache", () => {


### PR DESCRIPTION
### Motivation

- Prevent the configured TypeScript client from spinning indefinitely when a server (or caller-supplied conditional header) repeatedly returns `304 Not Modified` with no cached body.
- Preserve the intended behavior of a single unconditional retry to recover from a dropped cache entry while making the retry bounded and robust.

### Description

- Replace the unbounded `skipConditional` loop with a boolean `retriedUncachedNotModified` guard that allows a single unconditional retry and throws if a second `304` is received.
- Strip conditional validators by deleting `if-none-match` and `if-modified-since` on the single unconditional retry so caller-provided headers cannot re-trigger repeated `304`s.
- Update the code generator `scripts/generate-client.mjs` to emit the same bounded retry behavior so regenerated clients preserve the fix.
- Add a regression test in `tests/client-sdk.test.ts` that verifies the client strips caller `If-None-Match` on the retry and throws instead of looping when the origin returns repeated `304` responses.

### Testing

- Ran the unit tests with `npm test -- --run tests/client-sdk.test.ts` and all tests passed (`25 passed`).
- Ran `npx prettier --write` and `npm run format:check` to ensure formatting and they succeeded.
- Ran `npm run validate:generated-client` and `npm run lint` and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478686114832cafa9f5fa5dc4c695)