### PR TITLE
feat(api): time-series economics on the subnet trajectory (#1307)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -3637,10 +3637,15 @@ export interface components {
             netuid: number;
             point_count: number;
             points: ({
+                alpha_price_tao?: number | null;
                 completeness_score?: number | null;
                 date: string;
+                emission_share?: number | null;
                 endpoint_count?: number | null;
+                miner_count?: number | null;
                 surface_count?: number | null;
+                total_stake_tao?: number | null;
+                validator_count?: number | null;
             } & {
                 [key: string]: unknown;
             })[];

--- a/migrations/0008_economics_history.sql
+++ b/migrations/0008_economics_history.sql
@@ -1,0 +1,11 @@
+-- Time-series economics (#1307, epic #1302): capture per-subnet economic metrics
+-- into the existing daily subnet_snapshots rollup so the trajectory time series
+-- (/api/v1/subnets/{netuid}/trajectory) carries economic trends (alpha price,
+-- stake, validator/miner counts, emission share) alongside the structural ones.
+-- Additive nullable columns — existing rows and the structural trajectory are
+-- unaffected; history accrues from the first daily snapshot after this lands.
+ALTER TABLE subnet_snapshots ADD COLUMN validator_count INTEGER;
+ALTER TABLE subnet_snapshots ADD COLUMN miner_count INTEGER;
+ALTER TABLE subnet_snapshots ADD COLUMN total_stake_tao REAL;
+ALTER TABLE subnet_snapshots ADD COLUMN alpha_price_tao REAL;
+ALTER TABLE subnet_snapshots ADD COLUMN emission_share REAL;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -10301,6 +10301,12 @@
             "items": {
               "additionalProperties": true,
               "properties": {
+                "alpha_price_tao": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
                 "completeness_score": {
                   "type": [
                     "integer",
@@ -10310,13 +10316,37 @@
                 "date": {
                   "type": "string"
                 },
+                "emission_share": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
                 "endpoint_count": {
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
+                "miner_count": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "surface_count": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "total_stake_tao": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "validator_count": {
                   "type": [
                     "integer",
                     "null"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -3637,10 +3637,15 @@ export interface components {
             netuid: number;
             point_count: number;
             points: ({
+                alpha_price_tao?: number | null;
                 completeness_score?: number | null;
                 date: string;
+                emission_share?: number | null;
                 endpoint_count?: number | null;
+                miner_count?: number | null;
                 surface_count?: number | null;
+                total_stake_tao?: number | null;
+                validator_count?: number | null;
             } & {
                 [key: string]: unknown;
             })[];

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -10279,6 +10279,12 @@
             "items": {
               "additionalProperties": true,
               "properties": {
+                "alpha_price_tao": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
                 "completeness_score": {
                   "type": [
                     "integer",
@@ -10288,13 +10294,37 @@
                 "date": {
                   "type": "string"
                 },
+                "emission_share": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
                 "endpoint_count": {
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
+                "miner_count": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "surface_count": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "total_stake_tao": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "validator_count": {
                   "type": [
                     "integer",
                     "null"

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -640,7 +640,12 @@
                 "date": { "type": "string" },
                 "completeness_score": { "type": ["integer", "null"] },
                 "surface_count": { "type": ["integer", "null"] },
-                "endpoint_count": { "type": ["integer", "null"] }
+                "endpoint_count": { "type": ["integer", "null"] },
+                "validator_count": { "type": ["integer", "null"] },
+                "miner_count": { "type": ["integer", "null"] },
+                "total_stake_tao": { "type": ["number", "null"] },
+                "alpha_price_tao": { "type": ["number", "null"] },
+                "emission_share": { "type": ["number", "null"] }
               },
               "additionalProperties": true
             }

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -739,19 +739,33 @@ export async function writeSubnetSnapshot(env, overrides = {}) {
     : [];
   if (!profiles.length) return { ok: false, reason: "no_profiles" };
 
+  // Per-subnet economics for the time series (#1307). Best-effort: a missing
+  // economics artifact just leaves those columns null (structural trajectory
+  // still records).
+  const economicsResult = await readArtifact(env, "/metagraph/economics.json");
+  const economicsByNetuid = new Map(
+    (Array.isArray(economicsResult?.data?.subnets)
+      ? economicsResult.data.subnets
+      : []
+    ).map((row) => [row.netuid, row]),
+  );
+
   const date = new Date(now()).toISOString().slice(0, 10);
   const capturedAt = now();
   const stmt = db.prepare(
     `INSERT INTO subnet_snapshots
        (netuid, snapshot_date, completeness_score, surface_count,
-        endpoint_count, monitored_count, candidate_count, captured_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        endpoint_count, monitored_count, candidate_count,
+        validator_count, miner_count, total_stake_tao, alpha_price_tao,
+        emission_share, captured_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT (netuid, snapshot_date) DO NOTHING`,
   );
   const statements = profiles
     .filter((profile) => Number.isInteger(profile.netuid))
-    .map((profile) =>
-      stmt.bind(
+    .map((profile) => {
+      const econ = economicsByNetuid.get(profile.netuid) || {};
+      return stmt.bind(
         profile.netuid,
         date,
         profile.completeness_score ?? null,
@@ -759,9 +773,14 @@ export async function writeSubnetSnapshot(env, overrides = {}) {
         profile.endpoint_count ?? null,
         profile.monitored_endpoint_count ?? null,
         profile.candidate_count ?? null,
+        econ.validator_count ?? null,
+        econ.miner_count ?? null,
+        econ.total_stake_tao ?? null,
+        econ.alpha_price_tao ?? null,
+        econ.emission_share ?? null,
         capturedAt,
-      ),
-    );
+      );
+    });
   if (!statements.length) return { ok: false, reason: "no_rows" };
   try {
     await db.batch(statements);

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -808,6 +808,13 @@ export function formatTrajectory({ netuid, rows }) {
       completeness_score: row.completeness_score ?? null,
       surface_count: row.surface_count ?? null,
       endpoint_count: row.endpoint_count ?? null,
+      // Economic time series (#1307) — null on rows captured before the columns
+      // existed / when economics was unavailable that day.
+      validator_count: row.validator_count ?? null,
+      miner_count: row.miner_count ?? null,
+      total_stake_tao: row.total_stake_tao ?? null,
+      alpha_price_tao: row.alpha_price_tao ?? null,
+      emission_share: row.emission_share ?? null,
     }))
     .sort((a, b) => String(a.date).localeCompare(String(b.date)));
 

--- a/tests/economics-history.test.mjs
+++ b/tests/economics-history.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { formatTrajectory } from "../src/health-serving.mjs";
+
+// #1307: the daily subnet_snapshots rollup now carries per-subnet economics, so
+// the trajectory time series exposes economic trends alongside the structural ones.
+test("formatTrajectory carries economic fields in the time series (#1307)", () => {
+  const rows = [
+    {
+      snapshot_date: "2026-06-20",
+      completeness_score: 80,
+      surface_count: 5,
+      endpoint_count: 3,
+      validator_count: 9,
+      miner_count: 247,
+      total_stake_tao: 2522266,
+      alpha_price_tao: 0.04,
+      emission_share: 0.01,
+    },
+    {
+      snapshot_date: "2026-06-21",
+      completeness_score: 82,
+      surface_count: 6,
+      endpoint_count: 4,
+      validator_count: 10,
+      miner_count: 246,
+      total_stake_tao: 2600000,
+      alpha_price_tao: 0.05,
+      emission_share: 0.011,
+    },
+  ];
+  const out = formatTrajectory({ netuid: 1, rows });
+  assert.equal(out.point_count, 2);
+  const latest = out.points[1];
+  assert.equal(latest.date, "2026-06-21");
+  assert.equal(latest.validator_count, 10);
+  assert.equal(latest.miner_count, 246);
+  assert.equal(latest.total_stake_tao, 2600000);
+  assert.equal(latest.alpha_price_tao, 0.05);
+  assert.equal(latest.emission_share, 0.011);
+  // structural fields still present.
+  assert.equal(latest.completeness_score, 82);
+});
+
+test("formatTrajectory nulls economics on pre-migration rows", () => {
+  const out = formatTrajectory({
+    netuid: 1,
+    rows: [{ snapshot_date: "2026-06-01", completeness_score: 70 }],
+  });
+  assert.equal(out.points[0].validator_count, null);
+  assert.equal(out.points[0].total_stake_tao, null);
+  assert.equal(out.points[0].alpha_price_tao, null);
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1689,7 +1689,9 @@ async function handleTrajectory(request, env, netuid, url) {
   // ASC + LIMIT would freeze on the oldest 400 days once history exceeds the cap.
   const rows = await d1All(
     env,
-    `SELECT snapshot_date, completeness_score, surface_count, endpoint_count
+    `SELECT snapshot_date, completeness_score, surface_count, endpoint_count,
+            validator_count, miner_count, total_stake_tao, alpha_price_tao,
+            emission_share
      FROM subnet_snapshots
      WHERE netuid = ?
      ORDER BY snapshot_date DESC


### PR DESCRIPTION
Closes #1307 (epic #1302). The last metagraph-depth piece — economic trends over time.

## What
The daily `subnet_snapshots` rollup now captures per-subnet economics, so `GET /api/v1/subnets/{netuid}/trajectory` carries **economic trends** (validator/miner counts, total_stake_tao, alpha_price_tao, emission_share) alongside the existing structural metrics.

- **migration 0008** — additive nullable economics columns (already applied to prod D1).
- **writeSubnetSnapshot** — reads `economics.json` best-effort and records the economics columns in the daily snapshot (nulls when unavailable).
- **handleTrajectory + formatTrajectory + SubnetTrajectoryArtifact** — select + expose the new fields per point.

Chose to extend the existing trajectory time series rather than add a parallel `/economics/history` route — same data, far less surface area, no new route/contract machinery.

## Notes
- History **accrues from the next daily snapshot** (the columns are null on older rows / when economics is unavailable that day).
- Migration applied to prod ahead of the deploy so the new-column writes/reads can't error.

## Verified
`tests/economics-history.test.mjs` (economics carried in points + null on pre-migration rows). `npm test` 1320 pass; all validators (incl. docs + public-safety), eslint, prettier, committed-artifacts gate green; codecov patch 100% locally.