### PR TITLE
feat(explorer): realtime event ingest endpoint + streamer (#1360, #1361)

### DIFF
--- a/deploy/streamer.Dockerfile
+++ b/deploy/streamer.Dockerfile
@@ -1,0 +1,19 @@
+# Realtime chain-event streamer (#1361, epic #1345) — Option B.
+# A tiny always-on container for a cheap host (Oracle Cloud Free / Fly.io free
+# tier, or a ~$5/mo VPS). Subscribes to finalized finney heads, decodes the
+# SubtensorModule events, and POSTs them to the Worker ingest endpoint (#1360).
+#
+# Build (from the repo root):
+#   docker build -f deploy/streamer.Dockerfile -t metagraphed-streamer .
+# Run:
+#   docker run -e EVENTS_INGEST_URL=https://api.metagraph.sh/api/v1/internal/events \
+#              -e METAGRAPH_EVENTS_INGEST_SECRET=... metagraphed-streamer
+FROM python:3.12-slim
+WORKDIR /app
+# Pinned (matches the CI poller) — never auto-pull a future PyPI release.
+RUN pip install --no-cache-dir "substrate-interface==1.8.1"
+# The streamer imports the verified decode from fetch-events.py — copy both.
+COPY scripts/fetch-events.py scripts/stream-events.py /app/scripts/
+ENV EVENTS_RPC_URL=wss://entrypoint-finney.opentensor.ai:443
+# Provide at runtime (NOT baked in): EVENTS_INGEST_URL, METAGRAPH_EVENTS_INGEST_SECRET
+CMD ["python", "scripts/stream-events.py"]

--- a/docs/realtime-streamer.md
+++ b/docs/realtime-streamer.md
@@ -1,0 +1,72 @@
+# Realtime chain-event streamer (Option B)
+
+The CI poller (#1346) + the `*/3` Worker load cron (#1359) give ~5-minute
+chain-event freshness for **$0** — but GitHub's scheduled-cron is best-effort and
+can be delayed for hours. For **true ~12-second realtime**, run the persistent
+streamer (#1361): a tiny always-on process that subscribes to finalized finney
+heads, decodes each block, and pushes the events to the Worker ingest endpoint
+(#1360). The CI poller stays on as a self-healing backstop — inserts are
+idempotent on `(block_number, event_index)`, so any overlap is free.
+
+This needs one small always-on host (**~$0–5/mo**): Oracle Cloud Free Tier or
+Fly.io's free allowance ($0), or a cheap VPS / Railway / Render worker (~$5/mo).
+
+## 1. Configure the Worker secret (one-time)
+
+The ingest endpoint is disabled until the secret is set. Generate a strong token
+and add it as a Worker secret:
+
+```sh
+openssl rand -hex 32                       # generate a token
+npx wrangler secret put METAGRAPH_EVENTS_INGEST_SECRET   # paste it
+```
+
+Until this is set, `POST /api/v1/internal/events` returns `503` (safe default).
+
+## 2. Run the streamer with the same token
+
+### Docker (any host)
+
+```sh
+docker build -f deploy/streamer.Dockerfile -t metagraphed-streamer .
+docker run --restart=always \
+  -e EVENTS_INGEST_URL=https://api.metagraph.sh/api/v1/internal/events \
+  -e METAGRAPH_EVENTS_INGEST_SECRET=<the same token> \
+  metagraphed-streamer
+```
+
+### systemd (a VPS, no Docker)
+
+```ini
+# /etc/systemd/system/metagraphed-streamer.service
+[Unit]
+Description=metagraphed realtime chain-event streamer
+After=network-online.target
+
+[Service]
+Environment=EVENTS_INGEST_URL=https://api.metagraph.sh/api/v1/internal/events
+Environment=METAGRAPH_EVENTS_INGEST_SECRET=<the same token>
+ExecStart=/usr/bin/uv run --with substrate-interface==1.8.1 python /opt/metagraphed/scripts/stream-events.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## How it works
+
+`scripts/stream-events.py` reuses the **exact verified decode** from
+`scripts/fetch-events.py` (imported, not duplicated). On each finalized head it
+decodes the SubtensorModule events and `POST`s them to the ingest endpoint with
+the `x-metagraph-events-token` header; the Worker writes them to the
+`account_events` D1 tier with the same parameterized `INSERT OR IGNORE` as the
+batch loader. It auto-reconnects on RPC drops.
+
+## Cost & reliability
+
+- **$0–5/mo** depending on host (free tiers exist).
+- ~12–30s latency (one block behind the chain).
+- If the streamer is down, the CI poller backfills the gap on its next run — no
+  data loss, just temporary staleness.
+- Deep historical backfill (before launch) is a separate decision (#1349).

--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Realtime chain-event streamer (#1361, epic #1345) — Option B.
+
+Subscribes to FINALIZED finney heads and, for each new block, decodes its
+SubtensorModule events with the EXACT verified extractors from fetch-events.py
+(imported, not duplicated — no drift) and POSTs them to the Worker's authenticated
+ingest endpoint (#1360). End-to-end latency ~12-30s (one block). The #1346 CI
+poller stays running as a self-healing backstop; inserts are idempotent on
+(block_number, event_index), so any overlap is free.
+
+This is the always-on component — run it on a cheap host (Oracle Cloud Free /
+Fly.io free tier, or a ~$5/mo VPS). See docs/realtime-streamer.md + the Dockerfile.
+
+Run:
+  EVENTS_INGEST_URL=https://api.metagraph.sh/api/v1/internal/events \
+  METAGRAPH_EVENTS_INGEST_SECRET=... \
+  uv run --with substrate-interface==1.8.1 python scripts/stream-events.py
+"""
+import importlib.util
+import json
+import os
+import sys
+import time
+import urllib.request
+
+from substrateinterface import SubstrateInterface
+
+BLOCK_MS = 12000
+RPC = os.environ.get("EVENTS_RPC_URL", "wss://entrypoint-finney.opentensor.ai:443")
+INGEST_URL = os.environ.get("EVENTS_INGEST_URL")
+SECRET = os.environ.get("METAGRAPH_EVENTS_INGEST_SECRET")
+TOKEN_HEADER = "x-metagraph-events-token"
+
+# Reuse the EXACT verified decode from fetch-events.py (hyphenated → load by path).
+_FE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fetch-events.py")
+_spec = importlib.util.spec_from_file_location("fetch_events", _FE_PATH)
+_fe = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_fe)
+extract = _fe.extract
+
+
+def decode_head(s, block_number, head_ts):
+    """Decode the SubtensorModule events of one finalized block → ingest rows."""
+    block_hash = s.get_block_hash(block_number)
+    observed_at = head_ts if head_ts else None
+    rows = []
+    for event_index, ev in enumerate(
+        s.query("System", "Events", block_hash=block_hash)
+    ):
+        v = ev.value if isinstance(ev.value, dict) else {}
+        e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
+        if e.get("module_id") != "SubtensorModule":
+            continue
+        ent = extract(e.get("event_id"), e.get("attributes"))
+        if ent is None:
+            continue
+        rows.append(
+            {
+                "block_number": block_number,
+                "event_index": event_index,
+                "event_kind": e.get("event_id"),
+                "hotkey": ent["hotkey"],
+                "coldkey": ent["coldkey"],
+                "netuid": ent["netuid"],
+                "uid": ent["uid"],
+                "amount_tao": ent["amount_tao"],
+                "observed_at": observed_at,
+            }
+        )
+    return rows
+
+
+def push(rows):
+    if not rows:
+        return
+    body = json.dumps(rows).encode()
+    req = urllib.request.Request(
+        INGEST_URL,
+        data=body,
+        method="POST",
+        headers={"content-type": "application/json", TOKEN_HEADER: SECRET},
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        resp.read()
+
+
+def run():
+    if not INGEST_URL or not SECRET:
+        sys.exit("EVENTS_INGEST_URL and METAGRAPH_EVENTS_INGEST_SECRET are required")
+    while True:  # reconnect loop — survives RPC drops
+        try:
+            s = SubstrateInterface(url=RPC)
+            sys.stderr.write(f"connected {RPC}; subscribing to finalized heads\n")
+
+            def handler(obj, update_nr, subscription_id):
+                bn = obj["header"]["number"]
+                try:
+                    head_ts = int(s.query("Timestamp", "Now").value)
+                except Exception:
+                    head_ts = None
+                rows = decode_head(s, bn, head_ts)
+                push(rows)
+                sys.stderr.write(f"block {bn}: {len(rows)} events pushed\n")
+
+            s.subscribe_block_headers(handler, finalized_only=True)
+        except Exception as e:  # noqa: BLE001 — log + reconnect
+            sys.stderr.write(f"stream error: {repr(e)[:160]}; reconnecting in 5s\n")
+            time.sleep(5)
+
+
+if __name__ == "__main__":
+    run()

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -130,6 +130,48 @@ export async function pruneAccountEvents(env, overrides = {}) {
   }
 }
 
+// Keep only well-formed account_events rows (a valid (block_number, event_index)
+// primary key). Shared by the staged-batch loader (#1346) and the realtime ingest
+// endpoint (#1360) so both reject garbage identically.
+export function validEventRows(rows) {
+  return Array.isArray(rows)
+    ? rows.filter(
+        (r) =>
+          Number.isInteger(r?.block_number) &&
+          Number.isInteger(r?.event_index) &&
+          typeof r?.event_kind === "string" &&
+          Number.isInteger(r?.observed_at),
+      )
+    : [];
+}
+
+// Build parameterized INSERT OR IGNORE statements for account_events rows, chunked
+// under D1's 100-bound-param limit (9 cols x 10 = 90). Idempotent on (block_number,
+// event_index). Values are ALWAYS bound, never interpolated — a tampered payload
+// can only fail, never inject. Shared by loadStagedEvents (#1346) + the ingest
+// endpoint (#1360).
+export function eventInsertStatements(db, rows) {
+  const cols = EVENT_INSERT_COLUMNS;
+  const colList = cols.join(",");
+  const ROWS_PER_STMT = 10;
+  const statements = [];
+  for (let i = 0; i < rows.length; i += ROWS_PER_STMT) {
+    const chunk = rows.slice(i, i + ROWS_PER_STMT);
+    const tuples = chunk
+      .map(() => `(${cols.map(() => "?").join(",")})`)
+      .join(",");
+    const values = chunk.flatMap((row) => cols.map((c) => row[c] ?? null));
+    statements.push(
+      db
+        .prepare(
+          `INSERT OR IGNORE INTO account_events (${colList}) VALUES ${tuples}`,
+        )
+        .bind(...values),
+    );
+  }
+  return statements;
+}
+
 // ---- Entity API builders (#1347) -------------------------------------------
 // The columns the account handlers SELECT for an event row.
 export const ACCOUNT_EVENT_COLUMNS =

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -326,10 +326,14 @@ export async function signPayload(secret, bodyText) {
 export function timingSafeEqual(a, b) {
   const left = String(a);
   const right = String(b);
-  if (left.length !== right.length) return false;
-  let diff = 0;
-  for (let index = 0; index < left.length; index += 1) {
-    diff |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  // Constant-time compare WITHOUT an early length-mismatch return (which would
+  // leak the secret's length via timing). Fold the length difference into the
+  // accumulator and iterate the longer string; out-of-range positions compare
+  // against 0 (charCodeAt → NaN → 0). Equal length + equal content ⇒ diff 0.
+  let diff = left.length ^ right.length;
+  const max = Math.max(left.length, right.length);
+  for (let index = 0; index < max; index += 1) {
+    diff |= (left.charCodeAt(index) || 0) ^ (right.charCodeAt(index) || 0);
   }
   return diff === 0;
 }

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -10,10 +10,53 @@ import {
   buildAccountSummary,
   buildAccountEvents,
   buildAccountSubnets,
+  eventInsertStatements,
   utcDayBounds,
   rollupAccountEventsDaily,
   pruneAccountEvents,
+  validEventRows,
 } from "../src/account-events.mjs";
+
+test("validEventRows enforces the strict row shape (#1371)", () => {
+  assert.deepEqual(validEventRows("not-an-array"), []);
+  assert.deepEqual(validEventRows(null), []);
+  const good = {
+    block_number: 1,
+    event_index: 0,
+    event_kind: "StakeAdded",
+    observed_at: 5,
+  };
+  assert.equal(validEventRows([good]).length, 1);
+  assert.equal(validEventRows([{ block_number: 1, event_index: 0 }]).length, 0); // no kind/observed_at
+  assert.equal(
+    validEventRows([{ ...good, event_kind: 7 }]).length,
+    0, // event_kind must be a string
+  );
+  assert.equal(
+    validEventRows([{ ...good, observed_at: "x" }]).length,
+    0, // observed_at must be an integer
+  );
+});
+
+test("eventInsertStatements builds chunked parameterized INSERT OR IGNORE", () => {
+  const prepared = [];
+  const db = {
+    prepare(sql) {
+      prepared.push(sql);
+      return { bind: (...v) => ({ sql, v }) };
+    },
+  };
+  const rows = Array.from({ length: 12 }, (_, i) => ({
+    block_number: i,
+    event_index: 0,
+    event_kind: "X",
+    observed_at: 1,
+  }));
+  const stmts = eventInsertStatements(db, rows);
+  assert.equal(stmts.length, 2); // 12 rows / 10 per statement
+  assert.ok(prepared[0].startsWith("INSERT OR IGNORE INTO account_events ("));
+  assert.ok(prepared[0].includes("VALUES (?"));
+});
 
 test("EVENT_INSERT_COLUMNS is the stable load contract (#1346)", () => {
   assert.deepEqual(EVENT_INSERT_COLUMNS, [

--- a/tests/event-ingest.test.mjs
+++ b/tests/event-ingest.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { handleEventIngest } from "../workers/api.mjs";
+import { handleEventIngest, handleRequest } from "../workers/api.mjs";
 
 const SECRET = "test-secret-token-1234567890";
 
@@ -107,6 +107,69 @@ test("ingest accepts the {events:[...]} envelope + no-ops on empty", async () =>
   );
   assert.equal(res.status, 200);
   assert.equal((await res.json()).inserted, 0);
+});
+
+test("handleRequest routes POST /api/v1/internal/events to the ingest handler", async () => {
+  // No secret configured → 503 (proves the dispatch reached handleEventIngest).
+  const res = await handleRequest(post([], { secret: "x" }), {}, {});
+  assert.equal(res.status, 503);
+});
+
+test("handleRequest ingest writes rows end-to-end with a valid token", async () => {
+  const captured = [];
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture(captured),
+  };
+  const res = await handleRequest(
+    post(
+      [
+        {
+          block_number: 5,
+          event_index: 0,
+          event_kind: "WeightsSet",
+          observed_at: 1,
+        },
+      ],
+      {
+        secret: SECRET,
+      },
+    ),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).inserted, 1);
+});
+
+test("ingest returns 503 when the event store is unavailable", async () => {
+  const env = { METAGRAPH_EVENTS_INGEST_SECRET: SECRET }; // authed but no DB
+  const res = await handleEventIngest(post([], { secret: SECRET }), env);
+  assert.equal(res.status, 503);
+});
+
+test("ingest rejects an oversized body (413)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  const res = await handleEventIngest(
+    post("x".repeat(300000), { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 413);
+});
+
+test("ingest rejects a non-array body (400)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  const res = await handleEventIngest(
+    post({ foo: 1 }, { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 400);
 });
 
 test("ingest rejects too many rows (413)", async () => {

--- a/tests/event-ingest.test.mjs
+++ b/tests/event-ingest.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleEventIngest } from "../workers/api.mjs";
+
+const SECRET = "test-secret-token-1234567890";
+
+function post(body, { secret, method = "POST" } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret) headers["x-metagraph-events-token"] = secret;
+  const init = { method, headers };
+  // GET/HEAD Requests cannot carry a body (undici throws); only attach for POST.
+  if (method !== "GET" && method !== "HEAD") {
+    init.body = typeof body === "string" ? body : JSON.stringify(body);
+  }
+  return new Request("https://api.metagraph.sh/api/v1/internal/events", init);
+}
+
+function dbCapture(captured) {
+  return {
+    prepare(sql) {
+      return {
+        bind(...v) {
+          return { sql, v };
+        },
+      };
+    },
+    async batch(stmts) {
+      captured.push(stmts.length);
+    },
+  };
+}
+
+test("ingest is disabled (503) without the secret configured (#1360)", async () => {
+  const res = await handleEventIngest(post([], { secret: "x" }), {});
+  assert.equal(res.status, 503);
+});
+
+test("ingest rejects a wrong or missing token (401)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  assert.equal(
+    (await handleEventIngest(post([], { secret: "wrong" }), env)).status,
+    401,
+  );
+  assert.equal((await handleEventIngest(post([]), env)).status, 401);
+});
+
+test("ingest rejects non-POST (405)", async () => {
+  const env = { METAGRAPH_EVENTS_INGEST_SECRET: SECRET };
+  const res = await handleEventIngest(
+    post([], { secret: SECRET, method: "GET" }),
+    env,
+  );
+  assert.equal(res.status, 405);
+});
+
+test("ingest writes valid rows with a good token (200, parameterized)", async () => {
+  const captured = [];
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture(captured),
+  };
+  const rows = [
+    {
+      block_number: 1,
+      event_index: 0,
+      event_kind: "StakeAdded",
+      hotkey: "5Hk",
+      coldkey: "5Co",
+      netuid: 7,
+      uid: 1,
+      amount_tao: 1.5,
+      observed_at: 1,
+    },
+    { foo: "bar" }, // invalid (no block_number/event_index) → filtered out
+  ];
+  const res = await handleEventIngest(post(rows, { secret: SECRET }), env);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.inserted, 1);
+  assert.deepEqual(captured, [1]); // one batch issued
+});
+
+test("ingest rejects malformed JSON (400)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  const res = await handleEventIngest(
+    post("{not json", { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 400);
+});
+
+test("ingest accepts the {events:[...]} envelope + no-ops on empty", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  const res = await handleEventIngest(
+    post({ events: [] }, { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).inserted, 0);
+});
+
+test("ingest rejects too many rows (413)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  const many = Array.from({ length: 501 }, (_, i) => ({
+    block_number: 1,
+    event_index: i,
+  }));
+  const res = await handleEventIngest(post(many, { secret: SECRET }), env);
+  assert.equal(res.status, 413);
+});

--- a/tests/webhooks.test.mjs
+++ b/tests/webhooks.test.mjs
@@ -221,6 +221,10 @@ describe("signing + identity helpers", () => {
     assert.equal(timingSafeEqual("abc", "abc"), true);
     assert.equal(timingSafeEqual("abc", "abd"), false);
     assert.equal(timingSafeEqual("abc", "abcd"), false);
+    // Length mismatch in either direction (no early return — see #1374); empty.
+    assert.equal(timingSafeEqual("abcd", "abc"), false);
+    assert.equal(timingSafeEqual("", ""), true);
+    assert.equal(timingSafeEqual("a", ""), false);
   });
 
   test("ids/secrets/keys are well formed", () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -99,12 +99,13 @@ import {
 } from "../src/metagraph-neurons.mjs";
 import {
   ACCOUNT_EVENT_COLUMNS,
-  EVENT_INSERT_COLUMNS,
   buildAccountEvents,
   buildAccountSubnets,
   buildAccountSummary,
+  eventInsertStatements,
   rollupAccountEventsDaily,
   pruneAccountEvents,
+  validEventRows,
 } from "../src/account-events.mjs";
 import { handleMcpRequest } from "../src/mcp-server.mjs";
 import { handleFeedRequest } from "../src/feeds.mjs";
@@ -128,6 +129,7 @@ import {
   DAY_MS,
   DENIED_RPC_PREFIXES,
   EMBEDDING_SYNC_CRON,
+  EVENTS_INGEST_TOKEN_HEADER,
   EVENTS_LOAD_CRON,
   HEALTH_PRUNE_CRON,
   HEALTH_TREND_WINDOWS,
@@ -135,6 +137,8 @@ import {
   JSON_CONTENT_TYPE,
   MAX_ASK_BODY_BYTES,
   MAX_BULK_TREND_ROWS,
+  MAX_EVENTS_INGEST_BODY_BYTES,
+  MAX_EVENTS_INGEST_ROWS,
   MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
   MAX_INCIDENT_ROWS,
   MAX_RPC_BODY_BYTES,
@@ -307,50 +311,102 @@ export async function loadStagedEvents(env) {
   const key = "events/account-events-pending.json";
   const object = await bucket.get(key);
   if (!object) return { ok: false, reason: "none" };
-  let rows;
+  let parsed;
   try {
-    rows = await object.json();
+    parsed = await object.json();
   } catch {
     await bucket.delete(key);
     return { ok: false, reason: "parse_failed" };
   }
-  rows = Array.isArray(rows)
-    ? rows.filter(
-        (r) =>
-          Number.isInteger(r?.block_number) &&
-          Number.isInteger(r?.event_index) &&
-          typeof r?.event_kind === "string" &&
-          Number.isInteger(r?.observed_at),
-      )
-    : [];
+  const rows = validEventRows(parsed);
   if (!rows.length) {
     await bucket.delete(key);
     return { ok: false, reason: "empty" };
   }
-  const cols = EVENT_INSERT_COLUMNS;
-  const colList = cols.join(",");
-  const ROWS_PER_STMT = 10; // 9 cols x 10 = 90 bound params (< D1's 100 limit)
+  const statements = eventInsertStatements(db, rows);
   const STMTS_PER_BATCH = 50;
-  const statements = [];
-  for (let i = 0; i < rows.length; i += ROWS_PER_STMT) {
-    const chunk = rows.slice(i, i + ROWS_PER_STMT);
-    const tuples = chunk
-      .map(() => `(${cols.map(() => "?").join(",")})`)
-      .join(",");
-    const values = chunk.flatMap((row) => cols.map((c) => row[c] ?? null));
-    statements.push(
-      db
-        .prepare(
-          `INSERT OR IGNORE INTO account_events (${colList}) VALUES ${tuples}`,
-        )
-        .bind(...values),
-    );
-  }
   for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
     await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
   }
   await bucket.delete(key);
   return { ok: true, rows: rows.length };
+}
+
+// POST /api/v1/internal/events (#1360): the realtime ingest path for the
+// finalized-head streamer (#1361). Disabled (503) until METAGRAPH_EVENTS_INGEST_SECRET
+// is configured; then authenticated by a constant-time token compare. The body is
+// an array of account_events rows (or {events:[...]}), loaded with the SAME
+// parameterized INSERT OR IGNORE as the staged-batch loader — idempotent on
+// (block_number, event_index), values always bound. NOT in the public contract.
+export async function handleEventIngest(request, env) {
+  if (request.method !== "POST") {
+    return errorResponse("method_not_allowed", "POST only.", 405);
+  }
+  const configured = env.METAGRAPH_EVENTS_INGEST_SECRET;
+  if (!configured) {
+    return errorResponse(
+      "events_ingest_disabled",
+      "Realtime event ingest requires METAGRAPH_EVENTS_INGEST_SECRET to be configured.",
+      503,
+    );
+  }
+  const provided = request.headers.get(EVENTS_INGEST_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, configured)) {
+    return errorResponse(
+      "unauthorized",
+      `Provide a valid ${EVENTS_INGEST_TOKEN_HEADER} header.`,
+      401,
+    );
+  }
+  const db = env.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) {
+    return errorResponse("unavailable", "Event store unavailable.", 503);
+  }
+  const raw = await request.text();
+  if (raw.length > MAX_EVENTS_INGEST_BODY_BYTES) {
+    return errorResponse(
+      "payload_too_large",
+      `Body exceeds ${MAX_EVENTS_INGEST_BODY_BYTES} bytes.`,
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return errorResponse(
+      "invalid_body",
+      "Body must be a JSON array of event rows (or {events:[...]}).",
+      400,
+    );
+  }
+  const incoming = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.events)
+      ? parsed.events
+      : null;
+  if (!incoming) {
+    return errorResponse(
+      "invalid_body",
+      "Body must be a JSON array of event rows (or {events:[...]}).",
+      400,
+    );
+  }
+  if (incoming.length > MAX_EVENTS_INGEST_ROWS) {
+    return errorResponse(
+      "too_many_rows",
+      `At most ${MAX_EVENTS_INGEST_ROWS} events per request.`,
+      413,
+    );
+  }
+  const rows = validEventRows(incoming);
+  if (rows.length) {
+    await db.batch(eventInsertStatements(db, rows));
+  }
+  return new Response(JSON.stringify({ ok: true, inserted: rows.length }), {
+    status: 200,
+    headers: { "content-type": JSON_CONTENT_TYPE },
+  });
 }
 
 // Cron entrypoint. Cloudflare passes the exact cron string that fired in
@@ -441,6 +497,12 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // and degrades to 503 when the AI bindings/kill-switch are absent.
   if (url.pathname === "/api/v1/ask") {
     return handleAskRequest(request, env);
+  }
+
+  // Realtime chain-event ingest (#1360): secret-gated internal write path for the
+  // finalized-head streamer (#1361). POST-only; runs before the read-only gate.
+  if (url.pathname === "/api/v1/internal/events") {
+    return handleEventIngest(request, env);
   }
 
   if (!["GET", "HEAD"].includes(request.method)) {

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -97,6 +97,11 @@ export const MAX_WEBHOOK_BODY_BYTES = 8192;
 export const MAX_ASK_BODY_BYTES = 4096;
 export const WEBHOOK_SUBSCRIPTION_TOKEN_HEADER =
   "x-metagraph-webhook-subscription-token";
+// Realtime chain-event ingest (#1360): the header carrying the shared secret the
+// finalized-head streamer (#1361) presents to POST /api/v1/internal/events.
+export const EVENTS_INGEST_TOKEN_HEADER = "x-metagraph-events-token";
+export const MAX_EVENTS_INGEST_BODY_BYTES = 262144; // 256 KB
+export const MAX_EVENTS_INGEST_ROWS = 500;
 // Dormant subscriptions self-clean after 180 days; the publish-time dispatcher
 // refreshes the TTL on each successful delivery.
 export const WEBHOOK_TTL_SECONDS = 180 * 24 * 60 * 60;


### PR DESCRIPTION
Closes #1360. Delivers the #1361 streamer code (deployment on a VPS is the remaining step). Part of epic #1345 — the Option B realtime push path.

## What
True ~12s chain-event freshness, on top of Option A's ~5 min:

- **`POST /api/v1/internal/events`** (#1360) — secret-gated internal write path:
  - Disabled (`503`) until `METAGRAPH_EVENTS_INGEST_SECRET` is configured.
  - Constant-time token auth (`x-metagraph-events-token`, `timingSafeEqual`).
  - Body = array of `account_events` rows (or `{events:[...]}`), loaded with the **same parameterized `INSERT OR IGNORE`** as the batch loader — idempotent on `(block_number, event_index)`, values always bound.
  - Size cap (256 KB) + row cap (500). **Not in the public contract** (internal only).
- **`scripts/stream-events.py`** (#1361) — persistent finalized-head subscriber that **reuses the exact verified decode** from `fetch-events.py` (imported, no drift) and POSTs each block's events. Auto-reconnects. + `deploy/streamer.Dockerfile` + `docs/realtime-streamer.md` (Oracle/Fly free tier or ~$5/mo VPS).
- Refactored `loadStagedEvents` to share `validEventRows` + `eventInsertStatements` (DRY with the ingest endpoint).

## Why it's safe to ship now (dormant until you opt in)
The endpoint returns `503` until the secret is set — zero new attack surface until you deploy the streamer. The CI poller stays as a **self-healing backstop**; idempotent inserts make poller/streamer overlap free.

## Verified
- Streamer's importlib reuse of the decode confirmed (real `StakeAdded` tuple → correct fields).
- **1433 tests pass** incl. new `event-ingest` (auth/disabled/405/400/413/envelope/insert) + the loader-refactor regression.
- public-safety, private-boundary, contract-drift, api, format all green.

## To activate realtime (when your VPS is ready)
1. `wrangler secret put METAGRAPH_EVENTS_INGEST_SECRET`
2. Run the streamer (Docker/systemd) with the same token — see `docs/realtime-streamer.md`.