### PR TITLE
fix(public-safety): remove loopback URL from LLM discovery docs

### DIFF
--- a/public/.well-known/llms.txt
+++ b/public/.well-known/llms.txt
@@ -34,7 +34,7 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1/{network}/…`. Bare paths default to mainnet, so every URL above is the mainnet view.
 - `mainnet` (alias `finney`): the full registry — curated services, schemas, 2-minute health. The default.
 - `testnet` (alias `test`): native chain registry only — subnet identity from the testnet chain, no curated services/health. Testnet netuids are independent of mainnet. e.g. `GET /api/v1/testnet/subnets`, `GET /api/v1/testnet/subnets/{netuid}`.
-- `local`: a per-developer subtensor metagraphed can't host — `GET /api/v1/local` returns setup guidance (point your SDK/RPC at `ws://127.0.0.1:9944`).
+- `local`: a per-developer subtensor metagraphed can't host — `GET /api/v1/local` returns setup guidance (point your SDK/RPC at your own local subtensor node).
 
 ## Optional
 - [llms-full.txt](https://api.metagraph.sh/llms-full.txt): expanded index with every subnet + route

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -34,7 +34,7 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1/{network}/…`. Bare paths default to mainnet, so every URL above is the mainnet view.
 - `mainnet` (alias `finney`): the full registry — curated services, schemas, 2-minute health. The default.
 - `testnet` (alias `test`): native chain registry only — subnet identity from the testnet chain, no curated services/health. Testnet netuids are independent of mainnet. e.g. `GET /api/v1/testnet/subnets`, `GET /api/v1/testnet/subnets/{netuid}`.
-- `local`: a per-developer subtensor metagraphed can't host — `GET /api/v1/local` returns setup guidance (point your SDK/RPC at `ws://127.0.0.1:9944`).
+- `local`: a per-developer subtensor metagraphed can't host — `GET /api/v1/local` returns setup guidance (point your SDK/RPC at your own local subtensor node).
 
 ## Subnets
 - SN0 root (root); no catalogued public API yet — https://api.metagraph.sh/api/v1/agent-catalog/0

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -34,7 +34,7 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1/{network}/…`. Bare paths default to mainnet, so every URL above is the mainnet view.
 - `mainnet` (alias `finney`): the full registry — curated services, schemas, 2-minute health. The default.
 - `testnet` (alias `test`): native chain registry only — subnet identity from the testnet chain, no curated services/health. Testnet netuids are independent of mainnet. e.g. `GET /api/v1/testnet/subnets`, `GET /api/v1/testnet/subnets/{netuid}`.
-- `local`: a per-developer subtensor metagraphed can't host — `GET /api/v1/local` returns setup guidance (point your SDK/RPC at `ws://127.0.0.1:9944`).
+- `local`: a per-developer subtensor metagraphed can't host — `GET /api/v1/local` returns setup guidance (point your SDK/RPC at your own local subtensor node).
 
 ## Optional
 - [llms-full.txt](https://api.metagraph.sh/llms-full.txt): expanded index with every subnet + route

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -2377,7 +2377,7 @@ const llmsHeader = [
   "Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1/{network}/…`. Bare paths default to mainnet, so every URL above is the mainnet view.",
   "- `mainnet` (alias `finney`): the full registry — curated services, schemas, 2-minute health. The default.",
   "- `testnet` (alias `test`): native chain registry only — subnet identity from the testnet chain, no curated services/health. Testnet netuids are independent of mainnet. e.g. `GET /api/v1/testnet/subnets`, `GET /api/v1/testnet/subnets/{netuid}`.",
-  "- `local`: a per-developer subtensor metagraphed can't host — `GET /api/v1/local` returns setup guidance (point your SDK/RPC at `ws://127.0.0.1:9944`).",
+  "- `local`: a per-developer subtensor metagraphed can't host — `GET /api/v1/local` returns setup guidance (point your SDK/RPC at your own local subtensor node).",
 ].join("\n");
 const llmsShort = `${llmsHeader}\n\n## Optional\n- [llms-full.txt](${llmsApiBase}/llms-full.txt): expanded index with every subnet + route\n`;
 const llmsSubnetLines = mergedSubnets


### PR DESCRIPTION
### Motivation
- The public LLM discovery artifacts were publishing a literal loopback WebSocket endpoint (`ws://127.0.0.1:9944`), which violates the repository's public-safety private-boundary rule and caused the `scan:public-safety` check to fail. 

### Description
- Replaced the literal loopback URL with generic local-node guidance in the generator (`scripts/build-artifacts.mjs`) so future builds do not emit private/loopback endpoints. 
- Updated the committed public artifacts to remove `ws://127.0.0.1:9944` and instead use non-actionable wording (`your own local subtensor node`) in `public/.well-known/llms.txt`, `public/llms.txt`, and `public/llms-full.txt`. 
- Changes are minimal text edits and preserve the original intent of advising developers to use a local subtensor node without publishing a concrete loopback address. 

### Testing
- Ran `npm run scan:public-safety` which passed after the change. 
- Ran `npx vitest run tests/public-safety.test.mjs` which reported 13/14 tests passing and 1 failure attributable to the environment DNS behavior classifying `example.com` as unsafe. 
- Verified with `rg` and `git diff --check` that the loopback URL is no longer present in the generator or generated public artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3506233348832ca8b34a68972329ca)