### PR TITLE
feat(api): robust conditional requests across live endpoints and the SSE feed

### DIFF
--- a/tests/responses-envelope.test.mjs
+++ b/tests/responses-envelope.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { dataResponse } from "../workers/responses.mjs";
+import { dataResponse, envelopeResponse } from "../workers/responses.mjs";
+import { ifNoneMatchSatisfied } from "../workers/http.mjs";
+
+const reqWith = (ifNoneMatch) =>
+  new Request("https://metagraph.sh/api/v1/anything", {
+    headers: ifNoneMatch == null ? {} : { "if-none-match": ifNoneMatch },
+  });
 
 // Regression guard: the two success builders (dataResponse + envelopeResponse)
 // must emit the identical SuccessEnvelope shape. dataResponse previously added an
@@ -23,4 +29,53 @@ test("dataResponse emits the SuccessEnvelope shape with no error key", async () 
   assert.equal(body.schema_version, 1);
   assert.deepEqual(body.data, { hello: "world" });
   assert.equal(body.meta.source, "test");
+});
+
+// ifNoneMatchSatisfied implements the RFC 7232 §3.2 precondition that backs every
+// 304 short-circuit (live envelopes, raw artifacts, and the edge/overlay caches).
+const ETAG = 'W/"abc123"';
+
+test("ifNoneMatchSatisfied: exact weak-tag echo matches", () => {
+  assert.equal(ifNoneMatchSatisfied(reqWith(ETAG), ETAG), true);
+});
+
+test("ifNoneMatchSatisfied: weak/strong validators compare equal", () => {
+  // If-None-Match uses the weak comparison, so the W/ prefix is ignored.
+  assert.equal(ifNoneMatchSatisfied(reqWith('"abc123"'), ETAG), true);
+  assert.equal(ifNoneMatchSatisfied(reqWith(ETAG), '"abc123"'), true);
+});
+
+test("ifNoneMatchSatisfied: the * form matches any current representation", () => {
+  assert.equal(ifNoneMatchSatisfied(reqWith("*"), ETAG), true);
+  // ...but only when a representation exists (there is a current etag).
+  assert.equal(ifNoneMatchSatisfied(reqWith("*"), null), false);
+});
+
+test("ifNoneMatchSatisfied: matches any tag in a comma-separated list", () => {
+  assert.equal(ifNoneMatchSatisfied(reqWith(`"x", ${ETAG}, "y"`), ETAG), true);
+  assert.equal(ifNoneMatchSatisfied(reqWith('"x", "y"'), ETAG), false);
+});
+
+test("ifNoneMatchSatisfied: no header or no etag is a miss", () => {
+  assert.equal(ifNoneMatchSatisfied(reqWith(null), ETAG), false);
+  assert.equal(ifNoneMatchSatisfied(reqWith(ETAG), null), false);
+});
+
+// envelopeResponse owns the response shape (the helper tests own the match
+// logic): a match is a bodiless 304 keeping the etag; a miss is a 200 with body.
+test("envelopeResponse: a match returns a bodiless 304, a miss returns the body", async () => {
+  const payload = { data: { hello: "world" }, meta: { contract_version: "x" } };
+  const fresh = await envelopeResponse(reqWith(null), payload, "standard");
+  const etag = fresh.headers.get("etag");
+  assert.equal(fresh.status, 200);
+  assert.ok(etag);
+
+  const matched = await envelopeResponse(reqWith(etag), payload, "standard");
+  assert.equal(matched.status, 304);
+  assert.equal(await matched.text(), "");
+  assert.equal(matched.headers.get("etag"), etag);
+
+  const stale = await envelopeResponse(reqWith('"stale"'), payload, "standard");
+  assert.equal(stale.status, 200);
+  assert.equal((await stale.json()).data.hello, "world");
 });

--- a/tests/webhooks-worker.test.mjs
+++ b/tests/webhooks-worker.test.mjs
@@ -236,6 +236,41 @@ describe("SSE change feed", () => {
     assert.equal(event.type, "metagraph.publish");
     assert.ok(Array.isArray(event.affected_netuids));
   });
