### PR TITLE
feat(metagraph): per-UID neuron snapshot pipeline → D1 (#1303)

### DIFF
--- a/.github/workflows/refresh-metagraph.yml
+++ b/.github/workflows/refresh-metagraph.yml
@@ -1,0 +1,74 @@
+name: Refresh Metagraph (per-UID neurons)
+
+# Fetches the per-UID metagraph for every subnet from Taostats and loads it into
+# the metagraphed-health D1 `neurons` table (#1303, epic #1302). Powers
+# /api/v1/subnets/{netuid}/metagraph, /neurons/{uid}, and /validators. Daily +
+# manual. Tolerant: a failed/partial fetch aborts before writing (the script
+# guards on >50% subnet failures), so the previous snapshot stays in place.
+#
+# Gated on TAOSTATS_API_KEY: until the maintainer adds that repo secret the job
+# is a no-op (green), not a daily red failure.
+on:
+  schedule:
+    - cron: "23 5 * * *" # daily 05:23 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: refresh-metagraph
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40 # the Taostats fetch is rate-limited (~129 subnets w/ backoff)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22.22.3
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Gate on Taostats key
+        id: gate
+        env:
+          TAOSTATS_API_KEY: ${{ secrets.TAOSTATS_API_KEY }}
+        run: |
+          if [ -n "$TAOSTATS_API_KEY" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::TAOSTATS_API_KEY not set — skipping metagraph refresh."
+          fi
+
+      - name: Fetch per-UID metagraph (Taostats)
+        if: steps.gate.outputs.ready == 'true'
+        run: node scripts/fetch-metagraph.mjs
+        env:
+          TAOSTATS_API_KEY: ${{ secrets.TAOSTATS_API_KEY }}
+
+      - name: Load neurons into D1
+        if: steps.gate.outputs.ready == 'true'
+        run: npx wrangler d1 execute metagraphed-health --remote --file=dist/metagraph-neurons.sql
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Notify on failure
+        if: failure() && env.METAGRAPH_ALERT_WEBHOOK_URL != ''
+        env:
+          METAGRAPH_ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}
+        run: |
+          curl -fsS -X POST "$METAGRAPH_ALERT_WEBHOOK_URL" \
+            -H 'content-type: application/json' \
+            -d '{"content":"🔴 metagraphed refresh-metagraph FAILED — the per-UID neurons D1 tier may go stale."}' || true

--- a/migrations/0007_neurons.sql
+++ b/migrations/0007_neurons.sql
@@ -1,0 +1,43 @@
+-- Per-UID metagraph snapshot (#1303, epic #1302): the chain-level depth
+-- metagraphed previously lacked. One row per (netuid, uid), refreshed daily by
+-- the refresh-metagraph workflow (Taostats source) — latest-only, REPLACE-on-
+-- conflict, so the table stays bounded (~33k rows: 129 subnets x <=256 UIDs) and
+-- never grows unbounded. Powers /api/v1/subnets/{netuid}/metagraph + /neurons/{uid}
+-- (#1304) and /validators (#1305).
+--
+-- Units (verified against /api/v1/economics ground truth 2026-06-21):
+--   stake_tao   = Taostats total_alpha_stake / 1e9  (sum matches economics total_stake_tao)
+--   emission_tao= Taostats emission / 1e9
+--   trust/validator_trust/consensus/incentive/dividends = 0..1 ratios (as-is)
+--   validator_permit/active/is_immunity_period = 0/1 booleans
+CREATE TABLE IF NOT EXISTS neurons (
+  netuid               INTEGER NOT NULL,
+  uid                  INTEGER NOT NULL,
+  hotkey               TEXT,
+  coldkey              TEXT,
+  active               INTEGER,            -- 0/1
+  validator_permit     INTEGER,            -- 0/1
+  rank                 REAL,
+  trust                REAL,
+  validator_trust      REAL,
+  consensus            REAL,
+  incentive            REAL,
+  dividends            REAL,
+  emission_tao         REAL,
+  stake_tao            REAL,               -- total_alpha_stake / 1e9 (canonical stake)
+  registered_at_block  INTEGER,
+  is_immunity_period   INTEGER,            -- 0/1
+  axon                 TEXT,               -- "host:port" or NULL
+  block_number         INTEGER,            -- chain height at capture
+  captured_at          INTEGER NOT NULL,   -- epoch milliseconds
+  PRIMARY KEY (netuid, uid)
+);
+
+-- Validator discovery (#1305) + per-subnet listing (#1304): filter by subnet and
+-- validator_permit, order by stake/emission.
+CREATE INDEX IF NOT EXISTS idx_neurons_netuid_permit
+  ON neurons (netuid, validator_permit);
+
+-- Cross-subnet hotkey lookup: "which subnets does this hotkey operate on".
+CREATE INDEX IF NOT EXISTS idx_neurons_hotkey
+  ON neurons (hotkey);

--- a/scripts/fetch-metagraph.mjs
+++ b/scripts/fetch-metagraph.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// Fetch the per-UID metagraph for every active subnet from Taostats and emit a
+// D1 load script (#1303, epic #1302) — the chain-level depth metagraphed lacked.
+//
+// Reads TAOSTATS_API_KEY from the env; the netuid list from the committed native
+// snapshot (registry/native/finney-subnets.json). Output: a .sql file of
+// `INSERT OR REPLACE` statements that the refresh-metagraph workflow loads into
+// the metagraphed-health D1 via `wrangler d1 execute`. PK (netuid, uid) means a
+// re-run overwrites in place (slots are reused on the chain), so the table stays
+// bounded (~33k rows).
+//
+// Units verified against /api/v1/economics ground truth (2026-06-21):
+//   stake_tao    = total_alpha_stake / 1e9   (Σ matches economics total_stake_tao)
+//   emission_tao = emission / 1e9
+//   trust / validator_trust / consensus / incentive / dividends = 0..1 ratios.
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TAOSTATS_BASE = "https://api.taostats.io/api/metagraph/latest/v1";
+const RAO = 1e9;
+const PAGE_LIMIT = 256; // max UIDs per subnet → single page per subnet
+const OUT_PATH =
+  process.env.METAGRAPH_NEURONS_SQL || "dist/metagraph-neurons.sql";
+
+const num = (v) => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+const tao = (v) => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n / RAO : null;
+};
+const bool = (v) => (v ? 1 : 0);
+
+function formatAxon(axon) {
+  if (!axon || typeof axon !== "object") return null;
+  const ip = axon.ip ?? axon.host ?? null;
+  if (!ip) return null;
+  return axon.port ? `${ip}:${axon.port}` : String(ip);
+}
+
+// Map one raw Taostats neuron to the D1 `neurons` row shape. Pure + exported for
+// tests. Defensive: any missing/odd field becomes null rather than failing.
+export function normalizeNeuron(raw, capturedAt) {
+  return {
+    netuid: num(raw?.netuid),
+    uid: num(raw?.uid),
+    hotkey: raw?.hotkey?.ss58 ?? null,
+    coldkey: raw?.coldkey?.ss58 ?? null,
+    active: bool(raw?.active),
+    validator_permit: bool(raw?.validator_permit),
+    rank: num(raw?.rank),
+    trust: num(raw?.trust),
+    validator_trust: num(raw?.validator_trust),
+    consensus: num(raw?.consensus),
+    incentive: num(raw?.incentive),
+    dividends: num(raw?.dividends),
+    emission_tao: tao(raw?.emission),
+    stake_tao: tao(raw?.total_alpha_stake),
+    registered_at_block: num(raw?.registered_at_block),
+    is_immunity_period: bool(raw?.is_immunity_period),
+    axon: formatAxon(raw?.axon),
+    block_number: num(raw?.block_number),
+    captured_at: capturedAt,
+  };
+}
+
+const COLS = [
+  "netuid",
+  "uid",
+  "hotkey",
+  "coldkey",
+  "active",
+  "validator_permit",
+  "rank",
+  "trust",
+  "validator_trust",
+  "consensus",
+  "incentive",
+  "dividends",
+  "emission_tao",
+  "stake_tao",
+  "registered_at_block",
+  "is_immunity_period",
+  "axon",
+  "block_number",
+  "captured_at",
+];
+
+function sqlVal(v) {
+  if (v === null || v === undefined) return "NULL";
+  if (typeof v === "number") return Number.isFinite(v) ? String(v) : "NULL";
+  return "'" + String(v).replace(/'/g, "''") + "'";
+}
+
+// Batched INSERT OR REPLACE statements (default 50 rows/statement keeps each
+// statement well under D1's query-size limit). Exported for tests.
+export function buildNeuronSql(rows, batchSize = 50) {
+  const valid = rows.filter(
+    (r) => Number.isInteger(r.netuid) && Number.isInteger(r.uid),
+  );
+  const statements = [];
+  for (let i = 0; i < valid.length; i += batchSize) {
+    const values = valid
+      .slice(i, i + batchSize)
+      .map((r) => "(" + COLS.map((c) => sqlVal(r[c])).join(",") + ")")
+      .join(",");
+    statements.push(
+      `INSERT OR REPLACE INTO neurons (${COLS.join(",")}) VALUES ${values};`,
+    );
+  }
+  return statements;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Taostats exposes no rate-limit headers and a tight per-key burst limit, so a
+// 429 is expected under load. Respect Retry-After when present, else back off
+// exponentially, and retry. The daily cron can afford the wait; coverage matters
+// more than speed.
+async function fetchSubnet(
+  netuid,
+  key,
+  { maxRetries = 5, baseBackoffMs = 12000 } = {},
+) {
+  const url = `${TAOSTATS_BASE}?netuid=${netuid}&limit=${PAGE_LIMIT}`;
+  for (let attempt = 0; ; attempt += 1) {
+    const res = await fetch(url, {
+      headers: { Authorization: key, accept: "application/json" },
+    });
+    if (res.ok) {
+      const json = await res.json();
+      return Array.isArray(json?.data) ? json.data : [];
+    }
+    if (res.status === 429 && attempt < maxRetries) {
+      const retryAfter = Number(res.headers.get("retry-after"));
+      const waitMs =
+        Number.isFinite(retryAfter) && retryAfter > 0
+          ? retryAfter * 1000
+          : baseBackoffMs * (attempt + 1);
+      process.stderr.write(
+        `netuid ${netuid}: 429, backing off ${waitMs}ms (attempt ${attempt + 1}/${maxRetries})\n`,
+      );
+      await sleep(waitMs);
+      continue;
+    }
+    throw new Error(`taostats netuid ${netuid} -> HTTP ${res.status}`);
+  }
+}
+
+// Parse the optional METAGRAPH_FETCH_NETUIDS subset (testing). Exported + careful
+// about the Number("") === 0 trap: an empty/unset value must yield [] (→ full
+// network), NOT [0] (which would silently fetch only subnet 0, incl. in the cron).
+export function parseNetuidSubset(raw) {
+  return String(raw ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s !== "")
+    .map(Number)
+    .filter((n) => Number.isInteger(n));
+}
+
+function readNetuids() {
+  const subset = parseNetuidSubset(process.env.METAGRAPH_FETCH_NETUIDS);
+  if (subset.length) return subset.sort((a, b) => a - b);
+  const native = JSON.parse(
+    readFileSync("registry/native/finney-subnets.json", "utf8"),
+  );
+  const subnets = Array.isArray(native)
+    ? native
+    : native.subnets || native.data || [];
+  return subnets
+    .map((s) => s.netuid)
+    .filter((n) => Number.isInteger(n))
+    .sort((a, b) => a - b);
+}
+
+async function main() {
+  const key = process.env.TAOSTATS_API_KEY;
+  if (!key) {
+    console.error("TAOSTATS_API_KEY is required");
+    process.exit(1);
+  }
+  const netuids = readNetuids();
+  const delayMs = Number(process.env.METAGRAPH_FETCH_DELAY_MS) || 1200;
+  const capturedAt = Date.now();
+  const rows = [];
+  let failures = 0;
+  for (const netuid of netuids) {
+    try {
+      const neurons = await fetchSubnet(netuid, key);
+      for (const n of neurons) rows.push(normalizeNeuron(n, capturedAt));
+      process.stderr.write(`netuid ${netuid}: ${neurons.length} neurons\n`);
+    } catch (error) {
+      failures += 1;
+      process.stderr.write(`netuid ${netuid}: FAIL ${error.message}\n`);
+    }
+    await sleep(delayMs); // gentle throttle; fetchSubnet handles 429 backoff
+  }
+  // A daily refresh that lost most subnets to a transient outage should not wipe
+  // the table — bail before writing if coverage collapsed.
+  if (failures > netuids.length / 2) {
+    console.error(
+      `aborting: ${failures}/${netuids.length} subnet fetches failed`,
+    );
+    process.exit(1);
+  }
+  const statements = buildNeuronSql(rows);
+  mkdirSync(path.dirname(OUT_PATH), { recursive: true });
+  writeFileSync(OUT_PATH, statements.join("\n") + "\n");
+  console.log(
+    `wrote ${rows.length} neurons across ${netuids.length - failures}/${netuids.length} subnets -> ${OUT_PATH} (${statements.length} statements)`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/tests/metagraph-fetch.test.mjs
+++ b/tests/metagraph-fetch.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  normalizeNeuron,
+  buildNeuronSql,
+  parseNetuidSubset,
+} from "../scripts/fetch-metagraph.mjs";
+
+// A realistic raw Taostats neuron (shape verified against the live API 2026-06-21).
+const raw = {
+  hotkey: { ss58: "5HbNZ77cXQXbUjXG3YLVBGk6N4WbtKtGQYAWLXd2aWa8fqGe" },
+  coldkey: { ss58: "5FRXwb2qsEhqDQQKcm5m2MF26xTWwW65MHTEtKFFydypuqjG" },
+  netuid: 1,
+  uid: 252,
+  block_number: 8454388,
+  stake: "0",
+  trust: "0",
+  validator_trust: "0.99998474097810330358",
+  consensus: "0",
+  incentive: "0",
+  dividends: "0.53974212252994583047",
+  emission: "22129845598",
+  active: true,
+  validator_permit: true,
+  rank: 1,
+  total_alpha_stake: "1344255529357282",
+  registered_at_block: 6702485,
+  is_immunity_period: false,
+  axon: { ip: "1.2.3.4", port: 8091 },
+};
+
+test("normalizeNeuron applies verified dTAO units (#1303)", () => {
+  const n = normalizeNeuron(raw, 1000);
+  // total_alpha_stake (rao) / 1e9 → canonical stake_tao (Σ matches economics).
+  assert.equal(n.stake_tao, 1344255.529357282);
+  assert.equal(n.emission_tao, 22.129845598);
+  // ratios pass through 0..1 (assert against the same Number() conversion to
+  // avoid long-precision literals that lose precision identically at runtime).
+  assert.equal(n.validator_trust, Number(raw.validator_trust));
+  assert.equal(n.dividends, Number(raw.dividends));
+  assert.ok(n.validator_trust > 0.99 && n.validator_trust <= 1);
+  // booleans → 0/1.
+  assert.equal(n.validator_permit, 1);
+  assert.equal(n.active, 1);
+  assert.equal(n.is_immunity_period, 0);
+  // ss58 keys flattened; axon "ip:port".
+  assert.equal(n.hotkey, "5HbNZ77cXQXbUjXG3YLVBGk6N4WbtKtGQYAWLXd2aWa8fqGe");
+  assert.equal(n.axon, "1.2.3.4:8091");
+  assert.equal(n.netuid, 1);
+  assert.equal(n.uid, 252);
+  assert.equal(n.captured_at, 1000);
+});
+
+test("normalizeNeuron is defensive about missing/odd fields", () => {
+  const n = normalizeNeuron({ netuid: 5, uid: 0 }, 2000);
+  assert.equal(n.netuid, 5);
+  assert.equal(n.uid, 0);
+  assert.equal(n.hotkey, null);
+  assert.equal(n.stake_tao, null);
+  assert.equal(n.axon, null);
+  assert.equal(n.validator_permit, 0);
+});
+
+test("buildNeuronSql batches INSERT OR REPLACE + escapes + NULLs", () => {
+  const rows = [
+    normalizeNeuron(raw, 1000),
+    normalizeNeuron({ ...raw, uid: 253, axon: null }, 1000),
+    normalizeNeuron({ ...raw, uid: 254 }, 1000),
+  ];
+  const stmts = buildNeuronSql(rows, 2);
+  assert.equal(stmts.length, 2); // 3 rows, batch 2 → 2 statements
+  assert.ok(stmts[0].startsWith("INSERT OR REPLACE INTO neurons ("));
+  assert.ok(stmts[0].includes("VALUES ("));
+  assert.ok(stmts.some((s) => s.includes("NULL"))); // uid 253 axon is NULL
+  assert.ok(stmts.every((s) => s.endsWith(";")));
+});
+
+test("parseNetuidSubset avoids the Number('') === 0 trap (empty → full network)", () => {
+  // Critical: an empty/unset env must yield [] so the cron fetches the whole
+  // network, not [0] (which would silently fetch only subnet 0).
+  assert.deepEqual(parseNetuidSubset(""), []);
+  assert.deepEqual(parseNetuidSubset(undefined), []);
+  assert.deepEqual(parseNetuidSubset(null), []);
+  assert.deepEqual(parseNetuidSubset("1,7,64"), [1, 7, 64]);
+  assert.deepEqual(parseNetuidSubset("1, ,7"), [1, 7]);
+  assert.deepEqual(parseNetuidSubset("0"), [0]);
+});
+
+test("buildNeuronSql escapes single quotes + drops rows missing keys", () => {
+  const rows = [
+    normalizeNeuron({ netuid: 9, uid: 1, coldkey: { ss58: "a'b" } }, 1),
+    normalizeNeuron({ uid: 2 }, 1), // no netuid → dropped
+  ];
+  const stmts = buildNeuronSql(rows, 50);
+  assert.equal(stmts.length, 1);
+  assert.ok(stmts[0].includes("'a''b'")); // doubled single quote
+});


### PR DESCRIPTION
Part of epic #1302. Foundation for per-UID metagraph depth — the chain data Bittensor users (validators/miners/stakers/agents) need that metagraphed previously lacked.

## What this adds
- **`migrations/0007_neurons.sql`** — `neurons` D1 table, PK `(netuid,uid)` (daily REPLACE in place → ~33k rows steady-state, bounded), indexed on `(netuid,validator_permit)` + `(hotkey)` for validator discovery + cross-subnet hotkey lookup.
- **`scripts/fetch-metagraph.mjs`** — Taostats fetch (256 neurons/subnet, ~129 calls), 429 backoff, batched `INSERT OR REPLACE` SQL emitter. Units **verified against `/api/v1/economics` ground truth**: `total_alpha_stake/1e9 = stake_tao` (Σ matches `total_stake_tao`, max matches `max_stake_tao`, validator_permit count matches `validator_count`). `parseNetuidSubset` guards the `Number('')===0` trap (an unset subset must fetch the whole network, not just subnet 0).
- **`.github/workflows/refresh-metagraph.yml`** — daily cron, **gated on `TAOSTATS_API_KEY`** so it's a green no-op until the secret is added; loads via `wrangler d1 execute`.

## Verified
- `tests/metagraph-fetch.test.mjs` — normalizer units, SQL batching/escaping, the subnet-subset trap. Full round-trip verified end-to-end against **local + prod D1** (load → query → matches economics ground truth).
- `npm test` 1302 pass; build (0 artifact drift), eslint, prettier, `validate:workflows` all green.

## Deploy state (done via authorized wrangler CLI)
- Migration **applied to prod D1**; table **seeded with verified real data** (netuid 1/7).
- The endpoints that read this (#1304 per-UID, #1305 validators) follow in the next PR.

## ⚠️ One maintainer action to fully activate
Add repo secret **`TAOSTATS_API_KEY`** (Settings → Secrets and variables → Actions) so the daily cron populates all subnets. Until then the cron is a green no-op.