### PR TITLE
feat(metagraph): re-source per-UID neurons to the Bittensor SDK — drop Taostats from state (#1348)

### DIFF
--- a/.github/workflows/refresh-metagraph.yml
+++ b/.github/workflows/refresh-metagraph.yml
@@ -1,13 +1,12 @@
 name: Refresh Metagraph (per-UID neurons)
 
-# Fetches the per-UID metagraph for every subnet from Taostats and loads it into
-# the metagraphed-health D1 `neurons` table (#1303, epic #1302). Powers
-# /api/v1/subnets/{netuid}/metagraph, /neurons/{uid}, and /validators. Daily +
-# manual. Tolerant: a failed/partial fetch aborts before writing (the script
-# guards on >50% subnet failures), so the previous snapshot stays in place.
-#
-# Gated on TAOSTATS_API_KEY: until the maintainer adds that repo secret the job
-# is a no-op (green), not a daily red failure.
+# Fetches the per-UID metagraph for every subnet FIRST-PARTY via the Bittensor SDK
+# (#1348 — chain-direct, no Taostats, no API key) and loads it into the
+# metagraphed-health D1 `neurons` table (#1303). Powers
+# /api/v1/subnets/{netuid}/metagraph, /neurons/{uid}, /validators, and the account
+# entity API (#1347). Daily + manual. The snapshot is signed (sign-staged-neurons)
+# before staging to R2; the Worker authenticates + bounds it before loading into D1
+# via its binding (loadStagedNeurons) — no API-token D1 permission required.
 on:
   schedule:
     - cron: "23 5 * * *" # daily 05:23 UTC
@@ -23,51 +22,41 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
-    timeout-minutes: 40 # the Taostats fetch is rate-limited (~129 subnets w/ backoff)
+    timeout-minutes: 30 # one get_all_metagraphs_info call + per-subnet storage reads
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
 
+      # No `cache: npm` here on purpose: this workflow holds Cloudflare + signing
+      # secrets, so it doesn't consume a shared npm cache another workflow could poison.
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22.23.0
-          cache: npm
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Install
         run: npm ci
 
-      - name: Gate on Taostats key
-        id: gate
-        env:
-          TAOSTATS_API_KEY: ${{ secrets.TAOSTATS_API_KEY }}
-        run: |
-          if [ -n "$TAOSTATS_API_KEY" ]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::TAOSTATS_API_KEY not set — skipping metagraph refresh."
-          fi
-
-      - name: Fetch per-UID metagraph (Taostats)
-        if: steps.gate.outputs.ready == 'true'
-        run: node scripts/fetch-metagraph.mjs
-        env:
-          TAOSTATS_API_KEY: ${{ secrets.TAOSTATS_API_KEY }}
+      # First-party chain-direct fetch (pinned bittensor, matching sync-subnets):
+      # get_all_metagraphs_info for the per-UID core + SubtensorModule.ValidatorTrust
+      # storage; rank is derived from incentive. Units parity-verified vs the prior
+      # Taostats source (#1348). No Taostats, no API key.
+      - name: Fetch per-UID metagraph (Bittensor SDK)
+        run: uvx --from bittensor==10.4.0 python scripts/fetch-metagraph-native.py
 
       - name: Sign staged neuron snapshot
-        if: steps.gate.outputs.ready == 'true'
         run: node scripts/sign-staged-neurons.mjs dist/metagraph-neurons.json
         env:
           METAGRAPH_STAGING_SIGNING_KEY: ${{ secrets.METAGRAPH_STAGING_SIGNING_KEY }}
 
-      # Stage the signed snapshot to R2 (the token's existing R2 permission),
-      # then the Worker's scheduled handler authenticates and bounds it before
-      # loading into D1 through its METAGRAPH_HEALTH_DB binding.
+      # Stage the signed snapshot to R2 (the token's existing R2 permission); the
+      # Worker authenticates + bounds it before loading into D1 via its binding.
       - name: Stage neurons to R2 for the Worker to load into D1
-        if: steps.gate.outputs.ready == 'true'
         run: npx wrangler r2 object put metagraphed-artifacts/metagraph/neurons-pending.json --file=dist/metagraph-neurons.json --remote
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/scripts/fetch-metagraph-native.py
+++ b/scripts/fetch-metagraph-native.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""First-party per-UID metagraph fetcher (#1348) — chain-direct, REPLACING the
+Taostats fetch (scripts/fetch-metagraph.mjs). One `get_all_metagraphs_info` call
+yields most per-UID fields for every subnet; `rank` + `validator_trust` come from
+SubtensorModule storage (MetagraphInfo doesn't carry them in dTAO). Emits the exact
+`NEURON_INSERT_COLUMNS` shape to dist/metagraph-neurons.json — a drop-in for the
+Worker's token-free `loadStagedNeurons`. No Taostats, no API key.
+
+Units (verified by the parity check vs the prior Taostats data, #1348):
+  stake_tao/emission_tao = float(Balance, alpha-denominated)
+  consensus/incentive/dividends = on-chain 0..1 floats
+  rank/validator_trust = SubtensorModule u16 (0..65535) ÷ 65535
+  trust = 0.0 (dead in dTAO — 0 across all neurons, Taostats included)
+
+Run: uv run --with bittensor python scripts/fetch-metagraph-native.py
+"""
+import argparse
+import ipaddress
+import json
+import os
+import sys
+import time
+
+import bittensor as bt
+
+OUT = os.environ.get("METAGRAPH_NEURONS_JSON", "dist/metagraph-neurons.json")
+
+
+def to_float(value):
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def u16_ratio(value):
+    """SubtensorModule Rank/ValidatorTrust are u16 (0..65535) → 0..1 ratio."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return None
+    return round(n / 65535, 9)
+
+
+def fmt_axon(axon):
+    """axons[uid] = {ip:int, port:int, ...}; ip 0 → not serving."""
+    if not isinstance(axon, dict):
+        return None
+    ip = axon.get("ip") or 0
+    port = axon.get("port") or 0
+    if not ip:
+        return None
+    try:
+        host = str(ipaddress.ip_address(int(ip)))
+    except (ValueError, TypeError):
+        return None
+    return f"{host}:{port}" if port else host
+
+
+def _at(arr, i):
+    return arr[i] if i < len(arr) else None
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--network", default="finney")
+    args = parser.parse_args()
+
+    s = bt.SubtensorApi(network=args.network)
+    infos = s.metagraphs.get_all_metagraphs_info(all_mechanisms=True)
+
+    # Dedupe by netuid (mechid 0 is canonical), matching fetch-native-subnets.py.
+    by_netuid = {}
+    for info in infos:
+        nu = int(info.netuid)
+        mechid = int(getattr(info, "mechid", 0) or 0)
+        if mechid == 0 or nu not in by_netuid:
+            by_netuid[nu] = info
+
+    def storage_vec(netuid, name):
+        try:
+            r = s.substrate.query("SubtensorModule", name, [netuid])
+            return list(getattr(r, "value", r) or [])
+        except Exception:
+            return []
+
+    captured_at = int(time.time() * 1000)
+    rows = []
+    for netuid in sorted(by_netuid):
+        info = by_netuid[netuid]
+        hotkeys = list(getattr(info, "hotkeys", []) or [])
+        n = len(hotkeys)
+        if not n:
+            continue
+        coldkeys = list(getattr(info, "coldkeys", []) or [])
+        active = list(getattr(info, "active", []) or [])
+        permits = list(getattr(info, "validator_permit", []) or [])
+        consensus = list(getattr(info, "consensus", []) or [])
+        incentives = list(getattr(info, "incentives", []) or [])
+        dividends = list(getattr(info, "dividends", []) or [])
+        emission = list(getattr(info, "emission", []) or [])
+        stake = list(getattr(info, "total_stake", []) or [])
+        axons = list(getattr(info, "axons", []) or [])
+        reg_at = list(getattr(info, "block_at_registration", []) or [])
+        block = int(getattr(info, "block", 0) or 0)
+        immunity = int(getattr(info, "immunity_period", 0) or 0)
+        vtrust_vec = storage_vec(netuid, "ValidatorTrust")
+        subnet_rows = []
+        for uid in range(n):
+            reg = _at(reg_at, uid)
+            subnet_rows.append(
+                {
+                    "netuid": netuid,
+                    "uid": uid,
+                    "hotkey": _at(hotkeys, uid),
+                    "coldkey": _at(coldkeys, uid),
+                    "active": 1 if _at(active, uid) else 0,
+                    "validator_permit": 1 if _at(permits, uid) else 0,
+                    "rank": None,  # derived below (no chain rank-position storage)
+                    "trust": 0.0,
+                    "validator_trust": u16_ratio(_at(vtrust_vec, uid)),
+                    "consensus": to_float(_at(consensus, uid)),
+                    "incentive": to_float(_at(incentives, uid)),
+                    "dividends": to_float(_at(dividends, uid)),
+                    "emission_tao": to_float(_at(emission, uid)),
+                    "stake_tao": to_float(_at(stake, uid)),
+                    "registered_at_block": reg,
+                    "is_immunity_period": 1
+                    if (reg is not None and block - reg < immunity)
+                    else 0,
+                    "axon": fmt_axon(_at(axons, uid)),
+                    "block_number": block,
+                    "captured_at": captured_at,
+                }
+            )
+        # SubtensorModule has no rank-position storage in dTAO; derive the
+        # Taostats-style ranking — 1-based position by incentive desc (null for
+        # non-incentivized neurons; consumers can also sort by incentive directly).
+        for pos, row in enumerate(
+            sorted(
+                (r for r in subnet_rows if r["incentive"]),
+                key=lambda r: (-r["incentive"], r["uid"]),
+            ),
+            start=1,
+        ):
+            row["rank"] = float(pos)
+        rows.extend(subnet_rows)
+
+    valid = [r for r in rows if r["hotkey"]]
+    os.makedirs(os.path.dirname(OUT) or ".", exist_ok=True)
+    with open(OUT, "w") as fh:
+        json.dump(valid, fh)
+    sys.stderr.write(
+        f"wrote {len(valid)} neurons across {len(by_netuid)} subnets -> {OUT}\n"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #1348. The last child of the block-explorer epic (#1345) that touches chain **state**: re-sources the per-UID metagraph (#1303) from the Taostats REST API to the **first-party Bittensor SDK** — chain-direct, **no API key**.

## What changes
- **`scripts/fetch-metagraph-native.py`** (new): one `get_all_metagraphs_info(all_mechanisms=True)` call yields the per-UID core for **every** subnet (hotkey, coldkey, active, validator_permit, consensus, incentive, dividends, emission, total_stake, axon, registered_at_block). `validator_trust` comes from `SubtensorModule.ValidatorTrust` storage; `rank` is derived from incentive (dTAO exposes no rank-position storage); `trust=0` (dead in dTAO — 0 across all neurons, Taostats included). Emits the exact `NEURON_INSERT_COLUMNS` shape to `dist/metagraph-neurons.json` — a **drop-in** for the existing signed `loadStagedNeurons` pipeline (the Worker still authenticates + bounds the snapshot before loading into D1 via its binding; no changes there).
- **`refresh-metagraph.yml`**: swaps the fetch step to `uvx --from bittensor==10.4.0` (matching `sync-subnets`), adds `setup-uv`, and **drops the `TAOSTATS_API_KEY` gate** (no longer needed). Sign + stage steps unchanged.

## Units verified (the dTAO risk)
Parity-checked against the live Taostats-sourced `neurons` table on matching UIDs/hotkeys — values agree within block drift:

| netuid 1 | uid 251 | uid 252 |
|---|---|---|
| stake (SDK / D1) | 274,963 / 272,660 | 1,344,191 / 1,345,406 |
| emission (SDK / D1) | 4.508 / 4.491 | 22.080 / 22.149 |
| validator_trust | 1.0 / 1.0 | 1.0 / 1.0 |

`consensus`/`incentive`/`dividends` are on-chain 0–1 floats; `stake_tao`/`emission_tao` = `float(Balance, α)`; `validator_trust` = u16÷65535; `rank` = 1-based incentive-desc position.

## Verification
- Ran the fetcher with the pinned CI version (`bittensor==10.4.0`): **30,006 neurons across 129 subnets, 0 failures**, rank + axons populate correctly.
- `validate:workflows`, `scan:public-safety`, `validate:private-boundary`, prettier — all green.
- `scripts/fetch-metagraph.mjs` kept as the documented Taostats fallback.

## Why
Removes the project's last reliance on Taostats for **state** (the epic's hard architectural principle — chain-direct spine, Taostats only as enrichment/fallback). Also: 1 SDK call replaces 129 rate-limited REST calls, and the daily job no longer needs a secret.