### PR TITLE
fix(health): success-only latency with tail percentiles and sample counts

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -929,7 +929,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch 7d/30d uptime and latency trends for one subnet's operational surfaces (computed live from D1). */
+        /** Fetch 7d/30d uptime and success-only latency trends (mean + p50/p95/p99 tail + healthy-sample count) per operational surface for one subnet (computed live from D1). */
         get: operations["subnetHealthTrends"];
         put?: never;
         post?: never;
@@ -1340,10 +1340,12 @@ export interface components {
                     subnet_count: number;
                     subnets: {
                         avg_latency_ms: number | null;
+                        latency_sample_count: number;
                         netuid: number;
                         points: {
                             avg_latency_ms: number | null;
                             date: string;
+                            latency_sample_count: number;
                             samples: number;
                             uptime_ratio: number | null;
                         }[];
@@ -2102,6 +2104,7 @@ export interface components {
             failed_count: number;
             last_checked?: string | null;
             last_ok?: string | null;
+            latency_sample_count?: number;
             name?: string;
             netuid?: number;
             ok_count: number;
@@ -2171,9 +2174,18 @@ export interface components {
             source: string;
             windows: {
                 [key: string]: {
+                    latency_sample_count: number;
                     samples: number;
                     surfaces: ({
                         avg_latency_ms: number | null;
+                        latency_ms: {
+                            p50?: number | null;
+                            p95?: number | null;
+                            p99?: number | null;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                        latency_sample_count: number;
                         samples: number;
                         surface_id: string;
                         uptime_ratio: number | null;
@@ -2455,6 +2467,7 @@ export interface components {
             day_count?: number;
             /** @enum {string} */
             grade: "A" | "B" | "C" | "D" | "F";
+            latency_sample_count: number;
             sample_count: number;
             score: number;
             surface_count?: number;
@@ -3723,6 +3736,14 @@ export interface components {
                 days: ({
                     avg_latency_ms?: number | null;
                     day: string;
+                    latency_ms?: {
+                        p50?: number | null;
+                        p95?: number | null;
+                        p99?: number | null;
+                    } & {
+                        [key: string]: unknown;
+                    };
+                    latency_sample_count?: number;
                     samples: number;
                     status: string;
                     uptime_ratio: number | null;
@@ -6842,11 +6863,13 @@ export interface operations {
                      *             "subnets": [
                      *               {
                      *                 "avg_latency_ms": 120,
+                     *                 "latency_sample_count": 120,
                      *                 "netuid": 7,
                      *                 "points": [
                      *                   {
                      *                     "avg_latency_ms": 120,
                      *                     "date": "2026-06-01",
+                     *                     "latency_sample_count": 120,
                      *                     "samples": 1,
                      *                     "uptime_ratio": 0.9966
                      *                   }
@@ -11217,6 +11240,7 @@ export interface operations {
                      *           "failed_count": 1,
                      *           "last_checked": "2026-06-01T00:00:00.000Z",
                      *           "last_ok": "2026-06-01T00:00:00.000Z",
+                     *           "latency_sample_count": 120,
                      *           "name": "Example Subnet",
                      *           "netuid": 7,
                      *           "ok_count": 1,
@@ -11578,10 +11602,13 @@ export interface operations {
                      *         "source": "live-cron-prober",
                      *         "windows": {
                      *           "example": {
+                     *             "latency_sample_count": 120,
                      *             "samples": 1,
                      *             "surfaces": [
                      *               {
                      *                 "avg_latency_ms": 120,
+                     *                 "latency_ms": {},
+                     *                 "latency_sample_count": 120,
                      *                 "samples": 1,
                      *                 "surface_id": "example",
                      *                 "uptime_ratio": 0.9966
@@ -12598,6 +12625,7 @@ export interface operations {
                      *           "computed_at": "2026-06-01T00:00:00.000Z",
                      *           "day_count": 1,
                      *           "grade": "A",
+                     *           "latency_sample_count": 120,
                      *           "sample_count": 1,
                      *           "score": 100,
                      *           "surface_count": 1,

--- a/migrations/0007_latency_percentiles.sql
+++ b/migrations/0007_latency_percentiles.sql
@@ -1,0 +1,16 @@
+-- Success-only latency completeness + durable tail latency on the daily rollup.
+--
+-- Latency is now recorded only for `ok` probes. The daily rollup additionally
+-- stores how many healthy probes backed each day's mean (latency_samples) and
+-- that day's exact p50/p95/p99, so tail latency survives the 30-day raw prune
+-- (percentiles can't be reconstructed from a stored mean).
+--
+-- ALTER TABLE ... ADD COLUMN is non-destructive in SQLite; existing rows read
+-- NULL until the next hourly rollup recomputes that day. Apply BEFORE deploying
+-- the prober code that writes these columns so a missing column can never make
+-- the (try/catch-wrapped) rollup silently drop history.
+
+ALTER TABLE surface_uptime_daily ADD COLUMN latency_samples INTEGER;
+ALTER TABLE surface_uptime_daily ADD COLUMN p50_latency_ms INTEGER;
+ALTER TABLE surface_uptime_daily ADD COLUMN p95_latency_ms INTEGER;
+ALTER TABLE surface_uptime_daily ADD COLUMN p99_latency_ms INTEGER;

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -205,7 +205,7 @@ Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1
 - `GET /api/v1/health/history/{date}` — Fetch compact daily health history.
 - `GET /api/v1/subnets/{netuid}/health` — Fetch health detail for one subnet.
 - `GET /api/v1/health/trends` — Fetch compact 7d/30d daily uptime and latency trends for all subnets (computed live from D1).
-- `GET /api/v1/subnets/{netuid}/health/trends` — Fetch 7d/30d uptime and latency trends for one subnet's operational surfaces (computed live from D1).
+- `GET /api/v1/subnets/{netuid}/health/trends` — Fetch 7d/30d uptime and success-only latency trends (mean + p50/p95/p99 tail + healthy-sample count) per operational surface for one subnet (computed live from D1).
 - `GET /api/v1/subnets/{netuid}/health/percentiles` — Fetch latency percentiles (p50/p95/p99) per operational surface for one subnet over a 7d or 30d window (computed live from D1).
 - `GET /api/v1/subnets/{netuid}/health/incidents` — Fetch SLA (uptime ratio) and reconstructed downtime incidents per operational surface for one subnet over a 7d or 30d window (computed live from D1).
 - `GET /api/v1/subnets/{netuid}/trajectory` — Fetch the week-over-week structural trajectory (completeness + surface/endpoint counts) for one subnet from daily snapshots (computed live from D1).

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -3677,7 +3677,7 @@
     {
       "artifact_path": "/metagraph/health/trends/{netuid}.json",
       "cache": "short",
-      "description": "Fetch 7d/30d uptime and latency trends for one subnet's operational surfaces (computed live from D1).",
+      "description": "Fetch 7d/30d uptime and success-only latency trends (mean + p50/p95/p99 tail + healthy-sample count) per operational surface for one subnet (computed live from D1).",
       "id": "subnet-health-trends",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/health/trends",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -408,7 +408,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
-      "description": "Computed 7d/30d uptime + latency trends for one subnet's operational surfaces. Served live from D1 at /api/v1/subnets/{netuid}/health/trends (no static file).",
+      "description": "Computed 7d/30d uptime + success-only latency trends (mean, p50/p95/p99 tail, and healthy-sample count) for one subnet's operational surfaces. Served live from D1 at /api/v1/subnets/{netuid}/health/trends (no static file).",
       "id": "health-trends",
       "path": "/metagraph/health/trends/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthTrendsArtifact",
@@ -417,7 +417,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
-      "description": "Compact all-subnet 7d/30d daily uptime + latency trend matrix. Served live from D1 at /api/v1/health/trends (no static file).",
+      "description": "Compact all-subnet 7d/30d daily uptime + success-only latency trend matrix (mean + healthy-sample count). Served live from D1 at /api/v1/health/trends (no static file).",
       "id": "health-trends-bulk",
       "path": "/metagraph/health/trends.json",
       "schema_ref": "#/components/schemas/BulkHealthTrendsArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1085,6 +1085,10 @@
                           "null"
                         ]
                       },
+                      "latency_sample_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
                       "netuid": {
                         "minimum": 0,
                         "type": "integer"
@@ -1104,6 +1108,10 @@
                               "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
                               "type": "string"
                             },
+                            "latency_sample_count": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
                             "samples": {
                               "minimum": 0,
                               "type": "integer"
@@ -1121,7 +1129,8 @@
                             "date",
                             "samples",
                             "uptime_ratio",
-                            "avg_latency_ms"
+                            "avg_latency_ms",
+                            "latency_sample_count"
                           ],
                           "type": "object"
                         },
@@ -1145,6 +1154,7 @@
                       "samples",
                       "uptime_ratio",
                       "avg_latency_ms",
+                      "latency_sample_count",
                       "points"
                     ],
                     "type": "object"
@@ -4192,6 +4202,10 @@
               "null"
             ]
           },
+          "latency_sample_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
           "name": {
             "type": "string"
           },
@@ -4464,6 +4478,10 @@
             "additionalProperties": {
               "additionalProperties": true,
               "properties": {
+                "latency_sample_count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
                 "samples": {
                   "minimum": 0,
                   "type": "integer"
@@ -4477,6 +4495,34 @@
                           "integer",
                           "null"
                         ]
+                      },
+                      "latency_ms": {
+                        "additionalProperties": true,
+                        "properties": {
+                          "p50": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "p95": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "p99": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "latency_sample_count": {
+                        "minimum": 0,
+                        "type": "integer"
                       },
                       "samples": {
                         "minimum": 0,
@@ -4496,7 +4542,9 @@
                       "surface_id",
                       "samples",
                       "uptime_ratio",
-                      "avg_latency_ms"
+                      "avg_latency_ms",
+                      "latency_sample_count",
+                      "latency_ms"
                     ],
                     "type": "object"
                   },
@@ -4512,6 +4560,7 @@
               "required": [
                 "samples",
                 "uptime_ratio",
+                "latency_sample_count",
                 "surfaces"
               ],
               "type": "object"
@@ -5434,6 +5483,10 @@
             ],
             "type": "string"
           },
+          "latency_sample_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
           "sample_count": {
             "minimum": 0,
             "type": "integer"
@@ -5464,7 +5517,8 @@
           "score",
           "grade",
           "uptime_ratio",
-          "sample_count"
+          "sample_count",
+          "latency_sample_count"
         ],
         "type": "object"
       },
@@ -10738,6 +10792,34 @@
                       "day": {
                         "type": "string"
                       },
+                      "latency_ms": {
+                        "additionalProperties": true,
+                        "properties": {
+                          "p50": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "p95": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "p99": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "latency_sample_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
                       "samples": {
                         "minimum": 0,
                         "type": "integer"
@@ -15440,11 +15522,13 @@
                         "subnets": [
                           {
                             "avg_latency_ms": 120,
+                            "latency_sample_count": 120,
                             "netuid": 7,
                             "points": [
                               {
                                 "avg_latency_ms": 120,
                                 "date": "2026-06-01",
+                                "latency_sample_count": 120,
                                 "samples": 1,
                                 "uptime_ratio": 0.9966
                               }
@@ -22650,6 +22734,7 @@
                       "failed_count": 1,
                       "last_checked": "2026-06-01T00:00:00.000Z",
                       "last_ok": "2026-06-01T00:00:00.000Z",
+                      "latency_sample_count": 120,
                       "name": "Example Subnet",
                       "netuid": 7,
                       "ok_count": 1,
@@ -23114,10 +23199,13 @@
                     "source": "live-cron-prober",
                     "windows": {
                       "example": {
+                        "latency_sample_count": 120,
                         "samples": 1,
                         "surfaces": [
                           {
                             "avg_latency_ms": 120,
+                            "latency_ms": {},
+                            "latency_sample_count": 120,
                             "samples": 1,
                             "surface_id": "example",
                             "uptime_ratio": 0.9966
@@ -23226,7 +23314,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch 7d/30d uptime and latency trends for one subnet's operational surfaces (computed live from D1).",
+        "summary": "Fetch 7d/30d uptime and success-only latency trends (mean + p50/p95/p99 tail + healthy-sample count) per operational surface for one subnet (computed live from D1).",
         "tags": [
           "health",
           "subnets"
@@ -24358,6 +24446,7 @@
                       "computed_at": "2026-06-01T00:00:00.000Z",
                       "day_count": 1,
                       "grade": "A",
+                      "latency_sample_count": 120,
                       "sample_count": 1,
                       "score": 100,
                       "surface_count": 1,

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,61 +1,76 @@
 {
-  "artifact_count": 5,
-  "artifact_size_bytes": 1461620,
+  "artifact_count": 6,
+  "artifact_size_bytes": 1497380,
   "artifacts": [
     {
+      "content_sha256": "cb2cf8db5e14b6b7418e12865e074a461f9f4bffe602a530072f6ff816fe6e9b",
       "content_type": "application/json",
-      "key": "runs/2026-06-18T00-00-00-000Z/api-index.json",
+      "key": "runs/1970-01-01T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "3a730ab97210f043c4abc401f19295c29d322ffc78e6eed9f2a684766dddbff1",
-      "size_bytes": 114064,
+      "sha256": "56424800e413eb795e1f74803e52d809a7c6854b1057c4f9e223be47d36bd88b",
+      "size_bytes": 114231,
       "storage_tier": "dual"
     },
     {
+      "content_sha256": "d70c3153ead9b623d163f6a3a6852b42f1bbe5acacdf336f034c9a77aa1c74ff",
       "content_type": "application/json",
-      "key": "runs/2026-06-18T00-00-00-000Z/contracts.json",
+      "key": "runs/1970-01-01T00-00-00-000Z/contracts.json",
       "latest_key": "latest/contracts.json",
       "path": "/metagraph/contracts.json",
-      "sha256": "f07e9a28c4f5423f758972faa90ff995f117b2fb77b42ced9b5f94ffb248e254",
-      "size_bytes": 28908,
+      "sha256": "1b4a2edfc025a94d7f5d64f108227bb1ab5669b0927b1784a941a92de9a3c67e",
+      "size_bytes": 29018,
       "storage_tier": "dual"
     },
     {
+      "content_sha256": "b66888d2656ecf8bfbdcb85ec9f684e390ce0f737986c703f81e8161ba8ed1f8",
       "content_type": "application/json",
-      "key": "runs/2026-06-18T00-00-00-000Z/openapi.json",
+      "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "719e737d1a0c51751651d657ee3a3f44def223b78b3c623426d39a63ceafa12a",
-      "size_bytes": 744473,
+      "sha256": "527a02abeb85f0547dd51f7fe969c9dc81059b1a28fbb645b6648aa63dd4c77e",
+      "size_bytes": 748147,
       "storage_tier": "dual"
     },
     {
+      "content_sha256": "a506ca94e37aed907d734bf5136ef73b27bafc57fbf3c8813764f1bddafb1042",
       "content_type": "application/json",
-      "key": "runs/2026-06-18T00-00-00-000Z/schemas/index.json",
+      "key": "runs/1970-01-01T00-00-00-000Z/operational-surfaces.json",
+      "latest_key": "latest/operational-surfaces.json",
+      "path": "/metagraph/operational-surfaces.json",
+      "sha256": "ebdc0256e2aae06531c78b0556feca7c0e791bd96e43e458b74c0b38fba513ff",
+      "size_bytes": 28439,
+      "storage_tier": "dual"
+    },
+    {
+      "content_sha256": "3d16f529dc1116cdb730b6a982d4cf2afc58f7a1248a8ec22c1f26dfa04b85b7",
+      "content_type": "application/json",
+      "key": "runs/1970-01-01T00-00-00-000Z/schemas/index.json",
       "latest_key": "latest/schemas/index.json",
       "path": "/metagraph/schemas/index.json",
-      "sha256": "8c492328cbcc45813a0563b8f587b125dd06d88e931e3286ba8df88386658607",
-      "size_bytes": 23965,
+      "sha256": "051577f5d877a6dcd409688ffc7f0b642a0e04ef556050f80d2c2584293fa898",
+      "size_bytes": 25814,
       "storage_tier": "dual"
     },
     {
+      "content_sha256": "2afe5daf623a299d6ffa8fca2a3c0c17a735dfe765137a965a5ef3e248abc920",
       "content_type": "text/plain; charset=utf-8",
-      "key": "runs/2026-06-18T00-00-00-000Z/types.d.ts",
+      "key": "runs/1970-01-01T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "a4d4c221e7fc842e8e74fee8dfe7ed98dfe15616e8f38bdda587f5a9c3418804",
-      "size_bytes": 550210,
+      "sha256": "2afe5daf623a299d6ffa8fca2a3c0c17a735dfe765137a965a5ef3e248abc920",
+      "size_bytes": 551731,
       "storage_tier": "dual"
     }
   ],
   "bucket_binding": "METAGRAPH_ARCHIVE",
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
-  "full_artifact_count": 2185,
-  "full_artifact_size_bytes": 38151278,
+  "full_artifact_count": 2247,
+  "full_artifact_size_bytes": 37973933,
   "full_manifest_key": "latest/r2-manifest.json",
-  "full_manifest_run_key": "runs/2026-06-18T00-00-00-000Z/r2-manifest.json",
-  "generated_at": "2026-06-18T00:00:00.000Z",
+  "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
+  "generated_at": "1970-01-01T00:00:00.000Z",
   "latest_prefix": "latest/",
   "manifest_kind": "compact",
   "required_artifact_paths": [
@@ -67,14 +82,14 @@
     "/metagraph/types.d.ts",
     "/metagraph/verification/latest.json"
   ],
-  "run_prefix": "runs/2026-06-18T00-00-00-000Z/",
+  "run_prefix": "runs/1970-01-01T00-00-00-000Z/",
   "schema_version": 1,
   "storage_tier_counts": {
-    "dual": 5,
-    "r2": 2180
+    "dual": 6,
+    "r2": 2241
   },
   "storage_tier_size_bytes": {
-    "dual": 1461620,
-    "r2": 36689658
+    "dual": 1497380,
+    "r2": 36476553
   }
 }

--- a/public/metagraph/schemas/index.json
+++ b/public/metagraph/schemas/index.json
@@ -1,8 +1,8 @@
 {
   "contract_version": "2026-06-06.1",
-  "generated_at": "2026-06-14T09:03:05.163Z",
+  "generated_at": "1970-01-01T00:00:00.000Z",
   "notes": "Machine-readable OpenAPI/Swagger JSON snapshots only. HTML Swagger UI pages are not treated as schema-backed.",
-  "observed_at": "2026-06-14T09:03:05.163Z",
+  "observed_at": "2026-06-21T08:55:41.808Z",
   "schema_version": 1,
   "schemas": [
     {
@@ -14,6 +14,12 @@
       "previous_hash": "5b564b4af01b36ab2d106b2d58684b157e3fb55b7f728c7a16cde2364d12263f",
       "schema_url": "https://api.numinouslabs.io/api/openapi.json",
       "snapshot": {
+        "auth_detail": {
+          "location": "header",
+          "name": "X-API-Key",
+          "scheme": "api-key",
+          "value_format": "<api-key>"
+        },
         "auth_required": true,
         "auth_schemes": [
           "apiKey"
@@ -21,10 +27,10 @@
         "component_schema_count": 42,
         "contract_version": "2026-06-06.1",
         "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
+        "generated_at": "1970-01-01T00:00:00.000Z",
         "hash": "5b564b4af01b36ab2d106b2d58684b157e3fb55b7f728c7a16cde2364d12263f",
         "netuid": 6,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.1.0",
         "path_count": 20,
         "previous_hash": "5b564b4af01b36ab2d106b2d58684b157e3fb55b7f728c7a16cde2364d12263f",
@@ -53,6 +59,12 @@
       "previous_hash": "5b564b4af01b36ab2d106b2d58684b157e3fb55b7f728c7a16cde2364d12263f",
       "schema_url": "https://api.numinouslabs.io/api/openapi.json",
       "snapshot": {
+        "auth_detail": {
+          "location": "header",
+          "name": "X-API-Key",
+          "scheme": "api-key",
+          "value_format": "<api-key>"
+        },
         "auth_required": true,
         "auth_schemes": [
           "apiKey"
@@ -60,10 +72,10 @@
         "component_schema_count": 42,
         "contract_version": "2026-06-06.1",
         "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
+        "generated_at": "1970-01-01T00:00:00.000Z",
         "hash": "5b564b4af01b36ab2d106b2d58684b157e3fb55b7f728c7a16cde2364d12263f",
         "netuid": 6,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.1.0",
         "path_count": 20,
         "previous_hash": "5b564b4af01b36ab2d106b2d58684b157e3fb55b7f728c7a16cde2364d12263f",
@@ -92,15 +104,16 @@
       "previous_hash": "66ed39e7b6e658cbf6f493bbdd472fbda145229ba11dae6510352ae3af1bc15b",
       "schema_url": "https://api.all-ways.io/swagger-json",
       "snapshot": {
+        "auth_detail": null,
         "auth_required": false,
         "auth_schemes": [],
         "component_schema_count": 0,
         "contract_version": "2026-06-06.1",
         "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
+        "generated_at": "1970-01-01T00:00:00.000Z",
         "hash": "66ed39e7b6e658cbf6f493bbdd472fbda145229ba11dae6510352ae3af1bc15b",
         "netuid": 7,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.0.0",
         "path_count": 33,
         "previous_hash": "66ed39e7b6e658cbf6f493bbdd472fbda145229ba11dae6510352ae3af1bc15b",
@@ -129,6 +142,12 @@
       "previous_hash": "4b0f0742c087e8bfae13ca5759ad5f744f997a1134baed15597b44eaf34519e9",
       "schema_url": "https://www.desearch.ai/openapi.json",
       "snapshot": {
+        "auth_detail": {
+          "location": "header",
+          "name": "Authorization",
+          "scheme": "api-key",
+          "value_format": "<api-key>"
+        },
         "auth_required": true,
         "auth_schemes": [
           "apiKey"
@@ -136,10 +155,10 @@
         "component_schema_count": 76,
         "contract_version": "2026-06-06.1",
         "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
+        "generated_at": "1970-01-01T00:00:00.000Z",
         "hash": "4b0f0742c087e8bfae13ca5759ad5f744f997a1134baed15597b44eaf34519e9",
         "netuid": 22,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.1.0",
         "path_count": 35,
         "previous_hash": "4b0f0742c087e8bfae13ca5759ad5f744f997a1134baed15597b44eaf34519e9",
@@ -168,6 +187,12 @@
       "previous_hash": "4b0f0742c087e8bfae13ca5759ad5f744f997a1134baed15597b44eaf34519e9",
       "schema_url": "https://desearch.ai/openapi.json",
       "snapshot": {
+        "auth_detail": {
+          "location": "header",
+          "name": "Authorization",
+          "scheme": "api-key",
+          "value_format": "<api-key>"
+        },
         "auth_required": true,
         "auth_schemes": [
           "apiKey"
@@ -175,10 +200,10 @@
         "component_schema_count": 76,
         "contract_version": "2026-06-06.1",
         "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
+        "generated_at": "1970-01-01T00:00:00.000Z",
         "hash": "4b0f0742c087e8bfae13ca5759ad5f744f997a1134baed15597b44eaf34519e9",
         "netuid": 22,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.1.0",
         "path_count": 35,
         "previous_hash": "4b0f0742c087e8bfae13ca5759ad5f744f997a1134baed15597b44eaf34519e9",
@@ -200,24 +225,30 @@
     },
     {
       "content_type": "application/json; charset=utf-8",
-      "drift_status": "unchanged",
-      "hash": "7d5fd0eaa0408d0ee0c6a6d0602937767433d563c73784804e836cdf084712df",
+      "drift_status": "changed",
+      "hash": "706a053f891659d31c62f8069c87acf4a85bb367bf8d3af5b66448dc1982931c",
       "netuid": 46,
       "path": "/metagraph/schemas/sn-46-website-common-openapi-json.json",
       "previous_hash": "7d5fd0eaa0408d0ee0c6a6d0602937767433d563c73784804e836cdf084712df",
       "schema_url": "https://zipcode.ai/openapi.json",
       "snapshot": {
+        "auth_detail": {
+          "location": "header",
+          "name": "Hotkey",
+          "scheme": "api-key",
+          "value_format": "<api-key>"
+        },
         "auth_required": true,
         "auth_schemes": [
           "apiKey"
         ],
         "component_schema_count": 3,
         "contract_version": "2026-06-06.1",
-        "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
-        "hash": "7d5fd0eaa0408d0ee0c6a6d0602937767433d563c73784804e836cdf084712df",
+        "drift_status": "changed",
+        "generated_at": "1970-01-01T00:00:00.000Z",
+        "hash": "706a053f891659d31c62f8069c87acf4a85bb367bf8d3af5b66448dc1982931c",
         "netuid": 46,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.0.0",
         "path_count": 41,
         "previous_hash": "7d5fd0eaa0408d0ee0c6a6d0602937767433d563c73784804e836cdf084712df",
@@ -246,6 +277,12 @@
       "previous_hash": "ca6a6dea6bbf3f867393796711900c431ba333bcab6aaec1d8ce70445523317a",
       "schema_url": "https://tournament-api.nepher.ai/openapi.json",
       "snapshot": {
+        "auth_detail": {
+          "location": "header",
+          "name": "Authorization",
+          "scheme": "bearer",
+          "value_format": "Bearer <token>"
+        },
         "auth_required": true,
         "auth_schemes": [
           "http"
@@ -253,10 +290,10 @@
         "component_schema_count": 116,
         "contract_version": "2026-06-06.1",
         "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
+        "generated_at": "1970-01-01T00:00:00.000Z",
         "hash": "ca6a6dea6bbf3f867393796711900c431ba333bcab6aaec1d8ce70445523317a",
         "netuid": 49,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.1.0",
         "path_count": 137,
         "previous_hash": "ca6a6dea6bbf3f867393796711900c431ba333bcab6aaec1d8ce70445523317a",
@@ -285,6 +322,12 @@
       "previous_hash": "fe9ff34b255bfc17af9321a91d8d30c7ea66833c57bb53b9ef01558d5a051b05",
       "schema_url": "https://api.gradients.io/openapi.json",
       "snapshot": {
+        "auth_detail": {
+          "location": "header",
+          "name": "Authorization",
+          "scheme": "api-key",
+          "value_format": "<api-key>"
+        },
         "auth_required": true,
         "auth_schemes": [
           "apiKey"
@@ -292,10 +335,10 @@
         "component_schema_count": 104,
         "contract_version": "2026-06-06.1",
         "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
+        "generated_at": "1970-01-01T00:00:00.000Z",
         "hash": "fe9ff34b255bfc17af9321a91d8d30c7ea66833c57bb53b9ef01558d5a051b05",
         "netuid": 56,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.1.0",
         "path_count": 56,
         "previous_hash": "fe9ff34b255bfc17af9321a91d8d30c7ea66833c57bb53b9ef01558d5a051b05",
@@ -324,15 +367,16 @@
       "previous_hash": "122dbc524dbed62b6840249afbd03b9f2567fcfdba9603e94e2230237d73fc8e",
       "schema_url": "https://handshake58.com/openapi.json",
       "snapshot": {
+        "auth_detail": null,
         "auth_required": false,
         "auth_schemes": [],
         "component_schema_count": 5,
         "contract_version": "2026-06-06.1",
         "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
+        "generated_at": "1970-01-01T00:00:00.000Z",
         "hash": "122dbc524dbed62b6840249afbd03b9f2567fcfdba9603e94e2230237d73fc8e",
         "netuid": 58,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.0.3",
         "path_count": 4,
         "previous_hash": "122dbc524dbed62b6840249afbd03b9f2567fcfdba9603e94e2230237d73fc8e",
@@ -355,26 +399,32 @@
     {
       "content_type": "application/json",
       "drift_status": "changed",
-      "hash": "67314412ead631b738ca83bee717e61e938f4c55dc8d2b652441e6ae19764879",
+      "hash": "3b9020b3f79b2f5ab53ee4066a7bc6fff39c021350a4d04917ee128f71b56ace",
       "netuid": 64,
       "path": "/metagraph/schemas/sn-64-chutes-openapi.json",
-      "previous_hash": "0c81e7d1180c3512dac9c967edf7771034253d03475e5e254b76cfa0090bc372",
+      "previous_hash": "67314412ead631b738ca83bee717e61e938f4c55dc8d2b652441e6ae19764879",
       "schema_url": "https://api.chutes.ai/openapi.json",
       "snapshot": {
+        "auth_detail": {
+          "location": "header",
+          "name": "Authorization",
+          "scheme": "api-key",
+          "value_format": "<api-key>"
+        },
         "auth_required": true,
         "auth_schemes": [
           "apiKey"
         ],
-        "component_schema_count": 2,
+        "component_schema_count": 95,
         "contract_version": "2026-06-06.1",
         "drift_status": "changed",
-        "generated_at": "2026-06-14T09:03:05.163Z",
-        "hash": "67314412ead631b738ca83bee717e61e938f4c55dc8d2b652441e6ae19764879",
+        "generated_at": "1970-01-01T00:00:00.000Z",
+        "hash": "3b9020b3f79b2f5ab53ee4066a7bc6fff39c021350a4d04917ee128f71b56ace",
         "netuid": 64,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.1.0",
-        "path_count": 1,
-        "previous_hash": "0c81e7d1180c3512dac9c967edf7771034253d03475e5e254b76cfa0090bc372",
+        "path_count": 166,
+        "previous_hash": "67314412ead631b738ca83bee717e61e938f4c55dc8d2b652441e6ae19764879",
         "schema_url": "https://api.chutes.ai/openapi.json",
         "schema_version": 1,
         "server_count": 0,
@@ -400,6 +450,12 @@
       "previous_hash": "e1e19edbb99626a13f782c9ecdf5a192cbf1376045062e17da492c5ccac93c9d",
       "schema_url": "https://api.gittensor.io/swagger-json",
       "snapshot": {
+        "auth_detail": {
+          "location": "header",
+          "name": "x-api-key",
+          "scheme": "api-key",
+          "value_format": "<api-key>"
+        },
         "auth_required": true,
         "auth_schemes": [
           "apiKey"
@@ -407,10 +463,10 @@
         "component_schema_count": 0,
         "contract_version": "2026-06-06.1",
         "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
+        "generated_at": "1970-01-01T00:00:00.000Z",
         "hash": "e1e19edbb99626a13f782c9ecdf5a192cbf1376045062e17da492c5ccac93c9d",
         "netuid": 74,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.0.0",
         "path_count": 32,
         "previous_hash": "e1e19edbb99626a13f782c9ecdf5a192cbf1376045062e17da492c5ccac93c9d",
@@ -439,15 +495,16 @@
       "previous_hash": "d8beda16e5e6228216d2ccca4ebd09f6d600ad266eeb1963f7163a58058bdac3",
       "schema_url": "https://api.subnet90.com/openapi.json",
       "snapshot": {
+        "auth_detail": null,
         "auth_required": false,
         "auth_schemes": [],
         "component_schema_count": 5,
         "contract_version": "2026-06-06.1",
         "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
+        "generated_at": "1970-01-01T00:00:00.000Z",
         "hash": "d8beda16e5e6228216d2ccca4ebd09f6d600ad266eeb1963f7163a58058bdac3",
         "netuid": 90,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.1.0",
         "path_count": 10,
         "previous_hash": "d8beda16e5e6228216d2ccca4ebd09f6d600ad266eeb1963f7163a58058bdac3",
@@ -476,15 +533,16 @@
       "previous_hash": "c6d9b04b2e9582f1f21caae8a80b0d607e5d24f402bdec92c3b6095ed1303463",
       "schema_url": "https://verathos.ai/openapi.json",
       "snapshot": {
+        "auth_detail": null,
         "auth_required": false,
         "auth_schemes": [],
         "component_schema_count": 20,
         "contract_version": "2026-06-06.1",
         "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
+        "generated_at": "1970-01-01T00:00:00.000Z",
         "hash": "c6d9b04b2e9582f1f21caae8a80b0d607e5d24f402bdec92c3b6095ed1303463",
         "netuid": 96,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.1.0",
         "path_count": 24,
         "previous_hash": "c6d9b04b2e9582f1f21caae8a80b0d607e5d24f402bdec92c3b6095ed1303463",
@@ -513,6 +571,12 @@
       "previous_hash": "3a8e7781d720ec3591dec934c18df619bdabf365349d967efa9c976df7526558",
       "schema_url": "https://us-east-1.hippius.com/openapi.json",
       "snapshot": {
+        "auth_detail": {
+          "location": "header",
+          "name": "Authorization",
+          "scheme": "bearer",
+          "value_format": "Bearer <token>"
+        },
         "auth_required": true,
         "auth_schemes": [
           "http"
@@ -520,10 +584,10 @@
         "component_schema_count": 7,
         "contract_version": "2026-06-06.1",
         "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
+        "generated_at": "1970-01-01T00:00:00.000Z",
         "hash": "3a8e7781d720ec3591dec934c18df619bdabf365349d967efa9c976df7526558",
         "netuid": 97,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.1.0",
         "path_count": 12,
         "previous_hash": "3a8e7781d720ec3591dec934c18df619bdabf365349d967efa9c976df7526558",
@@ -545,24 +609,25 @@
     },
     {
       "content_type": "application/json",
-      "drift_status": "unchanged",
-      "hash": "31182e26d7df3f09419d9b48bf6144621d5f0f57cdbb2dc3da93a54b52e51b2f",
+      "drift_status": "changed",
+      "hash": "0c150038ecde26f07837e3b4b77f3e699143ede4fb0d5d6dec9913c342f6bb45",
       "netuid": 110,
       "path": "/metagraph/schemas/sn-110-green-compute-openapi.json",
       "previous_hash": "31182e26d7df3f09419d9b48bf6144621d5f0f57cdbb2dc3da93a54b52e51b2f",
       "schema_url": "https://api.green-compute.com/openapi.json",
       "snapshot": {
+        "auth_detail": null,
         "auth_required": false,
         "auth_schemes": [],
         "component_schema_count": 24,
         "contract_version": "2026-06-06.1",
-        "drift_status": "unchanged",
-        "generated_at": "2026-06-14T09:03:05.163Z",
-        "hash": "31182e26d7df3f09419d9b48bf6144621d5f0f57cdbb2dc3da93a54b52e51b2f",
+        "drift_status": "changed",
+        "generated_at": "1970-01-01T00:00:00.000Z",
+        "hash": "0c150038ecde26f07837e3b4b77f3e699143ede4fb0d5d6dec9913c342f6bb45",
         "netuid": 110,
-        "observed_at": "2026-06-14T09:03:05.163Z",
+        "observed_at": "2026-06-21T08:55:41.808Z",
         "openapi_version": "3.1.0",
-        "path_count": 98,
+        "path_count": 99,
         "previous_hash": "31182e26d7df3f09419d9b48bf6144621d5f0f57cdbb2dc3da93a54b52e51b2f",
         "schema_url": "https://api.green-compute.com/openapi.json",
         "schema_version": 1,
@@ -584,8 +649,8 @@
   "source": "openapi-snapshot",
   "summary": {
     "by_drift_status": {
-      "changed": 1,
-      "unchanged": 14
+      "changed": 3,
+      "unchanged": 12
     },
     "by_status": {
       "captured": 15

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -929,7 +929,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch 7d/30d uptime and latency trends for one subnet's operational surfaces (computed live from D1). */
+        /** Fetch 7d/30d uptime and success-only latency trends (mean + p50/p95/p99 tail + healthy-sample count) per operational surface for one subnet (computed live from D1). */
         get: operations["subnetHealthTrends"];
         put?: never;
         post?: never;
@@ -1340,10 +1340,12 @@ export interface components {
                     subnet_count: number;
                     subnets: {
                         avg_latency_ms: number | null;
+                        latency_sample_count: number;
                         netuid: number;
                         points: {
                             avg_latency_ms: number | null;
                             date: string;
+                            latency_sample_count: number;
                             samples: number;
                             uptime_ratio: number | null;
                         }[];
@@ -2102,6 +2104,7 @@ export interface components {
             failed_count: number;
             last_checked?: string | null;
             last_ok?: string | null;
+            latency_sample_count?: number;
             name?: string;
             netuid?: number;
             ok_count: number;
@@ -2171,9 +2174,18 @@ export interface components {
             source: string;
             windows: {
                 [key: string]: {
+                    latency_sample_count: number;
                     samples: number;
                     surfaces: ({
                         avg_latency_ms: number | null;
+                        latency_ms: {
+                            p50?: number | null;
+                            p95?: number | null;
+                            p99?: number | null;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                        latency_sample_count: number;
                         samples: number;
                         surface_id: string;
                         uptime_ratio: number | null;
@@ -2455,6 +2467,7 @@ export interface components {
             day_count?: number;
             /** @enum {string} */
             grade: "A" | "B" | "C" | "D" | "F";
+            latency_sample_count: number;
             sample_count: number;
             score: number;
             surface_count?: number;
@@ -3723,6 +3736,14 @@ export interface components {
                 days: ({
                     avg_latency_ms?: number | null;
                     day: string;
+                    latency_ms?: {
+                        p50?: number | null;
+                        p95?: number | null;
+                        p99?: number | null;
+                    } & {
+                        [key: string]: unknown;
+                    };
+                    latency_sample_count?: number;
                     samples: number;
                     status: string;
                     uptime_ratio: number | null;
@@ -6842,11 +6863,13 @@ export interface operations {
                      *             "subnets": [
                      *               {
                      *                 "avg_latency_ms": 120,
+                     *                 "latency_sample_count": 120,
                      *                 "netuid": 7,
                      *                 "points": [
                      *                   {
                      *                     "avg_latency_ms": 120,
                      *                     "date": "2026-06-01",
+                     *                     "latency_sample_count": 120,
                      *                     "samples": 1,
                      *                     "uptime_ratio": 0.9966
                      *                   }
@@ -11217,6 +11240,7 @@ export interface operations {
                      *           "failed_count": 1,
                      *           "last_checked": "2026-06-01T00:00:00.000Z",
                      *           "last_ok": "2026-06-01T00:00:00.000Z",
+                     *           "latency_sample_count": 120,
                      *           "name": "Example Subnet",
                      *           "netuid": 7,
                      *           "ok_count": 1,
@@ -11578,10 +11602,13 @@ export interface operations {
                      *         "source": "live-cron-prober",
                      *         "windows": {
                      *           "example": {
+                     *             "latency_sample_count": 120,
                      *             "samples": 1,
                      *             "surfaces": [
                      *               {
                      *                 "avg_latency_ms": 120,
+                     *                 "latency_ms": {},
+                     *                 "latency_sample_count": 120,
                      *                 "samples": 1,
                      *                 "surface_id": "example",
                      *                 "uptime_ratio": 0.9966
@@ -12598,6 +12625,7 @@ export interface operations {
                      *           "computed_at": "2026-06-01T00:00:00.000Z",
                      *           "day_count": 1,
                      *           "grade": "A",
+                     *           "latency_sample_count": 120,
                      *           "sample_count": 1,
                      *           "score": 100,
                      *           "surface_count": 1,

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -1071,6 +1071,10 @@
                           "null"
                         ]
                       },
+                      "latency_sample_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
                       "netuid": {
                         "minimum": 0,
                         "type": "integer"
@@ -1090,6 +1094,10 @@
                               "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
                               "type": "string"
                             },
+                            "latency_sample_count": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
                             "samples": {
                               "minimum": 0,
                               "type": "integer"
@@ -1107,7 +1115,8 @@
                             "date",
                             "samples",
                             "uptime_ratio",
-                            "avg_latency_ms"
+                            "avg_latency_ms",
+                            "latency_sample_count"
                           ],
                           "type": "object"
                         },
@@ -1131,6 +1140,7 @@
                       "samples",
                       "uptime_ratio",
                       "avg_latency_ms",
+                      "latency_sample_count",
                       "points"
                     ],
                     "type": "object"
@@ -4170,6 +4180,10 @@
               "null"
             ]
           },
+          "latency_sample_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
           "name": {
             "type": "string"
           },
@@ -4442,6 +4456,10 @@
             "additionalProperties": {
               "additionalProperties": true,
               "properties": {
+                "latency_sample_count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
                 "samples": {
                   "minimum": 0,
                   "type": "integer"
@@ -4455,6 +4473,34 @@
                           "integer",
                           "null"
                         ]
+                      },
+                      "latency_ms": {
+                        "additionalProperties": true,
+                        "properties": {
+                          "p50": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "p95": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "p99": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "latency_sample_count": {
+                        "minimum": 0,
+                        "type": "integer"
                       },
                       "samples": {
                         "minimum": 0,
@@ -4474,7 +4520,9 @@
                       "surface_id",
                       "samples",
                       "uptime_ratio",
-                      "avg_latency_ms"
+                      "avg_latency_ms",
+                      "latency_sample_count",
+                      "latency_ms"
                     ],
                     "type": "object"
                   },
@@ -4490,6 +4538,7 @@
               "required": [
                 "samples",
                 "uptime_ratio",
+                "latency_sample_count",
                 "surfaces"
               ],
               "type": "object"
@@ -5412,6 +5461,10 @@
             ],
             "type": "string"
           },
+          "latency_sample_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
           "sample_count": {
             "minimum": 0,
             "type": "integer"
@@ -5442,7 +5495,8 @@
           "score",
           "grade",
           "uptime_ratio",
-          "sample_count"
+          "sample_count",
+          "latency_sample_count"
         ],
         "type": "object"
       },
@@ -10715,6 +10769,34 @@
                       },
                       "day": {
                         "type": "string"
+                      },
+                      "latency_ms": {
+                        "additionalProperties": true,
+                        "properties": {
+                          "p50": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "p95": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "p99": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "latency_sample_count": {
+                        "minimum": 0,
+                        "type": "integer"
                       },
                       "samples": {
                         "minimum": 0,

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -229,6 +229,10 @@
           "avg_latency_ms": {
             "type": ["integer", "null"],
             "minimum": 0
+          },
+          "latency_sample_count": {
+            "type": "integer",
+            "minimum": 0
           }
         },
         "additionalProperties": false
@@ -420,10 +424,16 @@
             "type": "object",
             "additionalProperties": {
               "type": "object",
-              "required": ["samples", "uptime_ratio", "surfaces"],
+              "required": [
+                "samples",
+                "uptime_ratio",
+                "latency_sample_count",
+                "surfaces"
+              ],
               "properties": {
                 "samples": { "type": "integer", "minimum": 0 },
                 "uptime_ratio": { "type": ["number", "null"] },
+                "latency_sample_count": { "type": "integer", "minimum": 0 },
                 "surfaces": {
                   "type": "array",
                   "items": {
@@ -432,13 +442,28 @@
                       "surface_id",
                       "samples",
                       "uptime_ratio",
-                      "avg_latency_ms"
+                      "avg_latency_ms",
+                      "latency_sample_count",
+                      "latency_ms"
                     ],
                     "properties": {
                       "surface_id": { "type": "string" },
                       "samples": { "type": "integer", "minimum": 0 },
                       "uptime_ratio": { "type": ["number", "null"] },
-                      "avg_latency_ms": { "type": ["integer", "null"] }
+                      "avg_latency_ms": { "type": ["integer", "null"] },
+                      "latency_sample_count": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "latency_ms": {
+                        "type": "object",
+                        "properties": {
+                          "p50": { "type": ["integer", "null"] },
+                          "p95": { "type": ["integer", "null"] },
+                          "p99": { "type": ["integer", "null"] }
+                        },
+                        "additionalProperties": true
+                      }
                     },
                     "additionalProperties": true
                   }
@@ -475,6 +500,7 @@
                       "samples",
                       "uptime_ratio",
                       "avg_latency_ms",
+                      "latency_sample_count",
                       "points"
                     ],
                     "properties": {
@@ -489,6 +515,10 @@
                         "type": ["integer", "null"],
                         "minimum": 0
                       },
+                      "latency_sample_count": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
                       "points": {
                         "type": "array",
                         "items": {
@@ -497,7 +527,8 @@
                             "date",
                             "samples",
                             "uptime_ratio",
-                            "avg_latency_ms"
+                            "avg_latency_ms",
+                            "latency_sample_count"
                           ],
                           "properties": {
                             "date": {
@@ -512,6 +543,10 @@
                             },
                             "avg_latency_ms": {
                               "type": ["integer", "null"],
+                              "minimum": 0
+                            },
+                            "latency_sample_count": {
+                              "type": "integer",
                               "minimum": 0
                             }
                           },
@@ -801,13 +836,20 @@
       "ReliabilityScore": {
         "type": "object",
         "description": "Composite reliability score (0-100) from durable uptime history: sample-weighted uptime with a mild latency penalty. Null when no probe data exists.",
-        "required": ["score", "grade", "uptime_ratio", "sample_count"],
+        "required": [
+          "score",
+          "grade",
+          "uptime_ratio",
+          "sample_count",
+          "latency_sample_count"
+        ],
         "properties": {
           "score": { "type": "integer", "minimum": 0, "maximum": 100 },
           "grade": { "type": "string", "enum": ["A", "B", "C", "D", "F"] },
           "uptime_ratio": { "type": ["number", "null"] },
           "avg_latency_ms": { "type": ["integer", "null"] },
           "sample_count": { "type": "integer", "minimum": 0 },
+          "latency_sample_count": { "type": "integer", "minimum": 0 },
           "window": { "type": ["string", "null"] },
           "surface_count": { "type": "integer", "minimum": 0 },
           "day_count": { "type": "integer", "minimum": 0 },
@@ -861,6 +903,19 @@
                       "samples": { "type": "integer", "minimum": 0 },
                       "uptime_ratio": { "type": ["number", "null"] },
                       "avg_latency_ms": { "type": ["integer", "null"] },
+                      "latency_sample_count": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "latency_ms": {
+                        "type": "object",
+                        "properties": {
+                          "p50": { "type": ["integer", "null"] },
+                          "p95": { "type": ["integer", "null"] },
+                          "p99": { "type": ["integer", "null"] }
+                        },
+                        "additionalProperties": true
+                      },
                       "status": { "type": "string" }
                     },
                     "additionalProperties": true

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -844,13 +844,13 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "health-trends",
     "/metagraph/health/trends/{netuid}.json",
-    "Computed 7d/30d uptime + latency trends for one subnet's operational surfaces. Served live from D1 at /api/v1/subnets/{netuid}/health/trends (no static file).",
+    "Computed 7d/30d uptime + success-only latency trends (mean, p50/p95/p99 tail, and healthy-sample count) for one subnet's operational surfaces. Served live from D1 at /api/v1/subnets/{netuid}/health/trends (no static file).",
     "HealthTrendsArtifact",
   ),
   artifact(
     "health-trends-bulk",
     "/metagraph/health/trends.json",
-    "Compact all-subnet 7d/30d daily uptime + latency trend matrix. Served live from D1 at /api/v1/health/trends (no static file).",
+    "Compact all-subnet 7d/30d daily uptime + success-only latency trend matrix (mean + healthy-sample count). Served live from D1 at /api/v1/health/trends (no static file).",
     "BulkHealthTrendsArtifact",
   ),
   artifact(
@@ -1413,7 +1413,7 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/health/trends",
     "/metagraph/health/trends/{netuid}.json",
-    "Fetch 7d/30d uptime and latency trends for one subnet's operational surfaces (computed live from D1).",
+    "Fetch 7d/30d uptime and success-only latency trends (mean + p50/p95/p99 tail + healthy-sample count) per operational surface for one subnet (computed live from D1).",
     "short",
     ["health", "subnets"],
     [],

--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -324,6 +324,13 @@ export function rollupSubnetStatus({
   return "failed";
 }
 
+// Latency is a success-only signal: keep a probe's latency only when it resolved
+// `ok`. Every failure (timeout, 5xx, unsafe, thrown) collapses to null, so it
+// counts toward uptime but never toward the latency mean or percentiles.
+export function okLatencyMs(status, latencyMs) {
+  return status === "ok" && Number.isFinite(latencyMs) ? latencyMs : null;
+}
+
 export function statusForClassification(classification, surface = null) {
   if (["live", "redirected"].includes(classification)) {
     return "ok";

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -17,9 +17,11 @@
 import {
   isUnsafePublicUrl,
   mapLimit,
+  okLatencyMs,
   probeSurface as coreProbeSurface,
   rollupSubnetStatus,
 } from "./health-probe-core.mjs";
+import { latencyStatColumns, rankedChecksCte } from "./health-sql.mjs";
 import {
   KV_HEALTH_CURRENT,
   KV_HEALTH_META,
@@ -333,6 +335,8 @@ function summarizeGroup(rows) {
     avg_latency_ms: latencies.length
       ? Math.round(latencies.reduce((s, v) => s + v, 0) / latencies.length)
       : null,
+    // How many surfaces backed the mean (a 1-reading mean vs a 300-reading one).
+    latency_sample_count: latencies.length,
   };
 }
 
@@ -426,7 +430,8 @@ export async function runHealthProber(env, ctx, overrides = {}) {
       url: surface.url,
       status: base.status,
       classification: base.classification || null,
-      latency_ms: Number.isFinite(base.latency_ms) ? base.latency_ms : null,
+      // Success-only: failures store null latency (counted in uptime, not latency).
+      latency_ms: okLatencyMs(base.status, base.latency_ms),
       status_code: Number.isInteger(base.status_code) ? base.status_code : null,
       archive_support: base.archive_support ?? null,
       latest_block: safeRpcBlockNumber(base.latest_block),
@@ -634,57 +639,58 @@ function utcDayBounds(ms) {
 // retained indefinitely for long-term uptime analytics — so the 30-day raw
 // prune never loses history. MUST run before pruneHealthHistory. Rolls up today
 // + yesterday each hour (the post-midnight fire finalizes the prior day; upsert
-// keeps it idempotent). No-ops when D1 is unbound/cold.
+// keeps it idempotent). No-ops when D1 is unbound/cold. Latency is rolled up
+// success-only with its sample count, plus the day's exact p50/p95/p99 so tail
+// latency survives the raw prune (percentiles can't be rebuilt from a mean).
 export async function rollupDailyUptime(env, overrides = {}) {
   const now = overrides.now || (() => Date.now());
   const db = overrides.db || env.METAGRAPH_HEALTH_DB;
   if (!db?.prepare) return { rolled: false };
   const runAt = now();
   const days = [utcDayBounds(runAt), utcDayBounds(runAt - 24 * 60 * 60 * 1000)];
-  const stmt = db.prepare(
-    `INSERT INTO surface_uptime_daily
-       (surface_id, surface_key, netuid, day, samples, ok_count, uptime_ratio,
-        avg_latency_ms, status, updated_at)
-     SELECT
-       MAX(surface_id) AS surface_id,
-       COALESCE(surface_key, surface_id) AS surface_key,
-       netuid,
-       ? AS day,
-       COUNT(*) AS samples,
-       SUM(ok) AS ok_count,
-       ROUND(CAST(SUM(ok) AS REAL) / COUNT(*), 4) AS uptime_ratio,
-       CAST(ROUND(AVG(latency_ms)) AS INTEGER) AS avg_latency_ms,
-       CASE
-         WHEN SUM(ok) = COUNT(*) THEN 'ok'
-         WHEN SUM(ok) = 0 THEN 'failed'
-         ELSE 'degraded'
-       END AS status,
-       ? AS updated_at
-     FROM surface_checks
-     WHERE checked_at >= ? AND checked_at < ?
-     GROUP BY COALESCE(surface_key, surface_id), netuid
-     ON CONFLICT(surface_key, day) WHERE surface_key IS NOT NULL DO UPDATE SET
+  const conflictColumns = `
        surface_id = excluded.surface_id,
-       netuid = excluded.netuid,
-       samples = excluded.samples,
-       ok_count = excluded.ok_count,
-       uptime_ratio = excluded.uptime_ratio,
-       avg_latency_ms = excluded.avg_latency_ms,
-       status = excluded.status,
-       updated_at = excluded.updated_at
-     ON CONFLICT(surface_id, day) DO UPDATE SET
        surface_key = excluded.surface_key,
        netuid = excluded.netuid,
        samples = excluded.samples,
        ok_count = excluded.ok_count,
        uptime_ratio = excluded.uptime_ratio,
        avg_latency_ms = excluded.avg_latency_ms,
+       latency_samples = excluded.latency_samples,
+       p50_latency_ms = excluded.p50_latency_ms,
+       p95_latency_ms = excluded.p95_latency_ms,
+       p99_latency_ms = excluded.p99_latency_ms,
        status = excluded.status,
-       updated_at = excluded.updated_at`,
+       updated_at = excluded.updated_at`;
+  const stmt = db.prepare(
+    `${rankedChecksCte("checked_at >= ? AND checked_at < ?")}
+     INSERT INTO surface_uptime_daily
+       (surface_id, surface_key, netuid, day, samples, ok_count, uptime_ratio,
+        latency_samples, avg_latency_ms, p50_latency_ms, p95_latency_ms,
+        p99_latency_ms, status, updated_at)
+     SELECT
+       MAX(surface_id) AS surface_id,
+       surface_key,
+       netuid,
+       ? AS day,
+       COUNT(*) AS samples,
+       SUM(ok) AS ok_count,
+       ROUND(CAST(SUM(ok) AS REAL) / COUNT(*), 4) AS uptime_ratio,
+       ${latencyStatColumns({ roundedAvg: true, includeMinMax: false })},
+       CASE
+         WHEN SUM(ok) = COUNT(*) THEN 'ok'
+         WHEN SUM(ok) = 0 THEN 'failed'
+         ELSE 'degraded'
+       END AS status,
+       ? AS updated_at
+     FROM ranked
+     GROUP BY surface_key, netuid
+     ON CONFLICT(surface_key, day) WHERE surface_key IS NOT NULL DO UPDATE SET${conflictColumns}
+     ON CONFLICT(surface_id, day) DO UPDATE SET${conflictColumns}`,
   );
   try {
     await db.batch(
-      days.map(({ date, start, end }) => stmt.bind(date, runAt, start, end)),
+      days.map(({ date, start, end }) => stmt.bind(start, end, date, runAt)),
     );
     return { rolled: true, days: days.map((d) => d.date) };
   } catch {

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -9,6 +9,7 @@
 
 import { computeReliability } from "./reliability.mjs";
 import { rollupSubnetStatus } from "./health-probe-core.mjs";
+import { dailyLatencyColumns } from "./health-sql.mjs";
 import { KV_ECONOMICS_CURRENT, KV_HEALTH_CURRENT } from "./kv-keys.mjs";
 
 // Must exceed the probe cadence (15 min) so a live D1 health row is never treated
@@ -121,6 +122,7 @@ export function summarizeRows(rows) {
     avg_latency_ms: latencies.length
       ? Math.round(latencies.reduce((s, v) => s + v, 0) / latencies.length)
       : null,
+    latency_sample_count: latencies.length,
   };
 }
 
@@ -292,32 +294,41 @@ export function mergeFreshness(staticFreshness, liveMeta) {
 
 // Format D1 GROUP BY aggregates into a trends payload. `windows` maps a label to
 // an array of per-surface aggregate rows {surface_id, surface_key?, total,
-// ok_count, avg_latency_ms}. SQL groups by stable surface_key and keeps surface_id
-// as the current display alias.
+// ok_count, avg_latency_ms, latency_samples, p50, p95, p99}. SQL groups by stable
+// surface_key and keeps surface_id as the current display alias. Latency is
+// success-only: avg_latency_ms / the p50/p95/p99 tail describe healthy probes,
+// and latency_sample_count says how many backed them (0 ⇒ no healthy reading).
 export function formatTrends({ netuid, observedAt, windows }) {
   const formatWindow = (rows) => {
     let total = 0;
     let okCount = 0;
+    let latencySampleTotal = 0;
     const perSurface = [];
     for (const row of rows) {
       const rowTotal = Number(row.total) || 0;
       const rowOk = Number(row.ok_count) || 0;
+      const latencySamples = Number(row.latency_samples) || 0;
       total += rowTotal;
       okCount += rowOk;
+      latencySampleTotal += latencySamples;
       perSurface.push({
         surface_id: row.surface_id,
         samples: rowTotal,
         uptime_ratio: rowTotal ? Number((rowOk / rowTotal).toFixed(4)) : null,
-        avg_latency_ms:
-          row.avg_latency_ms == null
-            ? null
-            : Math.round(Number(row.avg_latency_ms)),
+        avg_latency_ms: roundInt(row.avg_latency_ms),
+        latency_sample_count: latencySamples,
+        latency_ms: {
+          p50: roundInt(row.p50),
+          p95: roundInt(row.p95),
+          p99: roundInt(row.p99),
+        },
       });
     }
     perSurface.sort((a, b) => a.surface_id.localeCompare(b.surface_id));
     return {
       samples: total,
       uptime_ratio: total ? Number((okCount / total).toFixed(4)) : null,
+      latency_sample_count: latencySampleTotal,
       surfaces: perSurface,
     };
   };
@@ -357,6 +368,13 @@ export function formatBulkTrends({ observedAt, windows, windowDays = {} }) {
       const avgLatency = Number.isFinite(latencyRaw)
         ? Math.round(latencyRaw)
         : null;
+      // Healthy readings behind this day's mean — weight by these, not total
+      // samples. Legacy rows lack the count, so fall back to total samples.
+      const latencyCount = !Number.isFinite(latencyRaw)
+        ? 0
+        : row.latency_samples == null
+          ? samples
+          : Math.max(0, Number(row.latency_samples) || 0);
 
       let entry = bySubnet.get(netuid);
       if (!entry) {
@@ -373,15 +391,16 @@ export function formatBulkTrends({ observedAt, windows, windowDays = {} }) {
 
       entry.samples += samples;
       entry.okCount += okCount;
-      if (Number.isFinite(latencyRaw) && samples > 0) {
-        entry.latencyTotal += latencyRaw * samples;
-        entry.latencySamples += samples;
+      if (Number.isFinite(latencyRaw) && latencyCount > 0) {
+        entry.latencyTotal += latencyRaw * latencyCount;
+        entry.latencySamples += latencyCount;
       }
       entry.points.push({
         date,
         samples,
         uptime_ratio: samples ? round4(okCount / samples) : null,
         avg_latency_ms: avgLatency,
+        latency_sample_count: latencyCount,
       });
     }
 
@@ -395,6 +414,7 @@ export function formatBulkTrends({ observedAt, windows, windowDays = {} }) {
         avg_latency_ms: entry.latencySamples
           ? Math.round(entry.latencyTotal / entry.latencySamples)
           : null,
+        latency_sample_count: entry.latencySamples,
         points: entry.points.sort((a, b) => a.date.localeCompare(b.date)),
       }))
       .sort((a, b) => a.netuid - b.netuid);
@@ -450,7 +470,9 @@ export function formatPercentiles({ netuid, window, observedAt, rows }) {
   const surfaces = (rows || [])
     .map((row) => ({
       surface_id: row.surface_id,
-      samples: Number(row.samples) || 0,
+      // `latency_samples` (shared latency-stat column); legacy callers still pass
+      // `samples`. This is the count of healthy readings behind the percentiles.
+      samples: Number(row.latency_samples ?? row.samples) || 0,
       latency_ms: {
         p50: roundInt(row.p50),
         p95: roundInt(row.p95),
@@ -887,10 +909,13 @@ export function formatUptime({ netuid, window, rows, now = null }) {
       samples: Number(row.samples) || 0,
       ok_count: Number(row.ok_count) || 0,
       uptime_ratio: row.uptime_ratio == null ? null : Number(row.uptime_ratio),
-      avg_latency_ms:
-        row.avg_latency_ms == null
-          ? null
-          : Math.round(Number(row.avg_latency_ms)),
+      avg_latency_ms: roundInt(row.avg_latency_ms),
+      latency_sample_count: Number(row.latency_samples) || 0,
+      latency_ms: {
+        p50: roundInt(row.p50),
+        p95: roundInt(row.p95),
+        p99: roundInt(row.p99),
+      },
       status: row.status || "unknown",
     });
     bySurface.set(key, entry);
@@ -913,6 +938,8 @@ export function formatUptime({ netuid, window, rows, now = null }) {
           samples: d.samples,
           uptime_ratio: d.uptime_ratio,
           avg_latency_ms: d.avg_latency_ms,
+          latency_sample_count: d.latency_sample_count,
+          latency_ms: d.latency_ms,
           status: d.status,
         })),
       };
@@ -954,14 +981,7 @@ export async function loadSubnetReliability({
                 day,
                 SUM(samples) AS samples,
                 SUM(ok_count) AS ok_count,
-                CASE
-                  WHEN SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN samples ELSE 0 END) > 0
-                    THEN CAST(ROUND(
-                      SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN avg_latency_ms * samples ELSE 0 END) /
-                      SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN samples ELSE 0 END)
-                    ) AS INTEGER)
-                  ELSE NULL
-                END AS avg_latency_ms
+                ${dailyLatencyColumns({ roundedAvg: true })}
          FROM surface_uptime_daily
          WHERE netuid = ? AND day >= ?
          GROUP BY COALESCE(surface_key, surface_id), day

--- a/src/health-sql.mjs
+++ b/src/health-sql.mjs
@@ -1,0 +1,77 @@
+// Shared D1 SQL for operational-health latency + uptime aggregation.
+//
+// One definition of "latency is a success-only signal": every latency aggregate
+// counts only healthy probes that recorded a latency (`ok = 1 AND latency_ms IS
+// NOT NULL`), while uptime counts every probe. Reused by the daily rollup, the
+// trends route, and the percentiles route so the mean, its p50/p95/p99 tail, and
+// its sample count stay consistent — and pre-fix raw rows (a stray 0/elapsed
+// latency on a failure) are corrected on read, not only on the next write.
+
+// A probe whose latency counts toward latency statistics.
+export const OK_LATENCY = "ok = 1 AND latency_ms IS NOT NULL";
+
+// CTE over `surface_checks` that ranks each stable surface's ok-latency rows by
+// latency (`rn`) and counts them (`lat_cnt`), passing all rows through so uptime
+// still totals over every check. The grp term in the PARTITION isolates
+// ok-latency rows, so `rn` ranks among them alone. `whereSql`'s `?` binds lead.
+export function rankedChecksCte(whereSql) {
+  return `WITH ranked AS (
+    SELECT
+      surface_id,
+      COALESCE(surface_key, surface_id) AS surface_key,
+      netuid,
+      ok,
+      latency_ms,
+      CASE WHEN ${OK_LATENCY} THEN ROW_NUMBER() OVER (
+        PARTITION BY COALESCE(surface_key, surface_id), netuid,
+                     CASE WHEN ${OK_LATENCY} THEN 0 ELSE 1 END
+        ORDER BY latency_ms
+      ) END AS rn,
+      SUM(CASE WHEN ${OK_LATENCY} THEN 1 ELSE 0 END) OVER (
+        PARTITION BY COALESCE(surface_key, surface_id), netuid
+      ) AS lat_cnt
+    FROM surface_checks
+    WHERE ${whereSql}
+  )`;
+}
+
+// SELECT columns over `ranked`: sample count, mean, optional min/max, and the
+// p50/p95/p99 order statistics (SQLite has no PERCENTILE_CONT, so they are picked
+// from `rn`). `roundedAvg` casts the mean to INTEGER for the rollup's column; the
+// rollup table has no min/max, so it drops them via `includeMinMax: false`.
+export function latencyStatColumns({
+  roundedAvg = false,
+  includeMinMax = true,
+} = {}) {
+  const avg = `AVG(CASE WHEN ${OK_LATENCY} THEN latency_ms END)`;
+  const pick = (q, name) =>
+    `MAX(CASE WHEN rn = CAST(${q} * lat_cnt AS INTEGER) + 1 THEN latency_ms END) AS ${name}`;
+  const columns = [
+    `MAX(lat_cnt) AS latency_samples`,
+    `${roundedAvg ? `CAST(ROUND(${avg}) AS INTEGER)` : avg} AS avg_latency_ms`,
+  ];
+  if (includeMinMax) {
+    columns.push(
+      `MIN(CASE WHEN ${OK_LATENCY} THEN latency_ms END) AS min_latency_ms`,
+      `MAX(CASE WHEN ${OK_LATENCY} THEN latency_ms END) AS max_latency_ms`,
+    );
+  }
+  columns.push(pick(0.5, "p50"), pick(0.95, "p95"), pick(0.99, "p99"));
+  return columns.join(",\n            ");
+}
+
+// SELECT columns that re-aggregate stored `surface_uptime_daily` rows: the
+// healthy-reading count and the latency mean weighted by it. Legacy rows predate
+// the latency_samples column, so weighting falls back to total samples.
+// `roundedAvg` casts to INTEGER for stored/long-term views; the bulk matrix keeps
+// the raw quotient and rounds in the formatter.
+export function dailyLatencyColumns({ roundedAvg = false } = {}) {
+  const weight = `CASE WHEN avg_latency_ms IS NOT NULL THEN COALESCE(latency_samples, samples) ELSE 0 END`;
+  const denom = `SUM(${weight})`;
+  const mean = `SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN avg_latency_ms * COALESCE(latency_samples, samples) ELSE 0 END) / ${denom}`;
+  return `${denom} AS latency_samples,
+            CASE WHEN ${denom} > 0
+              THEN ${roundedAvg ? `CAST(ROUND(${mean}) AS INTEGER)` : mean}
+              ELSE NULL
+            END AS avg_latency_ms`;
+}

--- a/src/reliability.mjs
+++ b/src/reliability.mjs
@@ -25,8 +25,14 @@ function gradeFor(score) {
 }
 
 // Score a single rolled-up window of stats. Returns null when there are no
-// samples (no probe data → no score, by design).
-export function scoreFromStats({ samples, okCount, avgLatencyMs }) {
+// samples (no probe data → no score, by design). `latencySamples` is how many
+// healthy probes backed `avgLatencyMs`, distinct from `samples` (the uptime total).
+export function scoreFromStats({
+  samples,
+  okCount,
+  avgLatencyMs,
+  latencySamples = 0,
+}) {
   if (!samples) {
     return null;
   }
@@ -49,12 +55,15 @@ export function scoreFromStats({ samples, okCount, avgLatencyMs }) {
     uptime_ratio: Number(uptimeRatio.toFixed(4)),
     avg_latency_ms: avgLatencyMs == null ? null : Math.round(avgLatencyMs),
     sample_count: samples,
+    latency_sample_count: latencySamples,
   };
 }
 
 // Aggregate surface_uptime_daily rows into a subnet-level score + a per-surface
-// score map. `rows`: [{ surface_id, day, samples, ok_count, avg_latency_ms }].
-// `subnet` is null when there are no samples across the window.
+// score map. `rows`: [{ surface_id, day, samples, ok_count, avg_latency_ms,
+// latency_samples }]. The window mean is weighted by latency_samples (healthy
+// readings per day), not total samples; legacy rows fall back to total samples.
+// `subnet` is null when there are no samples.
 export function computeReliability(rows, { window = null, now = null } = {}) {
   const bySurface = new Map();
   let totalSamples = 0;
@@ -68,6 +77,11 @@ export function computeReliability(rows, { window = null, now = null } = {}) {
     const okCount = Number(row.ok_count) || 0;
     const latency =
       row.avg_latency_ms == null ? null : Number(row.avg_latency_ms);
+    // Healthy readings behind this day's mean; legacy rows lack it → total samples.
+    const latencyCount =
+      row.latency_samples == null
+        ? samples
+        : Number(row.latency_samples) || 0;
     const surface = bySurface.get(row.surface_id) || {
       samples: 0,
       okCount: 0,
@@ -76,11 +90,11 @@ export function computeReliability(rows, { window = null, now = null } = {}) {
     };
     surface.samples += samples;
     surface.okCount += okCount;
-    if (latency != null && Number.isFinite(latency)) {
-      surface.latencyWeighted += latency * samples;
-      surface.latencySamples += samples;
-      latencyWeighted += latency * samples;
-      latencySamples += samples;
+    if (latency != null && Number.isFinite(latency) && latencyCount > 0) {
+      surface.latencyWeighted += latency * latencyCount;
+      surface.latencySamples += latencyCount;
+      latencyWeighted += latency * latencyCount;
+      latencySamples += latencyCount;
     }
     bySurface.set(row.surface_id, surface);
     totalSamples += samples;
@@ -98,6 +112,7 @@ export function computeReliability(rows, { window = null, now = null } = {}) {
       avgLatencyMs: surface.latencySamples
         ? surface.latencyWeighted / surface.latencySamples
         : null,
+      latencySamples: surface.latencySamples,
     });
   }
 
@@ -105,6 +120,7 @@ export function computeReliability(rows, { window = null, now = null } = {}) {
     samples: totalSamples,
     okCount: totalOk,
     avgLatencyMs: latencySamples ? latencyWeighted / latencySamples : null,
+    latencySamples,
   });
   const subnet = base
     ? {

--- a/src/reliability.mjs
+++ b/src/reliability.mjs
@@ -79,9 +79,7 @@ export function computeReliability(rows, { window = null, now = null } = {}) {
       row.avg_latency_ms == null ? null : Number(row.avg_latency_ms);
     // Healthy readings behind this day's mean; legacy rows lack it → total samples.
     const latencyCount =
-      row.latency_samples == null
-        ? samples
-        : Number(row.latency_samples) || 0;
+      row.latency_samples == null ? samples : Number(row.latency_samples) || 0;
     const surface = bySurface.get(row.surface_id) || {
       samples: 0,
       okCount: 0,

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -619,7 +619,10 @@ describe("analytics routes (fake D1 with data)", () => {
     // surface_key ?? surface_id once, then groups on that stable key.
     const trendsSql =
       queries.find((query) => query.sql.includes("FROM ranked"))?.sql || "";
-    assert.match(trendsSql, /COALESCE\(surface_key, surface_id\) AS surface_key/);
+    assert.match(
+      trendsSql,
+      /COALESCE\(surface_key, surface_id\) AS surface_key/,
+    );
     assert.match(trendsSql, /GROUP BY surface_key/);
     assert.match(
       queries.find((query) => query.sql.includes("FROM surface_uptime_daily"))

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -366,9 +366,14 @@ function captureD1Env(queries) {
 }
 function rowsForSql(sql) {
   if (sql.includes("WITH ranked")) {
+    // Shared ok-latency CTE backs BOTH the percentiles and the trends routes, so
+    // the fixture row carries uptime (total/ok_count) AND the latency stats.
     return [
       {
         surface_id: "s1",
+        total: 100,
+        ok_count: 98,
+        latency_samples: 96,
         samples: 100,
         p50: 120,
         p95: 400,
@@ -556,6 +561,8 @@ describe("analytics routes (fake D1 with data)", () => {
       /PARTITION BY COALESCE\(surface_key, surface_id\)/,
     );
     assert.match(queries[0].sql, /GROUP BY surface_key/);
+    // Surfaces with no healthy-latency reading are excluded (no all-null rows).
+    assert.match(queries[0].sql, /HAVING MAX\(lat_cnt\) > 0/);
   });
   test("incidents computes uptime + incidents from D1", async () => {
     const queries = [];
@@ -608,11 +615,12 @@ describe("analytics routes (fake D1 with data)", () => {
       "https://api.metagraph.sh/api/v1/subnets/7/uptime",
       envWithCapture,
     );
-    assert.match(
-      queries.find((query) => query.sql.includes("FROM surface_checks"))?.sql ||
-        "",
-      /GROUP BY COALESCE\(surface_key, surface_id\)/,
-    );
+    // Trends rolls raw checks through the shared ok-latency CTE, which coalesces
+    // surface_key ?? surface_id once, then groups on that stable key.
+    const trendsSql =
+      queries.find((query) => query.sql.includes("FROM ranked"))?.sql || "";
+    assert.match(trendsSql, /COALESCE\(surface_key, surface_id\) AS surface_key/);
+    assert.match(trendsSql, /GROUP BY surface_key/);
     assert.match(
       queries.find((query) => query.sql.includes("FROM surface_uptime_daily"))
         ?.sql || "",

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -1260,7 +1260,11 @@ describe("summarizeGroup / rollupStatus via per-subnet rollup", () => {
               classification: "unsafe",
               latency_ms: 0,
             },
-            threw: { status: "failed", classification: "dead", latency_ms: null },
+            threw: {
+              status: "failed",
+              classification: "dead",
+              latency_ms: null,
+            },
           })[input.id],
         probeOptions: {},
       },

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -1220,9 +1220,89 @@ describe("summarizeGroup / rollupStatus via per-subnet rollup", () => {
     assert.equal(subnet.status, "degraded");
     assert.equal(subnet.ok_count, 1);
     assert.equal(subnet.failed_count, 1);
-    // Average of 100 and 300.
-    assert.equal(subnet.avg_latency_ms, 200);
+    // Latency is success-only: the failed surface's 300ms is excluded, so the
+    // mean is the lone healthy reading (100) — NOT (100+300)/2 — and exactly one
+    // sample backed it.
+    assert.equal(subnet.avg_latency_ms, 100);
+    assert.equal(subnet.latency_sample_count, 1);
     assert.equal(subnet.last_ok, new Date(6000).toISOString());
+  });
+
+  test("failures (fast, timed-out, unsafe) never pollute the latency mean", async () => {
+    // Regression for issue 4: a fast-fail stored 0ms and a timeout stored its
+    // elapsed time, so both leaked into AVG(latency_ms) while a thrown probe's
+    // null was excluded — the mean silently blended them. Now every failure is
+    // excluded uniformly: the mean is the single healthy 100ms reading.
+    const kv = makeKv();
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 7000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => [
+          buildSurface("ok", 55),
+          buildSurface("timeout", 55),
+          buildSurface("unsafe", 55),
+          buildSurface("threw", 55),
+        ],
+        probeSurface: async (input) =>
+          ({
+            ok: { status: "ok", classification: "live", latency_ms: 100 },
+            timeout: {
+              status: "degraded",
+              classification: "timeout",
+              latency_ms: 8000,
+            },
+            unsafe: {
+              status: "failed",
+              classification: "unsafe",
+              latency_ms: 0,
+            },
+            threw: { status: "failed", classification: "dead", latency_ms: null },
+          })[input.id],
+        probeOptions: {},
+      },
+    );
+    const current = kv.json(KV_HEALTH_CURRENT);
+    const subnet = current.subnets.find((s) => s.netuid === 55);
+    assert.equal(subnet.avg_latency_ms, 100);
+    assert.equal(subnet.latency_sample_count, 1);
+    // Stored per-surface latency is null for every non-ok probe.
+    const byId = new Map(current.surfaces.map((s) => [s.surface_id, s]));
+    assert.equal(byId.get("ok").latency_ms, 100);
+    assert.equal(byId.get("timeout").latency_ms, null);
+    assert.equal(byId.get("unsafe").latency_ms, null);
+    assert.equal(byId.get("threw").latency_ms, null);
+  });
+
+  test("all-failed subnet reports a null latency mean and zero latency samples", async () => {
+    const kv = makeKv();
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 7500,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => [
+          buildSurface("x1", 66),
+          buildSurface("x2", 66),
+        ],
+        probeSurface: async () => ({
+          status: "failed",
+          classification: "timeout",
+          latency_ms: 9000,
+        }),
+        probeOptions: {},
+      },
+    );
+    const subnet = kv
+      .json(KV_HEALTH_CURRENT)
+      .subnets.find((s) => s.netuid === 66);
+    assert.equal(subnet.avg_latency_ms, null);
+    assert.equal(subnet.latency_sample_count, 0);
   });
 
   test("all-failed subnet rolls up to failed", async () => {
@@ -1367,24 +1447,28 @@ describe("rollupDailyUptime (durable daily history)", () => {
     const stmts = db.calls.batches[0];
     assert.equal(stmts.length, 2);
     assert.match(stmts[0].sql, /INSERT INTO surface_uptime_daily/);
-    assert.match(
-      stmts[0].sql,
-      /GROUP BY COALESCE\(surface_key, surface_id\), netuid/,
-    );
+    // Latency is rolled up via the shared ok-latency ranking CTE → success-only
+    // mean + sample count + p50/p95/p99 stored for long-term tail latency.
+    assert.match(stmts[0].sql, /WITH ranked AS/);
+    assert.match(stmts[0].sql, /latency_samples/);
+    assert.match(stmts[0].sql, /p50_latency_ms/);
+    assert.match(stmts[0].sql, /p99_latency_ms/);
+    assert.match(stmts[0].sql, /GROUP BY surface_key, netuid/);
     assert.match(
       stmts[0].sql,
       /ON CONFLICT\(surface_key, day\) WHERE surface_key IS NOT NULL/,
     );
     assert.match(stmts[0].sql, /ON CONFLICT\(surface_id, day\) DO UPDATE SET/);
-    // binds: [day, updated_at, dayStart, dayEnd]
+    // binds: [dayStart, dayEnd, day, updated_at] — the CTE's checked_at window
+    // binds lead the statement, then `? AS day` / `? AS updated_at`.
     assert.deepEqual(stmts[0].binds, [
-      "2026-06-13",
-      fixedNow,
       Date.UTC(2026, 5, 13),
       Date.UTC(2026, 5, 14),
+      "2026-06-13",
+      fixedNow,
     ]);
-    assert.equal(stmts[1].binds[0], "2026-06-12");
-    assert.equal(stmts[1].binds[2], Date.UTC(2026, 5, 12));
+    assert.equal(stmts[1].binds[2], "2026-06-12");
+    assert.equal(stmts[1].binds[0], Date.UTC(2026, 5, 12));
   });
 
   test("no-ops without a D1 binding", async () => {

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -244,6 +244,33 @@ describe("formatTrends", () => {
     });
     assert.equal(out.windows["7d"].uptime_ratio, null);
     assert.equal(out.windows["7d"].samples, 0);
+    assert.equal(out.windows["7d"].latency_sample_count, 0);
+  });
+  test("exposes p50/p95/p99 tail + healthy-sample count per surface", () => {
+    const out = formatTrends({
+      netuid: 7,
+      observedAt: "r",
+      windows: {
+        "7d": [
+          {
+            surface_id: "a",
+            total: 100,
+            ok_count: 96,
+            latency_samples: 96,
+            avg_latency_ms: 50.4,
+            p50: 40.6,
+            p95: 410.2,
+            p99: 900,
+          },
+        ],
+      },
+    });
+    const surface = out.windows["7d"].surfaces[0];
+    assert.equal(surface.avg_latency_ms, 50);
+    assert.equal(surface.latency_sample_count, 96);
+    assert.deepEqual(surface.latency_ms, { p50: 41, p95: 410, p99: 900 });
+    // Window total rolls up the healthy-sample counts.
+    assert.equal(out.windows["7d"].latency_sample_count, 96);
   });
 });
 
@@ -339,6 +366,7 @@ describe("summarizeRows / rollupStatus", () => {
       row("ok", { latency_ms: null, last_checked: null, last_ok: null }),
     ]);
     assert.equal(out.avg_latency_ms, 18); // round((10+25)/2)
+    assert.equal(out.latency_sample_count, 2); // the null-latency row is excluded
     assert.equal(out.last_checked, "2026-06-11T00:05:00.000Z"); // latest
     assert.equal(out.last_ok, "2026-06-11T00:00:00.000Z"); // latest non-null
   });
@@ -735,6 +763,40 @@ describe("formatBulkTrends", () => {
     assert.equal(sn7.points[1].uptime_ratio, 0.9);
     assert.equal(sn7.points[1].avg_latency_ms, 50);
     assert.equal(out.windows["30d"].subnet_count, 0);
+  });
+
+  test("weights the mean by latency_samples (not total) and reports the count", () => {
+    const out = formatBulkTrends({
+      windowDays: { "7d": 7 },
+      windows: {
+        "7d": [
+          // 100ms backed by 10 healthy readings, 200ms by 90 — failure-heavy day
+          // one must NOT drag the mean toward 100 by its larger total.
+          {
+            netuid: 7,
+            date: "2026-06-10",
+            total: 100,
+            ok_count: 10,
+            avg_latency_ms: 100,
+            latency_samples: 10,
+          },
+          {
+            netuid: 7,
+            date: "2026-06-11",
+            total: 90,
+            ok_count: 90,
+            avg_latency_ms: 200,
+            latency_samples: 90,
+          },
+        ],
+      },
+    });
+    const sn7 = out.windows["7d"].subnets[0];
+    // (100*10 + 200*90) / 100 = 190, weighted by healthy readings.
+    assert.equal(sn7.avg_latency_ms, 190);
+    assert.equal(sn7.latency_sample_count, 100);
+    assert.equal(sn7.points[0].latency_sample_count, 10);
+    assert.equal(sn7.points[1].latency_sample_count, 90);
   });
 
   test("empty or invalid rows keep the schema-stable cold shape", () => {
@@ -2073,6 +2135,46 @@ describe("computeReliability (score from uptime history)", () => {
     // healthy surface a -> high score; failing+slow surface b -> low
     assert.ok(out.surfaces.a.score > out.surfaces.b.score);
     assert.equal(out.surfaces.b.grade, "F");
+  });
+
+  test("weights latency by healthy readings and reports latency_sample_count", () => {
+    const out = computeReliability(
+      [
+        // Same day-means as a samples-weighted view, but the failure-heavy day
+        // carries few healthy readings, so it must barely move the mean.
+        {
+          surface_id: "a",
+          day: "2026-06-12",
+          samples: 720,
+          ok_count: 36,
+          avg_latency_ms: 100,
+          latency_samples: 36,
+        },
+        {
+          surface_id: "a",
+          day: "2026-06-13",
+          samples: 720,
+          ok_count: 720,
+          avg_latency_ms: 200,
+          latency_samples: 720,
+        },
+      ],
+      { window: "30d", now: "2026-06-13T00:00:00.000Z" },
+    );
+    // (100*36 + 200*720) / 756 = 195 (healthy-weighted), NOT 150 (samples-weighted).
+    assert.equal(out.subnet.avg_latency_ms, 195);
+    assert.equal(out.subnet.latency_sample_count, 756);
+    assert.equal(out.surfaces.a.latency_sample_count, 756);
+    // sample_count remains the total probe count behind uptime.
+    assert.equal(out.subnet.sample_count, 1440);
+  });
+
+  test("legacy rows without latency_samples fall back to total samples", () => {
+    const out = computeReliability([
+      { surface_id: "a", day: "2026-06-12", samples: 100, ok_count: 90, avg_latency_ms: 300 },
+    ]);
+    assert.equal(out.subnet.avg_latency_ms, 300);
+    assert.equal(out.subnet.latency_sample_count, 100);
   });
 
   test("latency penalty is bounded and only applies above 500ms", () => {

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -2171,7 +2171,13 @@ describe("computeReliability (score from uptime history)", () => {
 
   test("legacy rows without latency_samples fall back to total samples", () => {
     const out = computeReliability([
-      { surface_id: "a", day: "2026-06-12", samples: 100, ok_count: 90, avg_latency_ms: 300 },
+      {
+        surface_id: "a",
+        day: "2026-06-12",
+        samples: 100,
+        ok_count: 90,
+        avg_latency_ms: 300,
+      },
     ]);
     assert.equal(out.subnet.avg_latency_ms, 300);
     assert.equal(out.subnet.latency_sample_count, 100);

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -52,6 +52,11 @@ import {
   workerWebSocketConnector,
   writeSubnetSnapshot,
 } from "../src/health-prober.mjs";
+import {
+  dailyLatencyColumns,
+  latencyStatColumns,
+  rankedChecksCte,
+} from "../src/health-sql.mjs";
 import { findSurface, verifySurface } from "../src/surface-verify.mjs";
 import { SURFACE_ALIASES_PATH } from "../src/surface-aliases.mjs";
 import {
@@ -1195,12 +1200,7 @@ async function handleBulkHealthTrends(
             day AS date,
             SUM(samples) AS total,
             SUM(ok_count) AS ok_count,
-            CASE
-              WHEN SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN samples ELSE 0 END) > 0
-                THEN SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN avg_latency_ms * samples ELSE 0 END) /
-                     SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN samples ELSE 0 END)
-              ELSE NULL
-            END AS avg_latency_ms
+            ${dailyLatencyColumns()}
      FROM surface_uptime_daily
      WHERE day >= ?
      GROUP BY netuid, day
@@ -1259,14 +1259,14 @@ async function handleHealthTrends(request, env, netuid) {
         const result = await withTimeout(
           db
             .prepare(
-              `SELECT MAX(surface_id) AS surface_id,
-                    COALESCE(surface_key, surface_id) AS surface_key,
+              `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
+             SELECT MAX(surface_id) AS surface_id,
+                    surface_key,
                     COUNT(*) AS total,
                     SUM(ok) AS ok_count,
-                    AVG(latency_ms) AS avg_latency_ms
-             FROM surface_checks
-             WHERE netuid = ? AND checked_at >= ?
-             GROUP BY COALESCE(surface_key, surface_id)`,
+                    ${latencyStatColumns({ includeMinMax: false })}
+             FROM ranked
+             GROUP BY surface_key`,
             )
             .bind(netuid, nowMs - days * DAY_MS)
             .all(),
@@ -1384,31 +1384,13 @@ async function handleHealthPercentiles(request, env, netuid, url) {
   if (error) return analyticsQueryError(error);
   const rows = await d1All(
     env,
-    `WITH ranked AS (
-       SELECT COALESCE(surface_key, surface_id) AS surface_key,
-              surface_id,
-              latency_ms,
-              ROW_NUMBER() OVER (
-                PARTITION BY COALESCE(surface_key, surface_id)
-                ORDER BY latency_ms
-              ) AS rn,
-              COUNT(*) OVER (
-                PARTITION BY COALESCE(surface_key, surface_id)
-              ) AS cnt
-       FROM surface_checks
-       WHERE netuid = ? AND checked_at >= ? AND latency_ms IS NOT NULL
-     )
+    `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
      SELECT MAX(surface_id) AS surface_id,
             surface_key,
-            MAX(cnt) AS samples,
-            MAX(CASE WHEN rn = CAST(0.50 * cnt AS INTEGER) + 1 THEN latency_ms END) AS p50,
-            MAX(CASE WHEN rn = CAST(0.95 * cnt AS INTEGER) + 1 THEN latency_ms END) AS p95,
-            MAX(CASE WHEN rn = CAST(0.99 * cnt AS INTEGER) + 1 THEN latency_ms END) AS p99,
-            AVG(latency_ms) AS avg_latency_ms,
-            MIN(latency_ms) AS min_latency_ms,
-            MAX(latency_ms) AS max_latency_ms
+            ${latencyStatColumns()}
      FROM ranked
-     GROUP BY surface_key`,
+     GROUP BY surface_key
+     HAVING MAX(lat_cnt) > 0`,
     [netuid, Date.now() - days * DAY_MS],
   );
   const meta = await readHealthKv(env, KV_HEALTH_META);
@@ -1646,14 +1628,10 @@ async function handleUptime(request, env, netuid, url) {
               WHEN SUM(samples) > 0 THEN ROUND(CAST(SUM(ok_count) AS REAL) / SUM(samples), 4)
               ELSE NULL
             END AS uptime_ratio,
-            CASE
-              WHEN SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN samples ELSE 0 END) > 0
-                THEN CAST(ROUND(
-                  SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN avg_latency_ms * samples ELSE 0 END) /
-                  SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN samples ELSE 0 END)
-                ) AS INTEGER)
-              ELSE NULL
-            END AS avg_latency_ms,
+            ${dailyLatencyColumns({ roundedAvg: true })},
+            MAX(p50_latency_ms) AS p50,
+            MAX(p95_latency_ms) AS p95,
+            MAX(p99_latency_ms) AS p99,
             CASE
               WHEN SUM(samples) = 0 THEN 'unknown'
               WHEN SUM(ok_count) = SUM(samples) THEN 'ok'


### PR DESCRIPTION
## Summary

- Latency was reported only as a mean that silently blended failed probes (stored as `0`, elapsed time, or `null`) with healthy ones, so the figure could not be trusted for sorting or alerting, and nothing showed how many samples backed it.
- Latency is now a success-only signal: a probe's latency is kept only when it resolved `ok`, so failures count toward uptime but never toward the latency mean or percentiles.
- Tail latency (p50/p95/p99) and a `latency_sample_count` are now surfaced across the trends, percentiles, uptime, and reliability payloads. Percentiles are exact from raw checks for the live routes, and stored per-day in the durable rollup so they survive the 30-day raw prune.

## What Changed

- **`src/health-probe-core.mjs`**: new `okLatencyMs(status, latencyMs)`, the one rule that keeps latency only for healthy probes.
- **`src/health-sql.mjs`** (new): shared D1 builders so the latency math is defined once. `rankedChecksCte` + `latencyStatColumns` back the rollup, the trends route, and the percentiles route; `dailyLatencyColumns` re-aggregates the stored daily rows for the bulk matrix, uptime, and reliability.
- **`src/health-prober.mjs`**: applies `okLatencyMs` at the single persistence point, and the daily rollup now stores `latency_samples` and exact p50/p95/p99 per surface per day.
- **`src/health-serving.mjs` + `src/reliability.mjs`**: `latency_sample_count` flows through trends, bulk trends, uptime, the live summaries, and the reliability score, which now weights the window mean by healthy readings (with a fallback for rows written before the new columns existed).
- **`workers/api.mjs`**: trends, percentiles, bulk-trends, and uptime routes use the shared SQL.
- **`migrations/0007_latency_percentiles.sql`** (new): additive `latency_samples` + `p50/p95/p99_latency_ms` columns on `surface_uptime_daily`.
- **Schemas + generated artifacts**: `06-health.schema.json` updated and the OpenAPI, bundled components, and typed clients regenerated.
- **Tests**: covers an all-failure window, a mixed window, the regression where a timeout and a fast-fail polluted the mean, the percentile math, and the sample-count weighting.

## Notes for reviewers

- The percentile SQL (the ranking CTE, the daily rollup `WITH ... INSERT`, and the upsert) was validated against a real SQLite engine: failures are excluded from latency, percentiles are exact, and the rollup upsert is idempotent.
- Migration 0007 is additive (`ADD COLUMN`, non-destructive). Per the deploy ordering note in the file, apply it to the production `metagraphed-health` D1 before this ships so the rollup never references a missing column.
- The committed `public/metagraph/contracts.json` keeps its prior trends prose; it is a data-build output that refreshes on the next pipeline run and is not gated at commit time (only `openapi.json` and `types.d.ts` are, and both were regenerated).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:contract-drift`
- [x] `npm test`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`