### PR TITLE
fix(lib): keep trailing-comma cleanup out of string literals in stripJsonComments

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -232,7 +232,44 @@ export function stripJsonComments(value) {
     }
     out += ch;
   }
-  return out.replace(/,\s*([}\]])/g, "$1");
+
+  // Drop trailing commas (",}" / ",]") outside string literals only. A blanket
+  // regex over the whole output spliced commas out of string contents too, so a
+  // value like "a, }" lost its comma. Re-walk string-aware; for a removed comma
+  // the look-ahead (j) also skips the whitespace up to the closing bracket, so
+  // ",\n }" collapses to "}" exactly as the old regex did.
+  let result = "";
+  inString = false;
+  for (let i = 0; i < out.length; i += 1) {
+    const ch = out[i];
+    if (inString) {
+      result += ch;
+      if (ch === "\\") {
+        result += out[i + 1] ?? "";
+        i += 1;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      result += ch;
+      continue;
+    }
+    if (ch === ",") {
+      let j = i + 1;
+      while (j < out.length && /\s/.test(out[j])) {
+        j += 1;
+      }
+      if (out[j] === "}" || out[j] === "]") {
+        i = j - 1;
+        continue;
+      }
+    }
+    result += ch;
+  }
+  return result;
 }
 
 export async function formatRepositoryJson(value) {

--- a/tests/strip-json-comments.test.mjs
+++ b/tests/strip-json-comments.test.mjs
@@ -38,6 +38,33 @@ describe("stripJsonComments", () => {
     assert.deepEqual(parsed.triggers.crons, ["*/2 * * * *", "0 * * * *"]);
   });
 
+  test("preserves comma-then-bracket sequences inside string literals", () => {
+    // The trailing-comma cleanup must not splice a ", }" / ", ]" out of a string
+    // value, while still dropping a genuine trailing comma before the close.
+    const input = `{ "note": "use a, } or b, ] here", "items": [1, 2, ], "x": 1, }`;
+    const parsed = JSON.parse(stripJsonComments(input));
+    assert.equal(parsed.note, "use a, } or b, ] here");
+    assert.deepEqual(parsed.items, [1, 2]);
+    assert.equal(parsed.x, 1);
+  });
+
+  test("keeps a trailing-comma-like sequence after an escaped backslash", () => {
+    // The string ends in a literal backslash; the following real ", }" is a
+    // genuine trailing comma and must still be removed without eating the value.
+    const input = `{ "path": "C:\\\\dir\\\\", "y": 2, }`;
+    const parsed = JSON.parse(stripJsonComments(input));
+    assert.equal(parsed.path, "C:\\dir\\");
+    assert.equal(parsed.y, 2);
+  });
+
+  test("drops trailing commas in empty-ish and nested collections", () => {
+    const input = `{ "a": [1, ], "b": { "c": 3, }, }`;
+    assert.deepEqual(JSON.parse(stripJsonComments(input)), {
+      a: [1],
+      b: { c: 3 },
+    });
+  });
+
   test("handles escaped quotes inside strings", () => {
     const input = `{ "q": "a \\"quoted\\" // not-a-comment" }`;
     assert.equal(


### PR DESCRIPTION
## Summary

Re-opens the focused fix from #1287 (closed on a red CI run, not on content — the AI review called the change "sound"). `stripJsonComments` removed trailing commas with one regex over the whole output (`/,\s*([}\]])/g`), which also matched **inside string literals**, so a value containing `, }` or `, ]` lost its comma:

```js
stripJsonComments('{ "note": "use a, } here" }')
// before -> { "note": "use a} here" }   (corrupted)
// after  -> { "note": "use a, } here" }  (intact)
```

The cleanup now re-walks the output string-aware, dropping a trailing comma only outside a string; the look-ahead also discards whitespace up to the close bracket so `",\n }"` still collapses to `"}"` as before. Addressed the prior review nits: reuse the existing `inString` flag (no `inStringTail`), added a comment explaining the look-ahead, and added edge-case tests (string contents, trailing backslash, nested trailing commas).

## Tests

- `npx vitest run tests/strip-json-comments.test.mjs` -> 7 passed
- `npx vitest run tests/script-utils.test.mjs` -> 43 passed (no regression)
- prettier + eslint clean
