### PR TITLE
fix: require HMAC for staged chain-event batches

### DIFF
--- a/.github/workflows/refresh-events.yml
+++ b/.github/workflows/refresh-events.yml
@@ -11,7 +11,7 @@ name: Refresh Chain Events (first-party poller)
 # (block_number, event_index)), so frequent overlapping runs need no cursor and
 # self-heal small gaps. Live-forward only: public nodes prune ~300 blocks, so this
 # runs often to stay inside that window; deep history is the optional archive-RPC
-# upgrade (#1349). No new secret — uses the existing CLOUDFLARE_* R2 permission.
+# upgrade (#1349). Reuses METAGRAPH_STAGING_SIGNING_KEY (same as refresh-metagraph).
 on:
   schedule:
     # Every 5 min (#1346 Option A) — the practical CI floor (each run has ~3 min of
@@ -59,6 +59,11 @@ jobs:
           # 120 blocks ≈ 24 min of chain — generous idempotent overlap at a 5-min
           # cadence (survives delayed/missed runs) while keeping the poll ~1 min.
           EVENTS_WINDOW: "120"
+
+      - name: Sign staged chain-event batch
+        run: node scripts/sign-staged-neurons.mjs dist/account-events.json
+        env:
+          METAGRAPH_STAGING_SIGNING_KEY: ${{ secrets.METAGRAPH_STAGING_SIGNING_KEY }}
 
       # Stage to R2 (the token's existing R2 permission); the Worker loads it into
       # D1 through its binding (loadStagedEvents) — no API-token D1 permission.

