### PR TITLE
fix(docker): narrow streamer build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,8 @@
 # + speed. Only the streamer's sources are needed; never ship .git, node_modules,
 # build artifacts, or any env/secret files into the build context.
 *
-!scripts/
-!scripts/**
 !deploy/
-!deploy/**
+!deploy/streamer.Dockerfile
+!scripts/
+!scripts/fetch-events.py
+!scripts/stream-events.py


### PR DESCRIPTION
### Motivation
- Prevent accidental disclosure of local ignored env/secret or private files to Docker daemons or remote builders by avoiding a broad recursive allowlist for `scripts/` and `deploy/` in the build context.

### Description
- Replace the recursive `!scripts/**` and `!deploy/**` allowlist entries in `.dockerignore` with explicit allowlist lines for `deploy/streamer.Dockerfile`, `scripts/fetch-events.py`, and `scripts/stream-events.py`, while preserving the deny-by-default `*` rule.

### Testing
- Verified the required files exist with `test -f deploy/streamer.Dockerfile && test -f scripts/fetch-events.py && test -f scripts/stream-events.py`, asserted via a Python check that `.dockerignore` contains the three explicit `!` entries and does not contain `!deploy/**` or `!scripts/**`, and ran `git diff --check`; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3903e8b418832c878ab1cfd4aadb5e)