### PR TITLE
fix(prober): backfill NULL economics in daily snapshots (COALESCE DO UPDATE)

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -752,6 +752,13 @@ export async function writeSubnetSnapshot(env, overrides = {}) {
 
   const date = new Date(now()).toISOString().slice(0, 10);
   const capturedAt = now();
+  // The structural columns + captured_at are owned by the first same-day fire.
+  // The economics columns can arrive late (economics.json is pure chain state
+  // with no committed-asset fallback, unlike profiles.json), so DO NOTHING
+  // would freeze a NULL-economics first fire and the 23 later hourly fires could
+  // never backfill it — a permanent gap in the trajectory series. Backfill them
+  // with COALESCE(existing, excluded): a later fire fills a NULL, but a later
+  // NULL can never wipe an earlier fire's good value.
   const stmt = db.prepare(
     `INSERT INTO subnet_snapshots
        (netuid, snapshot_date, completeness_score, surface_count,
@@ -759,7 +766,12 @@ export async function writeSubnetSnapshot(env, overrides = {}) {
         validator_count, miner_count, total_stake_tao, alpha_price_tao,
         emission_share, captured_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT (netuid, snapshot_date) DO NOTHING`,
+     ON CONFLICT (netuid, snapshot_date) DO UPDATE SET
+       validator_count = COALESCE(subnet_snapshots.validator_count, excluded.validator_count),
+       miner_count = COALESCE(subnet_snapshots.miner_count, excluded.miner_count),
+       total_stake_tao = COALESCE(subnet_snapshots.total_stake_tao, excluded.total_stake_tao),
+       alpha_price_tao = COALESCE(subnet_snapshots.alpha_price_tao, excluded.alpha_price_tao),
+       emission_share = COALESCE(subnet_snapshots.emission_share, excluded.emission_share)`,
   );
   const statements = profiles
     .filter((profile) => Number.isInteger(profile.netuid))

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -329,6 +329,46 @@ describe("writeSubnetSnapshot", () => {
     );
     assert.equal(r.reason, "write_failed");
   });
+  test("backfills NULL economics via COALESCE DO UPDATE, not DO NOTHING", async () => {
+    let captured = "";
+    const db = {
+      prepare(sql) {
+        captured = sql;
+        return { bind: () => ({}) };
+      },
+      batch: (s) => Promise.resolve(s.map(() => ({}))),
+    };
+    await writeSubnetSnapshot(
+      {},
+      { db, readArtifact: reader(profiles), now: () => Date.UTC(2026, 5, 10) },
+    );
+    // A later same-day fire backfills economics rather than freezing the row.
+    assert.match(
+      captured,
+      /ON CONFLICT \(netuid, snapshot_date\) DO UPDATE SET/,
+    );
+    assert.doesNotMatch(captured, /DO NOTHING/);
+    // Each economics column is COALESCE(existing, excluded): fills a NULL, but a
+    // later NULL can never wipe an earlier fire's good value.
+    for (const col of [
+      "validator_count",
+      "miner_count",
+      "total_stake_tao",
+      "alpha_price_tao",
+      "emission_share",
+    ]) {
+      assert.match(
+        captured,
+        new RegExp(
+          `${col} = COALESCE\\(subnet_snapshots\\.${col}, excluded\\.${col}\\)`,
+        ),
+      );
+    }
+    // Structural columns + captured_at stay owned by the first fire (not in SET).
+    for (const col of ["completeness_score", "surface_count", "captured_at"]) {
+      assert.doesNotMatch(captured, new RegExp(`${col}\\s*=`));
+    }
+  });
 });
 
 // --- Worker dispatch (cold D1 -> empty-valid; fake D1 -> with data) ----------


### PR DESCRIPTION
## What

`writeSubnetSnapshot` writes one `subnet_snapshots` row per subnet per UTC day with `ON CONFLICT (netuid, snapshot_date) DO NOTHING` — so the **first** successful same-day fire wins and freezes the row for 24h (it runs hourly, `HEALTH_PRUNE_CRON "0 * * * *"`).

The economics columns (`validator_count`, `miner_count`, `total_stake_tao`, `alpha_price_tao`, `emission_share`, added in #1307/#1308) can arrive **late**: `economics.json` is pure chain state with no committed-asset fallback, whereas `profiles.json` has one. If the first fire of a day reads profiles but economics is transiently unavailable, the row commits with **NULL economics** — and the 23 later hourly fires can never backfill it. The result is a permanent NULL gap for that subnet/day, breaking the 7d/30d economic series on `/api/v1/subnets/{netuid}/trajectory`.

## Fix (one line of behavior)

`DO NOTHING` → `DO UPDATE SET <economics col> = COALESCE(subnet_snapshots.<col>, excluded.<col>)` for the five economics columns only.

- `COALESCE(existing, excluded)` is the key: a later fire fills a `NULL`, but a later `NULL`-economics fire can **never wipe** an earlier fire's good value (the inverse bug).
- Structural columns + `captured_at` are **not** in the `SET`, so they stay owned by the first fire (the row's identity is stable).
- Legitimate `0` values survive — bind uses `?? null`, so `0` is stored as `0`, not `NULL`.

This mirrors the `DO UPDATE SET … = excluded.…` shape the `surface_status` rollup already uses in the same file.

## Validation

- New test asserts the upsert uses `DO UPDATE SET` (not `DO NOTHING`), each economics column is `COALESCE(existing, excluded)`, and structural columns / `captured_at` are absent from the `SET` (matches the repo's `prepare(sql)` shape-test pattern, e.g. `health-prober.test.mjs:440`)
- `tests/analytics.test.mjs` + `tests/health-prober.test.mjs` — **98 pass**; full suite **1323/1323**
- **100% patch coverage**, `npm run lint` + Prettier clean