### PR TITLE
fix(lib): treat a non-finite registration cost as unknown in computeMinerReadiness

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -2393,12 +2393,14 @@ export function computeMinerReadiness(economics, openSlots, emissionShare) {
   if (economics.registration_allowed) score += 40; // can register at all
   if (typeof openSlots === "number" && openSlots > 0) score += 30; // room
   const cost = economics.registration_cost_tao;
-  if (typeof cost === "number") {
+  if (Number.isFinite(cost)) {
     if (cost <= 1) score += 20;
     else if (cost <= 10) score += 10;
     else if (cost <= 100) score += 5;
   } else {
-    score += 10; // unknown cost — don't over-penalize
+    // unknown cost (missing, or a NaN/Infinity that slipped through a typeof
+    // check) — don't over-penalize.
+    score += 10;
   }
   const active =
     (typeof emissionShare === "number" && emissionShare > 0) ||

--- a/tests/miner-readiness.test.mjs
+++ b/tests/miner-readiness.test.mjs
@@ -42,6 +42,22 @@ test("computeMinerReadiness scores joinability 0-100 (#1306)", () => {
     60,
   );
   assert.equal(computeMinerReadiness(null, 5, 0.1), null);
+
+  // A non-finite cost (NaN/Infinity) is "unknown", not free: it must take the
+  // +10 unknown-cost path, not slip past a typeof check and score 0 cost points.
+  // open + slots + unknown-cost + active → 40+30+10+10.
+  assert.equal(
+    computeMinerReadiness(
+      {
+        registration_allowed: true,
+        registration_cost_tao: Number.NaN,
+        total_stake_tao: 100,
+      },
+      50,
+      0.01,
+    ),
+    90,
+  );
 });
 
 test("buildEconomicsArtifact derives open_slots + miner_readiness (#1306)", () => {


### PR DESCRIPTION
## Summary

`computeMinerReadiness` (new in #1306) gates the registration-cost score with `typeof cost === "number"`. A `NaN` or `Infinity` passes that check but matches none of the `<= 1 / <= 10 / <= 100` thresholds, so an invalid cost scored **0 cost points** instead of taking the `else` unknown-cost branch the comment intends ("unknown cost — don't over-penalize", +10). A non-finite cost is effectively unknown, so it should score like a missing one.

Fix: use `Number.isFinite(cost)` so `NaN`/`Infinity` fall through to the +10 unknown path, same as a missing cost.

```js
computeMinerReadiness({ registration_allowed: true, registration_cost_tao: NaN, total_stake_tao: 100 }, 50, 0.01)
// before: 80 (NaN slipped the typeof check -> 0 cost points)
// after:  90 (40 open + 30 slots + 10 unknown-cost + 10 active)
```

Committed economics artifacts can't carry `NaN`/`Infinity` (JSON serializes them to `null`, which already hits the `else`), so this only affects the live API path — **no committed-artifact churn**.

## Tests

Extends `tests/miner-readiness.test.mjs` with the non-finite-cost case.

- `npx vitest run tests/miner-readiness.test.mjs` -> passed
- prettier + eslint clean
