### PR TITLE
fix(publish): keep manifest timestamp from production build

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -60,9 +60,7 @@ jobs:
           echo "METAGRAPH_PUBLISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" >> "$GITHUB_ENV"
 
       - name: Prepare reviewed publish artifacts
-        run: |
-          npm run build
-          npm run r2:manifest
+        run: npm run build
         env:
           # The production build re-snapshots adapters from live GitHub metadata
           # so the publish is fresh by construction. A token is always present

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -203,10 +203,14 @@ for (const workflow of workflows) {
     );
     check(
       refreshJob.includes('METAGRAPH_PRODUCTION_BUILD: "1"') &&
-        refreshJob.includes("npm run build") &&
-        refreshJob.includes("npm run r2:manifest"),
+        refreshJob.includes("npm run build"),
       workflow,
       "publish workflow refresh job must prepare R2 artifacts with the production probe-health build path",
+    );
+    check(
+      !refreshJob.includes("npm run r2:manifest"),
+      workflow,
+      "publish workflow refresh job must not regenerate the R2 manifest outside the production build timestamp context",
     );
     check(
       /\brefresh:\n[\s\S]*\bpublish:\n[\s\S]*needs:\s+refresh/.test(content),


### PR DESCRIPTION
### Motivation

- The refresh job ran `npm run build` (which writes an R2 manifest using a production build timestamp) and then reran `npm run r2:manifest` outside that timestamp context, which could overwrite the manifest with the 1970 fallback timestamp and collapse versioned artifact history.
- The intent is to ensure the manifest produced by the production build retains its effective `METAGRAPH_BUILD_TIMESTAMP` and is not recomputed out of context.

### Description

- Remove the standalone `npm run r2:manifest` invocation from the `refresh` job in `.github/workflows/publish-cloudflare.yml` so the manifest written by `npm run build` is preserved.
- Update `scripts/validate-workflows.mjs` to continue requiring the production build path and to explicitly reject refresh-job standalone R2 manifest regeneration by adding a check that `npm run r2:manifest` is not present in the refresh job.
- The change is minimal and workflow-only and preserves the existing production build path and artifact staging logic.

### Testing

- Ran `npm run validate:workflows` and it completed successfully, validating the updated workflow checks.
- Ran `npm test` which produced unrelated failures because the test checkout in this environment is missing generated public artifacts (e.g., `public/metagraph/providers.json` and `public/metagraph/build-summary.json`), so the broad artifact/API test failures are not caused by this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34786789c4832c9aec00f9d82d15fa)