### PR TITLE
fix(security): rate-limit GraphQL, drop spoofable XFF, auth webhook before validate

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -10,6 +10,7 @@
 // Artifact/KV reads are injected (`deps.readArtifact`, `deps.readHealthKv`) so
 // this module is pure and unit-testable, and so it reuses the exact same
 // R2/ASSETS resolution the REST routes use.
+import { resolveClientIp } from "../workers/config.mjs";
 import { PRIMARY_DOMAIN } from "./contracts.mjs";
 import { generateServiceSnippets } from "./integration-snippets.mjs";
 import {
@@ -2203,11 +2204,7 @@ function jsonResponse(payload, status = 200, headers = {}) {
 }
 
 function mcpClientKey(request) {
-  return (
-    request.headers.get("cf-connecting-ip") ||
-    request.headers.get("x-forwarded-for") ||
-    "anonymous"
-  );
+  return resolveClientIp(request);
 }
 
 async function enforceMcpRateLimit(request, env) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -11,6 +11,7 @@ import {
   maxDepthRule,
 } from "../src/graphql.mjs";
 import { handleRequest } from "../workers/api.mjs";
+import { resolveClientIp } from "../workers/config.mjs";
 
 // Minimal fake env — no R2 or ASSETS, so readArtifact always returns ok:false.
 const emptyEnv = {};
@@ -529,5 +530,108 @@ describe("handleGraphQLRequest — coverage edge cases", () => {
     );
     assert.equal(status, 200);
     assert.deepEqual(body.data.provider.netuids, [1, 7]);
+  });
+});
+
+// Security hardening (#1: GraphQL must run through the rate limiter). GraphQL is
+// POST-only and fans out into artifact reads, so it shares the strict RPC
+// limiter binding. A counting limiter that allows the first N keyed hits and
+// denies the rest models the Cloudflare binding closely enough to prove the
+// gate fires on /api/v1/graphql.
+function countingRateLimiterEnv(limit, extra = {}) {
+  const counts = new Map();
+  return {
+    ...extra,
+    RPC_RATE_LIMITER: {
+      limit({ key }) {
+        const next = (counts.get(key) || 0) + 1;
+        counts.set(key, next);
+        return Promise.resolve({ success: next <= limit });
+      },
+    },
+  };
+}
+
+const gqlPost = (env, headers = {}) =>
+  handleRequest(
+    new Request("https://api.metagraph.sh/api/v1/graphql", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify({ query: "{ __typename }" }),
+    }),
+    env,
+    {},
+  );
+
+describe("handleRequest — GraphQL rate limiting (#security)", () => {
+  test("N requests within the window pass, the N+1 returns 429", async () => {
+    const N = 3;
+    const env = countingRateLimiterEnv(N);
+    // The first N requests are under the limit and reach the handler (200).
+    for (let i = 0; i < N; i += 1) {
+      const res = await gqlPost(env);
+      assert.equal(res.status, 200, `request ${i + 1} should pass`);
+    }
+    // The N+1th request is over the limit -> 429 from the GraphQL gate.
+    const limited = await gqlPost(env);
+    assert.equal(limited.status, 429);
+    const body = await limited.json();
+    assert.equal(body.error.code, "graphql_rate_limited");
+    assert.equal(limited.headers.get("retry-after"), "60");
+    assert.equal(limited.headers.get("x-ratelimit-remaining"), "0");
+  });
+
+  test("no limiter binding (local/CI) lets GraphQL through", async () => {
+    // emptyEnv has no RPC_RATE_LIMITER; the gate must no-op, not 429.
+    const res = await gqlPost(emptyEnv);
+    assert.equal(res.status, 200);
+  });
+});
+
+describe("client IP resolution — x-forwarded-for is not trusted (#security)", () => {
+  test("resolveClientIp ignores x-forwarded-for, uses cf-connecting-ip only", () => {
+    const sameCf = (xff) =>
+      resolveClientIp(
+        new Request("https://api.metagraph.sh/api/v1/graphql", {
+          method: "POST",
+          headers: {
+            "cf-connecting-ip": "203.0.113.7",
+            "x-forwarded-for": xff,
+          },
+        }),
+      );
+    // Two forged XFF values, same trusted cf-connecting-ip -> identical key.
+    assert.equal(sameCf("1.1.1.1"), sameCf("9.9.9.9"));
+    assert.equal(sameCf("1.1.1.1"), "203.0.113.7");
+  });
+
+  test("absent cf-connecting-ip falls back to a fixed bucket, not the XFF header", () => {
+    const key = resolveClientIp(
+      new Request("https://api.metagraph.sh/api/v1/graphql", {
+        method: "POST",
+        headers: { "x-forwarded-for": "attacker-controlled" },
+      }),
+    );
+    assert.equal(key, "anonymous");
+    assert.notEqual(key, "attacker-controlled");
+  });
+
+  test("two forged x-forwarded-for share ONE rate-limit bucket (2nd is limited)", async () => {
+    // limit=1: the first request from cf-connecting-ip 203.0.113.7 passes; a
+    // second request with the SAME cf-connecting-ip but a DIFFERENT forged
+    // x-forwarded-for must be counted in the same bucket -> 429. If the forged
+    // header were honored it would mint a fresh bucket and wrongly pass.
+    const env = countingRateLimiterEnv(1);
+    const first = await gqlPost(env, {
+      "cf-connecting-ip": "203.0.113.7",
+      "x-forwarded-for": "10.0.0.1",
+    });
+    assert.equal(first.status, 200);
+    const second = await gqlPost(env, {
+      "cf-connecting-ip": "203.0.113.7",
+      "x-forwarded-for": "10.0.0.2",
+    });
+    assert.equal(second.status, 429);
+    assert.equal((await second.json()).error.code, "graphql_rate_limited");
   });
 });

