### PR TITLE
fix: rollup prune gate and require HMAC for staged events

### DIFF
--- a/.github/workflows/refresh-events.yml
+++ b/.github/workflows/refresh-events.yml
@@ -11,7 +11,7 @@ name: Refresh Chain Events (first-party poller)
 # (block_number, event_index)), so frequent overlapping runs need no cursor and
 # self-heal small gaps. Live-forward only: public nodes prune ~300 blocks, so this
 # runs often to stay inside that window; deep history is the optional archive-RPC
-# upgrade (#1349). No new secret — uses the existing CLOUDFLARE_* R2 permission.
+# upgrade (#1349). Reuses METAGRAPH_STAGING_SIGNING_KEY (same as refresh-metagraph).
 on:
   schedule:
     # Every 5 min (#1346 Option A) — the practical CI floor (each run has ~3 min of
@@ -59,6 +59,11 @@ jobs:
           # 120 blocks ≈ 24 min of chain — generous idempotent overlap at a 5-min
           # cadence (survives delayed/missed runs) while keeping the poll ~1 min.
           EVENTS_WINDOW: "120"
+
+      - name: Sign staged chain-event batch
+        run: node scripts/sign-staged-neurons.mjs dist/account-events.json
+        env:
+          METAGRAPH_STAGING_SIGNING_KEY: ${{ secrets.METAGRAPH_STAGING_SIGNING_KEY }}
 
       # Stage to R2 (the token's existing R2 permission); the Worker loads it into
       # D1 through its binding (loadStagedEvents) — no API-token D1 permission.

