### PR TITLE
feat(badge): add uptime variant, style/label options, and CORS header

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ curl https://api.metagraph.sh/api/v1/subnets
 
 ## For agents
 
-| Resource              | URL                                                                                                                                                                                   |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Copyable agent prompt | [`/agent.md`](https://api.metagraph.sh/agent.md)                                                                                                                                      |
-| Agent workflows       | [`/agent-workflows.md`](https://api.metagraph.sh/agent-workflows.md)                                                                                                                  |
-| Machine index         | [`/llms.txt`](https://api.metagraph.sh/llms.txt)                                                                                                                                      |
-| Drop-in skill         | [`/skills/bittensor/SKILL.md`](https://api.metagraph.sh/skills/bittensor/SKILL.md)                                                                                                    |
-| Resources index       | [`/metagraph/agent-resources.json`](https://api.metagraph.sh/metagraph/agent-resources.json)                                                                                          |
-| Content feeds         | [`/api/v1/feeds/registry`](https://api.metagraph.sh/api/v1/feeds/registry) — registry changes + incidents, as RSS / Atom / JSON Feed (per-subnet at `/api/v1/feeds/subnets/{netuid}`) |
-| Readiness badge       | `![metagraphed](https://api.metagraph.sh/api/v1/subnets/{netuid}/badge.svg)` — embeddable SVG (also `/providers/{slug}/badge.svg`)                                                    |
+| Resource              | URL                                                                                                                                                                                                 |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Copyable agent prompt | [`/agent.md`](https://api.metagraph.sh/agent.md)                                                                                                                                                    |
+| Agent workflows       | [`/agent-workflows.md`](https://api.metagraph.sh/agent-workflows.md)                                                                                                                                |
+| Machine index         | [`/llms.txt`](https://api.metagraph.sh/llms.txt)                                                                                                                                                    |
+| Drop-in skill         | [`/skills/bittensor/SKILL.md`](https://api.metagraph.sh/skills/bittensor/SKILL.md)                                                                                                                  |
+| Resources index       | [`/metagraph/agent-resources.json`](https://api.metagraph.sh/metagraph/agent-resources.json)                                                                                                        |
+| Content feeds         | [`/api/v1/feeds/registry`](https://api.metagraph.sh/api/v1/feeds/registry) — registry changes + incidents, as RSS / Atom / JSON Feed (per-subnet at `/api/v1/feeds/subnets/{netuid}`)               |
+| Embeddable badge      | `![metagraphed](https://api.metagraph.sh/api/v1/subnets/{netuid}/badge.svg)` — SVG (also `/providers/{slug}/badge.svg`); `?metric=uptime` for reliability, plus `?style=flat-square` and `?label=…` |
 
 ## This repo
 

--- a/src/badge.mjs
+++ b/src/badge.mjs
@@ -1,16 +1,43 @@
-// Embeddable shields.io-style SVG badges (#744) — a distribution flywheel: a
-// subnet/provider drops `![metagraphed](…/badge.svg)` in its README, creating a
-// backlink + social pressure to improve the score we already compute.
+// Embeddable shields.io-style SVG badges: a subnet/provider drops
+// `![metagraphed](…/badge.svg)` in its README for a backlink + a visible score.
 //
-//   GET /api/v1/subnets/{netuid}/badge.svg   → that subnet's integration readiness
-//   GET /api/v1/providers/{slug}/badge.svg   → mean readiness across its subnets
+//   GET /api/v1/subnets/{netuid}/badge.svg   subnet score
+//   GET /api/v1/providers/{slug}/badge.svg   mean across its subnets
 //
-// Worker-computed (image/svg+xml, not a JSON-envelope route), read-only, edge-
-// cached. Unknown entities degrade to an "n/a" badge (HTTP 200) so an embedded
-// <img> never shows a broken image.
+// Query options (allow-listed / sanitized in parseBadgeOptions):
+//   metric=readiness   integration readiness 0–100 (default)
+//   metric=uptime      window uptime %, colored by the A–F reliability grade
+//                      (alias: reliability), from the live uptime rollup in D1
+//   style=flat-square  square corners, no gradient (default: flat)
+//   label=…            override the left "metagraphed" segment text
+//
+// Worker-computed image/svg+xml, read-only, edge-cached, CORS-open. Unknown
+// entities or missing data render an "n/a" badge (200) so an <img> never breaks.
+import { loadReliabilityAggregate } from "./health-serving.mjs";
 
 const BADGE_CACHE_SECONDS = 3600;
 const BADGE_LABEL = "metagraphed";
+const MAX_LABEL_LENGTH = 40;
+const NA_MESSAGE = "n/a";
+const UNKNOWN_COLOR = "#9f9f9f";
+const NA_CONTENT = { message: NA_MESSAGE, color: UNKNOWN_COLOR };
+
+// metric query value → internal metric ("uptime"/"reliability" are aliases).
+const BADGE_METRICS = {
+  readiness: "readiness",
+  uptime: "reliability",
+  reliability: "reliability",
+};
+// Allow-listed render styles; an unknown value falls back to "flat".
+const BADGE_STYLES = new Set(["flat", "flat-square"]);
+// A–F grade → color band (gray for unknown); bands match reliability.mjs.
+const GRADE_COLOR = {
+  A: "#2ea44f",
+  B: "#97ca00",
+  C: "#a4a61d",
+  D: "#dfb317",
+  F: "#e05d44",
+};
 
 function escapeXml(value) {
   return String(value ?? "")
@@ -33,16 +60,23 @@ function textWidth(text) {
   return Math.ceil(w);
 }
 
-// Accessible score → color (green / amber / red; gray for unknown).
+// Readiness score (0–100) → color (green / amber / red; gray for unknown).
 export function scoreColor(score) {
-  if (typeof score !== "number" || Number.isNaN(score)) return "#9f9f9f";
+  if (typeof score !== "number" || Number.isNaN(score)) return UNKNOWN_COLOR;
   if (score >= 80) return "#2ea44f";
   if (score >= 50) return "#dfb317";
   return "#e05d44";
 }
 
-// Render a flat two-segment badge: gray label + colored message.
-export function renderBadge(message, color, label = BADGE_LABEL) {
+// Reliability grade (A–F) → color band; gray when unknown / no data.
+export function gradeColor(grade) {
+  return GRADE_COLOR[grade] || UNKNOWN_COLOR;
+}
+
+// Render a two-segment badge: gray label + colored message. `style` is "flat"
+// (rounded + glossy gradient) or "flat-square" (square, matte).
+export function renderBadge(message, color, options = {}) {
+  const { label = BADGE_LABEL, style = "flat" } = options;
   const eLabel = escapeXml(label);
   const eMsg = escapeXml(message);
   const pad = 12;
@@ -51,15 +85,19 @@ export function renderBadge(message, color, label = BADGE_LABEL) {
   const total = labelW + msgW;
   const labelMid = labelW / 2;
   const msgMid = labelW + msgW / 2;
+  const square = style === "flat-square";
+  const rx = square ? 0 : 3;
   return [
     `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="20" role="img" aria-label="${eLabel}: ${eMsg}">`,
     `<title>${eLabel}: ${eMsg}</title>`,
-    `<linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>`,
-    `<clipPath id="r"><rect width="${total}" height="20" rx="3" fill="#fff"/></clipPath>`,
+    square
+      ? null
+      : `<linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>`,
+    `<clipPath id="r"><rect width="${total}" height="20" rx="${rx}" fill="#fff"/></clipPath>`,
     `<g clip-path="url(#r)">`,
     `<rect width="${labelW}" height="20" fill="#555"/>`,
     `<rect x="${labelW}" width="${msgW}" height="20" fill="${color}"/>`,
-    `<rect width="${total}" height="20" fill="url(#s)"/>`,
+    square ? null : `<rect width="${total}" height="20" fill="url(#s)"/>`,
     `</g>`,
     `<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">`,
     `<text x="${labelMid}" y="15" fill="#010101" fill-opacity=".3">${eLabel}</text>`,
@@ -69,7 +107,9 @@ export function renderBadge(message, color, label = BADGE_LABEL) {
     `</g>`,
     `</svg>`,
     ``,
-  ].join("\n");
+  ]
+    .filter((line) => line != null)
+    .join("\n");
 }
 
 async function readData(readArtifact, env, path) {
@@ -81,7 +121,12 @@ async function readData(readArtifact, env, path) {
   }
 }
 
-// Mean integration_readiness across a provider's subnets, rounded — or null when
+// A provider entry by slug (providers carry either `slug` or legacy `id`).
+function findProvider(providers, slug) {
+  return (providers?.providers || []).find((p) => (p.slug || p.id) === slug);
+}
+
+// Mean integration_readiness across a provider's subnets, rounded; null when
 // none of them resolve to a numeric score.
 function averageReadiness(netuids, subnetsIndex) {
   const byNetuid = new Map(
@@ -97,6 +142,12 @@ function averageReadiness(netuids, subnetsIndex) {
   return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
 }
 
+// uptime_ratio (0–1) → trimmed percent: 0.9983 → "99.83%", 1 → "100%".
+function formatUptimePercent(ratio) {
+  const pct = Math.round((Number(ratio) || 0) * 10000) / 100;
+  return `${pct}%`;
+}
+
 export function parseBadgePath(pathname) {
   let m = /^\/api\/v1\/subnets\/(\d+)\/badge\.svg$/.exec(pathname);
   if (m) return { kind: "subnet", netuid: Number(m[1]) };
@@ -107,42 +158,117 @@ export function parseBadgePath(pathname) {
   return null;
 }
 
+// Drop C0 control chars + DEL (invalid in XML), trim, then length-cap so a label
+// override can't break the SVG or overflow a segment. A code-point filter (no
+// control-char regex literals) keeps the source clean.
+function sanitizeLabel(raw) {
+  let out = "";
+  for (const ch of String(raw)) {
+    const code = ch.codePointAt(0);
+    if (code >= 0x20 && code !== 0x7f) out += ch;
+  }
+  return out.trim().slice(0, MAX_LABEL_LENGTH) || BADGE_LABEL;
+}
+
+// Parse the public query options. Metric + style are allow-listed; the label is
+// sanitized (escapeXml runs again at render).
+export function parseBadgeOptions(searchParams) {
+  const metric =
+    BADGE_METRICS[(searchParams.get("metric") || "").toLowerCase()] ||
+    "readiness";
+  const styleParam = (searchParams.get("style") || "").toLowerCase();
+  const style = BADGE_STYLES.has(styleParam) ? styleParam : "flat";
+  const rawLabel = searchParams.get("label");
+  const label = rawLabel == null ? BADGE_LABEL : sanitizeLabel(rawLabel);
+  return { metric, style, label };
+}
+
+// Readiness: the subnet's own integration_readiness, or a provider's mean.
+async function readinessContent({ target, readArtifact, env }) {
+  let score = null;
+  if (target.kind === "subnet") {
+    const index = await readData(readArtifact, env, "/metagraph/subnets.json");
+    const s = (index?.subnets || []).find((x) => x.netuid === target.netuid);
+    if (s && typeof s.integration_readiness === "number") {
+      score = s.integration_readiness;
+    }
+  } else {
+    const [providers, index] = await Promise.all([
+      readData(readArtifact, env, "/metagraph/providers.json"),
+      readData(readArtifact, env, "/metagraph/subnets.json"),
+    ]);
+    const provider = findProvider(providers, target.slug);
+    if (provider) score = averageReadiness(provider.netuids, index);
+  }
+  return {
+    message: typeof score === "number" ? `${score}/100` : NA_MESSAGE,
+    color: scoreColor(score),
+  };
+}
+
+// Reliability: the subnet's netuid, or all of a provider's netuids, scored from
+// the live uptime rollup in one aggregate query. Message is the window uptime %.
+async function reliabilityContent({
+  target,
+  readArtifact,
+  env,
+  db,
+  loadReliability,
+}) {
+  let netuids = [];
+  if (target.kind === "subnet") {
+    netuids = [target.netuid];
+  } else {
+    const providers = await readData(
+      readArtifact,
+      env,
+      "/metagraph/providers.json",
+    );
+    const provider = findProvider(providers, target.slug);
+    if (provider) netuids = provider.netuids || [];
+  }
+  const rel = netuids.length ? await loadReliability({ db, netuids }) : null;
+  return rel
+    ? {
+        message: formatUptimePercent(rel.uptime_ratio),
+        color: gradeColor(rel.grade),
+      }
+    : NA_CONTENT;
+}
+
+function badgeHeaders() {
+  return {
+    "content-type": "image/svg+xml; charset=utf-8",
+    "cache-control": `public, max-age=${BADGE_CACHE_SECONDS}`,
+    "x-content-type-options": "nosniff",
+    // Public read-only SVG: fetchable cross-origin like every apiHeaders() response.
+    "access-control-allow-origin": "*",
+  };
+}
+
 export async function handleBadgeRequest(request, env, url, deps = {}) {
   const readArtifact = deps.readArtifact;
   const target = parseBadgePath(url.pathname);
-  let score = null;
+  const { metric, style, label } = parseBadgeOptions(url.searchParams);
+  const ctx = {
+    target,
+    readArtifact,
+    env,
+    db: deps.db ?? env?.METAGRAPH_HEALTH_DB,
+    loadReliability: deps.loadReliability || loadReliabilityAggregate,
+  };
 
+  let content = NA_CONTENT;
   if (target && typeof readArtifact === "function") {
-    if (target.kind === "subnet") {
-      const index = await readData(
-        readArtifact,
-        env,
-        "/metagraph/subnets.json",
-      );
-      const s = (index?.subnets || []).find((x) => x.netuid === target.netuid);
-      if (s && typeof s.integration_readiness === "number") {
-        score = s.integration_readiness;
-      }
-    } else {
-      const [providers, index] = await Promise.all([
-        readData(readArtifact, env, "/metagraph/providers.json"),
-        readData(readArtifact, env, "/metagraph/subnets.json"),
-      ]);
-      const p = (providers?.providers || []).find(
-        (x) => (x.slug || x.id) === target.slug,
-      );
-      if (p) score = averageReadiness(p.netuids, index);
-    }
+    content =
+      metric === "reliability"
+        ? await reliabilityContent(ctx)
+        : await readinessContent(ctx);
   }
 
-  const message = typeof score === "number" ? `${score}/100` : "n/a";
-  const svg = renderBadge(message, scoreColor(score));
+  const svg = renderBadge(content.message, content.color, { label, style });
   return new Response(request.method === "HEAD" ? null : svg, {
     status: 200,
-    headers: {
-      "content-type": "image/svg+xml; charset=utf-8",
-      "cache-control": `public, max-age=${BADGE_CACHE_SECONDS}`,
-      "x-content-type-options": "nosniff",
-    },
+    headers: badgeHeaders(),
   });
 }

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -7,7 +7,7 @@
 // serving zero-downtime and regression-proof. No I/O here: callers pass parsed
 // objects + D1 rows in.
 
-import { computeReliability } from "./reliability.mjs";
+import { computeReliability, scoreFromStats } from "./reliability.mjs";
 import { rollupSubnetStatus } from "./health-probe-core.mjs";
 import { KV_ECONOMICS_CURRENT, KV_HEALTH_CURRENT } from "./kv-keys.mjs";
 
@@ -975,6 +975,54 @@ export async function loadSubnetReliability({
       window: `${windowDays}d`,
       now: computedAt,
     }).subnet;
+  } catch {
+    return null;
+  }
+}
+
+// Sample-weighted reliability score over one or many subnets in a single
+// aggregate query, so a provider spanning dozens of subnets stays one D1
+// round-trip. Returns the scoreFromStats shape (no per-surface breakdown the
+// badge doesn't need), or null when D1 is unbound/cold or has no history.
+export async function loadReliabilityAggregate({
+  db,
+  netuids,
+  windowDays = 30,
+  now = null,
+}) {
+  // Keep only integer netuids (no coercion, so Number(null) can't slip in as
+  // subnet 0), then dedupe so the IN-list has no repeats.
+  const ids = [...new Set((netuids || []).filter((n) => Number.isInteger(n)))];
+  if (!db?.prepare || ids.length === 0) {
+    return null;
+  }
+  const nowMs = now ? Date.parse(now) : Date.now();
+  const cutoff = new Date(nowMs - windowDays * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  const placeholders = ids.map(() => "?").join(",");
+  try {
+    const row = await db
+      .prepare(
+        `SELECT SUM(samples) AS samples,
+                SUM(ok_count) AS ok_count,
+                CASE
+                  WHEN SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN samples ELSE 0 END) > 0
+                    THEN SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN avg_latency_ms * samples ELSE 0 END) /
+                         SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN samples ELSE 0 END)
+                  ELSE NULL
+                END AS avg_latency_ms
+         FROM surface_uptime_daily
+         WHERE netuid IN (${placeholders}) AND day >= ?`,
+      )
+      .bind(...ids, cutoff)
+      .first();
+    return scoreFromStats({
+      samples: Number(row?.samples) || 0,
+      okCount: Number(row?.ok_count) || 0,
+      avgLatencyMs:
+        row?.avg_latency_ms == null ? null : Number(row.avg_latency_ms),
+    });
   } catch {
     return null;
   }

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -4,7 +4,9 @@ import {
   handleBadgeRequest,
   renderBadge,
   scoreColor,
+  gradeColor,
   parseBadgePath,
+  parseBadgeOptions,
 } from "../src/badge.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
@@ -33,6 +35,20 @@ function makeReadArtifact(fixtures) {
     );
 }
 
+// Fake reliability loader keyed by the set of netuids it's asked to score —
+// stands in for the live D1 surface_uptime_daily rollup (loadReliabilityAggregate).
+function makeLoadReliability(byNetuids) {
+  return ({ netuids }) =>
+    Promise.resolve(
+      byNetuids[[...netuids].sort((a, b) => a - b).join(",")] ?? null,
+    );
+}
+
+const RELIABILITY = {
+  7: { score: 99, grade: "A", uptime_ratio: 0.9983 }, // subnet 7
+  "7,12": { score: 88, grade: "D", uptime_ratio: 0.88 }, // provider datura
+};
+
 async function badge(pathname, { method = "GET" } = {}) {
   const url = new URL(`https://api.metagraph.sh${pathname}`);
   const res = await handleBadgeRequest(new Request(url, { method }), {}, url, {
@@ -40,6 +56,7 @@ async function badge(pathname, { method = "GET" } = {}) {
       "/metagraph/subnets.json": SUBNETS,
       "/metagraph/providers.json": PROVIDERS,
     }),
+    loadReliability: makeLoadReliability(RELIABILITY),
   });
   return { res, text: await res.text() };
 }
@@ -56,10 +73,22 @@ describe("badge — rendering", () => {
   });
 
   test("renderBadge escapes message + label (SVG injection-safe)", () => {
-    const svg = renderBadge('"><script>x</script>', "#000", "a&b");
+    const svg = renderBadge('"><script>x</script>', "#000", { label: "a&b" });
     assert.ok(!svg.includes("<script>"));
     assert.match(svg, /&lt;script&gt;/);
     assert.match(svg, /a&amp;b/);
+  });
+
+  test("renderBadge style=flat-square drops the gradient + rounding", () => {
+    const flat = renderBadge("92/100", "#2ea44f");
+    assert.match(flat, /linearGradient/);
+    assert.match(flat, /rx="3"/);
+    const square = renderBadge("92/100", "#2ea44f", { style: "flat-square" });
+    assert.ok(!square.includes("linearGradient"));
+    assert.ok(!square.includes('fill="url(#s)"'));
+    assert.match(square, /rx="0"/);
+    // Still a valid two-segment badge with both text layers.
+    assert.ok((square.match(/<text /g) || []).length === 4);
   });
 
   test("scoreColor thresholds (green / amber / red / gray)", () => {
@@ -70,6 +99,44 @@ describe("badge — rendering", () => {
     assert.equal(scoreColor(0), "#e05d44");
     assert.equal(scoreColor(null), "#9f9f9f");
     assert.equal(scoreColor(NaN), "#9f9f9f");
+  });
+
+  test("gradeColor maps A–F to bands aligned with the grade cutoffs", () => {
+    assert.equal(gradeColor("A"), "#2ea44f");
+    assert.equal(gradeColor("B"), "#97ca00");
+    assert.equal(gradeColor("C"), "#a4a61d");
+    assert.equal(gradeColor("D"), "#dfb317");
+    assert.equal(gradeColor("F"), "#e05d44");
+    assert.equal(gradeColor(undefined), "#9f9f9f"); // unknown / no data
+    assert.equal(gradeColor("Z"), "#9f9f9f");
+  });
+
+  test("parseBadgeOptions allow-lists metric/style + sanitizes label", () => {
+    const sp = (q) => new URL(`https://x/?${q}`).searchParams;
+    // metric: readiness default; uptime + reliability both map to reliability.
+    assert.equal(parseBadgeOptions(sp("")).metric, "readiness");
+    assert.equal(parseBadgeOptions(sp("metric=UPTIME")).metric, "reliability");
+    assert.equal(
+      parseBadgeOptions(sp("metric=reliability")).metric,
+      "reliability",
+    );
+    assert.equal(parseBadgeOptions(sp("metric=bogus")).metric, "readiness");
+    // style: flat default; flat-square allowed; anything else → flat.
+    assert.equal(parseBadgeOptions(sp("")).style, "flat");
+    assert.equal(
+      parseBadgeOptions(sp("style=flat-square")).style,
+      "flat-square",
+    );
+    assert.equal(parseBadgeOptions(sp("style=plastic")).style, "flat");
+    // label: default brand; override kept; control chars stripped; capped; blank→brand.
+    assert.equal(parseBadgeOptions(sp("")).label, "metagraphed");
+    assert.equal(parseBadgeOptions(sp("label=uptime")).label, "uptime");
+    assert.equal(parseBadgeOptions(sp("label=a%09%00b")).label, "ab");
+    assert.equal(
+      parseBadgeOptions(sp("label=" + "x".repeat(60))).label.length,
+      40,
+    );
+    assert.equal(parseBadgeOptions(sp("label=%20%20")).label, "metagraphed");
   });
 
   test("parseBadgePath resolves subnet/provider + rejects others", () => {
@@ -132,6 +199,65 @@ describe("badge — handleBadgeRequest", () => {
     assert.equal(res.status, 200);
     assert.match(res.headers.get("content-type"), /image\/svg\+xml/);
     assert.equal(text, "");
+  });
+
+  test("badge response is CORS-open + keeps cache/nosniff", async () => {
+    const { res } = await badge("/api/v1/subnets/7/badge.svg");
+    assert.equal(res.headers.get("access-control-allow-origin"), "*");
+    assert.match(res.headers.get("cache-control"), /max-age=3600/);
+    assert.equal(res.headers.get("x-content-type-options"), "nosniff");
+    // Headers are uniform across metric/entity (n/a included).
+    const { res: na } = await badge(
+      "/api/v1/subnets/999/badge.svg?metric=uptime",
+    );
+    assert.equal(na.headers.get("access-control-allow-origin"), "*");
+  });
+});
+
+describe("badge — uptime / reliability metric", () => {
+  test("subnet uptime renders the window % colored by the A grade", async () => {
+    const { text } = await badge("/api/v1/subnets/7/badge.svg?metric=uptime");
+    assert.match(text, /99\.83%/); // 0.9983 → trimmed percent
+    assert.match(text, /#2ea44f/); // grade A → green
+    assert.ok(!text.includes("/100")); // not the readiness rendering
+  });
+
+  test("metric=reliability is an alias for uptime", async () => {
+    const { text } = await badge(
+      "/api/v1/subnets/7/badge.svg?metric=reliability",
+    );
+    assert.match(text, /99\.83%/);
+  });
+
+  test("provider uptime is the rollup across all its subnets (one query)", async () => {
+    const { text } = await badge(
+      "/api/v1/providers/datura/badge.svg?metric=uptime",
+    );
+    assert.match(text, /88%/); // 0.88 → "88%"
+    assert.match(text, /#dfb317/); // grade D → yellow
+  });
+
+  test("unknown subnet uptime degrades to n/a (gray, still 200)", async () => {
+    const { res, text } = await badge(
+      "/api/v1/subnets/999/badge.svg?metric=uptime",
+    );
+    assert.equal(res.status, 200);
+    assert.match(text, /n\/a/);
+    assert.match(text, /#9f9f9f/);
+  });
+
+  test("provider with no reliability data is n/a", async () => {
+    const { text } = await badge(
+      "/api/v1/providers/byid/badge.svg?metric=uptime",
+    );
+    assert.match(text, /n\/a/);
+  });
+
+  test("label override applies to the uptime variant too", async () => {
+    const { text } = await badge(
+      "/api/v1/subnets/7/badge.svg?metric=uptime&label=uptime",
+    );
+    assert.match(text, /aria-label="uptime: 99\.83%"/);
   });
 });
 

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -16,6 +16,7 @@ import {
   overlaySubnetHealth,
   formatUptime,
   loadSubnetReliability,
+  loadReliabilityAggregate,
   parseLive,
   resolveLiveHealth,
   subnetBadgeStatus,
@@ -2190,6 +2191,104 @@ describe("loadSubnetReliability (D1-backed)", () => {
   test("returns null when there is no history yet", async () => {
     assert.equal(
       await loadSubnetReliability({ db: uptimeDb([]), netuid: 7 }),
+      null,
+    );
+  });
+});
+
+describe("loadReliabilityAggregate (D1-backed, one query for many subnets)", () => {
+  // Fake D1 returning a single aggregate row from .first(); also records the
+  // bound params so we can assert the netuid IN-list was built correctly.
+  function aggregateDb(row, sink = {}) {
+    return {
+      prepare(sql) {
+        sink.sql = sql;
+        return {
+          bind(...params) {
+            sink.params = params;
+            return this;
+          },
+          async first() {
+            return row;
+          },
+        };
+      },
+    };
+  }
+
+  test("returns null when D1 is unbound or no netuids given", async () => {
+    assert.equal(
+      await loadReliabilityAggregate({ db: undefined, netuids: [7] }),
+      null,
+    );
+    assert.equal(
+      await loadReliabilityAggregate({ db: aggregateDb({}), netuids: [] }),
+      null,
+    );
+  });
+
+  test("scores the summed samples/ok_count via scoreFromStats", async () => {
+    const sink = {};
+    const out = await loadReliabilityAggregate({
+      db: aggregateDb(
+        { samples: 1440, ok_count: 1080, avg_latency_ms: 600 },
+        sink,
+      ),
+      netuids: [7, 12],
+      now: "2026-06-13T00:00:00.000Z",
+    });
+    // (1080/1440)=0.75 uptime; latency 600 → -1 penalty → score 74, grade F.
+    assert.deepEqual(
+      out,
+      scoreFromStats({ samples: 1440, okCount: 1080, avgLatencyMs: 600 }),
+    );
+    assert.equal(out.uptime_ratio, 0.75);
+    // One IN-list query over a deduped, sorted netuid set + the day cutoff.
+    assert.match(sink.sql, /netuid IN \(\?,\?\)/);
+    assert.deepEqual(sink.params, [7, 12, "2026-05-14"]);
+  });
+
+  test("dedupes netuids and ignores non-integers", async () => {
+    const sink = {};
+    await loadReliabilityAggregate({
+      db: aggregateDb({ samples: 10, ok_count: 10 }, sink),
+      netuids: [7, 7, 12, "x", null, undefined],
+    });
+    assert.match(sink.sql, /netuid IN \(\?,\?\)/);
+    assert.deepEqual(sink.params.slice(0, 2), [7, 12]);
+  });
+
+  test("no rows → null (no samples, by design)", async () => {
+    assert.equal(
+      await loadReliabilityAggregate({
+        db: aggregateDb({
+          samples: null,
+          ok_count: null,
+          avg_latency_ms: null,
+        }),
+        netuids: [7],
+      }),
+      null,
+    );
+    assert.equal(
+      await loadReliabilityAggregate({
+        db: aggregateDb(null),
+        netuids: [7],
+      }),
+      null,
+    );
+  });
+
+  test("returns null (not throw) when the query fails", async () => {
+    assert.equal(
+      await loadReliabilityAggregate({
+        db: {
+          prepare() {
+            throw new Error("d1 down");
+          },
+        },
+        netuids: [7],
+      }),
       null,
     );
   });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -296,13 +296,17 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     });
   }
 
-  // Embeddable SVG readiness badges (#744) — /api/v1/{subnets/{netuid}|
-  // providers/{slug}}/badge.svg. Worker-computed image, caught before the generic
-  // entity routing so `badge.svg` isn't resolved as an entity sub-resource.
+  // Embeddable SVG badges at /api/v1/{subnets/{netuid}|providers/{slug}}/
+  // badge.svg. Worker-computed image, caught before the generic entity routing so
+  // `badge.svg` isn't resolved as an entity sub-resource. `?metric=uptime` reads
+  // the live reliability rollup, hence the health DB binding.
   if (
     /^\/api\/v1\/(?:subnets|providers)\/[^/]+\/badge\.svg$/.test(url.pathname)
   ) {
-    return handleBadgeRequest(request, env, url, { readArtifact });
+    return handleBadgeRequest(request, env, url, {
+      readArtifact,
+      db: env.METAGRAPH_HEALTH_DB,
+    });
   }
 
   // Dynamic Open Graph card (/og.png, alias /og) for the landing page's


### PR DESCRIPTION
## Summary

The embeddable badge gains an uptime variant alongside readiness, plus basic style and label options, and the response becomes reachable from another origin. The reliability data (grade, uptime ratio, latency) already exists in `src/reliability.mjs` and is now embeddable.

## What Changed

- `src/badge.mjs`: a `metric` query option (`readiness` default, `uptime` aliased to `reliability`). The uptime variant renders the window uptime percentage colored by the A to F grade bands. Added a `flat-square` `style` and a sanitized, width-capped `label` override. The response now sets `access-control-allow-origin: *` and keeps the cache and nosniff headers.
- `src/health-serving.mjs`: `loadReliabilityAggregate` scores one or many subnets from `surface_uptime_daily` in a single aggregate query (reusing `scoreFromStats`), so a provider spanning many subnets stays one round trip.
- `workers/api.mjs`: the badge route passes the health DB binding so the uptime metric can read the live rollup.
- `README.md`: documents the new query options.
- Tests cover each metric, the provider rollup, the unknown entity fallback, the new headers, option parsing, the grade colors, and the aggregate loader.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [x] `git diff --check`

Notes: `lint` and `format:check` pass. `tests/badge.test.mjs` and `tests/health-serving.test.mjs` pass at 135 of 135. The badge runtime change does not touch artifacts, schemas, or the build pipeline.