### PR TITLE
refactor(health): unify subnet-status rollup into one shared function (SSOT)

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -2,7 +2,10 @@ import { execFile } from "node:child_process";
 import { promises as fs } from "node:fs";
 import { promisify } from "node:util";
 import path from "node:path";
-import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.mjs";
+import {
+  OPERATIONAL_SURFACE_KINDS,
+  rollupSubnetStatus,
+} from "../src/health-probe-core.mjs";
 import { generateServiceSnippets } from "../src/integration-snippets.mjs";
 import {
   backfilledIdentityUrl,
@@ -5139,12 +5142,12 @@ function buildHealthArtifacts(surfaceHealth, subnets, options) {
     const degradedCount = subnetSurfaces.filter(
       (surface) => surface.status === "degraded",
     ).length;
-    const status = classifySubnetStatus({
-      okCount,
-      failedCount,
-      unknownCount,
-      degradedCount,
-      surfaceCount: subnetSurfaces.length,
+    const status = rollupSubnetStatus({
+      ok: okCount,
+      failed: failedCount,
+      unknown: unknownCount,
+      degraded: degradedCount,
+      total: subnetSurfaces.length,
     });
     const summary = {
       netuid: subnet.netuid,
@@ -6764,25 +6767,6 @@ function countGapKinds(subnets) {
       }, {}),
     ).sort(([a], [b]) => a.localeCompare(b)),
   );
-}
-
-function classifySubnetStatus({
-  okCount,
-  failedCount,
-  unknownCount,
-  degradedCount,
-  surfaceCount,
-}) {
-  if (surfaceCount === 0 || unknownCount === surfaceCount) {
-    return "unknown";
-  }
-  if (failedCount === 0 && degradedCount === 0) {
-    return "ok";
-  }
-  if (okCount > 0 || degradedCount > 0) {
-    return "degraded";
-  }
-  return "failed";
 }
 
 // Promote the per-subnet completeness scoring into a public, explained

--- a/scripts/probes-smoke.mjs
+++ b/scripts/probes-smoke.mjs
@@ -19,6 +19,7 @@ import {
   mapLimit,
   nodeWebSocketConnector,
   probeSurface as coreProbeSurface,
+  rollupSubnetStatus,
 } from "../src/health-probe-core.mjs";
 
 const contractVersion = "2026-06-06.1";
@@ -357,12 +358,12 @@ function summarizeSubnet(subnet, subnetSurfaces) {
     netuid: subnet.netuid,
     slug: subnet.slug,
     name: subnet.name,
-    status: classifySubnetStatus({
-      okCount,
-      failedCount,
-      degradedCount,
-      unknownCount,
-      surfaceCount: subnetSurfaces.length,
+    status: rollupSubnetStatus({
+      ok: okCount,
+      failed: failedCount,
+      degraded: degradedCount,
+      unknown: unknownCount,
+      total: subnetSurfaces.length,
     }),
     surface_count: subnetSurfaces.length,
     ok_count: okCount,
@@ -381,25 +382,6 @@ function summarizeSubnet(subnet, subnetSurfaces) {
         .filter(Number.isFinite),
     ),
   };
-}
-
-function classifySubnetStatus({
-  okCount,
-  failedCount,
-  degradedCount,
-  unknownCount,
-  surfaceCount,
-}) {
-  if (surfaceCount === 0 || unknownCount === surfaceCount) {
-    return "unknown";
-  }
-  if (failedCount === 0 && degradedCount === 0) {
-    return "ok";
-  }
-  if (okCount > 0 || degradedCount > 0) {
-    return "degraded";
-  }
-  return "failed";
 }
 
 async function loadPriorHistory() {

--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -304,6 +304,26 @@ export function contentMismatch(probe, surface) {
   return false;
 }
 
+// Canonical subnet operational-status rollup — the SINGLE source of the
+// ok/degraded/failed/unknown precedence shared by the live serve overlay
+// (health-serving), the 15-minute prober, and the build/smoke status columns.
+// Keeping every caller here means build-time status and live-served status can
+// never silently diverge — drift in the health domain that is the product's core
+// promise. Precedence: all-unknown (or empty) → unknown; no failed/degraded → ok;
+// any ok or degraded present → degraded; else → failed.
+export function rollupSubnetStatus({
+  ok = 0,
+  degraded = 0,
+  failed = 0,
+  unknown = 0,
+  total,
+}) {
+  if (total === 0 || unknown === total) return "unknown";
+  if (failed === 0 && degraded === 0) return "ok";
+  if (ok > 0 || degraded > 0) return "degraded";
+  return "failed";
+}
+
 export function statusForClassification(classification, surface = null) {
   if (["live", "redirected"].includes(classification)) {
     return "ok";

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -18,6 +18,7 @@ import {
   isUnsafePublicUrl,
   mapLimit,
   probeSurface as coreProbeSurface,
+  rollupSubnetStatus,
 } from "./health-probe-core.mjs";
 
 export const KV_HEALTH_CURRENT = "health:current";
@@ -304,13 +305,6 @@ export async function loadOperationalSurfaces(env) {
   return [];
 }
 
-function rollupStatus({ ok, degraded, failed, unknown, total }) {
-  if (total === 0 || unknown === total) return "unknown";
-  if (failed === 0 && degraded === 0) return "ok";
-  if (ok > 0 || degraded > 0) return "degraded";
-  return "failed";
-}
-
 function summarizeGroup(rows) {
   const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
   let lastChecked = 0;
@@ -323,7 +317,7 @@ function summarizeGroup(rows) {
     if (Number.isFinite(row.latency_ms)) latencies.push(row.latency_ms);
   }
   return {
-    status: rollupStatus({ ...counts, total: rows.length }),
+    status: rollupSubnetStatus({ ...counts, total: rows.length }),
     surface_count: rows.length,
     ok_count: counts.ok,
     degraded_count: counts.degraded,

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -8,6 +8,7 @@
 // objects + D1 rows in.
 
 import { computeReliability } from "./reliability.mjs";
+import { rollupSubnetStatus } from "./health-probe-core.mjs";
 
 // Must exceed the probe cadence (15 min) so a live D1 health row is never treated
 // as stale just because the next probe hasn't run yet. 25 min = cadence + a
@@ -91,13 +92,6 @@ export function parseLive(raw) {
   }
 }
 
-function rollupStatus(counts, total) {
-  if (total === 0 || counts.unknown === total) return "unknown";
-  if ((counts.failed || 0) === 0 && (counts.degraded || 0) === 0) return "ok";
-  if ((counts.ok || 0) > 0 || (counts.degraded || 0) > 0) return "degraded";
-  return "failed";
-}
-
 function latestIso(values) {
   let best = null;
   for (const value of values) {
@@ -115,7 +109,7 @@ export function summarizeRows(rows) {
     if (Number.isFinite(row.latency_ms)) latencies.push(row.latency_ms);
   }
   return {
-    status: rollupStatus(counts, rows.length),
+    status: rollupSubnetStatus({ ...counts, total: rows.length }),
     surface_count: rows.length,
     ok_count: counts.ok,
     degraded_count: counts.degraded,

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -15,9 +15,38 @@ import {
   probeSubtensorWss,
   probeSurface,
   probeUrl,
+  rollupSubnetStatus,
   statusForClassification,
   summarizeRpcProbe,
 } from "../src/health-probe-core.mjs";
+
+describe("rollupSubnetStatus (shared subnet-status precedence)", () => {
+  test("empty / all-unknown → unknown", () => {
+    assert.equal(rollupSubnetStatus({ total: 0 }), "unknown");
+    assert.equal(rollupSubnetStatus({ unknown: 3, total: 3 }), "unknown");
+  });
+  test("no failed and no degraded → ok (even with unknowns present)", () => {
+    assert.equal(rollupSubnetStatus({ ok: 2, total: 2 }), "ok");
+    assert.equal(rollupSubnetStatus({ ok: 1, unknown: 1, total: 2 }), "ok");
+  });
+  test("any ok or degraded alongside a failure → degraded", () => {
+    assert.equal(
+      rollupSubnetStatus({ ok: 1, failed: 1, total: 2 }),
+      "degraded",
+    );
+    assert.equal(
+      rollupSubnetStatus({ degraded: 1, failed: 1, total: 2 }),
+      "degraded",
+    );
+  });
+  test("only failures/unknowns (no ok, no degraded) → failed", () => {
+    assert.equal(rollupSubnetStatus({ failed: 2, total: 2 }), "failed");
+    assert.equal(
+      rollupSubnetStatus({ failed: 1, unknown: 1, total: 2 }),
+      "failed",
+    );
+  });
+});
 
 // Minimal Response-like stub for an injected fetch.
 function fakeResponse({


### PR DESCRIPTION
Audit's one genuine SSOT violation: the subnet-status precedence (ok/degraded/failed/unknown) was duplicated in 4 places. Hoisted `rollupSubnetStatus` into `src/health-probe-core.mjs` (the shared leaf), repointed all 4 call sites, removed the locals, added a precedence unit test. **Byte-identical** build output verified (diff over all R2 artifacts clean); suite 1251 green.