### PR TITLE
fix(api): restrict subnet economics overlay to mainnet

### DIFF
--- a/tests/network-routing.test.mjs
+++ b/tests/network-routing.test.mjs
@@ -159,6 +159,40 @@ describe("multi-network routing prefix (Phase 1)", () => {
     assert.equal(detail.body.data.subnet.netuid, 11);
   });
 
+  test("testnet subnet details do not receive mainnet live economics", async () => {
+    const economicsBlob = {
+      schema_version: 1,
+      captured_at: new Date().toISOString(),
+      summary: { with_economics_count: 1 },
+      subnets: [
+        {
+          netuid: 1,
+          name: "MAINNET economics row for netuid 1",
+          emission_share: 1,
+          validators: 123,
+          miners: 456,
+        },
+      ],
+    };
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: {
+        async get(key) {
+          return key === "economics:current" ? economicsBlob : null;
+        },
+      },
+    });
+
+    const detail = await get(env, "/api/v1/testnet/subnets/1");
+
+    assert.equal(detail.res.status, 200);
+    assert.equal(
+      detail.body.meta.artifact_path,
+      "/metagraph/testnet/subnets/1.json",
+    );
+    assert.equal(detail.body.data.subnet.netuid, 1);
+    assert.equal(detail.body.data.economics, undefined);
+  });
+
   test("local network route 404s cleanly (no data published)", async () => {
     const env = createLocalArtifactEnv();
     const { res } = await get(env, "/api/v1/local/coverage");

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1097,6 +1097,7 @@ async function handleApiRequest(
   // and alpha price in one call. Null-safe — a cold/stale economics tier leaves
   // the detail unchanged. Served live (not baked) so it never churns the artifact.
   if (
+    network.isDefault &&
     matched.id === "subnet-detail" &&
     baseData &&
     typeof baseData === "object"


### PR DESCRIPTION
### Motivation
- Prevent cross-network contamination where a mainnet live `economics:current` KV blob could be attached to non-default network subnet-detail responses (e.g. `/api/v1/testnet/subnets/{netuid}`), producing incorrect economics fields for testnet responses.

### Description
- Gate the per-subnet live economics overlay so it only runs when `network.isDefault` is true by adding a guard around the overlay invocation in `workers/api.mjs` (avoid calling `resolveLiveEconomics` for non-default networks).
- Add a regression test in `tests/network-routing.test.mjs` that stubs a mainnet `economics:current` blob and asserts that a `/api/v1/testnet/subnets/1` response remains the partitioned testnet artifact and does not receive an `economics` field.
- The change touches `workers/api.mjs` and `tests/network-routing.test.mjs` and preserves the existing `overlaySubnetEconomics` semantics for mainnet.

### Testing
- Ran the targeted network-regression test with `npx vitest run tests/network-routing.test.mjs -t "testnet subnet details do not receive mainnet live economics"` and it passed.
- Ran the economics unit tests with `npx vitest run tests/subnet-economics-overlay.test.mjs` and they passed.
- A broader `npx vitest run tests/network-routing.test.mjs tests/subnet-economics-overlay.test.mjs` attempt showed unrelated 404s for other network-routing tests in this checkout due to missing mainnet-local artifacts, but the new regression and the existing overlay unit tests succeed in isolation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37b4bd5f4c832c987ee8a6ed436dc0)