### PR TITLE
fix(discover): skip derived probes for generic hosts

### DIFF
--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -885,6 +885,9 @@ function collectOpenApiBaseOrigins() {
     } catch {
       return;
     }
+    if (isGenericHost(new URL(origin).hostname)) {
+      return;
+    }
     pushOrigin(netuid, provider, origin);
     // #1004 — also probe the conventional api./docs. subdomains of the same
     // registrable domain; live specs frequently live there, not on the marketing


### PR DESCRIPTION
### Motivation
- The change prevents `api.`/`docs.` sibling origins being derived from a source origin that would have been excluded by the generic-host denylist, fixing a logic regression that allowed generic hosts to trigger probes of unrelated registrable domains.

### Description
- Add an early return in `collectOpenApiBaseOrigins()` (`scripts/discover-candidates.mjs`) within `add()` that checks `if (isGenericHost(new URL(origin).hostname)) { return; }` to avoid calling `apiDocsSubdomainOrigins(origin)` for generic-source hosts while preserving the existing per-target `pushOrigin` guard.

### Testing
- Ran `npm test -- --run tests/openapi-discovery.test.mjs` and the test suite for `tests/openapi-discovery.test.mjs` passed (18 tests); ran `npm run lint` and the linter succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36af6ec428832c8a4b72053f7876da)