### PR TITLE
refactor(publish): deterministic build + serve the real date live (static-git foundation)

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -82,7 +82,13 @@ jobs:
 
       - name: Stamp publish time
         run: |
-          echo "METAGRAPH_PUBLISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" >> "$GITHUB_ENV"
+          # The real publish moment — served LIVE as meta.published_at, never baked.
+          published_at="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+          echo "METAGRAPH_PUBLISHED_AT=$published_at" >> "$GITHUB_ENV"
+          # Unique R2 run-prefix id for every r2:manifest invocation (build + the
+          # post-changelog re-stamp). generated_at stays the deterministic epoch
+          # marker (issue #349) so artifacts don't churn; this keeps runs/ unique.
+          echo "METAGRAPH_RUN_ID=$published_at" >> "$GITHUB_ENV"
 
       - name: Prepare reviewed publish artifacts
         run: npm run build
@@ -93,7 +99,9 @@ jobs:
           # shipping degraded adapter data (mirrors sync-subnets.yml).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          METAGRAPH_BUILD_TIMESTAMP: ${{ env.METAGRAPH_PUBLISHED_AT }}
+          # No METAGRAPH_BUILD_TIMESTAMP override: generated_at stays the epoch
+          # marker (deterministic, no churn). The real time is served live
+          # (meta.published_at); the unique run prefix comes from METAGRAPH_RUN_ID.
           METAGRAPH_REQUIRE_ADAPTER_AUTH: "1"
 
       # Belt-and-suspenders for Finding 1: the build just re-snapshotted adapters

