### PR TITLE
feat(api): server-side filter/sort on /api/v1/economics (#1313)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -215,7 +215,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share), ordered by emission share. */
+        /** List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share), ordered by emission share. Filter by netuid/registration_allowed, search by name/slug, and sort by any economic metric. */
         get: operations["economics"];
         put?: never;
         post?: never;
@@ -5437,7 +5437,16 @@ export interface operations {
     };
     economics: {
         parameters: {
-            query?: never;
+            query?: {
+                netuid?: number;
+                registration_allowed?: "true" | "false";
+                q?: string;
+                fields?: string;
+                limit?: number;
+                cursor?: number;
+                sort?: "alpha_price_tao" | "emission_share" | "max_stake_tao" | "max_uids" | "max_validators" | "miner_count" | "name" | "netuid" | "registration_cost_tao" | "subnet_volume_tao" | "total_stake_tao" | "validator_count";
+                order?: "asc" | "desc";
+            };
             header?: never;
             path?: never;
             cookie?: never;

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -187,7 +187,7 @@ Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1
 - `GET /api/v1/providers/{slug}/endpoints` — List endpoint resources for one provider or operator.
 - `GET /api/v1/coverage` — Fetch registry coverage summary.
 - `GET /api/v1/coverage-depth` — Fetch the machine-usable coverage depth scorecard and ranked enrichment queue.
-- `GET /api/v1/economics` — List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share), ordered by emission share.
+- `GET /api/v1/economics` — List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share), ordered by emission share. Filter by netuid/registration_allowed, search by name/slug, and sort by any economic metric.
 - `GET /api/v1/registry/summary` — Fetch the registry-wide summary (completeness, top subnets, level counts, latest changes).
 - `GET /api/v1/lineage` — Fetch maintainer-approved cross-network subnet lineage (graduated subnets + the deploying-soon testnet pipeline).
 - `GET /api/v1/fixtures` — Fetch the index of captured live request/response fixtures (which surfaces carry a sanitized sample). Fetch one with get_fixture / GET /metagraph/fixtures/{surface_id}.json.

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1992,14 +1992,92 @@
     {
       "artifact_path": "/metagraph/economics.json",
       "cache": "standard",
-      "description": "List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share), ordered by emission share.",
+      "description": "List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share), ordered by emission share. Filter by netuid/registration_allowed, search by name/slug, and sort by any economic metric.",
       "id": "economics",
       "method": "GET",
       "path": "/api/v1/economics",
       "public": true,
-      "query_collection": null,
-      "query_filter_names": [],
-      "query_parameters": []
+      "query_collection": "economics",
+      "query_filter_names": [
+        "netuid",
+        "registration_allowed"
+      ],
+      "query_parameters": [
+        {
+          "name": "netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "registration_allowed",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "q",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "cursor",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "sort",
+          "schema": {
+            "enum": [
+              "alpha_price_tao",
+              "emission_share",
+              "max_stake_tao",
+              "max_uids",
+              "max_validators",
+              "miner_count",
+              "name",
+              "netuid",
+              "registration_cost_tao",
+              "subnet_volume_tao",
+              "total_stake_tao",
+              "validator_count"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "order",
+          "schema": {
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/registry-summary.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -13182,7 +13182,98 @@
     "/api/v1/economics": {
       "get": {
         "operationId": "economics",
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "registration_allowed",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "alpha_price_tao",
+                "emission_share",
+                "max_stake_tao",
+                "max_uids",
+                "max_validators",
+                "miner_count",
+                "name",
+                "netuid",
+                "registration_cost_tao",
+                "subnet_volume_tao",
+                "total_stake_tao",
+                "validator_count"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -13326,7 +13417,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share), ordered by emission share.",
+        "summary": "List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share), ordered by emission share. Filter by netuid/registration_allowed, search by name/slug, and sort by any economic metric.",
         "tags": [
           "subnets"
         ]

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -215,7 +215,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share), ordered by emission share. */
+        /** List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share), ordered by emission share. Filter by netuid/registration_allowed, search by name/slug, and sort by any economic metric. */
         get: operations["economics"];
         put?: never;
         post?: never;
@@ -5437,7 +5437,16 @@ export interface operations {
     };
     economics: {
         parameters: {
-            query?: never;
+            query?: {
+                netuid?: number;
+                registration_allowed?: "true" | "false";
+                q?: string;
+                fields?: string;
+                limit?: number;
+                cursor?: number;
+                sort?: "alpha_price_tao" | "emission_share" | "max_stake_tao" | "max_uids" | "max_validators" | "miner_count" | "name" | "netuid" | "registration_cost_tao" | "subnet_volume_tao" | "total_stake_tao" | "validator_count";
+                order?: "asc" | "desc";
+            };
             header?: never;
             path?: never;
             cookie?: never;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -185,6 +185,27 @@ export const API_QUERY_COLLECTIONS = {
     search: ["title", "subtitle", "slug", "tokens"],
     sort: ["kind", "netuid", "slug", "title"],
   }),
+  economics: queryCollection("subnets", {
+    filters: {
+      netuid: integerSchema,
+      registration_allowed: enumSchema(["true", "false"]),
+    },
+    search: ["name", "slug"],
+    sort: [
+      "alpha_price_tao",
+      "emission_share",
+      "max_stake_tao",
+      "max_uids",
+      "max_validators",
+      "miner_count",
+      "name",
+      "netuid",
+      "registration_cost_tao",
+      "subnet_volume_tao",
+      "total_stake_tao",
+      "validator_count",
+    ],
+  }),
   endpoints: queryCollection("endpoints", {
     filters: {
       kind: enumSchema(QUERY_ENUMS.surfaceKind),
@@ -1231,9 +1252,10 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/economics",
     "/metagraph/economics.json",
-    "List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share), ordered by emission share.",
+    "List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share), ordered by emission share. Filter by netuid/registration_allowed, search by name/slug, and sort by any economic metric.",
     "standard",
     ["subnets"],
+    listQuery("economics"),
   ),
   route(
     "registry-summary",

--- a/tests/economics-query.test.mjs
+++ b/tests/economics-query.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { applyQueryFilters } from "../workers/list-query.mjs";
+
+// Per-subnet economics rows (a subset of the /api/v1/economics blob shape).
+const blob = {
+  subnets: [
+    {
+      netuid: 1,
+      name: "apex",
+      validator_count: 50,
+      registration_allowed: true,
+    },
+    {
+      netuid: 2,
+      name: "beta",
+      validator_count: 10,
+      registration_allowed: false,
+    },
+    {
+      netuid: 3,
+      name: "gamma",
+      validator_count: 90,
+      registration_allowed: true,
+    },
+  ],
+};
+
+test("economics collection ranks by validator_count desc (#1313)", () => {
+  const url = new URL(
+    "https://x/api/v1/economics?sort=validator_count&order=desc",
+  );
+  const { data } = applyQueryFilters(blob, url, "economics", []);
+  assert.deepEqual(
+    data.subnets.map((s) => s.netuid),
+    [3, 1, 2],
+  );
+});
+
+test("economics collection filters by registration_allowed (boolean as string)", () => {
+  const url = new URL("https://x/api/v1/economics?registration_allowed=true");
+  const { data } = applyQueryFilters(blob, url, "economics", []);
+  assert.deepEqual(data.subnets.map((s) => s.netuid).sort(), [1, 3]);
+});
+
+test("economics collection searches by name", () => {
+  const url = new URL("https://x/api/v1/economics?q=gamma");
+  const { data } = applyQueryFilters(blob, url, "economics", []);
+  assert.deepEqual(
+    data.subnets.map((s) => s.netuid),
+    [3],
+  );
+});
+
+test("economics collection passes the blob through unchanged with no query", () => {
+  const url = new URL("https://x/api/v1/economics");
+  const { data } = applyQueryFilters(blob, url, "economics", []);
+  assert.equal(data.subnets.length, 3);
+});


### PR DESCRIPTION
Closes #1313.

## Problem
`/api/v1/economics` served rich per-subnet metrics but offered **no server-side filtering or ranking** — a client wanting "top subnets by validator count" or "subnets with open registration" had to download the full set and sort/filter in-process.

## Fix
Add an `economics` query collection (`data_key: subnets`) to `API_QUERY_COLLECTIONS` and wire `listQuery("economics")` onto the route — reusing the existing `applyQueryFilters` machinery (no handler changes).

Enables on `/api/v1/economics`:
- **filter**: `netuid`, `registration_allowed`
- **search**: `q` over name/slug
- **sort/rank**: validator_count, miner_count, total_stake_tao, max_stake_tao, alpha_price_tao, emission_share, subnet_volume_tao, registration_cost_tao, max_uids, max_validators, name, netuid
- **paginate**: order/limit/cursor

## Tests
`tests/economics-query.test.mjs` — rank by validator_count desc, filter by registration_allowed, search by name, pass-through with no query.

## Verification
`npm test` → 62 files / 1297 tests; all 8 contract validators, eslint, prettier pass; committed-derived-artifacts gate clean.