### PR TITLE
fix(api): avoid caching D1 fallback analytics

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -70,7 +70,10 @@ function rowsForSql(sql) {
 // Local artifact env + a query-recording D1 + a KV control plane that serves the
 // snapshot stamp. `queries` records every {sql, params} so a test can assert
 // whether D1 was touched at all (the whole point of the cache).
-function analyticsEnv(queries, { lastRunAt = LAST_RUN_AT } = {}) {
+function analyticsEnv(
+  queries,
+  { lastRunAt = LAST_RUN_AT, d1Error = null } = {},
+) {
   return {
     ...createLocalArtifactEnv(),
     METAGRAPH_HEALTH_DB: {
@@ -79,7 +82,10 @@ function analyticsEnv(queries, { lastRunAt = LAST_RUN_AT } = {}) {
           bind(...params) {
             queries.push({ sql, params });
             return {
-              all: () => Promise.resolve({ results: rowsForSql(sql) }),
+              all: () =>
+                d1Error
+                  ? Promise.reject(d1Error)
+                  : Promise.resolve({ results: rowsForSql(sql) }),
             };
           },
         };
@@ -335,6 +341,30 @@ describe("analytics edge cache", () => {
       0,
       "a cold snapshot skips the cache lookup entirely",
     );
+  });
+
+  test("NO-CACHE-ON-ERROR: a D1 failure with a snapshot stamp is served but not cached", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries, { d1Error: new Error("D1 unavailable") });
+
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles?window=7d",
+      ),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(res.status, 200);
+    assert.deepEqual(
+      cache.putKeys,
+      [],
+      "a D1 fallback response must not poison the edge cache",
+    );
+    assert.equal(cache.store.size, 0);
   });
 
   test("transparency: the cached body equals the uncached body for the same handler", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1859,7 +1859,7 @@ async function handleBulkHealthTrends(
       windows,
       windowDays: HEALTH_TREND_WINDOWS,
     });
-    return envelopeResponse(
+    const response = envelopeResponse(
       request,
       {
         data,
@@ -1874,6 +1874,9 @@ async function handleBulkHealthTrends(
       },
       "short",
     );
+    return hasD1FallbackRows(rows)
+      ? markD1FallbackResponse(response)
+      : response;
   });
 }
 
@@ -1917,7 +1920,7 @@ async function handleHealthTrends(request, env, netuid, url, ctx = {}) {
           );
           return [label, result?.results || []];
         } catch {
-          return [label, []];
+          return [label, markD1FallbackRows([])];
         }
       }),
     );
@@ -1930,7 +1933,7 @@ async function handleHealthTrends(request, env, netuid, url, ctx = {}) {
       observedAt: meta?.last_run_at || null,
       windows,
     });
-    return envelopeResponse(
+    const response = envelopeResponse(
       request,
       {
         data,
@@ -1945,6 +1948,9 @@ async function handleHealthTrends(request, env, netuid, url, ctx = {}) {
       },
       "short",
     );
+    return hasD1FallbackRows(...Object.values(windows))
+      ? markD1FallbackResponse(response)
+      : response;
   });
 }
 
@@ -1992,6 +1998,25 @@ function analyticsQueryError(error) {
   });
 }
 
+let d1FallbackGeneration = 0;
+const D1_FALLBACK_ROWS = new WeakSet();
+const D1_FALLBACK_RESPONSES = new WeakSet();
+
+function markD1FallbackRows(rows = []) {
+  d1FallbackGeneration += 1;
+  D1_FALLBACK_ROWS.add(rows);
+  return rows;
+}
+
+function hasD1FallbackRows(...rowSets) {
+  return rowSets.some((rows) => D1_FALLBACK_ROWS.has(rows));
+}
+
+function markD1FallbackResponse(response) {
+  D1_FALLBACK_RESPONSES.add(response);
+  return response;
+}
+
 async function d1All(env, sql, params) {
   const db = env.METAGRAPH_HEALTH_DB;
   if (!db?.prepare) return [];
@@ -2005,7 +2030,7 @@ async function d1All(env, sql, params) {
     );
     return result?.results || [];
   } catch {
-    return [];
+    return markD1FallbackRows([]);
   }
 }
 
