### PR TITLE
fix(publish): preserve R2 run id across jobs

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -60,6 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      metagraph_run_id: ${{ steps.stamp-publish-time.outputs.metagraph_run_id }}
+      metagraph_published_at: ${{ steps.stamp-publish-time.outputs.metagraph_published_at }}
     env:
       METAGRAPH_PRODUCTION_BUILD: "1"
     steps:
@@ -81,14 +84,17 @@ jobs:
         run: npm ci
 
       - name: Stamp publish time
+        id: stamp-publish-time
         run: |
           # The real publish moment — served LIVE as meta.published_at, never baked.
           published_at="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
           echo "METAGRAPH_PUBLISHED_AT=$published_at" >> "$GITHUB_ENV"
+          echo "metagraph_published_at=$published_at" >> "$GITHUB_OUTPUT"
           # Unique R2 run-prefix id for every r2:manifest invocation (build + the
           # post-changelog re-stamp). generated_at stays the deterministic epoch
           # marker (issue #349) so artifacts don't churn; this keeps runs/ unique.
           echo "METAGRAPH_RUN_ID=$published_at" >> "$GITHUB_ENV"
+          echo "metagraph_run_id=$published_at" >> "$GITHUB_OUTPUT"
 
       - name: Prepare reviewed publish artifacts
         run: npm run build
@@ -162,6 +168,11 @@ jobs:
     env:
       METAGRAPH_PRODUCTION_BUILD: "1"
       METAGRAPH_REQUIRE_PROBE_HEALTH: "1"
+      # $GITHUB_ENV is job-local; carry the refresh job's unique publish stamp
+      # into the publish job so the final r2:manifest restamp cannot fall back to
+      # the deterministic generated_at epoch and reuse runs/1970.../.
+      METAGRAPH_RUN_ID: ${{ needs.refresh.outputs.metagraph_run_id }}
+      METAGRAPH_PUBLISHED_AT: ${{ needs.refresh.outputs.metagraph_published_at }}
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1


### PR DESCRIPTION
### Motivation
- The `refresh` job wrote `METAGRAPH_RUN_ID` into the job-local `$GITHUB_ENV` but the separate `publish` job later re-runs `npm run r2:manifest` without that variable, allowing the manifest to fall back to the deterministic epoch and reuse the `runs/1970...` prefix which can overwrite immutable history.

### Description
- Expose the refresh job's publish timestamp/run id as explicit job outputs `metagraph_run_id` and `metagraph_published_at` from the `stamp-publish-time` step.
- Add an `id` to the `stamp-publish-time` step and emit `metagraph_run_id`/`metagraph_published_at` via `GITHUB_OUTPUT` so they become job outputs.
- Inject those outputs into the `publish` job environment as `METAGRAPH_RUN_ID` and `METAGRAPH_PUBLISHED_AT` so the final `npm run r2:manifest` restamp cannot fall back to the deterministic epoch.
- Change localized to the workflow file ` .github/workflows/publish-cloudflare.yml`.

### Testing
- Ran `npm run validate:workflows` which completed successfully and validated the workflow file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a378f45dac8832caba6164b3c403a53)