### PR TITLE
fix(publish): exempt adapter snapshots from soft wallet/key wording scan

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -80,6 +80,14 @@ function isMirroredExternalSpec(relativePath) {
   return [
     /^public\/metagraph\/schemas\/(?!index\.json$)[^/]+\.json$/,
     /^dist\/metagraph-r2\/metagraph\/schemas\/(?!index\.json$)[^/]+\.json$/,
+    // Adapter snapshots are machine-generated, live-fetched from each subnet's own
+    // upstream API/repo each publish — the same "published docs" case as schemas:
+    // legitimate wallet/key API vocabulary (e.g. Hippius SN75 documents "private
+    // key"/"seed phrase") false-positives the SOFT terminology heuristic and
+    // wedges the publish. Exempt the source snapshot + its R2 mirror from the soft
+    // patterns only; the HARD secret-value patterns above still apply to them.
+    /^registry\/adapters\/latest\/[^/]+\.json$/,
+    /^dist\/metagraph-r2\/metagraph\/adapters\/[^/]+\.json$/,
     ...mirroredFixturePatterns,
   ].some((pattern) => pattern.test(relativePath));
 }


### PR DESCRIPTION
Second production-publish failure (after #1239). The publish failed at `Public-safety scan` on the live-fetched **SN75 (Hippius) adapter snapshot** — legit "private key"/"seed phrase" API vocabulary tripping the **soft** terminology heuristic. Adapter snapshots are machine-generated from each subnet's own upstream API/repo every publish — the same case already exempted for schemas + fixtures. Extends the soft-pattern exemption to `registry/adapters/latest/*.json` + its `dist/metagraph-r2` mirror. HARD secret-value patterns still apply. Scan passes; lint/prettier clean.