### PR TITLE
feat(reviews): provenance review queue — auto-surface high-signal elevations

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "curate:baseline:dry-run": "node scripts/curate-baseline.mjs --dry-run",
     "review:promote": "node scripts/promote-reviewed.mjs --write",
     "review:promote:dry-run": "node scripts/promote-reviewed.mjs --dry-run",
+    "review:queue": "node scripts/review-queue.mjs --write",
+    "review:queue:dry-run": "node scripts/review-queue.mjs --dry-run",
     "schemas:snapshot": "node scripts/snapshot-openapi.mjs --write",
     "schemas:snapshot:dry-run": "node scripts/snapshot-openapi.mjs --dry-run",
     "capture:fixtures": "node scripts/capture-fixtures.mjs --write",

--- a/registry/reviews/review-queue.json
+++ b/registry/reviews/review-queue.json
@@ -1,0 +1,26 @@
+{
+  "generated_at": "1970-01-01T00:00:00.000Z",
+  "generated_by": "metagraphed-review-queue",
+  "notes": "Suggested maintainer-review elevations: provenance-strong, live callable APIs on each subnet's own on-chain-asserted domain that are not yet at the top trust tier. Machine-proposed; promote by moving an entry into maintainer-reviewed.json. Regenerate with `npm run review:queue`.",
+  "queue": [
+    {
+      "current_level": "machine-verified",
+      "domain": "babelbit.ai",
+      "kinds": ["subnet-api"],
+      "netuid": 59,
+      "rationale": "Live subnet-api on the subnet's on-chain-asserted domain (babelbit.ai). Strong provenance — elevate by adding a decision to maintainer-reviewed.json after a quick confirm.",
+      "slug": "sn-59",
+      "source_urls": ["https://api.babelbit.ai/"]
+    },
+    {
+      "current_level": "machine-verified",
+      "domain": "theminos.ai",
+      "kinds": ["subnet-api"],
+      "netuid": 107,
+      "rationale": "Live subnet-api on the subnet's on-chain-asserted domain (theminos.ai). Strong provenance — elevate by adding a decision to maintainer-reviewed.json after a quick confirm.",
+      "slug": "sn-107",
+      "source_urls": ["https://api.theminos.ai/"]
+    }
+  ],
+  "schema_version": 1
+}

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1706,6 +1706,142 @@ export function apiDocsSubdomainOrigins(origin) {
   return [`https://api.${registrable}`, `https://docs.${registrable}`];
 }
 
