### PR TITLE
Fix R2 latest uploads to compare real artifact hashes

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1251,15 +1251,12 @@ export function hashJson(value) {
   return sha256Hex(stableStringify(value));
 }
 
-// Content hash for the R2 delta-skip: an artifact's hash with the pure build stamp
-// (`generated_at`) normalized out, so a republish whose ONLY difference is the
-// wall-clock build time (METAGRAPH_BUILD_TIMESTAMP, set per-publish in production —
-// see ADR 0007) is skipped instead of re-uploaded. `captured_at` is deliberately
-// NOT normalized: it is the chain-snapshot time consumers read as freshness, so an
-// artifact that was genuinely re-snapshotted still re-uploads. Non-JSON artifacts
-// (svg/txt) and unparseable files hash as-is.
-// NOTE: this is a delta-comparison hash only. Integrity verification (r2:download)
-// still uses the real `sha256` of the actual uploaded bytes, which is untouched.
+// Content hash for publish diagnostics: an artifact's hash with the pure build
+// stamp (`generated_at`) normalized out. `captured_at` is deliberately NOT
+// normalized: it is the chain-snapshot time consumers read as freshness. Non-JSON
+// artifacts (svg/txt) and unparseable files hash as-is.
+// NOTE: this is not an integrity hash. Upload/download decisions must use the
+// real `sha256` of the actual bytes so latest manifests and objects stay aligned.
 const DELTA_GENERATED_AT_PLACEHOLDER = "1970-01-01T00:00:00.000Z";
 
 export function artifactContentHash(relativePath, raw) {

--- a/scripts/r2-upload.mjs
+++ b/scripts/r2-upload.mjs
@@ -69,15 +69,10 @@ if (process.env.METAGRAPH_ALLOW_R2_UPLOAD !== "1") {
 const remoteManifestResult = forceUpload
   ? { status: "not-checked", manifest: null }
   : getRemoteManifest(manifest.bucket_name, "latest/r2-manifest.json");
-const remoteManifestByPath = new Map(
+const remoteManifestShaByPath = new Map(
   (remoteManifestResult.manifest?.artifacts ?? []).map((artifact) => [
     artifact.path,
-    // Compare on the delta hash (generated_at-normalized) so a republish whose
-    // only change is the wall-clock build stamp is skipped. Fall back to sha256
-    // for a pre-content_sha256 remote manifest — the first publish after this
-    // ships re-uploads once (the hashes can't match across the change), then
-    // deltas resume.
-    artifact.content_sha256 ?? artifact.sha256,
+    artifact.sha256,
   ]),
 );
 let changedArtifactCount = 0;
@@ -91,8 +86,7 @@ for (const artifact of plannedArtifacts) {
   const changed =
     forceUpload ||
     remoteManifestResult.status !== "found" ||
-    remoteManifestByPath.get(artifact.path) !==
-      (artifact.content_sha256 ?? artifact.sha256);
+    remoteManifestShaByPath.get(artifact.path) !== artifact.sha256;
   if (changed) {
     changedArtifactCount += 1;
     artifactUploadJobs.push(

--- a/tests/r2-upload.test.mjs
+++ b/tests/r2-upload.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "vitest";
+import { r2StagingRoot } from "../scripts/lib.mjs";
+
+test("R2 latest upload uses real sha256 even when content hash matches", () => {
+  const temporaryDirectory = mkdtempSync(
+    path.join(tmpdir(), "metagraphed-r2-upload-sha-"),
+  );
+  const wranglerPath = path.join(temporaryDirectory, "wrangler");
+  const putLogPath = path.join(temporaryDirectory, "put-log.jsonl");
+  const remoteManifestPath = path.join(
+    temporaryDirectory,
+    "remote-manifest.json",
+  );
+  const manifest = JSON.parse(
+    readFileSync(path.join(r2StagingRoot, "r2-manifest.json"), "utf8"),
+  );
+  const firstArtifact = manifest.artifacts[0];
+  const remoteManifest = {
+    ...manifest,
+    artifacts: manifest.artifacts.map((artifact, index) =>
+      index === 0
+        ? {
+            ...artifact,
+            sha256: "0".repeat(64),
+            content_sha256: artifact.content_sha256,
+          }
+        : artifact,
+    ),
+  };
+  writeFileSync(remoteManifestPath, JSON.stringify(remoteManifest));
+  writeFileSync(
+    wranglerPath,
+    String.raw`#!/usr/bin/env node
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+if (args[0] !== "r2" || args[1] !== "object") {
+  process.exit(2);
+}
+if (args[2] === "get") {
+  writeFileSync(1, readFileSync(process.env.FAKE_REMOTE_MANIFEST));
+  process.exit(0);
+}
+if (args[2] === "put") {
+  appendFileSync(
+    process.env.FAKE_PUT_LOG,
+    JSON.stringify({ key: args[3].slice(args[3].indexOf("/") + 1) }) + "\n",
+  );
+  process.exit(0);
+}
+process.exit(2);
+`,
+  );
+  chmodSync(wranglerPath, 0o755);
+
+  try {
+    const output = execFileSync(
+      process.execPath,
+      ["scripts/r2-upload.mjs", "--write"],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_PUT_LOG: putLogPath,
+          FAKE_REMOTE_MANIFEST: remoteManifestPath,
+          METAGRAPH_ALLOW_R2_UPLOAD: "1",
+          METAGRAPH_R2_UPLOAD_LIMIT: "1",
+          METAGRAPH_WRANGLER_BIN: wranglerPath,
+        },
+        stdio: "pipe",
+      },
+    );
+    const summary = JSON.parse(output);
+    const putKeys = readFileSync(putLogPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line).key);
+
+    assert.equal(summary.remote_manifest_status, "found");
+    assert.equal(summary.changed_artifact_count, 1);
+    assert.equal(summary.skipped_artifact_count, 0);
+    assert.equal(summary.uploaded_latest_count, 1);
+    assert.deepEqual(putKeys, [firstArtifact.latest_key]);
+  } finally {
+    rmSync(temporaryDirectory, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
### Motivation
- Prevent `latest/` manifest objects describing bytes that were never uploaded by avoiding delta-skip decisions based on `content_sha256` (which normalizes out `generated_at`) when the real uploaded bytes differ.
- Preserve integrity guarantees: upload/download decisions and verification must be driven by the real artifact `sha256`, while `content_sha256` remains a delta/diagnostic hash.
- Add a regression test that reproduces the mismatch scenario so the regression cannot recur.

### Description
- Change `scripts/r2-upload.mjs` to build a remote map of real `sha256` values and to decide whether to upload `latest` artifacts by comparing the remote `sha256` to the local `artifact.sha256` instead of using `content_sha256`.
- Update the `artifactContentHash` documentation in `scripts/lib.mjs` to clarify that the `content_sha256` is diagnostic only and not an integrity hash used for upload/download decisions.
- Add `tests/r2-upload.test.mjs`, a fake-R2 test that simulates a remote manifest where `content_sha256` matches but `sha256` differs and asserts that the latest artifact is uploaded.
- Run formatting and linting on the changed files as part of the change set.

### Testing
- Ran formatting: `npx prettier --write scripts/lib.mjs scripts/r2-upload.mjs tests/r2-upload.test.mjs` (succeeded).
- Ran lint: `npm run lint -- --quiet` (succeeded).
- Ran unit tests: `npx vitest run tests/artifact-content-hash.test.mjs tests/r2-upload.test.mjs`, which completed with all tests passing (2 test files, 8 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a378a9463a8832c87909bbedaa510f4)