### PR TITLE
fix(graphql): memoize fragment validation limits

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -86,26 +86,35 @@ function buildFragmentMap(documentNode) {
 // complexity 1 and fully bypassing both limits. `visited` guards against
 // fragment cycles: validate() reports those, but our rules run in the same pass
 // and would otherwise recurse forever.
-function selectionDepth(selectionSet, fragments, visited, depth = 0) {
-  let max = depth;
+function selectionDepth(selectionSet, fragments, visited, memo, max) {
+  let deepest = 0;
   for (const sel of selectionSet.selections) {
+    let depth = 0;
     if (sel.kind === "FragmentSpread") {
-      const frag = fragments.get(sel.name.value);
-      if (frag && !visited.has(sel.name.value)) {
-        const d = selectionDepth(
-          frag.selectionSet,
-          fragments,
-          new Set(visited).add(sel.name.value),
-          depth,
-        );
-        if (d > max) max = d;
+      const fragName = sel.name.value;
+      const frag = fragments.get(fragName);
+      if (frag && !visited.has(fragName)) {
+        if (memo.has(fragName)) {
+          depth = memo.get(fragName);
+        } else {
+          depth = selectionDepth(
+            frag.selectionSet,
+            fragments,
+            new Set(visited).add(fragName),
+            memo,
+            max,
+          );
+          memo.set(fragName, depth);
+        }
       }
     } else if (sel.selectionSet) {
-      const d = selectionDepth(sel.selectionSet, fragments, visited, depth + 1);
-      if (d > max) max = d;
+      depth =
+        1 + selectionDepth(sel.selectionSet, fragments, visited, memo, max);
     }
+    if (depth > deepest) deepest = depth;
+    if (deepest > max) return max + 1;
   }
-  return max;
+  return deepest;
 }
 
 export function maxDepthRule(max) {
@@ -119,6 +128,8 @@ export function maxDepthRule(max) {
               def.selectionSet,
               fragments,
               new Set(),
+              new Map(),
+              max,
             );
             if (depth > max) {
               context.reportError(
@@ -135,24 +146,40 @@ export function maxDepthRule(max) {
   });
 }
 
-function selectionComplexity(selectionSet, fragments, visited) {
+function selectionComplexity(selectionSet, fragments, visited, memo, max) {
   let count = 0;
   for (const sel of selectionSet.selections) {
     if (sel.kind === "FragmentSpread") {
-      const frag = fragments.get(sel.name.value);
-      if (frag && !visited.has(sel.name.value)) {
+      const fragName = sel.name.value;
+      const frag = fragments.get(fragName);
+      if (frag && !visited.has(fragName)) {
+        if (memo.has(fragName)) {
+          count += memo.get(fragName);
+        } else {
+          const fragCount = selectionComplexity(
+            frag.selectionSet,
+            fragments,
+            new Set(visited).add(fragName),
+            memo,
+            max,
+          );
+          memo.set(fragName, fragCount);
+          count += fragCount;
+        }
+      }
+    } else {
+      count += 1;
+      if (sel.selectionSet) {
         count += selectionComplexity(
-          frag.selectionSet,
+          sel.selectionSet,
           fragments,
-          new Set(visited).add(sel.name.value),
+          visited,
+          memo,
+          max,
         );
       }
-      continue;
     }
-    count += 1;
-    if (sel.selectionSet) {
-      count += selectionComplexity(sel.selectionSet, fragments, visited);
-    }
+    if (count > max) return max + 1;
   }
   return count;
 }
@@ -168,6 +195,8 @@ export function maxComplexityRule(max) {
               def.selectionSet,
               fragments,
               new Set(),
+              new Map(),
+              max,
             );
             if (complexity > max) {
               context.reportError(

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -207,6 +207,23 @@ describe("handleGraphQLRequest — validation rules", () => {
     );
   });
 
+  test("validation memoizes repeated named fragment spreads", async () => {
+    const fragments = ["fragment F0 on Query { __typename }"];
+    for (let i = 1; i <= 20; i += 1) {
+      fragments.push(`fragment F${i} on Query { ...F${i - 1} ...F${i - 1} }`);
+    }
+    const q = `query { ...F20 } ${fragments.join(" ")}`;
+    const { status, body } = await gql(q);
+    assert.equal(status, 400);
+    const ext = body.errors.find(
+      (e) => e.extensions?.code === "COMPLEXITY_LIMIT_EXCEEDED",
+    );
+    assert.ok(
+      ext,
+      `expected COMPLEXITY_LIMIT_EXCEEDED, got: ${JSON.stringify(body.errors)}`,
+    );
+  });
+
   test("complexity exceeded returns COMPLEXITY_LIMIT_EXCEEDED extension", async () => {
     // GRAPHQL_MAX_COMPLEXITY is 50. Build a query with many fields by using
     // inline fragments or repeating aliases to exceed the limit.


### PR DESCRIPTION
### Motivation
- The custom GraphQL depth and complexity validators were recursively expanding named `FragmentSpread`s without memoization or early cutoff, enabling small acyclic fragment DAGs to cause exponential CPU work during validation on the public `/api/v1/graphql` endpoint.

### Description
- Add a per-operation `memo` map to `selectionDepth` to cache computed fragment depths and avoid re-expanding the same fragment across different paths.
- Add a per-operation `memo` map to `selectionComplexity` to cache computed fragment complexities and avoid repeated recomputation of shared fragments.
- Short-circuit traversal once the configured `max` limit is exceeded by returning a value > `max` to stop further recursion early.
- Propagate the new `memo` and `max` parameters through recursive calls and update the `maxDepthRule` and `maxComplexityRule` invocations accordingly.
- Add a regression test (`validation memoizes repeated named fragment spreads`) that constructs a repeated-fragment DAG and asserts the validator returns `COMPLEXITY_LIMIT_EXCEEDED` rather than incurring exponential work.

### Testing
- Ran the targeted GraphQL tests with `npm test -- --run tests/graphql.test.mjs` and they all passed. 
- Ran the linter with `npm run lint` and it succeeded. 
- Ran the full test suite with `npm test`; GraphQL-related tests passed, but the full suite reported unrelated failures (missing generated `public/metagraph` artifacts, an R2 upload timeout, and a DNS/environment-dependent public-safety test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39062308cc832cb45df6bf201fdb80)