### PR TITLE
perf(api): edge-cache the D1 analytics endpoints

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -1,0 +1,368 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.mjs";
+
+// Edge-cache coverage for the D1-backed analytics routes (audit #6). These four
+// handlers (per-subnet health trends / percentiles / incidents + the bulk-trends
+// route) used to re-run a full-window D1 aggregation on EVERY request; they are
+// now wrapped in withEdgeCache, which mirrors the existing live-overlay
+// collection cache (Cloudflare Cache API keyed on contract_version + the cron
+// snapshot's last_run_at). These tests assert the cache is correct AND
+// transparent: same body, keyed on what changes the data, never caching errors.
+
+const LAST_RUN_AT = "2026-06-18T00:00:00.000Z";
+
+// One row backs every shape the analytics SQL returns (the shared ok-latency CTE
+// carries both uptime and latency stats; incidents reuse the same row).
+function rowsForSql(sql) {
+  if (sql.includes("WITH ranked") || sql.includes("FROM ranked")) {
+    return [
+      {
+        surface_id: "s1",
+        surface_key: "s1",
+        total: 100,
+        ok_count: 98,
+        lat_cnt: 96,
+        latency_samples: 96,
+        samples: 100,
+        p50: 120,
+        p95: 400,
+        p99: 800,
+        avg_latency_ms: 150,
+        min_latency_ms: 40,
+        max_latency_ms: 900,
+      },
+    ];
+  }
+  if (sql.includes("SUM(ok) AS ok_count")) {
+    return [{ surface_id: "s1", surface_key: "s1", total: 100, ok_count: 98 }];
+  }
+  if (sql.includes("WITH checks")) {
+    return [
+      {
+        surface_id: "s1",
+        surface_key: "s1",
+        started_at: 1_000_000_000_000,
+        ended_at: 1_000_000_120_000,
+        failed_samples: 2,
+      },
+    ];
+  }
+  if (sql.includes("FROM surface_uptime_daily")) {
+    return [
+      {
+        netuid: 7,
+        day: "2026-06-17",
+        date: "2026-06-17",
+        total: 100,
+        ok_count: 98,
+        latency_samples: 96,
+        p50: 120,
+        p95: 400,
+      },
+    ];
+  }
+  return [];
+}
+
+// Local artifact env + a query-recording D1 + a KV control plane that serves the
+// snapshot stamp. `queries` records every {sql, params} so a test can assert
+// whether D1 was touched at all (the whole point of the cache).
+function analyticsEnv(queries, { lastRunAt = LAST_RUN_AT } = {}) {
+  return {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind(...params) {
+            queries.push({ sql, params });
+            return {
+              all: () => Promise.resolve({ results: rowsForSql(sql) }),
+            };
+          },
+        };
+      },
+    },
+    METAGRAPH_CONTROL: {
+      async get(key) {
+        if (key === "health:meta") {
+          return lastRunAt ? { last_run_at: lastRunAt } : null;
+        }
+        return null;
+      },
+    },
+  };
+}
+
+// A minimal stand-in for the Workers `caches.default`: a Map keyed on the
+// Request URL, recording every put key and every match call (mirrors the
+// existing edge-cache test stub in worker-runtime.test.mjs).
+function mockCaches() {
+  const store = new Map();
+  const putKeys = [];
+  let matchCalls = 0;
+  return {
+    store,
+    putKeys,
+    get matchCalls() {
+      return matchCalls;
+    },
+    install() {
+      globalThis.caches = {
+        default: {
+          async match(request) {
+            matchCalls += 1;
+            const cached = store.get(request.url);
+            return cached ? cached.clone() : undefined;
+          },
+          async put(request, response) {
+            putKeys.push(request.url);
+            store.set(request.url, response.clone());
+          },
+        },
+      };
+    },
+  };
+}
+
+// Rebuild the exact cache key the worker computes, so the invariant assertions
+// don't hard-code a brittle literal and survive a contract-version bump.
+function expectedKey(keyParts, pathname, search = "") {
+  return `https://edge-cache.metagraph.sh/analytics/${encodeURIComponent(
+    CONTRACT_VERSION,
+  )}/${encodeURIComponent(LAST_RUN_AT)}/${keyParts}${pathname}${search}`;
+}
+
+const ctx = { waitUntil: (promise) => promise };
+
+let originalCaches;
+afterEach(() => {
+  globalThis.caches = originalCaches;
+});
+
+describe("analytics edge cache", () => {
+  test("INVARIANT: cache key includes contract_version + snapshot stamp + netuid + window", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+
+    // Per-subnet percentiles (netuid + window both vary the key).
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles?window=30d",
+      ),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(res.status, 200);
+    assert.deepEqual(cache.putKeys, [
+      expectedKey(
+        "percentiles",
+        "/api/v1/subnets/7/health/percentiles",
+        "?window=30d",
+      ),
+    ]);
+    const key = cache.putKeys[0];
+    assert.ok(key.includes(encodeURIComponent(CONTRACT_VERSION)), "contract");
+    assert.ok(key.includes(encodeURIComponent(LAST_RUN_AT)), "snapshot stamp");
+    assert.ok(key.includes("/subnets/7/"), "netuid");
+    assert.ok(key.includes("window=30d"), "window");
+  });
+
+  test("INVARIANT: a different window and a different netuid key separately", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+
+    for (const url of [
+      "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles?window=7d",
+      "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles?window=30d",
+      "https://api.metagraph.sh/api/v1/subnets/9/health/percentiles?window=7d",
+    ]) {
+      await handleRequest(new Request(url), env, ctx);
+      await Promise.resolve();
+    }
+    // Three distinct (netuid, window) combinations → three distinct entries.
+    assert.equal(cache.store.size, 3);
+    assert.equal(cache.putKeys.length, 3);
+    assert.equal(new Set(cache.putKeys).size, 3);
+  });
+
+  test("HIT: a pre-populated cache serves the cached body WITHOUT touching D1", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+    const url =
+      "https://api.metagraph.sh/api/v1/subnets/7/health/incidents?window=7d";
+
+    // First request is a MISS: it runs D1 and populates the cache.
+    const first = await handleRequest(new Request(url), env, ctx);
+    await Promise.resolve();
+    const firstBody = await first.text();
+    assert.equal(first.status, 200);
+    assert.ok(queries.length > 0, "the cold MISS must run the D1 aggregation");
+
+    // Second request is a HIT: served from cache, D1 untouched.
+    const queryCountAfterMiss = queries.length;
+    const second = await handleRequest(new Request(url), env, ctx);
+    assert.equal(second.status, 200);
+    assert.equal(
+      await second.text(),
+      firstBody,
+      "the cached body is byte-identical",
+    );
+    assert.equal(
+      queries.length,
+      queryCountAfterMiss,
+      "a cache HIT must not issue any D1 query",
+    );
+  });
+
+  test("HIT: a warm cache honours conditional requests with a 304", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+    const url = "https://api.metagraph.sh/api/v1/health/trends";
+
+    const first = await handleRequest(new Request(url), env, ctx);
+    await Promise.resolve();
+    const etag = first.headers.get("etag");
+    assert.equal(first.status, 200);
+    const queryCountAfterMiss = queries.length;
+
+    const conditional = await handleRequest(
+      new Request(url, { headers: { "if-none-match": etag } }),
+      env,
+      ctx,
+    );
+    assert.equal(conditional.status, 304);
+    assert.equal(await conditional.text(), "");
+    assert.equal(
+      queries.length,
+      queryCountAfterMiss,
+      "a 304 from the warm cache must not touch D1",
+    );
+  });
+
+  test("MISS: an empty cache runs D1 once and issues a cache.put via waitUntil", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+
+    let putAt = null;
+    const putCtx = {
+      waitUntil: (promise) => {
+        putAt = promise;
+        return promise;
+      },
+    };
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/health/trends"),
+      env,
+      putCtx,
+    );
+    assert.equal(res.status, 200);
+    assert.ok(putAt, "the MISS must schedule the cache write under waitUntil");
+    await putAt;
+    assert.deepEqual(cache.putKeys, [
+      expectedKey("bulk-trends", "/api/v1/health/trends"),
+    ]);
+    // The cached response is the success 200 (never a placeholder/error).
+    const cached = cache.store.get(cache.putKeys[0]);
+    assert.equal(cached.status, 200);
+  });
+
+  test("NO-CACHE-ON-ERROR: a 400 (bad window) is never cached", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles?window=bogus",
+      ),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(res.status, 400);
+    assert.equal(res.headers.get("x-metagraph-error-code"), "invalid_query");
+    assert.deepEqual(cache.putKeys, [], "a 400 must not be cached");
+    assert.equal(cache.store.size, 0);
+  });
+
+  test("NO-CACHE-ON-ERROR: a D1 failure still serves a 200 empty envelope but is not cached when the snapshot stamp is cold", async () => {
+    // When KV is cold (no last_run_at) the handler still returns a schema-stable
+    // 200, but the cache must be skipped entirely so a cold/empty payload can
+    // never seed a stale entry (mirrors the overlay cache's lastRunAt guard).
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries, { lastRunAt: null });
+
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/health/incidents?window=7d",
+      ),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(res.status, 200);
+    assert.deepEqual(
+      cache.putKeys,
+      [],
+      "a cold-snapshot response must not be cached",
+    );
+    assert.equal(
+      cache.matchCalls,
+      0,
+      "a cold snapshot skips the cache lookup entirely",
+    );
+  });
+
+  test("transparency: the cached body equals the uncached body for the same handler", async () => {
+    // Same request, once with the cache stubbed and once without — the served
+    // body must be byte-identical (the cache adds nothing to the payload).
+    originalCaches = globalThis.caches;
+    const url =
+      "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles?window=7d";
+
+    // Uncached: no globalThis.caches → withEdgeCache falls through to D1.
+    globalThis.caches = undefined;
+    const uncached = await handleRequest(
+      new Request(url),
+      analyticsEnv([]),
+      ctx,
+    );
+    const uncachedBody = await uncached.text();
+
+    // Cached MISS path.
+    const cache = mockCaches();
+    cache.install();
+    const cachedMiss = await handleRequest(
+      new Request(url),
+      analyticsEnv([]),
+      ctx,
+    );
+    const cachedBody = await cachedMiss.text();
+
+    assert.equal(cachedBody, uncachedBody);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -866,7 +866,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       resolved.url.pathname,
     );
     if (bulkTrendsMatch) {
-      return handleBulkHealthTrends(request, env, resolved.url);
+      return handleBulkHealthTrends(request, env, resolved.url, ctx);
     }
     const trendsMatch = TRENDS_PATH_PATTERN.exec(resolved.url.pathname);
     if (trendsMatch) {
@@ -875,6 +875,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         env,
         Number(trendsMatch[1]),
         resolved.url,
+        ctx,
       );
     }
     const percentilesMatch = PERCENTILES_PATH_PATTERN.exec(
@@ -886,6 +887,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         env,
         Number(percentilesMatch[1]),
         resolved.url,
+        ctx,
       );
     }
     const incidentsMatch = INCIDENTS_PATH_PATTERN.exec(resolved.url.pathname);
