### PR TITLE
perf(api): memoize economics:current KV reads in-isolate with 60 s TTL

### DIFF
--- a/tests/economics-current-kv-cache.test.mjs
+++ b/tests/economics-current-kv-cache.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  ECONOMICS_CURRENT_KV_TTL_MS,
+  readEconomicsCurrentKv,
+} from "../workers/api.mjs";
+import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.mjs";
+
+// readEconomicsCurrentKv wraps readHealthKv(env, KV_ECONOMICS_CURRENT) with a
+// 60-second in-isolate memo — same pattern as readHealthMetaKv (#1375),
+// readRpcPoolArtifact (#1309), and latestPointer (#367). resolveLiveEconomics
+// reads this large blob on every /api/v1/economics request AND every
+// /api/v1/subnets/{netuid} request (the per-subnet overlay, #1308); neither is
+// edge-cached for the live overlay, so the memo collapses warm-isolate reads.
+
+function mkKvEnv(
+  blob = { captured_at: "2026-06-22T00:00:00.000Z", subnets: [] },
+) {
+  let gets = 0;
+  let lastKey = null;
+  return {
+    get gets() {
+      return gets;
+    },
+    get lastKey() {
+      return lastKey;
+    },
+    METAGRAPH_CONTROL: {
+      async get(key) {
+        gets += 1;
+        lastKey = key;
+        return blob;
+      },
+    },
+  };
+}
+
+test("readEconomicsCurrentKv reads the economics:current KV key", async () => {
+  const env = mkKvEnv();
+  await readEconomicsCurrentKv(env, 10_000);
+  assert.equal(env.lastKey, KV_ECONOMICS_CURRENT);
+});
+
+test("readEconomicsCurrentKv memoizes within the TTL — one KV read for repeated calls", async () => {
+  const env = mkKvEnv();
+  const t0 = 1_000_000;
+  const a = await readEconomicsCurrentKv(env, t0);
+  const b = await readEconomicsCurrentKv(env, t0 + 1000);
+  assert.equal(a.captured_at, "2026-06-22T00:00:00.000Z");
+  assert.deepEqual(a, b);
+  assert.equal(
+    env.gets,
+    1,
+    "the second call within the TTL must be served from the in-isolate memo",
+  );
+
+  // Past the TTL it re-reads.
+  await readEconomicsCurrentKv(env, t0 + ECONOMICS_CURRENT_KV_TTL_MS + 1);
+  assert.equal(env.gets, 2, "an expired memo triggers a fresh KV read");
+});
+
+test("readEconomicsCurrentKv never cross-reads a different env (isolation safety)", async () => {
+  const envA = mkKvEnv({ captured_at: "a", subnets: [] });
+  const envB = mkKvEnv({ captured_at: "b", subnets: [] });
+  const t0 = 2_000_000;
+  const a = await readEconomicsCurrentKv(envA, t0);
+  const b = await readEconomicsCurrentKv(envB, t0);
+  assert.equal(a.captured_at, "a");
+  assert.equal(b.captured_at, "b", "a different env object must miss the memo");
+  assert.equal(envA.gets, 1);
+  assert.equal(envB.gets, 1);
+});
+
+test("readEconomicsCurrentKv returns null when KV binding is absent", async () => {
+  const result = await readEconomicsCurrentKv({}, 3_000_000);
+  assert.equal(result, null);
+});
+
+test("readEconomicsCurrentKv does not cache a null result (no sticky cold miss)", async () => {
+  let gets = 0;
+  const env = {
+    METAGRAPH_CONTROL: {
+      async get() {
+        gets += 1;
+        return null;
+      },
+    },
+  };
+  const t0 = 4_000_000;
+  await readEconomicsCurrentKv(env, t0);
+  await readEconomicsCurrentKv(env, t0 + 1000);
+  assert.equal(gets, 2, "a null result must not be memoized");
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -57,6 +57,7 @@ import {
   workerWebSocketConnector,
   writeSubnetSnapshot,
 } from "../src/health-prober.mjs";
+import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.mjs";
 import {
   dailyLatencyColumns,
   latencyStatColumns,
@@ -1381,6 +1382,37 @@ export async function readHealthMetaKv(env, now = Date.now()) {
   return value;
 }
 
+// economics:current is a large blob (one row per subnet) that resolveLiveEconomics
+// reads on every /api/v1/economics request AND every /api/v1/subnets/{netuid}
+// request (the per-subnet economics overlay, #1308). Neither route is edge-cached
+// for the live overlay, so a warm isolate re-fetches + re-parses the same blob per
+// request. Memoize the read in-isolate — same pattern as readHealthMetaKv (#1375),
+// readRpcPoolArtifact (#1309), latestPointer (#367). Safe: resolveLiveEconomics
+// re-validates the blob's captured_at freshness against the live clock on every
+// call, so the 60 s memo (≪ the 8 h freshness window) never extends how long a
+// stale blob can serve. Null results are not cached so a transient cold KV does
+// not stay sticky; keyed on env so tests / multi-binding callers never cross-read.
+export const ECONOMICS_CURRENT_KV_TTL_MS = 60_000;
+let economicsCurrentKvMemo = { env: null, value: null, expiresAt: 0 };
+
+export async function readEconomicsCurrentKv(env, now = Date.now()) {
+  if (
+    economicsCurrentKvMemo.env === env &&
+    now < economicsCurrentKvMemo.expiresAt
+  ) {
+    return economicsCurrentKvMemo.value;
+  }
+  const value = await readHealthKv(env, KV_ECONOMICS_CURRENT);
+  if (value !== null) {
+    economicsCurrentKvMemo = {
+      env,
+      value,
+      expiresAt: now + ECONOMICS_CURRENT_KV_TTL_MS,
+    };
+  }
+  return value;
+}
+
 async function resolveSubnetSlugRoute(
   env,
   url,
@@ -1596,7 +1628,7 @@ async function handleApiRequest(
     // fallback, so it can never 404.
     artifact = await readArtifact(env, artifactPath);
     live = await resolveLiveEconomics({
-      readHealthKv,
+      readHealthKv: (e) => readEconomicsCurrentKv(e),
       env,
       contractVersion: contractVersion(env),
     });
@@ -1627,7 +1659,7 @@ async function handleApiRequest(
     typeof baseData === "object"
   ) {
     const liveEconomics = await resolveLiveEconomics({
-      readHealthKv,
+      readHealthKv: (e) => readEconomicsCurrentKv(e),
       env,
       contractVersion: contractVersion(env),
     });


### PR DESCRIPTION
## Problem

`resolveLiveEconomics` reads the `economics:current` KV blob — one row per subnet (~129 rows carrying stake / alpha price / emission share / validator+miner counts) — on:

- **every** `GET /api/v1/economics` request, and
- **every** `GET /api/v1/subnets/{netuid}` request (the per-subnet economics overlay, #1308).

Both are live-overlay routes excluded from the static edge cache, and neither is in `CACHEABLE_OVERLAY_ROUTE_IDS` (only the large `endpoints` index is). So on a warm isolate every such request re-issues the KV GET and re-parses the full blob. It is the **last hot KV key without an in-isolate memo** — `KV_HEALTH_META` (#1375), the RPC-pool R2 artifact (#1309), and `latestPointer` (#367) are all already memoized.

## Fix

Add `readEconomicsCurrentKv(env, now)` following the exact pattern of `readHealthMetaKv`: an `env`-keyed 60 s memo that collapses the repeated KV GET + JSON parse on warm isolates. The two `resolveLiveEconomics` call sites pass it through the **existing `readHealthKv` injection seam**:

```js
live = await resolveLiveEconomics({
  readHealthKv: (e) => readEconomicsCurrentKv(e),
  env,
  contractVersion: contractVersion(env),
});
```

so `src/health-serving.mjs` and its unit tests are untouched (they still inject their own unmemoized reader, exercising the validation logic directly).

## Why it is safe (no added staleness)

- `resolveLiveEconomics` re-validates the blob's `captured_at` against the live clock on **every call** (`currentMs - capturedMs > ECONOMICS_FRESHNESS_MAX_AGE_MS`, 8 h). The memo caches only the *read*, not the validated result — so the 60 s TTL (≪ the 8 h freshness window) can never extend how long a stale blob serves. A blob that ages out mid-window is still rejected by the per-call freshness check and falls back to the R2 artifact.
- Null reads are **not** cached, so a transient cold KV never sticks.
- The memo is keyed on the `env` object, so tests / multi-binding callers never cross-read (same isolation guarantee as `readHealthMetaKv`).
- The blob is never mutated by readers (`resolveLiveEconomics` only sums; `overlaySubnetEconomics` spreads into a new object), so sharing the memoized reference is safe.

## Tests

New `tests/economics-current-kv-cache.test.mjs` (5 tests, mirroring `health-meta-kv-cache.test.mjs`):

- reads the `economics:current` key
- memoizes within the TTL (one KV read for repeated calls) and re-reads past it
- never cross-reads a different `env` (isolation)
- returns null when the KV binding is absent
- does not cache a null result (no sticky cold miss)

Existing `economics-live.test.mjs` (asserts `source: "live-kv"`) and `subnet-economics-overlay.test.mjs` continue to pass, giving end-to-end coverage of the memoized path. Full suite: **1508 passing**; `lint`, `prettier --check`, and `validate:types` all clean.