### PR TITLE
fix(intake): process endpoint submissions

### DIFF
--- a/.github/workflows/intake-import-pr.yml
+++ b/.github/workflows/intake-import-pr.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   import:
-    if: contains(github.event.issue.labels.*.name, 'interface-submission') && contains(github.event.issue.labels.*.name, 'metagraphed-import-approved')
+    if: (contains(github.event.issue.labels.*.name, 'interface-submission') || contains(github.event.issue.labels.*.name, 'endpoint-submission')) && contains(github.event.issue.labels.*.name, 'metagraphed-import-approved')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -227,6 +227,7 @@ export function buildIssueIntakeReport({
 
   const auth = normalizeAuth(
     fields["does this interface require authentication?"] ||
+      fields["does this endpoint require authentication?"] ||
       fields.auth_required,
   );
   if (auth.value === null) {

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -2149,6 +2149,28 @@ describe("submission policy helpers", () => {
     assert.equal(valid.public_state, "submit_pr");
     assert.equal(valid.import_allowed, false);
 
+    const endpointBody = validBody
+      .replace("### Interface kind", "### Endpoint kind")
+      .replace("### Provider or team", "### Provider or operator slug")
+      .replace(
+        "### Does this interface require authentication?",
+        "### Does this endpoint require authentication?",
+      );
+    const endpoint = buildIssueIntakeReport({
+      issue: {
+        number: 11,
+        title: "endpoint: docs",
+        user: { login: "jsonbored" },
+        labels: [{ name: "endpoint-submission" }],
+        body: endpointBody,
+      },
+      native,
+      providers,
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+    assert.equal(endpoint.public_state, "submit_pr");
+    assert.equal(endpoint.candidate.auth_required, false);
+
     const manual = buildIssueIntakeReport({
       issue: {
         number: 8,


### PR DESCRIPTION
### Motivation
- New endpoint issue template used the `endpoint-submission` label and a different auth heading (`Does this endpoint require authentication?`), so endpoint issues were not picked up by the existing intake import workflow and their auth field was not parsed, causing valid endpoint submissions to fail intake.

### Description
- Update the import workflow condition in `.github/workflows/intake-import-pr.yml` to allow either `interface-submission` or `endpoint-submission` to trigger the import when `metagraphed-import-approved` is present.
- Extend the intake parser in `scripts/submission-policy.mjs` to read `fields["does this endpoint require authentication?"]` in addition to the existing interface heading and raw `auth_required` fallback before calling `normalizeAuth`.
- Add a regression case to `tests/script-utils.test.mjs` that constructs an `endpoint-submission` issue body using `Endpoint kind`, `Provider or operator slug`, and `Does this endpoint require authentication?`, and asserts the parsed intake state and `candidate.auth_required`.

### Testing
- Ran `npx vitest run tests/script-utils.test.mjs --test-name-pattern "submission policy helpers"`, and the targeted suite passed (tests for endpoint parsing succeeded). 
- Ran `npm run validate:intake`, and the intake template validation passed (`Issue intake templates passed validation`).
- Ran `git diff --check` with no issues reported. 
- A broader `npm test -- --test-name-pattern "submission policy helpers"` invocation failed earlier because it imported an unrelated test (`tests/search-quality.test.mjs`) that requires artifact path configuration in this environment, but the targeted test runs used for this PR succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478683bb0832cb4bb5347c4a1ce99)