### PR TITLE
feat(python): honor configured retries and backoff on RPC reads

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -58,8 +58,9 @@ from metagraphed import (
     metagraphed_rpc,
 )
 
-# Opt-in retry/backoff for idempotent GETs (retries 429/5xx + network errors,
-# honoring a numeric Retry-After). Disabled by default.
+# Opt-in retry/backoff for idempotent reads — GETs *and* the read-only RPC proxy
+# (retries 429/5xx + network errors, honoring a numeric Retry-After). Off by
+# default.
 client = MetagraphedClient(retries=3)
 
 # Iterate every page of a list endpoint (follows meta.pagination.next_cursor):
@@ -67,8 +68,12 @@ for page in client.paginate("/api/v1/subnets", query={"limit": 100}):
     for subnet in page["data"]["subnets"]:
         print(subnet["netuid"])
 
-# Call the read-only Subtensor RPC proxy and get back the JSON-RPC result:
-info = metagraphed_rpc("finney", "system_health")
+# Call the read-only Subtensor RPC proxy and get back the JSON-RPC result. Via
+# the client, RPC reads honor the same retries/backoff as GETs:
+info = client.rpc("finney", "system_health")
+
+# Or as a standalone call with explicit retries:
+info = metagraphed_rpc("finney", "system_health", retries=3)
 ```
 
 ### `fetch_all` + typed models

--- a/python/src/metagraphed/aio.py
+++ b/python/src/metagraphed/aio.py
@@ -19,12 +19,13 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, List, Mapping, Optional, S
 
 from .client import (
     DEFAULT_BASE_URL,
-    DEFAULT_USER_AGENT,
     MetagraphedError,
     _MAX_RETRY_AFTER_SECONDS,
     _RETRY_STATUSES,
     _collection_rows,
+    _default_headers,
     _interpolate,
+    _jsonrpc_result,
 )
 from .models import AgentCatalogSubnet, Endpoint, Provider, Subnet, Surface
 
@@ -106,6 +107,50 @@ class AsyncMetagraphedClient:
         """Close the underlying connection pool."""
         await self._client.aclose()
 
+    async def _send_json(self, send: Any, *, label: str) -> Any:
+        """Perform a request via ``send`` (an async thunk returning a response),
+        retrying transient failures, and return the parsed JSON body.
+
+        Retries HTTP 429/5xx and network errors up to ``self.retries`` times with
+        exponential ``self.backoff`` seconds, honoring a numeric ``Retry-After``
+        capped at 60 seconds. ``label`` (e.g. ``"GET <url>"`` or ``"RPC
+        <method>"``) prefixes error messages. Raises :class:`MetagraphedError`
+        once retries are exhausted or if the body is not JSON.
+        """
+        attempt = 0
+        while True:
+            try:
+                response = await send()
+            except self._httpx.HTTPError as error:
+                if attempt < self.retries:
+                    await asyncio.sleep(self.backoff * (2**attempt))
+                    attempt += 1
+                    continue
+                raise MetagraphedError(f"{label} failed: {error}") from error
+            if response.status_code >= 400:
+                if (
+                    attempt < self.retries
+                    and response.status_code in _RETRY_STATUSES
+                ):
+                    await asyncio.sleep(
+                        _retry_after_seconds(response, attempt, self.backoff)
+                    )
+                    attempt += 1
+                    continue
+                raise MetagraphedError(
+                    f"{label} failed: HTTP {response.status_code}"
+                    f"{_response_error_detail(response)}",
+                    status=response.status_code,
+                )
+            break
+
+        try:
+            return response.json()
+        except ValueError as error:
+            raise MetagraphedError(
+                f"{label} returned a non-JSON response"
+            ) from error
+
     async def fetch(
         self,
         path: str,
@@ -126,47 +171,11 @@ class AsyncMetagraphedClient:
             if query
             else None
         )
-        merged_headers = {
-            "Accept": "application/json",
-            "User-Agent": DEFAULT_USER_AGENT,
-        }
-        merged_headers.update(headers or {})
-
-        attempt = 0
-        while True:
-            try:
-                response = await self._client.get(
-                    url, params=params, headers=merged_headers
-                )
-            except self._httpx.HTTPError as error:
-                if attempt < self.retries:
-                    await asyncio.sleep(self.backoff * (2**attempt))
-                    attempt += 1
-                    continue
-                raise MetagraphedError(f"GET {url} failed: {error}") from error
-            if response.status_code >= 400:
-                if (
-                    attempt < self.retries
-                    and response.status_code in _RETRY_STATUSES
-                ):
-                    await asyncio.sleep(
-                        _retry_after_seconds(response, attempt, self.backoff)
-                    )
-                    attempt += 1
-                    continue
-                raise MetagraphedError(
-                    f"GET {url} failed: HTTP {response.status_code}"
-                    f"{_response_error_detail(response)}",
-                    status=response.status_code,
-                )
-            break
-
-        try:
-            return response.json()
-        except ValueError as error:
-            raise MetagraphedError(
-                f"GET {url} returned a non-JSON response"
-            ) from error
+        merged_headers = _default_headers(headers)
+        return await self._send_json(
+            lambda: self._client.get(url, params=params, headers=merged_headers),
+            label=f"GET {url}",
+        )
 
     async def paginate(
         self,
@@ -226,7 +235,13 @@ class AsyncMetagraphedClient:
         headers: Optional[Mapping[str, str]] = None,
         request_id: Any = 1,
     ) -> Any:
-        """Call the read-only Subtensor RPC proxy and return the JSON-RPC result."""
+        """Call the read-only Subtensor RPC proxy and return the JSON-RPC result.
+
+        Honors this client's ``retries`` + ``backoff``: the proxy is a read-only
+        Subtensor read, so RPC reads are retried on transient errors (HTTP
+        429/5xx and network failures) exactly like GETs, honoring a numeric
+        ``Retry-After`` capped at 60 seconds.
+        """
         url = (
             self.base_url.rstrip("/")
             + "/rpc/v1/"
@@ -238,38 +253,12 @@ class AsyncMetagraphedClient:
             "method": method,
             "params": list(params or []),
         }
-        merged_headers = {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "User-Agent": DEFAULT_USER_AGENT,
-        }
-        merged_headers.update(headers or {})
-
-        try:
-            response = await self._client.post(
-                url, json=payload, headers=merged_headers
-            )
-        except self._httpx.HTTPError as error:
-            raise MetagraphedError(f"RPC {method} failed: {error}") from error
-        if response.status_code >= 400:
-            raise MetagraphedError(
-                f"RPC {method} failed: HTTP {response.status_code}"
-                f"{_response_error_detail(response)}",
-                status=response.status_code,
-            )
-        try:
-            parsed = response.json()
-        except ValueError as error:
-            raise MetagraphedError(
-                f"RPC {method} returned a non-JSON response"
-            ) from error
-        rpc_error = parsed.get("error") if isinstance(parsed, dict) else None
-        if rpc_error:
-            message = (
-                rpc_error.get("message") if isinstance(rpc_error, dict) else None
-            )
-            raise MetagraphedError(f"RPC {method} error: {message or rpc_error}")
-        return parsed.get("result") if isinstance(parsed, dict) else None
+        merged_headers = _default_headers(headers, json_body=True)
+        parsed = await self._send_json(
+            lambda: self._client.post(url, json=payload, headers=merged_headers),
+            label=f"RPC {method}",
+        )
+        return _jsonrpc_result(parsed, method)
 
     # -- typed convenience methods (raw-dict path stays via fetch/fetch_all) --
 

--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -96,6 +96,86 @@ def _interpolate(path: str, path_params: Optional[Mapping[str, Any]]) -> str:
     return _PATH_PARAM.sub(repl, path)
 
 
+def _default_headers(
+    headers: Optional[Mapping[str, str]], *, json_body: bool = False
+) -> dict:
+    """Metagraphed's default headers, overridable by ``headers`` (which wins, so
+    a caller can replace the User-Agent). ``json_body`` adds Content-Type."""
+    merged = {"Accept": "application/json", "User-Agent": DEFAULT_USER_AGENT}
+    if json_body:
+        merged["Content-Type"] = "application/json"
+    merged.update(headers or {})
+    return merged
+
+
+def _build_request(
+    url: str,
+    *,
+    method: str,
+    data: Optional[bytes] = None,
+    headers: Optional[Mapping[str, str]] = None,
+) -> urllib.request.Request:
+    """A urllib Request with default headers applied; ``data`` implies a POST body."""
+    request = urllib.request.Request(url, data=data, method=method)
+    for key, value in _default_headers(headers, json_body=data is not None).items():
+        request.add_header(key, value)
+    return request
+
+
+def _request_json(
+    request: urllib.request.Request,
+    *,
+    timeout: float,
+    retries: int,
+    backoff: float,
+    label: str,
+) -> Any:
+    """Open ``request`` and return its parsed JSON body, retrying transient
+    failures.
+
+    Retries HTTP 429/5xx and network errors up to ``retries`` times with
+    exponential ``backoff`` seconds, honoring a numeric ``Retry-After`` (capped
+    at 60s). ``label`` (e.g. ``"GET <url>"`` or ``"RPC <method>"``) prefixes
+    error messages. Raises :class:`MetagraphedError` once retries are exhausted
+    or if the body is not JSON.
+    """
+    attempt = 0
+    while True:
+        try:
+            with _open_request(request, timeout=timeout) as response:
+                body = response.read().decode("utf-8")
+            break
+        except urllib.error.HTTPError as error:
+            if attempt < retries and error.code in _RETRY_STATUSES:
+                time.sleep(_retry_delay(error, attempt, backoff))
+                attempt += 1
+                continue
+            raise MetagraphedError(
+                f"{label} failed: HTTP {error.code}{_error_detail(error)}",
+                status=error.code,
+            ) from error
+        except urllib.error.URLError as error:
+            if attempt < retries:
+                time.sleep(backoff * (2**attempt))
+                attempt += 1
+                continue
+            raise MetagraphedError(f"{label} failed: {error.reason}") from error
+
+    try:
+        return json.loads(body)
+    except ValueError as error:
+        raise MetagraphedError(f"{label} returned a non-JSON response") from error
+
+
+def _jsonrpc_result(parsed: Any, method: str) -> Any:
+    """Unwrap a JSON-RPC envelope: return its ``result``, or raise its ``error``."""
+    rpc_error = parsed.get("error") if isinstance(parsed, dict) else None
+    if rpc_error:
+        message = rpc_error.get("message") if isinstance(rpc_error, dict) else None
+        raise MetagraphedError(f"RPC {method} error: {message or rpc_error}")
+    return parsed.get("result") if isinstance(parsed, dict) else None
+
+
 def metagraphed_fetch(
     path: str,
     *,
@@ -124,42 +204,13 @@ def metagraphed_fetch(
         if pairs:
             url += "?" + urllib.parse.urlencode(pairs, doseq=True)
 
-    # Defaults first so a caller-supplied header (e.g. a custom User-Agent) wins.
-    merged_headers = {"Accept": "application/json", "User-Agent": DEFAULT_USER_AGENT}
-    merged_headers.update(headers or {})
-
-    request = urllib.request.Request(url, method="GET")
-    for key, value in merged_headers.items():
-        request.add_header(key, value)
-
-    attempt = 0
-    while True:
-        try:
-            with _open_request(request, timeout=timeout) as response:
-                body = response.read().decode("utf-8")
-            break
-        except urllib.error.HTTPError as error:
-            if attempt < retries and error.code in _RETRY_STATUSES:
-                time.sleep(_retry_delay(error, attempt, backoff))
-                attempt += 1
-                continue
-            raise MetagraphedError(
-                f"GET {url} failed: HTTP {error.code}{_error_detail(error)}",
-                status=error.code,
-            ) from error
-        except urllib.error.URLError as error:
-            if attempt < retries:
-                time.sleep(backoff * (2**attempt))
-                attempt += 1
-                continue
-            raise MetagraphedError(f"GET {url} failed: {error.reason}") from error
-
-    try:
-        return json.loads(body)
-    except ValueError as error:
-        raise MetagraphedError(
-            f"GET {url} returned a non-JSON response"
-        ) from error
+    return _request_json(
+        _build_request(url, method="GET", headers=headers),
+        timeout=timeout,
+        retries=retries,
+        backoff=backoff,
+        label=f"GET {url}",
+    )
 
 
 def _retry_delay(
@@ -212,6 +263,7 @@ def metagraphed_paginate(
     headers: Optional[Mapping[str, str]] = None,
     timeout: float = 30.0,
     retries: int = 0,
+    backoff: float = 0.5,
 ) -> Iterator[Any]:
     """Yield each page's envelope for a list endpoint, following
     ``meta.pagination.next_cursor`` until it is exhausted."""
@@ -229,6 +281,7 @@ def metagraphed_paginate(
             headers=headers,
             timeout=timeout,
             retries=retries,
+            backoff=backoff,
         )
         yield page
         pagination = (
@@ -276,6 +329,7 @@ def metagraphed_fetch_all(
     headers: Optional[Mapping[str, str]] = None,
     timeout: float = 30.0,
     retries: int = 0,
+    backoff: float = 0.5,
 ) -> List[Any]:
     """Follow pagination for a list endpoint and return every row across all
     pages (the nested ``data`` collection; see :func:`_collection_rows`)."""
@@ -288,6 +342,7 @@ def metagraphed_fetch_all(
         headers=headers,
         timeout=timeout,
         retries=retries,
+        backoff=backoff,
     ):
         items.extend(_collection_rows(page))
     return items
@@ -302,10 +357,18 @@ def metagraphed_rpc(
     headers: Optional[Mapping[str, str]] = None,
     timeout: float = 30.0,
     request_id: Any = 1,
+    retries: int = 0,
+    backoff: float = 0.5,
 ) -> Any:
     """Call the read-only Subtensor RPC proxy (POST ``/rpc/v1/<network>``) and
     return the JSON-RPC ``result``. Raises :class:`MetagraphedError` on a network
-    failure, a non-2xx response, or a JSON-RPC-level error object."""
+    failure, a non-2xx response, or a JSON-RPC-level error object.
+
+    The proxy is a read-only Subtensor read, so RPC reads are retried exactly
+    like idempotent GETs: set ``retries`` > 0 to retry transient errors (HTTP
+    429/5xx and network failures) with exponential ``backoff`` seconds, honoring
+    a numeric ``Retry-After`` capped at 60 seconds. Retries are opt-in
+    (default 0)."""
     url = (
         base_url.rstrip("/")
         + "/rpc/v1/"
@@ -320,46 +383,19 @@ def metagraphed_rpc(
         }
     ).encode("utf-8")
 
-    merged_headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-        "User-Agent": DEFAULT_USER_AGENT,
-    }
-    merged_headers.update(headers or {})
-
-    request = urllib.request.Request(url, data=payload, method="POST")
-    for key, value in merged_headers.items():
-        request.add_header(key, value)
-
-    try:
-        with _open_request(request, timeout=timeout) as response:
-            body = response.read().decode("utf-8")
-    except urllib.error.HTTPError as error:
-        raise MetagraphedError(
-            f"RPC {method} failed: HTTP {error.code}{_error_detail(error)}",
-            status=error.code,
-        ) from error
-    except urllib.error.URLError as error:
-        raise MetagraphedError(f"RPC {method} failed: {error.reason}") from error
-
-    try:
-        parsed = json.loads(body)
-    except ValueError as error:
-        raise MetagraphedError(
-            f"RPC {method} returned a non-JSON response"
-        ) from error
-
-    rpc_error = parsed.get("error") if isinstance(parsed, dict) else None
-    if rpc_error:
-        message = (
-            rpc_error.get("message") if isinstance(rpc_error, dict) else None
-        )
-        raise MetagraphedError(f"RPC {method} error: {message or rpc_error}")
-    return parsed.get("result") if isinstance(parsed, dict) else None
+    parsed = _request_json(
+        _build_request(url, method="POST", data=payload, headers=headers),
+        timeout=timeout,
+        retries=retries,
+        backoff=backoff,
+        label=f"RPC {method}",
+    )
+    return _jsonrpc_result(parsed, method)
 
 
 class MetagraphedClient:
-    """Convenience wrapper binding a ``base_url`` + default ``timeout``/``retries``."""
+    """Convenience wrapper binding a ``base_url`` + default
+    ``timeout``/``retries``/``backoff`` (applied to GETs and RPC reads alike)."""
 
     def __init__(
         self,
@@ -367,10 +403,12 @@ class MetagraphedClient:
         *,
         timeout: float = 30.0,
         retries: int = 0,
+        backoff: float = 0.5,
     ) -> None:
         self.base_url = base_url
         self.timeout = timeout
         self.retries = retries
+        self.backoff = backoff
 
     def fetch(
         self,
@@ -389,6 +427,7 @@ class MetagraphedClient:
             headers=headers,
             timeout=self.timeout,
             retries=self.retries,
+            backoff=self.backoff,
         )
 
     def paginate(
@@ -408,6 +447,7 @@ class MetagraphedClient:
             headers=headers,
             timeout=self.timeout,
             retries=self.retries,
+            backoff=self.backoff,
         )
 
     def rpc(
@@ -419,7 +459,10 @@ class MetagraphedClient:
         headers: Optional[Mapping[str, str]] = None,
         request_id: Any = 1,
     ) -> Any:
-        """Call the read-only RPC proxy and return the JSON-RPC ``result``."""
+        """Call the read-only RPC proxy and return the JSON-RPC ``result``.
+
+        Honors this client's ``retries`` + ``backoff``: RPC reads are retried on
+        transient errors exactly like GETs (see :func:`metagraphed_rpc`)."""
         return metagraphed_rpc(
             network,
             method,
@@ -428,6 +471,8 @@ class MetagraphedClient:
             headers=headers,
             timeout=self.timeout,
             request_id=request_id,
+            retries=self.retries,
+            backoff=self.backoff,
         )
 
     def fetch_all(
@@ -447,6 +492,7 @@ class MetagraphedClient:
             headers=headers,
             timeout=self.timeout,
             retries=self.retries,
+            backoff=self.backoff,
         )
 
     # -- typed convenience methods (the raw-dict path stays via fetch/fetch_all) --

--- a/python/tests/test_aio.py
+++ b/python/tests/test_aio.py
@@ -13,19 +13,29 @@ from metagraphed import AsyncMetagraphedClient, MetagraphedError, Subnet
 
 
 class _FakeAsyncHttp:
-    """Stand-in for ``httpx.AsyncClient``: returns queued responses, records calls."""
+    """Stand-in for ``httpx.AsyncClient``: returns queued responses, records calls.
+
+    A queued item that is an ``Exception`` is raised instead of returned, which
+    lets a test simulate a network failure (``httpx.HTTPError``) on a given call.
+    """
 
     def __init__(self, responses):
         self._responses = list(responses)
         self.calls = []
 
+    def _next(self):
+        item = self._responses.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
     async def get(self, url, params=None, headers=None):
         self.calls.append(("GET", url, params))
-        return self._responses.pop(0)
+        return self._next()
 
     async def post(self, url, json=None, headers=None):
         self.calls.append(("POST", url, json))
-        return self._responses.pop(0)
+        return self._next()
 
     async def aclose(self):
         self.closed = True
@@ -33,8 +43,8 @@ class _FakeAsyncHttp:
 
 @unittest.skipUnless(_HAS_HTTPX, "httpx not installed (metagraphed[async])")
 class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
-    def _client(self, *responses):
-        client = AsyncMetagraphedClient()
+    def _client(self, *responses, **kwargs):
+        client = AsyncMetagraphedClient(**kwargs)
         client._client = _FakeAsyncHttp(responses)
         return client
 
@@ -111,6 +121,43 @@ class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(method, "POST")
         self.assertTrue(url.endswith("/rpc/v1/finney"))
         self.assertEqual(body["method"], "chain_getBlockHash")
+
+    async def test_rpc_retries_transient_error_then_succeeds(self):
+        client = self._client(
+            httpx.Response(503, text="busy"),
+            httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": "0xok"}),
+            retries=1,
+            backoff=0,
+        )
+        out = await client.rpc("finney", "chain_getBlockHash", [0])
+        self.assertEqual(out, "0xok")
+        self.assertEqual(len(client._client.calls), 2)
+        self.assertTrue(all(call[0] == "POST" for call in client._client.calls))
+
+    async def test_rpc_retries_network_error_then_succeeds(self):
+        client = self._client(
+            httpx.ConnectError("connection reset"),
+            httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": "0xok"}),
+            retries=1,
+            backoff=0,
+        )
+        out = await client.rpc("finney", "chain_getBlockHash", [0])
+        self.assertEqual(out, "0xok")
+        self.assertEqual(len(client._client.calls), 2)
+
+    async def test_rpc_retries_exhausted_raises_after_configured_count(self):
+        client = self._client(
+            httpx.Response(503, text="busy"),
+            httpx.Response(503, text="busy"),
+            httpx.Response(503, text="busy"),
+            retries=2,
+            backoff=0,
+        )
+        with self.assertRaises(MetagraphedError) as ctx:
+            await client.rpc("finney", "system_health")
+        # Initial attempt + 2 retries, then it gives up.
+        self.assertEqual(len(client._client.calls), 3)
+        self.assertEqual(ctx.exception.status, 503)
 
     async def test_context_manager_closes_pool(self):
         client = self._client(httpx.Response(200, json={"data": []}))

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -314,6 +314,72 @@ class ClientTest(unittest.TestCase):
                 metagraphed_rpc("finney", "nope")
         self.assertIn("Method not found", str(ctx.exception))
 
+    def test_rpc_retries_transient_error_then_succeeds(self):
+        calls = {"n": 0}
+
+        def fake_urlopen(request, timeout=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise urllib.error.HTTPError(request.full_url, 503, "busy", {}, None)
+            return _FakeResponse({"jsonrpc": "2.0", "id": 1, "result": {"peers": 7}})
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            result = metagraphed_rpc(
+                "finney", "system_health", retries=1, backoff=0
+            )
+
+        self.assertEqual(calls["n"], 2)
+        self.assertEqual(result, {"peers": 7})
+
+    def test_rpc_retries_network_error_then_succeeds(self):
+        calls = {"n": 0}
+
+        def fake_urlopen(request, timeout=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise urllib.error.URLError("connection reset")
+            return _FakeResponse({"jsonrpc": "2.0", "id": 1, "result": "0xabc"})
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            result = metagraphed_rpc(
+                "finney", "chain_getBlockHash", [0], retries=1, backoff=0
+            )
+
+        self.assertEqual(calls["n"], 2)
+        self.assertEqual(result, "0xabc")
+
+    def test_rpc_retries_exhausted_raises_after_configured_count(self):
+        calls = {"n": 0}
+
+        def fake_urlopen(request, timeout=None):
+            calls["n"] += 1
+            raise urllib.error.HTTPError(request.full_url, 503, "busy", {}, None)
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            with self.assertRaises(MetagraphedError) as ctx:
+                metagraphed_rpc("finney", "system_health", retries=2, backoff=0)
+
+        # Initial attempt + 2 retries, then it gives up.
+        self.assertEqual(calls["n"], 3)
+        self.assertEqual(ctx.exception.status, 503)
+
+    def test_client_rpc_forwards_configured_retries_and_backoff(self):
+        calls = {"n": 0}
+
+        def fake_urlopen(request, timeout=None):
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                raise urllib.error.HTTPError(request.full_url, 503, "busy", {}, None)
+            return _FakeResponse({"jsonrpc": "2.0", "id": 1, "result": "ok"})
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            result = MetagraphedClient(retries=2, backoff=0).rpc(
+                "finney", "system_health"
+            )
+
+        self.assertEqual(calls["n"], 3)
+        self.assertEqual(result, "ok")
+
 
 class FetchAllAndModelsTest(unittest.TestCase):
     def _patch_pages(self, pages):

--- a/tests/responses-envelope.test.mjs
+++ b/tests/responses-envelope.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { dataResponse } from "../workers/responses.mjs";
+import { dataResponse, envelopeResponse } from "../workers/responses.mjs";
+import { ifNoneMatchSatisfied } from "../workers/http.mjs";
+
+const reqWith = (ifNoneMatch) =>
+  new Request("https://metagraph.sh/api/v1/anything", {
+    headers: ifNoneMatch == null ? {} : { "if-none-match": ifNoneMatch },
+  });
 
 // Regression guard: the two success builders (dataResponse + envelopeResponse)
 // must emit the identical SuccessEnvelope shape. dataResponse previously added an
@@ -23,4 +29,53 @@ test("dataResponse emits the SuccessEnvelope shape with no error key", async () 
   assert.equal(body.schema_version, 1);
   assert.deepEqual(body.data, { hello: "world" });
   assert.equal(body.meta.source, "test");
+});
+
+// ifNoneMatchSatisfied implements the RFC 7232 §3.2 precondition that backs every
+// 304 short-circuit (live envelopes, raw artifacts, and the edge/overlay caches).
+const ETAG = 'W/"abc123"';
+
+test("ifNoneMatchSatisfied: exact weak-tag echo matches", () => {
+  assert.equal(ifNoneMatchSatisfied(reqWith(ETAG), ETAG), true);
+});
+
+test("ifNoneMatchSatisfied: weak/strong validators compare equal", () => {
+  // If-None-Match uses the weak comparison, so the W/ prefix is ignored.
+  assert.equal(ifNoneMatchSatisfied(reqWith('"abc123"'), ETAG), true);
+  assert.equal(ifNoneMatchSatisfied(reqWith(ETAG), '"abc123"'), true);
+});
+
+test("ifNoneMatchSatisfied: the * form matches any current representation", () => {
+  assert.equal(ifNoneMatchSatisfied(reqWith("*"), ETAG), true);
+  // ...but only when a representation exists (there is a current etag).
+  assert.equal(ifNoneMatchSatisfied(reqWith("*"), null), false);
+});
+
+test("ifNoneMatchSatisfied: matches any tag in a comma-separated list", () => {
+  assert.equal(ifNoneMatchSatisfied(reqWith(`"x", ${ETAG}, "y"`), ETAG), true);
+  assert.equal(ifNoneMatchSatisfied(reqWith('"x", "y"'), ETAG), false);
+});
+
+test("ifNoneMatchSatisfied: no header or no etag is a miss", () => {
+  assert.equal(ifNoneMatchSatisfied(reqWith(null), ETAG), false);
+  assert.equal(ifNoneMatchSatisfied(reqWith(ETAG), null), false);
+});
+
+// envelopeResponse owns the response shape (the helper tests own the match
+// logic): a match is a bodiless 304 keeping the etag; a miss is a 200 with body.
+test("envelopeResponse: a match returns a bodiless 304, a miss returns the body", async () => {
+  const payload = { data: { hello: "world" }, meta: { contract_version: "x" } };
+  const fresh = await envelopeResponse(reqWith(null), payload, "standard");
+  const etag = fresh.headers.get("etag");
+  assert.equal(fresh.status, 200);
+  assert.ok(etag);
+
+  const matched = await envelopeResponse(reqWith(etag), payload, "standard");
+  assert.equal(matched.status, 304);
+  assert.equal(await matched.text(), "");
+  assert.equal(matched.headers.get("etag"), etag);
+
+  const stale = await envelopeResponse(reqWith('"stale"'), payload, "standard");
+  assert.equal(stale.status, 200);
+  assert.equal((await stale.json()).data.hello, "world");
 });

--- a/tests/webhooks-worker.test.mjs
+++ b/tests/webhooks-worker.test.mjs
@@ -236,6 +236,41 @@ describe("SSE change feed", () => {
     assert.equal(event.type, "metagraph.publish");
     assert.ok(Array.isArray(event.affected_netuids));
   });
+
+  test("Last-Event-ID matching the current snapshot short-circuits to a keepalive", async () => {
+    const env = envWith(makeKv());
+    const first = await handleRequest(req("/api/v1/events"), env, {});
+    const firstText = await first.text();
+    assert.equal(first.headers.get("x-metagraph-events"), "snapshot");
+    const idLine = firstText
+      .split("\n")
+      .find((line) => line.startsWith("id: "));
+    const eventId = idLine.slice("id: ".length);
+
+    const reconnect = await handleRequest(
+      req("/api/v1/events", { headers: { "last-event-id": eventId } }),
+      env,
+      {},
+    );
+    assert.equal(reconnect.status, 200);
+    assert.equal(reconnect.headers.get("x-metagraph-events"), "unchanged");
+    const reconnectText = await reconnect.text();
+    // No snapshot frame — just a retry directive and a keepalive comment.
+    assert.doesNotMatch(reconnectText, /event: snapshot/);
+    assert.doesNotMatch(reconnectText, /^data:/m);
+    assert.match(reconnectText, /retry: 300000/);
+    assert.match(reconnectText, /^: /m);
+  });
+
+  test("a stale Last-Event-ID still delivers the snapshot", async () => {
+    const res = await handleRequest(
+      req("/api/v1/events", { headers: { "last-event-id": "stale-id" } }),
+      envWith(makeKv()),
+      {},
+    );
+    assert.equal(res.headers.get("x-metagraph-events"), "snapshot");
+    assert.match(await res.text(), /event: snapshot/);
+  });
 });
 
 describe("webhook route edge cases", () => {

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -594,6 +594,23 @@ describe("Worker runtime", () => {
     assert.equal(cached.status, 304);
     assert.equal(await cached.text(), "");
 
+    // The raw artifact path revalidates too (a separate call site from the
+    // envelope path); `*` matches any current representation.
+    const raw = await handleRequest(
+      new Request("https://metagraph.sh/metagraph/subnets/7.json"),
+      env,
+      {},
+    );
+    const rawConditional = await handleRequest(
+      new Request("https://metagraph.sh/metagraph/subnets/7.json", {
+        headers: { "if-none-match": "*" },
+      }),
+      env,
+      {},
+    );
+    assert.ok(raw.headers.get("etag"));
+    assert.equal(rawConditional.status, 304);
+
     const options = await handleRequest(
       new Request("https://metagraph.sh/api/v1/contracts", {
         method: "OPTIONS",

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -6,7 +6,12 @@ import {
   compileRoutePattern,
 } from "../src/contracts.mjs";
 import { applyQueryFilters } from "./list-query.mjs";
-import { apiHeaders, errorResponse, weakEtag } from "./http.mjs";
+import {
+  apiHeaders,
+  errorResponse,
+  ifNoneMatchSatisfied,
+  weakEtag,
+} from "./http.mjs";
 import {
   d1TimeoutMs,
   latestPointer,
@@ -707,7 +712,7 @@ async function handleRawArtifactRequest(
     headers.set("x-metagraph-published-at", pub);
   }
   headers.set("etag", await weakEtag(body));
-  if (request.headers.get("if-none-match") === headers.get("etag")) {
+  if (ifNoneMatchSatisfied(request, headers.get("etag"))) {
     return new Response(null, { status: 304, headers });
   }
   return new Response(request.method === "HEAD" ? null : body, {
@@ -1046,8 +1051,7 @@ async function handleApiRequest(
       );
       const overlayHit = await overlayCache.match(overlayCacheKey);
       if (overlayHit) {
-        const etag = overlayHit.headers.get("etag");
-        if (etag && request.headers.get("if-none-match") === etag) {
+        if (ifNoneMatchSatisfied(request, overlayHit.headers.get("etag"))) {
           return new Response(null, {
             status: 304,
             headers: overlayHit.headers,
@@ -1062,8 +1066,7 @@ async function handleApiRequest(
     if (hit) {
       // Honour conditional requests against the cached body's weak ETag so
       // polling agents still get a 304 on a warm cache (mirrors envelopeResponse).
-      const etag = hit.headers.get("etag");
-      if (etag && request.headers.get("if-none-match") === etag) {
+      if (ifNoneMatchSatisfied(request, hit.headers.get("etag"))) {
         return new Response(null, { status: 304, headers: hit.headers });
       }
       return hit;
@@ -3199,13 +3202,18 @@ async function handleEventsRequest(request, env) {
   ]);
   const changelog = changelogArtifact.ok ? changelogArtifact.data : null;
   const event = buildChangeEvent({ changelog, pointer });
-  const frame =
-    [
-      "retry: 300000",
-      `id: ${event.published_at || event.generated_at || "0"}`,
-      "event: snapshot",
-      `data: ${JSON.stringify(event)}`,
-    ].join("\n") + "\n\n";
+  const eventId = event.published_at || event.generated_at || "0";
+  // Reconnect replays the last id; if the snapshot hasn't moved, answer with a
+  // bare keepalive instead of re-sending it (a 304 analogue for SSE).
+  const unchanged = request.headers.get("last-event-id") === eventId;
+  const frame = unchanged
+    ? `retry: 300000\n: no new snapshot since ${eventId}\n\n`
+    : [
+        "retry: 300000",
+        `id: ${eventId}`,
+        "event: snapshot",
+        `data: ${JSON.stringify(event)}`,
+      ].join("\n") + "\n\n";
 
   const headers = new Headers();
   headers.set("content-type", "text/event-stream; charset=utf-8");
@@ -3213,6 +3221,7 @@ async function handleEventsRequest(request, env) {
   headers.set("access-control-allow-origin", "*");
   headers.set("x-content-type-options", "nosniff");
   headers.set("x-metagraph-contract-version", contractVersion(env));
+  headers.set("x-metagraph-events", unchanged ? "unchanged" : "snapshot");
   return new Response(frame, { status: 200, headers });
 }
 

--- a/workers/http.mjs
+++ b/workers/http.mjs
@@ -59,3 +59,21 @@ export async function weakEtag(body) {
     .join("");
   return `W/"${hash.slice(0, 32)}"`;
 }
+
+// Strip the optional weak prefix so tags compare by opaque value alone:
+// If-None-Match uses weak comparison, so W/"x" and "x" are equivalent.
+function opaqueTag(tag) {
+  return tag.startsWith("W/") ? tag.slice(2) : tag;
+}
+
+// True when an If-None-Match precondition matches the current `etag` (caller
+// answers 304). Handles `*`, a comma-separated tag list, and weak validators.
+export function ifNoneMatchSatisfied(request, etag) {
+  const header = request.headers.get("if-none-match");
+  if (!header || !etag) return false;
+  const current = opaqueTag(etag);
+  return header
+    .split(",")
+    .map((candidate) => candidate.trim())
+    .some((candidate) => candidate === "*" || opaqueTag(candidate) === current);
+}

--- a/workers/responses.mjs
+++ b/workers/responses.mjs
@@ -4,7 +4,7 @@
 // http + storage leaf modules and the contract version; it calls nothing back
 // into api.mjs, so there is no import cycle.
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
-import { apiHeaders, weakEtag } from "./http.mjs";
+import { apiHeaders, ifNoneMatchSatisfied, weakEtag } from "./http.mjs";
 import { latestPointer } from "./storage.mjs";
 
 export function contractVersion(env) {
@@ -86,7 +86,7 @@ export async function envelopeResponse(request, payload, cacheProfile) {
       payload.meta.stale_contract.built_under,
     );
   }
-  if (request.headers.get("if-none-match") === etag) {
+  if (ifNoneMatchSatisfied(request, etag)) {
     return new Response(null, {
       status: 304,
       headers,


### PR DESCRIPTION
## Summary

- The Python client retried transient failures for GET requests but not for RPC calls, so a client created with `retries=3` still gave up on the first 429, 5xx, or network error from an RPC read. The RPC proxy reads from a live subtensor and is the surface most exposed to transient errors, which made it the least reliable method in the library.
- This routes the RPC path through the same retry and `Retry-After` logic as GETs, treating the read only proxy as idempotent, and threads `backoff` configuration through the sync client so every read honors the policy the caller set.

## What Changed

- Added `retries` and `backoff` parameters to `metagraphed_rpc` and routed it through a shared retry helper, so RPC reads retry on HTTP 429/5xx and network errors with exponential backoff and a capped numeric `Retry-After`.
- Both the sync and async `rpc` methods now forward the client's `retries` and `backoff`, matching what `fetch` already did.
- Added `backoff` to the sync `MetagraphedClient` and threaded it through `fetch`, `paginate`, and `fetch_all`, bringing the sync client to parity with the async one.
- Factored the duplicated request plumbing into shared helpers (`_default_headers`, `_build_request`, `_request_json` / `_send_json`, and `_jsonrpc_result`) so GET and RPC share one retry, header, and parsing path instead of four near copies.
- Documented in the docstrings and the README that RPC reads retry the same way as GETs, and that retries stay opt in (default 0).
- Added sync and async tests covering RPC retry on a 503, retry on a network error, exhaustion after the configured count, and that the client forwards its configured `retries` and `backoff`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. The new `retries` and `backoff` parameters are keyword only and additive, so existing callers are unaffected.

## Validation

Python client change only, so the relevant checks are the package test suite and a static pass. The npm schema, OpenAPI, and worker gates are not applicable because no schemas, contracts, or generated artifacts changed.

```bash
python -m pytest python/tests -q          # 36 passed, 1 skipped
python -m pyflakes python/src/metagraphed python/tests   # clean
```