### PR TITLE
fix(workflow): preserve R2 manifest publish timestamp

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -70,6 +70,7 @@ jobs:
           # shipping degraded adapter data (mirrors sync-subnets.yml).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          METAGRAPH_BUILD_TIMESTAMP: ${{ env.METAGRAPH_PUBLISHED_AT }}
           METAGRAPH_REQUIRE_ADAPTER_AUTH: "1"
 
       # Belt-and-suspenders for Finding 1: the build just re-snapshotted adapters


### PR DESCRIPTION
### Motivation
- The production publish workflow stamped `METAGRAPH_PUBLISHED_AT` but then ran a standalone `npm run r2:manifest` that did not inherit `METAGRAPH_BUILD_TIMESTAMP`, allowing the manifest to be rewritten with the epoch fallback timestamp (`1970-01-01T00:00:00.000Z`).

### Description
- Pass `METAGRAPH_BUILD_TIMESTAMP: ${{ env.METAGRAPH_PUBLISHED_AT }}` into the `Prepare reviewed publish artifacts` step in `.github/workflows/publish-cloudflare.yml` so both `npm run build` and the subsequent standalone `npm run r2:manifest` use the same production timestamp.

### Testing
- Ran `npm run validate:workflows` which validated the workflow files successfully. 
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478677e30832cad46cfac0c4d0890)