### PR TITLE
fix: require captured schema details for index reuse

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -5650,14 +5650,10 @@ function schemaIndexEntryMatchesSurface(entry, surface, capturedDetails) {
 
   const relativePath = schemaDetailArtifactRelativePath(entry.path);
   const captured = capturedDetails.get(relativePath);
-  // Clean local/CI builds do not have the R2-only per-surface schema detail
-  // files, so only enforce document-backed detail verification when such files
-  // were captured before the staging wipe.
   const detailMatches =
-    capturedDetails.size === 0 ||
-    (captured &&
-      captured.documentHash === entry.hash &&
-      stableStringify(captured.snapshot) === stableStringify(entry.snapshot));
+    captured &&
+    captured.documentHash === entry.hash &&
+    stableStringify(captured.snapshot) === stableStringify(entry.snapshot);
   return (
     entry.path === `/metagraph/schemas/${surface.id}.json` &&
     typeof entry.content_type === "string" &&

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -409,7 +409,7 @@ test("artifact build does not preserve forged schema snapshot metadata", () => {
   }
 }, 30_000);
 
-test("artifact build preserves committed schema index without R2 schema details", () => {
+test("artifact build regenerates schema index without R2 schema details", () => {
   const schemaIndexPath = artifactFilePath("schemas/index.json");
   const originalSchemaIndex = readFileSync(schemaIndexPath, "utf8");
   const originalSchemaIndexJson = JSON.parse(originalSchemaIndex);
@@ -424,8 +424,28 @@ test("artifact build preserves committed schema index without R2 schema details"
   assert.equal(originalSchemaIndexJson.source, "openapi-snapshot");
   assert.equal(originalSchemaIndexJson.schemas.length > 0, true);
 
+  const forgedMarker = "AUTOVALIDATOR_CLEAN_R2_SCHEMA_INDEX_FORGERY";
+  const tamperedSchemaIndex = JSON.parse(originalSchemaIndex);
+  const tamperedTarget = tamperedSchemaIndex.schemas.find(
+    (schema) => schema.status === "captured" && schema.snapshot,
+  );
+  assert(tamperedTarget, "expected a captured schema index entry to tamper");
+  tamperedTarget.hash = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+  tamperedTarget.snapshot = {
+    ...tamperedTarget.snapshot,
+    hash: tamperedTarget.hash,
+    title: forgedMarker,
+    auth_required: false,
+    path_count: 424242,
+    validation_forged_extra: { marker: forgedMarker },
+  };
+
   try {
     rmSync(r2StagingRoot, { recursive: true, force: true });
+    writeFileSync(
+      schemaIndexPath,
+      `${JSON.stringify(tamperedSchemaIndex, null, 2)}\n`,
+    );
     execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
       cwd: process.cwd(),
       encoding: "utf8",
@@ -433,8 +453,10 @@ test("artifact build preserves committed schema index without R2 schema details"
       stdio: "pipe",
     });
 
-    const rebuiltSchemaIndex = readFileSync(schemaIndexPath, "utf8");
-    assert.deepEqual(JSON.parse(rebuiltSchemaIndex), originalSchemaIndexJson);
+    const rebuiltSchemaIndexText = readFileSync(schemaIndexPath, "utf8");
+    const rebuiltSchemaIndex = JSON.parse(rebuiltSchemaIndexText);
+    assert.equal(rebuiltSchemaIndex.source, "artifact-build");
+    assert.equal(rebuiltSchemaIndexText.includes(forgedMarker), false);
   } finally {
     writeFileSync(schemaIndexPath, originalSchemaIndex);
     rmSync(r2StagingRoot, { recursive: true, force: true });


### PR DESCRIPTION
### Motivation
- Clean builds with no R2 per-surface schema detail files were treated as a valid match, allowing committed but unverified `public/metagraph/schemas/index.json` entries to pass verification and propagate forged or extra `snapshot` metadata.
- The schema contract allows additional properties in `snapshot`, so the build-side verification must refuse index reuse unless backed by captured per-surface schema details that match the recorded hash and snapshot.

### Description
- Remove the empty-capture bypass in `schemaIndexEntryMatchesSurface` so `detailMatches` now requires a captured detail whose `documentHash` equals `entry.hash` and whose `snapshot` stringifies identically (`scripts/build-artifacts.mjs`).
- Add a regression test that tampers a committed schema index entry (forged hash and extra snapshot fields), removes the R2 staging details, runs the artifact build, and asserts the regenerated index is produced by the build and does not contain the forged marker (`tests/artifacts.test.mjs`).
- Update the test name and assertions to reflect that a clean build should regenerate a fresh `artifact-build` schema index rather than preserving an unverified committed index (`tests/artifacts.test.mjs`).

### Testing
- Ran `npx vitest run tests/artifacts.test.mjs -t "artifact build regenerates schema index without R2 schema details"` and the test passed.
- Ran `npx vitest run tests/artifacts.test.mjs -t "artifact build does not preserve forged schema snapshot metadata"` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350008a58c832ca0d5331b20cbf7cd)