### PR TITLE
test(changelog): cover diffSubnets added/removed/renamed

### DIFF
--- a/tests/changelog-diff-subnets.test.mjs
+++ b/tests/changelog-diff-subnets.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { diffSubnets } from "../scripts/changelog.mjs";
+
+describe("diffSubnets", () => {
+  test("classifies added and removed subnets by netuid", () => {
+    const previous = [
+      { netuid: 1, name: "Apex", slug: "apex" },
+      { netuid: 2, name: "Old", slug: "old" },
+    ];
+    const current = [
+      { netuid: 1, name: "Apex", slug: "apex" },
+      { netuid: 3, name: "New", slug: "new" },
+    ];
+    assert.deepEqual(diffSubnets(previous, current), {
+      added: [{ netuid: 3, name: "New", slug: "new" }],
+      removed: [{ netuid: 2, name: "Old", slug: "old" }],
+      renamed: [],
+    });
+  });
+
+  test("reports a rename (same netuid, changed name) with before/after", () => {
+    // slug is unchanged — a rename keys off name, not slug.
+    assert.deepEqual(
+      diffSubnets(
+        [{ netuid: 1, name: "A", slug: "a" }],
+        [{ netuid: 1, name: "B", slug: "a" }],
+      ),
+      {
+        added: [],
+        removed: [],
+        renamed: [{ netuid: 1, before: "A", after: "B" }],
+      },
+    );
+  });
+
+  test("an unchanged subnet is neither added, removed, nor renamed", () => {
+    const same = [{ netuid: 5, name: "Stable", slug: "stable" }];
+    assert.deepEqual(diffSubnets(same, same), {
+      added: [],
+      removed: [],
+      renamed: [],
+    });
+  });
+
+  test("empty inputs produce empty buckets", () => {
+    assert.deepEqual(diffSubnets([], []), {
+      added: [],
+      removed: [],
+      renamed: [],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`diffSubnets` (scripts/changelog.mjs) buckets two subnet snapshots into **added** (netuid only in current), **removed** (only in previous), and **renamed** (same netuid, changed name → `{before, after}`). It drives the changelog but had no test. Adds a table-driven test for each bucket plus the unchanged and empty cases; a rename keys off `name` (not `slug`).

**Test-only — no source/behavior change, no artifact churn.** Expected values verified against the live function.

- `npx vitest run tests/changelog-diff-subnets.test.mjs` → 4 passed
- prettier + eslint clean
