### PR TITLE
fix(scripts): bound README netuid affinity to avoid prefix substring matches

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -2320,12 +2320,13 @@ function hasNetuidAffinity(value, netuid) {
     return true;
   }
 
+  // Bound the trailing edge so a short netuid isn't matched as the prefix of a
+  // longer number (netuid 1 must not match "sn123" / "subnets1000"). The leading
+  // edge can't be enforced on the compacted value — compaction strips the
+  // separators that would delimit it (e.g. "example.com/sn1" -> "examplecomsn1")
+  // — so only guard the digit boundary immediately after the netuid.
   const compactValue = compactReadmeValue(value);
-  return (
-    compactValue.includes(`sn${netuid}`) ||
-    compactValue.includes(`subnet${netuid}`) ||
-    compactValue.includes(`subnets${netuid}`)
-  );
+  return new RegExp(`(sn|subnets?)${escaped}(?![0-9])`).test(compactValue);
 }
 
 function repoTokens(repo = {}) {

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -575,6 +575,32 @@ describe("script utility contracts", () => {
     );
   });
 
+  test("README netuid affinity requires a digit boundary (no substring match)", () => {
+    const repo = { owner: "acme", repo: "widget" };
+    // netuid 1 must NOT match an unrelated "sn123" reference for subnet 123.
+    assert.equal(
+      isReviewableReadmeLink(
+        {
+          classification: { kind: "docs", label: "docs" },
+          url: "https://vendor-portal.example/sn123",
+        },
+        { netuid: 1, repo },
+      ),
+      false,
+    );
+    // ...but an exact "sn1" reference for subnet 1 is still reviewable.
+    assert.equal(
+      isReviewableReadmeLink(
+        {
+          classification: { kind: "docs", label: "docs" },
+          url: "https://vendor-portal.example/sn1",
+        },
+        { netuid: 1, repo },
+      ),
+      true,
+    );
+  });
+
   test("native subnet sync reports missing uvx without masking the error", () => {
     const result = spawnSync(
       process.execPath,


### PR DESCRIPTION
## Summary

Fixes #1397.

`hasNetuidAffinity` in `scripts/lib.mjs` decides whether a README link belongs to a given subnet. After two correct boundary-aware regexes it falls back to an **unbounded substring** check on the separator-stripped value, so a short netuid matches as the **prefix of a longer number**: for netuid `1`, `compactValue.includes("sn1")` is `true` for `sn123` / `subnets1000`. Wrong-subnet README links were therefore pulled into the served `registry/candidates/generated/public-sources.json` bundle (low netuids most exposed).

## What Changed

- `scripts/lib.mjs` — keep the compact fallback (it legitimately catches netuid references whose separators the regexes don't list, e.g. `sn.1`, `sn:1`) but bound its trailing edge with a negative-lookahead: `new RegExp(`(sn|subnets?)${escaped}(?![0-9])`).test(compactValue)`. The leading edge can't be enforced on the compacted value (compaction strips the separators that would delimit it — `example.com/sn1` → `examplecomsn1`), so only the digit boundary after the netuid is guarded.
- `tests/script-utils.test.mjs` — regression test: netuid 1 no longer matches `sn123` but still matches `sn1`.

No schema, OpenAPI, or generated-artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `npx vitest run tests/script-utils.test.mjs -t "README netuid affinity"` — passed (incl. the new regression test)
- [x] `git diff --check`

## Template Used

- Backend/code change
