### PR TITLE
fix(lib): keep trailing-comma cleanup out of string literals in stripJsonComments

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -232,7 +232,42 @@ export function stripJsonComments(value) {
     }
     out += ch;
   }
-  return out.replace(/,\s*([}\]])/g, "$1");
+
+  // Drop trailing commas (",}" / ",]") outside string literals only. A blanket
+  // regex over the whole output spliced commas out of string contents too, so a
+  // value like "a, }" lost its comma; walk string-aware instead.
+  let result = "";
+  let inStringTail = false;
+  for (let i = 0; i < out.length; i += 1) {
+    const ch = out[i];
+    if (inStringTail) {
+      result += ch;
+      if (ch === "\\") {
+        result += out[i + 1] ?? "";
+        i += 1;
+      } else if (ch === '"') {
+        inStringTail = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inStringTail = true;
+      result += ch;
+      continue;
+    }
+    if (ch === ",") {
+      let j = i + 1;
+      while (j < out.length && /\s/.test(out[j])) {
+        j += 1;
+      }
+      if (out[j] === "}" || out[j] === "]") {
+        i = j - 1;
+        continue;
+      }
+    }
+    result += ch;
+  }
+  return result;
 }
 
 export async function formatRepositoryJson(value) {

--- a/tests/strip-json-comments.test.mjs
+++ b/tests/strip-json-comments.test.mjs
@@ -38,6 +38,16 @@ describe("stripJsonComments", () => {
     assert.deepEqual(parsed.triggers.crons, ["*/2 * * * *", "0 * * * *"]);
   });
 
+  test("preserves comma-then-bracket sequences inside string literals", () => {
+    // The trailing-comma cleanup must not splice a ", }" / ", ]" out of a string
+    // value, while still dropping a genuine trailing comma before the close.
+    const input = `{ "note": "use a, } or b, ] here", "items": [1, 2, ], "x": 1, }`;
+    const parsed = JSON.parse(stripJsonComments(input));
+    assert.equal(parsed.note, "use a, } or b, ] here");
+    assert.deepEqual(parsed.items, [1, 2]);
+    assert.equal(parsed.x, 1);
+  });
+
   test("handles escaped quotes inside strings", () => {
     const input = `{ "q": "a \\"quoted\\" // not-a-comment" }`;
     assert.equal(


### PR DESCRIPTION
## Summary

`stripJsonComments` removed trailing commas with one regex over the whole output (`out.replace(/,\s*([}\]])/g, "$1")`). That regex also matched **inside string literals**, so any string value containing `, }` or `, ]` lost the comma:

```js
stripJsonComments('{ "note": "use a, } here" }')
// before -> { "note": "use a} here" }   (corrupted)
// after  -> { "note": "use a, } here" }  (intact)
```

JSONC config values (descriptions, globs, prose) can legitimately contain `, }`/`, ]`, so this silently mangled them. The existing pass already tracks string state for comment stripping; this does the trailing-comma cleanup the same string-aware way — dropping a comma only when it sits outside a string, followed by optional whitespace and a closing `}`/`]`.

## Tests

Adds `preserves comma-then-bracket sequences inside string literals` next to the existing string-preservation cases (it asserts both that `"use a, } or b, ] here"` survives and that a genuine trailing comma before the close is still dropped).

- `npx vitest run tests/strip-json-comments.test.mjs` -> 5 passed
- `npx vitest run tests/script-utils.test.mjs` -> 43 passed (no regression)
- prettier + eslint clean