+
+  test("Last-Event-ID matching the current snapshot short-circuits to a keepalive", async () => {
+    const env = envWith(makeKv());
+    const first = await handleRequest(req("/api/v1/events"), env, {});
+    const firstText = await first.text();
+    assert.equal(first.headers.get("x-metagraph-events"), "snapshot");
+    const idLine = firstText
+      .split("\n")
+      .find((line) => line.startsWith("id: "));
+    const eventId = idLine.slice("id: ".length);
+
+    const reconnect = await handleRequest(
+      req("/api/v1/events", { headers: { "last-event-id": eventId } }),
+      env,
+      {},
+    );
+    assert.equal(reconnect.status, 200);
+    assert.equal(reconnect.headers.get("x-metagraph-events"), "unchanged");
+    const reconnectText = await reconnect.text();
+    // No snapshot frame — just a retry directive and a keepalive comment.
+    assert.doesNotMatch(reconnectText, /event: snapshot/);
+    assert.doesNotMatch(reconnectText, /^data:/m);
+    assert.match(reconnectText, /retry: 300000/);
+    assert.match(reconnectText, /^: /m);
+  });
+
+  test("a stale Last-Event-ID still delivers the snapshot", async () => {
+    const res = await handleRequest(
+      req("/api/v1/events", { headers: { "last-event-id": "stale-id" } }),
+      envWith(makeKv()),
+      {},
+    );
+    assert.equal(res.headers.get("x-metagraph-events"), "snapshot");
+    assert.match(await res.text(), /event: snapshot/);
+  });
 });
 
 describe("webhook route edge cases", () => {

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -594,6 +594,23 @@ describe("Worker runtime", () => {
     assert.equal(cached.status, 304);
     assert.equal(await cached.text(), "");
 
+    // The raw artifact path revalidates too (a separate call site from the
+    // envelope path); `*` matches any current representation.
+    const raw = await handleRequest(
+      new Request("https://metagraph.sh/metagraph/subnets/7.json"),
+      env,
+      {},
+    );
+    const rawConditional = await handleRequest(
+      new Request("https://metagraph.sh/metagraph/subnets/7.json", {
+        headers: { "if-none-match": "*" },
+      }),
+      env,
+      {},
+    );
+    assert.ok(raw.headers.get("etag"));
+    assert.equal(rawConditional.status, 304);
+
     const options = await handleRequest(
       new Request("https://metagraph.sh/api/v1/contracts", {
         method: "OPTIONS",

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -6,7 +6,12 @@ import {
   compileRoutePattern,
 } from "../src/contracts.mjs";
 import { applyQueryFilters } from "./list-query.mjs";
-import { apiHeaders, errorResponse, weakEtag } from "./http.mjs";
+import {
+  apiHeaders,
+  errorResponse,
+  ifNoneMatchSatisfied,
+  weakEtag,
+} from "./http.mjs";
 import {
   d1TimeoutMs,
   latestPointer,
@@ -707,7 +712,7 @@ async function handleRawArtifactRequest(
     headers.set("x-metagraph-published-at", pub);
   }
   headers.set("etag", await weakEtag(body));
-  if (request.headers.get("if-none-match") === headers.get("etag")) {
+  if (ifNoneMatchSatisfied(request, headers.get("etag"))) {
     return new Response(null, { status: 304, headers });
   }
   return new Response(request.method === "HEAD" ? null : body, {
@@ -1046,8 +1051,7 @@ async function handleApiRequest(
       );
       const overlayHit = await overlayCache.match(overlayCacheKey);
       if (overlayHit) {
-        const etag = overlayHit.headers.get("etag");
-        if (etag && request.headers.get("if-none-match") === etag) {
+        if (ifNoneMatchSatisfied(request, overlayHit.headers.get("etag"))) {
           return new Response(null, {
             status: 304,
             headers: overlayHit.headers,
@@ -1062,8 +1066,7 @@ async function handleApiRequest(
     if (hit) {
       // Honour conditional requests against the cached body's weak ETag so
       // polling agents still get a 304 on a warm cache (mirrors envelopeResponse).
-      const etag = hit.headers.get("etag");
-      if (etag && request.headers.get("if-none-match") === etag) {
+      if (ifNoneMatchSatisfied(request, hit.headers.get("etag"))) {
         return new Response(null, { status: 304, headers: hit.headers });
       }
       return hit;
@@ -3199,13 +3202,18 @@ async function handleEventsRequest(request, env) {
   ]);
   const changelog = changelogArtifact.ok ? changelogArtifact.data : null;
   const event = buildChangeEvent({ changelog, pointer });
-  const frame =
-    [
-      "retry: 300000",
-      `id: ${event.published_at || event.generated_at || "0"}`,
-      "event: snapshot",
-      `data: ${JSON.stringify(event)}`,
-    ].join("\n") + "\n\n";
+  const eventId = event.published_at || event.generated_at || "0";
+  // Reconnect replays the last id; if the snapshot hasn't moved, answer with a
+  // bare keepalive instead of re-sending it (a 304 analogue for SSE).
+  const unchanged = request.headers.get("last-event-id") === eventId;
+  const frame = unchanged
+    ? `retry: 300000\n: no new snapshot since ${eventId}\n\n`
+    : [
+        "retry: 300000",
+        `id: ${eventId}`,
+        "event: snapshot",
+        `data: ${JSON.stringify(event)}`,
+      ].join("\n") + "\n\n";
 
   const headers = new Headers();
   headers.set("content-type", "text/event-stream; charset=utf-8");
@@ -3213,6 +3221,7 @@ async function handleEventsRequest(request, env) {
   headers.set("access-control-allow-origin", "*");
   headers.set("x-content-type-options", "nosniff");
   headers.set("x-metagraph-contract-version", contractVersion(env));
+  headers.set("x-metagraph-events", unchanged ? "unchanged" : "snapshot");
   return new Response(frame, { status: 200, headers });
 }
 

--- a/workers/http.mjs
+++ b/workers/http.mjs
@@ -59,3 +59,21 @@ export async function weakEtag(body) {
     .join("");
   return `W/"${hash.slice(0, 32)}"`;
 }
+
+// Strip the optional weak prefix so tags compare by opaque value alone:
+// If-None-Match uses weak comparison, so W/"x" and "x" are equivalent.
+function opaqueTag(tag) {
+  return tag.startsWith("W/") ? tag.slice(2) : tag;
+}
+
+// True when an If-None-Match precondition matches the current `etag` (caller
+// answers 304). Handles `*`, a comma-separated tag list, and weak validators.
+export function ifNoneMatchSatisfied(request, etag) {
+  const header = request.headers.get("if-none-match");
+  if (!header || !etag) return false;
+  const current = opaqueTag(etag);
+  return header
+    .split(",")
+    .map((candidate) => candidate.trim())
+    .some((candidate) => candidate === "*" || opaqueTag(candidate) === current);
+}

--- a/workers/responses.mjs
+++ b/workers/responses.mjs
@@ -4,7 +4,7 @@
 // http + storage leaf modules and the contract version; it calls nothing back
 // into api.mjs, so there is no import cycle.
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
-import { apiHeaders, weakEtag } from "./http.mjs";
+import { apiHeaders, ifNoneMatchSatisfied, weakEtag } from "./http.mjs";
 import { latestPointer } from "./storage.mjs";
 
 export function contractVersion(env) {
@@ -86,7 +86,7 @@ export async function envelopeResponse(request, payload, cacheProfile) {
       payload.meta.stale_contract.built_under,
     );
   }
-  if (request.headers.get("if-none-match") === etag) {
+  if (ifNoneMatchSatisfied(request, etag)) {
     return new Response(null, {
       status: 304,
       headers,


### PR DESCRIPTION
## Summary

- Conditional requests on the live API now follow standard semantics, and the SSE change feed stops resending an unchanged snapshot on reconnect. Both cut wasted transfer for agents that poll on a loop.
- The live endpoints (per-UID metagraph, neuron, validators, health trends, percentiles, incidents, trajectory, uptime, economics) already answered an exact `If-None-Match` with a 304 through `envelopeResponse`. This tightens the match logic and extends the same revalidation to the events feed.

## What Changed

- New shared `ifNoneMatchSatisfied` helper in `workers/http.mjs` evaluates `If-None-Match` per RFC 7232: the `*` form, comma-separated tag lists, and weak vs strong validators.
- Every 304 short-circuit routes through the helper instead of a raw `header === etag` compare: the envelope path (`envelopeResponse`), the raw artifact handler, and the overlay and edge cache hits.
- `/api/v1/events` honors `Last-Event-ID`. When the snapshot id has not moved, the response is a bare keepalive frame rather than a repeated snapshot, and a new `x-metagraph-events` header reports whether the frame is `snapshot` or `unchanged`.
- Tests cover the match matrix, the envelope 304 and 200 response shapes, the raw artifact path, and both events branches.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run check`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
