### PR TITLE
feat(explorer): chain-direct event poller + account_events D1 tier (#1346)

### DIFF
--- a/.github/workflows/refresh-events.yml
+++ b/.github/workflows/refresh-events.yml
@@ -34,11 +34,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # No `cache: npm` here on purpose: this workflow holds Cloudflare secrets, so
+      # we don't consume a shared npm cache another workflow could poison.
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22.22.3
-          cache: npm
 
       - name: Setup uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
@@ -46,8 +47,11 @@ jobs:
       - name: Install
         run: npm ci
 
+      # substrate-interface is PINNED to an exact, verified version: this step runs
+      # with Cloudflare secrets in scope, so we never auto-pull a future (possibly
+      # compromised) release from PyPI. Bump deliberately after re-verifying.
       - name: Poll finney events (first-party, public RPC, no key)
-        run: uv run --with substrate-interface python scripts/fetch-events.py
+        run: uv run --with substrate-interface==1.8.1 python scripts/fetch-events.py
         env:
           EVENTS_WINDOW: "250"
 

--- a/.github/workflows/refresh-events.yml
+++ b/.github/workflows/refresh-events.yml
@@ -1,0 +1,69 @@
+name: Refresh Chain Events (first-party poller)
+
+# Decodes recent finney chain events FIRST-PARTY — substrate System.Events over
+# PUBLIC RPC, no API key, NOT Taostats (#1346, epic #1345) — and stages them to
+# R2; the Worker's scheduled handler then bulk-loads them into the
+# metagraphed-health D1 `account_events` table through its binding
+# (loadStagedEvents), no API-token D1 permission required. Powers
+# /api/v1/accounts/{ss58} + history (#1347).
+#
+# Rolling recent-block window + idempotent load (INSERT OR IGNORE on
+# (block_number, event_index)), so frequent overlapping runs need no cursor and
+# self-heal small gaps. Live-forward only: public nodes prune ~300 blocks, so this
+# runs often to stay inside that window; deep history is the optional archive-RPC
+# upgrade (#1349). No new secret — uses the existing CLOUDFLARE_* R2 permission.
+on:
+  schedule:
+    - cron: "*/20 * * * *" # every 20 min — stays within the node's block retention
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: refresh-events
+  cancel-in-progress: false
+
+jobs:
+  poll:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22.22.3
+          cache: npm
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+
+      - name: Install
+        run: npm ci
+
+      - name: Poll finney events (first-party, public RPC, no key)
+        run: uv run --with substrate-interface python scripts/fetch-events.py
+        env:
+          EVENTS_WINDOW: "250"
+
+      # Stage to R2 (the token's existing R2 permission); the Worker loads it into
+      # D1 through its binding (loadStagedEvents) — no API-token D1 permission.
+      - name: Stage events to R2 for the Worker to load into D1
+        run: npx wrangler r2 object put metagraphed-artifacts/events/account-events-pending.json --file=dist/account-events.json --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Notify on failure
+        if: failure() && env.METAGRAPH_ALERT_WEBHOOK_URL != ''
+        env:
+          METAGRAPH_ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}
+        run: |
+          curl -fsS -X POST "$METAGRAPH_ALERT_WEBHOOK_URL" \
+            -H 'content-type: application/json' \
+            -d '{"content":"🔴 metagraphed refresh-events FAILED — chain-event index may go stale."}' || true

