### PR TITLE
fix(ci): contract at epoch stamp + de-flake /health max-age test (green main)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -2398,6 +2398,7 @@ export interface components {
             [key: string]: unknown;
         });
         R2ManifestEntry: {
+            content_sha256?: string;
             content_type: string;
             key: string;
             latest_key: string;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -5224,6 +5224,10 @@
       "R2ManifestEntry": {
         "additionalProperties": false,
         "properties": {
+          "content_sha256": {
+            "pattern": "^[a-f0-9]{64}$",
+            "type": "string"
+          },
           "content_type": {
             "type": "string"
           },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3569,7 +3569,7 @@
       "GeneratedOpenApiMarker": {
         "properties": {
           "generated_at": {
-            "const": "2026-06-20T00:00:00.000Z"
+            "const": "1970-01-01T00:00:00.000Z"
           }
         },
         "type": "object"
@@ -24726,7 +24726,7 @@
   "x-metagraphed": {
     "canonical_artifact_base_path": "/metagraph",
     "contract_version": "2026-06-06.1",
-    "generated_at": "2026-06-20T00:00:00.000Z",
+    "generated_at": "1970-01-01T00:00:00.000Z",
     "notes": "OpenAPI describes Worker response envelopes and canonical artifact payloads. Raw /metagraph JSON remains the reviewed source contract.",
     "schema_version": 1
   }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2398,6 +2398,7 @@ export interface components {
             [key: string]: unknown;
         });
         R2ManifestEntry: {
+            content_sha256?: string;
             content_type: string;
             key: string;
             latest_key: string;

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1936,7 +1936,7 @@ export interface components {
         };
         GeneratedOpenApiMarker: {
             /** @constant */
-            generated_at?: "2026-06-20T00:00:00.000Z";
+            generated_at?: "1970-01-01T00:00:00.000Z";
         };
         GenericArtifact: components["schemas"]["ArtifactBase"];
         /** @description Recent cross-subnet downtime incidents reconstructed from probe history; lists only surfaces that had an incident in the window. */

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -5202,6 +5202,10 @@
       "R2ManifestEntry": {
         "additionalProperties": false,
         "properties": {
+          "content_sha256": {
+            "pattern": "^[a-f0-9]{64}$",
+            "type": "string"
+          },
           "content_type": {
             "type": "string"
           },

--- a/schemas/components/09-schemas-adapters-r2.schema.json
+++ b/schemas/components/09-schemas-adapters-r2.schema.json
@@ -151,6 +151,10 @@
             "type": "string",
             "pattern": "^[a-f0-9]{64}$"
           },
+          "content_sha256": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          },
           "size_bytes": {
             "type": "integer",
             "minimum": 0

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -219,7 +219,9 @@ describe("/health readiness", () => {
   });
 
   test("reports degraded + 503 when the KV latest pointer is stale", async () => {
-    const stale = new Date(Date.now() - 48 * 3_600_000).toISOString();
+    // Clearly past the 48h default max-age — not exactly on the boundary, which
+    // raced (a few ms of test runtime decided 48.001h > 48h vs == 48h).
+    const stale = new Date(Date.now() - 72 * 3_600_000).toISOString();
     const env = createLocalArtifactEnv({
       METAGRAPH_CONTROL: makeKv({
         "metagraph:latest": { published_at: stale },


### PR DESCRIPTION
Fix-forward for two reds on main after #1289:

1. **Contract drift** — #1289 committed openapi/types with a wall-clock stamp (2026-06-20) but CI builds with the epoch marker → mismatch. Rebuilt the contract at epoch (its intended deterministic value); drift/generated-client/schemas pass.
2. **/health flake** — the test set published_at to *exactly* 48h (== the new default max_age from #1270), racing the boundary. Now 72h (deterministic, verified 3×).

verified_at change from #1289 unaffected. Suite 1265 green.