+// Provenance auto-elevation (Move A): a callable-API surface (openapi/subnet-api)
+// that is (1) live-verified and (2) hosted on the subnet's OWN on-chain-asserted
+// registrable domain (Subtensor SubnetIdentitiesV3 subnet_url) is trustworthy
+// WITHOUT a human review — the chain itself vouches for the domain and we probed
+// the API live. This computes that set so promote-reviewed can lift those subnets
+// to the maintainer-reviewed trust tier automatically, and validate can treat the
+// machine decision as backing for the tier. Pure + deterministic (sorted, deduped)
+// so it is unit-testable and the committed auto-reviewed.json can be drift-checked.
+//
+// Provenance bar (kept strict so a blind common-path guess never auto-trusts):
+//   - openapi  : source must be a probe-confirmed spec ("openapi-probe") or a
+//                human intake ("community-pr-intake") — never a blind path guess.
+//   - subnet-api: any source EXCEPT the blind "project-website-common-path" sweep.
+// Both require: kind on the chain-asserted domain + verification live/redirected +
+// the verify step judged the response content-type to match the kind.
+const AUTO_ELEVATE_OPENAPI_SOURCES = new Set([
+  "openapi-probe",
+  "community-pr-intake",
+]);
+export function computeProvenanceElevations({
+  candidates = [],
+  nativeSubnets = [],
+  verificationResults = [],
+}) {
+  const authByNetuid = new Map();
+  for (const subnet of nativeSubnets) {
+    const url = subnet?.chain_identity?.subnet_url;
+    const domain = url ? clusterDomainFromUrl(url) : null;
+    if (domain) authByNetuid.set(subnet.netuid, domain);
+  }
+  const verByCandidate = new Map(
+    verificationResults
+      .filter((result) => result?.candidate_id)
+      .map((result) => [result.candidate_id, result]),
+  );
+  const byNetuid = new Map();
+  for (const candidate of candidates) {
+    if (candidate.kind !== "openapi" && candidate.kind !== "subnet-api") {
+      continue;
+    }
+    const auth = authByNetuid.get(candidate.netuid);
+    if (!auth || clusterDomainFromUrl(candidate.url) !== auth) {
+      continue;
+    }
+    if (
+      candidate.kind === "openapi"
+        ? !AUTO_ELEVATE_OPENAPI_SOURCES.has(candidate.source_type)
+        : candidate.source_type === "project-website-common-path"
+    ) {
+      continue;
+    }
+    const verification = verByCandidate.get(candidate.id);
+    if (
+      !verification ||
+      (verification.classification !== "live" &&
+        verification.classification !== "redirected") ||
+      verification.quality_signals?.content_type_matches_kind !== true
+    ) {
+      continue;
+    }
+    if (!byNetuid.has(candidate.netuid)) {
+      byNetuid.set(candidate.netuid, {
+        netuid: candidate.netuid,
+        slug: candidate.slug ?? null,
+        domain: auth,
+        source_urls: new Set(),
+        kinds: new Set(),
+      });
+    }
+    const entry = byNetuid.get(candidate.netuid);
+    entry.source_urls.add(candidate.url);
+    entry.kinds.add(candidate.kind);
+    if (!entry.slug && candidate.slug) entry.slug = candidate.slug;
+  }
+  return [...byNetuid.values()]
+    .map((entry) => ({
+      netuid: entry.netuid,
+      slug: entry.slug,
+      domain: entry.domain,
+      kinds: [...entry.kinds].sort(),
+      source_urls: [...entry.source_urls].sort(),
+    }))
+    .sort((a, b) => a.netuid - b.netuid);
+}
+
+// Build the provenance review queue document from the elevation set: the subnets
+// a maintainer should elevate next, i.e. provenance-strong live APIs whose subnet
+// is NOT already at the top trust tier (maintainer-reviewed / adapter-backed).
+// Deterministic (generated_at is the fixed build placeholder) so the committed
+// queue is drift-checked by validate.mjs. Pure — takes the already-loaded inputs.
+const TOP_TRUST_LEVELS = new Set(["maintainer-reviewed", "adapter-backed"]);
+export function buildProvenanceReviewQueue({
+  candidates = [],
+  nativeSubnets = [],
+  verificationResults = [],
+  subnets = [],
+}) {
+  const levelByNetuid = new Map(
+    subnets.map((subnet) => [subnet.netuid, subnet.curation?.level ?? null]),
+  );
+  const slugByNetuid = new Map(
+    subnets.map((subnet) => [subnet.netuid, subnet.slug]),
+  );
+  const elevations = computeProvenanceElevations({
+    candidates,
+    nativeSubnets,
+    verificationResults,
+  });
+  const queue = elevations
+    .filter((entry) => !TOP_TRUST_LEVELS.has(levelByNetuid.get(entry.netuid)))
+    .map((entry) => ({
+      netuid: entry.netuid,
+      slug:
+        slugByNetuid.get(entry.netuid) ?? entry.slug ?? `sn-${entry.netuid}`,
+      current_level: levelByNetuid.get(entry.netuid) ?? null,
+      kinds: entry.kinds,
+      domain: entry.domain,
+      source_urls: entry.source_urls,
+      rationale:
+        `Live ${entry.kinds.join(" + ")} on the subnet's on-chain-asserted ` +
+        `domain (${entry.domain}). Strong provenance — elevate by adding a ` +
+        `decision to maintainer-reviewed.json after a quick confirm.`,
+    }));
+  return {
+    schema_version: 1,
+    generated_by: "metagraphed-review-queue",
+    generated_at: buildTimestamp(),
+    notes:
+      "Suggested maintainer-review elevations: provenance-strong, live callable " +
+      "APIs on each subnet's own on-chain-asserted domain that are not yet at the " +
+      "top trust tier. Machine-proposed; promote by moving an entry into " +
+      "maintainer-reviewed.json. Regenerate with `npm run review:queue`.",
+    queue,
+  };
+}
+
 // #1007: the distinct discovery sources (clustered domains) that independently
 // surfaced a candidate, from its source_urls. 2+ distinct sources is strong
 // corroboration — a URL claimed by both TaoMarketCap and a GitHub README is more

