### PR TITLE
ci(coverage): upload vitest results to codecov

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -137,8 +137,14 @@ jobs:
           METAGRAPH_PRESERVE_PROBE_HEALTH: "1"
         run: npm run build
 
+      - name: Prepare test reports dir
+        if: steps.route.outputs.mode == 'full'
+        run: mkdir -p reports/junit
+
       - name: Test (with coverage gate)
         if: steps.route.outputs.mode == 'full'
+        env:
+          VITEST_JUNIT_PATH: reports/junit/vitest.xml
         run: npm run test:coverage
 
       # Upload coverage to Codecov — the primary PR coverage gate (delta-based
@@ -151,6 +157,15 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
+          fail_ci_if_error: false
+
+      - name: Upload Vitest results to Codecov
+        if: ${{ !cancelled() && steps.route.outputs.mode == 'full' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./reports/junit/vitest.xml
+          report_type: test_results
           fail_ci_if_error: false
 
   checks:

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,5 +1,7 @@
 import { defineConfig } from "vitest/config";
 
+const junitPath = process.env.VITEST_JUNIT_PATH;
+
 export default defineConfig({
   test: {
     environment: "node",
@@ -22,6 +24,8 @@ export default defineConfig({
     // is the clean, low-risk fix. Per-file fork isolation is preserved; only
     // filesystem-race concurrency is removed.
     fileParallelism: false,
+    reporters: junitPath ? ["default", "junit"] : ["default"],
+    ...(junitPath ? { outputFile: { junit: junitPath } } : {}),
     coverage: {
       provider: "v8",
       // lcov for the Codecov upload (codecov/codecov-action reads


### PR DESCRIPTION
## Summary
- Upload Vitest JUnit results to Codecov from the existing coverage job.
- Keep the current coverage run and lcov upload unchanged.

## What changed
- Add opt-in JUnit reporter output when `VITEST_JUNIT_PATH` is set.
- Write the Vitest JUnit report during the full validation test path.
- Upload the JUnit report with `report_type: test_results`.

## Why
- Codecov evaluates reports; CI still produces the test and coverage artifacts.
- This adds Codecov Test Analytics without adding another test pass or changing the coverage gate.

## Validation
- `npm run format:check -- .github/workflows/validate.yml vitest.config.mjs`
- `actionlint .github/workflows/validate.yml`
- `VITEST_JUNIT_PATH=reports/junit/vitest-smoke.xml npx vitest run tests/strip-json-comments.test.mjs`
- `git diff --check`

## Notes
- Local dependency install for this validation used `npm ci --ignore-scripts` because native `sharp` install failed under the local Node runtime; the checked workflow still uses the repo default install path.