### PR TITLE
perf: edge-cache deterministic analytics routes + composite indexes (audit-driven)

### DIFF
--- a/migrations/0010_perf_indexes.sql
+++ b/migrations/0010_perf_indexes.sql
@@ -1,0 +1,34 @@
+-- Perf hardening (audit-driven, epic #512): composite indexes that let hot
+-- analytics queries SEEK instead of full-scan-then-sort. All additive
+-- (CREATE INDEX IF NOT EXISTS), idempotent, safe to re-apply. Each index is
+-- justified by a specific live query — see the comment above it.
+
+-- handleLeaderboards (workers/api.mjs): `... FROM subnet_snapshots
+-- WHERE snapshot_date >= ? ORDER BY netuid, snapshot_date`. The existing
+-- idx_subnet_snapshots_netuid_date (netuid, snapshot_date) leads with netuid, so a
+-- `snapshot_date >=` range filter cannot seek and must scan; (snapshot_date, netuid)
+-- seeks the date range and yields rows already ordered for the netuid grouping.
+CREATE INDEX IF NOT EXISTS idx_subnet_snapshots_date_netuid
+  ON subnet_snapshots (snapshot_date, netuid);
+
+-- handleBulkHealthTrends (workers/api.mjs): `... FROM surface_uptime_daily
+-- WHERE day >= ? GROUP BY netuid, day`. The existing
+-- idx_surface_uptime_daily_netuid_day (netuid, day) is backwards for a `day >=`
+-- range scan across all subnets; (day, netuid) matches the access pattern.
+CREATE INDEX IF NOT EXISTS idx_surface_uptime_daily_day_netuid
+  ON surface_uptime_daily (day, netuid);
+
+-- handleRpcUsage (workers/api.mjs): `... FROM rpc_proxy_events
+-- WHERE observed_at >= ? AND endpoint_id IS NOT NULL GROUP BY endpoint_id, provider`.
+-- The existing idx_rpc_proxy_events_observed (observed_at) seeks the range but then
+-- post-filters endpoint_id; (observed_at, endpoint_id) skips NULL endpoint_id rows
+-- inside the index.
+CREATE INDEX IF NOT EXISTS idx_rpc_proxy_events_observed_endpoint
+  ON rpc_proxy_events (observed_at, endpoint_id);
+
+-- loadStagedNeurons prune (workers/api.mjs): `DELETE FROM neurons WHERE captured_at < ?`
+-- (and the netuid-scoped variant) deregisters stale UIDs on every */3 staged load.
+-- No captured_at index existed, so this prune full-scanned the ~33k-row table each
+-- tick; this covers the captured_at predicate.
+CREATE INDEX IF NOT EXISTS idx_neurons_captured_at
+  ON neurons (captured_at);

--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -395,4 +395,60 @@ describe("analytics edge cache", () => {
 
     assert.equal(cachedBody, uncachedBody);
   });
+
+  test("the 4 additional deterministic routes are now edge-cached (MISS→put under their key, HIT→no D1)", async () => {
+    // These routes (global incidents, per-subnet trajectory, per-subnet uptime,
+    // registry leaderboards) were edgeCache=0 — they re-ran their D1 aggregation
+    // on every request. Now wrapped in withEdgeCache at the call site, keyed on
+    // the same contract_version + last_run_at + pathname + search.
+    const routes = [
+      {
+        keyParts: "leaderboards",
+        path: "/api/v1/registry/leaderboards",
+        search: "",
+      },
+      {
+        keyParts: "global-incidents",
+        path: "/api/v1/incidents",
+        search: "?window=7d",
+      },
+      {
+        keyParts: "trajectory",
+        path: "/api/v1/subnets/7/trajectory",
+        search: "",
+      },
+      {
+        keyParts: "uptime",
+        path: "/api/v1/subnets/7/uptime",
+        search: "?window=90d",
+      },
+    ];
+    originalCaches = globalThis.caches;
+    for (const r of routes) {
+      const cache = mockCaches();
+      cache.install();
+      const queries = [];
+      const env = analyticsEnv(queries);
+      const url = `https://api.metagraph.sh${r.path}${r.search}`;
+
+      // MISS: runs D1 and caches under the route's key.
+      const miss = await handleRequest(new Request(url), env, ctx);
+      await Promise.resolve();
+      assert.equal(miss.status, 200, `${r.keyParts}: MISS is 200`);
+      assert.ok(
+        cache.putKeys.includes(expectedKey(r.keyParts, r.path, r.search)),
+        `${r.keyParts}: cached under its expected key`,
+      );
+      const queriesAfterMiss = queries.length;
+
+      // HIT: served from cache, no additional D1.
+      const hit = await handleRequest(new Request(url), env, ctx);
+      assert.equal(hit.status, 200, `${r.keyParts}: HIT is 200`);
+      assert.equal(
+        queries.length,
+        queriesAfterMiss,
+        `${r.keyParts}: a HIT issues no further D1 query`,
+      );
+    }
+  });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -844,7 +844,12 @@ export async function handleRequest(request, env = {}, ctx = {}) {
 
   // Registry leaderboards (D1 + registry projections; fileless-D1 pattern).
   if (url.pathname === "/api/v1/registry/leaderboards") {
-    return handleLeaderboards(request, env, url);
+    // Deterministic per-cron-tick D1 leaderboard; edge-cache keyed on the health
+    // snapshot's last_run_at (auto-busts on the next probe) like the sibling
+    // analytics routes, so a polling/cross-colo burst doesn't re-run the SQL.
+    return withEdgeCache(request, ctx, env, "leaderboards", () =>
+      handleLeaderboards(request, env, url),
+    );
   }
 
   // RPC reverse-proxy usage analytics (D1 telemetry; fileless-D1 pattern, B3).
@@ -919,16 +924,20 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     }
     const trajectoryMatch = TRAJECTORY_PATH_PATTERN.exec(resolved.url.pathname);
     if (trajectoryMatch) {
-      return handleTrajectory(
-        request,
-        env,
-        Number(trajectoryMatch[1]),
-        resolved.url,
+      return withEdgeCache(request, ctx, env, "trajectory", () =>
+        handleTrajectory(
+          request,
+          env,
+          Number(trajectoryMatch[1]),
+          resolved.url,
+        ),
       );
     }
     const uptimeMatch = UPTIME_PATH_PATTERN.exec(resolved.url.pathname);
     if (uptimeMatch) {
-      return handleUptime(request, env, Number(uptimeMatch[1]), resolved.url);
+      return withEdgeCache(request, ctx, env, "uptime", () =>
+        handleUptime(request, env, Number(uptimeMatch[1]), resolved.url),
+      );
     }
     // Per-UID metagraph (#1304/#1305): computed live from the neurons D1 tier.
     const metagraphMatch = SUBNET_METAGRAPH_PATH_PATTERN.exec(
@@ -986,7 +995,9 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       return handleAccount(request, env, accountMatch[1]);
     }
     if (resolved.url.pathname === "/api/v1/incidents") {
-      return handleGlobalIncidents(request, env, resolved.url);
+      return withEdgeCache(request, ctx, env, "global-incidents", () =>
+        handleGlobalIncidents(request, env, resolved.url),
+      );
     }
     return handleApiRequest(request, env, resolved.url, DEFAULT_NETWORK, ctx);
   }


### PR DESCRIPTION
Closes #1482

## Two confirmed perf wins from the audit
1. **Composite indexes** (`migrations/0010`, already applied to prod): subnet_snapshots(snapshot_date,netuid), surface_uptime_daily(day,netuid), rpc_proxy_events(observed_at,endpoint_id), neurons(captured_at). Each verified against its real query.
2. **Edge-cache wraps** on the 4 deterministic D1 routes still missing it — global incidents, trajectory, uptime, leaderboards — at the call site (keyed on contract_version + last_run_at + pathname + search, like their cached siblings). Handler bodies untouched; only 200s cached.

## Two audit findings adversarially DROPPED (verified wrong)
- **leaderboards TTL** `standard`→`short`: audit assumed ~2-min cron, but the prober is `*/15`; 5-min cache is within freshness. The wrap is the real fix.
- **account_events OR→UNION**: `EXPLAIN QUERY PLAN` → `MULTI-INDEX OR` (SQLite already uses both single-column indexes). Rewrite unnecessary + risks double-counting.

## Tests
New edge-cache test asserts all 4 routes MISS→put-under-key, HIT→no-D1. 131 local tests green; build + prettier clean.