### PR TITLE
fix(health): only count consecutive FAILED probes toward pool eviction

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -419,7 +419,14 @@ export async function runHealthProber(env, ctx, overrides = {}) {
     const stableLookupKey = surface.surface_key || surface.surface_id;
     const prior = priorStatus.get(stableLookupKey);
     const lastOkMs = ok ? runAt : (prior?.last_ok ?? null);
-    const consecutiveFailures = ok ? 0 : (prior?.consecutive_failures ?? 0) + 1;
+    // Only a hard `failed` run feeds the sustained-down breaker. The counter is
+    // "consecutive FAILED prober runs" (see overlayRpcPoolEligibility), so a
+    // `degraded` run (rate-limited / auth-required / transient / timeout) is a
+    // soft signal — not an outage — and must reset the streak like `ok` rather
+    // than accrue toward pool eviction. Hard outages still hit the threshold,
+    // and the per-request circuit breaker + wrong-chain hard-fail cover the rest.
+    const consecutiveFailures =
+      base.status === "failed" ? (prior?.consecutive_failures ?? 0) + 1 : 0;
     return {
       surface_id: surface.surface_id,
       // #1005: stable key re-keyed onto D1 history; null for pre-#1005 artifacts.

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -444,6 +444,53 @@ describe("runHealthProber", () => {
     assert.equal(apiUpsert.binds[12], 3);
   });
 
+  test("a degraded run resets the breaker (only FAILED runs accrue)", async () => {
+    const db = makeDb({
+      priorStatus: [
+        {
+          surface_id: "sn7-api",
+          surface_key: "srf-sn7apikey000000",
+          last_ok: 1000,
+          consecutive_failures: 2,
+        },
+      ],
+    });
+    // The subnet-api surface probes `degraded` (e.g. rate-limited), not failed.
+    const degradedProbe = async (input) =>
+      input.kind === "subtensor-rpc"
+        ? {
+            status: "ok",
+            classification: "live",
+            latency_ms: 42,
+            status_code: 200,
+          }
+        : {
+            status: "degraded",
+            classification: "rate-limited",
+            latency_ms: null,
+            status_code: 429,
+          };
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 50000,
+        db,
+        kv: makeKv(),
+        loadSurfaces: async () => SURFACES,
+        probeSurface: degradedProbe,
+        probeOptions: {},
+      },
+    );
+    const apiUpsert = db.calls.batches[0]
+      .filter((s) => /INSERT INTO surface_status/.test(s.sql))
+      .find((s) => s.binds[0] === "sn7-api");
+    // binds[12] = consecutive_failures: a degraded run must NOT bump 2 -> 3; it
+    // resets to 0 so a persistently-degraded (still-usable) endpoint is not
+    // evicted from the RPC pool by the sustained-down breaker.
+    assert.equal(apiUpsert.binds[12], 0);
+  });
+
   test("no-ops cleanly when there are no operational surfaces", async () => {
     const result = await runHealthProber(
       {},


### PR DESCRIPTION
## Summary

- The live health prober's `consecutive_failures` counter incremented on **any** non-`ok` probe, including **`degraded`** (rate-limited / auth-required / transient / timeout).
- That counter is documented and consumed as *"consecutive **failed** prober runs"* and drives RPC-pool eviction (`overlayRpcPoolEligibility`), so two consecutive **degraded** probes (~30 min) wrongly evicted a still-usable endpoint from the proxy pool.

Fixes #1449

## Detail

`src/health-prober.mjs` set `consecutiveFailures = ok ? 0 : prior + 1`, where `ok = base.status === "ok"`. A `degraded` status is `!== "ok"`, so it accrued like a hard failure. The consumer then evicts:

```js
// "an endpoint is dropped only after 2+ consecutive failed prober runs"
const sustainedDown =
  live.status !== "ok" && (live.consecutive_failures || 0) >= POOL_SUSTAINED_DOWN_FAILURES;
```

A 429 → `degraded` endpoint hits `consecutive_failures = 2` after two runs and is dropped — even though it never *failed* (the per-request in-isolate circuit breaker already handles rate-limit/transient blips).

## What Changed

- `src/health-prober.mjs` — count only hard `failed` runs; a `degraded` run resets the streak like `ok`:
  ```js
  const consecutiveFailures =
    base.status === "failed" ? (prior?.consecutive_failures ?? 0) + 1 : 0;
  ```
  Hard outages still reach the threshold; `wrong-chain` remains a separate hard-fail.
- `tests/health-prober.test.mjs` — add a case asserting a `degraded` run resets `consecutive_failures` (`2 → 0`, not `→ 3`).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No OpenAPI/schema surface changes — internal breaker semantics only.

## Validation

- [x] `npx vitest run tests/health-prober.test.mjs` — 66 passed (new case fails on the pre-fix any-non-ok counter).
- [x] `npx prettier --check` + `npx eslint` on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
