### PR TITLE
feat(submission): hand all valid submissions to the autonomous reviewer (no maintainer pre-gating)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Skipping the rebuild trips `validate:contract-drift` in CI. Schemas are the sour
 
 Community data becomes a reviewed **candidate**, not direct registry truth. PR-first is the simplest path:
 
-> Add **exactly one** file — `registry/candidates/community/*.json` (a candidate) **or** `registry/providers/community/*.json` (a provider profile) — and **nothing else**. No generated artifacts.
+> Add **exactly one** file — `registry/candidates/community/*.json` (a candidate) **or** `registry/providers/community/*.json` (a provider profile) — and **nothing else**. No generated artifacts. First-time team? Add **both** in one PR (an atomic provider+candidate pair): the inline provider counts as registered, so your debut provider and first surface land together — no separate, pre-approved provider PR needed.
 
 Generate a candidate locally — three steps:
 
@@ -65,7 +65,7 @@ npm run validate:candidate -- registry/candidates/community/<your-file>.json
 
 A good candidate PR is small: one public URL, one source URL proving the claim, one active netuid, no generated files. Best kinds (these can be auto-reviewed): `docs`, `website`, `source-repo`, `dashboard`, `openapi`, `subnet-api`, `sse`, `data-artifact`, `sdk`, `example`.
 
