### PR TITLE
fix(lib): strip FQDN trailing dot before the self-domain brand check

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -908,7 +908,14 @@ export function isBrandImpersonationUrl(value) {
     return false;
   }
 
-  const host = url.hostname.toLowerCase().replace(/^www\./, "");
+  // A trailing dot is the FQDN-canonical form of the same hostname, so strip it
+  // before the self-domain exemption — otherwise "metagraph.sh." (and real
+  // subdomains like "api.metagraph.sh.") fail the `=== SELF_DOMAIN` / `.endsWith`
+  // check and get wrongly flagged as impersonating our own domain.
+  const host = url.hostname
+    .toLowerCase()
+    .replace(/\.$/, "")
+    .replace(/^www\./, "");
   if (host === SELF_DOMAIN || host.endsWith(`.${SELF_DOMAIN}`)) {
     return false;
   }

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -355,6 +355,9 @@ describe("isBrandImpersonationUrl", () => {
       "https://metagraph.sh/api/v1/subnets",
       "https://api.metagraph.sh/x",
       "https://www.metagraph.sh",
+      // FQDN-canonical trailing dot resolves to the same host, not a squat.
+      "https://metagraph.sh./api/v1/subnets",
+      "https://api.metagraph.sh./x",
     ]) {
       assert.equal(isBrandImpersonationUrl(url), false, url);
     }


### PR DESCRIPTION
## Summary

`isBrandImpersonationUrl` exempts the real `metagraph.sh` and its subdomains, but it derived the host with only `.replace(/^www\./, "")` — it never stripped a **trailing dot**. A trailing dot is the FQDN-canonical form of the same hostname, so `metagraph.sh.` and real subdomains like `api.metagraph.sh.` failed the `=== SELF_DOMAIN` / `.endsWith(".metagraph.sh")` exemption and were **wrongly flagged as impersonating our own domain** (a candidate base_url in that form would be rejected from the discovery bundle).

```js
isBrandImpersonationUrl('https://metagraph.sh./x')      // before: true (bug)  -> after: false
isBrandImpersonationUrl('https://api.metagraph.sh./x')  // before: true (bug)  -> after: false
isBrandImpersonationUrl('https://metagraph.sh.evil.com')// true (unchanged)
isBrandImpersonationUrl('https://metagraphsh.com')      // true (unchanged)
```

Fix: strip the trailing dot first (the same normalization `normalizeHostname` already applies on the SSRF path). Genuine squats are unaffected.

## Tests

Extends the existing `allows the real metagraph.sh and its subdomains` case with the trailing-dot forms.

- `npx vitest run tests/lib-helpers.test.mjs -t isBrandImpersonationUrl` -> passed
- prettier + eslint clean
