### PR TITLE
test(artifact-storage): cover isGeneratedPublicArtifactRelativePath

### DIFF
--- a/tests/artifact-storage-paths.test.mjs
+++ b/tests/artifact-storage-paths.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { isGeneratedPublicArtifactRelativePath } from "../src/artifact-storage.mjs";
+
+describe("isGeneratedPublicArtifactRelativePath", () => {
+  test("matches the committed (dual-tier) public artifacts", () => {
+    for (const relativePath of [
+      "api-index.json",
+      "r2-manifest.json",
+      "contracts.json",
+      "openapi.json",
+      "schemas/index.json",
+      "types.d.ts",
+      "operational-surfaces.json",
+    ]) {
+      assert.equal(
+        isGeneratedPublicArtifactRelativePath(relativePath),
+        true,
+        relativePath,
+      );
+    }
+  });
+
+  test("normalizes a leading slash and a /metagraph/ prefix first", () => {
+    assert.equal(isGeneratedPublicArtifactRelativePath("/openapi.json"), true);
+    assert.equal(
+      isGeneratedPublicArtifactRelativePath("/metagraph/openapi.json"),
+      true,
+    );
+    assert.equal(
+      isGeneratedPublicArtifactRelativePath("/metagraph/contracts.json"),
+      true,
+    );
+  });
+
+  test("does not match partial, suffixed, or differently-scoped paths", () => {
+    for (const relativePath of [
+      "xopenapi.json", // not anchored at the start
+      "openapi.jsonx", // not anchored at the end
+      "openapi.json/", // trailing segment
+      "schemas/other.json", // only schemas/index.json is dual
+      "testnet/openapi.json", // secondary-network prefix is not stripped
+      "subnets.json", // an R2/live artifact, not a committed one
+      "",
+    ]) {
+      assert.equal(
+        isGeneratedPublicArtifactRelativePath(relativePath),
+        false,
+        relativePath,
+      );
+    }
+  });
+
+  test("defaults a missing argument to a non-match", () => {
+    assert.equal(isGeneratedPublicArtifactRelativePath(), false);
+  });
+});


### PR DESCRIPTION
## Summary

`isGeneratedPublicArtifactRelativePath` (src/artifact-storage.mjs) flags the committed **dual-tier** public artifacts (api-index.json, r2-manifest.json, contracts.json, openapi.json, schemas/index.json, types.d.ts, operational-surfaces.json) — the ones kept in git *and* R2. It was exported but had no direct test (only `artifactStorageTierForRelativePath` was exercised nearby).

Adds a table-driven test covering: each dual match; the `artifactRelativePath` normalization it relies on (a leading slash and a `/metagraph/` prefix are stripped before matching, so `/metagraph/openapi.json` matches); non-matches for partial/suffixed paths (`xopenapi.json`, `openapi.jsonx`, `openapi.json/`), a non-dual sibling (`schemas/other.json`), a secondary-network path (`testnet/openapi.json`, prefix not stripped), and the default-argument case.

**Test-only — no source or behavior change, no committed-artifact churn.** Expected values were verified against the live function.

## Checks

- `npx vitest run tests/artifact-storage-paths.test.mjs` → 4 passed
- prettier + eslint clean
