### PR TITLE
refactor(kv): centralize KV key names (writer/reader can't drift)

### DIFF
--- a/scripts/refresh-economics.mjs
+++ b/scripts/refresh-economics.mjs
@@ -22,6 +22,7 @@ import {
   stableStringify,
 } from "./lib.mjs";
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.mjs";
 
 const args = new Set(process.argv.slice(2));
 const write = args.has("--write");
@@ -99,7 +100,7 @@ if (process.env.METAGRAPH_ALLOW_KV_WRITE === "1") {
       "kv",
       "key",
       "put",
-      "economics:current",
+      KV_ECONOMICS_CURRENT,
       "--path",
       blobPath,
       "--namespace-id",

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -20,10 +20,15 @@ import {
   probeSurface as coreProbeSurface,
   rollupSubnetStatus,
 } from "./health-probe-core.mjs";
+import {
+  KV_HEALTH_CURRENT,
+  KV_HEALTH_META,
+  KV_HEALTH_RPC_POOL,
+} from "./kv-keys.mjs";
 
-export const KV_HEALTH_CURRENT = "health:current";
-export const KV_HEALTH_RPC_POOL = "health:rpc-pool";
-export const KV_HEALTH_META = "health:meta";
+// Re-export so existing importers (workers/api.mjs, mcp-server, discovery) keep
+// resolving the KV health keys through the prober; the names now live in kv-keys.
+export { KV_HEALTH_CURRENT, KV_HEALTH_META, KV_HEALTH_RPC_POOL };
 export const OPERATIONAL_SURFACES_PATH = "/metagraph/operational-surfaces.json";
 
 const PROBE_CONCURRENCY = 8;

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -9,6 +9,7 @@
 
 import { computeReliability } from "./reliability.mjs";
 import { rollupSubnetStatus } from "./health-probe-core.mjs";
+import { KV_ECONOMICS_CURRENT, KV_HEALTH_CURRENT } from "./kv-keys.mjs";
 
 // Must exceed the probe cadence (15 min) so a live D1 health row is never treated
 // as stale just because the next probe hasn't run yet. 25 min = cadence + a
@@ -1035,7 +1036,7 @@ function liveFromD1Rows(rows) {
 export async function resolveLiveHealth({ readHealthKv, env, db, now } = {}) {
   if (typeof readHealthKv === "function" && env) {
     try {
-      const current = await readHealthKv(env, "health:current");
+      const current = await readHealthKv(env, KV_HEALTH_CURRENT);
       // The prober writes surfaces + subnets + summary; accept any live snapshot
       // that carries the per-surface or per-subnet rows the overlays consume —
       // but freshness-gate it exactly like the D1 fallback below. KV health:current
@@ -1106,7 +1107,7 @@ export async function resolveLiveEconomics({
   if (typeof readHealthKv !== "function" || !env) return null;
   let blob;
   try {
-    blob = await readHealthKv(env, "economics:current");
+    blob = await readHealthKv(env, KV_ECONOMICS_CURRENT);
   } catch {
     return null;
   }

--- a/src/kv-keys.mjs
+++ b/src/kv-keys.mjs
@@ -1,0 +1,9 @@
+// Single source of the Cloudflare KV key names, shared by the writers (the cron
+// prober, the economics refresher) and the Worker readers (resolveLiveHealth /
+// resolveLiveEconomics) so a key string can never drift between writer and reader
+// — a typo on one side would silently degrade the live tier to its R2 fallback
+// with no error. Leaf module (no imports) so any side can depend on it safely.
+export const KV_HEALTH_CURRENT = "health:current";
+export const KV_HEALTH_RPC_POOL = "health:rpc-pool";
+export const KV_HEALTH_META = "health:meta";
+export const KV_ECONOMICS_CURRENT = "economics:current";


### PR DESCRIPTION
Audit fix: `economics:current` was a raw literal in both the writer (refresh-economics) and reader (resolveLiveEconomics) — a typo would silently degrade the live tier to R2 with no signal. New leaf `src/kv-keys.mjs` is the single source; health-prober re-exports for back-compat (existing importers unchanged). Suite 1251 green, no artifact change.