### PR TITLE
feat(health): surface chain-event index freshness on /health (#1361)

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -285,6 +285,45 @@ describe("/health readiness", () => {
     assert.ok(body.chain_events.latest_event_at.startsWith("20"));
   });
 
+  test("chain_events is schema-stable nulls when the event tier is cold (#1361)", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: makeKv({
+        "metagraph:latest": { published_at: new Date().toISOString() },
+      }),
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  return { results: [] }; // empty account_events tier
+                },
+              };
+            },
+          };
+        },
+      },
+    });
+    const res = await handleRequest(req("/health"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.chain_events.latest_indexed_block, null);
+    assert.equal(body.chain_events.latest_event_at, null);
+    assert.equal(body.chain_events.age_seconds, null);
+  });
+
+  test("chain_events is null when no health DB is bound (#1361)", async () => {
+    const env = {
+      ASSETS: {
+        async fetch() {
+          return new Response("{}", { status: 404 });
+        },
+      },
+    };
+    const res = await handleRequest(req("/health"), env, {});
+    assert.equal((await res.json()).chain_events, null);
+  });
+
   test("HEAD /health returns no body", async () => {
     const res = await handleRequest(
       req("/health", { method: "HEAD" }),

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -252,6 +252,39 @@ describe("/health readiness", () => {
     assert.equal((await res.json()).status, "ok");
   });
 
+  test("reports chain-event index freshness (#1361)", async () => {
+    const atMs = Date.now() - 18_000; // latest indexed event ~18s ago
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: makeKv({
+        "metagraph:latest": { published_at: new Date().toISOString() },
+      }),
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  return { results: [{ block: 8461200, at: atMs }] };
+                },
+              };
+            },
+          };
+        },
+      },
+    });
+    const res = await handleRequest(req("/health"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.chain_events.latest_indexed_block, 8461200);
+    assert.equal(typeof body.chain_events.age_seconds, "number");
+    assert.ok(
+      body.chain_events.age_seconds >= 17 &&
+        body.chain_events.age_seconds <= 120,
+      `age_seconds out of range: ${body.chain_events.age_seconds}`,
+    );
+    assert.ok(body.chain_events.latest_event_at.startsWith("20"));
+  });
+
   test("HEAD /health returns no body", async () => {
     const res = await handleRequest(
       req("/health", { method: "HEAD" }),

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -3379,6 +3379,28 @@ async function handleHealthRequest(request, env) {
     ? (Date.now() - opRunAtMs) / 60_000
     : null;
 
+  // Chain-event index freshness (#1346/#1361) — the realtime streamer's heartbeat.
+  // MAX(observed_at) is the chain timestamp of the latest indexed event; age_seconds
+  // is ~12-30s while the streamer is live, growing toward the ~5-min poller backstop
+  // if it's down. Reported for observability (does NOT gate the HTTP status, like
+  // operational_health); best-effort + null on a cold/unbound store.
+  let chainEvents = null;
+  if (bindings.health_db) {
+    const rows = await d1All(
+      env,
+      "SELECT MAX(block_number) AS block, MAX(observed_at) AS at FROM account_events",
+      [],
+    );
+    const row = rows[0] || {};
+    const atMs = Number(row.at);
+    const fresh = Number.isFinite(atMs);
+    chainEvents = {
+      latest_indexed_block: row.block ?? null,
+      latest_event_at: fresh ? new Date(atMs).toISOString() : null,
+      age_seconds: fresh ? Math.round((Date.now() - atMs) / 1000) : null,
+    };
+  }
+
   const body = JSON.stringify({
     status: stale ? "degraded" : "ok",
     service: "metagraphed",
@@ -3398,6 +3420,7 @@ async function handleHealthRequest(request, env) {
       probed_count: meta?.probed_count ?? null,
       status_counts: meta?.status_counts ?? null,
     },
+    chain_events: chainEvents,
   });
 
   const headers = apiHeaders("short");


### PR DESCRIPTION
Part of epic #1345. Makes the realtime streamer observable through the existing API instead of exposing the Railway service.

## What
Adds a `chain_events` block to `GET /health`:
```json
"chain_events": {
  "latest_indexed_block": 8461200,
  "latest_event_at": "2026-06-22T...Z",
  "age_seconds": 18
}
```
- `age_seconds` ≈ 12–30s while the realtime streamer (#1361) is live; grows toward the ~5-min poller backstop (#1346/#1359) if the streamer is down — a clean liveness signal.
- One `MAX(block_number)/MAX(observed_at)` D1 query; **reported for observability, does not gate the HTTP status** (same pattern as `operational_health`); best-effort + null on a cold/unbound store.

## Why here (not a streamer subdomain)
The streamer is a push-only background worker with no inbound HTTP. Surfacing freshness on `/health` keeps it **private (zero public attack surface)** and observable in one place — point any uptime monitor at `api.metagraph.sh/health` and watch `chain_events.age_seconds`.

## Tests
New `/health` test asserts the `chain_events` block; existing `/health` + worker-runtime tests green.