### PR TITLE
fix(ci): allowlist documented local subtensor RPC in public-safety scan

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -29,6 +29,11 @@ const patterns = [
     name: "private or loopback URL",
     regex:
       /(?:https?|wss?):\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[0-1])\.\d+\.\d+)/i,
+    // The standard local subtensor RPC endpoint is documented setup guidance for
+    // the `local` network surface (llms.txt / setup docs), not a leaked internal
+    // URL. Scoped to the exact well-known endpoint; any other loopback URL on the
+    // same line is still flagged (allowlisted spans are stripped before testing).
+    allow: /wss?:\/\/127\.0\.0\.1:9944\b/gi,
   },
   {
     name: "token-like assignment",
@@ -137,7 +142,11 @@ for (const root of targetRoots) {
         if (pattern.soft && skipSoft) {
           continue;
         }
-        if (pattern.regex.test(line)) {
+        // Strip allowlisted spans (e.g. the documented local subtensor RPC
+        // endpoint) before testing, so a real leak elsewhere on the same line
+        // is still caught.
+        const probe = pattern.allow ? line.replace(pattern.allow, "") : line;
+        if (pattern.regex.test(probe)) {
           findings.push(`${relative}:${index + 1}: ${pattern.name}`);
         }
       }


### PR DESCRIPTION
Follow-up to #1211. The `checks` job's **Public-safety scan** failed on `ws://127.0.0.1:9944` in the generated llms.txt files — but that's documented setup guidance for the `local` network surface (the standard subtensor dev RPC endpoint), not a leaked internal URL. This failure was masked behind the Lint+format failure until #1211 fixed formatting.

Adds a scoped `allow` exemption for the exact endpoint; allowlisted spans are stripped before the regex test, so any *other* loopback URL on the same line is still flagged.

Local: `scan:public-safety` passes, `validate:private-boundary` passes, lint/format clean.