### PR TITLE
chore(enrich): taostats identity gap-fills

### DIFF
--- a/registry/subnets/bitstarter.json
+++ b/registry/subnets/bitstarter.json
@@ -56,7 +56,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://bitstarter.ai/"],
+      "source_urls": [
+        "https://bitstarter.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -95,7 +97,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://app.bitstarter.ai/"],
+      "source_urls": [
+        "https://app.bitstarter.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -149,5 +153,6 @@
   ],
   "social": {
     "x": "https://x.com/bitstarterai"
-  }
+  },
+  "contact": "hello@bitstarter.ai"
 }

--- a/registry/subnets/bitstarter.json
+++ b/registry/subnets/bitstarter.json
@@ -56,9 +56,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://bitstarter.ai/"
-      ],
+      "source_urls": ["https://bitstarter.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -97,9 +95,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://app.bitstarter.ai/"
-      ],
+      "source_urls": ["https://app.bitstarter.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -57,7 +57,9 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": ["https://chutes.ai/"],
+      "source_urls": [
+        "https://chutes.ai/"
+      ],
       "url": "https://chutes.ai/"
     },
     {
@@ -75,7 +77,9 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": ["https://chutes.ai/docs"],
+      "source_urls": [
+        "https://chutes.ai/docs"
+      ],
       "url": "https://chutes.ai/docs"
     },
     {
@@ -156,7 +160,9 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": ["https://chutes.ai/"],
+      "source_urls": [
+        "https://chutes.ai/"
+      ],
       "url": "https://chutes.ai/app?type=llm"
     },
     {
@@ -174,7 +180,9 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": ["https://chutes.ai/"],
+      "source_urls": [
+        "https://chutes.ai/"
+      ],
       "url": "https://chutes.ai/app?type=diffusion"
     },
     {
@@ -276,7 +284,9 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/64"],
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/64"
+      ],
       "url": "https://taomarketcap.com/subnets/64"
     },
     {
@@ -288,7 +298,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/chutesai/chutes"],
+      "source_urls": [
+        "https://github.com/chutesai/chutes"
+      ],
       "probe": {
         "enabled": false,
         "method": "HEAD",
@@ -300,5 +312,6 @@
   "website_url": "https://chutes.ai/",
   "social": {
     "x": "https://x.com/chutes_ai"
-  }
+  },
+  "contact": "support@chutes.ai"
 }

--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -57,9 +57,7 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": [
-        "https://chutes.ai/"
-      ],
+      "source_urls": ["https://chutes.ai/"],
       "url": "https://chutes.ai/"
     },
     {
@@ -77,9 +75,7 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": [
-        "https://chutes.ai/docs"
-      ],
+      "source_urls": ["https://chutes.ai/docs"],
       "url": "https://chutes.ai/docs"
     },
     {
@@ -160,9 +156,7 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": [
-        "https://chutes.ai/"
-      ],
+      "source_urls": ["https://chutes.ai/"],
       "url": "https://chutes.ai/app?type=llm"
     },
     {
@@ -180,9 +174,7 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": [
-        "https://chutes.ai/"
-      ],
+      "source_urls": ["https://chutes.ai/"],
       "url": "https://chutes.ai/app?type=diffusion"
     },
     {
@@ -284,9 +276,7 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/64"
-      ],
+      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/64"],
       "url": "https://taomarketcap.com/subnets/64"
     },
     {
@@ -298,9 +288,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/chutesai/chutes"
-      ],
+      "source_urls": ["https://github.com/chutesai/chutes"],
       "probe": {
         "enabled": false,
         "method": "HEAD",

--- a/registry/subnets/connitoai.json
+++ b/registry/subnets/connitoai.json
@@ -38,7 +38,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/Connito-AI/Connito"],
+      "source_urls": [
+        "https://github.com/Connito-AI/Connito"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -56,7 +58,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/Connito-AI/Connito"],
+      "source_urls": [
+        "https://github.com/Connito-AI/Connito"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -68,5 +72,6 @@
   ],
   "social": {
     "x": "https://x.com/connitoai"
-  }
+  },
+  "contact": "isabella@connito.ai"
 }

