### PR TITLE
test(economics): extract + unit-test the live-economics content floor

### DIFF
--- a/scripts/economics-floor.mjs
+++ b/scripts/economics-floor.mjs
@@ -1,0 +1,36 @@
+// Content floor for the live economics writer (refresh-economics.mjs). The live KV
+// tier ('economics:current') must never be overwritten with an empty / near-empty
+// blob: a partial chain-fetch (0 rows, or far below the subnet count) or a missing
+// captured_at must not clobber the last good value — the serve path keeps the last
+// live value (or falls back to R2) instead. Pure + side-effect-free so the writer
+// stays a thin script and the boundaries are unit-tested directly.
+
+// Publish only when at least this fraction of subnets carry economics. At exactly
+// the ratio the blob publishes (the check is strictly "below").
+export const ECONOMICS_FLOOR_RATIO = 0.5;
+
+// Decide whether an economics blob clears the content floor.
+//   summary: { with_economics_count, captured_at }
+//   expectedCount: subnet count the run was built from (0 ⇒ skip the ratio gate)
+// Returns { publish: boolean, reason: string }.
+export function shouldPublishEconomics(
+  { with_economics_count, captured_at } = {},
+  expectedCount = 0,
+) {
+  if (!Number.isFinite(with_economics_count) || with_economics_count === 0) {
+    return { publish: false, reason: "no-economics-rows" };
+  }
+  if (!captured_at) {
+    return { publish: false, reason: "missing-captured-at" };
+  }
+  if (
+    expectedCount > 0 &&
+    with_economics_count < expectedCount * ECONOMICS_FLOOR_RATIO
+  ) {
+    return {
+      publish: false,
+      reason: `below-floor (${with_economics_count} of ~${expectedCount})`,
+    };
+  }
+  return { publish: true, reason: "ok" };
+}

--- a/scripts/refresh-economics.mjs
+++ b/scripts/refresh-economics.mjs
@@ -23,6 +23,7 @@ import {
 } from "./lib.mjs";
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.mjs";
+import { shouldPublishEconomics } from "./economics-floor.mjs";
 
 const args = new Set(process.argv.slice(2));
 const write = args.has("--write");
@@ -59,17 +60,21 @@ if (!write) {
 // Content floor: never overwrite the live tier with an empty / near-empty blob. A
 // partial chain-fetch (0 rows, or far below the subnet count) or a missing
 // captured_at must not clobber the last good KV value — warn + exit 0 so the serve
-// path keeps the last live value (or falls back to R2).
+// path keeps the last live value (or falls back to R2). Logic lives in the pure
+// shouldPublishEconomics helper so its boundaries are unit-tested.
 const expectedCount = subnets.length;
-if (
-  summary.with_economics_count === 0 ||
-  !economics.captured_at ||
-  (expectedCount > 0 && summary.with_economics_count < expectedCount * 0.5)
-) {
+const floor = shouldPublishEconomics(summary, expectedCount);
+if (!floor.publish) {
   console.warn(
-    `::warning::economics blob failed the content floor (with_economics_count=${summary.with_economics_count} of ~${expectedCount}, captured_at=${economics.captured_at}); keeping the last live value.`,
+    `::warning::economics blob failed the content floor (${floor.reason}; with_economics_count=${summary.with_economics_count} of ~${expectedCount}, captured_at=${economics.captured_at}); keeping the last live value.`,
   );
-  console.log(stableStringify({ mode: "skipped-floor", ...summary }));
+  console.log(
+    stableStringify({
+      mode: "skipped-floor",
+      reason: floor.reason,
+      ...summary,
+    }),
+  );
   process.exit(0);
 }
 

--- a/tests/economics-floor.test.mjs
+++ b/tests/economics-floor.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  ECONOMICS_FLOOR_RATIO,
+  shouldPublishEconomics,
+} from "../scripts/economics-floor.mjs";
+
+const CAPTURED = "2026-06-20T00:00:00.000Z";
+
+describe("shouldPublishEconomics (live-economics content floor)", () => {
+  test("zero / non-finite rows never publish (won't clobber the live tier)", () => {
+    for (const count of [0, undefined, null, NaN]) {
+      const v = shouldPublishEconomics(
+        { with_economics_count: count, captured_at: CAPTURED },
+        100,
+      );
+      assert.equal(v.publish, false, `count=${count}`);
+      assert.equal(v.reason, "no-economics-rows");
+    }
+    // Defensive: even a missing summary object must not publish.
+    assert.equal(shouldPublishEconomics(undefined, 100).publish, false);
+  });
+
+  test("a missing captured_at blocks publish even with rows", () => {
+    const v = shouldPublishEconomics(
+      { with_economics_count: 80, captured_at: null },
+      100,
+    );
+    assert.equal(v.publish, false);
+    assert.equal(v.reason, "missing-captured-at");
+  });
+
+  test("just below the floor does not publish", () => {
+    const v = shouldPublishEconomics(
+      { with_economics_count: 49, captured_at: CAPTURED },
+      100,
+    );
+    assert.equal(v.publish, false);
+    assert.match(v.reason, /^below-floor/);
+  });
+
+  test("exactly at the floor publishes (the gate is strictly 'below')", () => {
+    const at = Math.ceil(100 * ECONOMICS_FLOOR_RATIO); // 50
+    const v = shouldPublishEconomics(
+      { with_economics_count: at, captured_at: CAPTURED },
+      100,
+    );
+    assert.equal(v.publish, true);
+    assert.equal(v.reason, "ok");
+  });
+
+  test("above the floor publishes", () => {
+    const v = shouldPublishEconomics(
+      { with_economics_count: 51, captured_at: CAPTURED },
+      100,
+    );
+    assert.equal(v.publish, true);
+    assert.equal(v.reason, "ok");
+  });
+
+  test("expectedCount=0 skips the ratio gate (any non-empty captured blob publishes)", () => {
+    const v = shouldPublishEconomics(
+      { with_economics_count: 1, captured_at: CAPTURED },
+      0,
+    );
+    assert.equal(v.publish, true);
+    assert.equal(v.reason, "ok");
+  });
+});


### PR DESCRIPTION
The content floor protecting the live KV economics tier from a partial chain-fetch lived inline in refresh-economics.mjs (a side-effects-on-import script → untestable). Extracted the pure `shouldPublishEconomics` into `scripts/economics-floor.mjs` + 6 boundary tests (0 rows / missing captured_at / just-below vs at the 50% ratio / expectedCount=0). Behavior-preserving. Suite 1258 green.