### PR TITLE
perf(health): probe every 15m instead of 2m + retune coupled thresholds

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -9,17 +9,21 @@
 
 import { computeReliability } from "./reliability.mjs";
 
-const D1_HEALTH_FALLBACK_MAX_AGE_MS = 10 * 60 * 1000;
+// Must exceed the probe cadence (15 min) so a live D1 health row is never treated
+// as stale just because the next probe hasn't run yet. 25 min = cadence + a
+// one-missed-run buffer. (KV health:current has no TTL, so this only bounds the
+// D1 fallback path.)
+const D1_HEALTH_FALLBACK_MAX_AGE_MS = 25 * 60 * 1000;
 
 // Pool-eligibility hysteresis (cosmos.directory-style "don't flap"): an RPC
 // endpoint is only dropped from the proxy pool after this many CONSECUTIVE
-// failed 2-min probes, so a single transient blip (~2-4 min) doesn't evict an
-// otherwise-healthy node. cosmos.directory tolerates ~10 errors before removal;
-// at a 2-min cadence, 4 (~8 min) is a conservative middle that still removes
-// genuinely-down nodes promptly. Env-overridable.
+// failed probes, so a single transient blip doesn't evict an otherwise-healthy
+// node. At the 15-min probe cadence, 2 (~30 min sustained-down) removes genuinely
+// dead nodes while the RPC proxy still fails over per-request in the meantime.
+// Env-overridable.
 const POOL_SUSTAINED_DOWN_FAILURES = Math.max(
   1,
-  Number(globalThis.process?.env?.METAGRAPH_POOL_SUSTAINED_DOWN_FAILURES) || 4,
+  Number(globalThis.process?.env?.METAGRAPH_POOL_SUSTAINED_DOWN_FAILURES) || 2,
 );
 
 const OPERATIONAL_KINDS = new Set([
@@ -422,10 +426,11 @@ export function formatBulkTrends({ observedAt, windows, windowDays = {} }) {
 
 // --- AI-4 historical analytics (pure transforms over D1 query rows) ---------
 
-// A gap larger than this between consecutive failing checks (probe cadence is
-// ~2 min) ends one incident and starts another. Used by the gap-island SQL in
-// the incidents handler.
-export const INCIDENT_GAP_MS = 6 * 60 * 1000;
+// A gap larger than this between consecutive failing checks ends one incident and
+// starts another. Must exceed the probe cadence (15 min) so consecutive failed
+// probes group into a single incident; 30 min = cadence + one missed-run buffer.
+// Used by the gap-island SQL in the incidents handler.
+export const INCIDENT_GAP_MS = 30 * 60 * 1000;
 
 // Minimum consecutive failed probes for a gap-island to count as an incident.
 // A single failed probe that recovers on the next (~2 min later) is transient

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -144,11 +144,11 @@ describe("overlayRpcPoolEligibility", () => {
       { id: "b", url: "https://b", pool_eligible: true },
     ],
   };
-  test("drops endpoints only after sustained (>=4) consecutive failures", () => {
+  test("drops endpoints only after sustained (>=2) consecutive failures", () => {
     const live = {
       endpoints: [
-        { id: "a", status: "failed", consecutive_failures: 3 }, // transient blip → stays (hysteresis)
-        { id: "b", status: "failed", consecutive_failures: 4 }, // sustained → drop
+        { id: "a", status: "failed", consecutive_failures: 1 }, // transient blip → stays (hysteresis)
+        { id: "b", status: "failed", consecutive_failures: 2 }, // sustained (~30 min at 15-min cadence) → drop
       ],
     };
     const out = overlayRpcPoolEligibility(pool, live);
@@ -1020,7 +1020,8 @@ describe("resolveLiveHealth (KV → D1 → null)", () => {
     assert.equal(live.surfaces[0].surface_key, "srf-d1fallback0000");
     assert.equal(live.subnets[0].netuid, 7);
     assert.equal(live.subnets[0].status, "failed");
-    assert.deepEqual(observedCutoffs, [1_700_000_000_000]);
+    // cutoff = now (1_700_000_600_000) − D1_HEALTH_FALLBACK_MAX_AGE_MS (25 min).
+    assert.deepEqual(observedCutoffs, [1_699_999_100_000]);
     // ms → ISO conversion for D1 timestamps.
     assert.match(live.surfaces[0].last_checked, /^20\d\d-/);
   });

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -6,10 +6,10 @@
 // without cycles.
 
 // Cron schedule strings (must match wrangler.jsonc `triggers.crons`). The hourly
-// trigger prunes the D1 time-series; every other trigger runs the 2-minute probe.
+// trigger prunes the D1 time-series; every other trigger runs the 15-minute probe.
 export const HEALTH_PRUNE_CRON = "0 * * * *";
 // Daily embedding-sync trigger (Worker-runtime, since CI has no AI bindings).
-// Distinct minute (odd) so it never collides with the 2-minute probe or the
+// Distinct minute (odd) so it never collides with the 15-minute probe or the
 // top-of-hour prune. Must match a wrangler.jsonc `triggers.crons` entry.
 export const EMBEDDING_SYNC_CRON = "37 3 * * *";
 // Trend windows for /api/v1/subnets/{netuid}/health/trends and

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -96,7 +96,7 @@
       "index_name": "metagraphed-registry-v2",
     },
   ],
-  // Live operational-health store. Written every 2 minutes by the cron prober
+  // Live operational-health store. Written every 15 minutes by the cron prober
   // (src/health-prober.mjs) and read live by the serving layer — decoupled from
   // the 6h build so a stale structural snapshot never freezes health.
   "d1_databases": [
@@ -107,11 +107,13 @@
       "migrations_dir": "migrations",
     },
   ],
-  // Cron prober: every 2 minutes probes the operational surfaces into D1/KV
-  // (served live); the hourly trigger prunes the D1 time-series. Registered
+  // Cron prober: every 15 minutes probes the operational surfaces into D1/KV
+  // (served live); the hourly trigger prunes the D1 time-series. 15 min (96
+  // checks/day/surface) is ample for a registry's uptime + incident signal and
+  // far politer to the probed subnets than the old 2-min sweep. Registered
   // automatically on the next Workers Builds deploy.
   "triggers": {
-    "crons": ["*/2 * * * *", "0 * * * *", "37 3 * * *"],
+    "crons": ["*/15 * * * *", "0 * * * *", "37 3 * * *"],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite
   // for enabling METAGRAPH_ENABLE_RPC_PROXY). 100 requests / 60s per client IP;


### PR DESCRIPTION
## Why

2-minute probing = **720 checks/day/surface** — overkill for a registry, and it hammers 129+ subnets' own endpoints. **15 minutes (96/day)** is ample for uptime %, trends, and incident detection, and far politer to the teams being probed. Less Worker/D1 burden too.

## Done properly — the cron isn't the only thing coupled to the cadence

- **Cron** `*/2`→`*/15` (wrangler.jsonc).
- **INCIDENT_GAP_MS** 6m→30m — must exceed the cadence or every failed probe (now 15m apart) reads as a separate incident in the gap-island SQL.
- **D1_HEALTH_FALLBACK_MAX_AGE_MS** 10m→25m — must exceed the cadence or a live D1 health row flaps to "stale" between runs. (KV `health:current` has no TTL, so this only bounds the D1 fallback path.)
- **POOL_SUSTAINED_DOWN_FAILURES** 4→2 — ~30m sustained-down before RPC-pool eviction at the new cadence (vs 60m if left at 4); the proxy still fails over per-request regardless.
- Updated cron comments + the 2 tests that asserted the old values.

Full health suite green (169 tests); lint/prettier clean. Deploys via Workers Builds on merge.