### PR TITLE
fix(api): honor If-None-Match lists and * on discovery endpoints

### DIFF
--- a/tests/discovery-conditional.test.mjs
+++ b/tests/discovery-conditional.test.mjs
@@ -1,0 +1,80 @@
+// Discovery endpoints must answer conditional GETs with the shared
+// ifNoneMatchSatisfied() semantics (RFC 9110 §13.1.2): an If-None-Match list
+// or the `*` wildcard yields 304, not a fresh 200 body. Regression for the
+// strict `===` comparison these handlers used previously.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  agentToolsResponse,
+  handleBadgeSvgRequest,
+  mcpServerCardResponse,
+} from "../workers/request-handlers/discovery.mjs";
+
+// Re-run a handler with each conditional variant and assert the 304/200 outcome.
+// `call(headers)` returns the handler's Response for the given request headers.
+async function assertConditional(call) {
+  const full = await call({});
+  assert.equal(full.status, 200);
+  const etag = full.headers.get("etag");
+  assert.ok(etag, "response advertises an etag");
+
+  // Exact echo -> 304 (unchanged behavior).
+  assert.equal((await call({ "if-none-match": etag })).status, 304);
+  // ETag list that includes the current tag -> 304 (was 200 before the fix).
+  assert.equal(
+    (await call({ "if-none-match": `"stale", ${etag}` })).status,
+    304,
+  );
+  // Wildcard -> 304 (was 200 before the fix).
+  assert.equal((await call({ "if-none-match": "*" })).status, 304);
+  // A non-matching validator still gets the full 200 body.
+  assert.equal((await call({ "if-none-match": `"nope"` })).status, 200);
+}
+
+describe("discovery conditional requests", () => {
+  test("agent tool specs honor If-None-Match lists and the * wildcard", async () => {
+    await assertConditional((headers) =>
+      agentToolsResponse(
+        new Request("https://api.metagraph.sh/agent-tools/openai.json", {
+          headers,
+        }),
+        {},
+        "openai",
+      ),
+    );
+  });
+
+  test("badge SVG honors If-None-Match lists and the * wildcard", async () => {
+    // An empty env makes readArtifact/readHealthKv miss, so the handler renders
+    // the graceful fallback badge — which still sets an etag + conditional path.
+    const url = "https://api.metagraph.sh/metagraph/health/badges/7.svg";
+    await assertConditional((headers) =>
+      handleBadgeSvgRequest(new Request(url, { headers }), {}, new URL(url)),
+    );
+  });
+
+  test("MCP server card honors If-None-Match lists and the * wildcard", async () => {
+    const card = {
+      serverInfo: { name: "metagraphed", version: "1" },
+      endpoint: "https://api.metagraph.sh/mcp",
+    };
+    const env = {
+      ASSETS: {
+        fetch: async () =>
+          new Response(JSON.stringify(card), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      },
+    };
+    await assertConditional((headers) =>
+      mcpServerCardResponse(
+        new Request(
+          "https://api.metagraph.sh/.well-known/mcp/server-card.json",
+          { headers },
+        ),
+        env,
+      ),
+    );
+  });
+});

--- a/workers/request-handlers/discovery.mjs
+++ b/workers/request-handlers/discovery.mjs
@@ -1,5 +1,5 @@
 import { CACHE_SECONDS, PRIMARY_DOMAIN } from "../../src/contracts.mjs";
-import { errorResponse, weakEtag } from "../http.mjs";
+import { errorResponse, ifNoneMatchSatisfied, weakEtag } from "../http.mjs";
 import { readArtifact, readHealthKv } from "../storage.mjs";
 import { contractVersion, publishedAt } from "../responses.mjs";
 import { KV_HEALTH_CURRENT } from "../../src/health-prober.mjs";
@@ -90,7 +90,7 @@ export async function handleBadgeSvgRequest(request, env, url) {
     `public, max-age=${maxAge}, stale-while-revalidate=300`,
   );
   headers.set("etag", await weakEtag(svg));
-  if (request.headers.get("if-none-match") === headers.get("etag")) {
+  if (ifNoneMatchSatisfied(request, headers.get("etag"))) {
     return new Response(null, { status: 304, headers });
   }
   return new Response(request.method === "HEAD" ? null : svg, {
@@ -298,7 +298,7 @@ export async function mcpServerCardResponse(request, env) {
   const body = `${JSON.stringify(card, null, 2)}\n`;
   const headers = discoveryHeaders("application/json");
   headers.set("etag", await weakEtag(body));
-  if (request.headers.get("if-none-match") === headers.get("etag")) {
+  if (ifNoneMatchSatisfied(request, headers.get("etag"))) {
     return new Response(null, { status: 304, headers });
   }
   return new Response(request.method === "HEAD" ? null : body, {
@@ -325,7 +325,7 @@ export async function agentToolsResponse(request, env, kind) {
   const body = `${JSON.stringify(data, null, 2)}\n`;
   const headers = discoveryHeaders("application/json");
   headers.set("etag", await weakEtag(body));
-  if (request.headers.get("if-none-match") === headers.get("etag")) {
+  if (ifNoneMatchSatisfied(request, headers.get("etag"))) {
     return new Response(null, { status: 304, headers });
   }
   return new Response(request.method === "HEAD" ? null : body, {


### PR DESCRIPTION
## Summary

- Three discovery endpoints compared `If-None-Match` to the response ETag with strict `===`, so they only emitted `304 Not Modified` when the client echoed the tag **verbatim**. An ETag **list** or the `*` wildcard fell through to a full `200` body, defeating conditional caching (RFC 9110 §13.1.2).
- The repo already has the correct primitive — `ifNoneMatchSatisfied()` in `workers/http.mjs` (handles `*`, comma-separated lists, and weak validators) — and every other conditional handler uses it (`workers/api.mjs:1175`, `:1534`, `:1549`). These three were the only ones doing strict `===`.

Fixes #1422

## What Changed

- `workers/request-handlers/discovery.mjs` — replace the strict `===` check with `ifNoneMatchSatisfied(request, headers.get("etag"))` at all three sites:
  - badge SVG (`/metagraph/health/badges/{n}.svg`)
  - MCP server card (`/.well-known/mcp/server-card.json`)
  - agent tool specs (OpenAI/Anthropic/index)
- `tests/discovery-conditional.test.mjs` — cover the conditional-GET path for **all three** handlers: an ETag list and `*` both yield `304`, an exact echo still yields `304`, and a non-matching validator still returns `200`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No OpenAPI/schema surface changes — aligns these endpoints with the rest of the API's conditional-request handling.

## Validation

- [x] `npx vitest run tests/discovery-conditional.test.mjs` — 3 passed (one per handler).
- [x] `npx prettier --check` + `npx eslint` on the changed files — clean.
- Patch coverage now exercises all three changed handlers (prior PR #1421 was closed for <80% patch coverage; this resubmits with the missing handler tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
