### PR TITLE
perf(worker): memoize rpc/pools.json per-isolate on the RPC proxy hot path (#1309)

### DIFF
--- a/tests/rpc-pool-cache.test.mjs
+++ b/tests/rpc-pool-cache.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  readRpcPoolArtifact,
+  RPC_POOL_ARTIFACT_TTL_MS,
+} from "../workers/api.mjs";
+
+// rpc/pools.json is R2-only (see src/artifact-storage.mjs R2_ONLY_PATTERNS), so a
+// successful read resolves through env.METAGRAPH_ARCHIVE.get. Counting those gets
+// proves the per-isolate memo collapses the per-request fetch (#1309).
+function mkR2Env(poolsData = { pools: [{ id: "finney-rpc", endpoints: [] }] }) {
+  let gets = 0;
+  return {
+    get gets() {
+      return gets;
+    },
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        gets += 1;
+        return { json: async () => poolsData };
+      },
+    },
+  };
+}
+
+test("readRpcPoolArtifact memoizes within the TTL — one R2 read for repeated calls (#1309)", async () => {
+  const env = mkR2Env();
+  const t0 = 1_000_000;
+  const a = await readRpcPoolArtifact(env, t0);
+  const b = await readRpcPoolArtifact(env, t0 + 1000);
+  assert.equal(a.ok, true);
+  assert.deepEqual(a.data, b.data);
+  assert.equal(
+    env.gets,
+    1,
+    "the second call within the TTL is served from memo",
+  );
+
+  // Past the TTL it re-reads.
+  await readRpcPoolArtifact(env, t0 + RPC_POOL_ARTIFACT_TTL_MS + 1);
+  assert.equal(env.gets, 2, "an expired memo triggers a fresh R2 read");
+});
+
+test("readRpcPoolArtifact never cross-reads a different env (test isolation + multi-binding safety)", async () => {
+  const envA = mkR2Env({ pools: [{ id: "a", endpoints: [] }] });
+  const envB = mkR2Env({ pools: [{ id: "b", endpoints: [] }] });
+  const t0 = 2_000_000;
+  const a = await readRpcPoolArtifact(envA, t0);
+  const b = await readRpcPoolArtifact(envB, t0);
+  assert.equal(a.data.pools[0].id, "a");
+  assert.equal(
+    b.data.pools[0].id,
+    "b",
+    "a different env object must miss the memo",
+  );
+  assert.equal(envA.gets, 1);
+  assert.equal(envB.gets, 1);
+});
+
+test("readRpcPoolArtifact does not cache a failed read (no sticky transient miss)", async () => {
+  let gets = 0;
+  const env = {
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        gets += 1;
+        return null; // R2 miss → readArtifact returns { ok: false, status: 404 }
+      },
+    },
+  };
+  const t0 = 3_000_000;
+  const first = await readRpcPoolArtifact(env, t0);
+  const second = await readRpcPoolArtifact(env, t0 + 1000);
+  assert.equal(first.ok, false);
+  assert.equal(second.ok, false);
+  assert.equal(gets, 2, "a failed read must not be memoized");
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -821,6 +821,35 @@ const subnetSlugIndexByNetwork = new Map(); // network.id -> { map, builtAt }
 const LEADERBOARD_PROFILES_TTL_MS = 300_000;
 let leaderboardProfilesCache = null; // { subnetMeta, mostComplete, builtAt }
 
+// rpc/pools.json is R2-only and static per-build (it changes only on redeploy).
+// The RPC proxy reads it on every POST to /rpc/v1/* before failover, so a burst
+// turns into N R2 reads of the same artifact (#1309). Memoize the successful read
+// per-isolate (5 min TTL, same as the other in-isolate caches). The per-endpoint
+// health that actually changes is overlaid separately from KV (readHealthKv) on
+// every request, so caching the static pool never staleness-pins live eligibility.
+// Keyed on env so tests / multi-binding callers never cross-read; only ok reads
+// are cached so a transient R2 miss isn't sticky.
+export const RPC_POOL_ARTIFACT_TTL_MS = 300_000;
+let rpcPoolArtifactCache = { env: null, value: null, expiresAt: 0 };
+
+export async function readRpcPoolArtifact(env, now = Date.now()) {
+  if (
+    rpcPoolArtifactCache.env === env &&
+    now < rpcPoolArtifactCache.expiresAt
+  ) {
+    return rpcPoolArtifactCache.value;
+  }
+  const poolArtifact = await readArtifact(env, "/metagraph/rpc/pools.json");
+  if (poolArtifact.ok) {
+    rpcPoolArtifactCache = {
+      env,
+      value: poolArtifact,
+      expiresAt: now + RPC_POOL_ARTIFACT_TTL_MS,
+    };
+  }
+  return poolArtifact;
+}
+
 async function resolveSubnetSlugRoute(
   env,
   url,
@@ -2172,7 +2201,7 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
     );
   }
 
-  const poolArtifact = await readArtifact(env, "/metagraph/rpc/pools.json");
+  const poolArtifact = await readRpcPoolArtifact(env);
   if (!poolArtifact.ok) {
     return errorResponse(
       poolArtifact.code,


### PR DESCRIPTION
Closes #1309.

## Problem
The RPC reverse-proxy read the **R2-only** `rpc/pools.json` artifact on **every** POST to `/rpc/v1/*` (before failover/cache), so a burst from one integration turned into N R2 `get`s of the same ~static artifact — wasted latency + R2 quota on the hot path.

## Fix
Memoize the successful read per-isolate (`readRpcPoolArtifact`, 5-min TTL), mirroring the established in-isolate cache patterns (`latestPointer` memo, leaderboard/slug caches). The per-endpoint health that actually changes is still overlaid separately from KV (`readHealthKv`) on every request, so caching the static pool **never** staleness-pins live eligibility.

Safety:
- Keyed on `env` so tests / multi-binding callers never cross-read.
- Only `ok` reads are cached, so a transient R2 miss isn't sticky.
- Verified downstream (`overlayRpcPoolEligibility`, `orderSafeRpcEndpoints`) is read-only on the pool object → caching a shared reference is safe.

## Tests
`tests/rpc-pool-cache.test.mjs` — memo hit within TTL (1 read), re-read past TTL, cross-env isolation, no caching of failed reads.

## Verification (local CI gate)
- `npm test` → 60 files / 1274 tests pass
- `eslint`, `prettier --check`, `validate:api` (61 routes), `validate:contract-drift` → all pass
- Source-only change (no `public/` artifact changes).