--- a/scripts/sign-staged-neurons.mjs
+++ b/scripts/sign-staged-neurons.mjs
@@ -12,7 +12,7 @@ if (!inputPath || !key) {
 
 const rows = JSON.parse(readFileSync(inputPath, "utf8"));
 if (!Array.isArray(rows))
-  throw new Error("staged neurons payload must be an array");
+  throw new Error("staged payload must be a JSON array");
 const payload = JSON.stringify(rows);
 const hmac_sha256 = createHmac("sha256", key).update(payload).digest("hex");
 writeFileSync(

--- a/tests/load-staged-events.test.mjs
+++ b/tests/load-staged-events.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
 import { test } from "vitest";
 import { handleScheduled, loadStagedEvents } from "../workers/api.mjs";
 import { EVENTS_LOAD_CRON } from "../workers/config.mjs";
+
+const SIGNING_KEY = "test-staged-events-secret";
 
 function eventRow(block_number, event_index) {
   return {
@@ -17,6 +20,16 @@ function eventRow(block_number, event_index) {
   };
 }
 
+function signedEnvelope(rows, key = SIGNING_KEY) {
+  return {
+    schema_version: 1,
+    hmac_sha256: createHmac("sha256", key)
+      .update(JSON.stringify(rows))
+      .digest("hex"),
+    rows,
+  };
+}
+
 function mockEnv({
   rows,
   bad = false,
@@ -24,14 +37,18 @@ function mockEnv({
   deleted = [],
   prepared = [],
   batches = [],
+  signingKey = SIGNING_KEY,
+  size,
 }) {
   return {
     env: {
+      METAGRAPH_STAGING_SIGNING_KEY: signingKey,
       METAGRAPH_ARCHIVE: {
         async get(key) {
           getCalls.push(key);
           if (rows == null) return null;
           return {
+            size: size ?? JSON.stringify(rows).length,
             async json() {
               if (bad) throw new Error("bad json");
               return rows;
@@ -59,16 +76,14 @@ function mockEnv({
   };
 }
 
-test("loadStagedEvents loads JSON via parameterized batches + deletes it (#1346)", async () => {
+test("loadStagedEvents loads signed JSON via parameterized batches + deletes it (#1346)", async () => {
   const rows = Array.from({ length: 12 }, (_, i) => eventRow(1000 + i, i));
-  const m = mockEnv({ rows });
+  const m = mockEnv({ rows: signedEnvelope(rows) });
   const r = await loadStagedEvents(m.env);
   assert.equal(r.ok, true);
   assert.equal(r.rows, 12);
   assert.deepEqual(m.getCalls, ["events/account-events-pending.json"]);
-  // 12 rows / 10 per statement = 2 statements, one batch (<=50).
   assert.deepEqual(m.batches, [2]);
-  // Idempotent + parameterized: INSERT OR IGNORE keyed (block,index), values bound.
   assert.ok(m.prepared[0].startsWith("INSERT OR IGNORE INTO account_events ("));
   assert.ok(m.prepared[0].includes("VALUES (?"));
   assert.ok(
@@ -88,14 +103,33 @@ test("loadStagedEvents no-ops when nothing is staged", async () => {
 });
 
 test("loadStagedEvents deletes + bails on unparseable JSON", async () => {
-  const m = mockEnv({ rows: [], bad: true });
+  const m = mockEnv({ rows: signedEnvelope([]), bad: true });
   const r = await loadStagedEvents(m.env);
   assert.equal(r.reason, "parse_failed");
   assert.deepEqual(m.deleted, ["events/account-events-pending.json"]);
 });
 
+test("loadStagedEvents rejects an unsigned envelope", async () => {
+  const rows = [eventRow(1000, 0)];
+  const m = mockEnv({ rows });
+  const r = await loadStagedEvents(m.env);
+  assert.equal(r.reason, "unauthenticated");
+  assert.equal(m.batches.length, 0);
+  assert.deepEqual(m.deleted, ["events/account-events-pending.json"]);
+});
+
+test("loadStagedEvents rejects a bad HMAC", async () => {
+  const rows = [eventRow(1000, 0)];
+  const envelope = signedEnvelope(rows);
+  envelope.hmac_sha256 = "0".repeat(64);
+  const m = mockEnv({ rows: envelope });
+  const r = await loadStagedEvents(m.env);
+  assert.equal(r.reason, "unauthenticated");
+  assert.equal(m.batches.length, 0);
+});
+
 test("loadStagedEvents drops rows lacking the (block, index) key", async () => {
-  const m = mockEnv({ rows: [{ event_kind: "X" }] }); // no block_number/event_index
+  const m = mockEnv({ rows: signedEnvelope([{ event_kind: "StakeAdded" }]) });
   const r = await loadStagedEvents(m.env);
   assert.equal(r.reason, "empty");
   assert.equal(m.batches.length, 0);
@@ -105,11 +139,11 @@ test("loadStagedEvents drops rows lacking the (block, index) key", async () => {
 test("loadStagedEvents drops rows missing required insert fields", async () => {
   const valid = eventRow(1000, 0);
   const m = mockEnv({
-    rows: [
+    rows: signedEnvelope([
       { ...valid, observed_at: null },
       { ...valid, event_index: 1, event_kind: null },
       { ...valid, event_index: 2 },
-    ],
+    ]),
   });
   const r = await loadStagedEvents(m.env);
   assert.equal(r.ok, true);
@@ -127,20 +161,20 @@ test("loadStagedEvents is a safe no-op without bindings", async () => {
 test("handleScheduled fast-load cron drains staged batches + skips the probe (#1346 Option A)", async () => {
   const drained = [];
   const env = {
+    METAGRAPH_STAGING_SIGNING_KEY: SIGNING_KEY,
     METAGRAPH_ARCHIVE: {
       async get(key) {
-        // Only the events batch is staged; the neuron key returns nothing.
         return key === "events/account-events-pending.json"
           ? {
               async json() {
-                return [
+                return signedEnvelope([
                   {
                     block_number: 1,
                     event_index: 0,
                     event_kind: "StakeAdded",
                     observed_at: 1,
                   },
-                ];
+                ]);
               },
             }
           : null;
@@ -157,7 +191,6 @@ test("handleScheduled fast-load cron drains staged batches + skips the probe (#1
     },
   };
   const r = await handleScheduled({ cron: EVENTS_LOAD_CRON }, env, {});
-  // Early-returns the fast-load marker (i.e. never falls through to the prober).
   assert.deepEqual(r, { ok: true, fast_load: true });
   assert.ok(
     drained.includes("events/account-events-pending.json"),

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -246,7 +246,10 @@ export default {
 // capped at the u16 max (65535) — matching the existing netuid guard in
 // src/webhooks.mjs and avoiding rejection of legitimately high subnet ids.
 const STAGED_NEURONS_KEY = "metagraph/neurons-pending.json";
+const STAGED_EVENTS_KEY = "events/account-events-pending.json";
 const MAX_STAGED_NEURONS_BYTES = 2_000_000;
+const MAX_STAGED_EVENTS_BYTES = 2_000_000;
+const MAX_STAGED_EVENT_ROWS = 50_000;
 const MAX_STAGED_NEURON_ROWS = 50_000;
 const MAX_STAGED_NEURON_STRING_BYTES = 512;
 const MAX_STAGED_NETUID = 65_535;
@@ -381,39 +384,62 @@ export async function loadStagedNeurons(env) {
 }
 
 // Load a staged chain-event batch from R2 into D1 (#1346, epic #1345). The
-// refresh-events CI job decodes finney's System.Events first-party (no Taostats)
-// and writes account_events rows as JSON to R2 (events/account-events-pending.json)
-// with its existing R2 permission; we load them here through the binding (no
-// API-token D1 permission) with PARAMETERIZED INSERT OR IGNORE keyed
+// refresh-events CI job decodes finney's System.Events first-party (no Taostats),
+// wraps rows in an HMAC-signed envelope, and writes it to R2 with its existing R2
+// permission; we load only authenticated, bounded, schema-valid rows through the
+// binding (no API-token D1 permission) with PARAMETERIZED INSERT OR IGNORE keyed
 // (block_number, event_index) — so overlapping poller windows re-insert harmlessly
-// (idempotent, no cursor needed) and a tampered file can only fail, never inject.
-// Then delete the object so each batch loads once.
+// (idempotent, no cursor needed). Then delete the object so each batch loads once.
 export async function loadStagedEvents(env) {
   const bucket = env.METAGRAPH_ARCHIVE;
   const db = env.METAGRAPH_HEALTH_DB;
-  if (!bucket?.get || !db?.prepare) return { ok: false, reason: "unavailable" };
-  const key = "events/account-events-pending.json";
+  const signingKey = env.METAGRAPH_STAGING_SIGNING_KEY;
+  if (!bucket?.get || !db?.prepare || !signingKey) {
+    return { ok: false, reason: "unavailable" };
+  }
+  const key = STAGED_EVENTS_KEY;
   const object = await bucket.get(key);
   if (!object) return { ok: false, reason: "none" };
-  let parsed;
+  if (Number(object.size || 0) > MAX_STAGED_EVENTS_BYTES) {
+    await bucket.delete(key);
+    return { ok: false, reason: "too_large" };
+  }
+  let envelope;
   try {
-    parsed = await object.json();
+    envelope = await object.json();
   } catch {
     await bucket.delete(key);
     return { ok: false, reason: "parse_failed" };
   }
-  const rows = validEventRows(parsed);
-  if (!rows.length) {
+  const rows = Array.isArray(envelope?.rows) ? envelope.rows : [];
+  if (
+    envelope?.schema_version !== 1 ||
+    !/^[a-f0-9]{64}$/.test(String(envelope?.hmac_sha256 || ""))
+  ) {
+    await bucket.delete(key);
+    return { ok: false, reason: "unauthenticated" };
+  }
+  if (rows.length > MAX_STAGED_EVENT_ROWS) {
+    await bucket.delete(key);
+    return { ok: false, reason: "too_many_rows" };
+  }
+  const expected = await hmacHex(signingKey, JSON.stringify(rows));
+  if (!timingSafeStringEqual(expected, envelope.hmac_sha256)) {
+    await bucket.delete(key);
+    return { ok: false, reason: "unauthenticated" };
+  }
+  const validRows = validEventRows(rows);
+  if (!validRows.length) {
     await bucket.delete(key);
     return { ok: false, reason: "empty" };
   }
-  const statements = eventInsertStatements(db, rows);
+  const statements = eventInsertStatements(db, validRows);
   const STMTS_PER_BATCH = 50;
   for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
     await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
   }
   await bucket.delete(key);
-  return { ok: true, rows: rows.length };
+  return { ok: true, rows: validRows.length };
 }
 
 // POST /api/v1/internal/events (#1360): the realtime ingest path for the


### PR DESCRIPTION
## Summary

Staged neuron snapshots already require an HMAC-signed envelope before R2 → D1 load. Staged **chain events** did not — any object at `events/account-events-pending.json` in R2 was parsed and inserted into D1 on the next cron tick.

This change mirrors the neuron path: CI signs batches before upload; the Worker verifies `METAGRAPH_STAGING_SIGNING_KEY` before loading.

## Problem

`loadStagedNeurons` verifies:

- `schema_version === 1`
- `hmac_sha256` over `JSON.stringify(rows)`
- size / row-count bounds

`loadStagedEvents` previously accepted a raw JSON array with no authentication. Anyone with R2 write access (leaked CI token, misconfigured bucket policy) could inject arbitrary rows into `account_events`, which `/api/v1/accounts/{ss58}` serves as chain-derived activity.

SQL injection was already prevented (parameterized inserts). **Data integrity was not.**

## Fix

### Worker (`workers/api.mjs`)

- Require `METAGRAPH_STAGING_SIGNING_KEY` (same secret as neurons).
- Parse `{ schema_version, hmac_sha256, rows }` envelope.
- Reject unsigned, tampered, oversized (`>2 MB`), or over-limit (`>50k rows`) batches.
- Delete rejected objects from R2 (same as neuron loader).

### CI (`.github/workflows/refresh-events.yml`)

- After `fetch-events.py`, run `node scripts/sign-staged-neurons.mjs dist/account-events.json`.
- Upload the signed envelope to R2 (reuses existing `METAGRAPH_STAGING_SIGNING_KEY` secret).

### Signing script (`scripts/sign-staged-neurons.mjs`)

- Generic array validation message (script is shared by neurons + events).

## Files changed

| File | Change |
|------|--------|
| `workers/api.mjs` | HMAC verification + bounds in `loadStagedEvents` |
| `.github/workflows/refresh-events.yml` | Sign batch before R2 upload |
| `scripts/sign-staged-neurons.mjs` | Shared envelope helper wording |
| `tests/load-staged-events.test.mjs` | Signed accept + unsigned/bad-HMAC reject tests |

## Test plan

- [x] `npm test -- tests/load-staged-events.test.mjs tests/load-staged-neurons.test.mjs`
  - Loads valid signed envelope into D1
  - Rejects unsigned envelope (`unauthenticated`)
  - Rejects bad HMAC (`unauthenticated`)
  - Fast-load cron still drains signed batches
- [ ] Full CI (`validate` workflow on Linux)