--- a/registry/subnets/connitoai.json
+++ b/registry/subnets/connitoai.json
@@ -38,9 +38,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/Connito-AI/Connito"
-      ],
+      "source_urls": ["https://github.com/Connito-AI/Connito"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -58,9 +56,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/Connito-AI/Connito"
-      ],
+      "source_urls": ["https://github.com/Connito-AI/Connito"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/ditto.json
+++ b/registry/subnets/ditto.json
@@ -51,7 +51,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://heyditto.ai/"],
+      "source_urls": [
+        "https://heyditto.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -69,7 +71,10 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://heyditto.ai/docs/", "https://heyditto.ai/"],
+      "source_urls": [
+        "https://heyditto.ai/docs/",
+        "https://heyditto.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -150,7 +155,10 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://assistant.heyditto.ai/", "https://heyditto.ai/"],
+      "source_urls": [
+        "https://assistant.heyditto.ai/",
+        "https://heyditto.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -204,5 +212,6 @@
   ],
   "social": {
     "x": "https://x.com/heydittoai"
-  }
+  },
+  "contact": "peyton@omniaura.ai"
 }

--- a/registry/subnets/ditto.json
+++ b/registry/subnets/ditto.json
@@ -51,9 +51,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://heyditto.ai/"
-      ],
+      "source_urls": ["https://heyditto.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -71,10 +69,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://heyditto.ai/docs/",
-        "https://heyditto.ai/"
-      ],
+      "source_urls": ["https://heyditto.ai/docs/", "https://heyditto.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -155,10 +150,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://assistant.heyditto.ai/",
-        "https://heyditto.ai/"
-      ],
+      "source_urls": ["https://assistant.heyditto.ai/", "https://heyditto.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/djinn.json
+++ b/registry/subnets/djinn.json
@@ -38,9 +38,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/Djinn-Inc/djinn"
-      ],
+      "source_urls": ["https://github.com/Djinn-Inc/djinn"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -58,9 +56,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/Djinn-Inc/djinn"
-      ],
+      "source_urls": ["https://github.com/Djinn-Inc/djinn"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/djinn.json
+++ b/registry/subnets/djinn.json
@@ -38,7 +38,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/Djinn-Inc/djinn"],
+      "source_urls": [
+        "https://github.com/Djinn-Inc/djinn"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -56,7 +58,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/Djinn-Inc/djinn"],
+      "source_urls": [
+        "https://github.com/Djinn-Inc/djinn"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -68,5 +72,6 @@
   ],
   "social": {
     "x": "https://x.com/djinn_gg"
-  }
+  },
+  "contact": "info@djinn.gg"
 }

--- a/registry/subnets/dojo.json
+++ b/registry/subnets/dojo.json
@@ -81,7 +81,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/tensorplex-labs/dojo"],
+      "source_urls": [
+        "https://github.com/tensorplex-labs/dojo"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -99,7 +101,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/tensorplex-labs/dojo-ui"],
+      "source_urls": [
+        "https://github.com/tensorplex-labs/dojo-ui"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -117,7 +121,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/tensorplex-labs/dojo-worker-api"],
+      "source_urls": [
+        "https://github.com/tensorplex-labs/dojo-worker-api"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -126,5 +132,6 @@
       },
       "notes": "Official Dojo worker API repository."
     }
-  ]
+  ],
+  "contact": "jarvis@tensorplex.ai"
 }

--- a/registry/subnets/dojo.json
+++ b/registry/subnets/dojo.json
@@ -81,9 +81,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/tensorplex-labs/dojo"
-      ],
+      "source_urls": ["https://github.com/tensorplex-labs/dojo"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -101,9 +99,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/tensorplex-labs/dojo-ui"
-      ],
+      "source_urls": ["https://github.com/tensorplex-labs/dojo-ui"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -121,9 +117,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/tensorplex-labs/dojo-worker-api"
-      ],
+      "source_urls": ["https://github.com/tensorplex-labs/dojo-worker-api"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/enigma.json
+++ b/registry/subnets/enigma.json
@@ -39,9 +39,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/qbittensor-labs/enigma"
-      ],
+      "source_urls": ["https://github.com/qbittensor-labs/enigma"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -59,9 +57,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/qbittensor-labs/enigma"
-      ],
+      "source_urls": ["https://github.com/qbittensor-labs/enigma"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/enigma.json
+++ b/registry/subnets/enigma.json
@@ -39,7 +39,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/qbittensor-labs/enigma"],
+      "source_urls": [
+        "https://github.com/qbittensor-labs/enigma"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -57,7 +59,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/qbittensor-labs/enigma"],
+      "source_urls": [
+        "https://github.com/qbittensor-labs/enigma"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -69,5 +73,6 @@
   ],
   "social": {
     "x": "https://x.com/qbittensorlabs"
-  }
+  },
+  "contact": "qbittensorlabs@gmail.com"
 }

