### PR TITLE
chore(release): combine release-please into one PR (end cross-component manifest conflicts)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "separate-pull-requests": true,
+  "separate-pull-requests": false,
   "include-component-in-tag": true,
-  "pull-request-title-pattern": "chore: release ${component} ${version}",
+  "pull-request-title-pattern": "chore: release ${version}",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
Closes #1478

## Problem

`separate-pull-requests: true` + 3 components (client, python, platform) sharing one `.release-please-manifest.json` means **every open release PR edits the same file**. When one merges, the others go stale → conflict. The perpetual platform marker PR hit this on every client/python release (most recently #1476, which I had to hand-rebase).

## Fix

Flip to `separate-pull-requests: false` → **one combined release PR**, so the manifest is updated atomically and can never conflict with itself.

**Preserved:**
- Independent version tags per component (`include-component-in-tag: true` → `client-vX`, `python-vY`, `platform-vZ`).
- Independent OIDC publishes — `release-please.yml` dispatch steps gate on per-component `*--release_created` outputs (independent `if`s), so a combined merge releasing both client+python fires **both** publish workflows.

**Trade-off:** you lose independent *merge-timing* — merging the one PR cuts all pending component releases together.

**Follow-up on merge:** release-please will close the separate component PRs (#1476 etc.) and open a single combined PR.