### PR TITLE
refactor(contracts): stamp scripts import CONTRACT_VERSION (no hardcoded literal)

### DIFF
--- a/scripts/probes-smoke.mjs
+++ b/scripts/probes-smoke.mjs
@@ -21,8 +21,9 @@ import {
   probeSurface as coreProbeSurface,
   rollupSubnetStatus,
 } from "../src/health-probe-core.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.mjs";
 
-const contractVersion = "2026-06-06.1";
+const contractVersion = CONTRACT_VERSION;
 const subnets = await loadSubnets();
 const providers = await loadProviders();
 const allSurfaces = flattenSurfaces(subnets);

--- a/scripts/r2-manifest.mjs
+++ b/scripts/r2-manifest.mjs
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, readdir, stat } from "node:fs/promises";
 import {
@@ -109,7 +110,7 @@ async function buildManifest(generatedAt = buildTimestamp()) {
   artifacts.sort((a, b) => a.path.localeCompare(b.path));
   return {
     schema_version: 1,
-    contract_version: "2026-06-06.1",
+    contract_version: CONTRACT_VERSION,
     generated_at: generatedAt,
     bucket_binding: "METAGRAPH_ARCHIVE",
     bucket_name: "metagraphed-artifacts",

--- a/scripts/snapshot-adapters.mjs
+++ b/scripts/snapshot-adapters.mjs
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import { pathToFileURL } from "node:url";
 import {
   buildTimestamp,
@@ -16,7 +17,7 @@ const args = new Set(process.argv.slice(2));
 const shouldWrite = args.has("--write");
 const dryRun = args.has("--dry-run") || !shouldWrite;
 const generatedAt = buildTimestamp();
-const contractVersion = "2026-06-06.1";
+const contractVersion = CONTRACT_VERSION;
 const MAX_OPENAPI_SCHEMA_BYTES = 2 * 1024 * 1024;
 const outputRoot = path.join(repoRoot, "registry/adapters/latest");
 // GitHub token plumbing: accept either env name (the project convention used by

--- a/scripts/snapshot-openapi.mjs
+++ b/scripts/snapshot-openapi.mjs
@@ -1,4 +1,5 @@
 import { promises as fs } from "node:fs";
+import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import {
   artifactFilePath,
   artifactOutputPath,
@@ -23,7 +24,7 @@ const observedAt =
   nonPlaceholderTimestamp(process.env.METAGRAPH_SCHEMA_OBSERVED_AT) ||
   nonPlaceholderTimestamp(process.env.METAGRAPH_BUILD_TIMESTAMP) ||
   new Date().toISOString();
-const contractVersion = "2026-06-06.1";
+const contractVersion = CONTRACT_VERSION;
 
 class SchemaSnapshotLimitError extends Error {
   constructor(message) {


### PR DESCRIPTION
Four stamp scripts (snapshot-openapi/adapters, probes-smoke, r2-manifest) carried their own `2026-06-06.1` literal — a CONTRACT_VERSION bump would silently stamp the stale version into their artifacts. They now import the canonical constant. Left the validate-api/worker-test literals (expected-value guards) and worker-deploy's `compatibility_date` (different value). Build byte-identical.