### PR TITLE
fix(search): return semantic capability facets

### DIFF
--- a/schemas/ai/semantic-search.schema.json
+++ b/schemas/ai/semantic-search.schema.json
@@ -22,7 +22,9 @@
           "slug",
           "title",
           "subtitle",
-          "url"
+          "url",
+          "categories",
+          "service_kinds"
         ],
         "properties": {
           "score": { "type": "number" },
@@ -31,7 +33,15 @@
           "slug": { "type": ["string", "null"] },
           "title": { "type": ["string", "null"] },
           "subtitle": { "type": ["string", "null"] },
-          "url": { "type": ["string", "null"] }
+          "url": { "type": ["string", "null"] },
+          "categories": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "service_kinds": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
         }
       }
     }

--- a/src/ai-search.mjs
+++ b/src/ai-search.mjs
@@ -231,6 +231,10 @@ function mapMatch(match) {
     title: metadata.title ?? null,
     subtitle: metadata.subtitle ?? null,
     url: metadata.url ?? null,
+    categories: Array.isArray(metadata.categories) ? metadata.categories : [],
+    service_kinds: Array.isArray(metadata.service_kinds)
+      ? metadata.service_kinds
+      : [],
   };
 }
 

--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -82,6 +82,8 @@ function stubVectorize() {
             title: `Subnet ${i + 1}`,
             subtitle: `summary ${i + 1}`,
             url: `https://api.metagraph.sh/api/v1/subnets/${i + 1}/overview`,
+            categories: i === 0 ? ["inference"] : [],
+            service_kinds: i === 0 ? ["openapi", "sse"] : [],
           },
         })),
       });
@@ -372,6 +374,8 @@ describe("semanticSearch", () => {
     assert.equal(out.count, 3);
     assert.equal(out.results[0].netuid, 1);
     assert.equal(typeof out.results[0].score, "number");
+    assert.deepEqual(out.results[0].categories, ["inference"]);
+    assert.deepEqual(out.results[0].service_kinds, ["openapi", "sse"]);
   });
   test("rejects a blank query", async () => {
     const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
@@ -629,6 +633,8 @@ describe("ai-search defensive branches", () => {
     const out = await semanticSearch(env, "x");
     assert.equal(out.results[0].score, 0);
     assert.equal(out.results[0].netuid, null);
+    assert.deepEqual(out.results[0].categories, []);
+    assert.deepEqual(out.results[0].service_kinds, []);
   });
 
   test("askQuestion frames retrieved descriptions as untrusted JSON data", async () => {


### PR DESCRIPTION
### Motivation

- The search index and `embeddingMetadata()` began storing `categories` and `service_kinds`, but the semantic search result mapper dropped those fields causing callers to be unable to read or post-filter on capability facets.

### Description

- Include `categories` and `service_kinds` from Vectorize metadata in the semantic result projection by updating `mapMatch()` in `src/ai-search.mjs` to return these fields (defaulting to empty arrays when absent).
- Update the semantic search response contract in `schemas/ai/semantic-search.schema.json` to require and type the `categories` and `service_kinds` arrays for each result.
- Add regression coverage in `tests/ai-search.test.mjs` by enriching the `VECTORIZE` test stub with `categories`/`service_kinds` and asserting the values are propagated and default to empty arrays when metadata is missing.

### Testing

- Ran the focused semantic tests with `npx vitest run tests/ai-search.test.mjs -t "semanticSearch"`, which passed.
- Ran the AI route validator with `npm run validate:ai`, which passed and accepted the updated schema.
- Ran the full test target `npm test -- tests/ai-search.test.mjs` and observed one unrelated pre-existing failure in the embedding-sync cron test (`embedding-sync cron > the daily cron triggers an embedding sync` returns `ok: false`), while all semantic-search related tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347868c120832c86563831bebdc09d)