### PR TITLE
fix(feeds): clamp by code points so a feed string can't split a surrogate pair

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -50,7 +50,11 @@ function escapeXml(value) {
 
 function clamp(value, max = 500) {
   const s = stripControl(value).trim();
-  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+  if (s.length <= max) return s;
+  // Truncate by code points, not UTF-16 code units: a plain slice() can sever a
+  // non-BMP character (e.g. an emoji) straddling the boundary into a lone
+  // surrogate, which is invalid in XML and breaks the RSS/Atom feed.
+  return `${[...s].slice(0, max - 1).join("")}…`;
 }
 
 // Accept an ISO string or epoch-ms; return a normalized ISO string or null.

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -150,6 +150,20 @@ describe("feeds — item builders", () => {
     assert.deepEqual(registryItems({}), []);
   });
 
+  test("registryItems clamp does not split a surrogate pair in a title", () => {
+    // Emoji placed so its surrogate pair straddles the 80-char title clamp.
+    const path = "a".repeat(78) + "😀" + "z".repeat(20);
+    const items = registryItems({ artifacts: { modified: [{ path }] } });
+    assert.equal(items.length, 1);
+    const loneSurrogate =
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+    assert.ok(
+      !loneSurrogate.test(items[0].title),
+      "feed title must not contain a lone surrogate",
+    );
+    assert.ok(!loneSurrogate.test(items[0].summary));
+  });
+
   test("incidentItems marks ongoing vs resolved + filters by netuid", () => {
     const all = incidentItems(INCIDENTS);
     assert.equal(all.length, 2); // the no-incidents surface contributes none


### PR DESCRIPTION
## Summary

Fixes #1444.

`clamp` truncated feed text with `String.slice(0, max - 1)`, which counts **UTF-16 code units**. A non-BMP character (e.g. an emoji) straddling the boundary was severed into a **lone surrogate** — invalid in XML 1.0, so the serialized RSS/Atom feed is no longer well-formed (and on the UTF-8 wire the surrogate becomes `�`). `clamp` feeds both feed titles (max 80) and summaries (max 500). `stripControl` already iterates by code point; `clamp` then undid that with a code-unit slice.

## What Changed

- `src/feeds.mjs` — truncate by code points (`[...s].slice(0, max - 1).join("")`), consistent with `stripControl`.
- `tests/feeds.test.mjs` — regression test asserting a feed title whose emoji straddles the 80-char clamp contains no lone surrogate.

No schema, OpenAPI, or generated-artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `npx vitest run tests/feeds.test.mjs` — 21 passed (incl. the new regression test, which fails without the fix)
- [x] `npx prettier --check` + `npx eslint` on changed files — clean
- [x] `git diff --check`

## Template Used

- Backend/code change
