### PR TITLE
fix(railway): include streamer files in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,6 @@
 # build artifacts, or any env/secret files into the build context.
 *
 !scripts/
+!scripts/**
 !deploy/
+!deploy/**


### PR DESCRIPTION
### Motivation
- A root `.dockerignore` used a blanket `*` exclusion and only re-included the `scripts/` and `deploy/` directories, which does not re-include their descendant files and can cause `deploy/streamer.Dockerfile` `COPY` instructions to fail in a clean Docker/Railway build.

### Description
- Re-added descendant paths to the allowlist by adding `!scripts/**` and `!deploy/**` to `.dockerignore` so the streamer source files are present in the build context for `deploy/streamer.Dockerfile`.

### Testing
- Ran `git diff --check` which completed without errors.
- Attempted `docker build -f deploy/streamer.Dockerfile -t metagraphed-streamer-dockerignore-test .` but it could not be executed in this environment because Docker is not installed (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38edc10158832c8d16a86cc615d312)