### PR TITLE
fix(evidence): verified_at is the real verification time or null, never the build clock

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1835,7 +1835,7 @@ export interface components {
             source_url: string;
             subject: string;
             support_summary: string;
-            verified_at?: string;
+            verified_at?: string | null;
         };
         EvidenceLedgerArtifact: components["schemas"]["ArtifactBase"] & ({
             claims: components["schemas"]["EvidenceClaim"][];

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3098,7 +3098,10 @@
             "type": "string"
           },
           "verified_at": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -3566,7 +3569,7 @@
       "GeneratedOpenApiMarker": {
         "properties": {
           "generated_at": {
-            "const": "1970-01-01T00:00:00.000Z"
+            "const": "2026-06-20T00:00:00.000Z"
           }
         },
         "type": "object"
@@ -24723,7 +24726,7 @@
   "x-metagraphed": {
     "canonical_artifact_base_path": "/metagraph",
     "contract_version": "2026-06-06.1",
-    "generated_at": "1970-01-01T00:00:00.000Z",
+    "generated_at": "2026-06-20T00:00:00.000Z",
     "notes": "OpenAPI describes Worker response envelopes and canonical artifact payloads. Raw /metagraph JSON remains the reviewed source contract.",
     "schema_version": 1
   }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1835,7 +1835,7 @@ export interface components {
             source_url: string;
             subject: string;
             support_summary: string;
-            verified_at?: string;
+            verified_at?: string | null;
         };
         EvidenceLedgerArtifact: components["schemas"]["ArtifactBase"] & ({
             claims: components["schemas"]["EvidenceClaim"][];
@@ -1936,7 +1936,7 @@ export interface components {
         };
         GeneratedOpenApiMarker: {
             /** @constant */
-            generated_at?: "1970-01-01T00:00:00.000Z";
+            generated_at?: "2026-06-20T00:00:00.000Z";
         };
         GenericArtifact: components["schemas"]["ArtifactBase"];
         /** @description Recent cross-subnet downtime incidents reconstructed from probe history; lists only surfaces that had an incident in the window. */

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3084,7 +3084,10 @@
             "type": "string"
           },
           "verified_at": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [

--- a/schemas/components/08-evidence-search-sources.schema.json
+++ b/schemas/components/08-evidence-search-sources.schema.json
@@ -93,7 +93,7 @@
             "type": "string"
           },
           "verified_at": {
-            "type": "string"
+            "type": ["string", "null"]
           }
         },
         "additionalProperties": false

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -2836,6 +2836,7 @@ await writeJson(
 const evidenceLedger = buildEvidenceLedger({
   candidates,
   generatedAt,
+  capturedAt: nativeSnapshot.captured_at,
   subnets: mergedSubnets,
   surfaces,
 });
@@ -6227,6 +6228,7 @@ function sourceStatus(classifications, rpcCount) {
 function buildEvidenceLedger({
   candidates: candidateRows,
   generatedAt: timestamp,
+  capturedAt,
   subnets,
   surfaces: surfaceRows,
 }) {
@@ -6240,7 +6242,9 @@ function buildEvidenceLedger({
     source_url: "registry/native/finney-subnets.json",
     subject: `subnet:${subnet.netuid}`,
     support_summary: `Captured from native snapshot at block ${subnet.block}.`,
-    verified_at: timestamp,
+    // Chain claims are verified by the snapshot — use its capture time (a real,
+    // deterministic observation timestamp), never the wall-clock build time.
+    verified_at: capturedAt || null,
   }));
 
   const surfaceClaims = surfaceRows.map((surface) => ({
@@ -6260,7 +6264,9 @@ function buildEvidenceLedger({
     source_url: surface.source_urls?.[0] || surface.url,
     subject: `surface:${surface.id}`,
     support_summary: `Listed in curated overlay for ${surface.subnet_slug}.`,
-    verified_at: surface.verification?.verified_at || timestamp,
+    // Real verification time when the surface was actually verified; null when it
+    // was not (honest + deterministic — never the build clock).
+    verified_at: surface.verification?.verified_at || null,
   }));
 
   const candidateClaims = candidateRows.slice(0, 250).map((candidate) => ({
@@ -6274,7 +6280,9 @@ function buildEvidenceLedger({
     subject: `candidate:${candidate.id}`,
     support_summary:
       candidate.review_notes || "Discovered from public source metadata.",
-    verified_at: candidate.verification?.verified_at || timestamp,
+    // Unverified discovery leads have no verification time — null, not the build
+    // clock (which falsely implied every candidate was "verified" at build time).
+    verified_at: candidate.verification?.verified_at || null,
   }));
 
   const claims = [...subnetClaims, ...surfaceClaims, ...candidateClaims].sort(


### PR DESCRIPTION
Foundation step 1 of the static-git migration (Option A).

Every evidence claim stamped `verified_at = buildTimestamp()` — unverified candidate leads falsely read as "verified at build time," and the value churned every build (the bulk of the residual non-determinism after the content_sha256 delta).

Now: chain claims → the snapshot `captured_at` (real observation time); surface/candidate → their real verification time, else `null`; never the build clock. `EvidenceClaim.verified_at` is now nullable (regenerated contract).

With the clock removed, evidence artifacts are byte-stable across same-snapshot builds → they only change when their data does. Verified: 0 build-clock stamps remain; suite 1265 green; contract-drift + schemas pass.