### PR TITLE
docs+fix(publish): ADR 0007 event-driven publish, /health max-age regression fix, cadence prose guard

### DIFF
--- a/docs/adr/0001-r2-only-data-artifacts.md
+++ b/docs/adr/0001-r2-only-data-artifacts.md
@@ -4,6 +4,9 @@
 - **Date:** 2026-06-09
 - **Supersedes:** the implicit "dual-tier everything" model and the
   push-triggered `publish-cloudflare.yml` full-publish.
+- **Superseded in part by:** [ADR 0007](0007-event-driven-publish.md) — the 6h
+  cron in the "Outcome" below is now an event-driven publish (on human-input
+  registry merges) + a daily floor.
 
 ## Context
 

--- a/docs/adr/0007-event-driven-publish.md
+++ b/docs/adr/0007-event-driven-publish.md
@@ -1,0 +1,76 @@
+# ADR 0007 — Event-driven data publish + daily floor (replacing the 6h cron)
+
+- **Status:** Accepted — implemented (#1250).
+- **Date:** 2026-06-19
+- **Supersedes:** the 6h-cron data refresh in ADR 0001's "Outcome — deploy
+  architecture" (the `metagraph:latest` pointer is now advanced on data change,
+  not on a fixed 6h timer).
+- **Relates to:** ADR 0002 (live operational health — the 15-minute prober) and
+  the live economics tier — the two volatile tiers this publish is decoupled
+  from.
+
+## Context
+
+ADR 0001 split serving into a slow **batch publish** (build → R2 → KV
+`metagraph:latest` pointer) and a fast committed contract. It ran the batch on a
+**6h cron**. After ADR 0002 moved operational health to a live 15-minute prober
+and the economics tier moved to its own ~3h KV refresh, the only thing the batch
+publish still produces is the **structural** dataset (subnets, providers,
+surfaces, search, profiles, evidence — things that change when a _human-curated
+registry input_ changes, plus slow on-chain identity/metadata drift).
+
+That left the 6h cron mismatched to its remaining job in both directions:
+
+1. **Too slow for contributor changes.** A merged registry PR (a new subnet,
+   provider, community candidate, maintainer review, or adapter) waited up to 6h
+   to appear in the served dataset — friction for the autonomous contributor
+   lane, whose whole point is "merge → it's live."
+2. **Mostly wasted work.** Most 6h ticks rebuilt and republished a dataset whose
+   human inputs had not changed at all — 1k+ surface re-probes and a full R2
+   upload for a no-op delta, four times a workday.
+
+The naive fix — "flip the pointer on every push to `main`" — is a **landmine**:
+a code- or docs-only push carries no fresh chain snapshot, so a build triggered
+by it could advance the live pointer onto structurally-stale data.
+
+## Decision
+
+**Publish on data change, not on a clock; keep a daily floor; never trust a
+trigger to carry freshness.** `publish-cloudflare.yml` is repurposed:
+
+1. **Push trigger scoped to human-input registry paths** — `registry/subnets`,
+   `registry/providers`, `registry/candidates/community`, `registry/reviews`,
+   `registry/adapters`. A merged contributor change republishes within minutes.
+   Machine-generated paths (`registry/native`, `registry/generated`,
+   `registry/candidates/generated`) are excluded — the build regenerates them, so
+   they must not self-trigger. Code/docs commits don't match the filter, so they
+   never re-probe (ADR 0001's decoupling intent is preserved).
+2. **A once-daily schedule floor** (07:17 UTC) catches slow chain/registry drift
+   that no human-input event covered.
+3. **Freshness by construction, not by trigger.** Every run fresh-fetches the
+   chain snapshot _first_ (`build.mjs` `productionSteps`, tolerant), so the KV
+   `latest` pointer always flips onto freshly-built data regardless of what
+   triggered the run. This is what makes a push trigger safe — the pointer can
+   never advance onto stale data, because there is no "reuse the last snapshot"
+   path.
+
+The two volatile tiers stay decoupled and refresh independently: operational
+health via the 15-minute prober (`src/health-prober.mjs`, ADR 0002), economics
+via `refresh-economics.yml` (~3h KV tier). `operational-surfaces.json` is
+DUAL/committed (#1247) so the live prober survives a publish outage.
+
+## Consequences
+
+- A contributor's merged change is live in minutes; no-op 6h ticks disappear.
+- Maximum structural-data staleness with zero input changes is bounded by the
+  daily floor (~24h) rather than the cron (~6h) — acceptable because the
+  _volatile_ data (health, economics) is served live, and structural data that
+  has no input change is by definition not drifting except for slow on-chain
+  metadata, which the daily floor covers.
+- The publish core (build → R2 → pointer) is unchanged and irreducible; only its
+  **cadence and trigger** changed. Any future "skip the rebuild and just reflip
+  the pointer" optimization is forbidden for the same reason the naive push fix
+  was: it would decouple the pointer from a fresh snapshot.
+- Docs/comments that described a "6h publish/cadence" are corrected to "the data
+  publish"; a `validate-docs` prose guard fails the build if the stale 6h/2-min
+  cadence language reappears in served-facing (non-ADR) docs.

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -163,7 +163,7 @@ curl -s 'https://api.metagraph.sh/api/v1/search?q=gittensor' | jq '.data'
 
 # Operational health for a subnet + its embeddable badge. Operational surfaces
 # (RPC/WSS/subnet-api/SSE) are probed LIVE every ~15 minutes (D1/KV) and overlaid
-# on the 6h static artifact; read freshness from meta.operational_observed_at.
+# on the published static artifact; read freshness from meta.operational_observed_at.
 curl -s https://api.metagraph.sh/api/v1/subnets/7/health | jq '.data'
 #   <img src="https://api.metagraph.sh/metagraph/health/badges/7.svg">
 

--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -217,12 +217,12 @@ The RPC proxy route is intentionally disabled unless `METAGRAPH_ENABLE_RPC_PROXY
 
 ## Change-Feed Webhooks + SSE
 
-metagraph.sh regenerates its dataset on a ~6h schedule (ADR 0001), so the realtime surface is a **change feed**: a notification within seconds of each publish, not a sub-second tail. These routes live outside the artifact contract (dynamic, KV-backed) and degrade to `503 webhooks_unavailable` when the `METAGRAPH_CONTROL` KV binding is absent.
+metagraph.sh regenerates its dataset on an event-driven publish — on each human-input registry merge, plus a daily floor (ADR 0007) — so the realtime surface is a **change feed**: a notification within seconds of each publish, not a sub-second tail. These routes live outside the artifact contract (dynamic, KV-backed) and degrade to `503 webhooks_unavailable` when the `METAGRAPH_CONTROL` KV binding is absent.
 
 - `POST /api/v1/webhooks/subscriptions` — register `{ url, filters?: { netuids?: integer[], kinds?: ("subnets"|"artifacts")[] }, secret? }`. The `url` must be a public `https://` endpoint (private/loopback/link-local hosts and non-default ports are rejected). Returns `{ id, secret, ... }` once; the secret is never echoed again.
 - `GET /api/v1/webhooks/subscriptions/{id}` — fetch a subscription's public view (no secret).
 - `DELETE /api/v1/webhooks/subscriptions/{id}` — delete; requires the secret in the `x-metagraph-webhook-secret` header.
-- `GET /api/v1/events` — thin SSE change feed: emits the current change snapshot (derived from `changelog.json` + the KV `latest` pointer) as one `event: snapshot`, with `retry: 300000` advising a 5-minute reconnect. There is no value in holding a connection across the 6h cadence.
+- `GET /api/v1/events` — thin SSE change feed: emits the current change snapshot (derived from `changelog.json` + the KV `latest` pointer) as one `event: snapshot`, with `retry: 300000` advising a 5-minute reconnect. There is no value in holding a connection open between publishes.
 
 At publish time the dispatcher reads `changelog.json`, matches each subscription's filters, and `POST`s the change event signed with `HMAC-SHA256` (hex) over the raw body in the `x-metagraph-signature` header. Subscriptions auto-expire after 180 days of inactivity. The SSRF guard is best-effort and cannot prevent DNS rebinding; the dispatcher runs on GitHub-hosted runners with no access to the project's network, which bounds the residual risk.
 

--- a/docs/beta-roadmap.md
+++ b/docs/beta-roadmap.md
@@ -94,8 +94,10 @@ subnets and demonstrate the product to the broader ecosystem.
    The deploy pipeline was decoupled: **Worker code deploys via Cloudflare
    Workers Builds on every push to `main`** (connected; native R2/KV/deploy creds,
    no GitHub secrets; `wrangler.jsonc` carries 100% logs+traces + Smart
-   Placement), and **data refreshes on a 6h schedule** (`publish-cloudflare.yml`
-   repurposed: build → validate → `r2:upload` + `kv:publish` → `smoke:live`).
+   Placement), and **data refreshes on an event-driven publish** (on each
+   human-input registry merge + a daily floor — see `docs/adr/0007`;
+   `publish-cloudflare.yml`: build → validate → `r2:upload` + `kv:publish` →
+   `smoke:live`).
    _Remaining verification:_ dispatch the scheduled data-refresh once
    (`workflow_dispatch publish_mode=publish`) to confirm the real `r2:upload`/
    `kv:publish`/`smoke` path end-to-end.
@@ -139,7 +141,7 @@ subnets and demonstrate the product to the broader ecosystem.
    each run so the Worker reads versioned R2 rather than only `latest/`; the
    pointer-first rollback is documented in `docs/operations.md`. _Added:_ `GET
 /health` is now freshness-aware — it reads the pointer's `published_at` and
-   returns `degraded` + HTTP 503 past `METAGRAPH_HEALTH_MAX_AGE_HOURS` (default 12),
+   returns `degraded` + HTTP 503 past `METAGRAPH_HEALTH_MAX_AGE_HOURS` (default 48),
    so an uptime monitor catches a silently-broken data-refresh.
 
 ### P2/P3 — Coverage-completeness flywheel (the moat, made visible)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -125,15 +125,16 @@ METAGRAPH_ALLOW_R2_DOWNLOAD=1 npm run r2:download
   "freshness": {
     "published_at": "…",
     "age_hours": 1.2,
-    "max_age_hours": 12,
+    "max_age_hours": 48,
     "stale": false
   }
 }
 ```
 
-- `published_at` comes from the KV `metagraph:latest` pointer, which the scheduled
-  refresh advances every ~6h.
-- When the data is older than `max_age_hours` (default 12 — two missed 6h refreshes;
+- `published_at` comes from the KV `metagraph:latest` pointer, which the
+  event-driven data publish (ADR 0007) advances on each human-input registry merge
+  and at least once daily (the 07:17 UTC floor).
+- When the data is older than `max_age_hours` (default 48 — two missed daily floors;
   override with `METAGRAPH_HEALTH_MAX_AGE_HOURS`), `status` becomes `degraded` and the
   route returns **HTTP 503**. Point an uptime monitor at `https://api.metagraph.sh/health`
   so a silently-broken data-refresh pages instead of serving stale data unnoticed.

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -3116,7 +3116,7 @@ await writeJson(artifactFile("registry-summary.json"), {
 // Operational-surfaces list — the input for the 15-minute Cloudflare cron health
 // prober (src/health-prober.mjs). Deterministic, committed (git-tier), and read
 // by the Worker at runtime via the ASSETS binding. Only probe-enabled,
-// public-safe, operational-kind surfaces; everything else stays on this 6h build.
+// public-safe, operational-kind surfaces; everything else stays on this batch build.
 const operationalKindSet = new Set(OPERATIONAL_SURFACE_KINDS);
 const operationalSurfaces = surfaces
   .filter(

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -42,6 +42,44 @@ for (const requiredReadmeText of [
   );
 }
 
+// --- Cadence prose guard (ADR 0007) -------------------------------------------
+// The data publish is event-driven (on human-input registry merges) + a daily
+// floor — NOT a 6h cron — and the operational prober is 15-minute — NOT 2-minute.
+// Fail the build if that stale cadence language reappears in served-facing docs so
+// they can't silently drift back to describing a system that no longer exists.
+// Excluded: docs/adr/** (immutable historical records that describe the 6h era as
+// period context) and the legitimate "6-hour buckets" of RPC usage analytics
+// (a bucket size, not a publish cadence — the patterns below require a cadence
+// noun like cron/publish/schedule, never "buckets").
+const STALE_CADENCE_PATTERNS = [
+  {
+    re: /~?\s*6\s*-?\s*h(?:our)?s?\s+(?:cron|publish|schedule|cadence|refresh|build)/i,
+    label:
+      "stale 6h publish cadence (the publish is event-driven + a daily floor — ADR 0007)",
+  },
+  {
+    re: /\bevery\s+6\s*-?\s*h(?:ours?)?\b/i,
+    label:
+      "stale 'every 6h' cadence (the publish is event-driven + a daily floor — ADR 0007)",
+  },
+  {
+    re: /\b2\s*-?\s*minute\s+(?:cron|prober|probe)/i,
+    label: "stale 2-minute prober cadence (the prober is 15-minute — ADR 0002)",
+  },
+];
+const docsDir = path.join(repoRoot, "docs");
+for (const file of await collectMarkdown(docsDir, [
+  path.join(docsDir, "adr"),
+])) {
+  const rel = path.relative(repoRoot, file);
+  const lines = (await fs.readFile(file, "utf8")).split("\n");
+  lines.forEach((line, index) => {
+    for (const { re, label } of STALE_CADENCE_PATTERNS) {
+      check(!re.test(line), `${rel}:${index + 1}: ${label} — "${line.trim()}"`);
+    }
+  });
+}
+
 if (errors.length > 0) {
   console.error(
     `Documentation validation failed with ${errors.length} issue(s):`,
@@ -62,4 +100,21 @@ function check(condition, message) {
   if (!condition) {
     errors.push(message);
   }
+}
+
+// Recursively collect *.md files under `dir`, skipping any directory in
+// `excludeDirs` (absolute paths).
+async function collectMarkdown(dir, excludeDirs = []) {
+  const out = [];
+  for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!excludeDirs.includes(full)) {
+        out.push(...(await collectMarkdown(full, excludeDirs)));
+      }
+    } else if (entry.name.endsWith(".md")) {
+      out.push(full);
+    }
+  }
+  return out;
 }

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1050,7 +1050,7 @@ async function validateGeneratedArtifacts(
     "coverage: native_only_count must be 0",
   );
   // The committed coverage.json is an inert cold-start seed (ADR 0006) that
-  // legitimately drifts from live source as candidate PRs merge — the 6h refresh
+  // legitimately drifts from live source as candidate PRs merge — the data publish
   // advances R2/D1, not the committed copy. These committed-vs-fresh count-parity
   // checks are a post-build freshness guarantee (CI builds before validating, and
   // pipeline:refresh rebuilds), so they are meaningless against the stale seed in

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -147,7 +147,7 @@ const DUAL_PATTERNS = [
   // surfaces, sorted, with a fixed-epoch generated_at), so it is committable like
   // the contract files. #1017 made it R2-only, which created a SPOF: the prober
   // reads it ASSETS-first then R2, but with no committed copy the ASSETS read
-  // 404s and the prober depends on the 6h publish's R2 latest/ surviving — so a
+  // 404s and the prober depends on the data publish's R2 latest/ surviving — so a
   // publish outage eventually freezes the *live* health tier too. DUAL (committed
   // + R2-mirrored) decouples the prober from the publish: its ASSETS read always
   // succeeds from the deployed bundle. The #1025 freshness gate keeps it current.

--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -1,4 +1,4 @@
-// Pure, isomorphic surface-probing primitives shared by the Node 6h build
+// Pure, isomorphic surface-probing primitives shared by the Node data build
 // (scripts/probes-smoke.mjs) and the Cloudflare cron prober (src/health-prober.mjs,
 // wired through workers/api.mjs `scheduled()`).
 //
@@ -33,7 +33,7 @@ function normalizeHash(value) {
 
 // Surface kinds whose health changes minute-to-minute and is worth probing live
 // (the 15-minute cron prober). Everything else — docs, website, source-repo,
-// dashboard, openapi, sdk, example, repo-registry — stays on the slower 6h build.
+// dashboard, openapi, sdk, example, repo-registry — stays on the slower batch build.
 // This is the single source of truth: scripts/build-artifacts.mjs emits the
 // operational-surfaces.json list from it, and the Worker prober consumes that list.
 export const OPERATIONAL_SURFACE_KINDS = [

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -11,7 +11,7 @@
 //   - KV health:meta     (last_run_at + counts → freshness + self-monitoring)
 //
 // Everything is injected (db, kv, loadSurfaces, probe, now) so the whole run is
-// unit-testable without a live runtime. Decoupled from the 6h build: a stale
+// unit-testable without a live runtime. Decoupled from the data build: a stale
 // structural snapshot can never freeze health again.
 
 import {
@@ -270,7 +270,7 @@ export function workerWebSocketConnector(fetchImpl = fetch) {
 
 // Read the operational-surfaces.json (DUAL tier — committed + R2-mirrored) via
 // the ASSETS binding, falling back to R2. It is committed precisely so this read
-// never depends on the 6h publish (see artifact-storage.mjs): a publish outage
+// never depends on the data publish (see artifact-storage.mjs): a publish outage
 // must not freeze the live health prober. Returns the surfaces array (empty on
 // failure — the run then no-ops rather than throwing).
 export async function loadOperationalSurfaces(env) {

--- a/src/og-image.mjs
+++ b/src/og-image.mjs
@@ -19,7 +19,7 @@ const INK = "#0B1F1A";
 const INK_TEXT = "#08110E";
 
 const OG_PATHS = new Set(["/og.png", "/og"]);
-// Stats refresh on the 6h publish; an hour of edge cache + a long
+// Stats refresh on the data publish; an hour of edge cache + a long
 // stale-while-revalidate keeps render cost near-zero without serving stale art.
 const CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400";
 // Bump on any visual change to the card. It's part of the edge-cache key, so a

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -1,6 +1,6 @@
 // Pure, isomorphic helpers for the metagraph.sh change-feed webhooks.
 //
-// metagraph.sh regenerates its dataset on a ~6h schedule (ADR 0001), so the
+// metagraph.sh regenerates its dataset on an event-driven publish (ADR 0007), so the
 // "real-time" surface is honestly a CHANGE FEED: a notification pushed within
 // seconds of each publish, not a sub-second tail. These helpers are shared by
 // the Worker (subscription routes + SSE) and the publish-time dispatch script.

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -152,7 +152,7 @@ const LIVE_OVERLAY_ROUTE_IDS = new Set([
   "subnet-endpoints",
   "provider-endpoints",
   // Economics serves live from KV 'economics:current' (refreshed independently of
-  // the 6h publish), falling back to the committed R2 economics.json — so it must
+  // the data publish), falling back to the committed R2 economics.json — so it must
   // not be static-edge-cached.
   "economics",
 ]);
@@ -1086,7 +1086,7 @@ async function handleApiRequest(
   const pub = await publishedAt(env);
   // A live tier whose blob carries its OWN freshness (economics' captured_at,
   // refreshed on its own 3h schedule) should report that as published_at, not the
-  // unrelated 6h publish pointer — otherwise a fresh live-kv economics blob looks
+  // unrelated data publish pointer — otherwise a fresh live-kv economics blob looks
   // as stale as the last full publish.
   const effectivePublishedAt =
     matched.id === "economics" &&
@@ -2692,13 +2692,17 @@ async function handleHealthRequest(request, env) {
     health_db: Boolean(env.METAGRAPH_HEALTH_DB?.prepare),
   };
 
-  // Data freshness — the scheduled refresh (ADR 0001) advances the KV `latest`
-  // pointer's published_at every ~6h. If that pipeline silently stops, the
-  // pointer goes stale; report `degraded` + HTTP 503 so an uptime monitor
-  // pointed at /health catches a broken data-refresh. Only a *present* stale
-  // pointer trips it, so local/dev and the worker-test harness (no published
-  // pointer) stay healthy.
-  const maxAgeHours = Number(env.METAGRAPH_HEALTH_MAX_AGE_HOURS) || 12;
+  // Data freshness — the event-driven data publish (ADR 0007) advances the KV
+  // `latest` pointer's published_at on each human-input registry merge and at
+  // least once daily (the 07:17 UTC floor). If that pipeline silently stops, the
+  // pointer goes stale; report `degraded` + HTTP 503 so an uptime monitor pointed
+  // at /health catches a broken data-refresh. Only a *present* stale pointer trips
+  // it, so local/dev and the worker-test harness (no published pointer) stay
+  // healthy.
+  // Default 48h = two missed daily floors. (The old 12h default — "two missed 6h
+  // crons" — would false-degrade on a quiet day now that the floor is daily, not
+  // 6-hourly.)
+  const maxAgeHours = Number(env.METAGRAPH_HEALTH_MAX_AGE_HOURS) || 48;
   // Read the publish pointer + the operational-health meta concurrently (one
   // round-trip instead of two) — both are independent KV gets.
   const [pointer, meta] = bindings.kv
@@ -2752,7 +2756,7 @@ async function handleHealthRequest(request, env) {
 }
 
 // --- Change-feed webhooks -----------------------------------------------------
-// Subscription management for the ~6h publish change feed. Subscriptions live in
+// Subscription management for the data publish change feed. Subscriptions live in
 // the METAGRAPH_CONTROL KV namespace under the `webhooks:sub:<id>` prefix; the
 // publish-time dispatcher (scripts/dispatch-webhooks.mjs) reads them and fires
 // HMAC-signed POSTs. Routes degrade to 503 when KV is unbound (local dev).
@@ -2979,7 +2983,7 @@ async function readWebhookSubscription(env, id) {
   }
 }
 
-// Thin SSE change feed. Given the ~6h cadence there is no value in holding a
+// Thin SSE change feed. Given the publish cadence there is no value in holding a
 // long-lived connection, so we emit the current change snapshot as one SSE event
 // and advise a 5-minute reconnect via `retry:`. EventSource clients reconnect on
 // that interval and re-read; `id:` is the publish timestamp for dedupe.


### PR DESCRIPTION
The 6h cron was replaced by event-driven publish (#1250) but docs/ADRs/comments still said "6h cron" — and that drift hid a real bug.

**Bug fix:** `/health` degrades+503s past `max_age_hours` (default 12 = "two missed 6h refreshes"). With a *daily* publish floor the pointer can legitimately age ~24h, so 12h false-degrades `/health` every quiet day. Default → 48h (two missed daily floors).

**ADR 0007** documents the event-driven publish (push on human-input registry paths + daily floor; freshness-by-construction); ADR 0001 gets a superseded-in-part note (history preserved).

**Accuracy:** fixed stale "6h" language in 5 served docs + 14 code comments; preserved the legit "6-hour buckets" (RPC analytics) and historical ADR text.

**Prose guard:** `validate-docs` now fails if 6h-cron/2-min-prober language reappears in non-ADR docs (verified both directions).

Suite 1258 green; no artifact drift.