### PR TITLE
perf(worker): memoize the latest publish pointer in-isolate (#367)

### DIFF
--- a/tests/storage-pointer-memo.test.mjs
+++ b/tests/storage-pointer-memo.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { latestPointer } from "../workers/storage.mjs";
+
+test("latestPointer memoizes within the TTL — one KV read for repeated same-env calls (#367)", async () => {
+  let gets = 0;
+  const env = {
+    METAGRAPH_CONTROL: {
+      async get() {
+        gets += 1;
+        return {
+          latest_prefix: "latest/",
+          published_at: "2026-06-21T00:00:00.000Z",
+        };
+      },
+    },
+  };
+  const a = await latestPointer(env);
+  const b = await latestPointer(env);
+  assert.equal(a.published_at, "2026-06-21T00:00:00.000Z");
+  assert.deepEqual(a, b);
+  assert.equal(
+    gets,
+    1,
+    "the second call within the TTL must be served from the in-isolate memo",
+  );
+});
+
+test("latestPointer never cross-reads a different env (test isolation + multi-binding safety)", async () => {
+  let gets = 0;
+  const mkEnv = (pub) => ({
+    METAGRAPH_CONTROL: {
+      async get() {
+        gets += 1;
+        return { latest_prefix: "latest/", published_at: pub };
+      },
+    },
+  });
+  const first = await latestPointer(mkEnv("a"));
+  const second = await latestPointer(mkEnv("b"));
+  assert.equal(first.published_at, "a");
+  assert.equal(
+    second.published_at,
+    "b",
+    "a different env object must miss the memo",
+  );
+  assert.equal(gets, 2);
+});
+
+test("latestPointer returns null (no memo poisoning) when the KV binding is absent", async () => {
+  assert.equal(await latestPointer({}), null);
+});

--- a/workers/storage.mjs
+++ b/workers/storage.mjs
@@ -184,15 +184,31 @@ export async function latestR2Key(artifactPath, env) {
   return `${prefix}${artifactPath.replace(/^\/metagraph\//, "")}`;
 }
 
+// In-isolate memo for the publish pointer (#367). Cloudflare reuses Worker
+// isolates across requests, so a short TTL collapses the per-request KV read on
+// the hot path — latestPointer feeds every origin-miss R2 read + /health. The
+// pointer changes at most a few times a day (event-driven publish, ADR 0007), so
+// a 60s TTL is bounded staleness: a flipped pointer propagates within the window,
+// and the immutable run-prefix means the previous prefix's objects stay valid in
+// the meantime, so a request served from a just-stale pointer never 404s. Keyed
+// on the env object so tests (and any multi-binding caller) never cross-read.
+const POINTER_MEMO_TTL_MS = 60_000;
+let pointerMemo = { env: null, value: null, expiresAt: 0 };
+
 export async function latestPointer(env) {
   if (!env.METAGRAPH_CONTROL?.get) {
     return null;
   }
-
+  const now = Date.now();
+  if (pointerMemo.env === env && now < pointerMemo.expiresAt) {
+    return pointerMemo.value;
+  }
   try {
-    return await env.METAGRAPH_CONTROL.get(METAGRAPH_LATEST_KEY, {
+    const value = await env.METAGRAPH_CONTROL.get(METAGRAPH_LATEST_KEY, {
       type: "json",
     });
+    pointerMemo = { env, value, expiresAt: now + POINTER_MEMO_TTL_MS };
+    return value;
   } catch {
     return null;
   }


### PR DESCRIPTION
`latestPointer` reads KV on every call, on the hot path (every origin-miss R2 read + /health). The pointer changes a few times a day, so per-request reads are wasted latency. Memoized per isolate (60s TTL); bounded staleness is safe (immutable run-prefix keeps prior objects valid). Keyed on env for test/multi-binding isolation. 3 unit tests; suite green. (#367 R2-prune half deferred — opt-in history + R2 is on the static-git deprecation path.)