### PR TITLE
fix(health): overlay live probe health on MCP find_subnet_for_task + /ask enrichment

### DIFF
--- a/src/ai-search.mjs
+++ b/src/ai-search.mjs
@@ -299,8 +299,15 @@ async function loadAskEnrichment(env, deps) {
       env,
       "/metagraph/agent-catalog.json",
     );
-    const subnets = catalog?.ok ? catalog.data?.subnets : catalog?.subnets;
+    let subnets = catalog?.ok ? catalog.data?.subnets : catalog?.subnets;
     if (!Array.isArray(subnets)) return new Map();
+    // Overlay live probe health (injected, so this module stays binding-free and
+    // stub-testable) so /ask context reflects the current cron-probed status —
+    // not the build-time "unknown" stub baked into the catalog artifact.
+    if (deps.liveHealth && typeof deps.overlayCatalogIndex === "function") {
+      const overlaid = deps.overlayCatalogIndex({ subnets }, deps.liveHealth);
+      if (Array.isArray(overlaid?.subnets)) subnets = overlaid.subnets;
+    }
     return new Map(
       subnets
         .filter((entry) => Number.isInteger(entry?.netuid))

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -1160,12 +1160,17 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const task = requireString(args, "task");
       const limit = clampLimit(args?.limit, 5, 20);
+      const live = await mcpLiveHealth(ctx);
       const catalog = await loadArtifactData(
         ctx,
         "/metagraph/agent-catalog.json",
       );
+      // Overlay live probe health onto the catalog index before ranking so each
+      // result's `health` reflects the current cron-probed status, not the
+      // build-time "unknown" stub baked into the artifact.
+      const overlaidCatalog = overlayCatalogIndex(catalog, live) || catalog;
       const byNetuid = new Map(
-        (catalog.subnets || []).map((entry) => [entry.netuid, entry]),
+        (overlaidCatalog.subnets || []).map((entry) => [entry.netuid, entry]),
       );
       const { mode, ranked } = await rankSubnetsForTask(
         ctx,

--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -18,6 +18,7 @@ import {
 } from "../src/ai-search.mjs";
 import { handleRequest, handleScheduled } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+import { overlayCatalogIndex } from "../src/health-serving.mjs";
 
 const SEMANTIC_URL = "https://api.metagraph.sh/api/v1/search/semantic";
 const ASK_URL = "https://api.metagraph.sh/api/v1/ask";
@@ -784,6 +785,41 @@ describe("ai-search defensive branches", () => {
     const askCall = env.AI.calls.find((c) => c.model === ASK_MODEL);
     const userMessage = askCall.input.messages.at(-1).content;
     assert.match(userMessage, /api\.one\.io/);
+  });
+
+  test("askQuestion overlays LIVE probe health onto the catalog enrichment", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    const readArtifact = () =>
+      Promise.resolve({
+        ok: true,
+        data: {
+          subnets: [
+            {
+              netuid: 1,
+              callable_count: 3,
+              base_url: "https://api.one.io",
+              health: "unknown", // build-time stub baked into the artifact
+            },
+          ],
+        },
+      });
+    // The /ask handler resolves the live snapshot and injects it + the overlay
+    // helper. Assert the live status reaches the prompt, overriding the stub.
+    const liveHealth = {
+      last_run_at: "2026-06-22T18:00:00.000Z",
+      subnets: [{ netuid: 1, status: "degraded" }],
+    };
+    const out = await askQuestion(
+      env,
+      "Which subnet does images?",
+      {},
+      { readArtifact, liveHealth, overlayCatalogIndex },
+    );
+    assert.ok(out.answer.length > 0);
+    const askCall = env.AI.calls.find((c) => c.model === ASK_MODEL);
+    const userMessage = askCall.input.messages.at(-1).content;
+    // Live "degraded" status overrides the baked "unknown" stub in the context.
+    assert.match(userMessage, /degraded/);
   });
 
   test("askQuestion degrades gracefully when the catalog read fails", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -2214,6 +2214,49 @@ describe("MCP goal-shaped tools — branch coverage", () => {
       assert.equal(out.health_source, "live-cron-prober");
     });
 
+    test("find_subnet_for_task overlays live health onto ranked results", async () => {
+      const deps = makeDeps(
+        {
+          "/metagraph/search.json": {
+            documents: [
+              {
+                type: "subnet",
+                netuid: 7,
+                slug: "x",
+                title: "X",
+                tokens: ["bitcoin", "data"],
+              },
+            ],
+          },
+          "/metagraph/agent-catalog.json": {
+            subnets: [
+              {
+                netuid: 7,
+                slug: "x",
+                name: "X",
+                categories: ["bitcoin"],
+                service_kinds: ["subnet-api"],
+                callable_count: 3,
+                integration_readiness: 80,
+              },
+            ],
+          },
+        },
+        { "health:current": liveKv },
+      );
+      const res = await callTool(
+        "find_subnet_for_task",
+        { task: "bitcoin" },
+        { deps },
+      );
+      const match = res.body.result.structuredContent.results.find(
+        (r) => r.netuid === 7,
+      );
+      assert.ok(match, "subnet 7 should rank for the task");
+      // health reflects the LIVE probe ("failed"), not the build-time stub.
+      assert.equal(match.health, "failed");
+    });
+
     test("cold KV → static current-health is NOT served (live-only); reports unknown", async () => {
       const deps = makeDeps({
         "/metagraph/health/subnets/7.json": staticHealth,

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -4172,11 +4172,19 @@ async function handleAskRequest(request, env) {
     );
   }
   try {
+    // Resolve live probe health once and inject it so /ask context reflects the
+    // current operational status of each subnet's surfaces, not the build-time
+    // "unknown" stub baked into the agent-catalog artifact.
+    const liveHealth = await resolveLiveHealth({
+      readHealthKv,
+      env,
+      db: env.METAGRAPH_HEALTH_DB,
+    });
     const data = await askQuestion(
       env,
       body?.question,
       { topK: body?.topK },
-      { readArtifact },
+      { readArtifact, liveHealth, overlayCatalogIndex },
     );
     return dataResponse(env, data, 200, { source: "ai-live" });
   } catch (error) {


### PR DESCRIPTION
Closes #1480

## Problem
Two read paths served the build-time `unknown` health stub from `agent-catalog.json` instead of the live 15-min prober status that the rest of the API/MCP already overlays:
- **MCP `find_subnet_for_task`** — `health: entry.health` (baked stub) → agents can't see live status when picking a subnet for a task.
- **`/api/v1/ask`** — `loadAskEnrichment` read the baked stub → grounded answers say `unknown`.

## Fix (reuses existing helpers — no new infra)
- `find_subnet_for_task`: `overlayCatalogIndex(catalog, mcpLiveHealth(ctx))` before ranking (identical to `get_agent_catalog`).
- `/ask`: handler resolves the live snapshot via `resolveLiveHealth` and injects it + `overlayCatalogIndex` into the enrichment deps — **ai-search.mjs stays import/binding-free and stub-testable** (its design contract).

## Tests
- mcp-server: `find_subnet_for_task` overlays live health onto ranked results (warm KV → `failed`).
- ai-search: `/ask` enrichment shows live `degraded` over the baked `unknown` stub.
- 161 tests green locally; prettier clean.

Schema polish (declaring `health_source`/`operational_observed_at` on `SubnetOverviewArtifact.health`) is intentionally split into a separate single-concern follow-up.