### PR TITLE
fix(ai-search): cap vectorId by UTF-8 byte length, not UTF-16 length

### DIFF
--- a/src/ai-search.mjs
+++ b/src/ai-search.mjs
@@ -119,9 +119,12 @@ export function embeddingText(doc) {
 
 // Vectorize ids are capped at 64 bytes; long surface ids are folded to a stable
 // hashed id. The real identity lives in metadata, so query results are unaffected.
+// Measure UTF-8 BYTES, not UTF-16 `.length`: a multi-byte id can be <=64 chars
+// yet >64 bytes, which would slip past the cap and be rejected on upsert.
 export function vectorId(docId) {
   const id = String(docId);
-  return id.length <= VECTOR_ID_MAX_BYTES ? id : `h:${contentHash(id)}`;
+  const byteLength = new TextEncoder().encode(id).length;
+  return byteLength <= VECTOR_ID_MAX_BYTES ? id : `h:${contentHash(id)}`;
 }
 
 export function embeddingMetadata(doc) {

--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -168,6 +168,12 @@ describe("embedding helpers", () => {
     const long = "surface:" + "x".repeat(80);
     assert.ok(vectorId(long).startsWith("h:"));
     assert.ok(vectorId(long).length <= 64);
+    // Vectorize caps ids at 64 BYTES, not UTF-16 length: a multi-byte id that is
+    // <=64 chars but >64 bytes must still be folded to a hashed id.
+    const multibyte = "é".repeat(40); // 40 chars, 80 UTF-8 bytes
+    assert.ok(new TextEncoder().encode(multibyte).length > 64);
+    assert.equal(multibyte.length <= 64, true); // would wrongly pass the old check
+    assert.ok(vectorId(multibyte).startsWith("h:"));
   });
   test("embeddingMetadata normalises missing fields to null", () => {
     assert.deepEqual(embeddingMetadata({ type: "subnet", netuid: 7 }), {


### PR DESCRIPTION
## Summary

- `vectorId` folds over-long ids to a stable hashed id so they fit Vectorize's id cap. The comment says the cap is **64 bytes**, but the check measured `String#length` (UTF-16 code units), not UTF-8 bytes.
- A multi-byte id that is ≤64 *characters* but >64 *bytes* slips past the fold and is upserted to Vectorize as-is, exceeding the cap — the upsert is rejected and that document silently never gets indexed for semantic search.

Fixes #1457

## Reproduction

```js
const id = "é".repeat(40); // 40 chars, 80 UTF-8 bytes
vectorId(id); // before: returns the 80-byte id (length 40 <= 64) — over the cap
              // after:  folds to "h:<hash>"
```

For ASCII ids `length === byteLength`, so behaviour is unchanged there; only multi-byte ids are affected. (Same UTF-16-length-vs-bytes class fixed for feeds in #1445.)

## What Changed

- `src/ai-search.mjs` — measure `new TextEncoder().encode(id).length` against `VECTOR_ID_MAX_BYTES` (64), so any id that would exceed Vectorize's byte cap is folded to the hashed id.
- `tests/ai-search.test.mjs` — extend the `vectorId` test with a multi-byte id (40 chars / 80 bytes) that must fold to `h:…`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No OpenAPI/schema surface changes — internal Vectorize id derivation only; query results are unaffected (real identity lives in metadata).

## Validation

- [x] `npx vitest run tests/ai-search.test.mjs` — the `vectorId` test passes (new multi-byte case fails on the pre-fix `.length` check).
- [x] `npx prettier --check` + `npx eslint` on the changed files — clean.
- Note: the pre-existing `embedding-sync cron > the daily cron triggers an embedding sync` failure reproduces on `main` unchanged (local-env only; unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