@@ -895,6 +897,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         env,
         Number(incidentsMatch[1]),
         resolved.url,
+        ctx,
       );
     }
     const trajectoryMatch = TRAJECTORY_PATH_PATTERN.exec(resolved.url.pathname);
@@ -1804,6 +1807,7 @@ async function handleBulkHealthTrends(
   request,
   env,
   url = new URL(request.url),
+  ctx = {},
 ) {
   for (const key of url.searchParams.keys()) {
     return errorResponse(
@@ -1814,14 +1818,15 @@ async function handleBulkHealthTrends(
     );
   }
 
-  const nowMs = Date.now();
-  const maxWindowDays = Math.max(...Object.values(HEALTH_TREND_WINDOWS));
-  const cutoffDay = new Date(nowMs - maxWindowDays * DAY_MS)
-    .toISOString()
-    .slice(0, 10);
-  const rows = await d1All(
-    env,
-    `SELECT netuid,
+  return withEdgeCache(request, ctx, env, "bulk-trends", async () => {
+    const nowMs = Date.now();
+    const maxWindowDays = Math.max(...Object.values(HEALTH_TREND_WINDOWS));
+    const cutoffDay = new Date(nowMs - maxWindowDays * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
+    const rows = await d1All(
+      env,
+      `SELECT netuid,
             day AS date,
             SUM(samples) AS total,
             SUM(ok_count) AS ok_count,
@@ -1831,65 +1836,67 @@ async function handleBulkHealthTrends(
      GROUP BY netuid, day
      ORDER BY netuid, day
      LIMIT ?`,
-    [cutoffDay, MAX_BULK_TREND_ROWS],
-  );
-  const windows = {};
-  for (const [label, days] of Object.entries(HEALTH_TREND_WINDOWS)) {
-    const windowCutoff = new Date(nowMs - days * DAY_MS)
-      .toISOString()
-      .slice(0, 10);
-    windows[label] = rows.filter(
-      (row) => String(row.day || row.date) >= windowCutoff,
+      [cutoffDay, MAX_BULK_TREND_ROWS],
     );
-  }
-  const meta = await readHealthMetaKv(env);
-  const data = formatBulkTrends({
-    observedAt: meta?.last_run_at || null,
-    windows,
-    windowDays: HEALTH_TREND_WINDOWS,
-  });
-  return envelopeResponse(
-    request,
-    {
-      data,
-      meta: {
-        artifact_path: "/metagraph/health/trends.json",
-        cache: "short",
-        contract_version: contractVersion(env),
-        generated_at: data.observed_at,
-        published_at: await publishedAt(env),
-        source: "live-cron-prober",
+    const windows = {};
+    for (const [label, days] of Object.entries(HEALTH_TREND_WINDOWS)) {
+      const windowCutoff = new Date(nowMs - days * DAY_MS)
+        .toISOString()
+        .slice(0, 10);
+      windows[label] = rows.filter(
+        (row) => String(row.day || row.date) >= windowCutoff,
+      );
+    }
+    const meta = await readHealthMetaKv(env);
+    const data = formatBulkTrends({
+      observedAt: meta?.last_run_at || null,
+      windows,
+      windowDays: HEALTH_TREND_WINDOWS,
+    });
+    return envelopeResponse(
+      request,
+      {
+        data,
+        meta: {
+          artifact_path: "/metagraph/health/trends.json",
+          cache: "short",
+          contract_version: contractVersion(env),
+          generated_at: data.observed_at,
+          published_at: await publishedAt(env),
+          source: "live-cron-prober",
+        },
       },
-    },
-    "short",
-  );
+      "short",
+    );
+  });
 }
 
 // D1-backed 7d/30d uptime + latency trends for one subnet's operational
 // surfaces. Returns a schema-stable empty payload when D1 is unbound/cold so it
 // never errors (mirrors the live-overlay fall-back philosophy).
-async function handleHealthTrends(request, env, netuid, url) {
+async function handleHealthTrends(request, env, netuid, url, ctx = {}) {
   // Reject unsupported query params (400) like every sibling analytics route
   // (percentiles/incidents/uptime/trajectory and the bulk trends route); this
   // route takes no params and returns all configured windows.
   const validationError = validateQueryParams(url, []);
   if (validationError) return analyticsQueryError(validationError);
-  const db = env.METAGRAPH_HEALTH_DB;
-  const nowMs = Date.now();
-  const windows = {};
-  // The per-window aggregations are independent — run them in parallel (one D1
-  // round-trip each) like handleHealthPercentiles/handleLeaderboards, rather than
-  // serializing the two with an await-in-loop.
-  const windowRows = await Promise.all(
-    Object.entries(HEALTH_TREND_WINDOWS).map(async ([label, days]) => {
-      if (!db?.prepare) {
-        return [label, []];
-      }
-      try {
-        const result = await withTimeout(
-          db
-            .prepare(
-              `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
+  return withEdgeCache(request, ctx, env, "trends", async () => {
+    const db = env.METAGRAPH_HEALTH_DB;
+    const nowMs = Date.now();
+    const windows = {};
+    // The per-window aggregations are independent — run them in parallel (one D1
+    // round-trip each) like handleHealthPercentiles/handleLeaderboards, rather than
+    // serializing the two with an await-in-loop.
+    const windowRows = await Promise.all(
+      Object.entries(HEALTH_TREND_WINDOWS).map(async ([label, days]) => {
+        if (!db?.prepare) {
+          return [label, []];
+        }
+        try {
+          const result = await withTimeout(
+            db
+              .prepare(
+                `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
              SELECT MAX(surface_id) AS surface_id,
                     surface_key,
                     COUNT(*) AS total,
@@ -1897,41 +1904,42 @@ async function handleHealthTrends(request, env, netuid, url) {
                     ${latencyStatColumns({ includeMinMax: false })}
              FROM ranked
              GROUP BY surface_key`,
-            )
-            .bind(netuid, nowMs - days * DAY_MS)
-            .all(),
-          d1TimeoutMs(env),
-        );
-        return [label, result?.results || []];
-      } catch {
-        return [label, []];
-      }
-    }),
-  );
-  for (const [label, rows] of windowRows) {
-    windows[label] = rows;
-  }
-  const meta = await readHealthMetaKv(env);
-  const data = formatTrends({
-    netuid,
-    observedAt: meta?.last_run_at || null,
-    windows,
-  });
-  return envelopeResponse(
-    request,
-    {
-      data,
-      meta: {
-        artifact_path: `/metagraph/health/trends/${netuid}.json`,
-        cache: "short",
-        contract_version: contractVersion(env),
-        generated_at: data.observed_at,
-        published_at: await publishedAt(env),
-        source: "live-cron-prober",
+              )
+              .bind(netuid, nowMs - days * DAY_MS)
+              .all(),
+            d1TimeoutMs(env),
+          );
+          return [label, result?.results || []];
+        } catch {
+          return [label, []];
+        }
+      }),
+    );
+    for (const [label, rows] of windowRows) {
+      windows[label] = rows;
+    }
+    const meta = await readHealthMetaKv(env);
+    const data = formatTrends({
+      netuid,
+      observedAt: meta?.last_run_at || null,
+      windows,
+    });
+    return envelopeResponse(
+      request,
+      {
+        data,
+        meta: {
+          artifact_path: `/metagraph/health/trends/${netuid}.json`,
+          cache: "short",
+          contract_version: contractVersion(env),
+          generated_at: data.observed_at,
+          published_at: await publishedAt(env),
+          source: "live-cron-prober",
+        },
       },
-    },
-    "short",
-  );
+      "short",
+    );
+  });
 }
 
 function validateQueryParams(url, allowedParams) {
@@ -2008,65 +2016,116 @@ async function analyticsMeta(env, artifactPath, observedAt) {
   };
 }
 