--- a/scripts/pipeline.mjs
+++ b/scripts/pipeline.mjs
@@ -99,6 +99,7 @@ function refreshCommands(refreshTimestamp) {
     step("verify:candidates", refreshEnv),
     step("curate:baseline", refreshEnv),
     step("review:promote"),
+    step("review:queue", refreshEnv),
     step("adapters:snapshot", refreshEnv),
     step("build", refreshEnv),
     step("schemas:snapshot", refreshEnv),

--- a/scripts/review-queue.mjs
+++ b/scripts/review-queue.mjs
@@ -1,0 +1,49 @@
+import path from "node:path";
+import {
+  buildProvenanceReviewQueue,
+  loadCandidates,
+  loadNativeSnapshot,
+  loadSubnets,
+  loadVerification,
+  repoRoot,
+  stableStringify,
+  writeRepositoryJson,
+} from "./lib.mjs";
+
+// Provenance review queue (Move A as promotion-by-exception). Regenerates
+// registry/reviews/review-queue.json: a short, high-signal list of subnets whose
+// callable API is live AND hosted on their own on-chain-asserted domain, but that
+// are NOT yet at the maintainer-reviewed/adapter-backed trust tier. These are the
+// elevations a maintainer should make next — the machine proposes (strong
+// provenance: chain-asserted domain + live probe), the human disposes by moving an
+// entry into maintainer-reviewed.json. Replaces blind hunting through the 2k-row
+// candidate pool. Pure transform of committed data (no network) → deterministic and
+// drift-checkable; validate.mjs fails if the committed queue is stale.
+
+const args = new Set(process.argv.slice(2));
+const shouldWrite = args.has("--write");
+const dryRun = !shouldWrite;
+const outputPath = path.join(repoRoot, "registry/reviews/review-queue.json");
+
+const [candidates, nativeSnapshot, verification, subnets] = await Promise.all([
+  loadCandidates(),
+  loadNativeSnapshot(),
+  loadVerification({ preferDetailed: false }),
+  loadSubnets(),
+]);
+
+const document = buildProvenanceReviewQueue({
+  candidates,
+  nativeSubnets: nativeSnapshot.subnets,
+  verificationResults: verification.results || [],
+  subnets,
+});
+
+if (dryRun) {
+  console.log(stableStringify({ mode: "dry-run", ...document }));
+} else {
+  await writeRepositoryJson(outputPath, document);
+  console.log(
+    stableStringify({ mode: "write", queued: document.queue.length }),
+  );
+}

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -7,6 +7,7 @@ import {
   subnetContact,
   flattenSurfaces,
   withSurfaceFreshness,
+  buildProvenanceReviewQueue,
   loadCandidates,
   loadVerification,
   loadNativeSnapshot,
@@ -1552,6 +1553,28 @@ for (const subnet of subnets) {
     );
   }
 }
+
+// Provenance review queue must stay fresh: it is a pure transform of committed
+// candidates + verification + chain identity, so a stale committed copy means a
+// new (or resolved) elevation suggestion was missed. Regenerate and compare.
+const committedReviewQueue = await readJson(
+  path.join(repoRoot, "registry/reviews/review-queue.json"),
+).catch(() => null);
+assert(
+  committedReviewQueue && Array.isArray(committedReviewQueue.queue),
+  "review queue: registry/reviews/review-queue.json must exist with a queue array",
+);
+const expectedReviewQueue = buildProvenanceReviewQueue({
+  candidates,
+  nativeSubnets: nativeSnapshot.subnets,
+  verificationResults: verificationDocument.results || [],
+  subnets,
+});
+assert(
+  stableStringify(committedReviewQueue) ===
+    stableStringify(expectedReviewQueue),
+  "review queue: registry/reviews/review-queue.json is stale — run `npm run review:queue` and commit the result",
+);
 
 await validateGeneratedArtifacts(nativeSnapshot, subnets, candidates);
 

