### PR TITLE
fix(health): count degraded RPC probes toward eviction

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -434,14 +434,18 @@ export async function runHealthProber(env, ctx, overrides = {}) {
     const stableLookupKey = surface.surface_key || surface.surface_id;
     const prior = priorStatus.get(stableLookupKey);
     const lastOkMs = ok ? runAt : (prior?.last_ok ?? null);
-    // Only a hard `failed` run feeds the sustained-down breaker. The counter is
-    // "consecutive FAILED prober runs" (see overlayRpcPoolEligibility), so a
-    // `degraded` run (rate-limited / auth-required / transient / timeout) is a
-    // soft signal — not an outage — and must reset the streak like `ok` rather
-    // than accrue toward pool eviction. Hard outages still hit the threshold,
-    // and the per-request circuit breaker + wrong-chain hard-fail cover the rest.
-    const consecutiveFailures =
-      base.status === "failed" ? (prior?.consecutive_failures ?? 0) + 1 : 0;
+    // The sustained-down breaker protects the public RPC pool from repeatedly
+    // routing to unusable endpoints. For RPC surfaces, any non-ok prober run
+    // counts toward that eviction threshold because `degraded` includes
+    // auth-required, rate-limited, transient, and timeout outcomes that are not
+    // necessarily usable by the proxy. Non-RPC degraded runs remain soft signals
+    // and reset the hard-failure streak.
+    const countsTowardBreaker =
+      base.status === "failed" ||
+      (surface.kind === "subtensor-rpc" && base.status !== "ok");
+    const consecutiveFailures = countsTowardBreaker
+      ? (prior?.consecutive_failures ?? 0) + 1
+      : 0;
     return {
       surface_id: surface.surface_id,
       // #1005: stable key re-keyed onto D1 history; null for pre-#1005 artifacts.

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -446,7 +446,7 @@ describe("runHealthProber", () => {
     assert.equal(apiUpsert.binds[12], 3);
   });
 
-  test("a degraded run resets the breaker (only FAILED runs accrue)", async () => {
+  test("a degraded non-RPC run resets the breaker", async () => {
     const db = makeDb({
       priorStatus: [
         {
@@ -491,6 +491,51 @@ describe("runHealthProber", () => {
     // resets to 0 so a persistently-degraded (still-usable) endpoint is not
     // evicted from the RPC pool by the sustained-down breaker.
     assert.equal(apiUpsert.binds[12], 0);
+  });
+
+  test("a degraded RPC run accrues toward pool eviction", async () => {
+    const db = makeDb({
+      priorStatus: [
+        {
+          surface_id: "opentensor-finney-rpc",
+          surface_key: "srf-rootrpckey00000",
+          last_ok: 1000,
+          consecutive_failures: 2,
+        },
+      ],
+    });
+    const degradedRpcProbe = async (input) =>
+      input.kind === "subtensor-rpc"
+        ? {
+            status: "degraded",
+            classification: "auth-required",
+            latency_ms: null,
+            status_code: 401,
+          }
+        : {
+            status: "ok",
+            classification: "live",
+            latency_ms: 42,
+            status_code: 200,
+          };
+
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 50000,
+        db,
+        kv: makeKv(),
+        loadSurfaces: async () => SURFACES,
+        probeSurface: degradedRpcProbe,
+        probeOptions: {},
+      },
+    );
+
+    const rpcUpsert = db.calls.batches[0]
+      .filter((s) => /INSERT INTO surface_status/.test(s.sql))
+      .find((s) => s.binds[0] === "opentensor-finney-rpc");
+    assert.equal(rpcUpsert.binds[12], 3);
   });
 
   test("no-ops cleanly when there are no operational surfaces", async () => {


### PR DESCRIPTION
### Motivation
- Fix an availability regression where sustained unusable RPC endpoints (e.g. `auth-required`/401, `rate-limited`, timeouts) never reached the pool eviction threshold because `degraded` probes reset the `consecutive_failures` counter.
- Ensure the public RPC proxy pool’s sustained-down breaker continues to protect clients from repeatedly routing to unusable upstreams while preserving soft-degraded behavior for non-RPC surfaces.

### Description
- Update `src/health-prober.mjs` to increment `consecutive_failures` for RPC surfaces (`surface.kind === "subtensor-rpc"`) on any non-`ok` probe while keeping non-RPC degraded runs as a reset; implemented via a `countsTowardBreaker` predicate.
- Preserve the previous semantics that only hard `failed` runs count for non-RPC surfaces by resetting the streak to `0` when appropriate.
- Rename the existing degraded-probe test to clarify non-RPC behavior and add a new regression test in `tests/health-prober.test.mjs` asserting that a degraded RPC run (e.g. `auth-required`/401) increases `consecutive_failures` from `2` → `3`.

### Testing
- Ran the targeted test file with `npm test -- --run tests/health-prober.test.mjs`, and the health-prober tests passed (`69` tests in that file passed). 
- Attempting the full suite with `npm test -- --run` showed unrelated environment/artifact failures (missing `public/metagraph/providers.json` and other committed artifact files, a long `R2` history-upload timeout, and a DNS-dependent public-safety assertion), so the broader CI run failed for reasons outside this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a394cae81a0832c94e95eb0d2a2166f)