### PR TITLE
fix: purge stale neuron rows after partial metagraph refresh

### DIFF
--- a/scripts/fetch-metagraph.mjs
+++ b/scripts/fetch-metagraph.mjs
@@ -3,11 +3,11 @@
 // #1302) — the chain-level depth metagraphed lacked.
 //
 // Reads TAOSTATS_API_KEY from the env; the netuid list from the committed native
-// snapshot (registry/native/finney-subnets.json). Output: a JSON array of neuron
-// rows that the refresh-metagraph workflow stages to R2; the Worker's scheduled
-// handler then loads them into the metagraphed-health D1 `neurons` table with
-// parameterized inserts (loadStagedNeurons), keyed (netuid, uid) so a re-run
-// overwrites in place (slots are reused on-chain) and the table stays bounded.
+// snapshot (registry/native/finney-subnets.json). Output: a staging object with
+// captured_at, refreshed_netuids (subnets successfully fetched), and neuron rows.
+// The refresh-metagraph workflow signs and stages it to R2; the Worker's scheduled
+// handler loads rows with parameterized INSERT OR REPLACE, then deletes prior-
+// capture rows within refreshed subnets so deregistered UIDs do not linger.
 //
 // Units verified against /api/v1/economics ground truth (2026-06-21):
 //   stake_tao    = total_alpha_stake / 1e9   (Σ matches economics total_stake_tao)
@@ -139,10 +139,12 @@ async function main() {
   const delayMs = Number(process.env.METAGRAPH_FETCH_DELAY_MS) || 1200;
   const capturedAt = Date.now();
   const rows = [];
+  const refreshedNetuids = [];
   let failures = 0;
   for (const netuid of netuids) {
     try {
       const neurons = await fetchSubnet(netuid, key);
+      refreshedNetuids.push(netuid);
       for (const n of neurons) rows.push(normalizeNeuron(n, capturedAt));
       process.stderr.write(`netuid ${netuid}: ${neurons.length} neurons\n`);
     } catch (error) {
@@ -163,9 +165,16 @@ async function main() {
     (r) => Number.isInteger(r.netuid) && Number.isInteger(r.uid),
   );
   mkdirSync(path.dirname(OUT_PATH), { recursive: true });
-  writeFileSync(OUT_PATH, JSON.stringify(valid));
+  writeFileSync(
+    OUT_PATH,
+    JSON.stringify({
+      captured_at: capturedAt,
+      refreshed_netuids: refreshedNetuids,
+      rows: valid,
+    }),
+  );
   console.log(
-    `wrote ${valid.length} neurons across ${netuids.length - failures}/${netuids.length} subnets -> ${OUT_PATH}`,
+    `wrote ${valid.length} neurons across ${refreshedNetuids.length}/${netuids.length} subnets -> ${OUT_PATH}`,
   );
 }
 

--- a/scripts/sign-staged-neurons.mjs
+++ b/scripts/sign-staged-neurons.mjs
@@ -10,12 +10,29 @@ if (!inputPath || !key) {
   );
 }
 
-const rows = JSON.parse(readFileSync(inputPath, "utf8"));
-if (!Array.isArray(rows))
-  throw new Error("staged neurons payload must be an array");
-const payload = JSON.stringify(rows);
+const parsed = JSON.parse(readFileSync(inputPath, "utf8"));
+let rows;
+let refreshed_netuids;
+let captured_at;
+let payload;
+if (Array.isArray(parsed)) {
+  rows = parsed;
+  payload = JSON.stringify(rows);
+} else if (parsed && typeof parsed === "object") {
+  rows = parsed.rows;
+  refreshed_netuids = parsed.refreshed_netuids;
+  captured_at = parsed.captured_at;
+  if (!Array.isArray(rows)) {
+    throw new Error("staged payload rows must be a JSON array");
+  }
+  payload = JSON.stringify({ rows, refreshed_netuids, captured_at });
+} else {
+  throw new Error("staged payload must be a JSON array or staging object");
+}
+
 const hmac_sha256 = createHmac("sha256", key).update(payload).digest("hex");
-writeFileSync(
-  outputPath,
-  `${JSON.stringify({ schema_version: 1, hmac_sha256, rows })}\n`,
-);
+const envelope = { schema_version: 1, hmac_sha256, rows };
+if (refreshed_netuids !== undefined)
+  envelope.refreshed_netuids = refreshed_netuids;
+if (captured_at !== undefined) envelope.captured_at = captured_at;
+writeFileSync(outputPath, `${JSON.stringify(envelope)}\n`);

--- a/tests/load-staged-neurons.test.mjs
+++ b/tests/load-staged-neurons.test.mjs
@@ -39,6 +39,22 @@ function signedEnvelope(rows, key = SIGNING_KEY) {
   };
 }
 
