### PR TITLE
feat(registry): add SN74 Gittensor issue stats data-artifact

### DIFF
--- a/registry/candidates/community/community-sn-74-data-artifact-gittensor-issue-stats-api-gittensor-io.json
+++ b/registry/candidates/community/community-sn-74-data-artifact-gittensor-issue-stats-api-gittensor-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-74-data-artifact-api-gittensor-io",
+      "kind": "data-artifact",
+      "name": "Gittensor issue stats data-artifact",
+      "netuid": 74,
+      "provider": "gittensor",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.gittensor.io/swagger-json",
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "state": "schema-valid",
+      "url": "https://api.gittensor.io/issues/stats"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jaso0n0818",
+    "submitted_by_url": "https://github.com/jaso0n0818"
+  }
+}


### PR DESCRIPTION
## Direct Candidate Submission

Adds one public, read-only `data-artifact` candidate for **SN74 Gittensor**.

## Candidate

- Netuid: 74
- Kind: `data-artifact`
- Public URL: https://api.gittensor.io/issues/stats
- Source URL: https://api.gittensor.io/swagger-json
- Provider/operator: gittensor

## Checklist

- [x] Changes exactly one `registry/candidates/community/*.json` file.
- [x] Generated with `npm run candidate:new`.
- [x] The URL is public and safe for read-only probes (returns aggregate issue / bounty stats as JSON, HTTP 200, no auth — verified on the canonical no-trailing-slash URL).
- [x] The source `swagger-json` publicly documents `GET /issues/stats`.
- [x] No authentication required.
- [x] Does not duplicate an existing surface — existing SN74 candidates cover `/dash/stats`, `/dash/languages`, `/dash/repos/commits`, `/miners`, `/swagger-json`.
- [x] No secrets, wallet data, private URLs, dashboards, validator internals, or generated artifacts.

## Validation

- validate:candidate, validate:intake, scan:public-safety, submission:pr all pass (schema-valid, no errors).

No linked issue: community public-interface candidate submission.