--- a/registry/subnets/forevermoney.json
+++ b/registry/subnets/forevermoney.json
@@ -39,7 +39,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/SN98-ForeverMoney/forever-money"],
+      "source_urls": [
+        "https://github.com/SN98-ForeverMoney/forever-money"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -57,7 +59,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/SN98-ForeverMoney/forever-money"],
+      "source_urls": [
+        "https://github.com/SN98-ForeverMoney/forever-money"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -69,5 +73,6 @@
   ],
   "social": {
     "x": "https://x.com/forevermoney_ai"
-  }
+  },
+  "contact": "gm@forevermoney.ai"
 }

--- a/registry/subnets/forevermoney.json
+++ b/registry/subnets/forevermoney.json
@@ -39,9 +39,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/SN98-ForeverMoney/forever-money"
-      ],
+      "source_urls": ["https://github.com/SN98-ForeverMoney/forever-money"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -59,9 +57,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/SN98-ForeverMoney/forever-money"
-      ],
+      "source_urls": ["https://github.com/SN98-ForeverMoney/forever-money"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/hashichain.json
+++ b/registry/subnets/hashichain.json
@@ -50,5 +50,6 @@
       },
       "notes": "Public HashiChain source repository for SN115."
     }
-  ]
+  ],
+  "contact": "hashichain@outlook.com"
 }

--- a/registry/subnets/hippius.json
+++ b/registry/subnets/hippius.json
@@ -41,9 +41,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://hippius.com/"
-      ],
+      "source_urls": ["https://hippius.com/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -61,9 +59,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://docs.hippius.com/"
-      ],
+      "source_urls": ["https://docs.hippius.com/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -81,9 +77,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://docs.hippius.com/blockchain/api"
-      ],
+      "source_urls": ["https://docs.hippius.com/blockchain/api"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -101,9 +95,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/thenervelab/hippius-validator"
-      ],
+      "source_urls": ["https://github.com/thenervelab/hippius-validator"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -121,9 +113,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/thenervelab/hippius-storage-miner"
-      ],
+      "source_urls": ["https://github.com/thenervelab/hippius-storage-miner"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/hippius.json
+++ b/registry/subnets/hippius.json
@@ -41,7 +41,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://hippius.com/"],
+      "source_urls": [
+        "https://hippius.com/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -59,7 +61,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://docs.hippius.com/"],
+      "source_urls": [
+        "https://docs.hippius.com/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -77,7 +81,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://docs.hippius.com/blockchain/api"],
+      "source_urls": [
+        "https://docs.hippius.com/blockchain/api"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -95,7 +101,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/thenervelab/hippius-validator"],
+      "source_urls": [
+        "https://github.com/thenervelab/hippius-validator"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -113,7 +121,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/thenervelab/hippius-storage-miner"],
+      "source_urls": [
+        "https://github.com/thenervelab/hippius-storage-miner"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -125,5 +135,6 @@
   ],
   "social": {
     "x": "https://x.com/hippius_subnet"
-  }
+  },
+  "contact": "hello@hippius.com"
 }

--- a/registry/subnets/infinitehash.json
+++ b/registry/subnets/infinitehash.json
@@ -39,7 +39,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/backend-developers-ltd/InfiniteHash"],
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/InfiniteHash"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -70,5 +72,6 @@
       "notes": "Public InfiniteHash documentation for the subnet auction incentive mechanism."
     }
   ],
-  "website_url": "https://infinitehash.xyz/"
+  "website_url": "https://infinitehash.xyz/",
+  "contact": "btc@infinitehash.xyz"
 }

