### PR TITLE
fix(mcp): rank keyword discovery by whole words, not substrings

### DIFF
--- a/src/keyword-search.mjs
+++ b/src/keyword-search.mjs
@@ -1,0 +1,89 @@
+// Keyword ranking shared by the MCP discovery tools (search_subnets,
+// find_subnets_by_capability, find_subnet_for_task's keyword fallback). Pure and
+// dependency-free so every call site ranks identically and it unit-tests
+// directly. The AI semantic_search path is separate.
+//
+// Improvements over a raw substring haystack:
+//   - word/prefix matching, so "ai" no longer matches "brain"/"domain";
+//   - field weighting, so a name/slug hit outranks a deep token hit;
+//   - boosts for an exact name/slug match and full term coverage.
+
+// Identity (name, slug) outweighs secondary text (subtitle, tokens, categories).
+const NAME_WEIGHT = 3;
+const TEXT_WEIGHT = 1;
+// A prefix hit ("infer" → "inference") counts, but less than a whole word.
+const PREFIX_FACTOR = 0.5;
+// Below this a term only matches whole words — a lone "a" must not prefix-explode.
+const MIN_PREFIX_LENGTH = 2;
+// A precise query — whole-query name/slug match, or every term landing — is a
+// strong intent signal.
+const EXACT_NAME_BOOST = 5;
+const FULL_COVERAGE_BOOST = 2;
+
+// Lowercase alphanumeric terms. Used for both the query and the document side so
+// they tokenize identically.
+export function queryTerms(query) {
+  return String(query ?? "")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((term) => term.length > 0);
+}
+
+// Distinct words across a list of field values (each a string or nullish).
+function wordSet(values) {
+  const words = new Set();
+  for (const value of values) {
+    for (const word of queryTerms(value)) words.add(word);
+  }
+  return words;
+}
+
+// Weight of a term against a field: full for a whole word, PREFIX_FACTOR for a
+// word prefix, 0 otherwise — never a mid-word substring (that kills "ai" → "brain").
+function termWeight(term, words, weight) {
+  if (words.has(term)) return weight;
+  if (term.length >= MIN_PREFIX_LENGTH) {
+    for (const word of words) {
+      if (word.length > term.length && word.startsWith(term)) {
+        return weight * PREFIX_FACTOR;
+      }
+    }
+  }
+  return 0;
+}
+
+// Relevance of a document (identity name/slug + recall-only text) against
+// pre-tokenized terms; 0 when nothing matches. Each term scores its strongest
+// field — so a name hit isn't diluted by the same word in the token list — then
+// the coverage and exact-match boosts apply.
+export function keywordScore({ name, slug, text } = {}, terms) {
+  if (!Array.isArray(terms) || terms.length === 0) return 0;
+
+  const nameTokens = queryTerms(name);
+  const slugTokens = queryTerms(slug);
+  const nameWords = new Set([...nameTokens, ...slugTokens]);
+  const textWords = wordSet(Array.isArray(text) ? text : [text]);
+
+  let score = 0;
+  let matched = 0;
+  for (const term of terms) {
+    const best = Math.max(
+      termWeight(term, nameWords, NAME_WEIGHT),
+      termWeight(term, textWords, TEXT_WEIGHT),
+    );
+    if (best > 0) {
+      score += best;
+      matched += 1;
+    }
+  }
+  if (score === 0) return 0;
+
+  // Every term matched → a precise, fully-covered query.
+  if (matched === terms.length) score += FULL_COVERAGE_BOOST;
+  // Whole query equals the name or slug → almost certainly the intended target.
+  const query = terms.join(" ");
+  if (nameTokens.join(" ") === query || slugTokens.join(" ") === query) {
+    score += EXACT_NAME_BOOST;
+  }
+  return score;
+}

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -39,6 +39,7 @@ import {
   semanticSearch,
   withinRateLimit,
 } from "./ai-search.mjs";
+import { keywordScore, queryTerms } from "./keyword-search.mjs";
 
 // Protocol versions we understand, newest first. We echo the client's requested
 // version when it is one of these, otherwise we answer with our latest. We meet
@@ -316,30 +317,17 @@ function clampLimit(value, fallback, max) {
   return Math.max(1, Math.min(max, Math.floor(value)));
 }
 
