### PR TITLE
perf(r2): skip re-uploading artifacts whose only change is the build stamp

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1251,6 +1251,43 @@ export function hashJson(value) {
   return sha256Hex(stableStringify(value));
 }
 
+// Content hash for the R2 delta-skip: an artifact's hash with the pure build stamp
+// (`generated_at`) normalized out, so a republish whose ONLY difference is the
+// wall-clock build time (METAGRAPH_BUILD_TIMESTAMP, set per-publish in production —
+// see ADR 0007) is skipped instead of re-uploaded. `captured_at` is deliberately
+// NOT normalized: it is the chain-snapshot time consumers read as freshness, so an
+// artifact that was genuinely re-snapshotted still re-uploads. Non-JSON artifacts
+// (svg/txt) and unparseable files hash as-is.
+// NOTE: this is a delta-comparison hash only. Integrity verification (r2:download)
+// still uses the real `sha256` of the actual uploaded bytes, which is untouched.
+const DELTA_GENERATED_AT_PLACEHOLDER = "1970-01-01T00:00:00.000Z";
+
+export function artifactContentHash(relativePath, raw) {
+  if (!relativePath.endsWith(".json")) return sha256Hex(raw);
+  let parsed;
+  try {
+    parsed = JSON.parse(typeof raw === "string" ? raw : raw.toString("utf8"));
+  } catch {
+    return sha256Hex(raw);
+  }
+  return hashJson(stripGeneratedAt(parsed));
+}
+
+function stripGeneratedAt(value) {
+  if (Array.isArray(value)) return value.map(stripGeneratedAt);
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const [key, val] of Object.entries(value)) {
+      out[key] =
+        key === "generated_at"
+          ? DELTA_GENERATED_AT_PLACEHOLDER
+          : stripGeneratedAt(val);
+    }
+    return out;
+  }
+  return value;
+}
+
 export function isJsonContentType(value) {
   return String(value || "")
     .toLowerCase()

--- a/scripts/r2-manifest.mjs
+++ b/scripts/r2-manifest.mjs
@@ -3,6 +3,7 @@ import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, readdir, stat } from "node:fs/promises";
 import {
+  artifactContentHash,
   buildTimestamp,
   readJson,
   repoRoot,
@@ -103,6 +104,8 @@ async function buildManifest(generatedAt = buildTimestamp()) {
       latest_key: `latest/${relative}`,
       path: `/metagraph/${relative}`,
       sha256: sha256Hex(raw),
+      // Delta-skip hash (generated_at normalized out); integrity stays on sha256.
+      content_sha256: artifactContentHash(relative, raw),
       size_bytes: fileStat.size,
       storage_tier: artifactStorageTierForRelativePath(relative),
     });

--- a/scripts/r2-upload.mjs
+++ b/scripts/r2-upload.mjs
@@ -72,7 +72,12 @@ const remoteManifestResult = forceUpload
 const remoteManifestByPath = new Map(
   (remoteManifestResult.manifest?.artifacts ?? []).map((artifact) => [
     artifact.path,
-    artifact.sha256,
+    // Compare on the delta hash (generated_at-normalized) so a republish whose
+    // only change is the wall-clock build stamp is skipped. Fall back to sha256
+    // for a pre-content_sha256 remote manifest — the first publish after this
+    // ships re-uploads once (the hashes can't match across the change), then
+    // deltas resume.
+    artifact.content_sha256 ?? artifact.sha256,
   ]),
 );
 let changedArtifactCount = 0;
