### PR TITLE
fix(python): fetch_all reads nested data[<collection>], not a flat array

### DIFF
--- a/python/src/metagraphed/aio.py
+++ b/python/src/metagraphed/aio.py
@@ -23,6 +23,7 @@ from .client import (
     MetagraphedError,
     _MAX_RETRY_AFTER_SECONDS,
     _RETRY_STATUSES,
+    _collection_rows,
     _interpolate,
 )
 from .models import AgentCatalogSubnet, Endpoint, Provider, Subnet, Surface
@@ -207,14 +208,13 @@ class AsyncMetagraphedClient:
         query: Optional[Mapping[str, Any]] = None,
         headers: Optional[Mapping[str, str]] = None,
     ) -> List[Any]:
-        """Follow pagination and return every item (flattened ``data`` arrays)."""
+        """Follow pagination and return every row across all pages (the nested
+        ``data`` collection; see :func:`~metagraphed.client._collection_rows`)."""
         items: List[Any] = []
         async for page in self.paginate(
             path, path_params=path_params, query=query, headers=headers
         ):
-            data = page.get("data") if isinstance(page, dict) else None
-            if isinstance(data, list):
-                items.extend(data)
+            items.extend(_collection_rows(page))
         return items
 
     async def rpc(

--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -243,6 +243,30 @@ def metagraphed_paginate(
             return
 
 
+def _collection_rows(page: Any) -> List[Any]:
+    """Extract the row list from a single list-endpoint page.
+
+    List endpoints nest their rows under ``data[meta['pagination']['collection']]``
+    (e.g. ``data['subnets']``), not as a bare array. Resolve the collection key,
+    falling back to a flat ``data`` list or the single list-valued field. Mirrors
+    the TypeScript client's ``fetchAll``.
+    """
+    if not isinstance(page, dict):
+        return []
+    data = page.get("data")
+    if isinstance(data, list):
+        return data
+    if not isinstance(data, dict):
+        return []
+    meta = page.get("meta")
+    pagination = meta.get("pagination") if isinstance(meta, dict) else None
+    collection = pagination.get("collection") if isinstance(pagination, dict) else None
+    if isinstance(collection, str) and isinstance(data.get(collection), list):
+        return data[collection]
+    arrays = [value for value in data.values() if isinstance(value, list)]
+    return arrays[0] if len(arrays) == 1 else []
+
+
 def metagraphed_fetch_all(
     path: str,
     *,
@@ -253,8 +277,8 @@ def metagraphed_fetch_all(
     timeout: float = 30.0,
     retries: int = 0,
 ) -> List[Any]:
-    """Follow pagination for a list endpoint and return every item — the
-    flattened ``data`` arrays across all pages."""
+    """Follow pagination for a list endpoint and return every row across all
+    pages (the nested ``data`` collection; see :func:`_collection_rows`)."""
     items: List[Any] = []
     for page in metagraphed_paginate(
         path,
@@ -265,9 +289,7 @@ def metagraphed_fetch_all(
         timeout=timeout,
         retries=retries,
     ):
-        data = page.get("data") if isinstance(page, dict) else None
-        if isinstance(data, list):
-            items.extend(data)
+        items.extend(_collection_rows(page))
     return items
 
 

--- a/python/tests/test_aio.py
+++ b/python/tests/test_aio.py
@@ -56,19 +56,20 @@ class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
         await client.fetch("/api/v1/subnets", query={"limit": 5, "cursor": None})
         self.assertEqual(client._client.calls[0][2], {"limit": 5})
 
-    async def test_fetch_all_flattens_pages_following_cursor(self):
+    async def test_fetch_all_collects_nested_collection_following_cursor(self):
+        # List endpoints nest rows under data[meta.pagination.collection].
         page1 = httpx.Response(
             200,
             json={
-                "data": [{"netuid": 1}],
-                "meta": {"pagination": {"next_cursor": "c2"}},
+                "data": {"subnets": [{"netuid": 1}]},
+                "meta": {"pagination": {"collection": "subnets", "next_cursor": "c2"}},
             },
         )
         page2 = httpx.Response(
             200,
             json={
-                "data": [{"netuid": 2}],
-                "meta": {"pagination": {"next_cursor": None}},
+                "data": {"subnets": [{"netuid": 2}]},
+                "meta": {"pagination": {"collection": "subnets", "next_cursor": None}},
             },
         )
         client = self._client(page1, page2)

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -324,14 +324,35 @@ class FetchAllAndModelsTest(unittest.TestCase):
 
         return mock.patch("metagraphed.client._open_request", fake_urlopen)
 
-    def test_fetch_all_flattens_pages_following_cursor(self):
+    def test_fetch_all_collects_nested_collection_following_cursor(self):
+        # List endpoints nest rows under data[meta.pagination.collection].
         pages = [
-            {"data": [{"netuid": 1}], "meta": {"pagination": {"next_cursor": "c2"}}},
-            {"data": [{"netuid": 2}], "meta": {"pagination": {"next_cursor": None}}},
+            {
+                "data": {"subnets": [{"netuid": 1}]},
+                "meta": {"pagination": {"collection": "subnets", "next_cursor": "c2"}},
+            },
+            {
+                "data": {"subnets": [{"netuid": 2}]},
+                "meta": {"pagination": {"collection": "subnets", "next_cursor": None}},
+            },
         ]
         with self._patch_pages(pages):
             items = metagraphed_fetch_all("/api/v1/subnets")
         self.assertEqual([item["netuid"] for item in items], [1, 2])
+
+    def test_fetch_all_falls_back_to_flat_and_lone_array(self):
+        flat = [{"data": [{"id": "a"}], "meta": {"pagination": {"next_cursor": None}}}]
+        with self._patch_pages(flat):
+            self.assertEqual(metagraphed_fetch_all("/api/v1/subnets"), [{"id": "a"}])
+        # No collection key, but data has a single list-valued field.
+        lone = [
+            {
+                "data": {"rows": [{"id": "b"}]},
+                "meta": {"pagination": {"next_cursor": None}},
+            }
+        ]
+        with self._patch_pages(lone):
+            self.assertEqual(metagraphed_fetch_all("/api/v1/subnets"), [{"id": "b"}])
 
     def test_subnets_convenience_returns_typed_models(self):
         pages = [


### PR DESCRIPTION
## What

The Python SDK's `fetch_all` — and **every** typed convenience method built on it (`.subnets()`, `.surfaces()`, `.endpoints()`, `.providers()`, sync **and** async) — returns `[]` against the live API.

List endpoints return `data` as an **object** whose rows live under `data[meta.pagination.collection]` (e.g. `data["subnets"]`), not as a bare array. Both `metagraphed_fetch_all` (sync) and `AsyncMetagraphedClient.fetch_all` only handled `isinstance(data, list)`, so against `api.metagraph.sh` they collected nothing — **silent data loss, no error raised**. The SDK's headline high-level API is non-functional in production.

This is the Python companion to the TypeScript fix in [#1257](https://github.com/JSONbored/metagraphed/pull/1257) (both SDKs had the same bug).

## Fix

Add a shared `_collection_rows(page)` helper in `client.py` (imported + reused by `aio.py` — no duplication) that resolves the collection key from `meta.pagination.collection`, falling back to a flat `data` list (forward-compat) or the single list-valued field. Mirrors the TS client exactly.

- `python/src/metagraphed/client.py` — `_collection_rows` helper + sync `fetch_all`
- `python/src/metagraphed/aio.py` — import the helper + async `fetch_all`
- `python/tests/test_client.py`, `python/tests/test_aio.py` — sync + async `fetch_all` tests updated to the real nested envelope, plus flat / lone-array fallback coverage

No version bump / CHANGELOG edit — release-please derives those from this `fix(python):` commit.

## Validation

- `python -m unittest tests.test_client tests.test_aio` → **30 passed** (1 pre-existing skip: httpx-absent guard)
- `ruff check --select F,E9` on all changed files → clean; my additions are `ruff format`-canonical