### PR TITLE
fix(graphql): bound request and query parsing

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -10,6 +10,8 @@ import { readArtifact } from "../workers/storage.mjs";
 
 export const GRAPHQL_MAX_DEPTH = 7;
 export const GRAPHQL_MAX_COMPLEXITY = 50;
+export const GRAPHQL_MAX_BODY_BYTES = 64 * 1024;
+export const GRAPHQL_MAX_QUERY_BYTES = 16 * 1024;
 
 const SDL = `
   type Query {
@@ -221,6 +223,12 @@ const rootValue = {
 
 const GRAPHQL_CONTENT_TYPE = "application/graphql-response+json";
 
+const graphqlError = (message, status = 400, extraHeaders = {}) =>
+  new Response(JSON.stringify({ errors: [{ message }] }), {
+    status,
+    headers: graphqlHeaders(extraHeaders),
+  });
+
 const graphqlHeaders = (extra = {}) => ({
   "content-type": GRAPHQL_CONTENT_TYPE,
   "access-control-allow-origin": "*",
@@ -229,6 +237,67 @@ const graphqlHeaders = (extra = {}) => ({
 });
 
 // --- Handler ---
+
+async function readLimitedJson(request) {
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null) {
+    const length = Number(declaredLength);
+    if (!Number.isFinite(length) || length < 0) {
+      return {
+        error: graphqlError("Invalid Content-Length header."),
+      };
+    }
+    if (length > GRAPHQL_MAX_BODY_BYTES) {
+      return {
+        error: graphqlError("GraphQL request body is too large.", 413),
+      };
+    }
+  }
+
+  if (!request.body) {
+    return { value: null };
+  }
+
+  const reader = request.body.getReader();
+  const chunks = [];
+  let total = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > GRAPHQL_MAX_BODY_BYTES) {
+        await reader.cancel();
+        return {
+          error: graphqlError("GraphQL request body is too large.", 413),
+        };
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  try {
+    return { value: JSON.parse(new TextDecoder().decode(bytes)) };
+  } catch {
+    return {
+      error: graphqlError("Request body must be valid JSON."),
+    };
+  }
+}
+
+function utf8ByteLength(value) {
+  return new TextEncoder().encode(value).byteLength;
+}
 
 export async function handleGraphQLRequest(request, env) {
   if (request.method !== "POST") {
@@ -243,17 +312,8 @@ export async function handleGraphQLRequest(request, env) {
     );
   }
 
-  let body;
-  try {
-    body = await request.json();
-  } catch {
-    return new Response(
-      JSON.stringify({
-        errors: [{ message: "Request body must be valid JSON." }],
-      }),
-      { status: 400, headers: graphqlHeaders() },
-    );
-  }
+  const { value: body, error: bodyError } = await readLimitedJson(request);
+  if (bodyError) return bodyError;
 
   const { query, variables, operationName } = body || {};
   if (typeof query !== "string" || !query.trim()) {
@@ -263,6 +323,10 @@ export async function handleGraphQLRequest(request, env) {
       }),
       { status: 400, headers: graphqlHeaders() },
     );
+  }
+
+  if (utf8ByteLength(query) > GRAPHQL_MAX_QUERY_BYTES) {
+    return graphqlError("GraphQL query is too large.", 413);
   }
 
   let document;

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
+import { Blob } from "node:buffer";
 import { describe, test } from "vitest";
 import {
+  GRAPHQL_MAX_BODY_BYTES,
   GRAPHQL_MAX_COMPLEXITY,
   GRAPHQL_MAX_DEPTH,
+  GRAPHQL_MAX_QUERY_BYTES,
   handleGraphQLRequest,
   maxComplexityRule,
   maxDepthRule,
@@ -73,6 +76,48 @@ describe("handleGraphQLRequest — request validation", () => {
     assert.equal(res.status, 400);
     const body = await res.json();
     assert.ok(body.errors[0].message.includes("JSON"));
+  });
+
+  test("oversized Content-Length is rejected before reading the body", async () => {
+    const req = new Request("https://api.metagraph.sh/api/v1/graphql", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(GRAPHQL_MAX_BODY_BYTES + 1),
+      },
+      body: JSON.stringify({ query: "{ __typename }" }),
+    });
+    const res = await handleGraphQLRequest(req, emptyEnv);
+    assert.equal(res.status, 413);
+    const body = await res.json();
+    assert.ok(body.errors[0].message.includes("body"));
+  });
+
+  test("oversized streaming body without Content-Length is rejected", async () => {
+    const req = new Request("https://api.metagraph.sh/api/v1/graphql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: new Blob([" ".repeat(GRAPHQL_MAX_BODY_BYTES + 1)]).stream(),
+      duplex: "half",
+    });
+    const res = await handleGraphQLRequest(req, emptyEnv);
+    assert.equal(res.status, 413);
+    const body = await res.json();
+    assert.ok(body.errors[0].message.includes("body"));
+  });
+
+  test("oversized GraphQL query is rejected before parsing", async () => {
+    const req = new Request("https://api.metagraph.sh/api/v1/graphql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        query: `# ${"x".repeat(GRAPHQL_MAX_QUERY_BYTES)}\n{ __typename }`,
+      }),
+    });
+    const res = await handleGraphQLRequest(req, emptyEnv);
+    assert.equal(res.status, 413);
+    const body = await res.json();
+    assert.ok(body.errors[0].message.includes("query"));
   });
 
   test("missing query field returns 400", async () => {


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated POST requests to `/api/v1/graphql` from causing unbounded body materialization or excessive parser work that can exhaust Worker memory/CPU by adding pre-parse limits and checks.
- Tighten the GraphQL handler to enforce reasonable request and query size caps so validation and parsing run only on bounded inputs.

### Description
- Add `GRAPHQL_MAX_BODY_BYTES` and `GRAPHQL_MAX_QUERY_BYTES` constants and a `graphqlError` helper to centralize error responses in `src/graphql.mjs`.
- Implement `readLimitedJson(request)` which rejects invalid or oversized `Content-Length` values and performs a bounded streaming read that cancels and returns HTTP 413 on too-large bodies, and replace unbounded `request.json()` with this bounded reader.
- Add `utf8ByteLength` and enforce the `GRAPHQL_MAX_QUERY_BYTES` limit before calling `parse(query)` so overly large query strings are rejected early with HTTP 413.
- Add regression tests in `tests/graphql.test.mjs` for oversized `Content-Length`, oversized streaming bodies without `Content-Length`, and oversized GraphQL queries, and import `Blob` for streaming test fixtures.

### Testing
- Ran `npx vitest run tests/graphql.test.mjs` and all tests passed (`1 test file, 34 tests` succeeded).
- Ran `npm run lint` after fixing the test import and the linter passed (previous `Blob` undefined error was fixed by adding `import { Blob } from "node:buffer"`).
- Ran `npm run format:check` and Prettier reported no formatting issues.
- Ran `git diff --check` to ensure no trailing whitespace/errors and it returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38fad1af54832c8331e3465acfec28)