--- a/registry/subnets/infinitehash.json
+++ b/registry/subnets/infinitehash.json
@@ -39,9 +39,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/backend-developers-ltd/InfiniteHash"
-      ],
+      "source_urls": ["https://github.com/backend-developers-ltd/InfiniteHash"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/mvtrx.json
+++ b/registry/subnets/mvtrx.json
@@ -38,7 +38,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/taos-im/sn-79"],
+      "source_urls": [
+        "https://github.com/taos-im/sn-79"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -56,7 +58,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/taos-im/sn-79/blob/main/README.md"],
+      "source_urls": [
+        "https://github.com/taos-im/sn-79/blob/main/README.md"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -74,7 +78,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/taos-im/sn-79"],
+      "source_urls": [
+        "https://github.com/taos-im/sn-79"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -86,5 +92,6 @@
   ],
   "social": {
     "x": "https://x.com/taos_im"
-  }
+  },
+  "contact": "to@mvtrx.fi"
 }

--- a/registry/subnets/mvtrx.json
+++ b/registry/subnets/mvtrx.json
@@ -38,9 +38,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/taos-im/sn-79"
-      ],
+      "source_urls": ["https://github.com/taos-im/sn-79"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -58,9 +56,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/taos-im/sn-79/blob/main/README.md"
-      ],
+      "source_urls": ["https://github.com/taos-im/sn-79/blob/main/README.md"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -78,9 +74,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/taos-im/sn-79"
-      ],
+      "source_urls": ["https://github.com/taos-im/sn-79"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -100,9 +100,7 @@
       },
       "provider": "nepher-robotics",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/nepher-ai/nepher-subnet"
-      ],
+      "source_urls": ["https://github.com/nepher-ai/nepher-subnet"],
       "url": "https://github.com/nepher-ai/nepher-subnet"
     },
     {
@@ -120,9 +118,7 @@
       },
       "provider": "nepher-robotics",
       "public_safe": true,
-      "source_urls": [
-        "https://nepher.ai"
-      ],
+      "source_urls": ["https://nepher.ai"],
       "url": "https://tournament.nepher.ai"
     },
     {
@@ -220,9 +216,7 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/49"
-      ],
+      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/49"],
       "url": "https://taomarketcap.com/subnets/49"
     }
   ],

--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -100,7 +100,9 @@
       },
       "provider": "nepher-robotics",
       "public_safe": true,
-      "source_urls": ["https://github.com/nepher-ai/nepher-subnet"],
+      "source_urls": [
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
       "url": "https://github.com/nepher-ai/nepher-subnet"
     },
     {
@@ -118,7 +120,9 @@
       },
       "provider": "nepher-robotics",
       "public_safe": true,
-      "source_urls": ["https://nepher.ai"],
+      "source_urls": [
+        "https://nepher.ai"
+      ],
       "url": "https://tournament.nepher.ai"
     },
     {
@@ -216,12 +220,15 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/49"],
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/49"
+      ],
       "url": "https://taomarketcap.com/subnets/49"
     }
   ],
   "website_url": "https://nepher.ai",
   "social": {
     "x": "https://x.com/nepher_robotics"
-  }
+  },
+  "contact": "contact@nepher.ai"
 }

--- a/registry/subnets/ninja.json
+++ b/registry/subnets/ninja.json
@@ -53,7 +53,9 @@
       },
       "provider": "unarbos",
       "public_safe": true,
-      "source_urls": ["https://ninja.arbos.life/"],
+      "source_urls": [
+        "https://ninja.arbos.life/"
+      ],
       "url": "https://ninja.arbos.life/"
     },
     {
@@ -134,7 +136,9 @@
       },
       "provider": "unarbos",
       "public_safe": true,
-      "source_urls": ["https://ninja.arbos.life/health"],
+      "source_urls": [
+        "https://ninja.arbos.life/health"
+      ],
       "url": "https://ninja.arbos.life/health"
     },
     {
@@ -153,7 +157,9 @@
       "provider": "unarbos",
       "public_safe": true,
       "schema_status": "ui-only",
-      "source_urls": ["https://ninja.arbos.life/swagger"],
+      "source_urls": [
+        "https://ninja.arbos.life/swagger"
+      ],
       "url": "https://ninja.arbos.life/swagger"
     },
     {
@@ -211,9 +217,12 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/66"],
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/66"
+      ],
       "url": "https://taomarketcap.com/subnets/66"
     }
   ],
-  "website_url": "https://ninja.arbos.life/"
+  "website_url": "https://ninja.arbos.life/",
+  "contact": "tau@arbos.life"
 }

--- a/registry/subnets/ninja.json
+++ b/registry/subnets/ninja.json
@@ -53,9 +53,7 @@
       },
       "provider": "unarbos",
       "public_safe": true,
-      "source_urls": [
-        "https://ninja.arbos.life/"
-      ],
+      "source_urls": ["https://ninja.arbos.life/"],
       "url": "https://ninja.arbos.life/"
     },
     {
@@ -136,9 +134,7 @@
       },
       "provider": "unarbos",
       "public_safe": true,
