### PR TITLE
fix(events): rescan overlap despite staged cursor

### DIFF
--- a/.github/workflows/refresh-events.yml
+++ b/.github/workflows/refresh-events.yml
@@ -81,12 +81,11 @@ jobs:
       - name: Poll finney events (first-party, public RPC, no key)
         run: uv run --with substrate-interface==1.8.1 python scripts/fetch-events.py
         env:
-          # Overlap FLOOR (not the whole story anymore): ~250 blocks ≈ 50 min of
-          # chain guarantees generous idempotent overlap so a cold/empty cursor is
-          # safe and re-loads are harmless. The cursor (above) handles gaps LONGER
-          # than this; the window just bounds the per-run scan + provides overlap.
+          # Bounded overlap: ~250 blocks ≈ 50 min of chain is re-scanned every
+          # run so staged-but-not-yet-loaded event batches can be regenerated if
+          # the single pending R2 object is overwritten before the Worker drains it.
           EVENTS_WINDOW: "250"
-          # Highest block already staged (blank on a cold start → window floor).
+          # Highest block already staged; used for lag/health accounting only.
           EVENTS_CURSOR: ${{ steps.cursor.outputs.block }}
           # Emit a ::warning:: (and webhook alert, if configured) when the cursor
           # falls within a window of the public-RPC prune horizon.
@@ -100,11 +99,10 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-      # Advance the durable cursor ONLY after a successful stage above. fetch-events
-      # wrote the next cursor (the max block it scanned) to dist/events-cursor.json;
-      # promote it to R2 so the next run resumes from here. If staging failed, this
-      # step is skipped and the cursor stays put — so the next run re-scans from the
-      # last *confirmed-staged* block rather than skipping the un-staged range.
+      # Advance the cursor ONLY after a successful stage above. fetch-events wrote
+      # the next cursor (the max block it scanned) to dist/events-cursor.json; promote
+      # it to R2 for lag/health accounting. The poller still re-scans the bounded
+      # overlap window because R2 staging is not proof of asynchronous D1 import.
       - name: Advance event cursor in R2
         run: npx wrangler r2 object put metagraphed-artifacts/events/cursor.json --file=dist/events-cursor.json --remote
         env:

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -75,33 +75,18 @@ def _parse_cursor(raw):
 def compute_from_block(cursor, head, window):
     """First block to scan this run — the testable core of the cursor logic.
 
-    `from = max(cursor + 1, head - window + 1)`, clamped to >= 0. The window is an
-    overlap FLOOR, the cursor a long-gap backstop:
-      * cold cursor (None)                → head - window + 1  (the floor)
-      * fresh cursor just behind head     → cursor + 1         (no needless rescan)
-      * stale cursor older than the window→ still cursor + 1 if it's within the
-        window of the head, else the floor — but we NEVER scan further back than
-        the floor would require for a cold start beyond it; i.e. a wildly stale
-        cursor is capped at the window so we don't try to re-scan the whole chain
-        (blocks older than the prune horizon are gone anyway; the alert fires)
-      * cursor >= head (reorg / clock skew) → head - window + 1 (the floor)
+    Always re-scan the bounded overlap window: `head - window + 1`, clamped to
+    >= 0. The workflow stages events to R2 and the Worker imports that pending
+    object into D1 asynchronously, so a promoted cursor only proves that a range
+    was staged, not that it was durably loaded. Re-scanning the overlap every run
+    lets a later run recreate a recent staged batch if the single pending R2
+    object was overwritten before the Worker drained it; D1 uses idempotent
+    inserts, so duplicated overlap rows are harmless.
 
-    Concretely: a cursor that is far behind head (gap > window) still resumes at
-    cursor+1 ONLY while cursor+1 >= floor; once the gap exceeds the window the
-    floor wins, bounding the scan to `window` blocks. That bound is the whole
-    point — the cursor recovers gaps up to ~prune-horizon, the window caps the
-    work, and pruned-out blocks are unrecoverable by design (alerted, not scanned).
+    The cursor is still useful for lag/health accounting, but it must not move
+    the start block ahead of the overlap floor.
     """
-    floor = max(0, head - window + 1)
-    if cursor is None:
-        return floor
-    if cursor >= head:
-        # Cursor at/ahead of head: nothing new, or a reorg/skew rewound the head.
-        # Re-scan the overlap window (idempotent) rather than an empty/negative range.
-        return floor
-    # cursor < head: resume just past it, but never further back than the floor
-    # (caps a wildly stale cursor at `window` blocks instead of the whole chain).
-    return max(cursor + 1, floor)
+    return max(0, head - window + 1)
 
 
 def _ss58(v):
@@ -276,10 +261,10 @@ def main():
 
     # Next-cursor sidecar: the highest block we covered this run (the finalized
     # head we scanned through). The workflow stages the events first, then — only
