### PR TITLE
Authenticate and bound R2-staged neuron loads before D1 writes

### DIFF
--- a/.github/workflows/refresh-metagraph.yml
+++ b/.github/workflows/refresh-metagraph.yml
@@ -57,9 +57,15 @@ jobs:
         env:
           TAOSTATS_API_KEY: ${{ secrets.TAOSTATS_API_KEY }}
 
-      # Stage the snapshot to R2 (the token's existing R2 permission), then the
-      # Worker's scheduled handler loads it into D1 through its METAGRAPH_HEALTH_DB
-      # binding (loadStagedNeurons) — no API-token D1 permission required.
+      - name: Sign staged neuron snapshot
+        if: steps.gate.outputs.ready == 'true'
+        run: node scripts/sign-staged-neurons.mjs dist/metagraph-neurons.json
+        env:
+          METAGRAPH_STAGING_SIGNING_KEY: ${{ secrets.METAGRAPH_STAGING_SIGNING_KEY }}
+
+      # Stage the signed snapshot to R2 (the token's existing R2 permission),
+      # then the Worker's scheduled handler authenticates and bounds it before
+      # loading into D1 through its METAGRAPH_HEALTH_DB binding.
       - name: Stage neurons to R2 for the Worker to load into D1
         if: steps.gate.outputs.ready == 'true'
         run: npx wrangler r2 object put metagraphed-artifacts/metagraph/neurons-pending.json --file=dist/metagraph-neurons.json --remote

--- a/scripts/sign-staged-neurons.mjs
+++ b/scripts/sign-staged-neurons.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { createHmac } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [inputPath, outputPath = inputPath] = process.argv.slice(2);
+const key = process.env.METAGRAPH_STAGING_SIGNING_KEY;
+if (!inputPath || !key) {
+  throw new Error(
+    "usage: METAGRAPH_STAGING_SIGNING_KEY=... node scripts/sign-staged-neurons.mjs <input> [output]",
+  );
+}
+
+const rows = JSON.parse(readFileSync(inputPath, "utf8"));
+if (!Array.isArray(rows))
+  throw new Error("staged neurons payload must be an array");
+const payload = JSON.stringify(rows);
+const hmac_sha256 = createHmac("sha256", key).update(payload).digest("hex");
+writeFileSync(
+  outputPath,
+  `${JSON.stringify({ schema_version: 1, hmac_sha256, rows })}\n`,
+);

--- a/tests/load-staged-neurons.test.mjs
+++ b/tests/load-staged-neurons.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
 import { test } from "vitest";
 import { loadStagedNeurons } from "../workers/api.mjs";
 
@@ -26,6 +27,18 @@ function neuronRow(netuid, uid) {
   };
 }
 