--- a/migrations/0009_account_events.sql
+++ b/migrations/0009_account_events.sql
@@ -1,0 +1,48 @@
+-- Chain-event index (#1346, epic #1345): first-party per-entity activity decoded
+-- DIRECTLY from finney (substrate System.Events), NOT Taostats. The chain-direct
+-- event poller (scripts/fetch-events.py) runs in CI over a rolling window of
+-- recent FINALIZED blocks, stages rows to R2, and the Worker loads them here via
+-- its D1 binding (loadStagedEvents) with PARAMETERIZED INSERT OR IGNORE keyed
+-- (block_number, event_index) — so overlapping windows re-insert harmlessly
+-- (idempotent) and the poller needs no cursor. Powers /api/v1/accounts/{ss58}
+-- + history (#1347).
+--
+-- Units: amount_tao = event tao field / 1e9 (matches neurons.stake_tao). netuid/
+-- uid as-is. observed_at = block timestamp (epoch ms, matches neurons.captured_at).
+
+CREATE TABLE IF NOT EXISTS account_events (
+  block_number INTEGER NOT NULL,
+  event_index  INTEGER NOT NULL,            -- position within the block's events
+  event_kind   TEXT    NOT NULL,            -- SubtensorModule event id
+  hotkey       TEXT,
+  coldkey      TEXT,
+  netuid       INTEGER,
+  uid          INTEGER,
+  amount_tao   REAL,                        -- tao field / 1e9 where applicable
+  observed_at  INTEGER NOT NULL,            -- block timestamp, epoch ms
+  PRIMARY KEY (block_number, event_index)
+);
+
+-- Per-entity history ("everything this hotkey/coldkey did"), newest-first.
+CREATE INDEX IF NOT EXISTS idx_account_events_hotkey  ON account_events (hotkey, block_number);
+CREATE INDEX IF NOT EXISTS idx_account_events_coldkey ON account_events (coldkey, block_number);
+-- Per-subnet event stream + the daily-rollup scan.
+CREATE INDEX IF NOT EXISTS idx_account_events_netuid  ON account_events (netuid, block_number);
+CREATE INDEX IF NOT EXISTS idx_account_events_observed ON account_events (observed_at);
+
+-- Durable daily rollup per (hotkey, netuid, day): the hot account_events window is
+-- pruned (90d) but this is retained indefinitely so long-term per-entity history
+-- survives (mirrors surface_uptime_daily). Rolled by the hourly cron before prune.
+CREATE TABLE IF NOT EXISTS account_events_daily (
+  hotkey      TEXT    NOT NULL,
+  netuid      INTEGER NOT NULL,
+  day         TEXT    NOT NULL,             -- UTC date, YYYY-MM-DD
+  event_count INTEGER NOT NULL,
+  event_kinds TEXT,                         -- comma-separated distinct kinds
+  first_block INTEGER,
+  last_block  INTEGER,
+  updated_at  INTEGER NOT NULL,             -- epoch ms of the last rollup write
+  PRIMARY KEY (hotkey, netuid, day)
+);
+CREATE INDEX IF NOT EXISTS idx_account_events_daily_netuid_day
+  ON account_events_daily (netuid, day);

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Chain-direct event poller (#1346, epic #1345) — FIRST-PARTY, not Taostats.
+
+Decodes SubtensorModule events from a rolling window of recent FINALIZED finney
+blocks via substrate-interface against PUBLIC RPC (no API key), normalizes the
+entity-relevant ones to `account_events` rows, and writes JSON to
+dist/account-events.json. The refresh-events workflow stages that to R2; the
+Worker's loadStagedEvents bulk-loads it into D1 with INSERT OR IGNORE keyed
+(block_number, event_index) — idempotent, so overlapping windows need no cursor.
+
+Run:  uv run --with substrate-interface python scripts/fetch-events.py
+Env:  EVENTS_RPC_URL        public finney WS endpoint (default below)
+      EVENTS_WINDOW         blocks back from the finalized head (default 256)
+      ACCOUNT_EVENTS_JSON   output path (default dist/account-events.json)
+
+Positional attribute order verified against live finney (2026-06-21); see
+src/account-events.mjs INDEXED_EVENT_KINDS for the loaded set. Extractors are
+defensive: a shape that doesn't match (e.g. after a runtime upgrade) yields a
+skipped event, never a corrupt row.
+"""
+import json
+import os
+import sys
+
+from substrateinterface import SubstrateInterface
+
+RAO = 1e9
+BLOCK_MS = 12000  # finney ~12s block time; observed_at derived from height
+DEFAULT_RPC = "wss://entrypoint-finney.opentensor.ai:443"
+WINDOW = int(os.environ.get("EVENTS_WINDOW", "256"))
+OUT = os.environ.get("ACCOUNT_EVENTS_JSON", "dist/account-events.json")
+
+
+def _ss58(v):
+    return v if isinstance(v, str) and v.startswith("5") else None
+
+
+def _idx(v):
+    return v if isinstance(v, int) and 0 <= v <= 65535 else None
+
+
+def _tao(v):
+    return (v / RAO) if isinstance(v, (int, float)) and v >= 0 else None
+
+
+# Each extractor maps a decoded attribute tuple -> the entity fields we store.
+def _stake(a):  # [coldkey, hotkey, tao_rao, alpha_rao, netuid, ...]
+    return {
+        "coldkey": _ss58(a[0]),
+        "hotkey": _ss58(a[1]),
+        "amount_tao": _tao(a[2]),
+        "netuid": _idx(a[4]) if len(a) > 4 else None,
+    }
+
+
+def _registered(a):  # [netuid, uid, hotkey]
+    return {"netuid": _idx(a[0]), "uid": _idx(a[1]), "hotkey": _ss58(a[2])}
+
+
+def _axon(a):  # [netuid, hotkey]
+    return {"netuid": _idx(a[0]), "hotkey": _ss58(a[1])}
+
+
+def _weights(a):  # [netuid, uid]  (no hotkey; resolvable via the neurons table)
+    return {"netuid": _idx(a[0]), "uid": _idx(a[1])}
+
+
+def _moved(a):  # [coldkey, hotkey, netuid, ...]
+    return {
+        "coldkey": _ss58(a[0]),
+        "hotkey": _ss58(a[1]),
+        "netuid": _idx(a[2]) if len(a) > 2 else None,
+    }
+
+
+def _root(a):  # {coldkey} (named) or [coldkey]
+    ck = a.get("coldkey") if isinstance(a, dict) else (a[0] if a else None)
+    return {"coldkey": _ss58(ck)}
+
+
+EXTRACTORS = {
+    "NeuronRegistered": _registered,
+    "StakeAdded": _stake,
+    "StakeRemoved": _stake,
+    "StakeMoved": _moved,
+    "AxonServed": _axon,
+    "WeightsSet": _weights,
+    "RootClaimed": _root,
+}
+
+
+def extract(event_id, attrs):
+    fn = EXTRACTORS.get(event_id)
+    if not fn:
+        return None
+    try:
+        f = fn(attrs)
+    except Exception:
+        return None  # shape drift → skip, never corrupt
+    return {
+        "hotkey": f.get("hotkey"),
+        "coldkey": f.get("coldkey"),
+        "netuid": f.get("netuid"),
+        "uid": f.get("uid"),
+        "amount_tao": f.get("amount_tao"),
+    }
+
+
+def main():
+    url = os.environ.get("EVENTS_RPC_URL", DEFAULT_RPC)
+    s = SubstrateInterface(url=url)
+    head = s.get_chain_finalised_head()
+    head_bn = s.get_block_header(block_hash=head)["header"]["number"]
+    try:
+        head_ts = int(s.query("Timestamp", "Now", block_hash=head).value)
+    except Exception:
+        head_ts = None
+    start = max(0, head_bn - WINDOW + 1)
+
+    rows = []
+    scanned = 0
+    skipped = 0
+    for bn in range(start, head_bn + 1):
+        observed_at = head_ts - (head_bn - bn) * BLOCK_MS if head_ts else None
+        try:
+            bh = s.get_block_hash(bn)
+            events = s.query("System", "Events", block_hash=bh)
+        except Exception as e:  # pruned/transient → skip this block, keep going
+            skipped += 1
+            sys.stderr.write(f"block {bn}: skip ({repr(e)[:80]})\n")
+            continue
+        scanned += 1
+        for event_index, ev in enumerate(events):
+            v = ev.value if isinstance(ev.value, dict) else {}
+            e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
+            if e.get("module_id") != "SubtensorModule":
+                continue
+            eid = e.get("event_id")
+            ent = extract(eid, e.get("attributes"))
+            if ent is None:
+                continue
+            rows.append(
+                {
+                    "block_number": bn,
+                    "event_index": event_index,
+                    "event_kind": eid,
+                    "hotkey": ent["hotkey"],
+                    "coldkey": ent["coldkey"],
+                    "netuid": ent["netuid"],
+                    "uid": ent["uid"],
+                    "amount_tao": ent["amount_tao"],
+                    "observed_at": observed_at,
+                }
+            )
+
+    os.makedirs(os.path.dirname(OUT) or ".", exist_ok=True)
+    with open(OUT, "w") as fh:
+        json.dump(rows, fh)
+    sys.stderr.write(
+        f"wrote {len(rows)} events from blocks {start}..{head_bn} "
+        f"(scanned {scanned}, skipped {skipped}) -> {OUT}\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -1,0 +1,131 @@
+// Chain-event index (#1346, epic #1345): the D1 `account_events` tier — first-party
+// per-entity activity decoded DIRECTLY from finney by scripts/fetch-events.py
+// (substrate System.Events), NOT Taostats. This module holds the load contract,
+// the daily rollup + prune (retention), and the row→API shaping (#1347). Pure +
+// exported for tests; the Worker runs the D1 I/O.
+
+// Hot window for raw events; rolled into account_events_daily before prune so
+// long-term per-entity history survives (mirrors the 30d surface_checks window).
+export const EVENT_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+
+// Columns written to account_events — THE load contract. scripts/fetch-events.py
+// emits rows with exactly these keys; loadStagedEvents binds them in this order.
+// Values are always bound, never interpolated into SQL.
+export const EVENT_INSERT_COLUMNS = [
+  "block_number",
+  "event_index",
+  "event_kind",
+  "hotkey",
+  "coldkey",
+  "netuid",
+  "uid",
+  "amount_tao",
+  "observed_at",
+];
+
+// The SubtensorModule events the poller indexes — entity-relevant only, which
+// keeps volume ~1 MB/day (not ~100 MB/day). Kept in sync with fetch-events.py
+// EXTRACTORS; positional field order verified against live finney (2026-06-21).
+export const INDEXED_EVENT_KINDS = [
+  "NeuronRegistered",
+  "StakeAdded",
+  "StakeRemoved",
+  "StakeMoved",
+  "AxonServed",
+  "WeightsSet",
+  "RootClaimed",
+];
+
+function toIso(ms) {
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+}
+
+// One D1 account_events row → a clean API event object (#1347 consumes this).
+export function formatAccountEvent(row) {
+  if (!row || typeof row !== "object") return null;
+  return {
+    block_number: row.block_number ?? null,
+    event_index: row.event_index ?? null,
+    event_kind: row.event_kind ?? null,
+    hotkey: row.hotkey ?? null,
+    coldkey: row.coldkey ?? null,
+    netuid: row.netuid ?? null,
+    uid: row.uid ?? null,
+    amount_tao: row.amount_tao ?? null,
+    observed_at: toIso(row.observed_at),
+  };
+}
+
+// UTC-day bounds for the timestamp `ms`: { date: 'YYYY-MM-DD', start, end } in
+// epoch ms. The rollup re-rolls the two active days each hour (past days are
+// already finalized + unchanged), keyed by these bounds.
+export function utcDayBounds(ms) {
+  const d = new Date(ms);
+  const start = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  return {
+    date: new Date(start).toISOString().slice(0, 10),
+    start,
+    end: start + 24 * 60 * 60 * 1000,
+  };
+}
+
+// Roll the raw account_events for the two active UTC days into the durable
+// per-(hotkey, netuid, day) summary, BEFORE the hot window is pruned. Upsert keeps
+// it idempotent; only hotkey-attributed events roll up (coldkey-only events like
+// RootClaimed stay queryable in the hot window). No-ops when D1 is cold.
+export async function rollupAccountEventsDaily(env, overrides = {}) {
+  const now = overrides.now || (() => Date.now());
+  const db = overrides.db || env.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) return { rolled: false };
+  const runAt = now();
+  const days = [utcDayBounds(runAt), utcDayBounds(runAt - 24 * 60 * 60 * 1000)];
+  const stmt = db.prepare(
+    `INSERT INTO account_events_daily
+       (hotkey, netuid, day, event_count, event_kinds, first_block, last_block, updated_at)
+     SELECT
+       hotkey,
+       netuid,
+       ? AS day,
+       COUNT(*) AS event_count,
+       GROUP_CONCAT(DISTINCT event_kind) AS event_kinds,
+       MIN(block_number) AS first_block,
+       MAX(block_number) AS last_block,
+       ? AS updated_at
+     FROM account_events
+     WHERE hotkey IS NOT NULL AND netuid IS NOT NULL
+       AND observed_at >= ? AND observed_at < ?
+     GROUP BY hotkey, netuid
+     ON CONFLICT(hotkey, netuid, day) DO UPDATE SET
+       event_count = excluded.event_count,
+       event_kinds = excluded.event_kinds,
+       first_block = excluded.first_block,
+       last_block = excluded.last_block,
+       updated_at = excluded.updated_at`,
+  );
+  try {
+    await db.batch(
+      days.map(({ date, start, end }) => stmt.bind(date, runAt, start, end)),
+    );
+    return { rolled: true, days: days.map((d) => d.date) };
+  } catch {
+    return { rolled: false };
+  }
+}
+
+// Hourly maintenance: prune raw events older than the retention window so the hot
+// table stays lean (the daily rollup preserves the long-term history).
+export async function pruneAccountEvents(env, overrides = {}) {
+  const now = overrides.now || (() => Date.now());
+  const db = overrides.db || env.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) return { pruned: false };
+  const cutoff = now() - (overrides.retentionMs || EVENT_RETENTION_MS);
+  try {
+    const result = await db
+      .prepare(`DELETE FROM account_events WHERE observed_at < ?`)
+      .bind(cutoff)
+      .run();
+    return { pruned: true, cutoff, changes: result?.meta?.changes ?? null };
+  } catch {
+    return { pruned: false };
+  }
+}

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  EVENT_INSERT_COLUMNS,
+  INDEXED_EVENT_KINDS,
+  EVENT_RETENTION_MS,
+  formatAccountEvent,
+  utcDayBounds,
+  rollupAccountEventsDaily,
+  pruneAccountEvents,
+} from "../src/account-events.mjs";
+
+test("EVENT_INSERT_COLUMNS is the stable load contract (#1346)", () => {
+  assert.deepEqual(EVENT_INSERT_COLUMNS, [
+    "block_number",
+    "event_index",
+    "event_kind",
+    "hotkey",
+    "coldkey",
+    "netuid",
+    "uid",
+    "amount_tao",
+    "observed_at",
+  ]);
+});
+
+test("INDEXED_EVENT_KINDS covers the core entity events", () => {
+  for (const k of [
+    "NeuronRegistered",
+    "StakeAdded",
+    "StakeRemoved",
+    "WeightsSet",
+    "AxonServed",
+  ]) {
+    assert.ok(INDEXED_EVENT_KINDS.includes(k), `missing ${k}`);
+  }
+});
+
+test("formatAccountEvent maps a D1 row to an API event (ISO time)", () => {
+  const out = formatAccountEvent({
+    block_number: 1000,
+    event_index: 3,
+    event_kind: "StakeAdded",
+    hotkey: "5Hk",
+    coldkey: "5Co",
+    netuid: 1,
+    uid: null,
+    amount_tao: 12.5,
+    observed_at: 1750000000000,
+  });
+  assert.equal(out.event_kind, "StakeAdded");
+  assert.equal(out.amount_tao, 12.5);
+  assert.equal(out.observed_at, new Date(1750000000000).toISOString());
+});
+
+test("formatAccountEvent is null-safe on junk + sparse rows", () => {
+  assert.equal(formatAccountEvent(null), null);
+  assert.equal(formatAccountEvent("x"), null);
+  const out = formatAccountEvent({ block_number: 1 });
+  assert.equal(out.hotkey, null);
+  assert.equal(out.observed_at, null);
+});
+
+test("utcDayBounds returns the UTC day window", () => {
+  const b = utcDayBounds(Date.UTC(2026, 5, 21, 14, 30, 0));
+  assert.equal(b.date, "2026-06-21");
+  assert.equal(b.start, Date.UTC(2026, 5, 21));
+  assert.equal(b.end - b.start, 86400000);
+});
+
+test("rollupAccountEventsDaily rolls today + yesterday via upsert", async () => {
+  const binds = [];
+  const env = {
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind: (...v) => {
+            binds.push(v);
+            return { sql, v };
+          },
+        };
+      },
+      async batch(stmts) {
+        return stmts;
+      },
+    },
+  };
+  const r = await rollupAccountEventsDaily(env, {
+    now: () => Date.UTC(2026, 5, 21, 12),
+  });
+  assert.equal(r.rolled, true);
+  assert.deepEqual(r.days, ["2026-06-21", "2026-06-20"]);
+  assert.equal(binds.length, 2);
+});
+
+test("rollupAccountEventsDaily no-ops without D1", async () => {
+  assert.equal((await rollupAccountEventsDaily({})).rolled, false);
+});
+
+test("pruneAccountEvents deletes below the retention cutoff", async () => {
+  let boundCutoff;
+  const env = {
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        return {
+          bind: (c) => {
+            boundCutoff = c;
+            return { run: async () => ({ meta: { changes: 7 } }) };
+          },
+        };
+      },
+    },
+  };
+  const now = 1_800_000_000_000;
+  const r = await pruneAccountEvents(env, { now: () => now });
+  assert.equal(r.pruned, true);
+  assert.equal(r.changes, 7);
+  assert.equal(boundCutoff, now - EVENT_RETENTION_MS);
+});
+
+test("pruneAccountEvents no-ops without D1", async () => {
+  assert.equal((await pruneAccountEvents({})).pruned, false);
+});
+
+test("rollupAccountEventsDaily returns rolled:false when D1 throws", async () => {
+  const env = {
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        return { bind: () => ({}) };
+      },
+      async batch() {
+        throw new Error("d1 down");
+      },
+    },
+  };
+  assert.equal(
+    (await rollupAccountEventsDaily(env, { now: () => 0 })).rolled,
+    false,
+  );
+});
+
+test("pruneAccountEvents returns pruned:false when D1 throws", async () => {
+  const env = {
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        return {
+          bind: () => ({
+            run: async () => {
+              throw new Error("d1 down");
+            },
+          }),
+        };
+      },
+    },
+  };
+  assert.equal((await pruneAccountEvents(env, { now: () => 0 })).pruned, false);
+});

--- a/tests/load-staged-events.test.mjs
+++ b/tests/load-staged-events.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { loadStagedEvents } from "../workers/api.mjs";
+
+function eventRow(block_number, event_index) {
+  return {
+    block_number,
+    event_index,
+    event_kind: "StakeAdded",
+    hotkey: `5Hk${event_index}`,
+    coldkey: `5Co${event_index}`,
+    netuid: 1,
+    uid: null,
+    amount_tao: 12.5,
+    observed_at: 1750000000000,
+  };
+}
+
+function mockEnv({
+  rows,
+  bad = false,
+  getCalls = [],
+  deleted = [],
+  prepared = [],
+  batches = [],
+}) {
+  return {
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key) {
+          getCalls.push(key);
+          if (rows == null) return null;
+          return {
+            async json() {
+              if (bad) throw new Error("bad json");
+              return rows;
+            },
+          };
+        },
+        async delete(key) {
+          deleted.push(key);
+        },
+      },
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          prepared.push(sql);
+          return { bind: (...v) => ({ sql, v }) };
+        },
+        async batch(stmts) {
+          batches.push(stmts.length);
+        },
+      },
+    },
+    getCalls,
+    deleted,
+    prepared,
+    batches,
+  };
+}
+
+test("loadStagedEvents loads JSON via parameterized batches + deletes it (#1346)", async () => {
+  const rows = Array.from({ length: 12 }, (_, i) => eventRow(1000 + i, i));
+  const m = mockEnv({ rows });
+  const r = await loadStagedEvents(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.rows, 12);
+  assert.deepEqual(m.getCalls, ["events/account-events-pending.json"]);
+  // 12 rows / 10 per statement = 2 statements, one batch (<=50).
+  assert.deepEqual(m.batches, [2]);
+  // Idempotent + parameterized: INSERT OR IGNORE keyed (block,index), values bound.
+  assert.ok(m.prepared[0].startsWith("INSERT OR IGNORE INTO account_events ("));
+  assert.ok(m.prepared[0].includes("VALUES (?"));
+  assert.ok(
+    !m.prepared.some((s) => s.includes("5Hk")),
+    "row values must never appear in the SQL text",
+  );
+  assert.deepEqual(m.deleted, ["events/account-events-pending.json"]);
+});
+
+test("loadStagedEvents no-ops when nothing is staged", async () => {
+  const m = mockEnv({ rows: null });
+  const r = await loadStagedEvents(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "none");
+  assert.equal(m.batches.length, 0);
+  assert.equal(m.deleted.length, 0);
+});
+
+test("loadStagedEvents deletes + bails on unparseable JSON", async () => {
+  const m = mockEnv({ rows: [], bad: true });
+  const r = await loadStagedEvents(m.env);
+  assert.equal(r.reason, "parse_failed");
+  assert.deepEqual(m.deleted, ["events/account-events-pending.json"]);
+});
+
+test("loadStagedEvents drops rows lacking the (block, index) key", async () => {
+  const m = mockEnv({ rows: [{ event_kind: "X" }] }); // no block_number/event_index
+  const r = await loadStagedEvents(m.env);
+  assert.equal(r.reason, "empty");
+  assert.equal(m.batches.length, 0);
+  assert.deepEqual(m.deleted, ["events/account-events-pending.json"]);
+});
+
+test("loadStagedEvents is a safe no-op without bindings", async () => {
+  const r = await loadStagedEvents({});
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "unavailable");
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -92,6 +92,11 @@ import {
   buildSubnetValidators,
   buildNeuronDetail,
 } from "../src/metagraph-neurons.mjs";
+import {
+  EVENT_INSERT_COLUMNS,
+  rollupAccountEventsDaily,
+  pruneAccountEvents,
+} from "../src/account-events.mjs";
 import { handleMcpRequest } from "../src/mcp-server.mjs";
 import { handleFeedRequest } from "../src/feeds.mjs";
 import { handleBadgeRequest } from "../src/badge.mjs";
@@ -273,6 +278,64 @@ export async function loadStagedNeurons(env) {
   return { ok: true, rows: rows.length };
 }
 
+// Load a staged chain-event batch from R2 into D1 (#1346, epic #1345). The
+// refresh-events CI job decodes finney's System.Events first-party (no Taostats)
+// and writes account_events rows as JSON to R2 (events/account-events-pending.json)
+// with its existing R2 permission; we load them here through the binding (no
+// API-token D1 permission) with PARAMETERIZED INSERT OR IGNORE keyed
+// (block_number, event_index) — so overlapping poller windows re-insert harmlessly
+// (idempotent, no cursor needed) and a tampered file can only fail, never inject.
+// Then delete the object so each batch loads once.
+export async function loadStagedEvents(env) {
+  const bucket = env.METAGRAPH_ARCHIVE;
+  const db = env.METAGRAPH_HEALTH_DB;
+  if (!bucket?.get || !db?.prepare) return { ok: false, reason: "unavailable" };
+  const key = "events/account-events-pending.json";
+  const object = await bucket.get(key);
+  if (!object) return { ok: false, reason: "none" };
+  let rows;
+  try {
+    rows = await object.json();
+  } catch {
+    await bucket.delete(key);
+    return { ok: false, reason: "parse_failed" };
+  }
+  rows = Array.isArray(rows)
+    ? rows.filter(
+        (r) =>
+          Number.isInteger(r?.block_number) && Number.isInteger(r?.event_index),
+      )
+    : [];
+  if (!rows.length) {
+    await bucket.delete(key);
+    return { ok: false, reason: "empty" };
+  }
+  const cols = EVENT_INSERT_COLUMNS;
+  const colList = cols.join(",");
+  const ROWS_PER_STMT = 10; // 9 cols x 10 = 90 bound params (< D1's 100 limit)
+  const STMTS_PER_BATCH = 50;
+  const statements = [];
+  for (let i = 0; i < rows.length; i += ROWS_PER_STMT) {
+    const chunk = rows.slice(i, i + ROWS_PER_STMT);
+    const tuples = chunk
+      .map(() => `(${cols.map(() => "?").join(",")})`)
+      .join(",");
+    const values = chunk.flatMap((row) => cols.map((c) => row[c] ?? null));
+    statements.push(
+      db
+        .prepare(
+          `INSERT OR IGNORE INTO account_events (${colList}) VALUES ${tuples}`,
+        )
+        .bind(...values),
+    );
+  }
+  for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
+    await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
+  }
+  await bucket.delete(key);
+  return { ok: true, rows: rows.length };
+}
+
 // Cron entrypoint. Cloudflare passes the exact cron string that fired in
 // `controller.cron`; the hourly trigger prunes the time-series, every other
 // trigger (the 15-minute one) runs a full operational-health probe sweep.
@@ -283,13 +346,20 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
   // snapshot and load it via the D1 binding on whichever cron fires next; it then
   // self-deletes. Isolated so a load failure never affects the prober/prune below.
   await loadStagedNeurons(env).catch(() => {});
+  // Token-free chain-event load (#1346): pick up any R2-staged event batch from
+  // the first-party poller and load it via the binding. Isolated like the neuron
+  // load so a failure never affects the prober/prune below.
+  await loadStagedEvents(env).catch(() => {});
   if (cron === HEALTH_PRUNE_CRON) {
     // Roll the day's raw checks into the durable daily uptime table BEFORE
     // pruning, so long-term history is never lost when 30-day raw rows are
-    // deleted (PR3). Then prune + snapshot.
+    // deleted (PR3). Roll the chain events the same way (#1346) before their
+    // 90-day window is pruned. Then prune + snapshot.
     await rollupDailyUptime(env);
+    await rollupAccountEventsDaily(env).catch(() => {});
     const [pruned] = await Promise.all([
       pruneHealthHistory(env),
+      pruneAccountEvents(env).catch(() => ({ pruned: false })),
       writeSubnetSnapshot(env, { readArtifact }),
     ]);
     return pruned;


### PR DESCRIPTION
Closes #1346. Foundation of the developer block explorer (epic #1345).

## What this is
The **first-party chain-event index** — the keystone of the explorer. It decodes Bittensor's `System.Events` **directly from finney** (substrate-interface over **public RPC, no API key, NOT Taostats**), and lands per-entity activity (registrations, stake, weights, axon) in a new D1 tier.

## Architecture (reuses the proven #1303 token-free pattern)
1. **`scripts/fetch-events.py`** — polls a rolling window of recent finalized blocks, decodes the entity-relevant `SubtensorModule` events, normalizes to `account_events` rows, writes JSON.
2. **`refresh-events.yml`** (cron every 20 min) — runs the poller via `uv` + stages the JSON to R2 (existing R2 permission; **no new secret**).
3. **`loadStagedEvents`** (Worker, `handleScheduled`) — loads the batch into D1 through the binding (**no API-token D1 permission**), parameterized `INSERT OR IGNORE` keyed `(block_number, event_index)` → overlapping windows are **idempotent, no cursor needed**.
4. **Rollup + prune** — daily `(hotkey, netuid, day)` rollup (kept forever) + 90d hot-window prune, mirroring `surface_uptime_daily`.

## Verified end-to-end against live finney
- Decoded **388 events from 20 blocks, 0 skips**; positional field order confirmed against real data (`StakeAdded` → coldkey/hotkey/netuid/amount_tao; `NeuronRegistered` → netuid/uid/hotkey; `WeightsSet` → netuid/uid …).
- **$0** — public RPC needs no key (also makes the poller locally verifiable).
- `1360` tests pass (incl. new `account-events` + `load-staged-events`); contract/schema/api/docs/workflows/public-safety gates green; eslint + prettier clean.

## Scope / notes
- **No API routes yet** — this only populates the tier; `/api/v1/accounts/{ss58}` is #1347 (so no contract-machinery changes here).
- **Deploy ordering is safe:** `loadStagedEvents` is isolated (`.catch`), so it no-ops harmlessly until migration `0009` is applied to prod D1 (done on land, like #1303).
- **Live-forward only** (public nodes prune ~300 blocks); deep history is the optional archive-RPC upgrade (#1349).