### PR TITLE
fix(api): reject unsupported query params on per-subnet /health/trends

### DIFF
--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -520,6 +520,7 @@ describe("analytics routes (cold local D1)", () => {
       ["/api/v1/subnets/7/health/incidents?window=7d&cacheBust=x", "cacheBust"],
       ["/api/v1/subnets/7/health/incidents?window=7d&window=7d", "window"],
       ["/api/v1/subnets/7/trajectory?x=random", "x"],
+      ["/api/v1/subnets/7/health/trends?bogus=x", "bogus"],
       ["/api/v1/registry/leaderboards?limit=10&x=random", "x"],
       ["/api/v1/registry/leaderboards?limit=10&limit=10", "limit"],
     ];

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -856,7 +856,12 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     }
     const trendsMatch = TRENDS_PATH_PATTERN.exec(resolved.url.pathname);
     if (trendsMatch) {
-      return handleHealthTrends(request, env, Number(trendsMatch[1]));
+      return handleHealthTrends(
+        request,
+        env,
+        Number(trendsMatch[1]),
+        resolved.url,
+      );
     }
     const percentilesMatch = PERCENTILES_PATH_PATTERN.exec(
       resolved.url.pathname,
@@ -1849,7 +1854,12 @@ async function handleBulkHealthTrends(
 // D1-backed 7d/30d uptime + latency trends for one subnet's operational
 // surfaces. Returns a schema-stable empty payload when D1 is unbound/cold so it
 // never errors (mirrors the live-overlay fall-back philosophy).
-async function handleHealthTrends(request, env, netuid) {
+async function handleHealthTrends(request, env, netuid, url) {
+  // Reject unsupported query params (400) like every sibling analytics route
+  // (percentiles/incidents/uptime/trajectory and the bulk trends route); this
+  // route takes no params and returns all configured windows.
+  const validationError = validateQueryParams(url, []);
+  if (validationError) return analyticsQueryError(validationError);
   const db = env.METAGRAPH_HEALTH_DB;
   const nowMs = Date.now();
   const windows = {};


### PR DESCRIPTION
## Summary

Fixes #1446.

The per-subnet `/api/v1/subnets/{netuid}/health/trends` route (`handleHealthTrends`) took no `url` and never called `validateQueryParams`, so it returned **200** for any unsupported query param — inconsistent with every sibling analytics route (`percentiles`/`incidents`/`uptime`/`trajectory` and the bulk `/health/trends` route all return **400 `invalid_query`**).

## What Changed

- `workers/api.mjs` — thread the resolved `url` into `handleHealthTrends` and validate against an empty allow-list (the route takes no params and always returns all configured windows), mirroring the bulk trends route.
- `tests/analytics.test.mjs` — add the route to the non-canonical-query rejection table (`?bogus=x` → 400 `invalid_query`).

No schema, OpenAPI, or generated-artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `npx vitest run tests/analytics.test.mjs` — 38 passed (the new `?bogus=x`→400 case fails without the fix)
- [x] `npx prettier --check` + `npx eslint` on changed files — clean
- [x] `git diff --check`

## Template Used

- Backend/code change
