### PR TITLE
fix(health): weight reliability-aggregate latency mean by healthy readings

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1033,12 +1033,7 @@ export async function loadReliabilityAggregate({
       .prepare(
         `SELECT SUM(samples) AS samples,
                 SUM(ok_count) AS ok_count,
-                CASE
-                  WHEN SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN samples ELSE 0 END) > 0
-                    THEN SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN avg_latency_ms * samples ELSE 0 END) /
-                         SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN samples ELSE 0 END)
-                  ELSE NULL
-                END AS avg_latency_ms
+                ${dailyLatencyColumns({ roundedAvg: true })}
          FROM surface_uptime_daily
          WHERE netuid IN (${placeholders}) AND day >= ?`,
       )
@@ -1049,6 +1044,7 @@ export async function loadReliabilityAggregate({
       okCount: Number(row?.ok_count) || 0,
       avgLatencyMs:
         row?.avg_latency_ms == null ? null : Number(row.avg_latency_ms),
+      latencySamples: Number(row?.latency_samples) || 0,
     });
   } catch {
     return null;

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -2356,6 +2356,22 @@ describe("loadReliabilityAggregate (D1-backed, one query for many subnets)", () 
     assert.deepEqual(sink.params, [7, 12, "2026-05-14"]);
   });
 
+  test("weights the latency mean by healthy readings, not total probes", async () => {
+    // Regression for the badge under-scoring failure-heavy days: avg_latency_ms
+    // is a success-only mean, so re-aggregating it must weight by latency_samples
+    // (healthy readings), not samples (total probes incl. failures). Mirrors the
+    // canonical dailyLatencyColumns() helper. The mocked .first() can't run SQL,
+    // so assert the weighting lives in the emitted query.
+    const sink = {};
+    await loadReliabilityAggregate({
+      db: aggregateDb({ samples: 10, ok_count: 8 }, sink),
+      netuids: [7],
+    });
+    assert.match(sink.sql, /COALESCE\(latency_samples, samples\)/);
+    // The bare `avg_latency_ms * samples` total-probe weighting must be gone.
+    assert.doesNotMatch(sink.sql, /avg_latency_ms \* samples\b/);
+  });
+
   test("dedupes netuids and ignores non-integers", async () => {
     const sink = {};
     await loadReliabilityAggregate({


### PR DESCRIPTION
## Summary

Fixes #1372.

`loadReliabilityAggregate` in `src/health-serving.mjs` — the live D1 loader behind the **public reliability badge** — weighted each day's success-only `avg_latency_ms` by the day's **total probe count (`samples`, including failures)** instead of the day's **healthy-reading count (`latency_samples`)**. On failure-heavy days this over-weights the slow latency tail, inflating the reported average latency and silently docking the badge score/grade — and it diverges from the per-subnet `/uptime` reliability for the same window, which already weights correctly.

This was a leftover from #1331, which introduced the healthy-weighted helper and fixed the sibling call sites but missed this one hand-rolled query.

## What Changed

- `src/health-serving.mjs` — `loadReliabilityAggregate` now reuses the canonical `dailyLatencyColumns({ roundedAvg: true })` helper instead of hand-rolling the weighted mean, so the latency average is weighted by `COALESCE(latency_samples, samples)` (legacy fallback) and can no longer drift from `computeReliability`. The now-available `latency_samples` count is threaded into `scoreFromStats`, so `latency_sample_count` is accurate instead of always 0.
- `tests/health-serving.test.mjs` — added a regression test asserting the emitted SQL weights by `COALESCE(latency_samples, samples)` and no longer uses the bare `avg_latency_ms * samples` total-probe weighting. The mocked `.first()` can't execute SQL, which is exactly why the original bug slipped past the existing tests.

No schema, OpenAPI, or generated-artifact changes — the badge output shape is unchanged; only the score it computes becomes correct.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `npx vitest run tests/health-serving.test.mjs` — 118 passed (incl. the new regression test)
- [x] `npx vitest run tests/badge.test.mjs` — 22 passed (the public badge consumer)
- [x] `git diff --check`

## Template Used

- Backend/code change

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
