### PR TITLE
fix(health): avoid full scan for chain events

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -254,12 +254,14 @@ describe("/health readiness", () => {
 
   test("reports chain-event index freshness (#1361)", async () => {
     const atMs = Date.now() - 18_000; // latest indexed event ~18s ago
+    const preparedSql = [];
     const env = createLocalArtifactEnv({
       METAGRAPH_CONTROL: makeKv({
         "metagraph:latest": { published_at: new Date().toISOString() },
       }),
       METAGRAPH_HEALTH_DB: {
-        prepare() {
+        prepare(sql) {
+          preparedSql.push(sql);
           return {
             bind() {
               return {
@@ -283,6 +285,10 @@ describe("/health readiness", () => {
       `age_seconds out of range: ${body.chain_events.age_seconds}`,
     );
     assert.ok(body.chain_events.latest_event_at.startsWith("20"));
+    assert.deepEqual(preparedSql, [
+      "SELECT block_number AS block, observed_at AS at FROM account_events " +
+        "ORDER BY observed_at DESC LIMIT 1",
+    ]);
   });
 
   test("chain_events is schema-stable nulls when the event tier is cold (#1361)", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -3403,15 +3403,17 @@ async function handleHealthRequest(request, env) {
     : null;
 
   // Chain-event index freshness (#1346/#1361) — the realtime streamer's heartbeat.
-  // MAX(observed_at) is the chain timestamp of the latest indexed event; age_seconds
-  // is ~12-30s while the streamer is live, growing toward the ~5-min poller backstop
-  // if it's down. Reported for observability (does NOT gate the HTTP status, like
-  // operational_health); best-effort + null on a cold/unbound store.
+  // The newest observed_at row is an index-friendly heartbeat for the latest
+  // indexed chain event; age_seconds is ~12-30s while the streamer is live,
+  // growing toward the ~5-min poller backstop if it's down. Reported for
+  // observability (does NOT gate the HTTP status, like operational_health);
+  // best-effort + null on a cold/unbound store.
   let chainEvents = null;
   if (bindings.health_db) {
     const rows = await d1All(
       env,
-      "SELECT MAX(block_number) AS block, MAX(observed_at) AS at FROM account_events",
+      "SELECT block_number AS block, observed_at AS at FROM account_events " +
+        "ORDER BY observed_at DESC LIMIT 1",
       [],
     );
     const row = rows[0] || {};


### PR DESCRIPTION
### Motivation
- The /health handler previously executed a two-`MAX` aggregate (`SELECT MAX(block_number), MAX(observed_at)`) which forces a full-table scan in SQLite/D1 and exposes a cost/amplification vector against the 90-day `account_events` hot table. 
- The intent is to surface latest chain-event freshness in `/health` while avoiding repeated expensive scans and preserving the existing response schema.

### Description
- Replaced the aggregate with an index-friendly newest-row lookup by changing the query to `SELECT block_number AS block, observed_at AS at FROM account_events ORDER BY observed_at DESC LIMIT 1` in `workers/api.mjs`. 
- Kept the public response fields (`latest_indexed_block`, `latest_event_at`, `age_seconds`) unchanged and updated the comment to document the index-friendly heartbeat. 
- Updated `tests/api-coverage.test.mjs` to capture the prepared SQL via `prepare(sql)` and assert the handler used the bounded indexed query.

### Testing
- Ran `npx prettier --write workers/api.mjs tests/api-coverage.test.mjs` which completed successfully. 
- Verified with SQLite `EXPLAIN QUERY PLAN` against `migrations/0009_account_events.sql` that the new query uses the `idx_account_events_observed` index. 
- Attempted to run the health test subset with `npx vitest run tests/api-coverage.test.mjs --testNamePattern "/health readiness"`, but the run failed because `npm install` was blocked by a `403` fetching `graphql@17.0.1`, so the full suite could not be executed. 
- Ensured `git diff --check` passed and the changes were committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38f9d6af40832c9a08a72394e85e7c)