### PR TITLE
fix(scan): tighten local subtensor allowlist

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -33,7 +33,7 @@ const patterns = [
     // the `local` network surface (llms.txt / setup docs), not a leaked internal
     // URL. Scoped to the exact well-known endpoint; any other loopback URL on the
     // same line is still flagged (allowlisted spans are stripped before testing).
-    allow: /wss?:\/\/127\.0\.0\.1:9944\b/gi,
+    allow: /wss?:\/\/127\.0\.0\.1:9944(?![A-Za-z0-9._~:/?#\]@!$&'()*+,;=%-])/gi,
   },
   {
     name: "token-like assignment",

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -13,6 +13,8 @@ import {
 const FIXTURE_DIR = path.join(repoRoot, "dist/metagraph-r2/metagraph/fixtures");
 const TEST_FIXTURE = "__public_safety_test__.json";
 const TEST_FIXTURE_PATH = path.join(FIXTURE_DIR, TEST_FIXTURE);
+const TEST_PUBLIC_FILE = "__public_safety_test__.txt";
+const TEST_PUBLIC_PATH = path.join(repoRoot, "public", TEST_PUBLIC_FILE);
 
 async function writeTestFixture(body) {
   await fs.mkdir(FIXTURE_DIR, { recursive: true });
@@ -115,6 +117,44 @@ describe("public URL safety checks", () => {
 describe("captured-fixture body scan", () => {
   afterEach(async () => {
     await fs.rm(TEST_FIXTURE_PATH, { force: true });
+    await fs.rm(TEST_PUBLIC_PATH, { force: true });
+  });
+
+  test("allows only the exact documented local subtensor endpoint", async () => {
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      "Use the documented local RPC at `ws://127.0.0.1:9944` for local development.\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.equal(
+      output.includes(TEST_PUBLIC_FILE),
+      false,
+      `the exact documented endpoint should be exempt; got:\n${output}`,
+    );
+  });
+
+  test("flags local subtensor allowlist prefix bypass attempts", async () => {
+    const bypassAttempts = [
+      "ws://127.0.0.1:9944/admin",
+      "ws://127.0.0.1:9944?token=abcdefghijklmnop",
+      "ws://127.0.0.1:9944@10.0.0.1/private",
+    ];
+
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      `${bypassAttempts.join("\n")}\n`,
+      "utf8",
+    );
+    const output = runScanOutput();
+    for (const [index] of bypassAttempts.entries()) {
+      assert.ok(
+        output.includes(
+          `${TEST_PUBLIC_FILE}:${index + 1}: private or loopback URL`,
+        ),
+        `bypass attempt on line ${index + 1} must be flagged; got:\n${output}`,
+      );
+    }
   });
 
   test("does not flag soft Bittensor terminology in a mirrored fixture body", async () => {


### PR DESCRIPTION
### Motivation
- The public-safety scanner allowed the documented `ws://127.0.0.1:9944` endpoint to be stripped using a `\b` word boundary, which could be abused to hide longer or credentialed private/loopback URLs on the same line. 
- The change narrows the allowlist to only the exact well-known endpoint so incidental documentation remains exempt while preventing prefix-based bypasses.

### Description
- Replace the `\b` allowlist with a negative lookahead so `ws://127.0.0.1:9944` is only matched when it is not followed by URL-continuation characters (`(?![A-Za-z0-9._~:/?#\]@!$&'()*+,;=%-])`) in `scripts/scan-public-safety.mjs`.
- Add regression tests in `tests/public-safety.test.mjs` that verify the exact documented endpoint remains allowed and that `ws://127.0.0.1:9944/admin`, `ws://127.0.0.1:9944?token=...`, and `ws://127.0.0.1:9944@10.0.0.1/private` are flagged.
- Apply a small lint-friendly escape adjustment to the regex to satisfy `eslint` and format changes with `prettier`.

### Testing
- Ran `npm run -s lint` and the lint pass succeeded after the regex escape adjustment. 
- Ran the targeted test selection `npm test -- --run tests/public-safety.test.mjs -t "local subtensor"` and the added regression tests passed. 
- Executed the scanner via `npm run -s scan:public-safety` and it reported `Public-safety scan passed.` on the adjusted checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3506ff378c832c825a351fe081eb67)