### PR TITLE
test(health): cover okLatencyMs success-only latency gate

### DIFF
--- a/tests/health-ok-latency.test.mjs
+++ b/tests/health-ok-latency.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { okLatencyMs } from "../src/health-probe-core.mjs";
+
+describe("okLatencyMs", () => {
+  test("returns the latency only for a successful probe with a finite reading", () => {
+    assert.equal(okLatencyMs("ok", 42), 42);
+    // a genuine zero-latency reading still counts (it is finite).
+    assert.equal(okLatencyMs("ok", 0), 0);
+  });
+
+  test("drops a non-finite latency even on a successful probe", () => {
+    for (const latency of [NaN, Infinity, -Infinity, null, undefined]) {
+      assert.equal(okLatencyMs("ok", latency), null, String(latency));
+    }
+  });
+
+  test("drops the latency for any non-ok status", () => {
+    for (const status of ["failed", "degraded", "timeout", "unknown"]) {
+      assert.equal(okLatencyMs(status, 42), null, status);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`okLatencyMs` (src/health-probe-core.mjs) is the read-side guard behind the success-only latency signal: it returns a latency only when the probe is `ok` **and** the reading is finite, otherwise `null`. It was untested.

Adds a matrix over status × reading: an ok finite reading (including a genuine `0`) is kept; a non-finite reading (`NaN`/`±Infinity`/`null`/`undefined`) is dropped even when ok; and any non-ok status drops the latency.

**Test-only — no source/behavior change, no artifact churn.** Verified against the live function.

- `npx vitest run tests/health-ok-latency.test.mjs` → 3 passed
- prettier + eslint clean
