### PR TITLE
fix(submissions): reject unknown provider fields in UGC preflight

### DIFF
--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -31,6 +31,30 @@ const PROVIDER_KINDS = new Set([
   "registry",
 ]);
 
+const PROVIDER_SCHEMA_FIELDS = new Set([
+  "schema_version",
+  "id",
+  "name",
+  "kind",
+  "website_url",
+  "docs_url",
+  "github_url",
+  "logo_url",
+  "social",
+  "team_url",
+  "contact_url",
+  "authority",
+  "public_notes",
+  "notes",
+]);
+
+const PROVIDER_SOCIAL_SCHEMA_FIELDS = new Set([
+  "x",
+  "telegram",
+  "reddit",
+  "youtube",
+]);
+
 const STATUS_REPORT_TYPES = new Set([
   "down",
   "degraded",
@@ -1497,6 +1521,23 @@ export function validateProviderForSubmission({
       warnings,
       manual_reasons,
     };
+  }
+
+  for (const field of Object.keys(provider)) {
+    if (!PROVIDER_SCHEMA_FIELDS.has(field)) {
+      errors.push({
+        category: "unsupported-shape",
+        message: `provider ${field} is not allowed`,
+      });
+    }
+  }
+  for (const [key] of socialEntries) {
+    if (!PROVIDER_SOCIAL_SCHEMA_FIELDS.has(key)) {
+      errors.push({
+        category: "unsupported-shape",
+        message: `provider social.${key} is not allowed`,
+      });
+    }
   }
 
   if (provider.schema_version !== 1) {

--- a/tests/coverage-fill.test.mjs
+++ b/tests/coverage-fill.test.mjs
@@ -132,8 +132,12 @@ describe("submission-policy provider extraction and validation", () => {
         github_url: "http://169.254.169.254",
         team_url: "http://192.168.0.1",
         contact_url: "ftp://example.com",
-        social: { x: "http://169.254.169.254/latest/meta-data" },
+        social: {
+          x: "http://169.254.169.254/latest/meta-data",
+          mastodon: "https://social.example/@bad",
+        },
         authority: "official",
+        unexpected: "will-fail-schema",
         notes: "legacy notes",
       },
       document: { submission: {} },
@@ -141,6 +145,11 @@ describe("submission-policy provider extraction and validation", () => {
       providers,
     });
     const messages = result.errors.map((error) => error.message);
+    assert.equal(messages.includes("provider unexpected is not allowed"), true);
+    assert.equal(
+      messages.includes("provider social.mastodon is not allowed"),
+      true,
+    );
     assert.equal(messages.includes("provider schema_version must be 1"), true);
     assert.equal(
       messages.includes("provider id must be a lowercase slug"),


### PR DESCRIPTION
### Motivation
- Community provider records were being loaded as first-class providers while the lightweight UGC PR lane did not enforce the canonical provider schema, allowing extra/top-level and social properties to slip into published artifacts.

### Description
- Add `PROVIDER_SCHEMA_FIELDS` and `PROVIDER_SOCIAL_SCHEMA_FIELDS` allowlists and enforce them in `validateProviderForSubmission` to reject unknown top-level provider keys and unknown `provider.social.*` keys. (`scripts/submission-policy.mjs`).
- Emit explicit `unsupported-shape` errors when unknown provider fields are present so the UGC preflight mirrors `additionalProperties: false` from `schemas/provider.schema.json` without changing the full-schema tooling.
- Extend `tests/coverage-fill.test.mjs` to assert rejection of unknown top-level and social provider fields.

### Testing
- Ran `npm test -- --run tests/coverage-fill.test.mjs` and the updated provider validation tests passed (19/19).
- Ran the inline Node verification reproducer which confirmed a provider submission with an extra field now returns `fix_required` and includes the `provider <field> is not allowed` error.
- Ran `npm run lint` on the modified files with no lint errors.
- Note: running `npm test -- --run tests/coverage-fill.test.mjs tests/submission-gate.test.mjs` and `npm run validate:schemas` in this checkout reported unrelated failures due to missing `public/metagraph/build-summary.json` and `public/metagraph/agent-catalog.json` artifacts present in other CI environments, not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a371dd00004832cb5f6979c9cb91742)