-    # on a successful stage — promotes this to events/cursor.json in R2 so the next
-    # run resumes from here. The window floor still guarantees overlap, so even if
-    # the staged batch is clobbered before the Worker drains it, recent blocks are
-    # re-scanned next run (INSERT OR IGNORE makes the re-load harmless).
+    # on a successful stage — promotes this to events/cursor.json in R2. Because
+    # staging and D1 loading are asynchronous, compute_from_block still re-scans
+    # the overlap window every run; the cursor is retained for lag/health alerts,
+    # not as proof that staged rows have already been imported into D1.
     next_cursor = max(head_bn, cursor) if cursor is not None else head_bn
     os.makedirs(os.path.dirname(CURSOR_OUT) or ".", exist_ok=True)
     with open(CURSOR_OUT, "w") as fh:

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -42,14 +42,15 @@ class ComputeFromBlockTest(unittest.TestCase):
             compute_from_block(None, self.HEAD, self.WINDOW), self.floor()
         )
 
-    def test_fresh_cursor_resumes_at_cursor_plus_one(self):
-        # A cursor just behind the head → cursor + 1 (no needless rescan, and
-        # ahead of the floor).
+    def test_fresh_cursor_still_uses_window_floor(self):
+        # A cursor just behind the head only proves the range was staged to R2,
+        # not that the asynchronous Worker imported it into D1. Keep re-scanning
+        # the overlap floor so an overwritten pending batch can be recreated.
         cursor = self.HEAD - 10
         self.assertEqual(
-            compute_from_block(cursor, self.HEAD, self.WINDOW), cursor + 1
+            compute_from_block(cursor, self.HEAD, self.WINDOW), self.floor()
         )
-        self.assertGreater(cursor + 1, self.floor())
+        self.assertLess(self.floor(), cursor + 1)
 
     def test_stale_cursor_older_than_window_is_capped_at_floor(self):
         # A cursor far older than the window must NOT trigger a whole-chain rescan;
@@ -75,10 +76,10 @@ class ComputeFromBlockTest(unittest.TestCase):
             compute_from_block(self.HEAD, self.HEAD, self.WINDOW), self.floor()
         )
 
-    def test_cursor_exactly_one_behind_resumes_at_head(self):
-        # Boundary: cursor == head - 1 → from == head (scan just the new block).
+    def test_cursor_exactly_one_behind_still_uses_floor(self):
+        # Boundary: cursor == head - 1 still re-scans the overlap window.
         self.assertEqual(
-            compute_from_block(self.HEAD - 1, self.HEAD, self.WINDOW), self.HEAD
+            compute_from_block(self.HEAD - 1, self.HEAD, self.WINDOW), self.floor()
         )
 
     def test_cursor_at_window_boundary_prefers_cursor(self):
@@ -91,9 +92,9 @@ class ComputeFromBlockTest(unittest.TestCase):
     def test_never_negative_near_genesis(self):
         # Window larger than the head must clamp the floor to 0, never go negative.
         self.assertEqual(compute_from_block(None, 5, 250), 0)
-        # With a low cursor near genesis we still resume at cursor+1 (block 2 is
-        # already staged → start at 3); the point is the result is never negative.
-        self.assertEqual(compute_from_block(2, 5, 250), 3)
+        # With a low cursor near genesis we still use the overlap floor because
+        # staging is not proof of D1 persistence.
+        self.assertEqual(compute_from_block(2, 5, 250), 0)
         self.assertGreaterEqual(compute_from_block(2, 5, 250), 0)
         # A None cursor with head 0 and any window clamps to 0 (not -249).
         self.assertEqual(compute_from_block(None, 0, 250), 0)


### PR DESCRIPTION
### Motivation
- The workflow advanced an R2 staging cursor immediately after writing the single pending batch, but R2 staging and the Worker’s D1 import are asynchronous which could let a later run overwrite the pending object and skip those blocks due to a fresh cursor, causing silent data loss. 
- The intent is to keep the per-run scan bounded but idempotent so a missed/asynchronous D1 load can be recovered by re-generating the recent staged batch.

### Description
- Change `compute_from_block` in `scripts/fetch-events.py` to always start at the bounded overlap floor (`max(0, head - window + 1)`) so every run re-scans the overlap window rather than resuming from a fresh `cursor + 1`.
- Update the next-cursor comment in `scripts/fetch-events.py` to clarify the cursor is retained for lag/health accounting and is not proof that staged rows were imported into D1.
- Update `.github/workflows/refresh-events.yml` comments to document that the overlap is re-scanned each run and that the cursor is used only for health/lag accounting.
- Adjust unit tests in `scripts/test_fetch_events.py` to expect overlap re-scan behavior for fresh/near-head and genesis-adjacent cursor cases.

### Testing
- Ran the unit tests with `python3 scripts/test_fetch_events.py`, which passed all cases (12 tests, OK). 
- Verified Python syntax with `python3 -m py_compile scripts/fetch-events.py`, which succeeded. 
- Validated workflow files with `npm run validate:workflows`, which reported all workflow files validated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a395974954c832ca3b50f347738fef6)