### PR TITLE
fix(ci): route invalid submissions through full validation

### DIFF
--- a/scripts/ci-validate-route.mjs
+++ b/scripts/ci-validate-route.mjs
@@ -7,7 +7,10 @@ import {
 const options = parseArgs(process.argv.slice(2));
 const changedFiles = await readChangedFiles(options.changedFiles);
 const classification = classifyPrScope(changedFiles);
-const mode = classification.scope === "normal-pr" ? "full" : "ugc";
+const mode =
+  classification.scope !== "normal-pr" && classification.errors.length === 0
+    ? "ugc"
+    : "full";
 
 const report = {
   schema_version: 1,

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -134,7 +134,7 @@ describe("Metagraphed submission gate policy", () => {
     assert.equal(scope.errors[0].category, "generated-artifact-tampering");
   });
 
-  test("routes tampered direct submissions through the UGC preflight", () => {
+  test("routes tampered direct submissions through full validation", () => {
     const tmp = mkdtempSync(path.join(tmpdir(), "metagraphed-route-"));
     try {
       const changedFilesPath = path.join(tmp, "changed-files.txt");
@@ -157,7 +157,7 @@ describe("Metagraphed submission gate policy", () => {
         },
       );
 
-      assert.match(readFileSync(outputPath, "utf8"), /^mode=ugc$/m);
+      assert.match(readFileSync(outputPath, "utf8"), /^mode=full$/m);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
@@ -276,7 +276,7 @@ describe("Metagraphed submission gate policy", () => {
     }
   });
 
-  test("routes mixed direct candidate PRs through the UGC gate", () => {
+  test("routes mixed direct candidate PRs through full validation", () => {
     const tmp = mkdtempSync(path.join(tmpdir(), "metagraphed-route-"));
     try {
       const changedFiles = path.join(tmp, "changed-files.txt");
@@ -295,7 +295,7 @@ describe("Metagraphed submission gate policy", () => {
       );
       const report = JSON.parse(output);
 
-      assert.equal(report.mode, "ugc");
+      assert.equal(report.mode, "full");
       assert.equal(report.scope, "direct-candidate");
       assert.deepEqual(
         report.errors.map((error) => error.category),


### PR DESCRIPTION
## Summary
- Align the standalone submission-gate route classifier with the main validation workflow routing.

## What changed
- Route invalid direct submission shapes through full validation instead of the UGC preflight.
- Update submission-gate regression tests for tampered and mixed direct-candidate PRs.

## Why
- Broad maintainer PRs that touch community candidate files can otherwise be misclassified as direct UGC submissions and fail the submission gate before full CI can decide the PR.

## Validation
- `npm test -- tests/submission-gate.test.mjs`
- `npm run validate:workflows`
- `npm run lint`
- `npm run format:check`
- `git diff --check`