### PR TITLE
feat(publish): event-driven data publish + daily floor (replace the 6h cron)

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -1,17 +1,42 @@
 name: Publish Cloudflare Backend
 
-# Scheduled DATA refresh (ADR 0001). Builds fresh artifacts (live probes +
-# adapter snapshots) and publishes them to R2 + the KV `latest` pointer. The
-# Worker CODE + committed assets are deployed separately by Cloudflare Workers
-# Builds on push to main; this workflow only refreshes the DATA the Worker
-# serves from R2/KV, decoupled from code pushes (so a docs commit no longer
-# re-probes 1k+ surfaces). Run with workflow_dispatch publish_mode=dry-run to
-# validate without writing to R2/KV.
+# DATA refresh (ADR 0001). Builds fresh artifacts (chain snapshot + live probes +
+# adapter snapshots) and publishes them to R2 + the KV `latest` pointer. The Worker
+# CODE + committed assets deploy separately via Cloudflare Workers Builds on push to
+# main; this workflow only refreshes the DATA the Worker serves from R2/KV.
+#
+# Triggers — event-driven + daily floor:
+#   - push to main on human-input registry paths → republish so a merged
+#     contributor change (subnet / provider / community candidate / maintainer
+#     review / adapter) appears in the served dataset within minutes, not hours.
+#     Code/docs commits don't match the path filter, so they never trigger a
+#     re-probe (the original decoupling intent is preserved).
+#   - schedule: once daily → a floor for slow chain/registry drift. The volatile
+#     tiers are already served LIVE and refresh independently: surface health via
+#     the 15m prober (src/health-prober.mjs), economics via refresh-economics.yml.
+#   - workflow_dispatch (publish_mode=dry-run validates without writing R2/KV).
+#
+# No stale-pointer hazard: every run fresh-fetches the chain snapshot FIRST
+# (build.mjs productionSteps, tolerant), so the KV `latest` pointer always flips to
+# freshly-built data regardless of trigger. The prober is decoupled from this
+# publish too — operational-surfaces.json is DUAL/committed (#1247), so the live
+# health tier survives a publish outage.
 on:
+  push:
+    branches: [main]
+    # Human-input data only — NOT machine-generated paths (registry/native,
+    # registry/generated, registry/candidates/generated), which the build
+    # regenerates itself and must not self-trigger.
+    paths:
+      - "registry/subnets/**"
+      - "registry/providers/**"
+      - "registry/candidates/community/**"
+      - "registry/reviews/**"
+      - "registry/adapters/**"
   schedule:
-    # Every 6h — keeps published data within the freshness windows
-    # (surface-health blocks at 6h, adapter-snapshots at 24h).
-    - cron: "17 1,7,13,19 * * *"
+    # Daily floor (07:17 UTC). Volatile data is live (health 15m, economics 3h);
+    # this only catches slow chain/registry drift no event trigger covered.
+    - cron: "17 7 * * *"
   workflow_dispatch:
     inputs:
       publish_mode:


### PR DESCRIPTION
Implements the chosen "event-driven + daily floor" design for the publish. The 6h publish **can't be deleted** (its `build → r2:upload → kv:publish` core is the sole writer of the machine-computed dataset; making that data live is the dropped Stage 2). But its **cadence** was the real friction — a merged contributor change waited up to 6h, and the cron ran 4×/day mostly to refresh data that is now served live.

## Change
- **`push` to main, path-filtered** to human-input registry dirs (`subnets`, `providers`, `candidates/community`, `reviews`, `adapters`) → a merged contributor change is republished within **minutes**. Code/docs commits don't match the filter → no re-probe (preserves the original decoupling). Machine-generated paths (`registry/native`, `registry/generated`, `candidates/generated`) are **excluded** so a build-regenerated dataset can't self-trigger.
- **`schedule`: 6h (4×/day) → daily** — a floor for slow chain/registry drift. Volatile tiers are already live: health (15m prober), economics (`refresh-economics.yml`, 3h).

## Why it's safe (the pointer-flip landmine doesn't apply here)
- **Every run fresh-fetches the chain FIRST** (`build.mjs` productionSteps, tolerant) → the KV `latest` pointer always flips to freshly-built data, *regardless of trigger*. There is no "push flips the pointer to a stale committed snapshot" hazard.
- **Prober already decoupled** from the publish (`operational-surfaces.json` DUAL/committed, #1247) → the live health tier survives a publish gap.
- **secrets-gate** treats `push`/`schedule` as real publishes (existing `PUBLISH_MODE` default, line 257); **concurrency** group serializes a merge + cron rather than clobbering.
- Release workflows push **tags only** (no `branches:[main]` / registry match). `actionlint` + `prettier` clean.

## Verification
YAML parses, `actionlint` passes, no direct-push/bot workflow writes the trigger paths. The live push-trigger fires on the next registry PR merge; `workflow_dispatch` (dry-run) remains for manual validation.