--- a/tests/provenance-elevation.test.mjs
+++ b/tests/provenance-elevation.test.mjs
@@ -1,0 +1,211 @@
+// Unit tests for provenance auto-elevation (Move A): a callable API that is live
+// AND on the subnet's own on-chain-asserted domain is trustworthy without a human.
+// computeProvenanceElevations + buildProvenanceReviewQueue are pure, so they are
+// exercised here with synthetic fixtures (no network, no committed-data coupling).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  computeProvenanceElevations,
+  buildProvenanceReviewQueue,
+} from "../scripts/lib.mjs";
+
+const nativeSubnets = [
+  { netuid: 1, chain_identity: { subnet_url: "https://acme.ai" } },
+  { netuid: 2, chain_identity: { subnet_url: "https://other.io" } },
+  { netuid: 3, chain_identity: {} }, // no asserted url
+];
+
+// content-type matched + live unless noted
+const live = (candidate_id, over = {}) => ({
+  candidate_id,
+  classification: "live",
+  quality_signals: { content_type_matches_kind: true },
+  ...over,
+});
+
+describe("computeProvenanceElevations", () => {
+  test("elevates a live API on the subnet's on-chain-asserted domain", () => {
+    const candidates = [
+      {
+        id: "c1",
+        netuid: 1,
+        kind: "subnet-api",
+        url: "https://api.acme.ai/",
+        source_type: "github-readme-link",
+      },
+      {
+        id: "c2",
+        netuid: 1,
+        kind: "openapi",
+        url: "https://api.acme.ai/openapi.json",
+        source_type: "openapi-probe",
+      },
+    ];
+    const out = computeProvenanceElevations({
+      candidates,
+      nativeSubnets,
+      verificationResults: [live("c1"), live("c2")],
+    });
+    assert.equal(out.length, 1);
+    assert.equal(out[0].netuid, 1);
+    assert.equal(out[0].domain, "acme.ai");
+    assert.deepEqual(out[0].kinds, ["openapi", "subnet-api"]);
+    assert.deepEqual(out[0].source_urls, [
+      "https://api.acme.ai/",
+      "https://api.acme.ai/openapi.json",
+    ]);
+  });
+
+  test("excludes a candidate NOT on the on-chain-asserted domain", () => {
+    const out = computeProvenanceElevations({
+      candidates: [
+        {
+          id: "c",
+          netuid: 2,
+          kind: "subnet-api",
+          url: "https://api.elsewhere.com/",
+          source_type: "github-readme-link",
+        },
+      ],
+      nativeSubnets,
+      verificationResults: [live("c")],
+    });
+    assert.equal(out.length, 0);
+  });
+
+  test("excludes blind common-path guesses (openapi and subnet-api)", () => {
+    const out = computeProvenanceElevations({
+      candidates: [
+        {
+          id: "o",
+          netuid: 1,
+          kind: "openapi",
+          url: "https://acme.ai/openapi.json",
+          source_type: "project-website-common-path",
+        },
+        {
+          id: "a",
+          netuid: 1,
+          kind: "subnet-api",
+          url: "https://acme.ai/api",
+          source_type: "project-website-common-path",
+        },
+      ],
+      nativeSubnets,
+      verificationResults: [live("o"), live("a")],
+    });
+    assert.equal(out.length, 0);
+  });
+
+  test("excludes subnets with no on-chain asserted url", () => {
+    const out = computeProvenanceElevations({
+      candidates: [
+        {
+          id: "c",
+          netuid: 3,
+          kind: "subnet-api",
+          url: "https://api.acme.ai/",
+          source_type: "github-readme-link",
+        },
+      ],
+      nativeSubnets,
+      verificationResults: [live("c")],
+    });
+    assert.equal(out.length, 0);
+  });
+
+  test("excludes dead / content-mismatch / unverified candidates", () => {
+    const candidates = [
+      {
+        id: "dead",
+        netuid: 1,
+        kind: "subnet-api",
+        url: "https://api.acme.ai/a",
+        source_type: "github-readme-link",
+      },
+      {
+        id: "mismatch",
+        netuid: 1,
+        kind: "subnet-api",
+        url: "https://api.acme.ai/b",
+        source_type: "github-readme-link",
+      },
+      {
+        id: "none",
+        netuid: 1,
+        kind: "subnet-api",
+        url: "https://api.acme.ai/c",
+        source_type: "github-readme-link",
+      },
+    ];
+    const out = computeProvenanceElevations({
+      candidates,
+      nativeSubnets,
+      verificationResults: [
+        live("dead", { classification: "dead" }),
+        live("mismatch", {
+          quality_signals: { content_type_matches_kind: false },
+        }),
+        // "none" has no verification result at all
+      ],
+    });
+    assert.equal(out.length, 0);
+  });
+
+  test("non-API kinds (docs, website, dashboard) are never elevated", () => {
+    const out = computeProvenanceElevations({
+      candidates: [
+        {
+          id: "d",
+          netuid: 1,
+          kind: "docs",
+          url: "https://docs.acme.ai/",
+          source_type: "github-readme-link",
+        },
+      ],
+      nativeSubnets,
+      verificationResults: [live("d")],
+    });
+    assert.equal(out.length, 0);
+  });
+});
+
+describe("buildProvenanceReviewQueue", () => {
+  const candidates = [
+    {
+      id: "c1",
+      netuid: 1,
+      kind: "subnet-api",
+      url: "https://api.acme.ai/",
+      source_type: "github-readme-link",
+    },
+  ];
+  const verificationResults = [live("c1")];
+
+  test("queues an elevation when the subnet is below the top trust tier", () => {
+    const doc = buildProvenanceReviewQueue({
+      candidates,
+      nativeSubnets,
+      verificationResults,
+      subnets: [
+        { netuid: 1, slug: "acme", curation: { level: "machine-verified" } },
+      ],
+    });
+    assert.equal(doc.queue.length, 1);
+    assert.equal(doc.queue[0].netuid, 1);
+    assert.equal(doc.queue[0].slug, "acme");
+    assert.equal(doc.queue[0].current_level, "machine-verified");
+  });
+
+  test("omits subnets already at maintainer-reviewed or adapter-backed", () => {
+    for (const level of ["maintainer-reviewed", "adapter-backed"]) {
+      const doc = buildProvenanceReviewQueue({
+        candidates,
+        nativeSubnets,
+        verificationResults,
+        subnets: [{ netuid: 1, slug: "acme", curation: { level } }],
+      });
+      assert.equal(doc.queue.length, 0, level);
+    }
+  });
+});


