### PR TITLE
feat(explorer): tighten chain-event ingestion to ~5 min (#1359, Option A)

### DIFF
--- a/.github/workflows/refresh-events.yml
+++ b/.github/workflows/refresh-events.yml
@@ -14,7 +14,10 @@ name: Refresh Chain Events (first-party poller)
 # upgrade (#1349). No new secret — uses the existing CLOUDFLARE_* R2 permission.
 on:
   schedule:
-    - cron: "*/20 * * * *" # every 20 min — stays within the node's block retention
+    # Every 5 min (#1346 Option A) — the practical CI floor (each run has ~3 min of
+    # setup). Paired with the Worker's */3 fast-load cron, this puts chain-event
+    # latency at ~5 min (down from ~20). True ~12s realtime is Option B (epic #1345).
+    - cron: "*/5 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -53,7 +56,9 @@ jobs:
       - name: Poll finney events (first-party, public RPC, no key)
         run: uv run --with substrate-interface==1.8.1 python scripts/fetch-events.py
         env:
-          EVENTS_WINDOW: "250"
+          # 120 blocks ≈ 24 min of chain — generous idempotent overlap at a 5-min
+          # cadence (survives delayed/missed runs) while keeping the poll ~1 min.
+          EVENTS_WINDOW: "120"
 
       # Stage to R2 (the token's existing R2 permission); the Worker loads it into
       # D1 through its binding (loadStagedEvents) — no API-token D1 permission.

--- a/tests/load-staged-events.test.mjs
+++ b/tests/load-staged-events.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { loadStagedEvents } from "../workers/api.mjs";
+import { handleScheduled, loadStagedEvents } from "../workers/api.mjs";
+import { EVENTS_LOAD_CRON } from "../workers/config.mjs";
 
 function eventRow(block_number, event_index) {
   return {
@@ -105,4 +106,45 @@ test("loadStagedEvents is a safe no-op without bindings", async () => {
   const r = await loadStagedEvents({});
   assert.equal(r.ok, false);
   assert.equal(r.reason, "unavailable");
+});
+
+test("handleScheduled fast-load cron drains staged batches + skips the probe (#1346 Option A)", async () => {
+  const drained = [];
+  const env = {
+    METAGRAPH_ARCHIVE: {
+      async get(key) {
+        // Only the events batch is staged; the neuron key returns nothing.
+        return key === "events/account-events-pending.json"
+          ? {
+              async json() {
+                return [
+                  {
+                    block_number: 1,
+                    event_index: 0,
+                    event_kind: "StakeAdded",
+                    observed_at: 1,
+                  },
+                ];
+              },
+            }
+          : null;
+      },
+      async delete(key) {
+        drained.push(key);
+      },
+    },
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        return { bind: () => ({}) };
+      },
+      async batch() {},
+    },
+  };
+  const r = await handleScheduled({ cron: EVENTS_LOAD_CRON }, env, {});
+  // Early-returns the fast-load marker (i.e. never falls through to the prober).
+  assert.deepEqual(r, { ok: true, fast_load: true });
+  assert.ok(
+    drained.includes("events/account-events-pending.json"),
+    "the staged event batch was loaded + deleted",
+  );
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -120,6 +120,7 @@ import {
   DAY_MS,
   DENIED_RPC_PREFIXES,
   EMBEDDING_SYNC_CRON,
+  EVENTS_LOAD_CRON,
   HEALTH_PRUNE_CRON,
   HEALTH_TREND_WINDOWS,
   INCIDENTS_PATH_PATTERN,
@@ -355,6 +356,12 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
   // the first-party poller and load it via the binding. Isolated like the neuron
   // load so a failure never affects the prober/prune below.
   await loadStagedEvents(env).catch(() => {});
+  // Fast-load cron (#1346 Option A): its whole job is to drain staged batches into
+  // D1 quickly (above) — return without running the heavier probe/prune so we can
+  // tick every ~3 min cheaply and keep chain-event latency at ~5 min.
+  if (cron === EVENTS_LOAD_CRON) {
+    return { ok: true, fast_load: true };
+  }
   if (cron === HEALTH_PRUNE_CRON) {
     // Roll the day's raw checks into the durable daily uptime table BEFORE
     // pruning, so long-term history is never lost when 30-day raw rows are

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -6,12 +6,18 @@
 // without cycles.
 
 // Cron schedule strings (must match wrangler.jsonc `triggers.crons`). The hourly
-// trigger prunes the D1 time-series; every other trigger runs the 15-minute probe.
+// trigger prunes the D1 time-series; the fast trigger only drains staged batches
+// into D1; every other trigger runs the 15-minute probe.
 export const HEALTH_PRUNE_CRON = "0 * * * *";
 // Daily embedding-sync trigger (Worker-runtime, since CI has no AI bindings).
 // Distinct minute (odd) so it never collides with the 15-minute probe or the
 // top-of-hour prune. Must match a wrangler.jsonc `triggers.crons` entry.
 export const EMBEDDING_SYNC_CRON = "37 3 * * *";
+// Fast event-load trigger (#1346 Option A): drains any R2-staged chain-event /
+// neuron batch into D1 within ~3 min — cutting ingestion latency from ~20 min to
+// ~5 min WITHOUT running the (heavier) health probe. Must match a wrangler.jsonc
+// `triggers.crons` entry.
+export const EVENTS_LOAD_CRON = "*/3 * * * *";
 // Trend windows for /api/v1/subnets/{netuid}/health/trends and
 // /api/v1/health/trends.
 export const RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN =

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -113,7 +113,10 @@
   // far politer to the probed subnets than the old 2-min sweep. Registered
   // automatically on the next Workers Builds deploy.
   "triggers": {
-    "crons": ["*/15 * * * *", "0 * * * *", "37 3 * * *"],
+    // */3 = fast drain of R2-staged chain-event/neuron batches into D1 (#1346
+    // Option A, ~5-min ingestion); */15 = health probe; 0 = hourly prune/rollup;
+    // 37 3 = daily embedding sync.
+    "crons": ["*/3 * * * *", "*/15 * * * *", "0 * * * *", "37 3 * * *"],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite
   // for enabling METAGRAPH_ENABLE_RPC_PROXY). 100 requests / 60s per client IP;


### PR DESCRIPTION
Closes #1359. Part of epic #1345. The free interim before true realtime (Option B: #1360 + #1361).

## What
Cuts chain-event ingestion latency from **~20 min → ~5 min** at **$0**, no new infrastructure.

- **Poller** (`refresh-events.yml`): cron `*/20` → `*/5`; `EVENTS_WINDOW` 250 → 120 (faster run, still ~24 min of idempotent overlap).
- **Worker fast-load cron** (`*/3`, `EVENTS_LOAD_CRON`): `handleScheduled` drains any R2-staged event/neuron batch into D1 and **returns early** — skipping the heavier probe/prune — so it ticks every 3 min cheaply. Removes the old ≤15-min load hop.

## Why ~5 min (not less)
GitHub Actions runs carry ~3 min of setup, so ~5 min is the practical **batch** floor. Sub-minute realtime needs a *persistent* finalized-head subscription → that's Option B (#1360 push endpoint + #1361 streamer), which the maintainer will host on a cheap VPS when ready.

## Tests
- New: `handleScheduled` fast-load cron drains staged batches **and skips the probe** (asserts the early-return marker).
- Existing handleScheduled tests (prune `0 * * * *`, prober `*/2`) unchanged + green; 120 affected tests pass; prettier/eslint/validate:workflows clean.

## Deploy note
The new `*/3` cron registers on the Workers Builds deploy at merge; the `*/5` poller cron takes effect on main immediately.