### PR TITLE
fix(registry): uniquify boosted Chutes candidate id

### DIFF
--- a/registry/candidates/community/community-sn-64-data-artifact-chutes-boosted-api-chutes-ai.json
+++ b/registry/candidates/community/community-sn-64-data-artifact-chutes-boosted-api-chutes-ai.json
@@ -3,7 +3,7 @@
     {
       "auth_required": false,
       "confidence": "medium",
-      "id": "community-sn-64-data-artifact-api-chutes-ai",
+      "id": "community-sn-64-data-artifact-chutes-boosted-api-chutes-ai",
       "kind": "data-artifact",
       "name": "Chutes community data-artifact",
       "netuid": 64,


### PR DESCRIPTION
### Motivation
- Fix a duplicated candidate id introduced by adding a new Chutes data-artifact candidate, which caused the registry validator to fail and could cause verification metadata collisions if ids are not unique.

### Description
- Rename the candidate id in `registry/candidates/community/community-sn-64-data-artifact-chutes-boosted-api-chutes-ai.json` from `community-sn-64-data-artifact-api-chutes-ai` to `community-sn-64-data-artifact-chutes-boosted-api-chutes-ai`, preserving the boosted URL and all other candidate metadata.

### Testing
- Ran a registry-wide duplicate-id check (`node --input-type=module <<'NODE' ... NODE`) which reported `2076` unique candidate ids, and ran `npm run validate` which completed successfully (validated 129 native subnet(s), 1135 surface(s), 92 provider(s), and 2076 candidate(s)).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34f0237c0c832c8bb0092834e37c03)