### PR TITLE
fix(api): analyticsWindow error names the invalid value and valid options

### DIFF
--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -511,6 +511,16 @@ describe("analytics routes (cold local D1)", () => {
       assert.equal(body.meta.parameter, parameter);
     }
   });
+  test("invalid window value names the bad value and valid options in the error", async () => {
+    const { body } = await getJson(
+      "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles?window=90d",
+      env,
+    );
+    assert.ok(body.error.message.includes("90d"), body.error.message);
+    assert.ok(body.error.message.includes("7d"), body.error.message);
+    assert.ok(body.error.message.includes("30d"), body.error.message);
+  });
+
   test("trajectory returns empty-but-valid", async () => {
     const { body } = await getJson(
       "https://api.metagraph.sh/api/v1/subnets/7/trajectory",

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1564,7 +1564,7 @@ function analyticsWindow(url) {
     return {
       error: {
         parameter: ANALYTICS_WINDOW_PARAM,
-        message: `${ANALYTICS_WINDOW_PARAM} is not supported for this route.`,
+        message: `"${requested}" is not a valid window. Supported: ${Object.keys(ANALYTICS_WINDOWS).join(", ")}.`,
       },
     };
   }


### PR DESCRIPTION
## Problem

When a caller passes an unrecognised `window` value to any of the analytics routes (percentiles, incidents, global incidents, RPC usage), the error message reads:

```
"window is not supported for this route."
```

This implies the `window` **parameter** is not supported when the route explicitly accepts it — only the **value** is invalid. It gives the caller no information about what values are valid, requiring them to consult external documentation.

## Fix

```js
// Before
message: `${ANALYTICS_WINDOW_PARAM} is not supported for this route.`

// After
message: `"${requested}" is not a valid window. Supported: ${Object.keys(ANALYTICS_WINDOWS).join(", ")}.`
```

Example response for `?window=90d`:
```json
{ "error": { "code": "invalid_query", "message": "\"90d\" is not a valid window. Supported: 7d, 30d." } }
```

This matches the style already used by `handleLeaderboards` (`"Unknown board …. Valid boards: …"`) and `handleUptime` (`"Query parameter \`window\` must be one of: 90d, 1y."`).

## Test

Added an assertion to `tests/analytics.test.mjs` that the response message for an invalid window value contains the bad value (`90d`), and the two valid values (`7d`, `30d`). The existing table-driven test still passes unchanged.