### PR TITLE
fix(client): fetchAll reads nested data[<collection>], not a flat array

### DIFF
--- a/generated/metagraphed-client.ts
+++ b/generated/metagraphed-client.ts
@@ -714,11 +714,30 @@ export function createMetagraphedClient(
   ): Promise<Item[]> {
     const items: Item[] = [];
     for await (const page of paginate(path, options)) {
+      // List endpoints nest their rows under data[meta.pagination.collection]
+      // (e.g. data.subnets), not as a bare array. Resolve the collection key,
+      // falling back to a flat data array or the single array-valued field.
       const data = (page as { data?: unknown }).data;
       if (Array.isArray(data)) {
         items.push(...(data as Item[]));
-      } else if (data !== undefined && data !== null) {
-        items.push(data as Item);
+        continue;
+      }
+      if (typeof data !== "object" || data === null) {
+        continue;
+      }
+      const record = data as Record<string, unknown>;
+      const collection = (
+        page as { meta?: { pagination?: { collection?: unknown } } }
+      ).meta?.pagination?.collection;
+      if (typeof collection === "string" && Array.isArray(record[collection])) {
+        items.push(...(record[collection] as Item[]));
+        continue;
+      }
+      const arrays = Object.values(record).filter((value) =>
+        Array.isArray(value),
+      );
+      if (arrays.length === 1) {
+        items.push(...(arrays[0] as Item[]));
       }
     }
     return items;

--- a/scripts/generate-client.mjs
+++ b/scripts/generate-client.mjs
@@ -734,11 +734,30 @@ export function createMetagraphedClient(
   ): Promise<Item[]> {
     const items: Item[] = [];
     for await (const page of paginate(path, options)) {
+      // List endpoints nest their rows under data[meta.pagination.collection]
+      // (e.g. data.subnets), not as a bare array. Resolve the collection key,
+      // falling back to a flat data array or the single array-valued field.
       const data = (page as { data?: unknown }).data;
       if (Array.isArray(data)) {
         items.push(...(data as Item[]));
-      } else if (data !== undefined && data !== null) {
-        items.push(data as Item);
+        continue;
+      }
+      if (typeof data !== "object" || data === null) {
+        continue;
+      }
+      const record = data as Record<string, unknown>;
+      const collection = (
+        page as { meta?: { pagination?: { collection?: unknown } } }
+      ).meta?.pagination?.collection;
+      if (typeof collection === "string" && Array.isArray(record[collection])) {
+        items.push(...(record[collection] as Item[]));
+        continue;
+      }
+      const arrays = Object.values(record).filter((value) =>
+        Array.isArray(value),
+      );
+      if (arrays.length === 1) {
+        items.push(...(arrays[0] as Item[]));
       }
     }
     return items;

--- a/tests/client-sdk.test.ts
+++ b/tests/client-sdk.test.ts
@@ -392,17 +392,18 @@ describe("createMetagraphedClient", () => {
     }
   });
 
-  test("fetchAll collects data rows across cursor pages", async () => {
+  test("fetchAll collects nested data[collection] rows across cursor pages", async () => {
+    // List endpoints nest rows under data[meta.pagination.collection].
     const pages = [
       {
         ok: true,
-        data: [{ netuid: 1 }, { netuid: 2 }],
-        meta: { pagination: { next_cursor: "c2" } },
+        data: { subnets: [{ netuid: 1 }, { netuid: 2 }] },
+        meta: { pagination: { collection: "subnets", next_cursor: "c2" } },
       },
       {
         ok: true,
-        data: [{ netuid: 3 }],
-        meta: { pagination: { next_cursor: null } },
+        data: { subnets: [{ netuid: 3 }] },
+        meta: { pagination: { collection: "subnets", next_cursor: null } },
       },
     ];
     let index = 0;
@@ -415,6 +416,37 @@ describe("createMetagraphedClient", () => {
     expect((fetchMock.mock.calls[1][0] as URL).searchParams.get("cursor")).toBe(
       "c2",
     );
+  });
+
+  test("fetchAll falls back to a flat data array and the lone array field", async () => {
+    const flat = vi.fn(async () =>
+      jsonResponse({
+        ok: true,
+        data: [{ id: "a" }],
+        meta: { pagination: { next_cursor: null } },
+      }),
+    );
+    const flatClient = createMetagraphedClient({
+      fetch: flat as unknown as typeof fetch,
+    });
+    expect(await flatClient.fetchAll("/api/v1/subnets" as never)).toEqual([
+      { id: "a" },
+    ]);
+
+    // No collection key, but data has a single array-valued field.
+    const lone = vi.fn(async () =>
+      jsonResponse({
+        ok: true,
+        data: { rows: [{ id: "b" }] },
+        meta: { pagination: { next_cursor: null } },
+      }),
+    );
+    const loneClient = createMetagraphedClient({
+      fetch: lone as unknown as typeof fetch,
+    });
+    expect(await loneClient.fetchAll("/api/v1/subnets" as never)).toEqual([
+      { id: "b" },
+    ]);
   });
 
   test("retries transport errors (network/timeout) then resolves", async () => {


### PR DESCRIPTION
## What

The generated TypeScript client's `fetchAll` — and the typed convenience methods built on it (`subnets()`, `surfaces()`, …) — returned the wrong shape against the live API.

List endpoints return `data` as an **object** whose rows live under `data[meta.pagination.collection]` (e.g. `data.subnets`), not as a bare array. `fetchAll` tested `Array.isArray(data)` and otherwise pushed the whole page-wrapper object, so it yielded `[{ subnets: [...], ... }]` instead of the rows.

## Fix

Resolve the collection key from `meta.pagination.collection`, falling back to a flat `data` array (forward-compat) or the single array-valued field. Mirrors the Python SDK's collection-row shape.

- `scripts/generate-client.mjs` — the generator template for `fetchAll`
- `generated/metagraphed-client.ts` — regenerated (the committed source `validate:generated-client` checks; the `packages/client` `src`/`dist` are synced/built from it at publish time)
- `tests/client-sdk.test.ts` — updated the `fetchAll` test to the real nested envelope and added flat-array / lone-array fallback coverage

## Validation

- `npm run validate:generated-client` — generated client is current
- `npm run lint` + Prettier — clean
- `tests/client-sdk.test.ts` — 27/27 pass