### PR TITLE
chore(enrich): taostats identity gap-fills

### DIFF
--- a/registry/subnets/byzantium.json
+++ b/registry/subnets/byzantium.json
@@ -4,11 +4,7 @@
   "name": "Byzantium",
   "slug": "sn-76",
   "status": "active",
-  "categories": [
-    "baseline-curated",
-    "identity-reviewed",
-    "official-website"
-  ],
+  "categories": ["baseline-curated", "identity-reviewed", "official-website"],
   "source_repo": "https://github.com/byzantiumaitao-arch/byzantium",
   "dashboard_url": "https://taomarketcap.com/subnets/76",
   "website_url": "https://www.byzantiumai.net/",
@@ -38,9 +34,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://www.byzantiumai.net/"
-      ],
+      "source_urls": ["https://www.byzantiumai.net/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/byzantium.json
+++ b/registry/subnets/byzantium.json
@@ -4,7 +4,11 @@
   "name": "Byzantium",
   "slug": "sn-76",
   "status": "active",
-  "categories": ["baseline-curated", "identity-reviewed", "official-website"],
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-website"
+  ],
   "source_repo": "https://github.com/byzantiumaitao-arch/byzantium",
   "dashboard_url": "https://taomarketcap.com/subnets/76",
   "website_url": "https://www.byzantiumai.net/",
@@ -34,7 +38,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://www.byzantiumai.net/"],
+      "source_urls": [
+        "https://www.byzantiumai.net/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -43,5 +49,8 @@
       },
       "notes": "Official Byzantium website."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/byzantiumai"
+  }
 }

--- a/registry/subnets/sn-17.json
+++ b/registry/subnets/sn-17.json
@@ -5,8 +5,15 @@
   "slug": "sn-17",
   "status": "active",
   "categories": [],
-  "curation": { "level": "candidate-discovered", "review_state": "unreviewed" },
+  "curation": {
+    "level": "candidate-discovered",
+    "review_state": "unreviewed"
+  },
   "surfaces": [],
-  "social": { "x": "https://x.com/404gen_" },
-  "contact": "404@404.xyz"
+  "social": {
+    "x": "https://x.com/404gen_"
+  },
+  "contact": "404@404.xyz",
+  "source_repo": "https://github.com/404-Repo/404-gen-subnet",
+  "website_url": "https://www.404.xyz/"
 }

--- a/registry/subnets/sn-18.json
+++ b/registry/subnets/sn-18.json
@@ -5,7 +5,14 @@
   "slug": "sn-18",
   "status": "active",
   "categories": [],
-  "curation": { "level": "candidate-discovered", "review_state": "unreviewed" },
+  "curation": {
+    "level": "candidate-discovered",
+    "review_state": "unreviewed"
+  },
   "surfaces": [],
-  "social": { "x": "https://x.com/zeussubnet" }
+  "social": {
+    "x": "https://x.com/zeussubnet"
+  },
+  "source_repo": "https://github.com/Orpheus-AI/Zeus",
+  "website_url": "https://www.zeussubnet.com/"
 }

--- a/registry/subnets/sn-26.json
+++ b/registry/subnets/sn-26.json
@@ -5,8 +5,15 @@
   "slug": "sn-26",
   "status": "active",
   "categories": [],
-  "curation": { "level": "candidate-discovered", "review_state": "unreviewed" },
+  "curation": {
+    "level": "candidate-discovered",
+    "review_state": "unreviewed"
+  },
   "surfaces": [],
-  "social": { "x": "https://x.com/perturbaix" },
-  "contact": "hello@perturbai.io"
+  "social": {
+    "x": "https://x.com/perturbaix"
+  },
+  "contact": "hello@perturbai.io",
+  "source_repo": "https://github.com/0xsigurd/Perturb",
+  "website_url": "https://www.perturbai.io/"
 }

--- a/registry/subnets/sn-35.json
+++ b/registry/subnets/sn-35.json
@@ -5,7 +5,15 @@
   "slug": "sn-35",
   "status": "active",
   "categories": [],
