### PR TITLE
fix(review-queue): keep generated timestamp deterministic

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1832,7 +1832,7 @@ export function buildProvenanceReviewQueue({
   return {
     schema_version: 1,
     generated_by: "metagraphed-review-queue",
-    generated_at: buildTimestamp(),
+    generated_at: "1970-01-01T00:00:00.000Z",
     notes:
       "Suggested maintainer-review elevations: provenance-strong, live callable " +
       "APIs on each subnet's own on-chain-asserted domain that are not yet at the " +

--- a/tests/provenance-elevation.test.mjs
+++ b/tests/provenance-elevation.test.mjs
@@ -197,6 +197,29 @@ describe("buildProvenanceReviewQueue", () => {
     assert.equal(doc.queue[0].current_level, "machine-verified");
   });
 
+  test("uses a deterministic generated_at under production build timestamps", () => {
+    const previous = process.env.METAGRAPH_BUILD_TIMESTAMP;
+    process.env.METAGRAPH_BUILD_TIMESTAMP = "2026-01-02T03:04:05.006Z";
+    try {
+      const doc = buildProvenanceReviewQueue({
+        candidates,
+        nativeSubnets,
+        verificationResults,
+        subnets: [
+          { netuid: 1, slug: "acme", curation: { level: "machine-verified" } },
+        ],
+      });
+
+      assert.equal(doc.generated_at, "1970-01-01T00:00:00.000Z");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.METAGRAPH_BUILD_TIMESTAMP;
+      } else {
+        process.env.METAGRAPH_BUILD_TIMESTAMP = previous;
+      }
+    }
+  });
+
   test("omits subnets already at maintainer-reviewed or adapter-backed", () => {
     for (const level of ["maintainer-reviewed", "adapter-backed"]) {
       const doc = buildProvenanceReviewQueue({


### PR DESCRIPTION
### Motivation

- The production refresh path was regenerating `registry/reviews/review-queue.json` with `METAGRAPH_BUILD_TIMESTAMP`, causing `npm run validate` in the separate publish job to drift-fail because the validate job does not set `METAGRAPH_BUILD_TIMESTAMP`.

### Description

- Stop using `buildTimestamp()` for the review queue header by setting `generated_at` to the deterministic epoch placeholder (`"1970-01-01T00:00:00.000Z"`) in `buildProvenanceReviewQueue` in `scripts/lib.mjs`.
- Add a regression test in `tests/provenance-elevation.test.mjs` that sets `METAGRAPH_BUILD_TIMESTAMP` and asserts the review-queue `generated_at` remains the epoch placeholder.
- This preserves the existing queue computation/contents while removing environment-dependent stamping that caused publish validation false-positives.

### Testing

- Ran `npm test -- tests/provenance-elevation.test.mjs` and the targeted test file passed.
- Ran `npm run build` and the build completed successfully.
- Ran `npm run validate` after building and validation completed successfully (a pre-build `npm run validate` invocation failed due to missing generated `public/metagraph/*` artifacts, so validation was verified post-build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c0977a34832cac59043abfd8618e)