--- a/scripts/r2-manifest.mjs
+++ b/scripts/r2-manifest.mjs
@@ -86,7 +86,13 @@ for (const artifact of validationManifest.artifacts) {
 console.log(stableStringify(summary));
 
 async function buildManifest(generatedAt = buildTimestamp()) {
-  const version = generatedAt.replace(/[:.]/g, "-");
+  // The R2 immutable run prefix must stay UNIQUE per publish even though
+  // generated_at is a deterministic epoch marker (issue #349) — otherwise every
+  // publish would collide on runs/1970.../ and lose atomic-swap safety. The publish
+  // workflow sets METAGRAPH_RUN_ID to a unique per-run value; local/dev builds fall
+  // back to the generated_at stamp (deterministic, fine with no remote history).
+  const runId = process.env.METAGRAPH_RUN_ID || generatedAt;
+  const version = runId.replace(/[:.]/g, "-").replace(/[^A-Za-z0-9._-]/g, "-");
   const publicRoot = path.join(repoRoot, "public/metagraph");
   const r2Root = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT);
   const files = await listManifestArtifactFiles({ publicRoot, r2Root });

--- a/tests/raw-artifact-freshness.test.mjs
+++ b/tests/raw-artifact-freshness.test.mjs
@@ -24,13 +24,13 @@ async function rawSubnets(env) {
 }
 
 describe("raw artifact published_at header", () => {
-  test("exposes the real publish time as a header without changing the body", async () => {
+  test("overlays the real publish time onto the body's generated_at + a header", async () => {
     const { res, body } = await rawSubnets(envWithPointer());
     assert.equal(res.headers.get("x-metagraph-published-at"), PUB);
-    // The body is unchanged: generated_at is NOT overlaid with the publish
-    // time (proven without assuming the build's generated_at value, which is
-    // the epoch locally but a real timestamp in the publish/sync build).
-    assert.notEqual(body.generated_at, PUB);
+    // The body's generated_at is served LIVE as the real publish time (serve-time
+    // overlay) so a raw fetcher sees the true date, not the baked epoch marker
+    // (the artifact on disk stays the deterministic epoch — issue #349).
+    assert.equal(body.generated_at, PUB);
   });
 
   test("omits the header when there is no latest pointer", async () => {

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -72,11 +72,12 @@ describe("Worker runtime", () => {
     assert.equal(response.status, 200);
     const body = await response.json();
     assert.equal(body.meta.published_at, publishedAt);
-    // generated_at stays the deterministic content marker, distinct from it.
-    assert.notEqual(body.meta.generated_at, publishedAt);
+    // generated_at is now served LIVE as the real publish time (serve-time overlay);
+    // the baked epoch marker (issue #349) is never exposed to consumers.
+    assert.equal(body.meta.generated_at, publishedAt);
   });
 
-  test("/api/v1/build populates the body's published_at from the KV pointer (generated_at stays the marker)", async () => {
+  test("/api/v1/build serves published_at + generated_at from the KV pointer (live, not the baked marker)", async () => {
     const publishedAt = "2026-06-12T21:06:24.956Z";
     const controlEnv = {
       ...env,
@@ -99,11 +100,9 @@ describe("Worker runtime", () => {
     // the real publish pointer so a body-reading agent sees genuine freshness.
     assert.equal(body.data.published_at, publishedAt);
     assert.equal(body.meta.published_at, publishedAt);
-    // generated_at is the build marker and must NOT be clobbered by the
-    // published_at overlay. It is epoch-0 in deterministic/CI builds but the real
-    // build time in a production refresh, so assert the invariant (distinct from
-    // the overlaid published_at), not a fixed fixture value (#349).
-    assert.notEqual(body.data.generated_at, publishedAt);
+    // generated_at is served LIVE as the real publish time (serve-time overlay), so
+    // a body-reading agent sees the true date, not the baked epoch marker (#349).
+    assert.equal(body.data.generated_at, publishedAt);
   });
 
   test("/api/v1/economics serves the live KV blob (meta.source: live-kv)", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -634,11 +634,21 @@ async function handleRawArtifactRequest(
     });
     data = overlayArtifactEndpoints(data, liveSnapshot) ?? data;
   }
-  // The raw artifact path has no envelope, so direct fetchers of
-  // /metagraph/*.json have no freshness signal — the body's generated_at is the
-  // deterministic epoch content marker by design. Expose the real publish time
-  // as a header; the operational-health fields are overlaid live (above).
+  // The raw artifact path has no envelope. Artifacts bake a deterministic epoch
+  // `generated_at` marker (issue #349) so their bytes don't churn; stamp the real
+  // publish time onto the served body's generated_at (and a header) so direct
+  // fetchers of /metagraph/*.json see the true date. Operational-health fields are
+  // overlaid live (above).
   const pub = await publishedAt(env);
+  if (
+    pub &&
+    data &&
+    typeof data === "object" &&
+    !Array.isArray(data) &&
+    "generated_at" in data
+  ) {
+    data = { ...data, generated_at: pub };
+  }
   const body = JSON.stringify(data);
   const headers = apiHeaders("standard");
   headers.set("content-type", JSON_CONTENT_TYPE);
@@ -1094,21 +1104,28 @@ async function handleApiRequest(
     baseData?.captured_at
       ? baseData.captured_at
       : pub;
-  // Static-asset artifacts that DECLARE a `published_at` field (e.g.
-  // build-summary, agent-catalog) carry it as null in the committed
-  // deterministic build, so an agent reading the response BODY (not just the
-  // envelope meta) sees no freshness signal. Populate it at serve from the same
-  // pointer that feeds meta.published_at; generated_at stays the marker.
+  // Freshness is served LIVE, never baked. Artifacts carry a deterministic epoch
+  // `generated_at` marker (issue #349) so their bytes change only when the data
+  // does (git-committable, no churn). The Worker stamps the real publish time onto
+  // the response here — the envelope meta (below) AND the body, so a consumer
+  // reading the raw body sees the true date instead of the 1970 marker. Same source
+  // that feeds meta.published_at; storage stays deterministic, serving stays honest.
   let responseData = transformed.data;
   if (
-    pub &&
     responseData &&
     typeof responseData === "object" &&
-    !Array.isArray(responseData) &&
-    "published_at" in responseData &&
-    !responseData.published_at
+    !Array.isArray(responseData)
   ) {
-    responseData = { ...responseData, published_at: pub };
+    const patch = {};
+    if (effectivePublishedAt && "generated_at" in responseData) {
+      patch.generated_at = effectivePublishedAt;
+    }
+    if (pub && "published_at" in responseData && !responseData.published_at) {
+      patch.published_at = pub;
+    }
+    if (Object.keys(patch).length) {
+      responseData = { ...responseData, ...patch };
+    }
   }
   const response = await envelopeResponse(
     request,
@@ -1118,7 +1135,7 @@ async function handleApiRequest(
         artifact_path: artifactPath,
         cache: matched.cache,
         contract_version: contractVersion(env),
-        generated_at: baseData?.generated_at || null,
+        generated_at: effectivePublishedAt || baseData?.generated_at || null,
         published_at: effectivePublishedAt,
         source: baseSource,
         ...(staleContract ? { stale_contract: staleContract } : {}),


### PR DESCRIPTION
Migration step 2 (Option A) — determinism foundation, no tier flip yet (R2 still serves).

- **Serve the date live**: the Worker overlays the real publish time onto `generated_at` (meta + body, enveloped + raw) so consumers never see the 1970 marker. Storage stays deterministic (epoch on disk); serving stays honest. Supersedes the #349 distinct-marker stance.
- **Deterministic build**: drop the `METAGRAPH_BUILD_TIMESTAMP` override → `generated_at` bakes epoch; decouple the R2 run-prefix via `METAGRAPH_RUN_ID` so epoch can't collide on `runs/`.
- Updated 3 tests to the new served-live behavior.

Full CI reproduced locally: suite 1265, all checks validators pass, ci-verify clean.