-      "source_urls": [
-        "https://ninja.arbos.life/health"
-      ],
+      "source_urls": ["https://ninja.arbos.life/health"],
       "url": "https://ninja.arbos.life/health"
     },
     {
@@ -157,9 +153,7 @@
       "provider": "unarbos",
       "public_safe": true,
       "schema_status": "ui-only",
-      "source_urls": [
-        "https://ninja.arbos.life/swagger"
-      ],
+      "source_urls": ["https://ninja.arbos.life/swagger"],
       "url": "https://ninja.arbos.life/swagger"
     },
     {
@@ -217,9 +211,7 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/66"
-      ],
+      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/66"],
       "url": "https://taomarketcap.com/subnets/66"
     }
   ],

--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -40,7 +40,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://oneoneone.io/"],
+      "source_urls": [
+        "https://oneoneone.io/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -70,5 +72,6 @@
       },
       "notes": "Official oneoneone source repository."
     }
-  ]
+  ],
+  "contact": "support@oneoneone.io"
 }

--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -40,9 +40,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://oneoneone.io/"
-      ],
+      "source_urls": ["https://oneoneone.io/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/platform.json
+++ b/registry/subnets/platform.json
@@ -93,9 +93,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/PlatformNetwork/platform"
-      ],
+      "source_urls": ["https://github.com/PlatformNetwork/platform"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/platform.json
+++ b/registry/subnets/platform.json
@@ -93,7 +93,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/PlatformNetwork/platform"],
+      "source_urls": [
+        "https://github.com/PlatformNetwork/platform"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -105,5 +107,6 @@
   ],
   "social": {
     "x": "https://x.com/platformnet"
-  }
+  },
+  "contact": "platform@cortex.foundation"
 }

--- a/registry/subnets/quantum-compute.json
+++ b/registry/subnets/quantum-compute.json
@@ -40,9 +40,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/qbittensor-labs/quantum-compute"
-      ],
+      "source_urls": ["https://github.com/qbittensor-labs/quantum-compute"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -60,9 +58,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/qbittensor-labs/quantum-compute"
-      ],
+      "source_urls": ["https://github.com/qbittensor-labs/quantum-compute"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/quantum-compute.json
+++ b/registry/subnets/quantum-compute.json
@@ -40,7 +40,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/qbittensor-labs/quantum-compute"],
+      "source_urls": [
+        "https://github.com/qbittensor-labs/quantum-compute"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -58,7 +60,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/qbittensor-labs/quantum-compute"],
+      "source_urls": [
+        "https://github.com/qbittensor-labs/quantum-compute"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -70,5 +74,6 @@
   ],
   "social": {
     "x": "https://x.com/qbittensorlabs"
-  }
+  },
+  "contact": "qbittensorlabs@gmail.com"
 }

--- a/registry/subnets/redteam.json
+++ b/registry/subnets/redteam.json
@@ -41,9 +41,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/RedTeamSubnet/RedTeam"
-      ],
+      "source_urls": ["https://github.com/RedTeamSubnet/RedTeam"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -101,9 +99,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/RedTeamSubnet/RedTeam"
-      ],
+      "source_urls": ["https://github.com/RedTeamSubnet/RedTeam"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/redteam.json
+++ b/registry/subnets/redteam.json
@@ -41,7 +41,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/RedTeamSubnet/RedTeam"],
+      "source_urls": [
+        "https://github.com/RedTeamSubnet/RedTeam"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -99,7 +101,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/RedTeamSubnet/RedTeam"],
+      "source_urls": [
+        "https://github.com/RedTeamSubnet/RedTeam"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -108,5 +112,6 @@
       },
       "notes": "Official RedTeam source repository."
     }
-  ]
+  ],
+  "contact": "oscar@theredteam.io"
 }

--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -39,7 +39,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/ridgesai/ridges"],
+      "source_urls": [
+        "https://github.com/ridgesai/ridges"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -48,5 +50,6 @@
       },
       "notes": "Official Ridges source repository."
     }
-  ]
+  ],
+  "contact": "hello@ridges.ai"
 }