@@ -86,7 +91,8 @@ for (const artifact of plannedArtifacts) {
   const changed =
     forceUpload ||
     remoteManifestResult.status !== "found" ||
-    remoteManifestByPath.get(artifact.path) !== artifact.sha256;
+    remoteManifestByPath.get(artifact.path) !==
+      (artifact.content_sha256 ?? artifact.sha256);
   if (changed) {
     changedArtifactCount += 1;
     artifactUploadJobs.push(

--- a/tests/artifact-content-hash.test.mjs
+++ b/tests/artifact-content-hash.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { artifactContentHash, sha256Hex } from "../scripts/lib.mjs";
+
+const buf = (obj) => Buffer.from(JSON.stringify(obj), "utf8");
+
+describe("artifactContentHash (R2 delta-skip hash)", () => {
+  test("ignores generated_at — same data + different build stamp ⇒ same hash", () => {
+    const a = buf({
+      generated_at: "2026-06-20T00:00:00.000Z",
+      netuid: 7,
+      x: 1,
+    });
+    const b = buf({
+      generated_at: "2026-06-21T11:22:33.000Z",
+      netuid: 7,
+      x: 1,
+    });
+    assert.equal(
+      artifactContentHash("subnets/7.json", a),
+      artifactContentHash("subnets/7.json", b),
+    );
+  });
+
+  test("ignores generated_at even when key order / whitespace differs", () => {
+    const a = Buffer.from(
+      '{"generated_at":"2026-06-20T00:00:00.000Z","x":1,"y":2}',
+      "utf8",
+    );
+    const b = Buffer.from(
+      '{\n  "y": 2,\n  "x": 1,\n  "generated_at": "2026-06-29T09:09:09.000Z"\n}',
+      "utf8",
+    );
+    assert.equal(
+      artifactContentHash("a.json", a),
+      artifactContentHash("a.json", b),
+    );
+  });
+
+  test("a real data change ⇒ different hash", () => {
+    const a = buf({ generated_at: "2026-06-20T00:00:00.000Z", value: 1 });
+    const b = buf({ generated_at: "2026-06-20T00:00:00.000Z", value: 2 });
+    assert.notEqual(
+      artifactContentHash("a.json", a),
+      artifactContentHash("a.json", b),
+    );
+  });
+
+  test("captured_at is NOT normalized — a re-snapshot ⇒ different hash (freshness preserved)", () => {
+    const a = buf({
+      generated_at: "x",
+      captured_at: "2026-06-20T00:00:00.000Z",
+    });
+    const b = buf({
+      generated_at: "x",
+      captured_at: "2026-06-21T00:00:00.000Z",
+    });
+    assert.notEqual(
+      artifactContentHash("economics.json", a),
+      artifactContentHash("economics.json", b),
+    );
+  });
+
+  test("nested generated_at is normalized too", () => {
+    const a = buf({ meta: { generated_at: "2026-06-20T00:00:00.000Z" }, n: 1 });
+    const b = buf({ meta: { generated_at: "2026-06-25T00:00:00.000Z" }, n: 1 });
+    assert.equal(
+      artifactContentHash("a.json", a),
+      artifactContentHash("a.json", b),
+    );
+  });
+
+  test("non-JSON artifacts hash their raw bytes (== integrity sha256)", () => {
+    const svg = Buffer.from("<svg>badge</svg>", "utf8");
+    assert.equal(artifactContentHash("badge.svg", svg), sha256Hex(svg));
+  });
+
+  test("unparseable .json falls back to the raw-byte hash", () => {
+    const broken = Buffer.from("{not json", "utf8");
+    assert.equal(artifactContentHash("a.json", broken), sha256Hex(broken));
+  });
+});


### PR DESCRIPTION
In production the publish stamps a wall-clock `generated_at` (ADR 0007), so every artifact's `sha256` changes every run — the r2:upload delta-skip re-uploaded ALL ~1,739 R2 artifacts every publish, defeating its optimization (costlier now with event-driven publishes).

Added a **delta-only** content hash (`artifactContentHash`) = the artifact hashed with `generated_at` normalized out; `r2-manifest` emits `content_sha256`, `r2-upload` compares on it (sha256 fallback for the one-time transition).

**Safety:** integrity untouched (verifyLocalArtifact + r2:download still verify the real `sha256`); `captured_at` deliberately preserved (a genuine re-snapshot still uploads); no false-skips possible. 7 unit tests; suite 1265 green.