### PR TITLE
fix(api): keep the current bucket in the /rpc/usage time-series

### DIFF
--- a/tests/rpc-usage.test.mjs
+++ b/tests/rpc-usage.test.mjs
@@ -258,6 +258,30 @@ describe("/api/v1/rpc/usage route", () => {
     assert.equal(bucketCall.params[1], 60 * 60 * 1000);
     assert.equal(bucketCall.params[3], 7 * 24);
   });
+
+  test("bucket query keeps the most-recent buckets (current bucket not dropped)", async () => {
+    // Regression: `since` is unaligned to bucket boundaries, so a full window
+    // spans maxBuckets+1 buckets. The LIMIT must keep the NEWEST maxBuckets
+    // (inner ORDER BY ts DESC) and re-order ascending for the chart — a bare
+    // ascending LIMIT would drop the current (leading-edge) bucket.
+    const calls = [];
+    const usageDb = {
+      prepare: (sql) => ({
+        bind: (...params) => ({
+          async all() {
+            calls.push({ sql, params });
+            return { results: [] };
+          },
+        }),
+      }),
+    };
+    const env = { ...createLocalArtifactEnv(), METAGRAPH_HEALTH_DB: usageDb };
+    await getJson("https://api.metagraph.sh/api/v1/rpc/usage", env);
+    const sql = calls.find((call) => call.sql.includes("GROUP BY ts")).sql;
+    // Inner query takes the newest buckets; outer query restores chronological order.
+    assert.match(sql, /ORDER BY ts DESC\s+LIMIT \?/);
+    assert.match(sql, /\)\s*ORDER BY ts ASC\s*$/);
+  });
 });
 
 // --- recordRpcUsage telemetry (via the live proxy) --------------------------

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -2562,15 +2562,24 @@ async function handleRpcUsage(request, env, url) {
       ),
       d1All(
         env,
-        `SELECT CAST(observed_at / ? AS INTEGER) * ? AS ts,
-                COUNT(*) AS requests,
-                SUM(CASE WHEN ok = 1 THEN 0 ELSE 1 END) AS errors,
-                AVG(latency_ms) AS avg_latency_ms
-         FROM rpc_proxy_events
-         WHERE observed_at >= ?
-         GROUP BY ts
-         ORDER BY ts ASC
-         LIMIT ?`,
+        // Buckets are aligned to absolute boundaries but `since` is not, so a
+        // full window spans maxBuckets+1 buckets. Keep the most-recent
+        // maxBuckets (inner ORDER BY ts DESC LIMIT) — dropping the partial
+        // oldest bucket rather than the current one — then re-order ascending
+        // for the chart. A bare `ORDER BY ts ASC LIMIT` would drop the current
+        // bucket, leaving the series permanently missing its leading edge.
+        `SELECT ts, requests, errors, avg_latency_ms FROM (
+           SELECT CAST(observed_at / ? AS INTEGER) * ? AS ts,
+                  COUNT(*) AS requests,
+                  SUM(CASE WHEN ok = 1 THEN 0 ELSE 1 END) AS errors,
+                  AVG(latency_ms) AS avg_latency_ms
+           FROM rpc_proxy_events
+           WHERE observed_at >= ?
+           GROUP BY ts
+           ORDER BY ts DESC
+           LIMIT ?
+         )
+         ORDER BY ts ASC`,
         [
           bucketConfig.bucketMs,
           bucketConfig.bucketMs,


### PR DESCRIPTION
## Summary

Fixes #1388.

The `/api/v1/rpc/usage` time-series sub-query in `handleRpcUsage` buckets `rpc_proxy_events` into absolute-aligned time buckets but bounded them with `ORDER BY ts ASC LIMIT maxBuckets`. Because the window start `since = Date.now() - days * DAY_MS` is not aligned to a bucket boundary, a fully-populated window spans `maxBuckets + 1` distinct buckets — so keeping the `maxBuckets` **oldest** of them silently dropped the **newest (current)** bucket. The served series was permanently missing its leading edge (the current hour for `7d`, the current 6h block for `30d`), and disagreed with the `summary` totals — which have no such `LIMIT` — for the same window.

## What Changed

- `workers/api.mjs` — keep the most-recent `maxBuckets` buckets: an inner `ORDER BY ts DESC LIMIT ?` retains the current bucket (dropping the partial *oldest* bucket instead, the more defensible end to trim), wrapped in an outer `ORDER BY ts ASC` that restores the chronological order the formatter expects. `bucketMs` and `maxBuckets` bind params are unchanged, so the response shape is identical — one previously-missing bucket now appears.
- `tests/rpc-usage.test.mjs` — added a regression test asserting the bucket query keeps the newest buckets (inner `ORDER BY ts DESC` + outer `ORDER BY ts ASC`), so the current bucket can't be silently dropped again.

No schema, OpenAPI, or generated-artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `npx vitest run tests/rpc-usage.test.mjs` — 12 passed (incl. the new regression test)
- [x] `git diff --check`

## Template Used

- Backend/code change

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