--- a/tests/webhooks-worker.test.mjs
+++ b/tests/webhooks-worker.test.mjs
@@ -111,6 +111,64 @@ describe("webhook subscription routes", () => {
     assert.equal((await res.json()).error.code, "unauthorized");
   });
 
+  // Security hardening (#3: authenticate BEFORE touching the untrusted payload).
+  // A request with a bad/missing token AND a malformed body must fail with the
+  // AUTH error (401), not the body-validation error (400). A 400 here would mean
+  // the worker parsed/validated attacker input before checking auth.
+  test("auth runs first: bad token + malformed body returns 401, not a 400 body error", async () => {
+    const kv = makeKv();
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-metagraph-webhook-subscription-token": "wrong-token",
+        },
+        body: "{not even json",
+      }),
+      envWith(kv),
+      {},
+    );
+    assert.equal(res.status, 401);
+    assert.equal((await res.json()).error.code, "unauthorized");
+    // Nothing should have been persisted for an unauthenticated caller.
+    assert.equal(kv.store.size, 0);
+  });
+
+  test("missing token + malformed body still returns 401 (no body parsing leaked)", async () => {
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "}{ broken",
+      }),
+      envWith(makeKv()),
+      {},
+    );
+    assert.equal(res.status, 401);
+    assert.equal((await res.json()).error.code, "unauthorized");
+  });
+
+  // The reorder must NOT break the authenticated body path: a VALID token with a
+  // malformed body still surfaces the JSON error, and a valid token + valid body
+  // still processes (covered by the create test above).
+  test("valid token + malformed body still returns the 400 body error", async () => {
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-metagraph-webhook-subscription-token": SUBSCRIPTION_TOKEN,
+        },
+        body: "{not json",
+      }),
+      envWith(makeKv()),
+      {},
+    );
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "invalid_json");
+  });
+
   test("disables subscription creation when the subscription token is unconfigured", async () => {
     const kv = makeKv();
     const res = await handleRequest(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -149,6 +149,7 @@ import {
   MAX_WEBHOOK_BODY_BYTES,
   PERCENTILES_PATH_PATTERN,
   RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN,
+  resolveClientIp,
   RPC_USAGE_BUCKETS,
   SAFE_RPC_METHODS,
   SUBNET_METAGRAPH_PATH_PATTERN,
@@ -741,7 +742,11 @@ export async function handleRequest(request, env = {}, ctx = {}) {
 
   // GraphQL read-only query layer over existing artifacts (issue #751). Runs
   // before the read-only method gate because GraphQL accepts POST requests.
+  // Rate-limited up front (same binding/strategy/429 as the RPC proxy) so a
+  // single client can't fan out into unbounded artifact reads + query execution.
   if (url.pathname === "/api/v1/graphql") {
+    const limited = await graphqlRateLimited(request, env);
+    if (limited) return limited;
     return handleGraphQLRequest(request, env);
   }
 
@@ -2887,10 +2892,7 @@ async function verifyMeta(env) {
 // confirm "callable right now" before wiring.
 async function handleSurfaceVerify(request, env, surfaceId, ctx = {}) {
   if (env.RPC_RATE_LIMITER?.limit) {
-    const clientKey =
-      request.headers.get("cf-connecting-ip") ||
-      request.headers.get("x-forwarded-for") ||
-      "anonymous";
+    const clientKey = resolveClientIp(request);
     const { success } = await env.RPC_RATE_LIMITER.limit({ key: clientKey });
     if (!success) {
       return errorResponse(
@@ -2999,10 +3001,7 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
   // (local dev / not yet provisioned) so tests and local runs are unaffected;
   // enforced on Cloudflare where the binding is bound.
   if (env.RPC_RATE_LIMITER?.limit) {
-    const clientKey =
-      request.headers.get("cf-connecting-ip") ||
-      request.headers.get("x-forwarded-for") ||
-      "anonymous";
+    const clientKey = resolveClientIp(request);
     const { success } = await env.RPC_RATE_LIMITER.limit({ key: clientKey });
     if (!success) {
       return errorResponse(
@@ -3427,6 +3426,34 @@ function setRpcRateLimitHeaders(headers) {
   );
 }
 
+// Per-client abuse control for the GraphQL endpoint. GraphQL is POST-only and
+// runs before the read-only method gate, so — unlike the GET REST routes that
+// the edge can cache — every call hits the worker and fans out into one or more
+// artifact reads + query execution. That makes it at least as expensive as the
+// RPC proxy, so it shares the SAME strict limiter binding, bucket strategy
+// (cf-connecting-ip only; see resolveClientIp), policy, and 429 shape. Skipped
+// only when the binding is absent (local dev / CI), matching the RPC/MCP paths.
+// Returns a 429 Response when the caller is over the limit, else null.
+async function graphqlRateLimited(request, env) {
+  if (!env.RPC_RATE_LIMITER?.limit) return null;
+  const { success } = await env.RPC_RATE_LIMITER.limit({
+    key: resolveClientIp(request),
+  });
+  if (success) return null;
+  return errorResponse(
+    "graphql_rate_limited",
+    "Too many GraphQL requests from this client; slow down.",
+    429,
+    {},
+    {
+      "retry-after": String(RPC_RATE_LIMIT.windowSeconds),
+      "x-ratelimit-limit": String(RPC_RATE_LIMIT.limit),
+      "x-ratelimit-policy": `${RPC_RATE_LIMIT.limit};w=${RPC_RATE_LIMIT.windowSeconds}`,
+      "x-ratelimit-remaining": "0",
+    },
+  );
+}
+
 // Try each ordered endpoint in turn; return the first success / non-transient
 // response, and a clean 502 only when every attempt is a transient failure.
 // Transient HTTP statuses are classified before reading bodies, and JSON-RPC
@@ -3743,6 +3770,17 @@ async function handleWebhookRequest(request, env, url) {
 }
 
 async function createWebhookSubscription(request, env) {
+  // Authenticate BEFORE touching the request body. An unauthenticated or
+  // wrong-token caller must be rejected (503 when disabled, else 401) before we
+  // read, JSON-parse, or validate any attacker-controlled payload — this avoids
+  // doing parsing/validation work for unauthenticated callers and avoids leaking
+  // body-validation behavior (which error fires for which input) to them. The
+  // token compare itself is constant-time (see validateWebhookSubscriptionToken).
+  const authorized = validateWebhookSubscriptionToken(request, env);
+  if (!authorized.ok) {
+    return authorized.response;
+  }
+
   if (
     Number(request.headers.get("content-length") || 0) > MAX_WEBHOOK_BODY_BYTES
   ) {
@@ -3774,11 +3812,6 @@ async function createWebhookSubscription(request, env) {
   const validated = validateSubscriptionInput(body);
   if (!validated.ok) {
     return errorResponse("invalid_subscription", validated.error, 400);
-  }
-
-  const authorized = validateWebhookSubscriptionToken(request, env);
-  if (!authorized.ok) {
-    return authorized.response;
   }
 
   const id = generateSubscriptionId();
@@ -3984,11 +4017,7 @@ function aiRateLimitedResponse() {
 }
 
 function aiClientKey(request, scope) {
-  const ip =
-    request.headers.get("cf-connecting-ip") ||
-    request.headers.get("x-forwarded-for") ||
-    "anon";
-  return `${scope}:${ip}`;
+  return `${scope}:${resolveClientIp(request)}`;
 }
 
 async function readBoundedRequestText(request, maxBytes) {

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -67,6 +67,22 @@ export const DAY_MS = 24 * 60 * 60 * 1000;
 
 export const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
 
+// Fixed bucket used as the rate-limit key (and request-scoped client id) when no
+// trustworthy client IP is available.
+export const ANONYMOUS_CLIENT_KEY = "anonymous";
+
+// Resolve the client IP for rate-limiting / per-client keys. On Cloudflare,
+// `CF-Connecting-IP` is set by the edge and cannot be spoofed by the client.
+// `X-Forwarded-For` is fully client-controlled and MUST NOT be trusted here: an
+// attacker could rotate it to mint a fresh rate-limit bucket per request and
+// evade the limiter. So we read `cf-connecting-ip` ONLY; when it is absent
+// (non-CF / local / the test harness) we collapse to a single fixed bucket
+// rather than honoring any client-supplied header. A shared fixed bucket is the
+// safe failure mode — worst case all such callers share one limit.
+export function resolveClientIp(request) {
+  return request.headers.get("cf-connecting-ip") || ANONYMOUS_CLIENT_KEY;
+}
+
 // Read-only, bounded Substrate/Subtensor methods safe to expose through the
 // public proxy. Deliberately excludes heavy/abusable reads (state_getMetadata,
 // state_getStorage) and anything mutating — those stay blocked by the allowlist


### PR DESCRIPTION
Three audit-confirmed hardening fixes (all verified real before fixing):
1. **GraphQL bypassed rate limiting** — `/api/v1/graphql` had depth/complexity caps but no per-client rate limit (REST/RPC/AI/MCP all have one). Wired through the same `RPC_RATE_LIMITER` (strictest bucket) before the handler.
2. **Spoofable `x-forwarded-for` for client IP** — 4 sites resolved `cf-connecting-ip || x-forwarded-for || fixed`. XFF is client-controlled → rotate it to mint a fresh rate-limit bucket per request. Added `resolveClientIp()` (cf-connecting-ip only, else a fixed `anonymous` bucket — never a client header).
3. **Webhook auth-after-validate** — subscription-create parsed/validated the body before the bearer-token check. Moved auth to the top.

**Tests (+9):** GraphQL 429-after-N; forged-XFF-shares-one-bucket + absent-cf-ip→fixed-bucket; webhook bad-token+malformed-body → 401 not 400 (KV untouched). Full suite 1541 + dry-run + contract-drift green.