### PR TITLE
fix(graphql): follow named fragments in depth/complexity limits

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -68,11 +68,38 @@ const schema = buildSchema(SDL);
 
 // --- Validation rules ---
 
-function selectionDepth(selectionSet, depth = 0) {
+function buildFragmentMap(documentNode) {
+  const fragments = new Map();
+  for (const def of documentNode.definitions) {
+    if (def.kind === "FragmentDefinition") {
+      fragments.set(def.name.value, def);
+    }
+  }
+  return fragments;
+}
+
+// Depth/complexity must follow named fragment spreads. Otherwise a client moves
+// the whole (expensive) selection into a fragment and the operation's own
+// selection set is just a single transparent spread — counting as depth 0 /
+// complexity 1 and fully bypassing both limits. `visited` guards against
+// fragment cycles: validate() reports those, but our rules run in the same pass
+// and would otherwise recurse forever.
+function selectionDepth(selectionSet, fragments, visited, depth = 0) {
   let max = depth;
   for (const sel of selectionSet.selections) {
-    if (sel.selectionSet) {
-      const d = selectionDepth(sel.selectionSet, depth + 1);
+    if (sel.kind === "FragmentSpread") {
+      const frag = fragments.get(sel.name.value);
+      if (frag && !visited.has(sel.name.value)) {
+        const d = selectionDepth(
+          frag.selectionSet,
+          fragments,
+          new Set(visited).add(sel.name.value),
+          depth,
+        );
+        if (d > max) max = d;
+      }
+    } else if (sel.selectionSet) {
+      const d = selectionDepth(sel.selectionSet, fragments, visited, depth + 1);
       if (d > max) max = d;
     }
   }
@@ -83,9 +110,14 @@ export function maxDepthRule(max) {
   return (context) => ({
     Document: {
       leave(node) {
+        const fragments = buildFragmentMap(node);
         for (const def of node.definitions) {
           if (def.kind === "OperationDefinition") {
-            const depth = selectionDepth(def.selectionSet);
+            const depth = selectionDepth(
+              def.selectionSet,
+              fragments,
+              new Set(),
+            );
             if (depth > max) {
               context.reportError(
                 new GraphQLError(
@@ -101,12 +133,23 @@ export function maxDepthRule(max) {
   });
 }
 
-function selectionComplexity(selectionSet) {
+function selectionComplexity(selectionSet, fragments, visited) {
   let count = 0;
   for (const sel of selectionSet.selections) {
+    if (sel.kind === "FragmentSpread") {
+      const frag = fragments.get(sel.name.value);
+      if (frag && !visited.has(sel.name.value)) {
+        count += selectionComplexity(
+          frag.selectionSet,
+          fragments,
+          new Set(visited).add(sel.name.value),
+        );
+      }
+      continue;
+    }
     count += 1;
     if (sel.selectionSet) {
-      count += selectionComplexity(sel.selectionSet);
+      count += selectionComplexity(sel.selectionSet, fragments, visited);
     }
   }
   return count;
@@ -116,9 +159,14 @@ export function maxComplexityRule(max) {
   return (context) => ({
     Document: {
       leave(node) {
+        const fragments = buildFragmentMap(node);
         for (const def of node.definitions) {
           if (def.kind === "OperationDefinition") {
-            const complexity = selectionComplexity(def.selectionSet);
+            const complexity = selectionComplexity(
+              def.selectionSet,
+              fragments,
+              new Set(),
+            );
             if (complexity > max) {
               context.reportError(
                 new GraphQLError(

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -123,6 +123,45 @@ describe("handleGraphQLRequest — validation rules", () => {
     );
   });
 
+  test("complexity counts fields inside named fragments (no spread bypass)", async () => {
+    // Moving the whole selection into a fragment must NOT bypass the limit: the
+    // spread is transparent, so its fields are counted at the operation level.
+    const fields = Array.from(
+      { length: GRAPHQL_MAX_COMPLEXITY + 1 },
+      (_, i) => `t${i}: __typename`,
+    ).join(" ");
+    const q = `query { ...Big } fragment Big on Query { ${fields} }`;
+    const { status, body } = await gql(q);
+    assert.equal(status, 400);
+    const ext = body.errors.find(
+      (e) => e.extensions?.code === "COMPLEXITY_LIMIT_EXCEEDED",
+    );
+    assert.ok(
+      ext,
+      `expected COMPLEXITY_LIMIT_EXCEEDED, got: ${JSON.stringify(body.errors)}`,
+    );
+  });
+
+  test("depth counts nesting inside named fragments (no spread bypass)", async () => {
+    // Deep nesting hidden inside a fragment must still be counted. Without
+    // following the spread, the operation's selection set is just `...Big` and
+    // counts as depth 0, bypassing the limit.
+    const nested =
+      "subnets { items { ".repeat(GRAPHQL_MAX_DEPTH + 1) +
+      "netuid" +
+      " } }".repeat(GRAPHQL_MAX_DEPTH + 1);
+    const q = `query { ...Big } fragment Big on Query { ${nested} }`;
+    const { status, body } = await gql(q);
+    assert.equal(status, 400);
+    const ext = body.errors.find(
+      (e) => e.extensions?.code === "DEPTH_LIMIT_EXCEEDED",
+    );
+    assert.ok(
+      ext,
+      `expected DEPTH_LIMIT_EXCEEDED, got: ${JSON.stringify(body.errors)}`,
+    );
+  });
+
   test("complexity exceeded returns COMPLEXITY_LIMIT_EXCEEDED extension", async () => {
     // GRAPHQL_MAX_COMPLEXITY is 50. Build a query with many fields by using
     // inline fragments or repeating aliases to exceed the limit.


### PR DESCRIPTION
## Summary

Fixes #1402.

The GraphQL endpoint's two DoS guards — `maxDepthRule` (limit 7) and `maxComplexityRule` (limit 50) — were **fully bypassed by named fragments**. `selectionDepth`/`selectionComplexity` only recursed into `sel.selectionSet`, and a `FragmentSpread` node has none, so the traversal never followed it. A client could move the entire expensive selection into a fragment; the operation's own selection set then counted as depth 0 / complexity 1, defeating both limits on the **public, unauthenticated** `POST /api/v1/graphql` endpoint.

## What Changed

- `src/graphql.mjs` — build a name→`FragmentDefinition` map from the document and follow `FragmentSpread` nodes when computing depth/complexity. A spread is transparent (adds no depth level; its fields are counted at the spread site). A `visited` set guards against fragment cycles so the custom rules can't recurse infinitely (validate() reports cycles, but our rules run in the same pass).
- `tests/graphql.test.mjs` — regression tests: a 51-field selection and deep nesting hidden inside a fragment are now rejected with `COMPLEXITY_LIMIT_EXCEEDED` / `DEPTH_LIMIT_EXCEEDED` (both passed `200 OK` before).

No schema, resolver-behavior, or generated-artifact changes — only the validation pass is tightened.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `npx vitest run tests/graphql.test.mjs` — 33 passed (incl. the 2 new regression tests)
- [x] `git diff --check`

## Template Used

- Backend/code change
