### PR TITLE
fix(health): use REAL division for the weighted latency mean

### DIFF
--- a/src/health-sql.mjs
+++ b/src/health-sql.mjs
@@ -64,11 +64,14 @@ export function latencyStatColumns({
 // healthy-reading count and the latency mean weighted by it. Legacy rows predate
 // the latency_samples column, so weighting falls back to total samples.
 // `roundedAvg` casts to INTEGER for stored/long-term views; the bulk matrix keeps
-// the raw quotient and rounds in the formatter.
+// the raw quotient and rounds in the formatter. The weighted-sum numerator is
+// cast to REAL so the division is floating-point — both `avg_latency_ms` and the
+// sample counts are INTEGER columns, so a plain `SUM(int)/SUM(int)` would be
+// SQLite integer division and truncate the mean before it is rounded.
 export function dailyLatencyColumns({ roundedAvg = false } = {}) {
   const weight = `CASE WHEN avg_latency_ms IS NOT NULL THEN COALESCE(latency_samples, samples) ELSE 0 END`;
   const denom = `SUM(${weight})`;
-  const mean = `SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN avg_latency_ms * COALESCE(latency_samples, samples) ELSE 0 END) / ${denom}`;
+  const mean = `CAST(SUM(CASE WHEN avg_latency_ms IS NOT NULL THEN avg_latency_ms * COALESCE(latency_samples, samples) ELSE 0 END) AS REAL) / ${denom}`;
   return `${denom} AS latency_samples,
             CASE WHEN ${denom} > 0
               THEN ${roundedAvg ? `CAST(ROUND(${mean}) AS INTEGER)` : mean}

--- a/tests/health-sql.test.mjs
+++ b/tests/health-sql.test.mjs
@@ -55,5 +55,9 @@ describe("health-sql latency builders", () => {
     assert.ok(
       dailyLatencyColumns({ roundedAvg: true }).includes("CAST(ROUND("),
     );
+    // The weighted mean must use REAL division — avg_latency_ms and the sample
+    // counts are INTEGER columns, so a plain SUM(int)/SUM(int) would truncate.
+    assert.ok(cols.includes("CAST(SUM("));
+    assert.ok(cols.includes("AS REAL) /"));
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1413.

`dailyLatencyColumns` computed the sample-weighted latency mean as `SUM(avg_latency_ms * count) / SUM(count)`. `avg_latency_ms` and the sample counts (`latency_samples`, `samples`) are all **INTEGER** columns, so SQLite did **integer division** and truncated the mean toward zero — contradicting the comment ("keeps the raw quotient and rounds in the formatter"). The bias is small (≤1 ms) but systematic and always downward.

Affected consumers: the bulk health-trends latency series (`/metagraph/health/trends.json`, raw quotient) and, via `roundedAvg: true`, the reliability badge and `/uptime` means (`CAST(ROUND(int/int))` truncates before it rounds).

## What Changed

- `src/health-sql.mjs` — cast the weighted-sum numerator to `REAL` so the division is floating-point. The `roundedAvg: true` branch then rounds the true quotient; the raw branch returns the real mean for the formatter to round.
- `tests/health-sql.test.mjs` — assert the generated SQL uses REAL division (`CAST(SUM(... ) AS REAL) /`).

No schema, OpenAPI, or generated-artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `npx vitest run tests/health-sql.test.mjs tests/health-serving.test.mjs` — 124 passed
- [x] `npx prettier --check` + `npx eslint` on changed files — clean
- [x] `git diff --check`

## Template Used

- Backend/code change
