### PR TITLE
docs(intake): add Graphite OpenAPI schema candidate (SN43)

### DIFF
--- a/registry/candidates/community/community-sn-43-openapi-api-graphite-ai-net.json
+++ b/registry/candidates/community/community-sn-43-openapi-api-graphite-ai-net.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-43-openapi-api-graphite-ai-net",
+      "kind": "openapi",
+      "name": "Graphite Knowledge Graph API (OpenAPI)",
+      "netuid": 43,
+      "provider": "graphite-ai",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.graphite-ai.net/docs",
+      "source_urls": ["https://api.graphite-ai.net/docs"],
+      "state": "schema-valid",
+      "url": "https://api.graphite-ai.net/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
Closes #729.

Adds SN43 Graphite's public **OpenAPI** schema as a community candidate (one file, `registry/candidates/community/`).

**Verification (live):**
- `url`: https://api.graphite-ai.net/openapi.json → HTTP 200, valid OpenAPI 3.x (spec title **"SN43 Knowledge Graph API"**, 30 paths)
- `source_url`: https://api.graphite-ai.net/docs → HTTP 200 (Swagger UI)
- On the subnet's **official** `graphite-ai.net` domain (matches the registered SN43 `website_url`), provider `graphite-ai` (registered)
- Read-only `GET`, no auth → `public_safe: true`

Passes locally: `validate:candidate`, `validate:intake`, `scan:public-safety`, `validate:private-boundary`, prettier, and the submission preflight (`public_state: submit_pr`, non-blocking, no warnings).