### PR TITLE
fix(scheduled): drain staged R2 only on the */3 cron — no cross-cron clobber

### DIFF
--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -15,6 +15,11 @@ import {
   workerWebSocketConnector,
 } from "../src/health-prober.mjs";
 import { handleScheduled } from "../workers/api.mjs";
+import {
+  EMBEDDING_SYNC_CRON,
+  EVENTS_LOAD_CRON,
+  HEALTH_PRUNE_CRON,
+} from "../workers/config.mjs";
 
 describe("workerResolvedUrlSafetyGuard (DNS-aware SSRF)", () => {
   // DoH JSON mock: maps host → { A: [...], AAAA: [...] }.
@@ -565,6 +570,75 @@ describe("handleScheduled dispatch", () => {
     const probeResult = await handleScheduled({ cron: "*/2 * * * *" }, {});
     assert.equal(probeResult.ok, false);
     assert.equal(probeResult.reason, "no-operational-surfaces");
+  });
+
+  test("non-fast-load crons never drain the staged R2 files (audit #9)", async () => {
+    // INVARIANT: only the EVENTS_LOAD_CRON tick owns the unlocked staged
+    // read-modify-write drain. Every other cron (prune/embedding/prober) must NOT
+    // call loadStagedNeurons / loadStagedEvents — running them on concurrent ticks
+    // let one invocation clobber a freshly-staged file via the delete path. We prove
+    // it by tracking R2 .get keys and asserting the two staged keys are never read.
+    const STAGED_KEYS = [
+      "metagraph/neurons-pending.json",
+      "events/account-events-pending.json",
+    ];
+    for (const cron of [
+      HEALTH_PRUNE_CRON,
+      EMBEDDING_SYNC_CRON,
+      "*/15 * * * *", // the prober tick (any cron that is not EVENTS_LOAD_CRON)
+    ]) {
+      const getKeys = [];
+      const env = {
+        METAGRAPH_HEALTH_DB: makeDb(),
+        // A tracking bucket: any staged-key read would push it here. Incidental,
+        // non-staged reads (e.g. the prober's surface fallback) are allowed and
+        // return null so the path stays a clean no-op.
+        METAGRAPH_ARCHIVE: {
+          async get(key) {
+            getKeys.push(key);
+            return null;
+          },
+        },
+        // A signing key is REQUIRED for loadStagedNeurons to even reach its
+        // bucket.get — present here so the guard can't mask a regression where the
+        // loader is wrongly invoked on this tick.
+        METAGRAPH_STAGING_SIGNING_KEY: "test-secret",
+      };
+      await handleScheduled({ cron }, env, {});
+      for (const stagedKey of STAGED_KEYS) {
+        assert.ok(
+          !getKeys.includes(stagedKey),
+          `cron ${cron} must not read staged key ${stagedKey}`,
+        );
+      }
+    }
+  });
+
+  test("fast-load cron drains BOTH staged files then returns the marker (audit #9)", async () => {
+    // REGRESSION: the EVENTS_LOAD_CRON tick must still run both loaders (one R2 .get
+    // per staged key) AND early-return the fast-load marker without falling through
+    // to the prober/prune.
+    const getKeys = [];
+    const env = {
+      METAGRAPH_HEALTH_DB: makeDb(),
+      METAGRAPH_ARCHIVE: {
+        async get(key) {
+          getKeys.push(key);
+          return null; // nothing staged → each loader no-ops after its read
+        },
+      },
+      METAGRAPH_STAGING_SIGNING_KEY: "test-secret",
+    };
+    const result = await handleScheduled({ cron: EVENTS_LOAD_CRON }, env, {});
+    assert.deepEqual(result, { ok: true, fast_load: true });
+    assert.ok(
+      getKeys.includes("metagraph/neurons-pending.json"),
+      "loadStagedNeurons read its staged key on the fast-load tick",
+    );
+    assert.ok(
+      getKeys.includes("events/account-events-pending.json"),
+      "loadStagedEvents read its staged key on the fast-load tick",
+    );
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -631,18 +631,24 @@ export async function handleEventIngest(request, env) {
 
 export async function handleScheduled(controller, env = {}, ctx = {}) {
   const cron = controller?.cron || "";
-  // Token-free per-UID metagraph load (#1303): pick up any R2-staged neuron
-  // snapshot and load it via the D1 binding on whichever cron fires next; it then
-  // self-deletes. Isolated so a load failure never affects the prober/prune below.
-  await loadStagedNeurons(env).catch(() => {});
-  // Token-free chain-event load (#1346): pick up any R2-staged event batch from
-  // the first-party poller and load it via the binding. Isolated like the neuron
-  // load so a failure never affects the prober/prune below.
-  await loadStagedEvents(env).catch(() => {});
-  // Fast-load cron (#1346 Option A): its whole job is to drain staged batches into
-  // D1 quickly (above) — return without running the heavier probe/prune so we can
-  // tick every ~3 min cheaply and keep chain-event latency at ~5 min.
+  // Fast-load cron (#1346 Option A): its whole job is to drain the R2-staged
+  // batches into D1 quickly, then return without running the heavier probe/prune so
+  // it can tick every ~3 min cheaply and keep chain-event latency at ~5 min.
+  //
+  // The drain is gated to THIS cron alone (audit #9). The four cron triggers fire as
+  // separate concurrent invocations whose minutes coincide (e.g. 0/15/30/45), and
+  // each staged load is an unlocked R2 read-modify-write (read → load → delete /
+  // rewrite). Running the loaders on every tick let a concurrent invocation clobber a
+  // freshly-staged file via the delete path; owning the drain on a single cron removes
+  // the cross-cron concurrency entirely. Each loader stays isolated (`.catch`) so a
+  // load failure never affects the early-return below.
   if (cron === EVENTS_LOAD_CRON) {
+    // Token-free per-UID metagraph load (#1303): pick up any R2-staged neuron
+    // snapshot and load it via the D1 binding; it then self-deletes.
+    await loadStagedNeurons(env).catch(() => {});
+    // Token-free chain-event load (#1346): pick up any R2-staged event batch from
+    // the first-party poller and load it via the binding.
+    await loadStagedEvents(env).catch(() => {});
     return { ok: true, fast_load: true };
   }
   if (cron === HEALTH_PRUNE_CRON) {


### PR DESCRIPTION
Audit finding #9 (high). `loadStagedNeurons` + `loadStagedEvents` ran at the top of `handleScheduled` on **every** cron tick. The 4 cron triggers fire as separate concurrent invocations at minutes 0/15/30/45, each doing an **unlocked R2 read-modify-write** (read → load → DELETE/rewrite) — a concurrent tick can clobber a freshly-staged batch via the delete path. Moved both loaders inside the `EVENTS_LOAD_CRON` (*/3) branch so a single cron owns the drain; prober/prune/embedding ticks no longer touch the staged files. **Tests:** invariant (non-*/3 ticks never read the staged keys) + regression (*/3 drains both + returns fast-load). Full suite 1533 + dry-run green.