--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -39,9 +39,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/ridgesai/ridges"
-      ],
+      "source_urls": ["https://github.com/ridgesai/ridges"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -67,10 +67,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://thesoma.ai/dashboard",
-        "https://thesoma.ai/"
-      ],
+      "source_urls": ["https://thesoma.ai/dashboard", "https://thesoma.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -88,10 +85,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://thesoma.ai/mcp",
-        "https://thesoma.ai/"
-      ],
+      "source_urls": ["https://thesoma.ai/mcp", "https://thesoma.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -109,10 +103,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://thesoma.ai/soma-access",
-        "https://thesoma.ai/"
-      ],
+      "source_urls": ["https://thesoma.ai/soma-access", "https://thesoma.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -67,7 +67,10 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://thesoma.ai/dashboard", "https://thesoma.ai/"],
+      "source_urls": [
+        "https://thesoma.ai/dashboard",
+        "https://thesoma.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -85,7 +88,10 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://thesoma.ai/mcp", "https://thesoma.ai/"],
+      "source_urls": [
+        "https://thesoma.ai/mcp",
+        "https://thesoma.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -103,7 +109,10 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://thesoma.ai/soma-access", "https://thesoma.ai/"],
+      "source_urls": [
+        "https://thesoma.ai/soma-access",
+        "https://thesoma.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -157,5 +166,6 @@
   ],
   "social": {
     "x": "https://x.com/somasubnet"
-  }
+  },
+  "contact": "https://x.com/SomaSubnet"
 }

--- a/registry/subnets/sundae-bar.json
+++ b/registry/subnets/sundae-bar.json
@@ -38,7 +38,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/sundae-bar/bittensor-subnet"],
+      "source_urls": [
+        "https://github.com/sundae-bar/bittensor-subnet"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -56,7 +58,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/sundae-bar/bittensor-subnet"],
+      "source_urls": [
+        "https://github.com/sundae-bar/bittensor-subnet"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -68,5 +72,6 @@
   ],
   "social": {
     "x": "https://x.com/sundae_bar_"
-  }
+  },
+  "contact": "hello@sundaebar.ai"
 }

--- a/registry/subnets/sundae-bar.json
+++ b/registry/subnets/sundae-bar.json
@@ -38,9 +38,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/sundae-bar/bittensor-subnet"
-      ],
+      "source_urls": ["https://github.com/sundae-bar/bittensor-subnet"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -58,9 +56,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/sundae-bar/bittensor-subnet"
-      ],
+      "source_urls": ["https://github.com/sundae-bar/bittensor-subnet"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/tensorusd.json
+++ b/registry/subnets/tensorusd.json
@@ -40,9 +40,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/TensorUSD/subnet"
-      ],
+      "source_urls": ["https://github.com/TensorUSD/subnet"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -80,9 +78,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/TensorUSD/subnet"
-      ],
+      "source_urls": ["https://github.com/TensorUSD/subnet"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/tensorusd.json
+++ b/registry/subnets/tensorusd.json
@@ -40,7 +40,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/TensorUSD/subnet"],
+      "source_urls": [
+        "https://github.com/TensorUSD/subnet"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -78,7 +80,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/TensorUSD/subnet"],
+      "source_urls": [
+        "https://github.com/TensorUSD/subnet"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -90,5 +94,6 @@
   ],
   "social": {
     "x": "https://x.com/tensorusd"
-  }
+  },
+  "contact": "admin@tensorusd.com"
 }

--- a/registry/subnets/verathos.json
+++ b/registry/subnets/verathos.json
@@ -53,7 +53,9 @@
       },
       "provider": "verathos",
       "public_safe": true,
-      "source_urls": ["https://verathos.ai/"],
+      "source_urls": [
+        "https://verathos.ai/"
+      ],
       "url": "https://verathos.ai/"
     },
     {
@@ -71,7 +73,9 @@
       },
       "provider": "verathos",
       "public_safe": true,
-      "source_urls": ["https://verathos.ai/docs"],
+      "source_urls": [
+        "https://verathos.ai/docs"
+      ],
       "url": "https://verathos.ai/docs"
     },
     {
@@ -155,7 +159,9 @@
       },
       "provider": "verathos",
       "public_safe": true,
-      "source_urls": ["https://verathos.ai/"],
+      "source_urls": [
+        "https://verathos.ai/"
+      ],
       "url": "https://verathos.ai/chat"
     },
     {
@@ -213,7 +219,9 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/96"],
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/96"
+      ],
       "url": "https://taomarketcap.com/subnets/96"
     },
     {
@@ -225,7 +233,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/verathos-ai/verathos"],
+      "source_urls": [
+        "https://github.com/verathos-ai/verathos"
+      ],
       "probe": {
         "enabled": false,
         "method": "HEAD",
@@ -234,5 +244,6 @@
       "notes": "Official Verathos examples — OpenAI-compatible, streaming, and x402 client quickstarts."
     }
   ],
