### PR TITLE
fix(api): use weak ETag comparison for badge/discovery 304s

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -435,6 +435,46 @@ describe("badge SVG handler", () => {
     assert.equal(res.status, 304);
   });
 
+  test("304 for a badge when if-none-match sends the strong (W/-less) validator", async () => {
+    // weakEtag emits W/"…", but If-None-Match uses weak comparison (RFC 7232),
+    // so the strong form "…" must also match. The previous strict === check
+    // only matched the exact W/"…" echo and returned 200 here.
+    const env = createLocalArtifactEnv();
+    const first = await handleRequest(
+      req("/metagraph/health/badges/7.svg"),
+      env,
+      {},
+    );
+    const strong = first.headers.get("etag").replace(/^W\//, "");
+    const res = await handleRequest(
+      req("/metagraph/health/badges/7.svg", {
+        headers: { "if-none-match": strong },
+      }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 304);
+  });
+
+  test("304 for the MCP server card / agent-tools with the strong validator", async () => {
+    // The same weak-comparison fix applies to the other two discovery handlers.
+    const env = createLocalArtifactEnv();
+    for (const path of [
+      "/.well-known/mcp/server-card.json",
+      "/.well-known/agent-tools/openai.json",
+    ]) {
+      const first = await handleRequest(req(path), env, {});
+      assert.equal(first.status, 200, `${path} first GET`);
+      const strong = first.headers.get("etag").replace(/^W\//, "");
+      const res = await handleRequest(
+        req(path, { headers: { "if-none-match": strong } }),
+        env,
+        {},
+      );
+      assert.equal(res.status, 304, `${path} strong-form revalidation`);
+    }
+  });
+
   test("prefers the live KV overlay status when present", async () => {
     const env = createLocalArtifactEnv({
       METAGRAPH_CONTROL: makeKv({

--- a/workers/request-handlers/discovery.mjs
+++ b/workers/request-handlers/discovery.mjs
@@ -1,5 +1,5 @@
 import { CACHE_SECONDS, PRIMARY_DOMAIN } from "../../src/contracts.mjs";
-import { errorResponse, weakEtag } from "../http.mjs";
+import { errorResponse, ifNoneMatchSatisfied, weakEtag } from "../http.mjs";
 import { readArtifact, readHealthKv } from "../storage.mjs";
 import { contractVersion, publishedAt } from "../responses.mjs";
 import { KV_HEALTH_CURRENT } from "../../src/health-prober.mjs";
@@ -90,7 +90,7 @@ export async function handleBadgeSvgRequest(request, env, url) {
     `public, max-age=${maxAge}, stale-while-revalidate=300`,
   );
   headers.set("etag", await weakEtag(svg));
-  if (request.headers.get("if-none-match") === headers.get("etag")) {
+  if (ifNoneMatchSatisfied(request, headers.get("etag"))) {
     return new Response(null, { status: 304, headers });
   }
   return new Response(request.method === "HEAD" ? null : svg, {
@@ -298,7 +298,7 @@ export async function mcpServerCardResponse(request, env) {
   const body = `${JSON.stringify(card, null, 2)}\n`;
   const headers = discoveryHeaders("application/json");
   headers.set("etag", await weakEtag(body));
-  if (request.headers.get("if-none-match") === headers.get("etag")) {
+  if (ifNoneMatchSatisfied(request, headers.get("etag"))) {
     return new Response(null, { status: 304, headers });
   }
   return new Response(request.method === "HEAD" ? null : body, {
@@ -325,7 +325,7 @@ export async function agentToolsResponse(request, env, kind) {
   const body = `${JSON.stringify(data, null, 2)}\n`;
   const headers = discoveryHeaders("application/json");
   headers.set("etag", await weakEtag(body));
-  if (request.headers.get("if-none-match") === headers.get("etag")) {
+  if (ifNoneMatchSatisfied(request, headers.get("etag"))) {
     return new Response(null, { status: 304, headers });
   }
   return new Response(request.method === "HEAD" ? null : body, {


### PR DESCRIPTION
## Summary

Fixes #1411.

Three discovery handlers — `handleBadgeSvgRequest`, `mcpServerCardResponse`, `agentToolsResponse` — decided `304 Not Modified` with a strict `request.headers.get("if-none-match") === headers.get("etag")` comparison. `weakEtag` emits a weak validator `W/"…"`, but `If-None-Match` uses the weak comparison (RFC 7232 §3.2): the strong form `"…"`, a comma-separated tag list, and `*` are all valid matches that the strict check rejected — returning a full `200` + body instead of `304`.

## What Changed

- `workers/request-handlers/discovery.mjs` — use the existing `ifNoneMatchSatisfied` helper (already exported from `workers/http.mjs` and used by `envelopeResponse` / the artifact + overlay cache paths) at all three 304 sites.
- `tests/api-coverage.test.mjs` — regression test: a badge request whose `If-None-Match` carries the strong (`W/`-less) form of the etag now returns `304`.

No schema, OpenAPI, or generated-artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `npx vitest run tests/api-coverage.test.mjs -t "if-none-match"` — badge 304 + new strong-form test pass. (Two unrelated raw-artifact/api-envelope 304 tests fail locally on a clean checkout — they need built `public/metagraph/` artifacts — and pass in CI.)
- [x] `npx prettier --check` + `npx eslint` on changed files — clean
- [x] `git diff --check`

## Template Used

- Backend/code change
