### PR TITLE
fix(publish): remove review-queue drift gate that breaks production publish

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -7,7 +7,6 @@ import {
   subnetContact,
   flattenSurfaces,
   withSurfaceFreshness,
-  buildProvenanceReviewQueue,
   loadCandidates,
   loadVerification,
   loadNativeSnapshot,
@@ -1553,28 +1552,6 @@ for (const subnet of subnets) {
     );
   }
 }
-
-// Provenance review queue must stay fresh: it is a pure transform of committed
-// candidates + verification + chain identity, so a stale committed copy means a
-// new (or resolved) elevation suggestion was missed. Regenerate and compare.
-const committedReviewQueue = await readJson(
-  path.join(repoRoot, "registry/reviews/review-queue.json"),
-).catch(() => null);
-assert(
-  committedReviewQueue && Array.isArray(committedReviewQueue.queue),
-  "review queue: registry/reviews/review-queue.json must exist with a queue array",
-);
-const expectedReviewQueue = buildProvenanceReviewQueue({
-  candidates,
-  nativeSubnets: nativeSnapshot.subnets,
-  verificationResults: verificationDocument.results || [],
-  subnets,
-});
-assert(
-  stableStringify(committedReviewQueue) ===
-    stableStringify(expectedReviewQueue),
-  "review queue: registry/reviews/review-queue.json is stale — run `npm run review:queue` and commit the result",
-);
 
 await validateGeneratedArtifacts(nativeSnapshot, subnets, candidates);
 


### PR DESCRIPTION
## Production was failing every 6h — my fault

The review-queue drift check I added in #1235 lives inside `npm run validate`, which the production publish runs *after* refreshing candidates ephemerally. The recomputed queue never matches the committed one → every publish HARD-FAILS at "Validate registry" → R2/KV goes stale. #1237 didn't fix it (the publish job restores refreshed candidates but not the regenerated queue).

## Fix

Remove the gate entirely (not paper over it). It also imposed the exact contributor friction we're trying to eliminate — an intake PR touching candidates would be forced to regenerate the committed queue. `npm run review:queue` remains an on-demand maintainer tool; `review-queue.json` is simply no longer a gated artifact.

Validate + eslint + prettier clean.