### PR TITLE
docs(intake): add Hippius API OpenAPI candidate (SN75)

### DIFF
--- a/registry/candidates/community/community-sn-75-openapi-api-hippius-com.json
+++ b/registry/candidates/community/community-sn-75-openapi-api-hippius-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-75-openapi-api-hippius-com",
+      "kind": "openapi",
+      "name": "Hippius API (OpenAPI)",
+      "netuid": 75,
+      "provider": "hippius",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.hippius.com/swagger",
+      "source_urls": ["https://api.hippius.com/swagger"],
+      "state": "schema-valid",
+      "url": "https://api.hippius.com/swagger.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
Closes #683.

Adds SN75 Hippius's public **OpenAPI/Swagger** schema as a community candidate (one file).

**Verification (live):**
- `url`: https://api.hippius.com/swagger.json → HTTP 200, valid spec (title **"Hippius API"**, 204 paths)
- `source_url`: https://api.hippius.com/swagger → HTTP 200 (Swagger UI, same API host)
- On the subnet's official `hippius.com` domain, provider `hippius` (registered), read-only `GET`, no auth → `public_safe: true`

Passes locally: `validate:candidate`, prettier, and the submission preflight (`public_state: submit_pr`, non-blocking, no warnings).