### PR TITLE
fix(rpc): circuit-breaker cooldown no longer resets under sustained load

### DIFF
--- a/tests/rpc-failover.test.mjs
+++ b/tests/rpc-failover.test.mjs
@@ -125,6 +125,14 @@ describe("circuit breaker", () => {
     assert.equal(isRpcEndpointEjected(map, "a", 1000 + 31_000), false);
   });
 
+  test("failures during ejection do not extend the cooldown", () => {
+    const map = new Map();
+    for (let i = 0; i < 3; i += 1) recordRpcFailure(map, "a", 0);
+    assert.equal(isRpcEndpointEjected(map, "a", 0), true);
+    recordRpcFailure(map, "a", 1000);
+    assert.equal(isRpcEndpointEjected(map, "a", 31_000), false);
+  });
+
   test("success clears breaker state", () => {
     const map = new Map();
     for (let i = 0; i < 3; i += 1) recordRpcFailure(map, "a", 0);

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -2683,7 +2683,7 @@ const RPC_EJECT_COOLDOWN_MS = 30_000;
 export function recordRpcFailure(map, id, now) {
   const entry = map.get(id) || { fails: 0, ejectedUntil: 0 };
   entry.fails += 1;
-  if (entry.fails >= RPC_EJECT_THRESHOLD) {
+  if (entry.fails >= RPC_EJECT_THRESHOLD && entry.ejectedUntil <= now) {
     entry.ejectedUntil = now + RPC_EJECT_COOLDOWN_MS;
   }
   map.set(id, entry);


### PR DESCRIPTION
## Problem

`recordRpcFailure` unconditionally overwrote `ejectedUntil` on **every** transient failure once the threshold was met:

```js
if (entry.fails >= RPC_EJECT_THRESHOLD) {
  entry.ejectedUntil = now + RPC_EJECT_COOLDOWN_MS;  // reset every call
}
```

Under continuous traffic to a fully-ejected pool, every request that tried the ejected endpoint (as a last-resort fallback) pushed the cooldown 30 s into the future. The breaker never reached its half-open window, so the pool could never self-heal without a cold start.

## Fix

Guard the assignment with `entry.ejectedUntil <= now` so the cooldown is only set when the endpoint is **not** already ejected:

```js
if (entry.fails >= RPC_EJECT_THRESHOLD && entry.ejectedUntil <= now) {
  entry.ejectedUntil = now + RPC_EJECT_COOLDOWN_MS;
}
```

Behaviour after the fix:
- Failures 1–2: no ejection (below threshold).
- Failure 3: endpoint ejected for 30 s (unchanged).
- Failures 4-N **during** the 30 s window: `ejectedUntil` is **not** extended.
- After 30 s: endpoint half-opens; a fresh failure there starts a new cooldown.

## Tests

Added `"failures during ejection do not extend the cooldown"` to `tests/rpc-failover.test.mjs`: ejects at t=0, fails again at t=1 000 ms, asserts the endpoint is half-open at t=31 000 ms.