@@ -2061,10 +2086,16 @@ async function withEdgeCache(request, ctx, env, keyParts, buildResponse) {
       return hit;
     }
   }
+  const fallbackGeneration = d1FallbackGeneration;
   const response = await buildResponse();
   // Never cache errors / non-200s (cold-D1 still returns a 200 empty envelope;
   // a 400 bad-window or 5xx must not be persisted).
-  if (cacheKey && response.status === 200) {
+  if (
+    cacheKey &&
+    response.status === 200 &&
+    !D1_FALLBACK_RESPONSES.has(response) &&
+    d1FallbackGeneration === fallbackGeneration
+  ) {
     ctx?.waitUntil?.(cache.put(cacheKey, response.clone()));
   }
   return response;
@@ -2093,7 +2124,7 @@ async function handleHealthPercentiles(request, env, netuid, url, ctx = {}) {
       observedAt: meta?.last_run_at || null,
       rows,
     });
-    return envelopeResponse(
+    const response = envelopeResponse(
       request,
       {
         data,
@@ -2105,6 +2136,9 @@ async function handleHealthPercentiles(request, env, netuid, url, ctx = {}) {
       },
       "short",
     );
+    return hasD1FallbackRows(rows)
+      ? markD1FallbackResponse(response)
+      : response;
   });
 }
 
@@ -2179,7 +2213,7 @@ async function handleHealthIncidents(request, env, netuid, url, ctx = {}) {
       incidentRows,
       maxIncidents: MAX_INCIDENT_ROWS,
     });
-    return envelopeResponse(
+    const response = envelopeResponse(
       request,
       {
         data,
@@ -2191,6 +2225,9 @@ async function handleHealthIncidents(request, env, netuid, url, ctx = {}) {
       },
       "short",
     );
+    return hasD1FallbackRows(slaRows, incidentRows)
+      ? markD1FallbackResponse(response)
+      : response;
   });
 }
 


### PR DESCRIPTION
### Motivation
- A D1 helper `d1All()` swallowed all errors and returned `[]`, and `withEdgeCache()` cached every `200` response when `last_run_at` existed, allowing a transient D1 failure to poison the edge cache with an empty-but-200 analytics envelope.

### Description
- Mark D1 fallback row sets returned from `d1All()` and make analytics handlers detectable when rows are a fallback via `markD1FallbackRows`, `hasD1FallbackRows`, and `markD1FallbackResponse` in `workers/api.mjs`.
- Prevent `withEdgeCache()` from persisting a cached entry when the response was produced from a D1 fallback by skipping `cache.put()` for marked responses and by using a lightweight `d1FallbackGeneration` guard to avoid races.
- Apply the no-cache fallback marker to the affected analytics routes: `handleBulkHealthTrends`, `handleHealthTrends`, `handleHealthPercentiles`, and `handleHealthIncidents` in `workers/api.mjs` so schema-stable fallback responses are served but not cached.
- Add a regression test `NO-CACHE-ON-ERROR: a D1 failure with a snapshot stamp is served but not cached` to `tests/analytics-edge-cache.test.mjs` that simulates D1 errors and asserts the edge cache is not poisoned.

### Testing
- Ran `npx vitest run tests/analytics-edge-cache.test.mjs` (targeted analytics edge-cache tests) and the modified test file passed (all analytics edge-cache tests green).
- Ran `npx prettier --write workers/api.mjs tests/analytics-edge-cache.test.mjs` and `npx eslint workers/api.mjs tests/analytics-edge-cache.test.mjs` with no issues reported.
- Ran the full `npm test` suite; it reported unrelated failures/timeouts caused by missing generated public artifacts and environment expectations (e.g. missing `public/metagraph/providers.json`, DNS/timeouts in public-safety tests), not by the analytics change; the targeted analytics tests included in this PR passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3959ddf198832c8649092f48914163)