### PR TITLE
feat(registry): add SN74 Gittensor repo commits data-artifact

### DIFF
--- a/registry/candidates/community/community-sn-74-data-artifact-gittensor-repos-commits-api-gittensor-io.json
+++ b/registry/candidates/community/community-sn-74-data-artifact-gittensor-repos-commits-api-gittensor-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-74-data-artifact-api-gittensor-io",
+      "kind": "data-artifact",
+      "name": "Gittensor repo commits data-artifact",
+      "netuid": 74,
+      "provider": "gittensor",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.gittensor.io/swagger-json",
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "state": "schema-valid",
+      "url": "https://api.gittensor.io/dash/repos/commits"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jaso0n0818",
+    "submitted_by_url": "https://github.com/jaso0n0818"
+  }
+}


### PR DESCRIPTION
## Direct Candidate Submission

Adds one public, read-only `data-artifact` candidate for **SN74 Gittensor**.

## Candidate

- Netuid: 74
- Kind: `data-artifact`
- Public URL: https://api.gittensor.io/dash/repos/commits
- Source URL: https://api.gittensor.io/swagger-json
- Provider/operator: gittensor

## Checklist

- [x] Changes exactly one `registry/candidates/community/*.json` file.
- [x] Generated with `npm run candidate:new`.
- [x] The URL is public and safe for read-only probes (returns per-repository commit / emission-share stats as JSON, HTTP 200, no auth).
- [x] The source `swagger-json` publicly documents `GET /dash/repos/commits`.
- [x] No authentication required.
- [x] Does not duplicate an existing surface — existing SN74 candidates cover `/dash/stats`, `/dash/languages`, `/miners`, `/swagger-json`.
- [x] No secrets, wallet data, private URLs, dashboards, validator internals, or generated artifacts.

## Validation

- validate:candidate, validate:intake, scan:public-safety, submission:pr all pass (schema-valid, no errors).

No linked issue: community public-interface candidate submission.
