### PR TITLE
test(agent-tool-specs): cover OpenAI/Anthropic spec + index builders

### DIFF
--- a/tests/agent-tool-specs.test.mjs
+++ b/tests/agent-tool-specs.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  buildAgentToolsIndex,
+  buildAnthropicToolSpecs,
+  buildOpenAIToolSpecs,
+} from "../src/agent-tool-specs.mjs";
+
+const TOOLS = [
+  {
+    name: "kb.search",
+    description: "Search the KB",
+    inputSchema: {
+      type: "object",
+      properties: { q: { type: "string" } },
+      required: ["q"],
+    },
+  },
+];
+
+describe("agent tool spec builders", () => {
+  test("buildOpenAIToolSpecs wraps each tool in the function-calling shape", () => {
+    assert.deepEqual(buildOpenAIToolSpecs(TOOLS), [
+      {
+        type: "function",
+        function: {
+          name: "kb.search",
+          description: "Search the KB",
+          parameters: TOOLS[0].inputSchema,
+        },
+      },
+    ]);
+  });
+
+  test("buildAnthropicToolSpecs maps inputSchema to input_schema", () => {
+    assert.deepEqual(buildAnthropicToolSpecs(TOOLS), [
+      {
+        name: "kb.search",
+        description: "Search the KB",
+        input_schema: TOOLS[0].inputSchema,
+      },
+    ]);
+  });
+
+  test("both builders are empty for an empty tool list", () => {
+    assert.deepEqual(buildOpenAIToolSpecs([]), []);
+    assert.deepEqual(buildAnthropicToolSpecs([]), []);
+  });
+
+  test("buildAgentToolsIndex describes the spec files, tool names, and executor", () => {
+    const idx = buildAgentToolsIndex(TOOLS);
+    assert.equal(idx.schema_version, 1);
+    // specs point at the published .well-known JSON, not inline spec arrays.
+    assert.match(idx.specs.openai, /\/agent-tools\/openai\.json$/);
+    assert.match(idx.specs.anthropic, /\/agent-tools\/anthropic\.json$/);
+    // the index lists tool names, and the single uniform executor is the MCP endpoint.
+    assert.deepEqual(idx.tools, ["kb.search"]);
+    assert.deepEqual(Object.keys(idx.executor).sort(), [
+      "endpoint",
+      "jsonrpc_method",
+      "transport",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

`buildOpenAIToolSpecs` / `buildAnthropicToolSpecs` map MCP tool definitions into each SDK's shape (OpenAI function-calling `{type:'function',function:{…parameters}}` vs Anthropic `{…input_schema}`), and `buildAgentToolsIndex` is the machine-readable hub (schema_version, the `.well-known` spec-file URLs, the tool-name list, and the single uniform MCP executor). None were tested.

Adds exact-shape tests for the two mappers (including the empty-list case) and a structural test for the index (spec URLs, tool names, executor keys).

**Test-only — no source/behavior change, no artifact churn.** Assertions verified against the live builders.

- `npx vitest run tests/agent-tool-specs.test.mjs` → 4 passed
- prettier + eslint clean