-  "curation": { "level": "candidate-discovered", "review_state": "unreviewed" },
+  "curation": {
+    "level": "candidate-discovered",
+    "review_state": "unreviewed"
+  },
   "surfaces": [],
-  "contact": "contact@0xmarkets.io"
+  "contact": "contact@0xmarkets.io",
+  "source_repo": "https://github.com/General-Tao-Ventures/cartha-validator",
+  "website_url": "https://www.0xmarkets.io/",
+  "social": {
+    "x": "https://x.com/0x_Markets"
+  }
 }

--- a/registry/subnets/sn-36.json
+++ b/registry/subnets/sn-36.json
@@ -5,7 +5,14 @@
   "slug": "sn-36",
   "status": "active",
   "categories": [],
-  "curation": { "level": "candidate-discovered", "review_state": "unreviewed" },
+  "curation": {
+    "level": "candidate-discovered",
+    "review_state": "unreviewed"
+  },
   "surfaces": [],
-  "social": { "x": "https://x.com/rendix_network" }
+  "social": {
+    "x": "https://x.com/rendix_network"
+  },
+  "source_repo": "https://github.com/RendixNetwork/eirel-ai",
+  "website_url": "https://eirel.ai/"
 }

--- a/registry/subnets/sn-37.json
+++ b/registry/subnets/sn-37.json
@@ -5,8 +5,15 @@
   "slug": "sn-37",
   "status": "active",
   "categories": [],
-  "curation": { "level": "candidate-discovered", "review_state": "unreviewed" },
+  "curation": {
+    "level": "candidate-discovered",
+    "review_state": "unreviewed"
+  },
   "surfaces": [],
-  "social": { "x": "https://x.com/aureliusaligned" },
-  "contact": "aurelius.subnet@gmail.com"
+  "social": {
+    "x": "https://x.com/aureliusaligned"
+  },
+  "contact": "aurelius.subnet@gmail.com",
+  "source_repo": "https://github.com/Aurelius-Protocol/Aurelius-Protocol",
+  "website_url": "https://aureliusaligned.ai/"
 }

--- a/registry/subnets/sn-44.json
+++ b/registry/subnets/sn-44.json
@@ -5,8 +5,15 @@
   "slug": "sn-44",
   "status": "active",
   "categories": [],
-  "curation": { "level": "candidate-discovered", "review_state": "unreviewed" },
+  "curation": {
+    "level": "candidate-discovered",
+    "review_state": "unreviewed"
+  },
   "surfaces": [],
-  "social": { "x": "https://x.com/webuildscore" },
-  "contact": "hello@wearescore.com"
+  "social": {
+    "x": "https://x.com/webuildscore"
+  },
+  "contact": "hello@wearescore.com",
+  "source_repo": "https://github.com/score-technologies/turbovision",
+  "website_url": "https://www.wearescore.com/"
 }


### PR DESCRIPTION
## Provenance

These are **third-party TAOSTATS gap-fills** sourced from `https://api.taostats.io/api/subnet/identity/v1` — not curated maintainer data. All values were sanitized through the repo's own helpers (`backfilledIdentityUrl`, `socialAccounts`) before being written. Gap-fill only: no existing field was overwritten.

## Fields touched

- `source_repo` (from `github_repo`)
- `website_url` (from `subnet_url`)
- `social.x` (from `twitter`, converted from `@handle` to full URL)

## Subnets / fields filled

| Subnet | Fields |
|--------|--------|
| SN17 404—GEN | `source_repo`, `website_url` |
| SN18 Zeus | `source_repo`, `website_url` |
| SN26 Perturb | `source_repo`, `website_url` |
| SN35 OxMarkets | `source_repo`, `website_url`, `social.x` |
| SN36 Eirel | `source_repo`, `website_url` |
| SN37 Aurelius | `source_repo`, `website_url` |
| SN44 Score | `source_repo`, `website_url` |
| SN76 Byzantium | `social.x` |

**16 fills across 8 subnets.** Please verify the URLs/handles are correct before merging.