### PR TITLE
fix(events): cap the staged-event R2→D1 drain + drain overflow progressively (#1346)

### DIFF
--- a/tests/load-staged-events.test.mjs
+++ b/tests/load-staged-events.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleScheduled, loadStagedEvents } from "../workers/api.mjs";
-import { EVENTS_LOAD_CRON } from "../workers/config.mjs";
+import {
+  EVENTS_LOAD_CRON,
+  MAX_STAGED_EVENTS_BYTES,
+  MAX_STAGED_EVENT_ROWS,
+} from "../workers/config.mjs";
 
 function eventRow(block_number, event_index) {
   return {
@@ -162,5 +166,172 @@ test("handleScheduled fast-load cron drains staged batches + skips the probe (#1
   assert.ok(
     drained.includes("events/account-events-pending.json"),
     "the staged event batch was loaded + deleted",
+  );
+});
+
+// ---- input caps on the staged drain (parity with the HTTP ingest caps) -------
+
+test("loadStagedEvents caps rows/tick + leaves the remainder in R2 (not deleted)", async () => {
+  const N = MAX_STAGED_EVENT_ROWS + 5;
+  const rows = Array.from({ length: N }, (_, i) => eventRow(1000 + i, i));
+  const puts = [];
+  const deleted = [];
+  const env = {
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return {
+          size: 1024,
+          async json() {
+            return rows;
+          },
+        };
+      },
+      async put(key, body) {
+        puts.push({ key, body });
+      },
+      async delete(key) {
+        deleted.push(key);
+      },
+    },
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        return { bind: () => ({}) };
+      },
+      async batch() {},
+    },
+  };
+  const r = await loadStagedEvents(env);
+  assert.equal(r.ok, true);
+  assert.equal(r.rows, MAX_STAGED_EVENT_ROWS);
+  assert.equal(r.remaining, 5);
+  assert.deepEqual(deleted, [], "must NOT delete while rows are un-persisted");
+  assert.equal(puts.length, 1, "remainder rewritten for the next tick");
+  assert.equal(
+    JSON.parse(puts[0].body).length,
+    5,
+    "exactly the un-loaded rows are kept",
+  );
+});
+
+test("loadStagedEvents drains a >cap file across ticks without dropping rows", async () => {
+  const N = MAX_STAGED_EVENT_ROWS + 5;
+  const all = Array.from({ length: N }, (_, i) => eventRow(1000 + i, i));
+  let stored = JSON.stringify(all); // a stateful in-memory R2 object
+  const env = {
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return stored == null
+          ? null
+          : {
+              size: stored.length,
+              async json() {
+                return JSON.parse(stored);
+              },
+            };
+      },
+      async put(_key, body) {
+        stored = body;
+      },
+      async delete() {
+        stored = null;
+      },
+    },
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        return { bind: () => ({}) };
+      },
+      async batch() {},
+    },
+  };
+  const t1 = await loadStagedEvents(env);
+  assert.equal(t1.rows, MAX_STAGED_EVENT_ROWS);
+  assert.equal(t1.remaining, 5);
+  assert.notEqual(stored, null, "remainder stays in R2 after tick 1");
+  const t2 = await loadStagedEvents(env);
+  assert.equal(t2.rows, 5);
+  assert.equal(t2.remaining, undefined);
+  assert.equal(stored, null, "object deleted only after the last row drained");
+  assert.equal(
+    t1.rows + t2.rows,
+    N,
+    "every row loaded across ticks — none dropped",
+  );
+});
+
+test("loadStagedEvents skips an over-byte-cap file without parsing or deleting it", async () => {
+  let jsonCalled = false;
+  const deleted = [];
+  const env = {
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return {
+          size: MAX_STAGED_EVENTS_BYTES + 1,
+          async json() {
+            jsonCalled = true;
+            return [];
+          },
+        };
+      },
+      async put() {},
+      async delete(key) {
+        deleted.push(key);
+      },
+    },
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        return { bind: () => ({}) };
+      },
+      async batch() {},
+    },
+  };
+  const r = await loadStagedEvents(env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "too_large");
+  assert.equal(jsonCalled, false, "never materialized the oversized body");
+  assert.deepEqual(
+    deleted,
+    [],
+    "must NOT delete — that would drop staged rows",
+  );
+});
+
+test("loadStagedEvents leaves the file intact if a D1 batch throws (no drop on crash)", async () => {
+  const rows = Array.from({ length: 12 }, (_, i) => eventRow(1000 + i, i));
+  const puts = [];
+  const deleted = [];
+  const env = {
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return {
+          size: 256,
+          async json() {
+            return rows;
+          },
+        };
+      },
+      async put(key, body) {
+        puts.push({ key, body });
+      },
+      async delete(key) {
+        deleted.push(key);
+      },
+    },
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        return { bind: () => ({}) };
+      },
+      async batch() {
+        throw new Error("d1 down");
+      },
+    },
+  };
+  // D1 writes happen BEFORE the R2 shrink, so a write failure must leave the full
+  // file in place to re-drain next tick — never a partial put/delete.
+  await assert.rejects(loadStagedEvents(env));
+  assert.deepEqual(puts, [], "no remainder written on failure");
+  assert.deepEqual(
+    deleted,
+    [],
+    "object NOT deleted — full file re-drains next tick",
   );
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -139,6 +139,8 @@ import {
   MAX_BULK_TREND_ROWS,
   MAX_EVENTS_INGEST_BODY_BYTES,
   MAX_EVENTS_INGEST_ROWS,
+  MAX_STAGED_EVENTS_BYTES,
+  MAX_STAGED_EVENT_ROWS,
   MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
   MAX_INCIDENT_ROWS,
   MAX_RPC_BODY_BYTES,
@@ -395,6 +397,17 @@ export async function loadStagedEvents(env) {
   const key = "events/account-events-pending.json";
   const object = await bucket.get(key);
   if (!object) return { ok: false, reason: "none" };
+  // Byte cap: never materialize a pathological body. `size` is object metadata,
+  // available before the body is streamed. Do NOT delete — that would drop rows the
+  // producer staged; leave it (loud) and let the overlapping poller's next window
+  // self-heal it. A misconfigured backfill exceeding this should be chunked by the
+  // producer, not parsed here.
+  if (Number(object.size || 0) > MAX_STAGED_EVENTS_BYTES) {
+    console.warn(
+      `loadStagedEvents: staged file ${object.size} bytes exceeds ${MAX_STAGED_EVENTS_BYTES}; skipping (poller overlap self-heals)`,
+    );
+    return { ok: false, reason: "too_large", size: Number(object.size || 0) };
+  }
   let parsed;
   try {
     parsed = await object.json();
@@ -407,13 +420,30 @@ export async function loadStagedEvents(env) {
     await bucket.delete(key);
     return { ok: false, reason: "empty" };
   }
-  const statements = eventInsertStatements(db, rows);
+  // Row cap: bound the D1 writes + subrequests per */3 tick. Drain up to the cap
+  // now; if rows remain, rewrite the object with ONLY the remainder so the next tick
+  // continues — never delete while rows are un-persisted. Order matters: write to D1
+  // FIRST, then shrink R2. A crash between them re-reads the full file next tick and
+  // re-inserts the loaded rows harmlessly (INSERT OR IGNORE), so nothing is dropped.
+  const batch =
+    rows.length > MAX_STAGED_EVENT_ROWS
+      ? rows.slice(0, MAX_STAGED_EVENT_ROWS)
+      : rows;
+  const remainder =
+    rows.length > MAX_STAGED_EVENT_ROWS
+      ? rows.slice(MAX_STAGED_EVENT_ROWS)
+      : [];
+  const statements = eventInsertStatements(db, batch);
   const STMTS_PER_BATCH = 50;
   for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
     await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
   }
+  if (remainder.length) {
+    await bucket.put(key, JSON.stringify(remainder));
+    return { ok: true, rows: batch.length, remaining: remainder.length };
+  }
   await bucket.delete(key);
-  return { ok: true, rows: rows.length };
+  return { ok: true, rows: batch.length };
 }
 
 // POST /api/v1/internal/events (#1360): the realtime ingest path for the

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -102,6 +102,17 @@ export const WEBHOOK_SUBSCRIPTION_TOKEN_HEADER =
 export const EVENTS_INGEST_TOKEN_HEADER = "x-metagraph-events-token";
 export const MAX_EVENTS_INGEST_BODY_BYTES = 262144; // 256 KB
 export const MAX_EVENTS_INGEST_ROWS = 500;
+// Caps on the R2-staged chain-event drain (loadStagedEvents, #1346). Unlike the
+// single bounded HTTP body above, a staged file is produced by the CI poller and
+// can grow large on a backfill or a stuck window. The byte cap guards against
+// materializing a pathological body; the row cap bounds the D1 writes + subrequests
+// PER */3 tick (10 000 rows -> ~1 000 INSERT statements -> ~20 db.batch() calls,
+// far under the 1 000-subrequest limit). On overflow the drain loads up to the row
+// cap and LEAVES the remainder in R2 for the next tick — it never deletes
+// un-persisted rows; INSERT OR IGNORE on (block_number, event_index) makes any
+// re-drain idempotent.
+export const MAX_STAGED_EVENTS_BYTES = 4_194_304; // 4 MiB parse-safety ceiling
+export const MAX_STAGED_EVENT_ROWS = 10_000;
 // Dormant subscriptions self-clean after 180 days; the publish-time dispatcher
 // refreshes the TTL on each successful delivery.
 export const WEBHOOK_TTL_SECONDS = 180 * 24 * 60 * 60;


### PR DESCRIPTION
## Problem
`loadStagedEvents(env)` (workers/api.mjs) had **no size or row cap** on its input path. It does a single R2 GET of `events/account-events-pending.json`, parses it, and runs parameterized `INSERT OR IGNORE` via `db.batch()` in groups of 50 statements. The HTTP ingest endpoint already has defense-in-depth caps (`MAX_EVENTS_INGEST_BODY_BYTES` / `MAX_EVENTS_INGEST_ROWS`, workers/config.mjs) — but those guard **only** the HTTP path, not the staged drain.

A stuck or backfilling poller window (`scripts/fetch-events.py`, `refresh-events.yml`) could stage a very large file. At ~500k rows the drain would approach the Worker **1000-subrequest/invocation limit** and serialize a large number of D1 `batch()` writes on the single D1 writer. Design volume is ~1 MB/day, so this is headroom, not a live bug — but the path was unguarded.

## Fix
Caps mirroring the ingest endpoint's intent, sized for a batch file:
- **`MAX_STAGED_EVENTS_BYTES` = 4 MiB** — a parse-safety ceiling checked via `object.size` **before** the body is materialized.
- **`MAX_STAGED_EVENT_ROWS` = 10 000/tick** — bounds D1 writes + subrequests (~1000 INSERTs → ~20 `db.batch()` calls, far under 1000).

Crucially, overflow is **not** dropped:
- **Over the byte cap:** skip + `console.warn`, and **leave the object in place** (do *not* delete). The overlapping poller window re-stages a normal-size file within ~5 min and self-heals; a misconfigured backfill is loud but loses nothing.
- **Over the row cap:** drain up to the cap, then rewrite **only the remainder** to R2 for the next `*/3` tick; delete the object **only once fully drained**.
- **Ordering:** D1 write happens **before** the R2 shrink. A crash between them re-reads the full file next tick and re-inserts idempotently (`INSERT OR IGNORE` on `(block_number, event_index)`), so **rows are never dropped** — not on overflow, not on a partial-batch failure.

## Tests (4 new, alongside the existing `loadStagedEvents` suite)
- row cap → first cap loaded, remainder rewritten to R2, object **not** deleted;
- multi-tick drain of a `>cap` file → every row loaded across ticks, deleted only at the end (no drop);
- over-byte-cap file → never parsed, never deleted, returns `too_large`;
- a mid-batch D1 throw → object left intact (no partial put/delete) so it re-drains next tick.

All 41 tests in the staged-events / ingest / account-events suites pass; prettier clean. Found via a code audit of the ingest caps' coverage.