### PR TITLE
feat(streamer): Railway deploy config-as-code + WAF-safe User-Agent (#1361)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Minimal Docker build context for the realtime streamer image (#1361) — security
+# + speed. Only the streamer's sources are needed; never ship .git, node_modules,
+# build artifacts, or any env/secret files into the build context.
+*
+!scripts/
+!deploy/

--- a/deploy/streamer.Dockerfile
+++ b/deploy/streamer.Dockerfile
@@ -1,19 +1,28 @@
 # Realtime chain-event streamer (#1361, epic #1345) — Option B.
-# A tiny always-on container for a cheap host (Oracle Cloud Free / Fly.io free
-# tier, or a ~$5/mo VPS). Subscribes to finalized finney heads, decodes the
+# A tiny always-on container. Subscribes to finalized finney heads, decodes the
 # SubtensorModule events, and POSTs them to the Worker ingest endpoint (#1360).
+# Cost on Railway is RAM-dominated (idle WebSocket between blocks → near-zero CPU);
+# kept lean (~150 MB) so it fits a tight free-credit budget. See
+# docs/realtime-streamer.md for the cost caps.
 #
 # Build (from the repo root):
 #   docker build -f deploy/streamer.Dockerfile -t metagraphed-streamer .
-# Run:
-#   docker run -e EVENTS_INGEST_URL=https://api.metagraph.sh/api/v1/internal/events \
-#              -e METAGRAPH_EVENTS_INGEST_SECRET=... metagraphed-streamer
 FROM python:3.12-slim
+
+# Run as a non-root user (least privilege).
+RUN useradd --create-home --uid 10001 streamer
 WORKDIR /app
-# Pinned (matches the CI poller) — never auto-pull a future PyPI release.
+
+# Single pinned dep (matches the CI poller) — never auto-pull a future release.
 RUN pip install --no-cache-dir "substrate-interface==1.8.1"
+
 # The streamer imports the verified decode from fetch-events.py — copy both.
 COPY scripts/fetch-events.py scripts/stream-events.py /app/scripts/
-ENV EVENTS_RPC_URL=wss://entrypoint-finney.opentensor.ai:443
+
+ENV EVENTS_RPC_URL=wss://entrypoint-finney.opentensor.ai:443 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+USER streamer
 # Provide at runtime (NOT baked in): EVENTS_INGEST_URL, METAGRAPH_EVENTS_INGEST_SECRET
 CMD ["python", "scripts/stream-events.py"]

--- a/docs/realtime-streamer.md
+++ b/docs/realtime-streamer.md
@@ -30,8 +30,8 @@ triggering pointless rebuilds.
 - **Service → Settings → Scale → Replica Limits:** drop Memory to ~512 MB (the
   streamer uses ~150 MB; this hard-caps the per-service cost). CPU can stay/at ~2 vCPU.
 - **Workspace → Settings → Usage:** set an account usage limit (hard stop) at your
-  comfort threshold. Note it's shared with other services (e.g. Umami), so size it to
-  cover both — Railway pauses services if the limit is hit.
+  comfort threshold. Note the limit is shared across every service on the account,
+  so size it to cover them all — Railway pauses services if the limit is hit.
 
 ## 1. Configure the Worker secret (one-time)
 

--- a/docs/realtime-streamer.md
+++ b/docs/realtime-streamer.md
@@ -11,6 +11,28 @@ idempotent on `(block_number, event_index)`, so any overlap is free.
 This needs one small always-on host (**~$0–5/mo**): Oracle Cloud Free Tier or
 Fly.io's free allowance ($0), or a cheap VPS / Railway / Render worker (~$5/mo).
 
+## Deployed on Railway (current)
+
+This project runs the streamer on Railway (project `metagraphed-streamer`). Cost is
+**RAM-dominated** — the streamer idles on a WebSocket between blocks, so CPU is
+near-zero; realistically **~$1.5/mo** (~150 MB held 24/7) on usage-based billing.
+
+Config is **config-as-code in `railway.json`** (build via `deploy/streamer.Dockerfile`,
+`ON_FAILURE` restart capped at 10 retries, and `watchPatterns` so a GitHub-connected
+deploy only rebuilds when the streamer's own files change — important because this
+repo's `main` is very active). To enable auto-deploys like the Cloudflare Workers
+Builds pipeline: **Service → Settings → Connect Repo** → `JSONbored/metagraphed`,
+branch `main`. The watch paths in `railway.json` keep unrelated merges from
+triggering pointless rebuilds.
+
+**Cost caps (set once, so the bill can't balloon):**
+
+- **Service → Settings → Scale → Replica Limits:** drop Memory to ~512 MB (the
+  streamer uses ~150 MB; this hard-caps the per-service cost). CPU can stay/at ~2 vCPU.
+- **Workspace → Settings → Usage:** set an account usage limit (hard stop) at your
+  comfort threshold. Note it's shared with other services (e.g. Umami), so size it to
+  cover both — Railway pauses services if the limit is hit.
+
 ## 1. Configure the Worker secret (one-time)
 
 The ingest endpoint is disabled until the secret is set. Generate a strong token

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "deploy/streamer.Dockerfile",
+    "watchPatterns": [
+      "scripts/stream-events.py",
+      "scripts/fetch-events.py",
+      "deploy/streamer.Dockerfile",
+      "railway.json"
+    ]
+  },
+  "deploy": {
+    "numReplicas": 1,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -78,7 +78,13 @@ def push(rows):
         INGEST_URL,
         data=body,
         method="POST",
-        headers={"content-type": "application/json", TOKEN_HEADER: SECRET},
+        headers={
+            "content-type": "application/json",
+            # A real User-Agent: the default Python-urllib UA is blocked by the
+            # Cloudflare WAF in front of the Worker (403).
+            "user-agent": "metagraphed-streamer/1.0",
+            TOKEN_HEADER: SECRET,
+        },
     )
     with urllib.request.urlopen(req, timeout=15) as resp:
         resp.read()


### PR DESCRIPTION
Part of epic #1345. Makes the realtime streamer (#1361) deploy reproducible + version-tracked, and fixes the one runtime issue found deploying it.

## Context
The streamer is **deployed + live on Railway** (project `metagraphed-streamer`), pushing **~12 s realtime** — verified with D1 lag at **0 blocks**. This PR commits the deploy config so it's all in git (answering "can we version-track the Railway setup?" — yes).

## Changes
- **`railway.json`** (config-as-code): build via `deploy/streamer.Dockerfile`, `ON_FAILURE` restart capped at 10 retries, and **`watchPatterns`** scoped to the streamer's own files — so a GitHub-connected auto-deploy only rebuilds when those change (metagraphed's `main` is very active; otherwise every unrelated merge would rebuild the streamer).
- **`.dockerignore`**: minimal build context (only `scripts/` + `deploy/`) — security + speed.
- **`deploy/streamer.Dockerfile`**: non-root user, `PYTHONUNBUFFERED`, lean (~150 MB → **~$1.5/mo** on Railway's RAM-dominated billing — it idles on a WebSocket between blocks).
- **`scripts/stream-events.py`**: send a real `User-Agent` — Cloudflare's WAF `403`s the default `Python-urllib` UA (caught during deploy; the fix verified live).
- **docs**: Railway deploy + connect-repo + cost-cap guidance (replica memory limit + account usage limit so the bill can't balloon).

## Cadence + cost
- ~12 s (one finalized block); CI poller stays as a ~5-min backstop.
- ~$1.5/mo, hard-cappable via Railway replica memory limit + account usage limit.

No app-code change to the Worker; the ingest endpoint (#1360) already shipped.