### PR TITLE
fix(registry): prevent candidate id collisions

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -414,10 +414,13 @@ export async function loadNativeSnapshot() {
   return readJson(path.join(repoRoot, "registry/native/finney-subnets.json"));
 }
 
-export async function loadCandidates() {
-  const files = await listJsonFilesRecursive(
-    path.join(repoRoot, "registry/candidates"),
+export async function loadCandidates(options = {}) {
+  const excludeFiles = new Set(
+    (options.excludeFiles || []).map((file) => path.resolve(file)),
   );
+  const files = (
+    await listJsonFilesRecursive(path.join(repoRoot, "registry/candidates"))
+  ).filter((file) => !excludeFiles.has(path.resolve(file)));
   const documents = await Promise.all(files.map(readJson));
   const candidates = documents.flatMap((document) => {
     if (Array.isArray(document.candidates)) {

--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -1289,6 +1289,16 @@ export function validateCandidateForSubmission({
     }),
   );
 
+  const idDuplicate = existingCandidates.find(
+    (existing) => existing.id === candidate.id,
+  );
+  if (idDuplicate) {
+    errors.push({
+      category: "duplicate",
+      message: `candidate id duplicates existing candidate ${idDuplicate.id}`,
+    });
+  }
+
   if (normalizedUrl && candidate.kind && Number.isInteger(candidate.netuid)) {
     const locator = registrySurfaceKey({
       netuid: candidate.netuid,

--- a/scripts/submission-pr.mjs
+++ b/scripts/submission-pr.mjs
@@ -81,12 +81,9 @@ const directSubmissionRaw = new Map(
   ).map(([file, raw]) => [file, raw]),
 );
 const existingCandidates = directCandidateFile
-  ? (await loadCandidates()).filter(
-      (candidate) =>
-        !candidateDocument?.candidates?.some(
-          (submitted) => submitted.id === candidate.id,
-        ),
-    )
+  ? await loadCandidates({
+      excludeFiles: [path.join(inputRoot, directCandidateFile)],
+    })
   : await loadCandidates();
 const existingProviders = directProviderFile
   ? (await loadProviders()).filter(

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -2259,6 +2259,32 @@ describe("submission policy helpers", () => {
       duplicate.errors.filter((error) => error.category === "duplicate").length,
       2,
     );
+
+    const duplicateId = validateCandidateForSubmission({
+      candidate: baseCandidate,
+      document: {
+        submission: {
+          submitted_by: "jsonbored",
+          submitted_by_url: "https://github.com/jsonbored",
+        },
+      },
+      submitter: "jsonbored",
+      native,
+      providers,
+      existingCandidates: [
+        { ...baseCandidate, url: "https://docs.all-ways.io/other" },
+      ],
+      existingSubnets: [],
+    });
+    assert.equal(
+      duplicateId.errors.some(
+        (error) =>
+          error.category === "duplicate" &&
+          error.message ===
+            `candidate id duplicates existing candidate ${baseCandidate.id}`,
+      ),
+      true,
+    );
   });
 
   test("builds issue intake states for valid, manual, and invalid submissions", () => {


### PR DESCRIPTION
### Motivation
- A newly added community candidate reused an existing `candidate.id`, violating the invariant that candidate IDs are unique and allowing verification/promote logic to mis-associate verification records by `candidate_id`.
- The UGC direct-submission preflight filtered existing candidates by submitted ID instead of rejecting ID collisions, letting a duplicate slip through reduced checks.

### Description
- Renamed the Chutes utilization candidate id to `community-sn-64-data-artifact-chutes-utilization-api-chutes-ai` in `registry/candidates/community/...` to avoid the collision with the existing GPU history candidate.
- Added an optional `excludeFiles` parameter to `loadCandidates(options)` in `scripts/lib.mjs` so callers can exclude only the submitted file when building the existing-candidates list.
- Changed `scripts/submission-pr.mjs` to load existing candidates with `excludeFiles: [path.join(inputRoot, directCandidateFile)]` for direct submissions so same-file updates are preserved while allowing duplicate-id checks against the rest of the registry.
- Added an explicit duplicate-ID rejection in `validateCandidateForSubmission` inside `scripts/submission-policy.mjs` that pushes a `duplicate` error when `existingCandidates` contains the same `candidate.id`.
- Added a regression assertion to `tests/script-utils.test.mjs` that verifies duplicate candidate IDs are reported as duplicate errors.

### Testing
- Ran the targeted unit test `npx vitest run tests/script-utils.test.mjs --testNamePattern "validates candidate submission"`, which passed the changed assertion.
- Ran `npm run format:check` on modified files, which succeeded (Prettier OK).
- Performed a targeted duplicate scan using `loadCandidates()` confirming the existing id counts and a reproduction of the preflight with `node scripts/submission-pr.mjs ... --no-fail`, which now reports `schema-invalid` with duplicate errors for a colliding submission (expected behavior).
- A fuller test run `npm test -- --run tests/script-utils.test.mjs tests/submission-gate.test.mjs` failed two unrelated artifact-index tests due to missing generated `public/metagraph/build-summary.json` in this checkout, and `npm run validate` failed earlier due to missing `public/metagraph/providers.json`, so those failures are environmental and not caused by the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35b93c76d4832cbcebf7564700f49b)