### PR TITLE
docs(intake): add EvolAI official website candidate (SN47)

### DIFF
--- a/registry/candidates/community/community-sn-47-website-evolai-ai.json
+++ b/registry/candidates/community/community-sn-47-website-evolai-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-47-website-evolai-ai",
+      "kind": "website",
+      "name": "EvolAI official website",
+      "netuid": 47,
+      "provider": "evolai",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/openevolai/evolai",
+      "source_urls": ["https://github.com/openevolai/evolai"],
+      "state": "schema-valid",
+      "url": "https://evolai.ai/"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
Closes #460.

Adds SN47 EvolAI's **official website** as a community candidate (one file).

**Verification (live):**
- `url`: https://evolai.ai/ → HTTP 200, site titled "Evolai"
- `source_url`: https://github.com/openevolai/evolai → the subnet's registered `source_repo` (openevolai team); `evolai.ai` is that team's site and matches the registered `evolai` provider's `website_url`
- Read-only, public → `public_safe: true`

Passes locally: `validate:candidate`, prettier, and the submission preflight (`public_state: submit_pr`, non-blocking, no warnings).