### PR TITLE
fix: chunk D1 health writes and surface persist failures

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -38,6 +38,21 @@ const PROBE_CONCURRENCY = 8;
 // headroom). Early signal to raise concurrency or shard before runs overlap.
 const PROBE_WALLTIME_WARN_MS = 8 * 60 * 1000;
 const HISTORY_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+// Cloudflare D1 batch() calls are capped (~100 statements per batch). Chunk large
+// probe/snapshot writes so a growing surface/subnet catalog cannot fail silently.
+export const D1_STATEMENTS_PER_BATCH = 50;
+
+export async function runD1StatementBatches(
+  db,
+  statements,
+  batchSize = D1_STATEMENTS_PER_BATCH,
+) {
+  if (!statements.length) return { ok: true, batches: 0 };
+  for (let i = 0; i < statements.length; i += batchSize) {
+    await db.batch(statements.slice(i, i + batchSize));
+  }
+  return { ok: true, batches: Math.ceil(statements.length / batchSize) };
+}
 const RPC_KINDS = new Set(["subtensor-rpc", "subtensor-wss", "archive"]);
 const DNS_JSON_ENDPOINT = "https://cloudflare-dns.com/dns-query";
 const DNS_RECORD_TYPES = ["A", "AAAA"];
@@ -443,7 +458,7 @@ export async function runHealthProber(env, ctx, overrides = {}) {
 
   sanitizeRpcLatestBlocks(probed);
 
-  await persistToD1(db, probed, runAt);
+  const d1Persist = await persistToD1(db, probed, runAt);
   await persistToKv(kv, probed, runAt);
 
   const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
@@ -464,11 +479,12 @@ export async function runHealthProber(env, ctx, overrides = {}) {
     counts,
     run_at: iso(runAt),
     duration_ms: durationMs,
+    d1_persisted: d1Persist.ok === true,
   };
 }
 
 async function persistToD1(db, probed, runAt) {
-  if (!db?.prepare) return;
+  if (!db?.prepare) return { ok: false, reason: "unavailable" };
   try {
     const checkStmt = db.prepare(
       `INSERT INTO surface_checks
@@ -532,9 +548,12 @@ async function persistToD1(db, probed, runAt) {
         ),
       );
     }
-    await db.batch(statements);
+    return await runD1StatementBatches(db, statements);
   } catch {
-    // D1 unavailable / schema cold: KV still gets written so serving stays live.
+    // D1 unavailable / schema cold: KV still gets written so serving stays live,
+    // but surface the split so operators can spot analytics drift.
+    console.warn("health prober: D1 persist failed; KV snapshot still updated");
+    return { ok: false, reason: "batch_failed" };
   }
 }
 
@@ -806,7 +825,7 @@ export async function writeSubnetSnapshot(env, overrides = {}) {
     });
   if (!statements.length) return { ok: false, reason: "no_rows" };
   try {
-    await db.batch(statements);
+    await runD1StatementBatches(db, statements);
     return { ok: true, date, rows: statements.length };
   } catch {
     return { ok: false, reason: "write_failed" };

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -318,6 +318,35 @@ describe("writeSubnetSnapshot", () => {
     assert.equal(r.date, "2026-06-10");
     assert.equal(db.calls.batched[0].length, 2);
   });
+  test("chunks large subnet snapshot writes into bounded D1 batches", async () => {
+    const db = fakeBatchDb();
+    const manyProfiles = {
+      ok: true,
+      data: {
+        profiles: Array.from({ length: 55 }, (_, netuid) => ({
+          netuid,
+          completeness_score: 90,
+          surface_count: 1,
+          endpoint_count: 1,
+          monitored_endpoint_count: 1,
+          candidate_count: 0,
+        })),
+      },
+    };
+    const r = await writeSubnetSnapshot(
+      {},
+      {
+        db,
+        readArtifact: reader(manyProfiles),
+        now: () => Date.UTC(2026, 5, 10),
+      },
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.rows, 55);
+    assert.equal(db.calls.batched.length, 2);
+    assert.equal(db.calls.batched[0].length, 50);
+    assert.equal(db.calls.batched[1].length, 5);
+  });
   test("still writes structural rows when optional economics read throws", async () => {
     const db = fakeBatchDb();
     const r = await writeSubnetSnapshot(

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -8,6 +8,8 @@ import {
   OPERATIONAL_SURFACES_PATH,
   pruneHealthHistory,
   rollupDailyUptime,
+  runD1StatementBatches,
+  D1_STATEMENTS_PER_BATCH,
   runHealthProber,
   workerResolvedUrlSafetyGuard,
   workerWebSocketConnector,
@@ -1048,9 +1050,50 @@ describe("persistToD1 via runHealthProber", () => {
       },
     );
     assert.equal(result.ok, true);
+    assert.equal(result.d1_persisted, false);
     // KV write happened despite the D1 batch throwing.
     assert.ok(kv.json(KV_HEALTH_CURRENT));
   });
+
+  test("chunks large D1 persists into bounded batches", async () => {
+    const db = makeDb();
+    const surfaces = Array.from({ length: 30 }, (_, i) => ({
+      ...SURFACES[0],
+      surface_id: `sn-api-${i}`,
+      surface_key: `srf-key-${String(i).padStart(14, "0")}`,
+    }));
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 1,
+        db,
+        kv: makeKv(),
+        loadSurfaces: async () => surfaces,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.d1_persisted, true);
+    assert.equal(db.calls.batches.length, 2);
+    assert.equal(db.calls.batches[0].length, D1_STATEMENTS_PER_BATCH);
+    assert.equal(db.calls.batches[1].length, 10);
+  });
+});
+
+test("runD1StatementBatches splits statements at the D1 cap", async () => {
+  const batches = [];
+  const db = {
+    batch: async (statements) => {
+      batches.push(statements.length);
+    },
+  };
+  const statements = Array.from({ length: 55 }, (_, i) => i);
+  const result = await runD1StatementBatches(db, statements);
+  assert.equal(result.ok, true);
+  assert.equal(result.batches, 2);
+  assert.deepEqual(batches, [50, 5]);
 });
 
 describe("persistToKv via runHealthProber", () => {


### PR DESCRIPTION
## Summary

The health prober and subnet snapshot writer sent **all D1 statements in a single `db.batch()` call**. With 55 operational surfaces (110 statements per probe) and 129 subnets (129 snapshot rows), batches exceeded Cloudflare D1 limits and failed silently. KV was still updated, so live health looked current while D1 analytics stayed empty or stale.

This change chunks large writes into bounded batches and exposes D1 persist status on the prober result.

## Problem

`persistToD1` built 2 statements per probed surface and called one `db.batch(statements)`:

- **55 surfaces → 110 statements** — exceeds D1's per-batch cap
- Errors were caught and swallowed; KV writes continued unconditionally
- Operators had no signal that analytics D1 was diverging from live KV health

`writeSubnetSnapshot` had the same pattern (**129 subnet rows → one batch**), returning `{ write_failed }` on error but never chunking.

## Fix

### Shared chunking (`src/health-prober.mjs`)

- Export `D1_STATEMENTS_PER_BATCH = 50` and `runD1StatementBatches()`.
- Mirror the pattern already used by `loadStagedNeurons` / `loadStagedEvents`.

### Health prober (`persistToD1`)

- Chunk surface check + status upserts into batches of 50 statements.
- Return `{ ok, reason?, batches? }` instead of void.
- Log a warning on failure; `runHealthProber` now returns `d1_persisted: boolean`.
- KV writes still proceed on D1 failure (live serving unchanged).

### Subnet snapshots (`writeSubnetSnapshot`)

- Chunk snapshot inserts via `runD1StatementBatches`.

## Files changed

| File | Change |
|------|--------|
| `src/health-prober.mjs` | Chunked D1 batches, `d1_persisted` on prober result |
| `tests/health-prober.test.mjs` | Chunking + `d1_persisted: false` tests |
| `tests/analytics.test.mjs` | 55-subnet snapshot chunking test |

## Test plan

- [x] `npm test -- tests/health-prober.test.mjs tests/analytics.test.mjs`
  - 30 surfaces → 2 D1 batches (50 + 10)
  - D1 batch throw → `d1_persisted: false`, KV still written
  - 55 subnet profiles → 2 snapshot batches (50 + 5)
- [ ] Full CI (`validate` workflow on Linux)

