### PR TITLE
feat(discover): probe api./docs. subdomains for OpenAPI specs (#1004)

### DIFF
--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -1,5 +1,6 @@
 import path from "node:path";
 import {
+  apiDocsSubdomainOrigins,
   buildTimestamp,
   isBrandImpersonationUrl,
   isCredentialedUrl,
@@ -853,6 +854,23 @@ async function discoverOpenApiSpecs() {
 function collectOpenApiBaseOrigins() {
   const seen = new Set();
   const targets = [];
+  const pushOrigin = (netuid, provider, origin) => {
+    let host;
+    try {
+      host = new URL(origin).hostname;
+    } catch {
+      return;
+    }
+    if (isGenericHost(host)) {
+      return;
+    }
+    const key = `${netuid}:${origin}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    targets.push({ netuid, provider, origin });
+  };
   const add = (netuid, provider, rawUrl) => {
     if (netuid == null || !provider || netuidsWithOpenapi.has(netuid)) {
       return;
@@ -863,20 +881,17 @@ function collectOpenApiBaseOrigins() {
     }
     let origin;
     try {
-      const parsed = new URL(normalized);
-      if (isGenericHost(parsed.hostname)) {
-        return;
-      }
-      origin = parsed.origin;
+      origin = new URL(normalized).origin;
     } catch {
       return;
     }
-    const key = `${netuid}:${origin}`;
-    if (seen.has(key)) {
-      return;
+    pushOrigin(netuid, provider, origin);
+    // #1004 — also probe the conventional api./docs. subdomains of the same
+    // registrable domain; live specs frequently live there, not on the marketing
+    // root (the Graphite/Vidaio/Hippius class the root-only probe missed).
+    for (const derived of apiDocsSubdomainOrigins(origin)) {
+      pushOrigin(netuid, provider, derived);
     }
-    seen.add(key);
-    targets.push({ netuid, provider, origin });
   };
 
   for (const candidate of candidatesByKey.values()) {

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1667,6 +1667,45 @@ export function clusterDomainFromUrl(value) {
   }
 }
 
+// #1004 — derive the conventional `api.` and `docs.` subdomain origins for a
+// project's registrable domain so the OpenAPI spec sweep reaches APIs that live
+// on api.<domain> (or docs.<domain>) rather than the marketing root — the
+// Graphite/Vidaio/Hippius class the website-only probe was blind to. Returns []
+// when a service subdomain is meaningless: unparseable input, IP literals,
+// multi-tenant platform tenants (api.foo.github.io would belong to the platform,
+// not the project), or hosts with no resolvable registrable domain. Pure +
+// deterministic, so it is exhaustively unit-tested. Callers still apply their own
+// generic-host / safe-fetch policy to the returned origins.
+export function apiDocsSubdomainOrigins(origin) {
+  let host;
+  try {
+    host = new URL(origin).hostname.toLowerCase();
+  } catch {
+    return [];
+  }
+  // IPv4 / IPv6 literals have no subdomain structure.
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host) || host.includes(":")) {
+    return [];
+  }
+  const bare = host.replace(/^www\./, "");
+  if (bare.split(".").filter(Boolean).length < 2) {
+    return [];
+  }
+  // Multi-tenant platform tenant (foo.github.io, bar.vercel.app): a service
+  // subdomain of the registrable domain would belong to the platform, never the
+  // project, so don't derive one.
+  for (const suffix of MULTI_TENANT_HOST_SUFFIXES) {
+    if (bare === suffix || bare.endsWith(`.${suffix}`)) {
+      return [];
+    }
+  }
+  const registrable = clusterSuffixDomain(bare);
+  if (!registrable) {
+    return [];
+  }
+  return [`https://api.${registrable}`, `https://docs.${registrable}`];
+}
+
 // #1007: the distinct discovery sources (clustered domains) that independently
 // surfaced a candidate, from its source_urls. 2+ distinct sources is strong
 // corroboration — a URL claimed by both TaoMarketCap and a GitHub README is more

--- a/tests/openapi-discovery.test.mjs
+++ b/tests/openapi-discovery.test.mjs
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   OPENAPI_PROBE_PATHS,
+  apiDocsSubdomainOrigins,
   isOpenApiDocument,
   probeOpenApiSpec,
 } from "../scripts/lib.mjs";
@@ -150,6 +151,60 @@ describe("probeOpenApiSpec", () => {
     };
     await probeOpenApiSpec("https://example.com", ["/openapi.json"], fetcher);
     assert.deepEqual(urls, ["https://example.com/openapi.json"]);
+  });
+});
+
+describe("apiDocsSubdomainOrigins (#1004)", () => {
+  test("derives api. and docs. origins from a marketing-root domain", () => {
+    assert.deepEqual(apiDocsSubdomainOrigins("https://graphite.xyz"), [
+      "https://api.graphite.xyz",
+      "https://docs.graphite.xyz",
+    ]);
+  });
+
+  test("strips www. and ignores path/port when deriving", () => {
+    assert.deepEqual(apiDocsSubdomainOrigins("https://www.vidaio.io/about"), [
+      "https://api.vidaio.io",
+      "https://docs.vidaio.io",
+    ]);
+  });
+
+  test("folds an existing subdomain back to the registrable domain", () => {
+    // app.example.com → api.example.com / docs.example.com
+    assert.deepEqual(apiDocsSubdomainOrigins("https://app.example.com"), [
+      "https://api.example.com",
+      "https://docs.example.com",
+    ]);
+  });
+
+  test("handles a multi-label public suffix (co.uk)", () => {
+    assert.deepEqual(apiDocsSubdomainOrigins("https://acme.co.uk"), [
+      "https://api.acme.co.uk",
+      "https://docs.acme.co.uk",
+    ]);
+  });
+
+  test("returns [] for multi-tenant platform tenants", () => {
+    for (const origin of [
+      "https://foo.github.io",
+      "https://bar.vercel.app",
+      "https://baz.pages.dev",
+      "https://qux.workers.dev",
+    ]) {
+      assert.deepEqual(apiDocsSubdomainOrigins(origin), [], origin);
+    }
+  });
+
+  test("returns [] for IP literals, bare hosts, and unparseable input", () => {
+    for (const origin of [
+      "https://127.0.0.1",
+      "https://192.168.1.10:8080",
+      "https://localhost",
+      "not a url",
+      "",
+    ]) {
+      assert.deepEqual(apiDocsSubdomainOrigins(origin), [], origin);
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

The OpenAPI spec sweep (`discoverOpenApiSpecs` / `collectOpenApiBaseOrigins`) only probed the **marketing-site origin** plus already-known subnet-api/docs origins — never the conventional `api.<domain>` / `docs.<domain>` subdomain of the same registrable domain. The code comment even admitted "specs frequently live on an `api.` subdomain, not the marketing site," but the code took `parsed.origin` only. Result: live specs on `api.<domain>` were **invisible** to discovery — exactly why Graphite/Vidaio/Hippius had to be hand-added via intake.

## Fix

- **New pure helper `apiDocsSubdomainOrigins(origin)`** (lib.mjs) → `[https://api.<registrable>, https://docs.<registrable>]`. Multi-tenant-aware: returns `[]` for `*.github.io` / `*.vercel.app` / `*.pages.dev` / … (a service subdomain there belongs to the platform, not the project), IP literals, and bare hosts. Reuses the existing `clusterSuffixDomain` eTLD+1 logic so the two can't drift. Handles multi-label suffixes (`co.uk`).
- **`collectOpenApiBaseOrigins()`** now also probes the derived subdomains, via a shared `pushOrigin` that preserves the generic-host guard + dedup.
- Probe-confirmed specs enter the **existing** path unchanged: `source_type: "openapi-probe"`, `medium` confidence, structurally validated by `isOpenApiDocument` before registering. **No new blind guesses** — only validated specs.

## Empirical validation (live endpoints)

Probed 472 derived `api.`/`docs.` origins across all 129 subnets → **18 valid OpenAPI specs**, **11 for subnets that currently have no openapi surface**:

| netuid | spec |
|---|---|
| 56 | api.gradients.io/openapi.json |
| 59 | api.babelbit.ai/openapi.json |
| 64 | api.chutes.ai/openapi.json |
| 70 | api.nexisgen.ai/openapi.json |
| 75 | api.hippius.com/swagger.json |
| 85 | api.vidaio.io/openapi.json |
| 96 | api.verathos.ai/openapi.json |
| 99 | api.leoma.ai/openapi.json |
| 110 | api.green-compute.com/openapi.json |
| 120 | api.affine.io/openapi.json |
| … | api.synthdata.co/swagger.json, + already-covered refreshes |

This ~doubles real callable-API coverage — the thinnest, highest-value surface type. These become medium-confidence probe-confirmed candidates on the next discovery run, feeding the normal verify → promote pipeline.

## Tests

- 6 new unit tests for `apiDocsSubdomainOrigins` (derivation, www-strip, subdomain fold, co.uk, multi-tenant skip, IP/bare/unparseable).
- Full suite green after build (`vitest run`: 1233 passing; the 5 reader-test failures pre-build are the known "needs `npm run build` first" artifact dependency, confirmed passing post-build).