+// Edge-cache wrapper for the D1-backed analytics routes (audit #6). Each of these
+// re-runs a full-window D1 aggregation on EVERY request, yet the result only
+// changes when the health cron writes a new snapshot — so a cross-colo / agent-
+// polling burst re-executes the same 7d/30d aggregation needlessly. Mirrors the
+// live-overlay collection cache exactly (the CACHEABLE_OVERLAY_ROUTE_IDS path):
+// same Cache API, same `edge-cache.metagraph.sh` key host, same last_run_at
+// keying, same conditional-GET 304 short-circuit, same ctx.waitUntil put.
+//
+// The key varies on everything that changes the body: contract_version (a deploy
+// can never serve a cross-version payload) + the cron snapshot stamp
+// (`last_run_at`) + the request path (carries netuid) + the canonical search
+// (carries `window`). `keyParts` is the extra namespace segment per route. When
+// the snapshot stamp is cold (null), caching is skipped entirely so a cold-KV
+// empty payload can never seed a stale entry — identical to the overlay cache's
+// `if (lastRunAt)` guard. The cache is transparent: body/shape/headers are
+// whatever buildResponse() produced; only 200s are cached, never errors.
+async function withEdgeCache(request, ctx, env, keyParts, buildResponse) {
+  const cache = request.method === "GET" ? globalThis.caches?.default : null;
+  // Cheap, per-isolate-memoized read of just the snapshot time. On a hit this +
+  // the cache match is the whole request (no D1 aggregation at all).
+  const lastRunAt = cache ? (await readHealthMetaKv(env))?.last_run_at : null;
+  let cacheKey = null;
+  if (cache && lastRunAt) {
+    const url = new URL(request.url);
+    cacheKey = new Request(
+      `https://edge-cache.metagraph.sh/analytics/${encodeURIComponent(
+        contractVersion(env),
+      )}/${encodeURIComponent(lastRunAt)}/${keyParts}${url.pathname}${url.search}`,
+    );
+    const hit = await cache.match(cacheKey);
+    if (hit) {
+      // Honour conditional requests against the cached body's weak ETag so
+      // polling agents still get a 304 on a warm cache (mirrors envelopeResponse).
+      if (ifNoneMatchSatisfied(request, hit.headers.get("etag"))) {
+        return new Response(null, { status: 304, headers: hit.headers });
+      }
+      return hit;
+    }
+  }
+  const response = await buildResponse();
+  // Never cache errors / non-200s (cold-D1 still returns a 200 empty envelope;
+  // a 400 bad-window or 5xx must not be persisted).
+  if (cacheKey && response.status === 200) {
+    ctx?.waitUntil?.(cache.put(cacheKey, response.clone()));
+  }
+  return response;
+}
+
 // p50/p95/p99 latency percentiles per surface, computed in D1.