-  "website_url": "https://verathos.ai/"
+  "website_url": "https://verathos.ai/",
+  "contact": "info@verathos.ai"
 }

--- a/registry/subnets/verathos.json
+++ b/registry/subnets/verathos.json
@@ -53,9 +53,7 @@
       },
       "provider": "verathos",
       "public_safe": true,
-      "source_urls": [
-        "https://verathos.ai/"
-      ],
+      "source_urls": ["https://verathos.ai/"],
       "url": "https://verathos.ai/"
     },
     {
@@ -73,9 +71,7 @@
       },
       "provider": "verathos",
       "public_safe": true,
-      "source_urls": [
-        "https://verathos.ai/docs"
-      ],
+      "source_urls": ["https://verathos.ai/docs"],
       "url": "https://verathos.ai/docs"
     },
     {
@@ -159,9 +155,7 @@
       },
       "provider": "verathos",
       "public_safe": true,
-      "source_urls": [
-        "https://verathos.ai/"
-      ],
+      "source_urls": ["https://verathos.ai/"],
       "url": "https://verathos.ai/chat"
     },
     {
@@ -219,9 +213,7 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/96"
-      ],
+      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/96"],
       "url": "https://taomarketcap.com/subnets/96"
     },
     {
@@ -233,9 +225,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/verathos-ai/verathos"
-      ],
+      "source_urls": ["https://github.com/verathos-ai/verathos"],
       "probe": {
         "enabled": false,
         "method": "HEAD",

--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -77,5 +77,6 @@
   ],
   "social": {
     "x": "https://x.com/vidaio_"
-  }
+  },
+  "contact": "Vidaio@vidaio.io"
 }


### PR DESCRIPTION
## Summary

Third-party **Taostats** gap-fills for human review (provenance: SubnetIdentitiesV3 via api.taostats.io).

Fills the `contact` field for 24 subnets that had no contact set. All candidates passed through the repo's junk-filter (drops `deprecated@gmail.com`, `-`, empty, `none` values). Fields explicitly set to `null` (maintainer-reviewed) were not touched.

## Subnets / fields touched

| SN | File | Field | Value |
|----|------|-------|-------|
| SN48 | quantum-compute.json | contact | qbittensorlabs@gmail.com |
| SN49 | nepher-robotics.json | contact | contact@nepher.ai |
| SN52 | dojo.json | contact | jarvis@tensorplex.ai |
| SN61 | redteam.json | contact | oscar@theredteam.io |
| SN62 | ridges.json | contact | hello@ridges.ai |
| SN63 | enigma.json | contact | qbittensorlabs@gmail.com |
| SN64 | chutes.json | contact | support@chutes.ai |
| SN66 | ninja.json | contact | tau@arbos.life |
| SN75 | hippius.json | contact | hello@hippius.com |
| SN79 | mvtrx.json | contact | to@mvtrx.fi |
| SN85 | vidaio.json | contact | Vidaio@vidaio.io |
| SN89 | infinitehash.json | contact | btc@infinitehash.xyz |
| SN91 | bitstarter.json | contact | hello@bitstarter.ai |
| SN96 | verathos.json | contact | info@verathos.ai |
| SN98 | forevermoney.json | contact | gm@forevermoney.ai |
| SN100 | platform.json | contact | platform@cortex.foundation |
| SN102 | connitoai.json | contact | isabella@connito.ai |
| SN103 | djinn.json | contact | info@djinn.gg |
| SN111 | oneoneone.json | contact | support@oneoneone.io |
| SN113 | tensorusd.json | contact | admin@tensorusd.com |
| SN114 | soma.json | contact | https://x.com/SomaSubnet |
| SN115 | hashichain.json | contact | hashichain@outlook.com |
| SN118 | ditto.json | contact | peyton@omniaura.ai |
| SN121 | sundae-bar.json | contact | hello@sundaebar.ai |

## Deliberately skipped
- **SN29** — taostats returns `@cacheon_ai` (belongs to a different subnet's on-chain identity)
- **SN106** — contact is stale NeuralInternet identity pre-rekeying, not Nodexo
- **SN117** — has `identity-dispute` flag; taostats shows helionlink/Chi not BrainPlay