### PR TITLE
fix(rollup): isolate account event rollup prepare failures

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -79,30 +79,30 @@ export async function rollupAccountEventsDaily(env, overrides = {}) {
   if (!db?.prepare) return { rolled: false };
   const runAt = now();
   const days = [utcDayBounds(runAt), utcDayBounds(runAt - 24 * 60 * 60 * 1000)];
-  const stmt = db.prepare(
-    `INSERT INTO account_events_daily
-       (hotkey, netuid, day, event_count, event_kinds, first_block, last_block, updated_at)
-     SELECT
-       hotkey,
-       netuid,
-       ? AS day,
-       COUNT(*) AS event_count,
-       GROUP_CONCAT(DISTINCT event_kind) AS event_kinds,
-       MIN(block_number) AS first_block,
-       MAX(block_number) AS last_block,
-       ? AS updated_at
-     FROM account_events
-     WHERE hotkey IS NOT NULL AND netuid IS NOT NULL
-       AND observed_at >= ? AND observed_at < ?
-     GROUP BY hotkey, netuid
-     ON CONFLICT(hotkey, netuid, day) DO UPDATE SET
-       event_count = excluded.event_count,
-       event_kinds = excluded.event_kinds,
-       first_block = excluded.first_block,
-       last_block = excluded.last_block,
-       updated_at = excluded.updated_at`,
-  );
   try {
+    const stmt = db.prepare(
+      `INSERT INTO account_events_daily
+         (hotkey, netuid, day, event_count, event_kinds, first_block, last_block, updated_at)
+       SELECT
+         hotkey,
+         netuid,
+         ? AS day,
+         COUNT(*) AS event_count,
+         GROUP_CONCAT(DISTINCT event_kind) AS event_kinds,
+         MIN(block_number) AS first_block,
+         MAX(block_number) AS last_block,
+         ? AS updated_at
+       FROM account_events
+       WHERE hotkey IS NOT NULL AND netuid IS NOT NULL
+         AND observed_at >= ? AND observed_at < ?
+       GROUP BY hotkey, netuid
+       ON CONFLICT(hotkey, netuid, day) DO UPDATE SET
+         event_count = excluded.event_count,
+         event_kinds = excluded.event_kinds,
+         first_block = excluded.first_block,
+         last_block = excluded.last_block,
+         updated_at = excluded.updated_at`,
+    );
     await db.batch(
       days.map(({ date, start, end }) => stmt.bind(date, runAt, start, end)),
     );

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -187,6 +187,20 @@ test("rollupAccountEventsDaily returns rolled:false when D1 throws", async () =>
   );
 });
 
+test("rollupAccountEventsDaily returns rolled:false when prepare throws", async () => {
+  const env = {
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        throw new Error("prepare exploded");
+      },
+    },
+  };
+  assert.equal(
+    (await rollupAccountEventsDaily(env, { now: () => 0 })).rolled,
+    false,
+  );
+});
+
 test("ACCOUNT_EVENT_COLUMNS lists the served event columns", () => {
   for (const c of [
     "block_number",


### PR DESCRIPTION
### Motivation
- The hourly scheduled handler began awaiting `rollupAccountEventsDaily` directly which allowed `db.prepare()` failures (thrown before the function's `try/catch`) to reject the scheduled handler and abort pruning, causing an availability regression. 
- The intent is to ensure prepare-time D1 failures are isolated and cause the rollup to noop (`{ rolled: false }`) so pruning still behaves predictably.

### Description
- Move the `db.prepare(...)` call for the `account_events_daily` upsert inside the existing `try` block in `rollupAccountEventsDaily` so prepare-time exceptions are caught and the function returns `{ rolled: false }` instead of rejecting. (`src/account-events.mjs`)
- Add a unit test that simulates `db.prepare()` throwing and asserts `rollupAccountEventsDaily` returns `{ rolled: false }`. (`tests/account-events.test.mjs`)
- Kept existing behavior for batch failures (still returns `{ rolled: false }`) and preserved idempotence of the rollup.

### Testing
- Ran the targeted unit tests with `npm test -- tests/account-events.test.mjs`, and the suite passed (19 tests passed). 
- Ran lint and formatting checks with `npm run lint` and `npm run format:check`, and both checks passed. 
- Attempting to run the broader health-prober tests failed in this environment because a required runtime dependency (`graphql`) is missing and `npm install` could not restore it due to a registry 403, so full test execution for `tests/health-prober.test.mjs` was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38f9d37114832cb2cd86337504a4d7)