### PR TITLE
fix: skip health prune when daily rollup fails.

### DIFF
--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -1527,4 +1527,38 @@ describe("rollupDailyUptime (durable daily history)", () => {
       "daily rollup must run before the raw prune so history is never lost",
     );
   });
+
+  test("hourly cron skips prune when uptime rollup fails", async () => {
+    const order = [];
+    const orderDb = {
+      prepare(sql) {
+        return {
+          sql,
+          bind: () => ({
+            sql,
+            async run() {
+              order.push(`run:${sql}`);
+              return { meta: { changes: 0 } };
+            },
+          }),
+        };
+      },
+      async batch() {
+        order.push("batch:uptime-rollup");
+        throw new Error("d1 unavailable");
+      },
+    };
+    const result = await handleScheduled(
+      { cron: "0 * * * *" },
+      { METAGRAPH_HEALTH_DB: orderDb },
+      {},
+    );
+    assert.equal(result.rollup_skipped_prune, true);
+    assert.equal(result.uptime_rolled, false);
+    assert.equal(result.pruned, false);
+    assert.ok(
+      !order.some((o) => o.includes("DELETE FROM surface_checks")),
+      "raw surface_checks must not be pruned when rollup fails",
+    );
+  });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -517,13 +517,25 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
     // Roll the day's raw checks into the durable daily uptime table BEFORE
     // pruning, so long-term history is never lost when 30-day raw rows are
     // deleted (PR3). Roll the chain events the same way (#1346) before their
-    // 90-day window is pruned. Then prune + snapshot.
-    await rollupDailyUptime(env);
-    await rollupAccountEventsDaily(env).catch(() => {});
+    // 90-day window is pruned. Skip prune when either rollup fails so raw rows
+    // are never deleted without being aggregated first.
+    const uptimeRollup = await rollupDailyUptime(env);
+    const eventsRollup = await rollupAccountEventsDaily(env);
+    const snapshotPromise = writeSubnetSnapshot(env, { readArtifact });
+    if (!uptimeRollup.rolled || !eventsRollup.rolled) {
+      const snapshot = await snapshotPromise;
+      return {
+        pruned: false,
+        rollup_skipped_prune: true,
+        uptime_rolled: uptimeRollup.rolled,
+        events_rolled: eventsRollup.rolled,
+        snapshot,
+      };
+    }
     const [pruned] = await Promise.all([
       pruneHealthHistory(env),
       pruneAccountEvents(env).catch(() => ({ pruned: false })),
-      writeSubnetSnapshot(env, { readArtifact }),
+      snapshotPromise,
     ]);
     return pruned;
   }


### PR DESCRIPTION
## Summary

The hourly maintenance cron rolls raw D1 rows into durable daily tables before pruning the hot window. Rollup functions return `{ rolled: false }` on failure instead of throwing, but prune always ran anyway — violating the documented invariant that long-term history must never be lost.

This change gates both `pruneHealthHistory` and `pruneAccountEvents` on successful rollups. Subnet snapshots still run every hour regardless.

## Problem

`handleScheduled` (health prune cron) previously did:

1. `rollupDailyUptime(env)` — swallows errors, returns `{ rolled: false }`
2. `rollupAccountEventsDaily(env).catch(() => {})` — same
3. `pruneHealthHistory` + `pruneAccountEvents` — **always attempted**

Rollup only aggregates **today + yesterday**. If it fails repeatedly while a day is in that window (D1 outage, missing migration, transient batch error), that day's raw rows can age out unaggregated. Prune then deletes them after 30 days (health) or 90 days (events) — permanent data loss.

## Fix

- Check `rolled` from both rollup functions before pruning.
- On failure, return `{ rollup_skipped_prune: true, uptime_rolled, events_rolled, snapshot }` and skip all deletes.
- Reuse the in-flight `writeSubnetSnapshot` promise so snapshots are not duplicated.

## Files changed

| File | Change |
|------|--------|
| `workers/api.mjs` | Gate prune on `rolled: true` from uptime + account-event rollups |
| `tests/health-prober.test.mjs` | Assert prune is skipped when uptime rollup throws |

## Test plan

- [x] `npm test -- tests/health-prober.test.mjs`
  - Existing: rollup runs before prune on success
  - New: `DELETE FROM surface_checks` never runs when rollup batch throws
- [ ] Full CI (`validate` workflow on Linux)

## Risk / notes

- **Conservative by design:** if either rollup fails, both health and account-event prunes are skipped for that hour. Raw tables may grow slightly during a D1 incident; that is preferable to deleting unaggregated history.
- **No behavior change** when both rollups succeed — prune + snapshot proceed as before.