-async function handleHealthPercentiles(request, env, netuid, url) {
+async function handleHealthPercentiles(request, env, netuid, url, ctx = {}) {
   const { label, days, error } = analyticsWindow(url);
   if (error) return analyticsQueryError(error);
-  const rows = await d1All(
-    env,
-    `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
+  return withEdgeCache(request, ctx, env, "percentiles", async () => {
+    const rows = await d1All(
+      env,
+      `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
      SELECT MAX(surface_id) AS surface_id,
             surface_key,
             ${latencyStatColumns()}
      FROM ranked
      GROUP BY surface_key
      HAVING MAX(lat_cnt) > 0`,
-    [netuid, Date.now() - days * DAY_MS],
-  );
-  const meta = await readHealthMetaKv(env);
-  const data = formatPercentiles({
-    netuid,
-    window: label,
-    observedAt: meta?.last_run_at || null,
-    rows,
+      [netuid, Date.now() - days * DAY_MS],
+    );
+    const meta = await readHealthMetaKv(env);
+    const data = formatPercentiles({
+      netuid,
+      window: label,
+      observedAt: meta?.last_run_at || null,
+      rows,
+    });
+    return envelopeResponse(
+      request,
+      {
+        data,
+        meta: await analyticsMeta(
+          env,
+          `/metagraph/health/percentiles/${netuid}.json`,
+          data.observed_at,
+        ),
+      },
+      "short",
+    );
   });
-  return envelopeResponse(
-    request,
-    {
-      data,
-      meta: await analyticsMeta(
-        env,
-        `/metagraph/health/percentiles/${netuid}.json`,
-        data.observed_at,
-      ),
-    },
-    "short",
-  );
 }
 
 // SLA + reconstructed downtime incidents per surface.
-async function handleHealthIncidents(request, env, netuid, url) {
+async function handleHealthIncidents(request, env, netuid, url, ctx = {}) {
   const { label, days, error } = analyticsWindow(url);
   if (error) return analyticsQueryError(error);
-  const since = Date.now() - days * DAY_MS;
-  const [slaRows, incidentRows] = await Promise.all([
-    d1All(
-      env,
-      `SELECT MAX(surface_id) AS surface_id,
+  return withEdgeCache(request, ctx, env, "incidents", async () => {
+    const since = Date.now() - days * DAY_MS;
+    const [slaRows, incidentRows] = await Promise.all([
+      d1All(
+        env,
+        `SELECT MAX(surface_id) AS surface_id,
               COALESCE(surface_key, surface_id) AS surface_key,
               COUNT(*) AS total,
               SUM(ok) AS ok_count
        FROM surface_checks
        WHERE netuid = ? AND checked_at >= ?
        GROUP BY COALESCE(surface_key, surface_id)`,
-      [netuid, since],
-    ),
-    // Gap-island grouping in SQL: collapse consecutive failures (gap <= the
-    // incident threshold) into one incident row, then cap the public payload so
-    // flapping endpoints cannot force unbounded result sets/responses.
-    d1All(
-      env,
-      `WITH checks AS (
+        [netuid, since],
+      ),
+      // Gap-island grouping in SQL: collapse consecutive failures (gap <= the
+      // incident threshold) into one incident row, then cap the public payload so
+      // flapping endpoints cannot force unbounded result sets/responses.
+      d1All(
+        env,
+        `WITH checks AS (
          SELECT COALESCE(surface_key, surface_id) AS surface_key,
                 surface_id,
                 checked_at,
@@ -2096,30 +2155,37 @@ async function handleHealthIncidents(request, env, netuid, url) {
        HAVING COUNT(*) >= ?
        ORDER BY surface_id, started_at
        LIMIT ?`,
-      [netuid, since, INCIDENT_GAP_MS, MIN_INCIDENT_SAMPLES, MAX_INCIDENT_ROWS],
-    ),
-  ]);
-  const meta = await readHealthMetaKv(env);
-  const data = formatIncidents({
-    netuid,
-    window: label,
-    observedAt: meta?.last_run_at || null,
-    slaRows,
-    incidentRows,
-    maxIncidents: MAX_INCIDENT_ROWS,
-  });
-  return envelopeResponse(
-    request,
-    {
-      data,
-      meta: await analyticsMeta(
-        env,
-        `/metagraph/health/incidents/${netuid}.json`,
-        data.observed_at,
+        [
+          netuid,
+          since,
+          INCIDENT_GAP_MS,
+          MIN_INCIDENT_SAMPLES,
+          MAX_INCIDENT_ROWS,
+        ],
       ),
-    },
-    "short",
-  );
+    ]);
+    const meta = await readHealthMetaKv(env);
+    const data = formatIncidents({
+      netuid,
+      window: label,
+      observedAt: meta?.last_run_at || null,
+      slaRows,
+      incidentRows,
+      maxIncidents: MAX_INCIDENT_ROWS,
+    });
+    return envelopeResponse(
+      request,
+      {
+        data,
+        meta: await analyticsMeta(
+          env,
+          `/metagraph/health/incidents/${netuid}.json`,
+          data.observed_at,
+        ),
+      },
+      "short",
+    );
+  });
 }
 
 // Global, cross-subnet incident ledger — the same gap-island grouping as the


### PR DESCRIPTION
Audit finding #6 (high) — top backend scaling risk. The health trends/percentiles/incidents + bulk-trends handlers re-ran full-window D1 aggregations on **every** request with no edge cache. Added `withEdgeCache()` mirroring the existing live-overlay cache: GET+200 only, key = contract_version + cron snapshot stamp + netuid + window, serve from `caches.default` on hit (incl. 304), else D1 + `ctx.waitUntil(put)`. Skips caching on cold stamp + errors; response shape unchanged (transparent). 8 tests + full suite (1531) + contract-drift + dry-run green.