### PR TITLE
fix(webhooks): block the full fe00::/8 reserved IPv6 range in the SSRF guard

### DIFF
--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -65,7 +65,7 @@ export function isPublicWebhookAddress(value) {
     if (
       host === "::1" ||
       host === "::" ||
-      host.startsWith("fe80") || // link-local
+      host.startsWith("fe") || // fe00::/8 reserved: link-local fe80::/10 + deprecated site-local fec0::/10
       host.startsWith("fc") || // unique-local fc00::/7
       host.startsWith("fd") ||
       host.startsWith("::ffff:") // IPv4-mapped

--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -32,6 +32,16 @@ describe("isPublicWebhookAddress", () => {
     assert.equal(isPublicWebhookAddress("::ffff:10.0.0.1"), false);
   });
 
+  test("the rest of the fe00::/8 reserved range → false", () => {
+    // Only fe80 was blocked before; the rest of fe00::/8 (none of it is global
+    // unicast, which is 2000::/3) was wrongly classified as public. Notably
+    // fec0::/10 is deprecated site-local — a real internal range, and URL
+    // parsing does not compress it away (unlike loopback).
+    assert.equal(isPublicWebhookAddress("fec0::1"), false);
+    assert.equal(isPublicWebhookAddress("fe00::1"), false);
+    assert.equal(isPublicWebhookAddress("feff::1"), false);
+  });
+
   test("public IPv6 → true", () => {
     assert.equal(isPublicWebhookAddress("2606:4700:4700::1111"), true);
   });


### PR DESCRIPTION
## Summary

- `isPublicWebhookAddress` (the SSRF guard for webhook delivery targets) only blocked the link-local `fe80::/10` slice of the `fe00::/8` reserved IPv6 range. The rest of `fe00::/8` — including deprecated **site-local `fec0::/10`** (a real internal range) — was classified as a **public** target.
- Global-unicast IPv6 is `2000::/3`; nothing in `fe00::/8` is routable, so none of it should be treated as public.

Fixes #1442

## Why it's reachable

The WHATWG URL parser canonicalizes `[0:0:0:0:0:0:0:1]` → `::1` (so loopback is caught), but it does **not** rewrite `fec0::1`: `new URL("https://[fec0::1]/").hostname === "fec0::1"`. So a webhook subscription to `https://[fec0::1]/…` passes `isPublicWebhookUrl` → `isPublicWebhookAddress` → accepted as public.

```js
isPublicWebhookAddress("fec0::1"); // before: true  → after: false
isPublicWebhookAddress("fe00::1"); // before: true  → after: false
```

## What Changed

- `src/webhooks.mjs` — block the whole `fe00::/8` range (`host.startsWith("fe")`) instead of just `fe80`. No legitimate public address starts with `fe`, so nothing valid is over-blocked; `2606:4700:4700::1111` etc. stay public.
- `tests/webhooks-core.test.mjs` — add cases for `fec0::1`, `fe00::1`, `feff::1` → `false`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No OpenAPI/schema surface changes — tightens an SSRF address classifier only.

## Validation

- [x] `npx vitest run tests/webhooks-core.test.mjs` — 59 passed (new cases fail on the pre-fix `fe80`-only check).
- [x] `npx prettier --check` + `npx eslint` on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
