### PR TITLE
fix(schemas): preserve committed index on clean builds

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -5650,6 +5650,14 @@ function schemaIndexEntryMatchesSurface(entry, surface, capturedDetails) {
 
   const relativePath = schemaDetailArtifactRelativePath(entry.path);
   const captured = capturedDetails.get(relativePath);
+  // Clean local/CI builds do not have the R2-only per-surface schema detail
+  // files, so only enforce document-backed detail verification when such files
+  // were captured before the staging wipe.
+  const detailMatches =
+    capturedDetails.size === 0 ||
+    (captured &&
+      captured.documentHash === entry.hash &&
+      stableStringify(captured.snapshot) === stableStringify(entry.snapshot));
   return (
     entry.path === `/metagraph/schemas/${surface.id}.json` &&
     typeof entry.content_type === "string" &&
@@ -5666,9 +5674,7 @@ function schemaIndexEntryMatchesSurface(entry, surface, capturedDetails) {
     entry.snapshot.hash === entry.hash &&
     (entry.snapshot.previous_hash || null) === (entry.previous_hash || null) &&
     entry.snapshot.drift_status === entry.drift_status &&
-    captured &&
-    captured.documentHash === entry.hash &&
-    stableStringify(captured.snapshot) === stableStringify(entry.snapshot)
+    detailMatches
   );
 }
 

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -409,6 +409,43 @@ test("artifact build does not preserve forged schema snapshot metadata", () => {
   }
 }, 30_000);
 
+test("artifact build preserves committed schema index without R2 schema details", () => {
+  const schemaIndexPath = artifactFilePath("schemas/index.json");
+  const originalSchemaIndex = readFileSync(schemaIndexPath, "utf8");
+  const originalSchemaIndexJson = JSON.parse(originalSchemaIndex);
+  const supportArtifacts = snapshotSupportArtifacts();
+  const backupDir = mkdtempSync(`${tmpdir()}/metagraphed-schema-r2-`);
+  const stagingBackup = `${backupDir}/metagraph-r2`;
+  const hadStagingRoot = existsSync(r2StagingRoot);
+  if (hadStagingRoot) {
+    cpSync(r2StagingRoot, stagingBackup, { recursive: true });
+  }
+
+  assert.equal(originalSchemaIndexJson.source, "openapi-snapshot");
+  assert.equal(originalSchemaIndexJson.schemas.length > 0, true);
+
+  try {
+    rmSync(r2StagingRoot, { recursive: true, force: true });
+    execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: process.env,
+      stdio: "pipe",
+    });
+
+    const rebuiltSchemaIndex = readFileSync(schemaIndexPath, "utf8");
+    assert.deepEqual(JSON.parse(rebuiltSchemaIndex), originalSchemaIndexJson);
+  } finally {
+    writeFileSync(schemaIndexPath, originalSchemaIndex);
+    rmSync(r2StagingRoot, { recursive: true, force: true });
+    if (hadStagingRoot) {
+      cpSync(stagingBackup, r2StagingRoot, { recursive: true });
+    }
+    restoreSupportArtifacts(supportArtifacts);
+    rmSync(backupDir, { recursive: true, force: true });
+  }
+}, 30_000);
+
 test("committed R2 manifest does not use fallback history keys", () => {
   const manifest = JSON.parse(
     readFileSync("public/metagraph/r2-manifest.json", "utf8"),


### PR DESCRIPTION
### Motivation
- A recent change required R2-only per-surface schema detail files to validate reuse of a committed `openapi-snapshot` index, which caused clean local/CI builds (without those R2 files) to drop the committed schema index and replace it with an empty placeholder.
- The intent is to keep the reproducible behavior for CI/local builds by preserving committed schema snapshot metadata when no R2 detail artifacts are present, while still enforcing stricter verification when those detail artifacts exist.

### Description
- Relax `schemaIndexEntryMatchesSurface` in `scripts/build-artifacts.mjs` to treat a missing `capturedDetails` map (`capturedDetails.size === 0`) as a signal to skip the per-surface document-backed verification, and otherwise continue to require captured document hash and snapshot equality.`
- Add a regression test in `tests/artifacts.test.mjs` that removes the R2 staging tree, runs `scripts/build-artifacts.mjs`, and asserts the committed `public/metagraph/schemas/index.json` is preserved when no R2 detail files exist.
- Keep strict verification unchanged for builds that have captured per-surface schema detail artifacts.

### Testing
- Ran `npx vitest run tests/artifacts.test.mjs -t "schema index"`, which passed (the focused test passed and the suite reported the test as successful).
- Ran `git diff --check` locally to ensure no whitespace or diff-check issues, which reported clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34ebf055f0832c9486bebe8b92b098)