### PR TITLE
feat(registry): add SN64 Chutes node availability data-artifact

### DIFF
--- a/registry/candidates/community/community-sn-64-data-artifact-chutes-nodes-api-chutes-ai.json
+++ b/registry/candidates/community/community-sn-64-data-artifact-chutes-nodes-api-chutes-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-64-data-artifact-api-chutes-ai",
+      "kind": "data-artifact",
+      "name": "Chutes node availability data-artifact",
+      "netuid": 64,
+      "provider": "chutes",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.chutes.ai/openapi.json",
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.chutes.ai/nodes"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jaso0n0818",
+    "submitted_by_url": "https://github.com/jaso0n0818"
+  }
+}


### PR DESCRIPTION
## Direct Candidate Submission

Adds one public, read-only `data-artifact` candidate for **SN64 Chutes**.

## Candidate

- Netuid: 64
- Kind: `data-artifact`
- Public URL: https://api.chutes.ai/nodes/
- Source URL: https://api.chutes.ai/openapi.json
- Provider/operator: chutes

## Checklist

- [x] Changes exactly one `registry/candidates/community/*.json` file.
- [x] Generated with `npm run candidate:new`.
- [x] The URL is public and safe for read-only probes (returns live GPU node availability by type as JSON, HTTP 200, no auth).
- [x] The source `openapi.json` publicly documents `GET /nodes/`.
- [x] No authentication required.
- [x] Does not duplicate an existing surface — no candidate currently maps this URL (existing SN64 chutes candidates cover `/chutes/gpu_count_history`, `/chutes/boosted`, `/chutes/utilization`).
- [x] No secrets, wallet data, private URLs, dashboards, validator internals, or generated artifacts.

## Validation

- validate:candidate, validate:intake, scan:public-safety, submission:pr all pass (schema-valid, no errors).

No linked issue: community public-interface candidate submission.
