### PR TITLE
fix(neuron): allow full staged neuron snapshots by raising pre-parse byte cap

### DIFF
--- a/tests/load-staged-neurons.test.mjs
+++ b/tests/load-staged-neurons.test.mjs
@@ -150,10 +150,29 @@ test("loadStagedNeurons rejects unsigned or tampered staged payloads", async () 
   assert.equal(m2.batches.length, 0);
 });
 
+test("loadStagedNeurons accepts full-network snapshots above the old 2 MB cap", async () => {
+  const rows = Array.from({ length: 2_000 }, (_, i) => ({
+    ...neuronRow(1, i),
+    hotkey: `h${"x".repeat(511)}`.slice(0, 512),
+    coldkey: `c${"y".repeat(511)}`.slice(0, 512),
+    axon: `a${"z".repeat(511)}`.slice(0, 512),
+  }));
+  const envelope = signedEnvelope(rows);
+  const size = JSON.stringify(envelope).length;
+  assert.ok(size > 2_000_000, "fixture must exceed the regressed 2 MB cap");
+
+  const m = mockEnv({ rows: envelope, size });
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.rows, rows.length);
+  assert.ok(m.batches.length > 0);
+  assert.deepEqual(m.deleted, ["metagraph/neurons-pending.json"]);
+});
+
 test("loadStagedNeurons rejects oversized and out-of-range rows", async () => {
   const oversized = mockEnv({
     rows: signedEnvelope([neuronRow(1, 0)]),
-    size: 2_000_001,
+    size: 32_000_001,
   });
   const oversizedResult = await loadStagedNeurons(oversized.env);
   assert.equal(oversizedResult.reason, "too_large");

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -242,11 +242,13 @@ export default {
 
 // Sanity bounds for an authenticated, HMAC-signed staged neuron batch (the data
 // is already trusted; these are defense-in-depth caps so a malformed signed file
-// can't blow up the D1 load). netuid and uid are both u16 on-chain, so each is
+// can't blow up the D1 load). The byte cap intentionally allows the
+// expected all-subnet signed JSON envelope (~33k rows) while still bounding
+// memory use before parsing. netuid and uid are both u16 on-chain, so each is
 // capped at the u16 max (65535) — matching the existing netuid guard in
 // src/webhooks.mjs and avoiding rejection of legitimately high subnet ids.
 const STAGED_NEURONS_KEY = "metagraph/neurons-pending.json";
-const MAX_STAGED_NEURONS_BYTES = 2_000_000;
+const MAX_STAGED_NEURONS_BYTES = 32_000_000;
 const MAX_STAGED_NEURON_ROWS = 50_000;
 const MAX_STAGED_NEURON_STRING_BYTES = 512;
 const MAX_STAGED_NETUID = 65_535;


### PR DESCRIPTION
### Motivation
- A recent hard cap of `2_000_000` bytes caused the Worker to delete legitimate signed all-subnet staged snapshots (≈33k rows), preventing D1 refreshes and degrading availability.
- The intent is to keep a pre-parse memory bound while allowing the documented full-network snapshot shape to be accepted and processed.

### Description
- Increase the pre-parse staged snapshot byte cap from `2_000_000` to `32_000_000` by changing `MAX_STAGED_NEURONS_BYTES` in `workers/api.mjs` and update the surrounding comment to document the intent.
- Add a regression test in `tests/load-staged-neurons.test.mjs` that creates a signed envelope exceeding the old 2 MB cap to assert the Worker accepts realistic full-network snapshots, and update the oversized fixture to reflect the new cap.
- Preserve existing row/field guards and the `MAX_STAGED_NEURON_ROWS` limit; only the byte pre-parse bound and test fixtures were adjusted.

### Testing
- Ran `npx prettier --check workers/api.mjs tests/load-staged-neurons.test.mjs`, which succeeded.
- Attempted `npx vitest run tests/load-staged-neurons.test.mjs` but the test run failed to start due to a missing dependency (`Cannot find package 'graphql'`), so unit tests could not be executed locally.
- Attempted `npm install` to fetch missing deps but it failed with a `403 Forbidden` from the registry for the `graphql` tarball, blocking a full test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38edc0ab24832cbff969f33c740d45)