### PR TITLE
feat(api): serve per-subnet economics on /api/v1/subnets/{netuid} (#1308)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -3185,6 +3185,7 @@ export interface components {
         SubnetDetailArtifact: components["schemas"]["ArtifactBase"] & ({
             candidate_surfaces: components["schemas"]["CandidateSurface"][];
             candidates?: components["schemas"]["CandidateSurface"][];
+            economics?: components["schemas"]["SubnetEconomics"];
             endpoints?: components["schemas"]["EndpointResource"][];
             gaps: components["schemas"]["Gaps"];
             subnet: components["schemas"]["SubnetDetail"];
@@ -10354,6 +10355,27 @@ export interface operations {
                      *           }
                      *         ],
                      *         "contract_version": "2026-06-06.1",
+                     *         "economics": {
+                     *           "alpha_in_pool": 0.5,
+                     *           "alpha_out_pool": 0.5,
+                     *           "alpha_price_tao": 0.5,
+                     *           "emission_share": 0.5,
+                     *           "max_stake_tao": 0.5,
+                     *           "max_uids": 1,
+                     *           "max_validators": 1,
+                     *           "miner_count": 1,
+                     *           "name": "Example Subnet",
+                     *           "netuid": 7,
+                     *           "owner_coldkey": "example",
+                     *           "owner_hotkey": "example",
+                     *           "registration_allowed": false,
+                     *           "registration_cost_tao": 0.5,
+                     *           "slug": "example-subnet",
+                     *           "subnet_volume_tao": 0.5,
+                     *           "tao_in_pool_tao": 0.5,
+                     *           "total_stake_tao": 0.5,
+                     *           "validator_count": 1
+                     *         },
                      *         "endpoints": [
                      *           {
                      *             "auth_required": true,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -8624,6 +8624,9 @@
                 },
                 "type": "array"
               },
+              "economics": {
+                "$ref": "#/components/schemas/SubnetEconomics"
+              },
               "endpoints": {
                 "items": {
                   "$ref": "#/components/schemas/EndpointResource"
@@ -21179,6 +21182,27 @@
                       }
                     ],
                     "contract_version": "2026-06-06.1",
+                    "economics": {
+                      "alpha_in_pool": 0.5,
+                      "alpha_out_pool": 0.5,
+                      "alpha_price_tao": 0.5,
+                      "emission_share": 0.5,
+                      "max_stake_tao": 0.5,
+                      "max_uids": 1,
+                      "max_validators": 1,
+                      "miner_count": 1,
+                      "name": "Example Subnet",
+                      "netuid": 7,
+                      "owner_coldkey": "example",
+                      "owner_hotkey": "example",
+                      "registration_allowed": false,
+                      "registration_cost_tao": 0.5,
+                      "slug": "example-subnet",
+                      "subnet_volume_tao": 0.5,
+                      "tao_in_pool_tao": 0.5,
+                      "total_stake_tao": 0.5,
+                      "validator_count": 1
+                    },
                     "endpoints": [
                       {
                         "auth_required": true,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -3185,6 +3185,7 @@ export interface components {
         SubnetDetailArtifact: components["schemas"]["ArtifactBase"] & ({
             candidate_surfaces: components["schemas"]["CandidateSurface"][];
             candidates?: components["schemas"]["CandidateSurface"][];
+            economics?: components["schemas"]["SubnetEconomics"];
             endpoints?: components["schemas"]["EndpointResource"][];
             gaps: components["schemas"]["Gaps"];
             subnet: components["schemas"]["SubnetDetail"];
@@ -10354,6 +10355,27 @@ export interface operations {
                      *           }
                      *         ],
                      *         "contract_version": "2026-06-06.1",
+                     *         "economics": {
+                     *           "alpha_in_pool": 0.5,
+                     *           "alpha_out_pool": 0.5,
+                     *           "alpha_price_tao": 0.5,
+                     *           "emission_share": 0.5,
+                     *           "max_stake_tao": 0.5,
+                     *           "max_uids": 1,
+                     *           "max_validators": 1,
+                     *           "miner_count": 1,
+                     *           "name": "Example Subnet",
+                     *           "netuid": 7,
+                     *           "owner_coldkey": "example",
+                     *           "owner_hotkey": "example",
+                     *           "registration_allowed": false,
+                     *           "registration_cost_tao": 0.5,
+                     *           "slug": "example-subnet",
+                     *           "subnet_volume_tao": 0.5,
+                     *           "tao_in_pool_tao": 0.5,
+                     *           "total_stake_tao": 0.5,
+                     *           "validator_count": 1
+                     *         },
                      *         "endpoints": [
                      *           {
                      *             "auth_required": true,

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -8602,6 +8602,9 @@
                 },
                 "type": "array"
               },
+              "economics": {
+                "$ref": "#/components/schemas/SubnetEconomics"
+              },
               "endpoints": {
                 "items": {
                   "$ref": "#/components/schemas/EndpointResource"

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1165,6 +1165,9 @@
               },
               "gaps": {
                 "$ref": "#/components/schemas/Gaps"
+              },
+              "economics": {
+                "$ref": "#/components/schemas/SubnetEconomics"
               }
             },
             "additionalProperties": true

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1189,6 +1189,21 @@ export async function resolveLiveEconomics({
   return { data: blob, source: "live-kv" };
 }
 
+// Attach the per-subnet economics row from the live economics blob onto a
+// subnet-detail artifact at serve time (#1308), so /api/v1/subnets/{netuid}
+// carries validator/miner counts, registration, stake and alpha price without a
+// second call to /api/v1/economics. Null-safe: when the live economics store is
+// cold/stale (resolveLiveEconomics → null) or the subnet has no economics row,
+// the detail is returned unchanged (no `economics` field).
+export function overlaySubnetEconomics(detail, economicsBlob, netuid) {
+  if (!detail || typeof detail !== "object") return detail;
+  const rows = economicsBlob?.subnets;
+  if (!Array.isArray(rows)) return detail;
+  const row = rows.find((entry) => entry?.netuid === netuid);
+  if (!row) return detail;
+  return { ...detail, economics: row };
+}
+
 // Overlay the live per-subnet operational rollup onto a composed overview
 // artifact's `health`. Returns null only when there is no live snapshot at all
 // (caller falls back); when the snapshot exists but the subnet has no probed

--- a/tests/subnet-economics-overlay.test.mjs
+++ b/tests/subnet-economics-overlay.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { overlaySubnetEconomics } from "../src/health-serving.mjs";
+
+const blob = {
+  subnets: [
+    { netuid: 0, name: "root", validator_count: 64, alpha_price_tao: 1 },
+    {
+      netuid: 1,
+      name: "apex",
+      validator_count: 50,
+      miner_count: 200,
+      registration_allowed: true,
+      max_stake_tao: 1234.5,
+      alpha_price_tao: 0.042,
+    },
+  ],
+};
+
+test("overlaySubnetEconomics attaches the matching per-subnet row (#1308)", () => {
+  const detail = { schema_version: 1, subnet: { netuid: 1 }, surfaces: [] };
+  const out = overlaySubnetEconomics(detail, blob, 1);
+  assert.equal(out.economics.netuid, 1);
+  assert.equal(out.economics.validator_count, 50);
+  assert.equal(out.economics.registration_allowed, true);
+  assert.equal(out.economics.alpha_price_tao, 0.042);
+  // Original fields preserved, no mutation of input.
+  assert.deepEqual(out.subnet, { netuid: 1 });
+  assert.equal("economics" in detail, false);
+});
+
+test("overlaySubnetEconomics is null-safe when the economics tier is cold", () => {
+  const detail = { subnet: { netuid: 1 }, surfaces: [] };
+  // resolveLiveEconomics → null means we pass undefined as the blob.
+  assert.deepEqual(overlaySubnetEconomics(detail, undefined, 1), detail);
+  assert.deepEqual(overlaySubnetEconomics(detail, {}, 1), detail);
+  assert.deepEqual(
+    overlaySubnetEconomics(detail, { subnets: null }, 1),
+    detail,
+  );
+});
+
+test("overlaySubnetEconomics leaves detail unchanged when no row matches", () => {
+  const detail = { subnet: { netuid: 99 }, surfaces: [] };
+  const out = overlaySubnetEconomics(detail, blob, 99);
+  assert.equal("economics" in out, false);
+  assert.deepEqual(out, detail);
+});
+
+test("overlaySubnetEconomics returns a non-object detail untouched", () => {
+  assert.equal(overlaySubnetEconomics(null, blob, 1), null);
+  assert.equal(overlaySubnetEconomics(undefined, blob, 1), undefined);
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -75,6 +75,7 @@ import {
   overlayCatalogIndex,
   overlayOverviewHealth,
   overlayRpcPoolEligibility,
+  overlaySubnetEconomics,
   overlaySubnetHealth,
   resolveLiveEconomics,
   resolveLiveHealth,
@@ -1090,7 +1091,27 @@ async function handleApiRequest(
     });
   }
 
-  const baseData = live ? live.data : artifact.data;
+  let baseData = live ? live.data : artifact.data;
+  // Per-subnet economics overlay (#1308): attach the live economics row so
+  // /api/v1/subnets/{netuid} carries validator/miner counts, registration, stake
+  // and alpha price in one call. Null-safe — a cold/stale economics tier leaves
+  // the detail unchanged. Served live (not baked) so it never churns the artifact.
+  if (
+    matched.id === "subnet-detail" &&
+    baseData &&
+    typeof baseData === "object"
+  ) {
+    const liveEconomics = await resolveLiveEconomics({
+      readHealthKv,
+      env,
+      contractVersion: contractVersion(env),
+    });
+    baseData = overlaySubnetEconomics(
+      baseData,
+      liveEconomics?.data,
+      Number(matched.params.netuid),
+    );
+  }
   const baseSource = live
     ? live.source || baseData?.health_source || "live-cron-prober"
     : matched.id === "economics"


### PR DESCRIPTION
Closes #1308.

## Problem
`/api/v1/subnets/{netuid}` returned identity + surfaces + health, but **no economics** — so a validator/miner/agent needed a second call to `/api/v1/economics` (and a client-side join) to see validator/miner counts, registration status, stake, and alpha price.

## Fix
Overlay the live per-subnet economics row onto the subnet-detail response **at serve time** (`overlaySubnetEconomics`), reusing `resolveLiveEconomics` and the existing `SubnetEconomics` schema as an additive optional `economics` field.

- **Served live, not baked** → never churns the R2 artifact, always as fresh as the economics KV tier (3h refresh, 8h freshness gate, contract + integrity checked).
- **Null-safe** → a cold/stale/off-contract economics tier (resolveLiveEconomics → null) or an unmatched netuid leaves the detail unchanged (no `economics` field).
- Mirrors the existing live-health overlay pattern; the source schema edit lives in `schemas/components/05-subnets.schema.json` (bundled + contract/types/client regenerated).

## Tests
`tests/subnet-economics-overlay.test.mjs` — attaches the matching row, null-safe on cold tier / unmatched netuid / non-object detail, no input mutation.

## Verification (local CI gate)
- `npm test` → 61 files / 1293 tests pass
- All 8 contract validators (contract-drift, schemas, schema-enums, openapi-examples, generated-client, committed-seed, api, mcp) pass
- eslint + prettier clean; committed-derived-artifacts-fresh gate simulated clean (only the economics openapi/types delta)