-**Routes to manual review** (still welcome, just won't auto-merge): provider/operator profiles, base-layer `subtensor-rpc`/`subtensor-wss`/`archive` endpoints, authenticated or paid APIs, unknown providers, adapter requests, status reports, identity disputes.
+**Higher-trust kinds** (provider/operator profiles, base-layer `subtensor-rpc`/`subtensor-wss`/`archive` endpoints, authenticated or paid APIs, unknown providers, adapter requests, status reports, identity disputes) are also welcome and no longer need a maintainer: they go to the same autonomous reviewer, which scrutinizes identity/evidence harder and, when in doubt, closes or escalates rather than merging. Make the proof airtight (an independent `source_url` proving ownership) and they can merge like any other surface.
 
 **Hard boundaries:**
 
@@ -81,7 +81,7 @@ A good candidate PR is small: one public URL, one source URL proving the claim, 
 | Exactly one `registry/candidates/community/*.json` (or `providers/community/*.json`)                                 | Touches generated artifacts, scripts, or workflows ([#296](https://github.com/JSONbored/metagraphed/pull/296)) |
 | A public `url` **plus** a `source_url` that proves the claim                                                         | `source_url` 404s or doesn't back the claim ([#328](https://github.com/JSONbored/metagraphed/pull/328))        |
 | An auto-review `kind` (docs, website, source-repo, openapi, subnet-api, dashboard, sse, data-artifact, sdk, example) | A surface the subnet already exposes — duplicate ([#90](https://github.com/JSONbored/metagraphed/pull/90))     |
-| `auth_required: false`, `public_safe: true`, an active netuid, a registered provider                                 | Secrets/PATs/wallet paths, private/localhost URLs, or base-layer RPC/WSS/archive                               |
+| `auth_required: false`, `public_safe: true`, an active netuid, a registered provider (or one added in the same PR)   | Secrets/PATs/wallet paths, private/localhost URLs, or unproven ownership claims                                |
 
 A clean accepted example to copy: [#87](https://github.com/JSONbored/metagraphed/pull/87).
 

--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -19,7 +19,13 @@ marker comment, no Discord notification, and no AI content verdict.
   scope.
 - `route_away`: the PR is not a direct UGC submission and should use normal
   backend review.
-- `manual_review`: the submission may be useful but needs human judgment.
+- `manual_review`: a state the **private reviewer** may assign when it chooses to
+  escalate a submission for human judgment. The public preflight no longer
+  pre-assigns it to whole risk classes — a schema-valid submission is handed to
+  the autonomous reviewer as `submit_pr` with advisory risk signals
+  (`manual_reasons`), and the reviewer decides merge / close / escalate (it
+  defaults to close-or-escalate when in doubt and must never merge false data as
+  real).
 
 ## Labels
 
@@ -39,12 +45,20 @@ The stable marker comment is:
 
 ## Direct PR Shape
 
-Direct UGC PRs must change exactly one candidate or provider review file:
+Direct UGC PRs must change exactly one candidate or provider review file, OR an
+atomic provider+candidate **pair** (one of each):
 
 ```text
 registry/candidates/community/<slug>.json
 registry/providers/community/<slug>.json
 ```
+
+The atomic pair is the **debut lane**: a first-time team registers its provider
+and lands its first surface in a single PR. The inline provider counts as
+registered for the candidate's checks, so no prior, separately-reviewed provider
+PR is required. (Submitting a candidate alone that references an unregistered
+provider is a non-terminal `fix_required` asking you to add the provider in the
+same PR — it is never auto-closed.)
 
 The file must contain exactly one candidate:
 
@@ -130,9 +144,11 @@ App after required public checks pass. Public preflight only decides whether a
 submission is shaped correctly enough for private review; it does not expose AI
 scoring, thresholds, prompts, examples, corpus weights, or model internals.
 
-Direct provider profile PRs always route to manual/private review. They are
-useful, but they identify operators and can affect future endpoint trust, so
-they are not direct-merge content.
+Direct provider profile PRs are handed to the private reviewer like any other
+submission (`submit_pr`), carrying the `provider profile submissions require
+review` advisory signal. They identify operators and can affect future endpoint
+trust, so the reviewer scrutinizes identity and defaults to close/escalate when
+in doubt — but a provider profile is no longer pre-blocked from autonomous merge.
 
 Maintainer automation branches such as `codex/*` are ignored before D1 state,
 labels, comments, AI review, or Discord notifications. Direct UGC examples
@@ -154,7 +170,11 @@ The public gate accepts or routes:
 - adapter requests and evidence/provenance corrections.
 
 Base-layer RPC/WSS/archive claims, unknown providers, authenticated APIs,
-adapter requests, and conflicting source claims route to manual/private review.
+adapter requests, and conflicting source claims are handed to the autonomous
+reviewer with advisory risk signals (`manual_reasons`) rather than pre-routed to
+a maintainer. These are the highest-trust surfaces, so the reviewer scrutinizes
+them hardest and defaults to close/escalate when evidence is thin — but the
+public preflight no longer forces a human gate on the whole class.
 
 Endpoint and status submissions can create candidates, reports, or re-probe
 work. They cannot directly set observed uptime, latency, status, health class,
@@ -181,11 +201,15 @@ The private `metagraphed-submission-gate` should run on Cloudflare:
 The public workflow job `metagraphed-submission-gate` only runs deterministic
 preflight. It must not publish, merge, or expose private review details.
 
-The private runtime makes the final UGC decision. For low-risk direct candidate
-PRs, the AI reviewer returns a strict public-safe verdict object. Deterministic
-hard guards still win over AI: unsafe URLs, secrets, private endpoints,
-duplicates, generated artifact edits, unsupported file shapes, base-layer
-RPC/archive claims, and authenticated surfaces cannot be merged automatically.
+The private runtime makes the final UGC decision for every schema-valid
+submission (`submit_pr`), returning a strict public-safe verdict object.
+Deterministic hard guards still win over AI and block the PR at preflight
+(`fix_required`): unsafe/private URLs, secrets, duplicates, generated-artifact
+edits, and unsupported file shapes cannot reach the reviewer at all. Higher-trust
+classes — base-layer RPC/WSS/archive claims, authenticated surfaces, owner
+mismatches, and provider profiles — are NOT deterministic hard blocks; they reach
+the reviewer as advisory `manual_reasons` so it can scrutinize them and, when in
+doubt, close or escalate to `manual_review` rather than merge.
 
 Production GitHub writes must use a GitHub App installation token. A fallback
 `GITHUB_TOKEN` can exist for emergency/local testing only when the private

--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -541,31 +541,22 @@ export function buildPrSubmissionReport({
     };
   }
 
-  if (errors.length === 0 && scope.scope === "direct-candidate") {
+  if (
+    errors.length === 0 &&
+    (scope.scope === "direct-candidate" || scope.scope === "direct-pair")
+  ) {
     const extracted = extractSingleCandidate(candidateDocument);
     errors.push(...extracted.errors);
     candidate = extracted.candidate;
   }
 
-  if (errors.length === 0 && scope.scope === "direct-provider") {
+  if (
+    errors.length === 0 &&
+    (scope.scope === "direct-provider" || scope.scope === "direct-pair")
+  ) {
     const extracted = extractSingleProvider(providerDocument);
     errors.push(...extracted.errors);
     provider = extracted.provider;
-  }
-
-  if (candidate) {
-    const deterministic = validateCandidateForSubmission({
-      candidate,
-      document: candidateDocument,
-      submitter,
-      native,
-      providers,
-      existingCandidates,
-      existingSubnets,
-    });
-    errors.push(...deterministic.errors);
-    manual_reasons.push(...deterministic.manual_reasons);
-    warnings.push(...deterministic.warnings);
   }
 
   if (provider) {
@@ -580,12 +571,37 @@ export function buildPrSubmissionReport({
     warnings.push(...deterministic.warnings);
   }
 
-  const publicState =
-    errors.length > 0
-      ? "fix_required"
-      : manual_reasons.length > 0
-        ? "manual_review"
-        : "submit_pr";
+  if (candidate) {
+    // Atomic provider+candidate pair: the inline provider counts as registered
+    // for the candidate's provider checks, so a first-time team can land its
+    // debut provider + first surface in one PR (the build writes both in the
+    // same merge) without a prior, separately-reviewed provider PR.
+    const providersForCandidate =
+      provider && scope.scope === "direct-pair"
+        ? [...providers, provider]
+        : providers;
+    const deterministic = validateCandidateForSubmission({
+      candidate,
+      document: candidateDocument,
+      submitter,
+      native,
+      providers: providersForCandidate,
+      existingCandidates,
+      existingSubnets,
+    });
+    errors.push(...deterministic.errors);
+    manual_reasons.push(...deterministic.manual_reasons);
+    warnings.push(...deterministic.warnings);
+  }
+
+  // reviewbot owns the merge / close / manual-review decision and defaults to
+  // close-or-escalate when in doubt (it must almost never merge false data as
+  // real). The gate therefore no longer pre-escalates whole risk CLASSES to a
+  // maintainer lane: a schema-valid submission is handed to the autonomous
+  // reviewer (submit_pr) regardless of manual_reasons, which are now ADVISORY
+  // risk signals the reviewer weighs — not a human gate. Only genuine,
+  // contributor-fixable problems block the PR (fix_required).
+  const publicState = errors.length > 0 ? "fix_required" : "submit_pr";
   const terminalRecommendation = errors.some((error) =>
     TERMINAL_FIX_CATEGORIES.has(error.category),
   )
@@ -609,8 +625,7 @@ export function buildPrSubmissionReport({
     provider,
     publish_allowed: false,
     auto_merge_eligible: false,
-    private_review_required:
-      publicState === "submit_pr" || publicState === "manual_review",
+    private_review_required: publicState === "submit_pr",
     blocking: publicState === "fix_required",
     terminal_recommendation: terminalRecommendation,
     review_marker: SUBMISSION_REVIEW_MARKER,
@@ -623,9 +638,7 @@ export function buildPrSubmissionReport({
     next_action:
       publicState === "submit_pr"
         ? "private-review"
-        : publicState === "manual_review"
-          ? "manual-review"
-          : terminalRecommendation || "resubmission-needed",
+        : terminalRecommendation || "resubmission-needed",
   };
 }
 
@@ -660,11 +673,16 @@ export function classifyPrScope(changedFiles) {
   }
 
   const submissionFileCount = candidateFiles.length + providerFiles.length;
-  if (submissionFileCount !== 1) {
+  // Allowed shapes: exactly one candidate, exactly one provider, OR an atomic
+  // provider+candidate PAIR (one of each) so a first-time team can land its debut
+  // provider + first surface together without a prior, separately-reviewed
+  // provider PR. Anything else is out-of-shape.
+  const isPair = candidateFiles.length === 1 && providerFiles.length === 1;
+  if (submissionFileCount !== 1 && !isPair) {
     errors.push({
       category: "unsupported-shape",
       message:
-        "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/community/*.json file",
+        "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/community/*.json file, or an atomic provider+candidate pair (one of each)",
     });
   }
 
@@ -681,7 +699,11 @@ export function classifyPrScope(changedFiles) {
   }
 
   return {
-    scope: providerFiles.length === 1 ? "direct-provider" : "direct-candidate",
+    scope: isPair
+      ? "direct-pair"
+      : providerFiles.length === 1
+        ? "direct-provider"
+        : "direct-candidate",
     candidateFiles,
     providerFiles,
     errors,
@@ -1202,9 +1224,13 @@ export function validateCandidateForSubmission({
     );
   }
   if (!providerIds.has(candidate.provider)) {
+    // Non-terminal: a brand-new team's debut surface references a provider that
+    // isn't registered yet. Don't auto-close — tell the contributor to include
+    // the provider in the SAME PR (an atomic provider+candidate pair), which the
+    // gate accepts and counts as registered. A contributor fix, never a maintainer.
     errors.push({
-      category: "unsupported-shape",
-      message: `candidate provider ${candidate.provider || "<missing>"} is not registered`,
+      category: "provider-not-registered",
+      message: `candidate provider ${candidate.provider || "<missing>"} is not registered — include its registry/providers/community/<id>.json in the same PR`,
     });
   }
   // Placeholder/example identity URLs (example.com, github.com/username/repo, "deprecated") are never

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -368,7 +368,7 @@ describe("Metagraphed submission gate policy", () => {
   // artifacts are now R2-only (ADR 0001), so there is nothing committed to diff.
   // The reject-arbitrary-artifact safety checks above still guard contributor PRs.
 
-  test("routes direct provider profile PRs to manual review", () => {
+  test("hands a direct provider profile PR to the autonomous reviewer with the provider-review advisory flag", () => {
     const document = structuredClone(validProviderDocument);
     document.submission.submitted_by = "jsonbored";
     document.submission.submitted_by_url = "https://github.com/jsonbored";
@@ -381,8 +381,11 @@ describe("Metagraphed submission gate policy", () => {
       submitter: "JSONbored",
     });
 
-    assert.equal(report.public_state, "manual_review");
-    assert.equal(report.next_action, "manual-review");
+    // Provider profiles no longer pre-escalate to a maintainer lane: a valid one
+    // is handed to reviewbot (submit_pr), which adjudicates using the advisory
+    // manual_reasons signal (provider identity affects future endpoint trust).
+    assert.equal(report.public_state, "submit_pr");
+    assert.equal(report.next_action, "private-review");
     assert.equal(report.private_review_required, true);
     assert.equal(report.blocking, false);
     assert.equal(
@@ -464,15 +467,105 @@ describe("Metagraphed submission gate policy", () => {
     );
   });
 
-  test("blocks mixed direct candidate and provider PRs", () => {
+  test("accepts an atomic provider+candidate pair PR (debut lane)", () => {
     const scope = classifyPrScope([
       "registry/candidates/community/allways-docs-example.json",
       "registry/providers/community/example-operator.json",
     ]);
 
-    assert.equal(scope.scope, "direct-provider");
-    assert.equal(scope.errors.length, 1);
-    assert.equal(scope.errors[0].category, "unsupported-shape");
+    // One candidate + one provider (and nothing else) is the atomic debut pair:
+    // a first-time team registers its provider and lands its first surface in one
+    // PR. No error — it routes down the UGC lane to reviewbot.
+    assert.equal(scope.scope, "direct-pair");
+    assert.equal(scope.errors.length, 0);
+  });
+
+  test("still blocks a direct submission bundled with unrelated files", () => {
+    const scope = classifyPrScope([
+      "registry/candidates/community/allways-docs-example.json",
+      "registry/providers/community/example-operator.json",
+      "scripts/build.mjs",
+    ]);
+
+    assert.equal(
+      scope.errors.some(
+        (error) => error.category === "generated-artifact-tampering",
+      ),
+      true,
+    );
+  });
+
+  test("still blocks two candidate files (only an atomic one-of-each pair is allowed)", () => {
+    const scope = classifyPrScope([
+      "registry/candidates/community/allways-docs-example.json",
+      "registry/candidates/community/another-candidate.json",
+    ]);
+
+    assert.equal(
+      scope.errors.some((error) => error.category === "unsupported-shape"),
+      true,
+    );
+  });
+
+  test("accepts an atomic provider+candidate debut pair end-to-end (inline provider counts as registered)", () => {
+    const providerDoc = structuredClone(validProviderDocument);
+    providerDoc.submission.submitted_by = "jsonbored";
+    providerDoc.submission.submitted_by_url = "https://github.com/jsonbored";
+    const candidateDoc = structuredClone(validCandidateDocument);
+    candidateDoc.candidates[0].id = "community-sn-7-docs-debut";
+    candidateDoc.candidates[0].provider = providerDoc.provider.id; // not yet registered
+
+    const report = buildPrSubmissionReport({
+      changedFiles: [
+        "registry/candidates/community/community-sn-7-docs-debut.json",
+        "registry/providers/community/example-operator.json",
+      ],
+      candidateDocument: candidateDoc,
+      providerDocument: providerDoc,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+
+    // The inline provider satisfies the candidate's registration check, so a
+    // brand-new team's debut provider + first surface land in one PR → reviewbot.
+    assert.equal(report.public_state, "submit_pr");
+    assert.equal(report.blocking, false);
+    assert.equal(
+      report.errors.some((error) => /is not registered/.test(error)),
+      false,
+    );
+    assert.equal(report.candidate.id, "community-sn-7-docs-debut");
+    assert.equal(report.provider.id, providerDoc.provider.id);
+  });
+
+  test("flags a candidate referencing an unregistered provider as a NON-terminal fix (not an auto-close)", () => {
+    const candidateDoc = structuredClone(validCandidateDocument);
+    candidateDoc.candidates[0].id = "community-sn-7-docs-noprovider";
+    candidateDoc.candidates[0].provider = "brand-new-unregistered-provider";
+
+    const report = buildPrSubmissionReport({
+      changedFiles: [
+        "registry/candidates/community/community-sn-7-docs-noprovider.json",
+      ],
+      candidateDocument: candidateDoc,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+
+    assert.equal(report.public_state, "fix_required");
+    assert.equal(report.blocking, true);
+    assert.equal(
+      report.error_categories.includes("provider-not-registered"),
+      true,
+    );
+    // Non-terminal: the contributor fixes it by adding the provider in the same
+    // PR — the gate must not recommend auto-closing the debut submission.
+    assert.equal(report.terminal_recommendation, null);
+    assert.notEqual(report.next_action, "close");
   });
 
   test("blocks unsafe candidate URLs", () => {
@@ -522,7 +615,7 @@ describe("Metagraphed submission gate policy", () => {
     );
   });
 
-  test("routes auth-required and base-layer endpoint claims to manual review", () => {
+  test("hands auth-required and base-layer endpoint claims to reviewbot with high-trust advisory flags", () => {
     const authDocument = structuredClone(validCandidateDocument);
     authDocument.candidates[0].auth_required = true;
     const authReport = buildPrSubmissionReport({
@@ -533,7 +626,15 @@ describe("Metagraphed submission gate policy", () => {
       existingSubnets: subnets,
       submitter: "jsonbored",
     });
-    assert.equal(authReport.public_state, "manual_review");
+    // High-trust surfaces are no longer pre-escalated to a maintainer lane —
+    // reviewbot adjudicates them, with the risk surfaced as advisory flags.
+    assert.equal(authReport.public_state, "submit_pr");
+    assert.equal(
+      authReport.manual_reasons.includes(
+        "authenticated interfaces require review",
+      ),
+      true,
+    );
 
     const rpcDocument = structuredClone(validCandidateDocument);
     rpcDocument.candidates[0].kind = "subtensor-rpc";
@@ -546,10 +647,16 @@ describe("Metagraphed submission gate policy", () => {
       existingSubnets: subnets,
       submitter: "jsonbored",
     });
-    assert.equal(rpcReport.public_state, "manual_review");
+    assert.equal(rpcReport.public_state, "submit_pr");
+    assert.equal(
+      rpcReport.manual_reasons.includes(
+        "base-layer RPC/WSS/archive endpoint claims require review",
+      ),
+      true,
+    );
   });
 
-  test("routes an ownership-sensitive surface whose owner does not match its provider to manual review", () => {
+  test("hands an ownership-mismatched surface to reviewbot with the owner-mismatch advisory flag", () => {
     const document = structuredClone(validCandidateDocument);
     Object.assign(document.candidates[0], {
       id: "community-sn-7-source-repo-mismatch",
@@ -566,7 +673,7 @@ describe("Metagraphed submission gate policy", () => {
       existingSubnets: subnets,
       submitter: "jsonbored",
     });
-    assert.equal(report.public_state, "manual_review");
+    assert.equal(report.public_state, "submit_pr");
     assert.equal(
       report.manual_reasons.some((reason) =>
         reason.includes("does not match its registered provider"),
@@ -575,7 +682,7 @@ describe("Metagraphed submission gate policy", () => {
     );
   });
 
-  test("routes an ownership-sensitive surface with mismatched url even when source_url matches provider to manual review", () => {
+  test("hands a masked ownership-mismatch (url owner differs, source_url matches) to reviewbot with the advisory flag", () => {
     const document = structuredClone(validCandidateDocument);
     Object.assign(document.candidates[0], {
       id: "community-sn-7-source-repo-masked-mismatch",
@@ -592,7 +699,7 @@ describe("Metagraphed submission gate policy", () => {
       existingSubnets: subnets,
       submitter: "jsonbored",
     });
-    assert.equal(report.public_state, "manual_review");
+    assert.equal(report.public_state, "submit_pr");
     assert.equal(
       report.manual_reasons.some((reason) =>
         reason.includes("url owner does not match its registered provider"),
@@ -639,7 +746,7 @@ describe("Metagraphed submission gate policy", () => {
     );
   });
 
-  test("routes a non-repo surface whose source_url equals its url (no independent proof) to manual review", () => {
+  test("hands a non-repo surface whose source_url equals its url (no independent proof) to reviewbot with the advisory flag", () => {
     const document = structuredClone(validCandidateDocument);
     Object.assign(document.candidates[0], {
       id: "community-sn-7-website-selfproof",
@@ -656,7 +763,7 @@ describe("Metagraphed submission gate policy", () => {
       existingSubnets: subnets,
       submitter: "jsonbored",
     });
-    assert.equal(report.public_state, "manual_review");
+    assert.equal(report.public_state, "submit_pr");
     assert.equal(
       report.manual_reasons.some((reason) =>
         reason.includes("independent proof source"),
@@ -705,7 +812,7 @@ describe("Metagraphed submission gate policy", () => {
       existingSubnets: subnets,
       submitter: "jsonbored",
     });
-    assert.equal(report.public_state, "manual_review");
+    assert.equal(report.public_state, "submit_pr");
     assert.equal(
       report.manual_reasons.some((reason) =>
         reason.includes("independent proof source"),


### PR DESCRIPTION
Makes the contributor lane fully autonomous on the **metagraphed side** so reviewbot can accept contributions across all data areas with **no maintainer action before or after merge**. reviewbot's own review rules are configured separately (it is the adjudicator) — this PR only changes what metagraphed hands it.

## Context (from the contributor-lane audit)
The direct-PR lane was *already* autonomous for the common case — proven by fork PR [#1231](https://github.com/JSONbored/metagraphed/pull/1231) (real external contributor, merged by `reviewwed[bot]`, zero human action). The trust/provenance layer is an **optional display tier**, never a serve-time or acceptance gate (auto-promote to `machine-verified` is self-healing; the Worker does zero tier filtering). The only remaining maintainer-forcing gates were the PR-gate's own pre-classifications.

## Changes
- **No class pre-escalation.** `public_state` drops the `manual_reasons → manual_review` branch: a schema-valid submission is `submit_pr` (the reviewer's *proven* autonomous lane) regardless of `manual_reasons`, which become **advisory risk signals** the reviewer weighs — owner mismatch, base-layer `subtensor-rpc`/`subtensor-wss`/`archive`, `auth_required`, provider profiles. Only genuine contributor-fixable problems block (`fix_required`).
- **Atomic provider+candidate pair (debut lane).** `classifyPrScope` accepts one-of-each; the inline provider counts as registered, so a first-time team lands its provider + first surface in one PR.
- **`provider-not-registered` is now non-terminal** (its own category, not `unsupported-shape`) → "add the provider in the same PR", never an auto-close.
- **Docs** (`submission-gate.md`, `CONTRIBUTING.md`) updated for the pair/debut lane + advisory-not-gating semantics.

## Safety
- Genuine hard guards still block at preflight (`fix_required`): unsafe/private URLs, secrets, duplicates, generated-artifact edits, unsupported shapes. High-trust classes reach the reviewer with their risk flags so it can scrutinize and **close/escalate when in doubt** (never merge false-as-real).
- Serving + auto-promote untouched (already tier-agnostic + self-healing).

## Validation
Full suite **1244** green (incl. 4 new/updated submission-gate cases: debut pair, non-terminal provider-not-registered, advisory flags preserved for all opened classes); `validate:intake` + `validate:contract-drift` clean.