### PR DESCRIPTION
## What

Move A, delivered as **promotion-by-exception**. Instead of the maintainer hunting through the ~2,000-row candidate pool, the machine now proposes exactly the subnets worth elevating to the trusted tier: a callable API (`openapi`/`subnet-api`) that is **verified live** AND hosted on the subnet's **own on-chain-asserted domain** (Subtensor `SubnetIdentitiesV3.subnet_url`). The chain vouches for the domain and we probed the API live — strong provenance, a one-confirm elevation.

## Why not silent auto-elevation?

I deliberately **do not** auto-write the `maintainer-reviewed` tier. That tier means "human-approved" and is now enforced as human-gated by the single-source-of-truth validator (#1234). Auto-claiming it on heuristics would make the served trust data dishonest. So the machine **proposes** (this queue) and the human **disposes** (moves an entry into `maintainer-reviewed.json`). Honest provenance, no silent trust claims, fully reversible.

## How

- **`lib.mjs`**
  - `computeProvenanceElevations()` — pure: on-chain-asserted domain + verification `live`/`redirected` + content-type matches kind. Strict source bar so a blind common-path guess never qualifies: `openapi` must be `openapi-probe` (structurally validated by #1004) or `community-pr-intake`; `subnet-api` must not be the blind `project-website-common-path` sweep.
  - `buildProvenanceReviewQueue()` — filters to subnets below the top trust tier.
- **`scripts/review-queue.mjs`** + `npm run review:queue` regenerate `registry/reviews/review-queue.json` deterministically from committed data (no network), prettier-clean via `writeRepositoryJson`.
- **`validate.mjs`** drift-gates the committed queue (recompute + compare) — it can never go stale silently (same pattern as the datasets freshness gate).
- **`pipeline.mjs`** regenerates the queue after `review:promote` on every 6h refresh.

## Effect today

The queue surfaces **SN59 (`api.babelbit.ai`)** and **SN107 (`api.theminos.ai`)** — live subnet-APIs on their chain-asserted domains, currently `machine-verified`. It grows automatically as the #1004 subdomain discovery lands more probe-confirmed specs (validated: of 455 API candidates on chain domains, the gate admits only the 11 live ones; the strict source bar narrows to the actionable set).

## Tests

8 new unit tests (on-domain include; off-domain / blind-source / no-chain-identity / dead / non-API exclude; queue tier filter). Full suite green (**1228**). Build produces no derived-artifact drift.