### PR TITLE
fix(api): tolerate optional economics snapshot read failures

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -742,7 +742,12 @@ export async function writeSubnetSnapshot(env, overrides = {}) {
   // Per-subnet economics for the time series (#1307). Best-effort: a missing
   // economics artifact just leaves those columns null (structural trajectory
   // still records).
-  const economicsResult = await readArtifact(env, "/metagraph/economics.json");
+  let economicsResult;
+  try {
+    economicsResult = await readArtifact(env, "/metagraph/economics.json");
+  } catch {
+    economicsResult = null;
+  }
   const economicsByNetuid = new Map(
     (Array.isArray(economicsResult?.data?.subnets)
       ? economicsResult.data.subnets

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -318,6 +318,28 @@ describe("writeSubnetSnapshot", () => {
     assert.equal(r.date, "2026-06-10");
     assert.equal(db.calls.batched[0].length, 2);
   });
+  test("still writes structural rows when optional economics read throws", async () => {
+    const db = fakeBatchDb();
+    const r = await writeSubnetSnapshot(
+      {},
+      {
+        db,
+        readArtifact: (_env, path) => {
+          if (path === "/metagraph/economics.json") {
+            throw new Error("malformed economics artifact");
+          }
+          return Promise.resolve(profiles);
+        },
+        now: () => Date.UTC(2026, 5, 10),
+      },
+    );
+
+    assert.equal(r.ok, true);
+    assert.equal(r.rows, 2);
+    assert.equal(db.calls.batched[0].length, 2);
+    assert.equal(db.calls.batched[0][0].__params[7], null);
+    assert.equal(db.calls.batched[0][0].__params[11], null);
+  });
   test("returns write_failed when the batch throws", async () => {
     const db = {
       prepare: () => ({ bind: () => ({}) }),


### PR DESCRIPTION
### Motivation

- The optional economics artifact read in `writeSubnetSnapshot` was awaited without error handling, so a thrown error (malformed JSON or storage failure) could abort the scheduled snapshot path and prevent structural rows from being recorded even though economics are intended to be best-effort.

### Description

- Add a `try/catch` around the `readArtifact(env, "/metagraph/economics.json")` call in `writeSubnetSnapshot` to fall back to `null` when the optional economics read fails.
- Keep existing behavior by constructing `economicsByNetuid` from an empty array when economics are absent so downstream binding uses `null` economics columns.
- Add a regression test in `tests/analytics.test.mjs` that simulates `readArtifact` throwing for `/metagraph/economics.json` and asserts structural snapshot rows are still written.
- Modified files: `src/health-prober.mjs` and `tests/analytics.test.mjs`.

### Testing

- Ran `npm run lint` (ESLint) and it passed.
- Ran `npm test -- tests/analytics.test.mjs` (Vitest) and the test file passed (`36 tests` passed).
- An initial attempt to run tests with the Jest-style `--runInBand` flag failed because Vitest does not accept that option, after which tests were run without that flag and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37cfa111c4832ca9db7b5c2cf24d38)