### PR TITLE
test(http-probe): cover isContentMismatch content-type gating

### DIFF
--- a/tests/http-probe-classification.test.mjs
+++ b/tests/http-probe-classification.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  classifyHttpProbe,
+  isContentMismatch,
+} from "../scripts/http-probe-classification.mjs";
+
+describe("isContentMismatch", () => {
+  test("never a mismatch without a candidate or on a non-ok probe", () => {
+    // No candidate to compare against.
+    assert.equal(
+      isContentMismatch({ ok: true, content_type: "text/html" }, null),
+      false,
+    );
+    // A non-ok probe carries no trustworthy content-type to judge.
+    assert.equal(
+      isContentMismatch(
+        { ok: false, content_type: "text/html" },
+        { kind: "openapi" },
+      ),
+      false,
+    );
+  });
+
+  test("openapi candidates require a JSON content-type", () => {
+    const openapi = { kind: "openapi" };
+    for (const ct of ["application/json", "application/openapi+json", "JSON"]) {
+      assert.equal(
+        isContentMismatch({ ok: true, content_type: ct }, openapi),
+        false,
+        ct,
+      );
+    }
+    for (const ct of ["text/html", "text/plain", "", undefined]) {
+      assert.equal(
+        isContentMismatch({ ok: true, content_type: ct }, openapi),
+        true,
+        String(ct),
+      );
+    }
+  });
+
+  test("subnet-api candidates accept any machine-readable content-type", () => {
+    const api = { kind: "subnet-api" };
+    for (const ct of [
+      "application/json",
+      "text/plain; charset=utf-8",
+      "text/event-stream",
+      "application/octet-stream",
+    ]) {
+      assert.equal(
+        isContentMismatch({ ok: true, content_type: ct }, api),
+        false,
+        ct,
+      );
+    }
+    for (const ct of ["text/html", "image/png", ""]) {
+      assert.equal(
+        isContentMismatch({ ok: true, content_type: ct }, api),
+        true,
+        ct,
+      );
+    }
+  });
+
+  test("sse candidates require an event-stream content-type", () => {
+    const sse = { kind: "sse" };
+    assert.equal(
+      isContentMismatch({ ok: true, content_type: "text/event-stream" }, sse),
+      false,
+    );
+    assert.equal(
+      isContentMismatch({ ok: true, content_type: "application/json" }, sse),
+      true,
+    );
+  });
+
+  test("unscoped kinds (website, docs, …) are never a content mismatch", () => {
+    for (const kind of ["website", "docs", "source-repo", "dashboard"]) {
+      assert.equal(
+        isContentMismatch({ ok: true, content_type: "text/html" }, { kind }),
+        false,
+        kind,
+      );
+    }
+  });
+});
+
+describe("classifyHttpProbe routes content mismatch", () => {
+  test("a live openapi surface serving HTML is content-mismatch, not live", () => {
+    assert.equal(
+      classifyHttpProbe(
+        { ok: true, status_code: 200, content_type: "text/html" },
+        { kind: "openapi" },
+      ),
+      "content-mismatch",
+    );
+    assert.equal(
+      classifyHttpProbe(
+        { ok: true, status_code: 200, content_type: "application/json" },
+        { kind: "openapi" },
+      ),
+      "live",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`isContentMismatch` (scripts/http-probe-classification.mjs) decides whether a 2xx/3xx probe's content-type contradicts the candidate kind:

- `openapi` → must be JSON
- `subnet-api` → must be machine-readable (json / text/plain / event-stream / octet-stream)
- `sse` → must be `text/event-stream`
- other kinds → never a mismatch; and no candidate / a non-ok probe is never a mismatch

It was exported but only exercised indirectly through `classifyHttpProbe`. This adds a direct, table-driven test for each branch (including the missing-content-type edge — an `openapi` surface with no content-type is a mismatch), plus one `classifyHttpProbe` routing case (a live `openapi` surface serving HTML classifies as `content-mismatch`, JSON as `live`).

**Test-only — no source or behavior change, no committed-artifact churn.**

## Checks

- `npx vitest run tests/http-probe-classification.test.mjs` → 6 passed
- prettier + eslint clean