-// Score a search document against the query terms: how many distinct terms
-// appear as substrings of the document's title/subtitle/tokens haystack.
+// A search.json document → keywordScore shape: title/slug are identity; subtitle
+// and tokens (which already fold in categories/service kinds) are recall-only.
 function scoreDocument(doc, terms) {
-  const haystack = [
-    doc.title,
-    doc.subtitle,
-    doc.slug,
-    ...(Array.isArray(doc.tokens) ? doc.tokens : []),
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-  let score = 0;
-  for (const term of terms) {
-    if (haystack.includes(term)) score += 1;
-  }
-  return score;
-}
-
-function queryTerms(query) {
-  return query
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
-    .filter((term) => term.length > 0);
+  return keywordScore(
+    {
+      name: doc.title,
+      slug: doc.slug,
+      text: [doc.subtitle, ...(Array.isArray(doc.tokens) ? doc.tokens : [])],
+    },
+    terms,
+  );
 }
 
 const COVERAGE_DEPTH_TIERS = [
@@ -639,22 +627,22 @@ export const MCP_TOOLS = [
       const terms = queryTerms(capability);
       const subnets = Array.isArray(catalog.subnets) ? catalog.subnets : [];
       const ranked = subnets
-        .map((subnet) => {
-          const haystack = [
-            subnet.name,
-            subnet.slug,
-            ...(Array.isArray(subnet.categories) ? subnet.categories : []),
-            ...(Array.isArray(subnet.service_kinds)
-              ? subnet.service_kinds
-              : []),
-          ]
-            .filter(Boolean)
-            .join(" ")
-            .toLowerCase();
-          let score = 0;
-          for (const term of terms) if (haystack.includes(term)) score += 1;
-          return { subnet, score };
-        })
+        .map((subnet) => ({
+          subnet,
+          score: keywordScore(
+            {
+              name: subnet.name,
+              slug: subnet.slug,
+              text: [
+                ...(Array.isArray(subnet.categories) ? subnet.categories : []),
+                ...(Array.isArray(subnet.service_kinds)
+                  ? subnet.service_kinds
+                  : []),
+              ],
+            },
+            terms,
+          ),
+        }))
         .filter((entry) => entry.score > 0 && entry.subnet.callable_count > 0)
         .sort(
           (a, b) =>

--- a/tests/keyword-search.test.mjs
+++ b/tests/keyword-search.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { keywordScore, queryTerms } from "../src/keyword-search.mjs";
+
+// Convenience: score a doc against a raw query string the way the tools do.
+const score = (doc, query) => keywordScore(doc, queryTerms(query));
+
+// Rank docs by score desc (matches the tools' primary sort) and return names.
+function rank(docs, query) {
+  return docs
+    .map((doc) => ({ doc, s: score(doc, query) }))
+    .filter((e) => e.s > 0)
+    .sort((a, b) => b.s - a.s)
+    .map((e) => e.doc.name);
+}
+
+describe("queryTerms", () => {
+  test("lowercases and splits on non-alphanumeric runs", () => {
+    assert.deepEqual(queryTerms("Image  Generation!"), ["image", "generation"]);
+    assert.deepEqual(queryTerms("sn-7 / bitcoin_data"), [
+      "sn",
+      "7",
+      "bitcoin",
+      "data",
+    ]);
+  });
+
+  test("nullish / empty / symbol-only input yields no terms", () => {
+    for (const v of [undefined, null, "", "   ", "---", "!@#"]) {
+      assert.deepEqual(queryTerms(v), [], `input=${JSON.stringify(v)}`);
+    }
+  });
+});
+
+describe("keywordScore — substring noise is gone (whole-word / prefix only)", () => {
+  test('"ai" no longer matches brain / chain / domain', () => {
+    // The classic false-positive set: each contains "ai" mid-word.
+    for (const word of ["brain", "chain", "domain", "captain"]) {
+      const doc = { name: word, slug: word, text: [word] };
+      assert.equal(score(doc, "ai"), 0, `"ai" must not match "${word}"`);
+    }
+    // ...but a real whole-word "ai" still matches.
+    assert.ok(score({ name: "AI Inference", slug: "ai", text: [] }, "ai") > 0);
+  });
+
+  test("a mid-word substring never matches", () => {
+    // "ata" sits inside "data" but is not a word or a prefix of one.
+    assert.equal(score({ name: "x", slug: "x", text: ["data"] }, "ata"), 0);
+  });
+
+  test('"price" beats "priceless": whole word outranks a weaker prefix hit', () => {
+    const real = { name: "Token Price", slug: "token-price", text: [] };
+    const noise = { name: "Priceless Art", slug: "priceless", text: [] };
+    // Both are reachable (prefix still matches "priceless"), but the genuine
+    // whole-word "price" must rank strictly higher than the "priceless" prefix.
+    assert.ok(score(real, "price") > score(noise, "price"));
+    assert.deepEqual(rank([noise, real], "price"), [
+      "Token Price",
+      "Priceless Art",
+    ]);
+  });
+
+  test("word-prefix matching still aids discovery (infer → inference)", () => {
+    const doc = { name: "x", slug: "x", text: ["inference"] };
+    assert.ok(score(doc, "infer") > 0);
+  });
+
+  test("a 1-char term does not prefix-explode across the index", () => {
+    // "a" is below the prefix floor: it only matches the whole word "a".
+    assert.equal(score({ name: "Apple", slug: "apple", text: [] }, "a"), 0);
+    assert.ok(score({ name: "a b", slug: "ab", text: [] }, "a") > 0);
+  });
+});
+
+describe("keywordScore — field weighting", () => {
+  test("a name/slug hit outranks the same word buried in a token list", () => {
+    const inName = { name: "Bitcoin", slug: "bitcoin", text: ["data"] };
+    const inTokens = {
+      name: "Allways",
+      slug: "allways",
+      text: ["a", "b", "c", "bitcoin", "d"],
+    };
+    assert.ok(score(inName, "bitcoin") > score(inTokens, "bitcoin"));
+    assert.deepEqual(rank([inTokens, inName], "bitcoin"), [
+      "Bitcoin",
+      "Allways",
+    ]);
+  });
+
+  test("the same word in both name and text is not double-counted", () => {
+    // Tokens fold in the name at build time; the name field should win, not sum.
+    const both = { name: "Bitcoin", slug: "bitcoin", text: ["bitcoin"] };
+    const nameOnly = { name: "Bitcoin", slug: "bitcoin", text: [] };
+    assert.equal(score(both, "bitcoin"), score(nameOnly, "bitcoin"));
+  });
+});
+
+describe("keywordScore — precision boosts", () => {
+  test("an exact whole-query name match lands its obvious target first", () => {
+    const exact = { name: "Targon", slug: "targon", text: [] };
+    // A partial mention of "targon" deep in another subnet's tokens.
+    const mention = {
+      name: "Aggregator",
+      slug: "aggregator",
+      text: ["targon", "proxy"],
+    };
+    assert.deepEqual(rank([mention, exact], "targon"), [
+      "Targon",
+      "Aggregator",
+    ]);
+  });
+
+  test("exact match works on the slug too, normalizing separators", () => {
+    const doc = { name: "Image Gen", slug: "image-gen", text: [] };
+    // "image gen" normalizes to the same token sequence as the slug.
+    assert.ok(score(doc, "image gen") > score(doc, "image"));
+  });
+
+  test("full multi-term coverage outranks a partial match", () => {
+    const both = {
+      name: "Stable Diffusion",
+      slug: "sd",
+      text: ["image", "generation"],
+    };
+    const partial = { name: "Art Engine", slug: "art", text: ["image"] };
+    assert.ok(
+      score(both, "image generation") > score(partial, "image generation"),
+    );
+    assert.deepEqual(rank([partial, both], "image generation"), [
+      "Stable Diffusion",
+      "Art Engine",
+    ]);
+  });
+});
+
+describe("keywordScore — non-matches and edge inputs", () => {
+  test("no matching term yields 0 (callers drop it)", () => {
+    const doc = { name: "Compute", slug: "compute", text: ["gpu"] };
+    assert.equal(score(doc, "bitcoin"), 0);
+  });
+
+  test("empty / non-array terms yield 0", () => {
+    const doc = { name: "Compute", slug: "compute", text: ["gpu"] };
+    assert.equal(keywordScore(doc, []), 0);
+    assert.equal(keywordScore(doc, undefined), 0);
+  });
+
+  test("missing fields are tolerated", () => {
+    assert.equal(keywordScore({}, ["gpu"]), 0);
+    assert.equal(keywordScore(undefined, ["gpu"]), 0);
+    // text may be a bare string rather than an array.
+    assert.ok(keywordScore({ name: "x", text: "gpu" }, ["gpu"]) > 0);
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1180,6 +1180,84 @@ describe("MCP tools (injected deps)", () => {
   });
 });
 
+// keyword-search.test.mjs covers the scoring matrix; here we only prove both
+// tools are wired to it — substring noise is gone and the precise target wins.
+describe("MCP keyword discovery relevance", () => {
+  const deps = makeDeps({
+    "/metagraph/search.json": {
+      documents: [
+        {
+          type: "subnet",
+          netuid: 1,
+          slug: "targon",
+          title: "Targon",
+          subtitle: "AI inference network",
+          tokens: ["ai", "inference", "llm"],
+        },
+        {
+          // "Brain" / "domain" only contain "ai" as a mid-word substring — the
+          // old includes() ranking surfaced these for a query of "ai".
+          type: "subnet",
+          netuid: 2,
+          slug: "braintrust",
+          title: "BrainTrust",
+          subtitle: "domain registrar",
+          tokens: ["brain", "domain", "captain"],
+        },
+      ],
+    },
+    "/metagraph/agent-catalog.json": {
+      subnets: [
+        {
+          netuid: 1,
+          slug: "targon",
+          name: "Targon",
+          categories: ["ai", "inference"],
+          service_kinds: ["subnet-api"],
+          callable_count: 5,
+          integration_readiness: 90,
+        },
+        {
+          netuid: 2,
+          slug: "braintrust",
+          name: "BrainTrust",
+          categories: ["brain", "domain"],
+          service_kinds: ["subnet-api"],
+          callable_count: 5,
+          integration_readiness: 90,
+        },
+      ],
+    },
+  });
+
+  test('search_subnets: "ai" matches the real AI subnet, not "brain"/"domain"', async () => {
+    const res = await callTool("search_subnets", { query: "ai" }, { deps });
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(
+      out.results.map((r) => r.netuid),
+      [1],
+    );
+  });
+
+  test("search_subnets: an exact name match wins outright", async () => {
+    const res = await callTool("search_subnets", { query: "targon" }, { deps });
+    assert.equal(res.body.result.structuredContent.results[0].netuid, 1);
+  });
+
+  test('find_subnets_by_capability: "ai" excludes the substring-only subnet', async () => {
+    const res = await callTool(
+      "find_subnets_by_capability",
+      { capability: "ai" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(
+      out.results.map((r) => r.netuid),
+      [1],
+    );
+  });
+});
+
 describe("MCP edge cases", () => {
   test("a request method behaves as a notification when sent without an id", async () => {
     // Covers the isNotification short-circuit on otherwise-valid methods.


### PR DESCRIPTION
## Summary

Keyword discovery in the MCP tools ranked subnets by substring containment, which surfaced irrelevant subnets and duplicated the scoring logic across two call sites. This replaces it with one shared, word aware ranking helper.

## What Changed

* Add `src/keyword-search.mjs` exporting `queryTerms` and `keywordScore`, a pure, dependency free ranking helper.
* Match whole words and word prefixes instead of raw substrings, so `ai` no longer matches `brain` or `domain`, and a precise term outranks a partial one.
* Weight name and slug above secondary text (subtitle, tokens, categories, service kinds) so the obvious target ranks first instead of a deep token hit.
* Boost an exact name or slug match and full query coverage so a precise query lands its intended subnet.
* Point `search_subnets`, `find_subnets_by_capability`, and the `find_subnet_for_task` keyword fallback at the shared helper, removing the duplicated inline copy.
* Add `tests/keyword-search.test.mjs` (the scoring matrix, including `ai`, `price`, exact name, and multi word phrase) plus three end to end relevance tests in `tests/mcp-server.test.mjs`.
* No change to tool input or output schemas. Ranking is behavioral only, and the surfaced `relevance` field stays an unconstrained number.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (no contract change; tool I/O unchanged)

## Validation

Commands run for this change, all green:

- [x] `eslint .`
- [x] `prettier --check .`
- [x] `npm run worker:test`
- [x] `npm run scan:public-safety`
- [x] `vitest run tests/keyword-search.test.mjs tests/mcp-server.test.mjs` (124 passed)
- [x] `git diff --check`
