### PR TITLE
fix(publish): point KV latest at immutable R2 run

### DIFF
--- a/scripts/kv-publish-pointer.mjs
+++ b/scripts/kv-publish-pointer.mjs
@@ -29,7 +29,11 @@ const pointer = {
   // build stamp). The Worker surfaces this as meta.published_at so consumers
   // read true freshness instead of the epoch content marker.
   published_at: buildSummary.published_at || null,
-  latest_prefix: manifest.latest_prefix,
+  // The Worker resolves live artifacts through latest_prefix. Point it at the
+  // immutable run prefix so a failed KV sidecar publish after R2 upload keeps
+  // the previous pointer on the previous run instead of mixing stale metadata
+  // with newly overwritten latest/ objects.
+  latest_prefix: manifest.run_prefix,
   run_prefix: manifest.run_prefix,
   manifest_hash: hashJson(manifest),
   artifact_count: manifest.artifact_count,
@@ -64,11 +68,10 @@ const sourceFreshness = {
   source_health: sourceHealth.summary,
 };
 // Order matters: metagraph:latest is the pointer the Worker reads to resolve the
-// live R2 run, so it is written LAST. The sidecar records (feature-flags,
-// endpoint-pools, source-freshness) go first, so a mid-sequence wrangler failure
-// (process.exit in putKv) can never leave the pointer advanced ahead of its
-// sidecars — the Worker keeps serving the previous, internally-consistent run
-// until the final pointer write succeeds.
+// live immutable R2 run prefix, so it is written LAST. The sidecar records
+// (feature-flags, endpoint-pools, source-freshness) go first, so a mid-sequence
+// wrangler failure (process.exit in putKv) keeps the previous pointer and its
+// previous run-specific artifacts live until the final pointer write succeeds.
 const kvEntries = [
   ["metagraph:feature-flags", featureFlags],
   ["metagraph:endpoint-pools", endpointPoolStatus],

--- a/tests/kv-publish-pointer.test.mjs
+++ b/tests/kv-publish-pointer.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "vitest";
+
+test("KV latest pointer uses immutable run prefix for Worker artifact reads", () => {
+  const source = readFileSync("scripts/kv-publish-pointer.mjs", "utf8");
+
+  assert.match(source, /latest_prefix: manifest\.run_prefix/);
+  assert.doesNotMatch(source, /latest_prefix: manifest\.latest_prefix/);
+  assert.match(source, /previous run-specific artifacts live/);
+});


### PR DESCRIPTION
### Motivation
- The publish workflow can make mutable R2 `latest/` objects live before the KV pointer is updated, which allows a sidecar KV write failure to leave new R2 content paired with stale KV metadata when `metagraph:latest` points at the mutable `latest/` prefix. 
- The pointer should keep Workers resolving artifacts via an immutable run-specific prefix until the final pointer write succeeds to avoid mixing new object contents with old metadata.

### Description
- Set `pointer.latest_prefix = manifest.run_prefix` in `scripts/kv-publish-pointer.mjs` and refresh the surrounding comment to reflect that the KV pointer references an immutable run prefix. 
- Add a regression test `tests/kv-publish-pointer.test.mjs` that asserts the published pointer uses `manifest.run_prefix` rather than `manifest.latest_prefix`.

### Testing
- Ran `npm run test -- tests/kv-publish-pointer.test.mjs`, which passed. 
- Ran `npm run lint` and `npm run format:check`, which succeeded. 
- Attempted `npm run kv:publish:dry-run`, which was exercised but cannot fully complete in this checkout due to a missing generated artifact (`public/metagraph/build-summary.json`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478680a90832ca2090be53eaec6bb)