### PR TITLE
fix(health): require consecutive failed incident samples

### DIFF
--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -382,7 +382,7 @@ function rowsForSql(sql) {
   if (sql.includes("SUM(ok) AS ok_count")) {
     return [{ surface_id: "s1", total: 100, ok_count: 98 }];
   }
-  if (sql.includes("WITH failures") || sql.includes("failures AS")) {
+  if (sql.includes("WITH checks") || sql.includes("checks AS")) {
     return [
       {
         netuid: 7,
@@ -545,6 +545,15 @@ describe("analytics routes (fake D1 with data)", () => {
       /GROUP BY COALESCE\(surface_key, surface_id\)/,
     );
     assert.match(queries[1].sql, /PARTITION BY surface_key/);
+    assert.doesNotMatch(
+      queries[1].sql,
+      /WHERE netuid = \? AND checked_at >= \? AND ok = 0/,
+    );
+    assert.match(
+      queries[1].sql,
+      /SUM\(CASE WHEN ok = 1 OR gap IS NULL OR gap > \?/,
+    );
+    assert.match(queries[1].sql, /FROM grouped\n {7}WHERE ok = 0/);
   });
   test("incidents SQL uses a hard incident row cap", async () => {
     const queries = [];
@@ -554,7 +563,7 @@ describe("analytics routes (fake D1 with data)", () => {
     );
     assert.equal(status, 200);
     const incidentQuery = queries.find((query) =>
-      query.sql.includes("WITH failures"),
+      query.sql.includes("WITH checks"),
     );
     assert.ok(incidentQuery.sql.includes("LIMIT ?"));
     assert.equal(incidentQuery.params.at(-1), 1000);
@@ -609,9 +618,15 @@ describe("analytics routes (fake D1 with data)", () => {
     );
     assert.equal(status, 200);
     const incidentQuery = queries.find((query) =>
-      query.sql.includes("WITH recent_failures"),
+      query.sql.includes("WITH recent_checks"),
     );
     assert.ok(incidentQuery.sql.includes("ORDER BY checked_at DESC"));
+    assert.doesNotMatch(incidentQuery.sql, /WHERE checked_at >= \? AND ok = 0/);
+    assert.match(
+      incidentQuery.sql,
+      /SUM\(CASE WHEN ok = 1 OR gap IS NULL OR gap > \?/,
+    );
+    assert.match(incidentQuery.sql, /FROM grouped\n {5}WHERE ok = 0/);
     assert.ok(incidentQuery.sql.includes("LIMIT ?"));
     assert.equal(incidentQuery.params[1], 5000);
     assert.equal(incidentQuery.params.at(-1), 1000);

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1352,23 +1352,24 @@ async function handleHealthIncidents(request, env, netuid, url) {
     // flapping endpoints cannot force unbounded result sets/responses.
     d1All(
       env,
-      `WITH failures AS (
+      `WITH checks AS (
          SELECT COALESCE(surface_key, surface_id) AS surface_key,
                 surface_id,
                 checked_at,
+                ok,
                 checked_at - LAG(checked_at)
                   OVER (
                     PARTITION BY COALESCE(surface_key, surface_id)
                     ORDER BY checked_at
                   ) AS gap
          FROM surface_checks
-         WHERE netuid = ? AND checked_at >= ? AND ok = 0
+         WHERE netuid = ? AND checked_at >= ?
        ),
        grouped AS (
-         SELECT surface_key, surface_id, checked_at,
-                SUM(CASE WHEN gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
+         SELECT surface_key, surface_id, checked_at, ok,
+                SUM(CASE WHEN ok = 1 OR gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
                   OVER (PARTITION BY surface_key ORDER BY checked_at) AS grp
-         FROM failures
+         FROM checks
        )
        SELECT MAX(surface_id) AS surface_id,
               surface_key,
@@ -1376,6 +1377,7 @@ async function handleHealthIncidents(request, env, netuid, url) {
               MAX(checked_at) AS ended_at,
               COUNT(*) AS failed_samples
        FROM grouped
+       WHERE ok = 0
        GROUP BY surface_key, grp
        HAVING COUNT(*) >= ?
        ORDER BY surface_id, started_at
@@ -1418,27 +1420,27 @@ async function handleGlobalIncidents(request, env, url) {
   const since = Date.now() - days * DAY_MS;
   const incidentRows = await d1All(
     env,
-    `WITH recent_failures AS (
-       SELECT netuid, COALESCE(surface_key, surface_id) AS surface_key, surface_id, checked_at
+    `WITH recent_checks AS (
+       SELECT netuid, COALESCE(surface_key, surface_id) AS surface_key, surface_id, checked_at, ok
        FROM surface_checks
-       WHERE checked_at >= ? AND ok = 0
+       WHERE checked_at >= ?
        ORDER BY checked_at DESC
        LIMIT ?
      ),
-     failures AS (
-       SELECT netuid, surface_key, surface_id, checked_at,
+     checks AS (
+       SELECT netuid, surface_key, surface_id, checked_at, ok,
               checked_at - LAG(checked_at)
                 OVER (
                   PARTITION BY netuid, surface_key
                   ORDER BY checked_at
                 ) AS gap
-       FROM recent_failures
+       FROM recent_checks
      ),
      grouped AS (
-       SELECT netuid, surface_key, surface_id, checked_at,
-              SUM(CASE WHEN gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
+       SELECT netuid, surface_key, surface_id, checked_at, ok,
+              SUM(CASE WHEN ok = 1 OR gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
                 OVER (PARTITION BY netuid, surface_key ORDER BY checked_at) AS grp
-       FROM failures
+       FROM checks
      )
      SELECT netuid,
             MAX(surface_id) AS surface_id,
@@ -1447,6 +1449,7 @@ async function handleGlobalIncidents(request, env, url) {
             MAX(checked_at) AS ended_at,
             COUNT(*) AS failed_samples
      FROM grouped
+     WHERE ok = 0
      GROUP BY netuid, surface_key, grp
      HAVING COUNT(*) >= ?
      ORDER BY started_at DESC


### PR DESCRIPTION
### Motivation
- The incident threshold semantics intended to require consecutive failed probes (e.g. ≥2 consecutive failures) but the SQL built its gap-islands from failure-only rows, allowing non-consecutive failures separated by successes to be grouped and counted as a sustained incident.
- This produced many spurious incidents (single-probe blips counted) and diverged from the documented `MIN_INCIDENT_SAMPLES` intent.

### Description
- Update incident SQL to build gap-islands from all checks (include `ok`) so intervening successes reset groups before counting failures, then filter grouped rows back to failures with `WHERE ok = 0` prior to applying `HAVING COUNT(*) >= ?` (per-subnet and global queries). (modified `workers/api.mjs`).
- Adjust the windowing expressions to include `ok` and change grouping logic to `SUM(CASE WHEN ok = 1 OR gap IS NULL OR gap > ? THEN 1 ELSE 0 END)` so only consecutive failed checks are grouped together.
- Update tests and fake-D1 fixtures to assert the new SQL shape and to expect queries to retain successes during grouping (modified `tests/analytics.test.mjs`).
- Keep the public payload cap and the existing `MIN_INCIDENT_SAMPLES` threshold semantics intact by applying the threshold after grouping and filtering back to failed checks.

### Testing
- Ran `npm run lint` and fixed reported issues (passed).
- Ran `npm test -- tests/analytics.test.mjs -t incidents` and the incidents-related tests passed.
- Ran full `npm test -- tests/analytics.test.mjs`; one unrelated pre-existing test in the cold-D1 leaderboards fixture still fails (assertion expecting non-empty `most-complete` board), so full-suite run shows that existing test failure remains unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347867bcc4832c9761085f1541ab39)