### PR TITLE
fix(neurons): snapshot-replace stale rows — no more phantom neurons

### DIFF
--- a/tests/load-staged-neurons.test.mjs
+++ b/tests/load-staged-neurons.test.mjs
@@ -58,6 +58,7 @@ function signedCoverageEnvelope(
 function mockEnv({
   rows,
   bad = false,
+  failBatch = false,
   getCalls = [],
   deleted = [],
   prepared = [],
@@ -100,6 +101,7 @@ function mockEnv({
         },
         async batch(stmts) {
           batches.push(stmts.length);
+          if (failBatch) throw new Error("simulated D1 batch failure");
         },
       },
     },
@@ -240,7 +242,11 @@ test("loadStagedNeurons rejects rows that fail per-field bounding (#1360)", asyn
   }
 });
 
-test("loadStagedNeurons purges prior-capture rows within refreshed subnets", async () => {
+test("loadStagedNeurons snapshot-replaces: deletes every row older than the snapshot stamp", async () => {
+  // INVARIANT: after a successful load, the prune deletes ALL prior-snapshot rows
+  // table-wide (not scoped to a subnet), keyed on the snapshot's captured_at — so
+  // no row with captured_at < the stamp can remain. A coverage envelope still
+  // verifies + loads, but the prune is derived from the rows, not the envelope.
   const captured_at = 2_000_000_000_000;
   const rows = [{ ...neuronRow(1, 0), captured_at }];
   const m = mockEnv({
@@ -249,9 +255,22 @@ test("loadStagedNeurons purges prior-capture rows within refreshed subnets", asy
   const r = await loadStagedNeurons(m.env);
   assert.equal(r.ok, true);
   assert.equal(r.purged, 1);
-  const purge = m.runs.find((run) => run.sql.includes("DELETE FROM neurons"));
-  assert.ok(purge);
-  assert.deepEqual(purge.v, [1, captured_at]);
+  const purges = m.runs.filter((run) =>
+    run.sql.includes("DELETE FROM neurons"),
+  );
+  assert.equal(
+    purges.length,
+    1,
+    "exactly one table-wide prune, not per-subnet",
+  );
+  // Cutoff is the snapshot stamp and ONLY the stamp (no netuid scoping).
+  assert.deepEqual(purges[0].v, [captured_at]);
+  assert.ok(
+    !/netuid/.test(purges[0].sql),
+    "prune must be table-wide, not scoped to a netuid",
+  );
+  // The prune runs strictly after the inserts (so a failed insert never prunes).
+  assert.ok(m.batches.length > 0);
 });
 
 test("loadStagedNeurons rejects coverage metadata that disagrees with row captured_at", async () => {
@@ -263,4 +282,129 @@ test("loadStagedNeurons rejects coverage metadata that disagrees with row captur
   const r = await loadStagedNeurons(m.env);
   assert.equal(r.reason, "invalid");
   assert.equal(m.batches.length, 0);
+});
+
+// A *stateful* D1 mock: a real table (Map keyed on the (netuid,uid) PK) that
+// honors the two SQL shapes loadStagedNeurons actually issues — INSERT OR REPLACE
+// (upsert by PK) and the snapshot-prune DELETE ... WHERE captured_at < ?. This is
+// what lets the regression test below prove a deregistered UID's row is actually
+// gone, not merely that a DELETE statement was prepared.
+function statefulEnv(table, { signingKey = SIGNING_KEY } = {}) {
+  const deleted = [];
+  function applyInsert(sql, values) {
+    // Columns from "INSERT OR REPLACE INTO neurons (a,b,...) VALUES ..."
+    const cols = sql.slice(sql.indexOf("(") + 1, sql.indexOf(")")).split(",");
+    const perRow = cols.length;
+    for (let i = 0; i < values.length; i += perRow) {
+      const row = {};
+      cols.forEach((c, j) => (row[c.trim()] = values[i + j]));
+      table.set(`${row.netuid}:${row.uid}`, row); // REPLACE by PK
+    }
+  }
+  return {
+    env: {
+      METAGRAPH_STAGING_SIGNING_KEY: signingKey,
+      METAGRAPH_ARCHIVE: {
+        _staged: null,
+        async get() {
+          return this._staged == null
+            ? null
+            : {
+                size: JSON.stringify(this._staged).length,
+                json: async () => this._staged,
+              };
+        },
+        async delete(key) {
+          deleted.push(key);
+          this._staged = null;
+        },
+      },
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          // Mirror the real bound-statement shape: carries { sql, v } so batch()
+          // (which receives already-bound statements) can apply them.
+          return {
+            bind: (...v) => ({
+              sql,
+              v,
+              async run() {
+                if (sql.startsWith("DELETE FROM neurons WHERE captured_at <")) {
+                  const cutoff = v[0];
+                  let changes = 0;
+                  for (const [k, row] of table) {
+                    if (row.captured_at < cutoff) {
+                      table.delete(k);
+                      changes += 1;
+                    }
+                  }
+                  return { meta: { changes } };
+                }
+                return { meta: { changes: 0 } };
+              },
+            }),
+          };
+        },
+        async batch(stmts) {
+          for (const stmt of stmts) applyInsert(stmt.sql, stmt.v);
+        },
+      },
+    },
+    deleted,
+    table,
+  };
+}
+
+test("loadStagedNeurons snapshot-replace removes a deregistered UID across snapshots (regression #1303)", async () => {
+  // THE BUG: INSERT OR REPLACE never deletes a (netuid,uid) that vanished from the
+  // next snapshot, so a deregistered neuron's row would persist forever → ghost
+  // metagraph entries + inflated neuron_count. snapshot-replace must clear it.
+  const table = new Map();
+  const m = statefulEnv(table);
+
+  // Snapshot 1 @T1: subnet 1 has UIDs 0 and 1.
+  const T1 = 1_700_000_000_000;
+  const snap1 = [
+    { ...neuronRow(1, 0), captured_at: T1 },
+    { ...neuronRow(1, 1), captured_at: T1 },
+  ];
+  m.env.METAGRAPH_ARCHIVE._staged = signedCoverageEnvelope(snap1, [1], T1);
+  const r1 = await loadStagedNeurons(m.env);
+  assert.equal(r1.ok, true);
+  assert.deepEqual([...table.keys()].sort(), ["1:0", "1:1"]);
+
+  // Snapshot 2 @T2>T1: UID 1 deregistered — only UID 0 remains in the snapshot.
+  const T2 = T1 + 60_000;
+  const snap2 = [{ ...neuronRow(1, 0), captured_at: T2 }];
+  m.env.METAGRAPH_ARCHIVE._staged = signedCoverageEnvelope(snap2, [1], T2);
+  const r2 = await loadStagedNeurons(m.env);
+  assert.equal(r2.ok, true);
+  assert.equal(r2.purged, 1, "exactly the one stale (1,1) row is pruned");
+
+  // The phantom (1,1) is gone; only the current (1,0) survives, at the new stamp.
+  assert.deepEqual(
+    [...table.keys()],
+    ["1:0"],
+    "deregistered UID must not linger as a phantom row",
+  );
+  assert.equal(table.get("1:0").captured_at, T2);
+  assert.equal(table.has("1:1"), false);
+});
+
+test("loadStagedNeurons makes NO prune and keeps the staged object when a batch fails (safety)", async () => {
+  // SAFETY: if any upsert batch throws mid-load, we must NOT issue the prune
+  // (which would delete the prior good snapshot) and must NOT delete the staged R2
+  // object (so the prior snapshot stays as a fallback and the next cron retries).
+  const rows = Array.from({ length: 12 }, (_, i) => neuronRow(1, i));
+  const m = mockEnv({ rows: signedEnvelope(rows), failBatch: true });
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "load_failed");
+  // No DELETE statement of any kind was prepared (no prune on a failed load).
+  assert.ok(
+    !m.prepared.some((s) => s.includes("DELETE FROM neurons")),
+    "a failed batch must never reach the snapshot prune",
+  );
+  assert.equal(m.runs.length, 0, "no DELETE .run() was issued");
+  // The staged object is preserved as the fallback snapshot.
+  assert.deepEqual(m.deleted, [], "the staged R2 object must not be deleted");
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -304,18 +304,6 @@ function parseNeuronStagingMeta(envelope, rows) {
   return { legacy: false, refreshed_netuids, captured_at };
 }
 
-async function purgeStaleNeuronRows(db, refreshed_netuids, captured_at) {
-  let purged = 0;
-  for (const netuid of refreshed_netuids) {
-    const result = await db
-      .prepare(`DELETE FROM neurons WHERE netuid = ? AND captured_at < ?`)
-      .bind(netuid, captured_at)
-      .run();
-    purged += result?.meta?.changes ?? 0;
-  }
-  return purged;
-}
-
 function utf8Bytes(value) {
   return new TextEncoder().encode(value);
 }
@@ -373,14 +361,17 @@ function validStagedNeuronRow(row) {
 }
 
 // Load a staged per-UID metagraph snapshot from R2 into D1 (#1303). The
-// refresh-metagraph CI job fetches Taostats, wraps the neuron rows in an
-// HMAC-signed envelope, and writes it to R2 (metagraph/neurons-pending.json)
-// using its existing R2 permission; we load only authenticated, bounded,
-// schema-valid rows through the METAGRAPH_HEALTH_DB binding — which needs no
-// API-token D1 permission — with PARAMETERIZED inserts (values are always bound,
-// never interpolated), then delete prior-capture rows within refreshed subnets
-// so deregistered UIDs do not linger after a partial refresh. Then delete the
-// staged object so it loads exactly once.
+// refresh-metagraph CI job fetches the metagraph first-party (#1348), wraps the
+// neuron rows in an HMAC-signed envelope, and writes it to R2
+// (metagraph/neurons-pending.json) using its existing R2 permission; we load only
+// authenticated, bounded, schema-valid rows through the METAGRAPH_HEALTH_DB
+// binding — which needs no API-token D1 permission — with PARAMETERIZED inserts
+// (values are always bound, never interpolated). The staged snapshot is a FULL
+// replacement: after every batch succeeds we delete any row older than the
+// snapshot's captured_at stamp, so deregistered UIDs (and entire vanished subnets)
+// never linger as phantoms — the read paths need no captured_at filter because the
+// table only ever holds the latest snapshot. Then delete the staged object so it
+// loads exactly once.
 export async function loadStagedNeurons(env) {
   const bucket = env.METAGRAPH_ARCHIVE;
   const db = env.METAGRAPH_HEALTH_DB;
@@ -451,20 +442,43 @@ export async function loadStagedNeurons(env) {
         .bind(...values),
     );
   }
-  for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
-    await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
-  }
-  let purged = 0;
-  if (!stagingMeta.legacy) {
-    try {
-      purged = await purgeStaleNeuronRows(
-        db,
-        stagingMeta.refreshed_netuids,
-        stagingMeta.captured_at,
-      );
-    } catch {
-      return { ok: false, reason: "purge_failed" };
+  // A staged snapshot is a FULL replacement of the neurons table: every row
+  // shares one captured_at stamp (set once by the producer). If ANY batch throws,
+  // bail WITHOUT deleting prior rows or the staged object — the prior snapshot
+  // stays as a fallback and the next cron retries the same staged file.
+  try {
+    for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
+      await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
     }
+  } catch {
+    return { ok: false, reason: "load_failed" };
+  }
+  // Snapshot-replace (#1303): only after EVERY upsert batch succeeds, delete any
+  // row older than this snapshot's stamp so the table holds exactly the current
+  // snapshot. This is what stops deregistered (netuid,uid) pairs — and entire
+  // vanished subnets — from lingering as phantoms (inflated neuron_count, ghost
+  // metagraphs) since the read paths don't filter by captured_at. Derived from
+  // the rows themselves (uniform stamp; use max defensively) so it works for both
+  // the bare-array native snapshot (#1348) and the coverage envelope alike.
+  let snapshotCapturedAt = 0;
+  for (const row of rows) {
+    if (
+      Number.isInteger(row.captured_at) &&
+      row.captured_at > snapshotCapturedAt
+    )
+      snapshotCapturedAt = row.captured_at;
+  }
+  let purged;
+  try {
+    const result = await db
+      .prepare(`DELETE FROM neurons WHERE captured_at < ?`)
+      .bind(snapshotCapturedAt)
+      .run();
+    purged = result?.meta?.changes ?? 0;
+  } catch {
+    // Rows are already loaded; a failed prune just leaves stale rows for the next
+    // run to clear. Do NOT delete the staged object — let the next cron re-prune.
+    return { ok: false, reason: "purge_failed" };
   }
   await bucket.delete(STAGED_NEURONS_KEY);
   return { ok: true, rows: rows.length, purged };


### PR DESCRIPTION
Audit finding #2 (high, confirmed). The per-UID `neurons` D1 table accumulated **phantom rows**: `loadStagedNeurons` used `INSERT OR REPLACE` with no delete, and the read paths don't filter `captured_at`, so a deregistered/vanished neuron's row persisted forever → ghost metagraphs + inflated `neuron_count` served indefinitely.

**Fix** (snapshot-replace, contained in loadStagedNeurons): after ALL upsert batches succeed, `DELETE FROM neurons WHERE captured_at < <snapshot max captured_at>` → the table holds only the latest full snapshot. On any batch failure: **no prune + keep the staged R2 object** (prior complete snapshot preserved). Removed the old `purgeStaleNeuronRows` (only deleted within `refreshed_netuids`, so a whole vanished subnet kept its rows). Reads unchanged — table now holds only current rows.

**Tests** (tests/load-staged-neurons.test.mjs): invariant (one table-wide prune bound to the cutoff), **regression** (snapshot1 {(1,0),(1,1)} → snapshot2 {(1,0)} via a stateful D1 mock → phantom (1,1) gone), safety (batch failure → no prune, staged object preserved). 36 staged/neuron tests green; worker dry-run passed. No API shape change.