+function signedCoverageEnvelope(
+  rows,
+  refreshed_netuids,
+  captured_at,
+  key = SIGNING_KEY,
+) {
+  const payload = JSON.stringify({ rows, refreshed_netuids, captured_at });
+  return {
+    schema_version: 1,
+    hmac_sha256: createHmac("sha256", key).update(payload).digest("hex"),
+    rows,
+    refreshed_netuids,
+    captured_at,
+  };
+}
+
 function mockEnv({
   rows,
   bad = false,
@@ -46,6 +62,7 @@ function mockEnv({
   deleted = [],
   prepared = [],
   batches = [],
+  runs = [],
   size,
 }) {
   return {
@@ -70,7 +87,16 @@ function mockEnv({
       METAGRAPH_HEALTH_DB: {
         prepare(sql) {
           prepared.push(sql);
-          return { bind: (...v) => ({ sql, v }) };
+          return {
+            bind: (...v) => ({
+              sql,
+              v,
+              async run() {
+                runs.push({ sql, v });
+                return { meta: { changes: 1 } };
+              },
+            }),
+          };
         },
         async batch(stmts) {
           batches.push(stmts.length);
@@ -81,6 +107,7 @@ function mockEnv({
     deleted,
     prepared,
     batches,
+    runs,
   };
 }
 
@@ -192,4 +219,29 @@ test("loadStagedNeurons rejects rows that fail per-field bounding (#1360)", asyn
     assert.equal(m.batches.length, 0, `${name} must never reach a D1 write`);
     assert.deepEqual(m.deleted, ["metagraph/neurons-pending.json"]);
   }
+});
+
+test("loadStagedNeurons purges prior-capture rows within refreshed subnets", async () => {
+  const captured_at = 2_000_000_000_000;
+  const rows = [{ ...neuronRow(1, 0), captured_at }];
+  const m = mockEnv({
+    rows: signedCoverageEnvelope(rows, [1], captured_at),
+  });
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.purged, 1);
+  const purge = m.runs.find((run) => run.sql.includes("DELETE FROM neurons"));
+  assert.ok(purge);
+  assert.deepEqual(purge.v, [1, captured_at]);
+});
+
+test("loadStagedNeurons rejects coverage metadata that disagrees with row captured_at", async () => {
+  const captured_at = 2_000_000_000_000;
+  const rows = [{ ...neuronRow(1, 0), captured_at: captured_at + 1 }];
+  const m = mockEnv({
+    rows: signedCoverageEnvelope(rows, [1], captured_at),
+  });
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.reason, "invalid");
+  assert.equal(m.batches.length, 0);
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -251,6 +251,65 @@ const MAX_STAGED_NEURON_ROWS = 50_000;
 const MAX_STAGED_NEURON_STRING_BYTES = 512;
 const MAX_STAGED_NETUID = 65_535;
 const MAX_STAGED_UID = 65_535;
+const MAX_STAGED_REFRESHED_NETUIDS = 256;
+
+function neuronStagingSignPayload(rows, refreshed_netuids, captured_at) {
+  if (refreshed_netuids == null && captured_at == null) {
+    return JSON.stringify(rows);
+  }
+  return JSON.stringify({ rows, refreshed_netuids, captured_at });
+}
+
+function parseNeuronStagingMeta(envelope, rows) {
+  const hasRefreshed = envelope?.refreshed_netuids !== undefined;
+  const hasCaptured = envelope?.captured_at !== undefined;
+  if (!hasRefreshed && !hasCaptured) {
+    return { legacy: true };
+  }
+  if (!hasRefreshed || !hasCaptured) {
+    return { invalid: true };
+  }
+  const refreshed_netuids = envelope.refreshed_netuids;
+  const captured_at = envelope.captured_at;
+  if (
+    !Array.isArray(refreshed_netuids) ||
+    refreshed_netuids.length > MAX_STAGED_REFRESHED_NETUIDS ||
+    !Number.isInteger(captured_at) ||
+    captured_at < 0
+  ) {
+    return { invalid: true };
+  }
+  const refreshedSet = new Set();
+  for (const netuid of refreshed_netuids) {
+    if (
+      !Number.isInteger(netuid) ||
+      netuid < 0 ||
+      netuid > MAX_STAGED_NETUID ||
+      refreshedSet.has(netuid)
+    ) {
+      return { invalid: true };
+    }
+    refreshedSet.add(netuid);
+  }
+  for (const row of rows) {
+    if (row.captured_at !== captured_at || !refreshedSet.has(row.netuid)) {
+      return { invalid: true };
+    }
+  }
+  return { legacy: false, refreshed_netuids, captured_at };
+}
+
+async function purgeStaleNeuronRows(db, refreshed_netuids, captured_at) {
+  let purged = 0;
+  for (const netuid of refreshed_netuids) {
+    const result = await db
+      .prepare(`DELETE FROM neurons WHERE netuid = ? AND captured_at < ?`)
+      .bind(netuid, captured_at)
+      .run();
+    purged += result?.meta?.changes ?? 0;
+  }
+  return purged;
+}
 
 function utf8Bytes(value) {
   return new TextEncoder().encode(value);
@@ -314,7 +373,9 @@ function validStagedNeuronRow(row) {
 // using its existing R2 permission; we load only authenticated, bounded,
 // schema-valid rows through the METAGRAPH_HEALTH_DB binding — which needs no
 // API-token D1 permission — with PARAMETERIZED inserts (values are always bound,
-// never interpolated), then delete the object so it loads exactly once.
+// never interpolated), then delete prior-capture rows within refreshed subnets
+// so deregistered UIDs do not linger after a partial refresh. Then delete the
+// staged object so it loads exactly once.
 export async function loadStagedNeurons(env) {
   const bucket = env.METAGRAPH_ARCHIVE;
   const db = env.METAGRAPH_HEALTH_DB;
@@ -347,14 +408,26 @@ export async function loadStagedNeurons(env) {
     await bucket.delete(STAGED_NEURONS_KEY);
     return { ok: false, reason: "too_many_rows" };
   }
-  const expected = await hmacHex(signingKey, JSON.stringify(rows));
-  if (!timingSafeStringEqual(expected, envelope.hmac_sha256)) {
-    await bucket.delete(STAGED_NEURONS_KEY);
-    return { ok: false, reason: "unauthenticated" };
-  }
   if (!rows.length || rows.some((row) => !validStagedNeuronRow(row))) {
     await bucket.delete(STAGED_NEURONS_KEY);
     return { ok: false, reason: "invalid" };
+  }
+  const stagingMeta = parseNeuronStagingMeta(envelope, rows);
+  if (stagingMeta.invalid) {
+    await bucket.delete(STAGED_NEURONS_KEY);
+    return { ok: false, reason: "invalid" };
+  }
+  const expected = await hmacHex(
+    signingKey,
+    neuronStagingSignPayload(
+      rows,
+      stagingMeta.legacy ? null : stagingMeta.refreshed_netuids,
+      stagingMeta.legacy ? null : stagingMeta.captured_at,
+    ),
+  );
+  if (!timingSafeStringEqual(expected, envelope.hmac_sha256)) {
+    await bucket.delete(STAGED_NEURONS_KEY);
+    return { ok: false, reason: "unauthenticated" };
   }
   const cols = NEURON_INSERT_COLUMNS;
   const colList = cols.join(",");
@@ -376,8 +449,20 @@ export async function loadStagedNeurons(env) {
   for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
     await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
   }
+  let purged = 0;
+  if (!stagingMeta.legacy) {
+    try {
+      purged = await purgeStaleNeuronRows(
+        db,
+        stagingMeta.refreshed_netuids,
+        stagingMeta.captured_at,
+      );
+    } catch {
+      return { ok: false, reason: "purge_failed" };
+    }
+  }
   await bucket.delete(STAGED_NEURONS_KEY);
-  return { ok: true, rows: rows.length };
+  return { ok: true, rows: rows.length, purged };
 }
 
 // Load a staged chain-event batch from R2 into D1 (#1346, epic #1345). The


### PR DESCRIPTION
## Summary

A partial Taostats refresh could leave **stale neuron rows in D1 indefinitely**. `loadStagedNeurons` used `INSERT OR REPLACE` for fetched subnets but never removed UIDs that deregistered or rows from prior captures within those subnets. Failed subnets correctly kept their last snapshot — the bug was only within **successfully refreshed** netuids.

This change records which subnets were refreshed, then deletes prior-capture rows for those netuids after upsert.

## Problem

`fetch-metagraph.mjs` tolerates up to 50% subnet fetch failures and still stages a partial snapshot. `loadStagedNeurons` then:

1. Upserts rows for subnets that succeeded
2. Does **nothing** for subnets that failed (correct)
3. Does **nothing** to remove old `(netuid, uid)` rows within refreshed subnets (bug)

After a partial outage, deregistered UIDs and other stale rows could linger forever in `/api/v1/subnets/{netuid}/metagraph`, validators, and stake endpoints.

## Fix

### Fetch (`scripts/fetch-metagraph.mjs`)

- Track `refreshed_netuids` on each successful fetch (including empty subnets).
- Write `{ captured_at, refreshed_netuids, rows }` instead of a bare array.

### Sign (`scripts/sign-staged-neurons.mjs`)

- Accept legacy array input or the new staging object.
- HMAC-sign `{ rows, refreshed_netuids, captured_at }` for coverage-aware envelopes.
- Legacy row-only signing unchanged for backward compatibility.

### Worker (`workers/api.mjs`)

- Validate coverage metadata (bounds, row `captured_at` match, rows ⊆ refreshed netuids).
- Verify HMAC over legacy or coverage payload.
- After upsert, `DELETE FROM neurons WHERE netuid = ? AND captured_at < ?` for each refreshed netuid.
- On purge failure: return `purge_failed`, keep R2 object for retry.

## Files changed

| File | Change |
|------|--------|
| `scripts/fetch-metagraph.mjs` | Emit `refreshed_netuids` + `captured_at` staging object |
| `scripts/sign-staged-neurons.mjs` | Sign coverage-aware staging payloads |
| `workers/api.mjs` | Validate metadata, purge stale rows after upsert |
| `tests/load-staged-neurons.test.mjs` | Purge + invalid metadata tests |

## Test plan

- [x] `npm test -- tests/load-staged-neurons.test.mjs`
  - Legacy signed envelopes still load (no purge)
  - Coverage envelope purges `DELETE FROM neurons WHERE netuid = ? AND captured_at < ?`
  - Rejects row `captured_at` mismatch with envelope
- [ ] Full CI (`validate` workflow on Linux)
