### PR TITLE
Fix review queue timestamp drift during refresh validation

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1797,6 +1797,7 @@ export function computeProvenanceElevations({
 // Deterministic (generated_at is the fixed build placeholder) so the committed
 // queue is drift-checked by validate.mjs. Pure — takes the already-loaded inputs.
 const TOP_TRUST_LEVELS = new Set(["maintainer-reviewed", "adapter-backed"]);
+const REVIEW_QUEUE_GENERATED_AT = "1970-01-01T00:00:00.000Z";
 export function buildProvenanceReviewQueue({
   candidates = [],
   nativeSubnets = [],
@@ -1832,7 +1833,7 @@ export function buildProvenanceReviewQueue({
   return {
     schema_version: 1,
     generated_by: "metagraphed-review-queue",
-    generated_at: buildTimestamp(),
+    generated_at: REVIEW_QUEUE_GENERATED_AT,
     notes:
       "Suggested maintainer-review elevations: provenance-strong, live callable " +
       "APIs on each subnet's own on-chain-asserted domain that are not yet at the " +

--- a/tests/provenance-elevation.test.mjs
+++ b/tests/provenance-elevation.test.mjs
@@ -197,6 +197,28 @@ describe("buildProvenanceReviewQueue", () => {
     assert.equal(doc.queue[0].current_level, "machine-verified");
   });
 
+  test("keeps generated_at deterministic when refresh timestamps are set", () => {
+    const previous = process.env.METAGRAPH_BUILD_TIMESTAMP;
+    process.env.METAGRAPH_BUILD_TIMESTAMP = "2025-01-02T03:04:05.000Z";
+    try {
+      const doc = buildProvenanceReviewQueue({
+        candidates,
+        nativeSubnets,
+        verificationResults,
+        subnets: [
+          { netuid: 1, slug: "acme", curation: { level: "machine-verified" } },
+        ],
+      });
+      assert.equal(doc.generated_at, "1970-01-01T00:00:00.000Z");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.METAGRAPH_BUILD_TIMESTAMP;
+      } else {
+        process.env.METAGRAPH_BUILD_TIMESTAMP = previous;
+      }
+    }
+  });
+
   test("omits subnets already at maintainer-reviewed or adapter-backed", () => {
     for (const level of ["maintainer-reviewed", "adapter-backed"]) {
       const doc = buildProvenanceReviewQueue({


### PR DESCRIPTION
### Motivation
- The provenance review queue document used `buildTimestamp()` for `generated_at`, making its output depend on `METAGRAPH_BUILD_TIMESTAMP` and causing `validate` to fail when the pipeline wrote the file with a refresh timestamp but recomputed it without one.
- The goal is to make the review queue deterministic so `validate`'s stable equality check does not fail due to a timestamp-only drift.

### Description
- Introduce a fixed deterministic marker `REVIEW_QUEUE_GENERATED_AT = "1970-01-01T00:00:00.000Z"` and use it for `generated_at` in `buildProvenanceReviewQueue()` in `scripts/lib.mjs` instead of `buildTimestamp()`.
- Add a regression test `keeps generated_at deterministic when refresh timestamps are set` to `tests/provenance-elevation.test.mjs` that sets `METAGRAPH_BUILD_TIMESTAMP` and asserts the queue's `generated_at` remains the deterministic epoch marker.
- The change is minimal and preserves other uses of `buildTimestamp()` elsewhere.

### Testing
- Ran `npm test -- tests/provenance-elevation.test.mjs`, which executed the file's test suite and passed (9 tests passed).
- Executed `METAGRAPH_BUILD_TIMESTAMP=2025-01-02T03:04:05.000Z npm run review:queue`, which completed and wrote the review queue without introducing diffs beyond the intended code changes.
- Attempted a full `npm run validate`, which could not complete in this checkout due to a missing generated artifact (`public/metagraph/providers.json`), so end-to-end validation was blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36af6ffaf8832cabb900e966587b41)