+const SIGNING_KEY = "test-staged-neurons-secret";
+
+function signedEnvelope(rows, key = SIGNING_KEY) {
+  return {
+    schema_version: 1,
+    hmac_sha256: createHmac("sha256", key)
+      .update(JSON.stringify(rows))
+      .digest("hex"),
+    rows,
+  };
+}
+
 function mockEnv({
   rows,
   bad = false,
@@ -33,14 +46,17 @@ function mockEnv({
   deleted = [],
   prepared = [],
   batches = [],
+  size,
 }) {
   return {
     env: {
+      METAGRAPH_STAGING_SIGNING_KEY: SIGNING_KEY,
       METAGRAPH_ARCHIVE: {
         async get(key) {
           getCalls.push(key);
           if (rows == null) return null;
           return {
+            size: size ?? JSON.stringify(rows).length,
             async json() {
               if (bad) throw new Error("bad json");
               return rows;
@@ -70,7 +86,7 @@ function mockEnv({
 
 test("loadStagedNeurons loads JSON via parameterized batches + deletes it (#1303)", async () => {
   const rows = Array.from({ length: 12 }, (_, i) => neuronRow(1, i));
-  const m = mockEnv({ rows });
+  const m = mockEnv({ rows: signedEnvelope(rows) });
   const r = await loadStagedNeurons(m.env);
   assert.equal(r.ok, true);
   assert.equal(r.rows, 12);
@@ -105,9 +121,9 @@ test("loadStagedNeurons deletes + bails on unparseable JSON", async () => {
 });
 
 test("loadStagedNeurons deletes a no-valid-rows payload without loading", async () => {
-  const m = mockEnv({ rows: [{ foo: 1 }] }); // no netuid/uid → filtered out
+  const m = mockEnv({ rows: signedEnvelope([{ foo: 1 }]) }); // no netuid/uid → invalid
   const r = await loadStagedNeurons(m.env);
-  assert.equal(r.reason, "empty");
+  assert.equal(r.reason, "invalid");
   assert.equal(m.batches.length, 0);
   assert.deepEqual(m.deleted, ["metagraph/neurons-pending.json"]);
 });
@@ -116,4 +132,41 @@ test("loadStagedNeurons is a safe no-op without bindings", async () => {
   const r = await loadStagedNeurons({});
   assert.equal(r.ok, false);
   assert.equal(r.reason, "unavailable");
+});
+
+test("loadStagedNeurons rejects unsigned or tampered staged payloads", async () => {
+  const m = mockEnv({ rows: [neuronRow(1, 0)] });
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "unauthenticated");
+  assert.equal(m.batches.length, 0);
+  assert.deepEqual(m.deleted, ["metagraph/neurons-pending.json"]);
+
+  const tampered = signedEnvelope([neuronRow(1, 0)]);
+  tampered.rows[0].uid = 1;
+  const m2 = mockEnv({ rows: tampered });
+  const r2 = await loadStagedNeurons(m2.env);
+  assert.equal(r2.reason, "unauthenticated");
+  assert.equal(m2.batches.length, 0);
+});
+
+test("loadStagedNeurons rejects oversized and out-of-range rows", async () => {
+  const oversized = mockEnv({
+    rows: signedEnvelope([neuronRow(1, 0)]),
+    size: 2_000_001,
+  });
+  const oversizedResult = await loadStagedNeurons(oversized.env);
+  assert.equal(oversizedResult.reason, "too_large");
+  assert.equal(oversized.batches.length, 0);
+
+  const m = mockEnv({ rows: signedEnvelope([neuronRow(999999, -7)]) });
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "invalid");
+  assert.equal(m.batches.length, 0);
+
+  const bigRows = Array.from({ length: 50_001 }, (_, i) => neuronRow(1, i));
+  const m2 = mockEnv({ rows: signedEnvelope(bigRows), size: 1 });
+  const r2 = await loadStagedNeurons(m2.env);
+  assert.equal(r2.reason, "too_many_rows");
 });

--- a/tests/load-staged-neurons.test.mjs
+++ b/tests/load-staged-neurons.test.mjs
@@ -170,3 +170,26 @@ test("loadStagedNeurons rejects oversized and out-of-range rows", async () => {
   const r2 = await loadStagedNeurons(m2.env);
   assert.equal(r2.reason, "too_many_rows");
 });
+
+test("loadStagedNeurons rejects rows that fail per-field bounding (#1360)", async () => {
+  // Each case is a correctly-signed, in-range (netuid/uid) row that still fails
+  // one of the per-field guards in validStagedNeuronRow — exercising the column
+  // allow-list, string-length cap, finiteness, and type checks that the
+  // netuid/uid-only cases never reach.
+  const cases = {
+    unknown_column: { ...neuronRow(1, 0), evil_extra: 1 },
+    oversized_string: { ...neuronRow(1, 0), hotkey: "x".repeat(513) },
+    non_finite_number: { ...neuronRow(1, 0), rank: Infinity },
+    wrong_typed_value: { ...neuronRow(1, 0), active: true },
+    out_of_range_uid: neuronRow(1, 999_999), // valid netuid, uid past MAX_STAGED_UID
+    non_object_row: null,
+  };
+  for (const [name, row] of Object.entries(cases)) {
+    const m = mockEnv({ rows: signedEnvelope([row]) });
+    const r = await loadStagedNeurons(m.env);
+    assert.equal(r.ok, false, `${name} must be rejected`);
+    assert.equal(r.reason, "invalid", `${name} must be rejected as invalid`);
+    assert.equal(m.batches.length, 0, `${name} must never reach a D1 write`);
+    assert.deepEqual(m.deleted, ["metagraph/neurons-pending.json"]);
+  }
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -236,37 +236,116 @@ export default {
   },
 };
 
+const STAGED_NEURONS_KEY = "metagraph/neurons-pending.json";
+const MAX_STAGED_NEURONS_BYTES = 2_000_000;
+const MAX_STAGED_NEURON_ROWS = 50_000;
+const MAX_STAGED_NEURON_STRING_BYTES = 512;
+const MAX_STAGED_NETUID = 1024;
+const MAX_STAGED_UID = 65_535;
+
+function utf8Bytes(value) {
+  return new TextEncoder().encode(value);
+}
+
+function timingSafeStringEqual(a, b) {
+  const left = utf8Bytes(String(a || ""));
+  const right = utf8Bytes(String(b || ""));
+  if (left.length !== right.length) return false;
+  let diff = 0;
+  for (let i = 0; i < left.length; i += 1) diff |= left[i] ^ right[i];
+  return diff === 0;
+}
+
+async function hmacHex(key, value) {
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    utf8Bytes(key),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", cryptoKey, utf8Bytes(value));
+  return [...new Uint8Array(sig)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function validStagedNeuronRow(row) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
+  if (
+    !Number.isInteger(row.netuid) ||
+    row.netuid < 0 ||
+    row.netuid > MAX_STAGED_NETUID
+  )
+    return false;
+  if (!Number.isInteger(row.uid) || row.uid < 0 || row.uid > MAX_STAGED_UID)
+    return false;
+  for (const [key, value] of Object.entries(row)) {
+    if (!NEURON_INSERT_COLUMNS.includes(key)) return false;
+    if (
+      typeof value === "string" &&
+      utf8Bytes(value).length > MAX_STAGED_NEURON_STRING_BYTES
+    )
+      return false;
+    if (typeof value === "number" && !Number.isFinite(value)) return false;
+    if (
+      typeof value === "boolean" ||
+      typeof value === "bigint" ||
+      typeof value === "symbol" ||
+      typeof value === "function"
+    )
+      return false;
+  }
+  return true;
+}
+
 // Load a staged per-UID metagraph snapshot from R2 into D1 (#1303). The
-// refresh-metagraph CI job fetches Taostats and writes the neuron rows as JSON to
-// R2 (metagraph/neurons-pending.json) using its existing R2 permission; we load
-// them here through the METAGRAPH_HEALTH_DB binding — which needs no API-token D1
-// permission — with PARAMETERIZED inserts (values are always bound, never
-// interpolated, so a tampered/garbage staged file can only fail, never inject
-// SQL), then delete the object so it loads exactly once. Batched to stay under
-// D1's 100-param-per-statement limit (→ 5 rows/statement) and the Worker's
-// subrequest limit.
+// refresh-metagraph CI job fetches Taostats, wraps the neuron rows in an
+// HMAC-signed envelope, and writes it to R2 (metagraph/neurons-pending.json)
+// using its existing R2 permission; we load only authenticated, bounded,
+// schema-valid rows through the METAGRAPH_HEALTH_DB binding — which needs no
+// API-token D1 permission — with PARAMETERIZED inserts (values are always bound,
+// never interpolated), then delete the object so it loads exactly once.
 export async function loadStagedNeurons(env) {
   const bucket = env.METAGRAPH_ARCHIVE;
   const db = env.METAGRAPH_HEALTH_DB;
-  if (!bucket?.get || !db?.prepare) return { ok: false, reason: "unavailable" };
-  const key = "metagraph/neurons-pending.json";
-  const object = await bucket.get(key);
+  const signingKey = env.METAGRAPH_STAGING_SIGNING_KEY;
+  if (!bucket?.get || !db?.prepare || !signingKey) {
+    return { ok: false, reason: "unavailable" };
+  }
+  const object = await bucket.get(STAGED_NEURONS_KEY);
   if (!object) return { ok: false, reason: "none" };
-  let rows;
+  if (Number(object.size || 0) > MAX_STAGED_NEURONS_BYTES) {
+    await bucket.delete(STAGED_NEURONS_KEY);
+    return { ok: false, reason: "too_large" };
+  }
+  let envelope;
   try {
-    rows = await object.json();
+    envelope = await object.json();
   } catch {
-    await bucket.delete(key);
+    await bucket.delete(STAGED_NEURONS_KEY);
     return { ok: false, reason: "parse_failed" };
   }
-  rows = Array.isArray(rows)
-    ? rows.filter(
-        (r) => Number.isInteger(r?.netuid) && Number.isInteger(r?.uid),
-      )
-    : [];
-  if (!rows.length) {
-    await bucket.delete(key);
-    return { ok: false, reason: "empty" };
+  const rows = Array.isArray(envelope?.rows) ? envelope.rows : [];
+  if (
+    envelope?.schema_version !== 1 ||
+    !/^[a-f0-9]{64}$/.test(String(envelope?.hmac_sha256 || ""))
+  ) {
+    await bucket.delete(STAGED_NEURONS_KEY);
+    return { ok: false, reason: "unauthenticated" };
+  }
+  if (rows.length > MAX_STAGED_NEURON_ROWS) {
+    await bucket.delete(STAGED_NEURONS_KEY);
+    return { ok: false, reason: "too_many_rows" };
+  }
+  const expected = await hmacHex(signingKey, JSON.stringify(rows));
+  if (!timingSafeStringEqual(expected, envelope.hmac_sha256)) {
+    await bucket.delete(STAGED_NEURONS_KEY);
+    return { ok: false, reason: "unauthenticated" };
+  }
+  if (!rows.length || rows.some((row) => !validStagedNeuronRow(row))) {
+    await bucket.delete(STAGED_NEURONS_KEY);
+    return { ok: false, reason: "invalid" };
   }
   const cols = NEURON_INSERT_COLUMNS;
   const colList = cols.join(",");
@@ -288,7 +367,7 @@ export async function loadStagedNeurons(env) {
   for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
     await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
   }
-  await bucket.delete(key);
+  await bucket.delete(STAGED_NEURONS_KEY);
   return { ok: true, rows: rows.length };
 }
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -236,11 +236,16 @@ export default {
   },
 };
 
+// Sanity bounds for an authenticated, HMAC-signed staged neuron batch (the data
+// is already trusted; these are defense-in-depth caps so a malformed signed file
+// can't blow up the D1 load). netuid and uid are both u16 on-chain, so each is
+// capped at the u16 max (65535) — matching the existing netuid guard in
+// src/webhooks.mjs and avoiding rejection of legitimately high subnet ids.
 const STAGED_NEURONS_KEY = "metagraph/neurons-pending.json";
 const MAX_STAGED_NEURONS_BYTES = 2_000_000;
 const MAX_STAGED_NEURON_ROWS = 50_000;
 const MAX_STAGED_NEURON_STRING_BYTES = 512;
-const MAX_STAGED_NETUID = 1024;
+const MAX_STAGED_NETUID = 65_535;
 const MAX_STAGED_UID = 65_535;
 
 function utf8Bytes(value) {


### PR DESCRIPTION
### Motivation
- The scheduled Worker previously trusted any JSON object written to the fixed R2 key and could therefore be used as a confused-deputy to mutate D1 when an attacker (or leaked token/CI step) could write that R2 key. 
- The change prevents unauthorized or oversized staged payloads from causing unauthorized D1 mutations or availability/cost impacts by adding provenance and bounds checks before any D1 writes.

### Description
- Require an HMAC-signed envelope for staged neuron snapshots and add a CI signing step using a new `scripts/sign-staged-neurons.mjs` helper and the `METAGRAPH_STAGING_SIGNING_KEY` secret, with the workflow calling the script before the R2 `put` step. 
- Add authentication and validation in `loadStagedNeurons` (`workers/api.mjs`): verify `schema_version` and `hmac_sha256` using the Worker `METAGRAPH_STAGING_SIGNING_KEY`, perform a timing-safe HMAC check, and delete the object on failure. 
- Add defensive bounds and schema checks including object size limit, maximum row count, allowed columns, per-string byte limits, finite-number checks, and `netuid`/`uid` range limits, while preserving parameterized batched `INSERT OR REPLACE` statements so values remain bound (no SQL interpolation). 
- Update and extend tests (`tests/load-staged-neurons.test.mjs`) to cover the signed happy path, unsigned/tampered rejection, oversized payload rejection, out-of-range rows, and row-count limits.

### Testing
- Ran the targeted unit tests with `npx vitest run tests/load-staged-neurons.test.mjs`, which passed. 
- Ran linting with `npm run lint`, which succeeded. 
- Manually exercised the signing helper with `METAGRAPH_STAGING_SIGNING_KEY=test node scripts/sign-staged-neurons.mjs <in> <out>` to confirm produced envelope format and HMAC.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38caac5c68832cac32487e871c5a58)