### PR TITLE
chore(enrich): taostats identity gap-fills

### DIFF
--- a/registry/subnets/nodexo.json
+++ b/registry/subnets/nodexo.json
@@ -44,6 +44,7 @@
       "No verified standalone static data artifact yet."
     ]
   },
+  "social": { "x": "https://x.com/nodex0_" },
   "surfaces": [
     {
       "id": "sn-106-nodexo-website",


### PR DESCRIPTION
## taostats identity gap-fills

Third-party data from the taostats API — for human review before merge.

### Fields filled

| Subnet | netuid | Field | Value |
|--------|--------|-------|-------|
| Nodexo | 106 | `social.x` | https://x.com/nodex0_ |

### Notes
- Source: https://api.taostats.io/api/subnet/identity/v1
- Values cleaned through repo sanitizers (`socialAccounts`); passed schema pattern validation
- `source_repo: null` in nodexo.json was treated as curated suppression and not overwritten
- 1 clean fill across 1 subnet