### PR TITLE
fix(api): preserve 404s for missing composed artifacts

### DIFF
--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -1490,6 +1490,29 @@ describe("composed-artifact health overlays", () => {
 });
 
 describe("worker live health overlay on composed routes", () => {
+  const seedComposedArchive = ({
+    overview = { netuid: 7, health: null },
+    catalog = { netuid: 7, services: [] },
+  } = {}) => ({
+    async get(key) {
+      if (String(key).includes("overview/7.json")) {
+        return {
+          async json() {
+            return overview;
+          },
+        };
+      }
+      if (String(key).includes("agent-catalog/7.json")) {
+        return {
+          async json() {
+            return catalog;
+          },
+        };
+      }
+      return null;
+    },
+  });
+
   test("/api/v1/subnets/7/overview overlays live health from KV", async () => {
     const env = createLocalArtifactEnv({
       METAGRAPH_CONTROL: kvWith({
@@ -1501,6 +1524,7 @@ describe("worker live health overlay on composed routes", () => {
           surfaces: [],
         },
       }),
+      METAGRAPH_ARCHIVE: seedComposedArchive(),
     });
     const res = await handleRequest(req("/api/v1/subnets/7/overview"), env, {});
     assert.equal(res.status, 200);
@@ -1519,6 +1543,7 @@ describe("worker live health overlay on composed routes", () => {
           surfaces: [],
         },
       }),
+      METAGRAPH_ARCHIVE: seedComposedArchive(),
     });
     const res = await handleRequest(req("/api/v1/agent-catalog/7"), env, {});
     assert.equal(res.status, 200);
@@ -1542,8 +1567,43 @@ describe("worker live health overlay on composed routes", () => {
     assert.equal((await res.json()).meta.source, "live-cron-prober");
   });
 
+  test("live overlays preserve missing composed artifact 404s", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: kvWith({
+        "health:current": {
+          last_run_at: "2026-06-13T00:00:00.000Z",
+          subnets: [{ netuid: 1, status: "ok" }],
+          surfaces: [],
+        },
+      }),
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return null;
+        },
+      },
+    });
+
+    const overview = await handleRequest(
+      req("/api/v1/subnets/999999/overview"),
+      env,
+      {},
+    );
+    assert.equal(overview.status, 404);
+    assert.equal((await overview.json()).ok, false);
+
+    const catalog = await handleRequest(
+      req("/api/v1/agent-catalog/999999"),
+      env,
+      {},
+    );
+    assert.equal(catalog.status, 404);
+    assert.equal((await catalog.json()).ok, false);
+  });
+
   test("composed routes fall back to the static artifact when KV+D1 are cold", async () => {
-    const env = createLocalArtifactEnv();
+    const env = createLocalArtifactEnv({
+      METAGRAPH_ARCHIVE: seedComposedArchive(),
+    });
     const res = await handleRequest(req("/api/v1/subnets/7/overview"), env, {});
     assert.equal(res.status, 200);
     assert.notEqual((await res.json()).meta.source, "live-cron-prober");
@@ -1721,7 +1781,9 @@ describe("worker live health overlay on composed routes", () => {
   test("composed overview no longer embeds a baked health status", async () => {
     // The built artifact carries health:null; cold reads must not surface a
     // stale status (the overlay would set it live in prod).
-    const env = createLocalArtifactEnv();
+    const env = createLocalArtifactEnv({
+      METAGRAPH_ARCHIVE: seedComposedArchive(),
+    });
     const res = await handleRequest(req("/api/v1/subnets/7/overview"), env, {});
     const body = await res.json();
     assert.equal(body.data.health, null);

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -3160,6 +3160,10 @@ async function liveHealthOverlay(env, matched, staticData) {
       break;
     }
     case "subnet-overview": {
+      if (!staticData) {
+        data = null;
+        break;
+      }
       data = overlayOverviewHealth(
         staticData,
         await getLive(),
@@ -3168,6 +3172,10 @@ async function liveHealthOverlay(env, matched, staticData) {
       break;
     }
     case "agent-catalog-subnet": {
+      if (!staticData) {
+        data = null;
+        break;
+      }
       data = overlayCatalogDetail(
         staticData,
         await getLive(),


### PR DESCRIPTION
### Motivation

- Prevent a regression where the live health overlay could synthesize HTTP 200 responses for missing composed artifacts (subnet overview and per-subnet agent catalog) when KV/D1 live snapshots exist, which breaks response integrity for nonexistent resources.

### Description

- Require an existing static composed artifact before applying the live overlay in `liveHealthOverlay` for the `subnet-overview` route by checking `staticData` and returning `null` when absent (`workers/api.mjs`).
- Apply the same `staticData` guard to the `agent-catalog-subnet` route so live health cannot fabricate an empty per-subnet catalog (`workers/api.mjs`).
- Add a regression test that asserts warm live health snapshots do not convert missing composed artifacts into HTTP 200 responses and seed composed-route fixtures used by successful overlay tests (`tests/health-serving.test.mjs`).

### Testing

- Ran `npx vitest run tests/health-serving.test.mjs` and the suite passed (`105 passed`).
- Ran `npx vitest run tests/worker-runtime.test.mjs` which failed due to unrelated local fixture expectations returning 404s before the changed path is reached (these failures are not caused by the live-overlay changes).
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347867fd50832c8afe2e762acf08ed)