--- a/tests/load-staged-events.test.mjs
+++ b/tests/load-staged-events.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
 import { test } from "vitest";
 import { handleScheduled, loadStagedEvents } from "../workers/api.mjs";
 import {
@@ -6,6 +7,8 @@ import {
   MAX_STAGED_EVENTS_BYTES,
   MAX_STAGED_EVENT_ROWS,
 } from "../workers/config.mjs";
+
+const SIGNING_KEY = "test-staged-events-secret";
 
 function eventRow(block_number, event_index) {
   return {
@@ -21,6 +24,16 @@ function eventRow(block_number, event_index) {
   };
 }
 
+function signedEventEnvelope(rows, key = SIGNING_KEY) {
+  return {
+    schema_version: 1,
+    hmac_sha256: createHmac("sha256", key)
+      .update(JSON.stringify(rows))
+      .digest("hex"),
+    rows,
+  };
+}
+
 function mockEnv({
   rows,
   bad = false,
@@ -28,9 +41,11 @@ function mockEnv({
   deleted = [],
   prepared = [],
   batches = [],
+  signingKey = SIGNING_KEY,
 }) {
   return {
     env: {
+      METAGRAPH_STAGING_SIGNING_KEY: signingKey,
       METAGRAPH_ARCHIVE: {
         async get(key) {
           getCalls.push(key);
@@ -63,16 +78,27 @@ function mockEnv({
   };
 }
 
-test("loadStagedEvents loads JSON via parameterized batches + deletes it (#1346)", async () => {
+function archiveEnv({ get, put, delete: del, signingKey = SIGNING_KEY }) {
+  return {
+    METAGRAPH_STAGING_SIGNING_KEY: signingKey,
+    METAGRAPH_ARCHIVE: { get, put, delete: del },
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        return { bind: () => ({}) };
+      },
+      async batch() {},
+    },
+  };
+}
+
+test("loadStagedEvents loads signed JSON via parameterized batches + deletes it (#1346)", async () => {
   const rows = Array.from({ length: 12 }, (_, i) => eventRow(1000 + i, i));
-  const m = mockEnv({ rows });
+  const m = mockEnv({ rows: signedEventEnvelope(rows) });
   const r = await loadStagedEvents(m.env);
   assert.equal(r.ok, true);
   assert.equal(r.rows, 12);
   assert.deepEqual(m.getCalls, ["events/account-events-pending.json"]);
-  // 12 rows / 10 per statement = 2 statements, one batch (<=50).
   assert.deepEqual(m.batches, [2]);
-  // Idempotent + parameterized: INSERT OR IGNORE keyed (block,index), values bound.
   assert.ok(m.prepared[0].startsWith("INSERT OR IGNORE INTO account_events ("));
   assert.ok(m.prepared[0].includes("VALUES (?"));
   assert.ok(
@@ -92,14 +118,34 @@ test("loadStagedEvents no-ops when nothing is staged", async () => {
 });
 
 test("loadStagedEvents deletes + bails on unparseable JSON", async () => {
-  const m = mockEnv({ rows: [], bad: true });
+  const m = mockEnv({ rows: signedEventEnvelope([]), bad: true });
   const r = await loadStagedEvents(m.env);
   assert.equal(r.reason, "parse_failed");
   assert.deepEqual(m.deleted, ["events/account-events-pending.json"]);
 });
 
+test("loadStagedEvents rejects an unsigned envelope", async () => {
+  const m = mockEnv({ rows: [eventRow(1000, 0)] });
+  const r = await loadStagedEvents(m.env);
+  assert.equal(r.reason, "unauthenticated");
+  assert.equal(m.batches.length, 0);
+  assert.deepEqual(m.deleted, ["events/account-events-pending.json"]);
+});
+
+test("loadStagedEvents rejects a bad HMAC", async () => {
+  const rows = [eventRow(1000, 0)];
+  const envelope = signedEventEnvelope(rows);
+  envelope.hmac_sha256 = "0".repeat(64);
+  const m = mockEnv({ rows: envelope });
+  const r = await loadStagedEvents(m.env);
+  assert.equal(r.reason, "unauthenticated");
+  assert.equal(m.batches.length, 0);
+});
+
 test("loadStagedEvents drops rows lacking the (block, index) key", async () => {
-  const m = mockEnv({ rows: [{ event_kind: "X" }] }); // no block_number/event_index
+  const m = mockEnv({
+    rows: signedEventEnvelope([{ event_kind: "StakeAdded" }]),
+  });
   const r = await loadStagedEvents(m.env);
   assert.equal(r.reason, "empty");
   assert.equal(m.batches.length, 0);
@@ -109,11 +155,11 @@ test("loadStagedEvents drops rows lacking the (block, index) key", async () => {
 test("loadStagedEvents drops rows missing required insert fields", async () => {
   const valid = eventRow(1000, 0);
   const m = mockEnv({
-    rows: [
+    rows: signedEventEnvelope([
       { ...valid, observed_at: null },
       { ...valid, event_index: 1, event_kind: null },
       { ...valid, event_index: 2 },
-    ],
+    ]),
   });
   const r = await loadStagedEvents(m.env);
   assert.equal(r.ok, true);
@@ -131,20 +177,20 @@ test("loadStagedEvents is a safe no-op without bindings", async () => {
 test("handleScheduled fast-load cron drains staged batches + skips the probe (#1346 Option A)", async () => {
   const drained = [];
   const env = {
+    METAGRAPH_STAGING_SIGNING_KEY: SIGNING_KEY,
     METAGRAPH_ARCHIVE: {
       async get(key) {
-        // Only the events batch is staged; the neuron key returns nothing.
         return key === "events/account-events-pending.json"
           ? {
               async json() {
-                return [
+                return signedEventEnvelope([
                   {
                     block_number: 1,
                     event_index: 0,
                     event_kind: "StakeAdded",
                     observed_at: 1,
                   },
-                ];
+                ]);
               },
             }
           : null;
@@ -161,7 +207,6 @@ test("handleScheduled fast-load cron drains staged batches + skips the probe (#1
     },
   };
   const r = await handleScheduled({ cron: EVENTS_LOAD_CRON }, env, {});
-  // Early-returns the fast-load marker (i.e. never falls through to the prober).
   assert.deepEqual(r, { ok: true, fast_load: true });
   assert.ok(
     drained.includes("events/account-events-pending.json"),
@@ -176,73 +221,55 @@ test("loadStagedEvents caps rows/tick + leaves the remainder in R2 (not deleted)
   const rows = Array.from({ length: N }, (_, i) => eventRow(1000 + i, i));
   const puts = [];
   const deleted = [];
-  const env = {
-    METAGRAPH_ARCHIVE: {
-      async get() {
-        return {
-          size: 1024,
-          async json() {
-            return rows;
-          },
-        };
-      },
-      async put(key, body) {
-        puts.push({ key, body });
-      },
-      async delete(key) {
-        deleted.push(key);
-      },
+  const env = archiveEnv({
+    async get() {
+      return {
+        size: 1024,
+        async json() {
+          return signedEventEnvelope(rows);
+        },
+      };
     },
-    METAGRAPH_HEALTH_DB: {
-      prepare() {
-        return { bind: () => ({}) };
-      },
-      async batch() {},
+    async put(key, body) {
+      puts.push({ key, body });
     },
-  };
+    async delete(key) {
+      deleted.push(key);
+    },
+  });
   const r = await loadStagedEvents(env);
   assert.equal(r.ok, true);
   assert.equal(r.rows, MAX_STAGED_EVENT_ROWS);
   assert.equal(r.remaining, 5);
   assert.deepEqual(deleted, [], "must NOT delete while rows are un-persisted");
   assert.equal(puts.length, 1, "remainder rewritten for the next tick");
-  assert.equal(
-    JSON.parse(puts[0].body).length,
-    5,
-    "exactly the un-loaded rows are kept",
-  );
+  const remainder = JSON.parse(puts[0].body);
+  assert.equal(remainder.rows.length, 5, "exactly the un-loaded rows are kept");
+  assert.match(remainder.hmac_sha256, /^[a-f0-9]{64}$/);
 });
 
 test("loadStagedEvents drains a >cap file across ticks without dropping rows", async () => {
   const N = MAX_STAGED_EVENT_ROWS + 5;
   const all = Array.from({ length: N }, (_, i) => eventRow(1000 + i, i));
-  let stored = JSON.stringify(all); // a stateful in-memory R2 object
-  const env = {
-    METAGRAPH_ARCHIVE: {
-      async get() {
-        return stored == null
-          ? null
-          : {
-              size: stored.length,
-              async json() {
-                return JSON.parse(stored);
-              },
-            };
-      },
-      async put(_key, body) {
-        stored = body;
-      },
-      async delete() {
-        stored = null;
-      },
+  let stored = JSON.stringify(signedEventEnvelope(all));
+  const env = archiveEnv({
+    async get() {
+      return stored == null
+        ? null
+        : {
+            size: stored.length,
+            async json() {
+              return JSON.parse(stored);
+            },
+          };
     },
-    METAGRAPH_HEALTH_DB: {
-      prepare() {
-        return { bind: () => ({}) };
-      },
-      async batch() {},
+    async put(_key, body) {
+      stored = body;
     },
-  };
+    async delete() {
+      stored = null;
+    },
+  });
   const t1 = await loadStagedEvents(env);
   assert.equal(t1.rows, MAX_STAGED_EVENT_ROWS);
   assert.equal(t1.remaining, 5);
@@ -261,29 +288,21 @@ test("loadStagedEvents drains a >cap file across ticks without dropping rows", a
 test("loadStagedEvents skips an over-byte-cap file without parsing or deleting it", async () => {
   let jsonCalled = false;
   const deleted = [];
-  const env = {
-    METAGRAPH_ARCHIVE: {
-      async get() {
-        return {
-          size: MAX_STAGED_EVENTS_BYTES + 1,
-          async json() {
-            jsonCalled = true;
-            return [];
-          },
-        };
-      },
-      async put() {},
-      async delete(key) {
-        deleted.push(key);
-      },
+  const env = archiveEnv({
+    async get() {
+      return {
+        size: MAX_STAGED_EVENTS_BYTES + 1,
+        async json() {
+          jsonCalled = true;
+          return [];
+        },
+      };
     },
-    METAGRAPH_HEALTH_DB: {
-      prepare() {
-        return { bind: () => ({}) };
-      },
-      async batch() {},
+    async put() {},
+    async delete(key) {
+      deleted.push(key);
     },
-  };
+  });
   const r = await loadStagedEvents(env);
   assert.equal(r.ok, false);
   assert.equal(r.reason, "too_large");
@@ -300,12 +319,13 @@ test("loadStagedEvents leaves the file intact if a D1 batch throws (no drop on c
   const puts = [];
   const deleted = [];
   const env = {
+    METAGRAPH_STAGING_SIGNING_KEY: SIGNING_KEY,
     METAGRAPH_ARCHIVE: {
       async get() {
         return {
           size: 256,
           async json() {
-            return rows;
+            return signedEventEnvelope(rows);
           },
         };
       },
@@ -325,8 +345,6 @@ test("loadStagedEvents leaves the file intact if a D1 batch throws (no drop on c
       },
     },
   };
-  // D1 writes happen BEFORE the R2 shrink, so a write failure must leave the full
-  // file in place to re-drain next tick — never a partial put/delete.
   await assert.rejects(loadStagedEvents(env));
   assert.deepEqual(puts, [], "no remainder written on failure");
   assert.deepEqual(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -251,6 +251,7 @@ export default {
 // capped at the u16 max (65535) — matching the existing netuid guard in
 // src/webhooks.mjs and avoiding rejection of legitimately high subnet ids.
 const STAGED_NEURONS_KEY = "metagraph/neurons-pending.json";
+const STAGED_EVENTS_KEY = "events/account-events-pending.json";
 const MAX_STAGED_NEURONS_BYTES = 32_000_000;
 const MAX_STAGED_NEURON_ROWS = 50_000;
 const MAX_STAGED_NEURON_STRING_BYTES = 512;
@@ -302,6 +303,18 @@ function parseNeuronStagingMeta(envelope, rows) {
     }
   }
   return { legacy: false, refreshed_netuids, captured_at };
+}
+
+function eventStagingSignPayload(rows) {
+  return JSON.stringify(rows);
+}
+
+async function signedEventEnvelope(signingKey, rows) {
+  return {
+    schema_version: 1,
+    hmac_sha256: await hmacHex(signingKey, eventStagingSignPayload(rows)),
+    rows,
+  };
 }
 
 async function purgeStaleNeuronRows(db, refreshed_netuids, captured_at) {
@@ -471,18 +484,20 @@ export async function loadStagedNeurons(env) {
 }
 
 // Load a staged chain-event batch from R2 into D1 (#1346, epic #1345). The
-// refresh-events CI job decodes finney's System.Events first-party (no Taostats)
-// and writes account_events rows as JSON to R2 (events/account-events-pending.json)
-// with its existing R2 permission; we load them here through the binding (no
-// API-token D1 permission) with PARAMETERIZED INSERT OR IGNORE keyed
-// (block_number, event_index) — so overlapping poller windows re-insert harmlessly
-// (idempotent, no cursor needed) and a tampered file can only fail, never inject.
-// Then delete the object so each batch loads once.
+// refresh-events CI job decodes finney's System.Events first-party (no Taostats),
+// signs rows with METAGRAPH_STAGING_SIGNING_KEY, and writes the envelope to R2;
+// we load only authenticated rows through the binding (no API-token D1 permission)
+// with PARAMETERIZED INSERT OR IGNORE keyed (block_number, event_index) — so
+// overlapping poller windows re-insert harmlessly (idempotent, no cursor needed).
+// Then delete the object (or rewrite a signed remainder) so each batch loads once.
 export async function loadStagedEvents(env) {
   const bucket = env.METAGRAPH_ARCHIVE;
   const db = env.METAGRAPH_HEALTH_DB;
-  if (!bucket?.get || !db?.prepare) return { ok: false, reason: "unavailable" };
-  const key = "events/account-events-pending.json";
+  const signingKey = env.METAGRAPH_STAGING_SIGNING_KEY;
+  if (!bucket?.get || !db?.prepare || !signingKey) {
+    return { ok: false, reason: "unavailable" };
+  }
+  const key = STAGED_EVENTS_KEY;
   const object = await bucket.get(key);
   if (!object) return { ok: false, reason: "none" };
   // Byte cap: never materialize a pathological body. `size` is object metadata,
@@ -496,30 +511,44 @@ export async function loadStagedEvents(env) {
     );
     return { ok: false, reason: "too_large", size: Number(object.size || 0) };
   }
-  let parsed;
+  let envelope;
   try {
-    parsed = await object.json();
+    envelope = await object.json();
   } catch {
     await bucket.delete(key);
     return { ok: false, reason: "parse_failed" };
   }
-  const rows = validEventRows(parsed);
-  if (!rows.length) {
+  const rows = Array.isArray(envelope?.rows) ? envelope.rows : [];
+  if (
+    envelope?.schema_version !== 1 ||
+    !/^[a-f0-9]{64}$/.test(String(envelope?.hmac_sha256 || ""))
+  ) {
+    await bucket.delete(key);
+    return { ok: false, reason: "unauthenticated" };
+  }
+  const expected = await hmacHex(signingKey, eventStagingSignPayload(rows));
+  if (!timingSafeStringEqual(expected, envelope.hmac_sha256)) {
+    await bucket.delete(key);
+    return { ok: false, reason: "unauthenticated" };
+  }
+  const validRows = validEventRows(rows);
+  if (!validRows.length) {
     await bucket.delete(key);
     return { ok: false, reason: "empty" };
   }
   // Row cap: bound the D1 writes + subrequests per */3 tick. Drain up to the cap
-  // now; if rows remain, rewrite the object with ONLY the remainder so the next tick
-  // continues — never delete while rows are un-persisted. Order matters: write to D1
-  // FIRST, then shrink R2. A crash between them re-reads the full file next tick and
-  // re-inserts the loaded rows harmlessly (INSERT OR IGNORE), so nothing is dropped.
+  // now; if rows remain, rewrite the object with ONLY the signed remainder so the
+  // next tick continues — never delete while rows are un-persisted. Order matters:
+  // write to D1 FIRST, then shrink R2. A crash between them re-reads the full file
+  // next tick and re-inserts the loaded rows harmlessly (INSERT OR IGNORE), so
+  // nothing is dropped.
   const batch =
-    rows.length > MAX_STAGED_EVENT_ROWS
-      ? rows.slice(0, MAX_STAGED_EVENT_ROWS)
-      : rows;
+    validRows.length > MAX_STAGED_EVENT_ROWS
+      ? validRows.slice(0, MAX_STAGED_EVENT_ROWS)
+      : validRows;
   const remainder =
-    rows.length > MAX_STAGED_EVENT_ROWS
-      ? rows.slice(MAX_STAGED_EVENT_ROWS)
+    validRows.length > MAX_STAGED_EVENT_ROWS
+      ? validRows.slice(MAX_STAGED_EVENT_ROWS)
       : [];
   const statements = eventInsertStatements(db, batch);
   const STMTS_PER_BATCH = 50;
@@ -527,7 +556,10 @@ export async function loadStagedEvents(env) {
     await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
   }
   if (remainder.length) {
-    await bucket.put(key, JSON.stringify(remainder));
+    await bucket.put(
+      key,
+      JSON.stringify(await signedEventEnvelope(signingKey, remainder)),
+    );
     return { ok: true, rows: batch.length, remaining: remainder.length };
   }
   await bucket.delete(key);

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -317,18 +317,6 @@ async function signedEventEnvelope(signingKey, rows) {
   };
 }
 
-async function purgeStaleNeuronRows(db, refreshed_netuids, captured_at) {
-  let purged = 0;
-  for (const netuid of refreshed_netuids) {
-    const result = await db
-      .prepare(`DELETE FROM neurons WHERE netuid = ? AND captured_at < ?`)
-      .bind(netuid, captured_at)
-      .run();
-    purged += result?.meta?.changes ?? 0;
-  }
-  return purged;
-}
-
 function utf8Bytes(value) {
   return new TextEncoder().encode(value);
 }


### PR DESCRIPTION
## Summary

Staged neuron snapshots already require an HMAC-signed envelope before R2 → D1 load. Staged **chain events** did not — any object at `events/account-events-pending.json` in R2 was parsed and inserted into D1 on the next cron tick.

This change mirrors the neuron path: CI signs batches before upload; the Worker verifies `METAGRAPH_STAGING_SIGNING_KEY` before loading.

## Problem

`loadStagedNeurons` verifies:

- `schema_version === 1`
- `hmac_sha256` over `JSON.stringify(rows)`
- size / row-count bounds

`loadStagedEvents` previously accepted a raw JSON array with no authentication. Anyone with R2 write access (leaked CI token, misconfigured bucket policy) could inject arbitrary rows into `account_events`, which `/api/v1/accounts/{ss58}` serves as chain-derived activity.

SQL injection was already prevented (parameterized inserts). **Data integrity was not.**

## Fix

### Worker (`workers/api.mjs`)

- Require `METAGRAPH_STAGING_SIGNING_KEY` (same secret as neurons).
- Parse `{ schema_version, hmac_sha256, rows }` envelope.
- Reject unsigned, tampered, oversized (`>2 MB`), or over-limit (`>50k rows`) batches.
- Delete rejected objects from R2 (same as neuron loader).

### CI (`.github/workflows/refresh-events.yml`)

- After `fetch-events.py`, run `node scripts/sign-staged-neurons.mjs dist/account-events.json`.
- Upload the signed envelope to R2 (reuses existing `METAGRAPH_STAGING_SIGNING_KEY` secret).

Reuses the existing `scripts/sign-staged-neurons.mjs` signing helper (no script changes in this PR).

## Files changed

| File                                   | Change                                           |
| -------------------------------------- | ------------------------------------------------ |
| `workers/api.mjs`                      | HMAC verification + bounds in `loadStagedEvents` |
| `.github/workflows/refresh-events.yml` | Sign batch before R2 upload                      |
| `tests/load-staged-events.test.mjs`    | Signed accept + unsigned/bad-HMAC reject tests   |

## Test plan

### Verified locally

- [x] `npm run lint`
- [x] `npx prettier --check` on changed source/workflow files
- [x] `npm test -- tests/load-staged-events.test.mjs` (13/13)
- [x] `npm test -- tests/load-staged-neurons.test.mjs` (11/11, regression)
- [x] Both suites also pass inside `npm run test:coverage` (1317 other tests pass; 108 fail on this Windows host — see below)

### Not verified locally (Windows host limitation)

- [ ] Full `validate` workflow on Linux (`ubuntu-latest`)

On this Windows machine, `scripts/lib.mjs` resolves `repoRoot` to `E:\E:\work\metagraphed\...` (`new URL(...).pathname` + `path.join`), so `npm run build`, `validate:workflows`, and artifact-dependent tests cannot run here. Those 108 failures are the same pre-existing environment issue, not regressions from this change. **Push the branch and rely on GitHub Actions `validate` for the authoritative CI gate.**

