### PR TITLE
fix(mcp): filter callable subnets before pool truncation in find_subnet_for_task

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -261,14 +261,22 @@ async function resolveNetuid(ctx, args) {
 // Rank subnets relevant to a free-form task. Uses semantic (intent) ranking when
 // the AI layer is available, else keyword overlap over the enriched search index
 // (categories + service_kinds). Returns the discovery mode + ordered candidates.
-async function rankSubnetsForTask(ctx, task, poolSize) {
+// byNetuid is the callable catalog map; both branches filter to callable-only
+// entries before truncating to poolSize so the slice never drops callable subnets
+// behind non-callable ones (see issue #1377).
+async function rankSubnetsForTask(ctx, task, poolSize, byNetuid) {
   if (aiEnabled(ctx.env)) {
     try {
       const out = await semanticSearch(ctx.env, task, {
         limit: Math.min(poolSize, 20),
       });
       const ranked = (out.results || [])
-        .filter((r) => r.type === "subnet" && Number.isInteger(r.netuid))
+        .filter(
+          (r) =>
+            r.type === "subnet" &&
+            Number.isInteger(r.netuid) &&
+            byNetuid.has(r.netuid),
+        )
         .map((r) => ({ netuid: r.netuid, relevance: r.score }));
       if (ranked.length > 0) return { mode: "semantic", ranked };
     } catch {
@@ -279,7 +287,7 @@ async function rankSubnetsForTask(ctx, task, poolSize) {
   const terms = queryTerms(task);
   const docs = Array.isArray(index.documents) ? index.documents : [];
   const ranked = docs
-    .filter((doc) => doc.type === "subnet")
+    .filter((doc) => doc.type === "subnet" && byNetuid.has(doc.netuid))
     .map((doc) => ({
       netuid: doc.netuid,
       relevance: scoreDocument(doc, terms),
@@ -1146,7 +1154,8 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const task = requireString(args, "task");
       const limit = clampLimit(args?.limit, 5, 20);
-      const { mode, ranked } = await rankSubnetsForTask(ctx, task, 50);
+      // Load the callable catalog first so rankSubnetsForTask can apply the
+      // callability filter before truncating to the pool size (issue #1377).
       const catalog = await loadArtifactData(
         ctx,
         "/metagraph/agent-catalog.json",
@@ -1154,10 +1163,16 @@ export const MCP_TOOLS = [
       const byNetuid = new Map(
         (catalog.subnets || []).map((entry) => [entry.netuid, entry]),
       );
+      const { mode, ranked } = await rankSubnetsForTask(
+        ctx,
+        task,
+        50,
+        byNetuid,
+      );
       const results = [];
       for (const { netuid, relevance } of ranked) {
         const entry = byNetuid.get(netuid);
-        if (!entry) continue; // Only subnets with callable services can do a task.
+        if (!entry) continue; // Safety net — all ranked entries are callable.
         results.push({
           netuid,
           name: entry.name,

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -2082,12 +2082,84 @@ describe("MCP goal-shaped tools — branch coverage", () => {
 
   test("find_subnet_for_task tolerates a catalog with no subnets field", async () => {
     const env = aiEnvWithMatches([1, 2]);
+    // After #1377 the callable catalog is loaded before ranking, so semantic
+    // results are filtered against the (empty) byNetuid map and fall through to
+    // keyword. Include an empty search.json so keyword can load without throwing.
     const res = await callTool(
       "find_subnet_for_task",
       { task: "anything" },
-      { deps: makeDeps({ "/metagraph/agent-catalog.json": {} }), env },
+      {
+        deps: makeDeps({
+          "/metagraph/agent-catalog.json": {},
+          "/metagraph/search.json": { documents: [] },
+        }),
+        env,
+      },
     );
     assert.equal(res.body.result.structuredContent.count, 0);
+  });
+
+  test("find_subnet_for_task returns the callable subnet even when 50+ non-callable subnets rank higher (regression #1377)", async () => {
+    // 51 non-callable subnets (not in catalog) that strongly match the task term
+    // would fill and exhaust the 50-entry pool before the fix, silently dropping
+    // the one callable subnet. After the fix the callability filter is applied
+    // before the slice so the callable subnet always surfaces.
+    const nonCallableCount = 51;
+    const nonCallableDocs = Array.from(
+      { length: nonCallableCount },
+      (_, i) => ({
+        id: `subnet:${i + 1}`,
+        type: "subnet",
+        netuid: i + 1,
+        slug: `sn-${i + 1}`,
+        title: `Non-callable ${i + 1}`,
+        subtitle: "data api scraping",
+        tokens: ["data", "api", "scraping"],
+      }),
+    );
+    // Callable subnet scores lower (fewer matching tokens).
+    const callableDoc = {
+      id: "subnet:99",
+      type: "subnet",
+      netuid: 99,
+      slug: "sn-99",
+      title: "Callable Data",
+      subtitle: "data",
+      tokens: ["data"],
+    };
+    const deps = makeDeps({
+      "/metagraph/search.json": {
+        documents: [...nonCallableDocs, callableDoc],
+      },
+      "/metagraph/agent-catalog.json": {
+        subnets: [
+          {
+            netuid: 99,
+            name: "Callable Data",
+            slug: "sn-99",
+            categories: ["data"],
+            integration_readiness: 60,
+            callable_count: 1,
+            service_kinds: ["subnet-api"],
+            base_url: "https://callable.io",
+            health: "operational",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "find_subnet_for_task",
+      { task: "data api scraping", limit: 5 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.discovery, "keyword");
+    assert.equal(
+      out.count,
+      1,
+      "callable subnet must be returned even when non-callable subnets fill the unfiltered top-50",
+    );
+    assert.equal(out.results[0].netuid, 99);
   });
 
   describe("live health overlay (warm KV overrides stale static)", () => {


### PR DESCRIPTION
Closes #1377.

## Root cause

`rankSubnetsForTask` ranked the full subnet index (all enriched subnets), truncated to `poolSize = 50`, and only then did the handler join against `agent-catalog.json` to filter for callability. When 50+ non-callable subnets out-ranked a callable one, the callable subnet was silently cut by the `slice(0, 50)` and `find_subnet_for_task` returned `count: 0` with a misleading `"No callable subnet matched this task."` — even when one genuinely matched.

## Fix

Load `agent-catalog.json` and build the `byNetuid` map **before** calling `rankSubnetsForTask`, then pass it in. Both branches apply the callable filter before truncation:

**Keyword branch** — filter added before `.slice(0, poolSize)`:
```js
.filter((doc) => doc.type === "subnet" && byNetuid.has(doc.netuid))
```

**Semantic branch** — filter added before the `ranked.length > 0` check:
```js
.filter((r) => r.type === "subnet" && Number.isInteger(r.netuid) && byNetuid.has(r.netuid))
```

A semantic pool whose results are all non-callable now falls through to keyword instead of returning `mode: "semantic"` with an empty result (also noted in the issue). The existing `if (!entry) continue` safety net is preserved as a harmless backstop.

This mirrors the correct order already used by `find_subnets_by_capability` (filters callability before truncating).

## Tests

Added regression test in `tests/mcp-server.test.mjs`:

> 51 non-callable subnets out-score the one callable subnet (more matching tokens). Pre-fix: `count: 0`. Post-fix: `count: 1`, `results[0].netuid === 99`.

Updated the pre-existing "tolerates a catalog with no subnets field" test: after the fix an empty `byNetuid` causes semantic fallthrough to keyword, so `search.json` must be present in the deps (added as `{ documents: [] }`).

All 1 480 tests pass.