### PR TITLE
fix(api): surface observed_at on /subnets/{netuid}/uptime responses

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -893,7 +893,13 @@ function shiftDate(isoDate, days) {
 // {surface_id, day, samples, ok_count, uptime_ratio, avg_latency_ms, status}.
 // Groups by surface, sorts days ascending, and rolls a window-wide uptime_ratio
 // from the summed ok_count/samples (exact, not an average of ratios).
-export function formatUptime({ netuid, window, rows, now = null }) {
+export function formatUptime({
+  netuid,
+  window,
+  observedAt = null,
+  rows,
+  now = null,
+}) {
   const reliabilityRows = (rows || []).map((row) => ({
     ...row,
     surface_id: surfaceLookupKey(row),
@@ -956,6 +962,7 @@ export function formatUptime({ netuid, window, rows, now = null }) {
     schema_version: 1,
     netuid,
     window: window || null,
+    observed_at: observedAt || null,
     source: "live-cron-prober",
     reliability: reliability.subnet,
     surfaces,

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -1961,6 +1961,7 @@ describe("formatUptime (daily uptime history)", () => {
     });
     assert.equal(out.netuid, 7);
     assert.equal(out.window, "90d");
+    assert.equal(out.observed_at, null);
     assert.equal(out.source, "live-cron-prober");
     // sorted by surface_id (a before b)
     assert.equal(out.surfaces[0].surface_id, "a");
@@ -2020,6 +2021,17 @@ describe("formatUptime (daily uptime history)", () => {
     assert.equal(out.reliability, null);
   });
 
+  test("propagates observedAt into observed_at", () => {
+    const ts = "2026-06-22T00:00:00.000Z";
+    const out = formatUptime({
+      netuid: 7,
+      window: "90d",
+      observedAt: ts,
+      rows: [],
+    });
+    assert.equal(out.observed_at, ts);
+  });
+
   test("handles null ratios/latency, missing status, zero samples, and no window", () => {
     const out = formatUptime({
       netuid: 7,
@@ -2044,6 +2056,7 @@ describe("formatUptime (daily uptime history)", () => {
 
 describe("worker /api/v1/subnets/{netuid}/uptime route", () => {
   test("serves the live daily uptime rollup from D1", async () => {
+    const UPTIME_RUN = "2026-06-22T01:00:00.000Z";
     const env = createLocalArtifactEnv({
       METAGRAPH_HEALTH_DB: d1With([
         {
@@ -2056,6 +2069,7 @@ describe("worker /api/v1/subnets/{netuid}/uptime route", () => {
           status: "ok",
         },
       ]),
+      METAGRAPH_CONTROL: kvWith({ "health:meta": { last_run_at: UPTIME_RUN } }),
     });
     const res = await handleRequest(
       req("/api/v1/subnets/7/uptime?window=1y"),
@@ -2066,9 +2080,11 @@ describe("worker /api/v1/subnets/{netuid}/uptime route", () => {
     const body = await res.json();
     assert.equal(body.data.netuid, 7);
     assert.equal(body.data.window, "1y");
+    assert.equal(body.data.observed_at, UPTIME_RUN);
     assert.equal(body.data.surfaces[0].surface_id, "7:subnet-api:x");
     assert.equal(body.data.surfaces[0].uptime_ratio, 1);
     assert.equal(body.meta.source, "live-cron-prober");
+    assert.equal(body.meta.generated_at, UPTIME_RUN);
   });
 
   test("defaults to 90d and returns an empty series when D1 is cold", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -2300,9 +2300,11 @@ async function handleUptime(request, env, netuid, url) {
      LIMIT ?`,
     [netuid, cutoff, MAX_UPTIME_ROWS],
   );
+  const healthMeta = await readHealthMetaKv(env);
   const data = formatUptime({
     netuid,
     window: windowParam,
+    observedAt: healthMeta?.last_run_at || null,
     rows,
     now: new Date().toISOString(),
   });
@@ -2313,7 +2315,7 @@ async function handleUptime(request, env, netuid, url) {
       meta: await analyticsMeta(
         env,
         `/metagraph/subnets/${netuid}/uptime.json`,
-        null,
+        data.observed_at,
       ),
     },
     "short",


### PR DESCRIPTION
## Problem

`formatUptime` was the only analytics formatter that did not accept or emit `observed_at`.  Every other D1-backed analytics route — `/health/percentiles`, `/health/incidents`, `/health/trends`, `/health/leaderboards` — follows this pattern:

```js
const meta = await readHealthMetaKv(env);
const data = formatXxx({ ..., observedAt: meta?.last_run_at || null });
// data.observed_at ↓
meta: await analyticsMeta(env, path, data.observed_at)
```

The `/uptime` route skipped both steps: `handleUptime` never called `readHealthMetaKv`, and `formatUptime` had no `observedAt` param. The result was `data.observed_at: undefined` and `meta.generated_at: null` on every response, even on warm isolates with a fresh health cron run — making it impossible for clients to judge data freshness.

## Fix

- Add `observedAt = null` param to `formatUptime`; include `observed_at: observedAt || null` in the return value
- In `handleUptime`, call `readHealthMetaKv(env)` and thread `last_run_at` through (the KV read is already memoized in-isolate by PR #1375, so zero extra latency on warm isolates)
- Pass `data.observed_at` to `analyticsMeta` instead of the hardcoded `null`

The uptime data comes from `surface_uptime_daily` which is populated by the same health-prober cron that writes `KV_HEALTH_META`, so `last_run_at` is the correct freshness signal.

## Tests

- Added `assert.equal(out.observed_at, null)` to the existing formatter test (no `observedAt` → null)
- Added `"propagates observedAt into observed_at"` unit test
- Updated the route-level integration test to supply a `health:meta` KV fixture and assert both `body.data.observed_at` and `body.meta.generated_at` surface the prober timestamp end-to-end

All 1 483 tests pass.