### PR TITLE
fix(mcp): filter find_subnet_for_task by callability before truncating the pool

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -261,15 +261,28 @@ async function resolveNetuid(ctx, args) {
 // Rank subnets relevant to a free-form task. Uses semantic (intent) ranking when
 // the AI layer is available, else keyword overlap over the enriched search index
 // (categories + service_kinds). Returns the discovery mode + ordered candidates.
-async function rankSubnetsForTask(ctx, task, poolSize) {
+async function rankSubnetsForTask(ctx, task, poolSize, callableByNetuid) {
+  // Only subnets exposing callable services can perform a task, so apply the
+  // callability filter BEFORE truncating to the pool. Otherwise a callable
+  // subnet ranked behind `poolSize` non-callable matches is cut from the pool
+  // and the tool falsely reports "no callable subnet matched". (Mirrors the
+  // filter-before-slice order in find_subnets_by_capability.)
+  const isCallable = (netuid) => callableByNetuid.has(netuid);
   if (aiEnabled(ctx.env)) {
     try {
       const out = await semanticSearch(ctx.env, task, {
         limit: Math.min(poolSize, 20),
       });
       const ranked = (out.results || [])
-        .filter((r) => r.type === "subnet" && Number.isInteger(r.netuid))
+        .filter(
+          (r) =>
+            r.type === "subnet" &&
+            Number.isInteger(r.netuid) &&
+            isCallable(r.netuid),
+        )
         .map((r) => ({ netuid: r.netuid, relevance: r.score }));
+      // Only commit to semantic mode when it yields callable hits; a pool of
+      // purely non-callable matches falls through to keyword discovery.
       if (ranked.length > 0) return { mode: "semantic", ranked };
     } catch {
       // AI hiccup → fall back to keyword discovery below.
@@ -284,7 +297,7 @@ async function rankSubnetsForTask(ctx, task, poolSize) {
       netuid: doc.netuid,
       relevance: scoreDocument(doc, terms),
     }))
-    .filter((entry) => entry.relevance > 0)
+    .filter((entry) => entry.relevance > 0 && isCallable(entry.netuid))
     .sort((a, b) => b.relevance - a.relevance || a.netuid - b.netuid)
     .slice(0, poolSize);
   return { mode: "keyword", ranked };
@@ -1146,13 +1159,18 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const task = requireString(args, "task");
       const limit = clampLimit(args?.limit, 5, 20);
-      const { mode, ranked } = await rankSubnetsForTask(ctx, task, 50);
       const catalog = await loadArtifactData(
         ctx,
         "/metagraph/agent-catalog.json",
       );
       const byNetuid = new Map(
         (catalog.subnets || []).map((entry) => [entry.netuid, entry]),
+      );
+      const { mode, ranked } = await rankSubnetsForTask(
+        ctx,
+        task,
+        50,
+        byNetuid,
       );
       const results = [];
       for (const { netuid, relevance } of ranked) {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1631,6 +1631,63 @@ describe("MCP goal-shaped tools (find_subnet_for_task + how_do_i_call)", () => {
     assert.ok(out.results.every((r) => r.netuid !== 8));
   });
 
+  test("find_subnet_for_task surfaces a callable subnet ranked beyond the non-callable pool", async () => {
+    // Regression: callability must be filtered BEFORE the rank pool is
+    // truncated. Here 51 non-callable subnets tie with (and, by the ascending
+    // netuid tiebreak, out-rank) the single callable subnet 999, pushing it to
+    // pool position 52 — past the hard-coded poolSize of 50. Filtering after the
+    // slice would drop it and falsely report "no callable subnet matched".
+    const documents = [];
+    for (let netuid = 1; netuid <= 51; netuid += 1) {
+      documents.push({
+        id: `subnet:${netuid}`,
+        type: "subnet",
+        netuid,
+        slug: `sn-${netuid}`,
+        title: "Data tool",
+        tokens: ["data"],
+        categories: ["data"],
+      });
+    }
+    documents.push({
+      id: "subnet:999",
+      type: "subnet",
+      netuid: 999,
+      slug: "sn-999",
+      title: "Data tool",
+      tokens: ["data"],
+      categories: ["data"],
+    });
+    const fixture = {
+      "/metagraph/search.json": { documents },
+      "/metagraph/agent-catalog.json": {
+        subnets: [
+          {
+            netuid: 999,
+            name: "Callable data API",
+            slug: "sn-999",
+            categories: ["data"],
+            integration_readiness: 60,
+            callable_count: 3,
+            service_kinds: ["subnet-api"],
+            base_url: "https://api.example.io",
+            health: "operational",
+          },
+        ],
+      },
+    };
+    const res = await callTool(
+      "find_subnet_for_task",
+      { task: "data", limit: 5 },
+      { deps: makeDeps(fixture) },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.discovery, "keyword");
+    assert.equal(out.count, 1);
+    assert.equal(out.results[0].netuid, 999);
+    assert.equal(out.note, undefined);
+  });
+
   test("find_subnet_for_task notes when nothing callable matches", async () => {
     const res = await callTool(
       "find_subnet_for_task",
@@ -2082,10 +2139,18 @@ describe("MCP goal-shaped tools — branch coverage", () => {
 
   test("find_subnet_for_task tolerates a catalog with no subnets field", async () => {
     const env = aiEnvWithMatches([1, 2]);
+    // Semantic hits that aren't callable (empty catalog) now fall through to
+    // keyword discovery, so search.json must be present (empty here) — still 0.
     const res = await callTool(
       "find_subnet_for_task",
       { task: "anything" },
-      { deps: makeDeps({ "/metagraph/agent-catalog.json": {} }), env },
+      {
+        deps: makeDeps({
+          "/metagraph/agent-catalog.json": {},
+          "/metagraph/search.json": { documents: [] },
+        }),
+        env,
+      },
     );
     assert.equal(res.body.result.structuredContent.count, 0);
   });


### PR DESCRIPTION
## Summary

Fixes #1377.

`find_subnet_for_task` ranked the **entire** subnet index, truncated to a fixed pool of 50, and **only then** joined the result against the callable catalog (`agent-catalog.json`). When 50+ non-callable subnets out-ranked a callable one for the task term, the callable subnet was cut from the pool before the join — so the tool returned an empty result with the misleading note *"No callable subnet matched this task."* even though a callable subnet genuinely matched.

This is the inverse of the order used by the sibling tool `find_subnets_by_capability`, which filters `callable_count > 0` **before** `.slice(0, limit)`.

## What Changed

- `src/mcp-server.mjs` — load the callable catalog first and pass it into `rankSubnetsForTask`, which now applies the callability filter **before** sorting and truncating to the pool, in **both** the semantic and keyword branches. A semantic pool of purely non-callable hits now falls through to keyword discovery instead of committing to `mode: "semantic"` with an empty result. The handler's existing `if (!entry) continue` stays as a harmless safety net.
- `tests/mcp-server.test.mjs` — added a regression test (keyword path, AI disabled) where 51 non-callable subnets out-rank a single callable subnet, asserting the callable subnet is still surfaced (`count === 1`) rather than dropped. Updated the empty-catalog edge-case test to supply an (empty) `search.json`, since non-callable semantic hits now reach the keyword path.

No schema, OpenAPI, or generated-artifact changes — the tool's output shape is unchanged; only which subnets it surfaces becomes correct.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `npx vitest run tests/mcp-server.test.mjs` — 110 passed (incl. the new regression test). The one remaining failure (`list_subnet_apis ... resolves real artifacts from the local env`) is pre-existing and unrelated — it requires built `public/metagraph/` artifacts and fails identically on `main` in a clean local checkout; it passes in CI where artifacts are built.
- [x] `git diff --check`

## Template Used

- Backend/code change

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
