### PR TITLE
fix(api): make error responses no-store so the edge cannot cache them

### DIFF
--- a/tests/responses-envelope.test.mjs
+++ b/tests/responses-envelope.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { dataResponse, envelopeResponse } from "../workers/responses.mjs";
-import { ifNoneMatchSatisfied } from "../workers/http.mjs";
+import { errorResponse, ifNoneMatchSatisfied } from "../workers/http.mjs";
 
 const reqWith = (ifNoneMatch) =>
   new Request("https://metagraph.sh/api/v1/anything", {
@@ -29,6 +29,18 @@ test("dataResponse emits the SuccessEnvelope shape with no error key", async () 
   assert.equal(body.schema_version, 1);
   assert.deepEqual(body.data, { hello: "world" });
   assert.equal(body.meta.source, "test");
+});
+
+// Error envelopes must not be cached by shared/edge caches — a transient 5xx or
+// a not-yet-published 404 would otherwise be served stale from the CDN.
+test("errorResponse is cache-control: no-store across 4xx and 5xx", async () => {
+  for (const status of [400, 404, 500, 503]) {
+    const res = errorResponse("some_error", "boom", status);
+    assert.equal(res.status, status);
+    assert.equal(res.headers.get("cache-control"), "no-store");
+    assert.equal(res.headers.get("x-metagraph-cache-profile"), "no-store");
+    assert.equal(res.headers.get("x-metagraph-error-code"), "some_error");
+  }
 });
 
 // ifNoneMatchSatisfied implements the RFC 7232 §3.2 precondition that backs every

--- a/workers/http.mjs
+++ b/workers/http.mjs
@@ -28,6 +28,12 @@ export function errorResponse(
   extraHeaders = {},
 ) {
   const headers = apiHeaders("short");
+  // Errors must never be cached by shared/edge caches: a transient 5xx (e.g. an
+  // R2 timeout) or a not-yet-published 404 would otherwise be served stale for
+  // up to max-age + stale-while-revalidate, turning a blip into a multi-minute
+  // edge outage. Mirror dataResponse / og-image error / webhook responses.
+  headers.set("cache-control", "no-store");
+  headers.set("x-metagraph-cache-profile", "no-store");
   headers.set("x-metagraph-error-code", code);
   for (const [key, value] of Object.entries(extraHeaders)) {
     headers.set(key, value);


### PR DESCRIPTION
## Summary

Fixes #1406.

The canonical error envelope `errorResponse` built its headers with `apiHeaders("short")` — `cache-control: public, max-age=60, stale-while-revalidate=300` — and never overrode it, so **every** error (400/404/500/503/504) was publicly cacheable. A shared/edge cache then serves the error to all clients for up to 60s + 300s SWR: a transient `5xx` (e.g. an R2 timeout) becomes a multi-minute edge outage, and a `404` for a resource published moments later is served stale. This also contradicted the rest of the codebase, where dynamic/error responses are `no-store` (`dataResponse`, og-image `503`, webhook responses).

## What Changed

- `workers/http.mjs` — `errorResponse` now overrides `cache-control` to `no-store` (and the cache-profile header), so error envelopes are never stored by shared caches. CORS/content-type/nosniff/vary from `apiHeaders` are unchanged.
- `tests/responses-envelope.test.mjs` — regression test asserting `errorResponse` is `no-store` across 4xx and 5xx.

No schema, OpenAPI, or generated-artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `npx vitest run tests/responses-envelope.test.mjs` — 8 passed (incl. the new regression test)
- [x] `npx prettier --check` + `npx eslint` on changed files — clean
- [x] `git diff --check`

## Template Used

- Backend/code change
