### PR TITLE
fix(publish): regenerate review-queue during candidate refresh

### DIFF
--- a/scripts/refresh-candidates.mjs
+++ b/scripts/refresh-candidates.mjs
@@ -31,6 +31,11 @@ const env = {
 const steps = [
   ["discover-candidates", ["scripts/discover-candidates.mjs", "--write"]],
   ["verify-candidates", ["scripts/verify-candidates.mjs", "--write"]],
+  // The provenance review queue is a pure transform of the candidates +
+  // verification just refreshed above; regenerate it in lockstep so the publish's
+  // `npm run validate` (which drift-checks the committed queue) sees a consistent
+  // state instead of failing whenever discovery finds something new.
+  ["review-queue", ["scripts/review-queue.mjs", "--write"]],
 ];
 
 for (const [label, args] of steps) {


### PR DESCRIPTION
## Bug (caught by a dry-run publish)

The production publish refreshes candidates+verification ephemerally each run (`refresh-candidates.mjs`, ADR 0006), then `npm run validate` runs — which (after #1235) drift-checks the committed `review-queue.json` against a recompute from the **fresh** candidates. The moment discovery finds anything new (e.g. an #1004 `api.<domain>` spec), recompute ≠ committed → **publish HARD-FAILS** at "Validate registry".

A dry-run publish (`workflow_dispatch publish_mode=dry-run`) reproduced it: the `refresh` job succeeded (discovery found new specs — #1004 working), but `publish` failed on `review-queue: ... is stale`.

## Fix

`refresh-candidates.mjs` now regenerates `review-queue.json` in lockstep with the candidates it just refreshed (third tolerant step), so the publish's `validate` sees a consistent state — exactly how the other publish-refreshed artifacts work. A failure keeps the last queue and the publish continues (issue #599 tolerance).