### PR TITLE
fix(feeds): coverage-delta item describes only the present side

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -126,14 +126,28 @@ function registryItems(changelog, netuid) {
     const candidateDelta = cov?.candidate_count?.delta || 0;
     if (surfaceDelta || candidateDelta) {
       const sign = (n) => (n >= 0 ? `+${n}` : `${n}`);
+      // Only describe the side(s) actually present — a partial coverage_delta
+      // (e.g. candidate_count only) must not emit "+0 surfaces" or interpolate
+      // "Surfaces undefined→undefined" for the absent side.
+      const titleParts = [];
+      const summaryParts = [];
+      if (cov?.surface_count) {
+        titleParts.push(`${sign(surfaceDelta)} surfaces`);
+        summaryParts.push(
+          `Surfaces ${cov.surface_count.before}→${cov.surface_count.after}`,
+        );
+      }
+      if (cov?.candidate_count) {
+        titleParts.push(`${sign(candidateDelta)} candidates`);
+        summaryParts.push(
+          `candidates ${cov.candidate_count.before}→${cov.candidate_count.after}`,
+        );
+      }
       items.push({
         id: `registry:coverage:${at}`,
         url: `${SITE_URL}/gaps`,
-        title: `Coverage updated: ${sign(surfaceDelta)} surfaces, ${sign(candidateDelta)} candidates`,
-        summary: clamp(
-          `Surfaces ${cov.surface_count?.before}→${cov.surface_count?.after}; ` +
-            `candidates ${cov.candidate_count?.before}→${cov.candidate_count?.after}.`,
-        ),
+        title: `Coverage updated: ${titleParts.join(", ")}`,
+        summary: clamp(`${summaryParts.join("; ")}.`),
         timestamp: at,
         tags: ["registry", "coverage"],
       });

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -164,6 +164,23 @@ describe("feeds — item builders", () => {
     assert.ok(!loneSurrogate.test(items[0].summary));
   });
 
+  test("registryItems coverage delta describes only the present side", () => {
+    // Partial coverage_delta (candidate_count only) must not emit "+0 surfaces"
+    // or "Surfaces undefined→undefined" for the absent surface side.
+    const items = registryItems({
+      summary: {
+        coverage_delta: {
+          candidate_count: { before: 50, after: 49, delta: -1 },
+        },
+      },
+    });
+    assert.equal(items.length, 1);
+    assert.equal(items[0].title, "Coverage updated: -1 candidates");
+    assert.equal(items[0].summary, "candidates 50→49.");
+    assert.ok(!items[0].summary.includes("undefined"));
+    assert.ok(!items[0].title.includes("surfaces"));
+  });
+
   test("incidentItems marks ongoing vs resolved + filters by netuid", () => {
     const all = incidentItems(INCIDENTS);
     assert.equal(all.length, 2); // the no-incidents surface contributes none


### PR DESCRIPTION
## Summary

Fixes #1452.

The coverage-delta feed item in `registryItems` rendered the absent side as the literal string `undefined` when `coverage_delta` carried only one of `surface_count` / `candidate_count`. `registryItems({ summary: { coverage_delta: { candidate_count: { before: 50, after: 49, delta: -1 } } } })` produced title `Coverage updated: +0 surfaces, -1 candidates` and summary `Surfaces undefined→undefined; candidates 50→49.` in the live `/api/v1/feeds/registry` feed.

## What Changed

- `src/feeds.mjs` — build the title and summary from only the side(s) actually present. The both-present output is byte-for-byte unchanged.
- `tests/feeds.test.mjs` — regression test for the candidate-only partial delta.

No schema, OpenAPI, or generated-artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `npx vitest run tests/feeds.test.mjs` — 22 passed (new partial-delta test fails without the fix; the both-present test confirms unchanged output)
- [x] `npx prettier --check` + `npx eslint` on changed files — clean
- [x] `git diff --check`

## Template Used

- Backend/code change
