### PR TITLE
fix(api): route GraphQL before read-only method gate

### DIFF
--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7,6 +7,7 @@ import {
   maxComplexityRule,
   maxDepthRule,
 } from "../src/graphql.mjs";
+import { handleRequest } from "../workers/api.mjs";
 
 // Minimal fake env — no R2 or ASSETS, so readArtifact always returns ok:false.
 const emptyEnv = {};
@@ -29,6 +30,35 @@ describe("handleGraphQLRequest — method guard", () => {
     const body = await res.json();
     assert.ok(body.errors[0].message.includes("POST"));
     assert.equal(res.headers.get("allow"), "POST");
+  });
+});
+
+describe("handleRequest — GraphQL routing", () => {
+  test("POST /api/v1/graphql reaches the GraphQL handler", async () => {
+    const req = new Request("https://api.metagraph.sh/api/v1/graphql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "{ __typename }" }),
+    });
+    const res = await handleRequest(req, emptyEnv, {});
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("allow"), null);
+    assert.deepEqual(await res.json(), { data: { __typename: "Query" } });
+  });
+
+  test("OPTIONS /api/v1/graphql advertises POST for CORS preflight", async () => {
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/graphql", {
+        method: "OPTIONS",
+      }),
+      emptyEnv,
+      {},
+    );
+    assert.equal(res.status, 204);
+    assert.equal(
+      res.headers.get("access-control-allow-methods"),
+      "POST, OPTIONS",
+    );
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -589,6 +589,12 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     return handleEventIngest(request, env);
   }
 
+  // GraphQL read-only query layer over existing artifacts (issue #751). Runs
+  // before the read-only method gate because GraphQL accepts POST requests.
+  if (url.pathname === "/api/v1/graphql") {
+    return handleGraphQLRequest(request, env);
+  }
+
   if (!["GET", "HEAD"].includes(request.method)) {
     return errorResponse(
       "method_not_allowed",
@@ -673,11 +679,6 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // artifact-backed) like /api/v1/events; degrades to 503 when AI is off.
   if (url.pathname === "/api/v1/search/semantic") {
     return handleSemanticSearchRequest(request, env, url);
-  }
-
-  // GraphQL read-only query layer over existing artifacts (issue #751).
-  if (url.pathname === "/api/v1/graphql") {
-    return handleGraphQLRequest(request, env);
   }
 
   // Registry leaderboards (D1 + registry projections; fileless-D1 pattern).
@@ -3970,7 +3971,11 @@ function corsPreflight(request) {
     methods = "POST, OPTIONS";
   } else if (url.pathname.startsWith("/api/v1/webhooks/")) {
     methods = "POST, GET, DELETE, OPTIONS";
-  } else if (url.pathname === "/mcp" || url.pathname === "/api/v1/ask") {
+  } else if (
+    url.pathname === "/mcp" ||
+    url.pathname === "/api/v1/ask" ||
+    url.pathname === "/api/v1/graphql"
+  ) {
     methods = "POST, OPTIONS";
   }
   headers.set("access-control-allow-methods", methods);


### PR DESCRIPTION
### Motivation
- The GraphQL read-only endpoint at `/api/v1/graphql` was intended to be reachable via `POST`, but the global read-only method gate rejected non-GET/HEAD methods before the GraphQL branch could run, making the documented POST API unreachable.
- Browser preflight handling did not advertise `POST` for `/api/v1/graphql`, so CORS preflight responses did not match the endpoint's POST-only contract.

### Description
- Dispatch `/api/v1/graphql` before the generic `GET`/`HEAD` method gate so `POST` requests reach `handleGraphQLRequest` instead of being rejected by the router (`workers/api.mjs`).
- Update `corsPreflight` to include `/api/v1/graphql` among routes that advertise `POST, OPTIONS` for CORS preflight (`workers/api.mjs`).
- Add worker-level tests in `tests/graphql.test.mjs` that assert `POST /api/v1/graphql` reaches the GraphQL handler and that `OPTIONS /api/v1/graphql` advertises `POST` for CORS.

### Testing
- Ran `node --check workers/api.mjs` and `node --check tests/graphql.test.mjs`, both succeeded in syntax/type checking.
- Attempted `npm test -- --run tests/graphql.test.mjs`, but test execution was blocked because the `graphql` package was not present in `node_modules` and `npm install` failed with a `403 Forbidden` when attempting to fetch `graphql@17.0.1` in this environment.
- Added tests are present and exercise the Worker router paths, but full `vitest` execution could not complete here due to the environment package installation restriction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38df717858832cb2c0c7159906b8a1)