### PR TITLE
docs(intake): add Vidaio API OpenAPI candidate (SN85)

### DIFF
--- a/registry/candidates/community/community-sn-85-openapi-api-vidaio-io.json
+++ b/registry/candidates/community/community-sn-85-openapi-api-vidaio-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-85-openapi-api-vidaio-io",
+      "kind": "openapi",
+      "name": "Vidaio API (OpenAPI)",
+      "netuid": 85,
+      "provider": "vidaio",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://vidaio.io/",
+      "source_urls": ["https://vidaio.io/"],
+      "state": "schema-valid",
+      "url": "https://api.vidaio.io/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
Closes #703.

Adds SN85 Vidaio's public **OpenAPI** schema as a community candidate (one file).

**Verification (live):**
- `url`: https://api.vidaio.io/openapi.json → HTTP 200, valid OpenAPI 3.x (spec title **"Vidaio API"**, 10 paths)
- `source_url`: https://vidaio.io/ → HTTP 200 (the subnet's registered official `website_url`; the spec is on its `api.` subdomain)
- provider `vidaio` (registered), read-only `GET`, no auth → `public_safe: true`

Passes locally: `validate:candidate`, prettier, and the submission preflight (`public_state: submit_pr`, non-blocking, no warnings).