### PR TITLE
fix(neurons): scope staged coverage prune to refreshed netuids

### DIFF
--- a/tests/load-staged-neurons.test.mjs
+++ b/tests/load-staged-neurons.test.mjs
@@ -242,11 +242,10 @@ test("loadStagedNeurons rejects rows that fail per-field bounding (#1360)", asyn
   }
 });
 
-test("loadStagedNeurons snapshot-replaces: deletes every row older than the snapshot stamp", async () => {
-  // INVARIANT: after a successful load, the prune deletes ALL prior-snapshot rows
-  // table-wide (not scoped to a subnet), keyed on the snapshot's captured_at — so
-  // no row with captured_at < the stamp can remain. A coverage envelope still
-  // verifies + loads, but the prune is derived from the rows, not the envelope.
+test("loadStagedNeurons coverage envelope prunes only refreshed netuids", async () => {
+  // INVARIANT: coverage envelopes can be partial refreshes, so after a successful
+  // load the prune deletes prior-snapshot rows only for refreshed netuids. This
+  // preserves rows for subnets that were not represented in the staged payload.
   const captured_at = 2_000_000_000_000;
   const rows = [{ ...neuronRow(1, 0), captured_at }];
   const m = mockEnv({
@@ -258,17 +257,9 @@ test("loadStagedNeurons snapshot-replaces: deletes every row older than the snap
   const purges = m.runs.filter((run) =>
     run.sql.includes("DELETE FROM neurons"),
   );
-  assert.equal(
-    purges.length,
-    1,
-    "exactly one table-wide prune, not per-subnet",
-  );
-  // Cutoff is the snapshot stamp and ONLY the stamp (no netuid scoping).
-  assert.deepEqual(purges[0].v, [captured_at]);
-  assert.ok(
-    !/netuid/.test(purges[0].sql),
-    "prune must be table-wide, not scoped to a netuid",
-  );
+  assert.equal(purges.length, 1, "exactly one coverage-scoped prune");
+  assert.deepEqual(purges[0].v, [1, captured_at]);
+  assert.match(purges[0].sql, /WHERE netuid IN \(\?\) AND captured_at < \?/);
   // The prune runs strictly after the inserts (so a failed insert never prunes).
   assert.ok(m.batches.length > 0);
 });
@@ -339,6 +330,18 @@ function statefulEnv(table, { signingKey = SIGNING_KEY } = {}) {
                   }
                   return { meta: { changes } };
                 }
+                if (sql.startsWith("DELETE FROM neurons WHERE netuid IN")) {
+                  const cutoff = v.at(-1);
+                  const refreshed = new Set(v.slice(0, -1));
+                  let changes = 0;
+                  for (const [k, row] of table) {
+                    if (refreshed.has(row.netuid) && row.captured_at < cutoff) {
+                      table.delete(k);
+                      changes += 1;
+                    }
+                  }
+                  return { meta: { changes } };
+                }
                 return { meta: { changes: 0 } };
               },
             }),
@@ -388,6 +391,27 @@ test("loadStagedNeurons snapshot-replace removes a deregistered UID across snaps
   );
   assert.equal(table.get("1:0").captured_at, T2);
   assert.equal(table.has("1:1"), false);
+});
+
+test("loadStagedNeurons keeps unrefreshed subnets during a partial coverage refresh", async () => {
+  const table = new Map();
+  const m = statefulEnv(table);
+
+  const T1 = 1_700_000_000_000;
+  table.set("1:0", { ...neuronRow(1, 0), captured_at: T1 });
+  table.set("1:1", { ...neuronRow(1, 1), captured_at: T1 });
+  table.set("2:0", { ...neuronRow(2, 0), captured_at: T1 });
+
+  const T2 = T1 + 60_000;
+  const partial = [{ ...neuronRow(1, 0), captured_at: T2 }];
+  m.env.METAGRAPH_ARCHIVE._staged = signedCoverageEnvelope(partial, [1], T2);
+
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.purged, 1, "only stale rows in refreshed subnet 1 are pruned");
+  assert.deepEqual([...table.keys()].sort(), ["1:0", "2:0"]);
+  assert.equal(table.get("1:0").captured_at, T2);
+  assert.equal(table.get("2:0").captured_at, T1);
 });
 
 test("loadStagedNeurons makes NO prune and keeps the staged object when a batch fails (safety)", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -366,12 +366,11 @@ function validStagedNeuronRow(row) {
 // (metagraph/neurons-pending.json) using its existing R2 permission; we load only
 // authenticated, bounded, schema-valid rows through the METAGRAPH_HEALTH_DB
 // binding — which needs no API-token D1 permission — with PARAMETERIZED inserts
-// (values are always bound, never interpolated). The staged snapshot is a FULL
-// replacement: after every batch succeeds we delete any row older than the
-// snapshot's captured_at stamp, so deregistered UIDs (and entire vanished subnets)
-// never linger as phantoms — the read paths need no captured_at filter because the
-// table only ever holds the latest snapshot. Then delete the staged object so it
-// loads exactly once.
+// (values are always bound, never interpolated). After every batch succeeds we
+// delete older rows for the coverage represented by the staged payload: legacy
+// bare-array snapshots replace the full table, while coverage envelopes replace
+// only their refreshed subnets. Then delete the staged object so it loads exactly
+// once.
 export async function loadStagedNeurons(env) {
   const bucket = env.METAGRAPH_ARCHIVE;
   const db = env.METAGRAPH_HEALTH_DB;
@@ -442,7 +441,7 @@ export async function loadStagedNeurons(env) {
         .bind(...values),
     );
   }
-  // A staged snapshot is a FULL replacement of the neurons table: every row
+  // A staged snapshot is replacement data for its declared coverage: every row
   // shares one captured_at stamp (set once by the producer). If ANY batch throws,
   // bail WITHOUT deleting prior rows or the staged object — the prior snapshot
   // stays as a fallback and the next cron retries the same staged file.
@@ -453,13 +452,12 @@ export async function loadStagedNeurons(env) {
   } catch {
     return { ok: false, reason: "load_failed" };
   }
-  // Snapshot-replace (#1303): only after EVERY upsert batch succeeds, delete any
-  // row older than this snapshot's stamp so the table holds exactly the current
-  // snapshot. This is what stops deregistered (netuid,uid) pairs — and entire
-  // vanished subnets — from lingering as phantoms (inflated neuron_count, ghost
-  // metagraphs) since the read paths don't filter by captured_at. Derived from
-  // the rows themselves (uniform stamp; use max defensively) so it works for both
-  // the bare-array native snapshot (#1348) and the coverage envelope alike.
+  // Snapshot-replace (#1303): only after EVERY upsert batch succeeds, delete
+  // rows older than this snapshot's stamp for the same replacement scope. Legacy
+  // bare-array snapshots have no coverage metadata, so they replace the whole
+  // table. Coverage envelopes can intentionally represent a partial refresh, so
+  // prune only those refreshed netuids; otherwise a subnet that failed to fetch
+  // could be erased by an unrelated newer captured_at stamp.
   let snapshotCapturedAt = 0;
   for (const row of rows) {
     if (
@@ -470,10 +468,18 @@ export async function loadStagedNeurons(env) {
   }
   let purged;
   try {
-    const result = await db
-      .prepare(`DELETE FROM neurons WHERE captured_at < ?`)
-      .bind(snapshotCapturedAt)
-      .run();
+    const prune = stagingMeta.legacy
+      ? db
+          .prepare(`DELETE FROM neurons WHERE captured_at < ?`)
+          .bind(snapshotCapturedAt)
+      : db
+          .prepare(
+            `DELETE FROM neurons WHERE netuid IN (${stagingMeta.refreshed_netuids
+              .map(() => "?")
+              .join(",")}) AND captured_at < ?`,
+          )
+          .bind(...stagingMeta.refreshed_netuids, stagingMeta.captured_at);
+    const result = await prune.run();
     purged = result?.meta?.changes ?? 0;
   } catch {
     // Rows are already loaded; a failed prune just leaves stale rows for the next


### PR DESCRIPTION
### Motivation
- A recent change pruned the `neurons` table table-wide based only on `captured_at`, which can erase rows for subnets that were not included in a partial coverage envelope and thus cause data loss for unrefreshed subnets. 
- The loader still accepts coverage envelopes that intentionally represent partial refreshes via `refreshed_netuids`, so the prune must respect that contract to avoid wiping unrelated subnets. 

### Description
- Modify `loadStagedNeurons` so the prune is coverage-scoped: legacy bare-array snapshots still execute `DELETE FROM neurons WHERE captured_at < ?`, while coverage envelopes execute `DELETE FROM neurons WHERE netuid IN (?,?,...) AND captured_at < ?` bound to `refreshed_netuids` and the snapshot cutoff. 
- Update comments in `workers/api.mjs` to document the distinction between full-table legacy replacement and coverage-scoped replacement. 
- Extend `tests/load-staged-neurons.test.mjs` to assert the new SQL shape for coverage envelopes and add a stateful regression test that proves unrefreshed subnets are preserved during a partial coverage refresh. 
- Update the stateful D1 mock in tests to honor the `DELETE ... WHERE netuid IN (...) AND captured_at < ?` shape. 

### Testing
- Ran the targeted staged-neurons tests with `npx vitest run tests/load-staged-neurons.test.mjs`, and the file-level test suite passed (`14/14` tests passed). 
- Ran `npm run lint` and `npm run format:check`, both of which succeeded. 
- Ran the full test matrix with `npm test`; unrelated repository/environment issues (missing generated public artifacts, DNS-sensitive tests, and a long-running R2 history test) caused unrelated failures, but the targeted staged-neuron tests remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39573495e0832c9a65f52e837f61b4)