### PR TITLE
fix(ci): isolate metagraph fetch from secrets

### DIFF
--- a/.github/workflows/refresh-metagraph.yml
+++ b/.github/workflows/refresh-metagraph.yml
@@ -14,13 +14,14 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: refresh-metagraph
   cancel-in-progress: false
 
 jobs:
-  refresh:
+  fetch:
     runs-on: ubuntu-latest
     timeout-minutes: 30 # one get_all_metagraphs_info call + per-subnet storage reads
     steps:
@@ -29,18 +30,8 @@ jobs:
         with:
           persist-credentials: false
 
-      # No `cache: npm` here on purpose: this workflow holds Cloudflare + signing
-      # secrets, so it doesn't consume a shared npm cache another workflow could poison.
-      - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        with:
-          node-version: 22.23.0
-
       - name: Setup uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
-
-      - name: Install
-        run: npm ci
 
       # First-party chain-direct fetch (pinned bittensor, matching sync-subnets):
       # get_all_metagraphs_info for the per-UID core + SubtensorModule.ValidatorTrust
@@ -48,6 +39,41 @@ jobs:
       # Taostats source (#1348). No Taostats, no API key.
       - name: Fetch per-UID metagraph (Bittensor SDK)
         run: uvx --from bittensor==10.4.0 python scripts/fetch-metagraph-native.py
+
+      - name: Upload unsigned neuron snapshot
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: metagraph-neurons-unsigned
+          path: dist/metagraph-neurons.json
+          if-no-files-found: error
+          retention-days: 1
+
+  sign-and-stage:
+    needs: fetch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      # Keep the secret-bearing job in a fresh workspace. The unpinned PyPI
+      # execution boundary above can only pass the JSON data artifact forward, not
+      # mutated repository scripts, shell startup files, or node_modules.
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22.23.0
+
+      - name: Install
+        run: npm ci
+
+      - name: Download unsigned neuron snapshot
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: metagraph-neurons-unsigned
+          path: dist
 
       - name: Sign staged neuron snapshot
         run: node scripts/sign-staged-neurons.mjs dist/metagraph-neurons.json
@@ -62,11 +88,19 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+  notify-on-failure:
+    needs: [fetch, sign-and-stage]
+    if: ${{ always() && (needs.fetch.result == 'failure' || needs.sign-and-stage.result == 'failure') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
       - name: Notify on failure
-        if: failure() && env.METAGRAPH_ALERT_WEBHOOK_URL != ''
         env:
           METAGRAPH_ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}
         run: |
+          if [ -z "$METAGRAPH_ALERT_WEBHOOK_URL" ]; then
+            exit 0
+          fi
           curl -fsS -X POST "$METAGRAPH_ALERT_WEBHOOK_URL" \
             -H 'content-type: application/json' \
-            -d '{"content":"🔴 metagraphed refresh-metagraph FAILED — the per-UID neurons D1 tier may go stale."}' || true
+            -d '{"content":"🔴 metagraphed refresh-metagraph FAILED — the per-UID neurons D1 tier may go stale."}'


### PR DESCRIPTION
### Motivation
- The workflow previously executed an unpinned PyPI-resolved Bittensor SDK inside the same job that later used signing and Cloudflare secrets, creating a CI supply-chain risk where malicious dependencies could persist changes and exfiltrate secrets. 
- The change aims to isolate untrusted third-party code execution from any step that has access to high-value secrets. 

### Description
- Split the single refresh job into a non-secret `fetch` job that runs `uvx --from bittensor==10.4.0 python scripts/fetch-metagraph-native.py` and uploads only the unsigned JSON as an artifact. 
- Added a separate `sign-and-stage` job that runs in a fresh workspace, runs `npm ci`, downloads the unsigned artifact, signs it with `METAGRAPH_STAGING_SIGNING_KEY`, and stages it to R2 using Cloudflare secrets. 
- Pinned the artifact `upload`/`download` actions to full commit SHAs to avoid mutable action tags and limited the data passed between jobs to the artifact JSON only. 
- Added a `notify-on-failure` job and adjusted permissions (added `actions: read`) so failures are reported while keeping secret-bearing steps isolated. 

### Testing
- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/refresh-metagraph.yml'); puts 'yaml ok'"` which succeeded. 
- Ran `git diff --check` which succeeded with no whitespace or YAML issues. 
- Attempted `python` YAML parse using `yaml.safe_load` which failed in the environment due to the missing `yaml` Python module (this is an environment limitation, not a workflow YAML error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a390197522c832ca6d4dda38b9f8769)