### PR TITLE
feat(history): per-UID daily metagraph history — block-explorer Tier-1 (#1345)

### DIFF
--- a/migrations/0011_neuron_daily.sql
+++ b/migrations/0011_neuron_daily.sql
@@ -1,0 +1,55 @@
+-- Per-UID daily metagraph HISTORY (block-explorer Tier-1, epic #1345 / depth #1302).
+--
+-- The refresh-metagraph cron lands the LATEST per-UID snapshot in `neurons`
+-- (migration 0007, overwrite-on-conflict — no history is kept). A dedicated daily
+-- rollup (rollupNeuronDaily, src/neuron-history.mjs) copies the current snapshot
+-- into this append-only DATED table, giving per-UID and per-subnet time-series for
+-- every subnet without a second fetch.
+--
+-- Shape mirrors `neurons` EXACTLY (so formatNeuron / buildSubnetMetagraph are
+-- reused verbatim on the read path) plus snapshot_date. It lives in the SAME
+-- database as `neurons` on purpose: D1 has no cross-database queries, so co-location
+-- makes the rollup a single, atomic INSERT...SELECT instead of a brittle
+-- Worker-mediated row shuttle. A 90-day prune (PR-A2) keeps it bounded (~3M rows /
+-- ~0.7GB steady-state, far under D1's 10GB cap); older days tier to an R2 cold
+-- archive (PR-A2).
+CREATE TABLE IF NOT EXISTS neuron_daily (
+  netuid               INTEGER NOT NULL,
+  uid                  INTEGER NOT NULL,
+  snapshot_date        TEXT    NOT NULL,   -- YYYY-MM-DD (UTC) derived from captured_at
+  hotkey               TEXT,
+  coldkey              TEXT,
+  active               INTEGER,            -- 0/1
+  validator_permit     INTEGER,            -- 0/1
+  rank                 REAL,
+  trust                REAL,
+  validator_trust      REAL,
+  consensus            REAL,
+  incentive            REAL,
+  dividends            REAL,
+  emission_tao         REAL,
+  stake_tao            REAL,
+  registered_at_block  INTEGER,
+  is_immunity_period   INTEGER,            -- 0/1
+  axon                 TEXT,
+  block_number         INTEGER,
+  captured_at          INTEGER NOT NULL,   -- epoch ms — the single consistent snapshot stamp
+  updated_at           INTEGER NOT NULL,   -- epoch ms when this daily row was (re)rolled
+  PRIMARY KEY (netuid, uid, snapshot_date)
+);
+
+-- Per-UID time series: WHERE netuid = ? AND uid = ? ORDER BY snapshot_date DESC.
+CREATE INDEX IF NOT EXISTS idx_neuron_daily_uid_date
+  ON neuron_daily (netuid, uid, snapshot_date);
+
+-- Per-subnet as-of / validators on a date: WHERE netuid = ? AND snapshot_date = ?.
+CREATE INDEX IF NOT EXISTS idx_neuron_daily_netuid_date
+  ON neuron_daily (netuid, snapshot_date);
+
+-- Point-in-time account history: which UID a hotkey held on a date.
+CREATE INDEX IF NOT EXISTS idx_neuron_daily_hotkey_date
+  ON neuron_daily (hotkey, snapshot_date);
+
+-- Lets the (PR-A2) retention prune SEEK the old-day tail instead of full-scanning.
+CREATE INDEX IF NOT EXISTS idx_neuron_daily_date
+  ON neuron_daily (snapshot_date);

--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -1,0 +1,118 @@
+// Per-UID daily metagraph HISTORY (block-explorer Tier-1, epic #1345 / depth #1302).
+//
+// The rollup snapshots the live `neurons` table into the dated `neuron_daily`
+// table once a day (its own cron); the read builders reuse the live formatters
+// (metagraph-neurons.mjs) so a historical row is byte-identical in shape to a live
+// one. Pure + injectable for tests — the Worker handlers run the D1 query and call
+// these.
+import {
+  NEURON_INSERT_COLUMNS,
+  NEURON_COLUMNS,
+  formatNeuron,
+} from "./metagraph-neurons.mjs";
+
+// Columns copied verbatim from `neurons` into `neuron_daily` (identical shape).
+const ROLLUP_COLUMNS = NEURON_INSERT_COLUMNS;
+
+// History windows. Deliberately NOT analyticsWindow (which only understands
+// 7d/30d and clamps anything else to 400 days). `all` → no lower bound.
+export const HISTORY_WINDOWS = {
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+  "1y": 365,
+  all: null,
+};
+export const DEFAULT_HISTORY_WINDOW = "30d";
+// Bounds any single time-series response (1y = 365 daily points < this cap).
+export const MAX_HISTORY_POINTS = 400;
+
+export function parseHistoryWindow(value) {
+  const v = typeof value === "string" && value ? value : DEFAULT_HISTORY_WINDOW;
+  if (!Object.prototype.hasOwnProperty.call(HISTORY_WINDOWS, v)) {
+    return {
+      error: `window must be one of: ${Object.keys(HISTORY_WINDOWS).join(", ")}`,
+    };
+  }
+  return { label: v, days: HISTORY_WINDOWS[v] };
+}
+
+// Validates the ?date= param for as-of reads (YYYY-MM-DD). Range/real-date checks
+// are left to SQLite (an impossible date simply matches no rows → empty 200).
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+export function isValidSnapshotDate(value) {
+  return typeof value === "string" && DATE_RE.test(value);
+}
+
+function toIso(ms) {
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+}
+
+/**
+ * Daily rollup: snapshot the current `neurons` table into `neuron_daily` for the
+ * captured UTC day. A single atomic INSERT...SELECT in the health DB:
+ *  - WHERE captured_at = MAX(captured_at): one consistent snapshot stamp, so a
+ *    concurrent partial load can't bleed two stamps into a single day.
+ *  - snapshot_date = the UTC day of that captured_at, computed in SQL.
+ *  - ON CONFLICT(netuid,uid,snapshot_date) DO UPDATE: intra-day re-runs are
+ *    idempotent (the row reflects the last capture that UTC day).
+ * Returns {rolled, rows} for cron observability; the caller .catch-isolates it so a
+ * failure never affects the rest of the scheduled run.
+ */
+export async function rollupNeuronDaily(env, { now = Date.now() } = {}) {
+  const db = env?.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) return { rolled: false, reason: "no-db" };
+  const cols = ROLLUP_COLUMNS.join(", ");
+  const setClause = ROLLUP_COLUMNS.filter((c) => c !== "netuid" && c !== "uid")
+    .map((c) => `${c} = excluded.${c}`)
+    .concat("updated_at = excluded.updated_at")
+    .join(", ");
+  const sql =
+    `INSERT INTO neuron_daily (${cols}, snapshot_date, updated_at) ` +
+    `SELECT ${cols}, date(captured_at / 1000, 'unixepoch'), ? ` +
+    `FROM neurons WHERE captured_at = (SELECT MAX(captured_at) FROM neurons) ` +
+    `ON CONFLICT(netuid, uid, snapshot_date) DO UPDATE SET ${setClause}`;
+  const res = await db.prepare(sql).bind(now).run();
+  return { rolled: true, rows: res?.meta?.changes ?? null };
+}
+
+// SELECT list for reading a neuron_daily row back as a live-shaped neuron
+// (formatNeuron consumes NEURON_COLUMNS) plus the history-specific snapshot_date.
+export const NEURON_DAILY_READ_COLUMNS = `snapshot_date, ${NEURON_COLUMNS}`;
+
+// Per-UID time series: one point per snapshot_date (the handler queries newest
+// first, bounded by MAX_HISTORY_POINTS), each a live-shaped neuron plus its date.
+export function buildNeuronHistory(rows, netuid, uid, { window } = {}) {
+  return {
+    schema_version: 1,
+    netuid,
+    uid,
+    window: window ?? null,
+    point_count: rows.length,
+    points: rows.map((r) => ({
+      snapshot_date: r.snapshot_date,
+      captured_at: toIso(r.captured_at),
+      block_number: r.block_number ?? null,
+      ...formatNeuron(r),
+    })),
+  };
+}
+
+// Per-subnet metric-over-time: the daily count + a couple of cheap aggregates per
+// snapshot_date (newest first), for a subnet-level history sparkline without
+// shipping every UID. Rows come from a GROUP BY snapshot_date query.
+export function buildSubnetHistory(rows, netuid, { window } = {}) {
+  return {
+    schema_version: 1,
+    netuid,
+    window: window ?? null,
+    point_count: rows.length,
+    points: rows.map((r) => ({
+      snapshot_date: r.snapshot_date,
+      neuron_count: r.neuron_count ?? null,
+      validator_count: r.validator_count ?? null,
+      total_stake_tao: r.total_stake_tao ?? null,
+      total_emission_tao: r.total_emission_tao ?? null,
+    })),
+  };
+}

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  parseHistoryWindow,
+  rollupNeuronDaily,
+  buildNeuronHistory,
+  buildSubnetHistory,
+  HISTORY_WINDOWS,
+  MAX_HISTORY_POINTS,
+} from "../src/neuron-history.mjs";
+import { handleRequest } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+// A neuron_daily read row (NEURON_DAILY_READ_COLUMNS shape: snapshot_date + the
+// live neuron columns) — formatNeuron consumes the same fields.
+function dailyRow(overrides = {}) {
+  return {
+    snapshot_date: "2026-06-20",
+    uid: 3,
+    hotkey: "5Hot",
+    coldkey: "5Cold",
+    active: 1,
+    validator_permit: 1,
+    rank: 0.5,
+    trust: 0.9,
+    validator_trust: 0.8,
+    consensus: 0.7,
+    incentive: 0.6,
+    dividends: 0.4,
+    emission_tao: 1.23,
+    stake_tao: 456.7,
+    registered_at_block: 100,
+    is_immunity_period: 0,
+    axon: "1.2.3.4:9000",
+    block_number: 5_000_000,
+    captured_at: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+// Stub METAGRAPH_HEALTH_DB whose .all() returns the given rows and records the SQL.
+function historyEnv(rows, captured = {}) {
+  return {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        captured.sql = sql;
+        return {
+          bind(...params) {
+            captured.params = params;
+            return { all: () => Promise.resolve({ results: rows }) };
+          },
+        };
+      },
+    },
+  };
+}
+
+const ctx = { waitUntil: (p) => p };
+
+describe("parseHistoryWindow", () => {
+  test("accepts the documented windows + defaults", () => {
+    assert.deepEqual(parseHistoryWindow("7d"), { label: "7d", days: 7 });
+    assert.deepEqual(parseHistoryWindow("1y"), { label: "1y", days: 365 });
+    assert.deepEqual(parseHistoryWindow("all"), { label: "all", days: null });
+    // Missing → the default window, not an error.
+    assert.equal(parseHistoryWindow(undefined).label, "30d");
+  });
+  test("rejects an unsupported window (NOT silently coerced like analyticsWindow)", () => {
+    assert.ok(parseHistoryWindow("400d").error);
+    assert.ok(parseHistoryWindow("bogus").error);
+  });
+  test("every window is bounded under MAX_HISTORY_POINTS", () => {
+    for (const days of Object.values(HISTORY_WINDOWS)) {
+      if (days != null) assert.ok(days <= MAX_HISTORY_POINTS);
+    }
+  });
+});
+
+describe("rollupNeuronDaily", () => {
+  test("issues a single INSERT...SELECT with a consistent captured_at snapshot + idempotent upsert", async () => {
+    const captured = {};
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          captured.sql = sql;
+          return {
+            bind(...params) {
+              captured.params = params;
+              return { run: () => Promise.resolve({ meta: { changes: 42 } }) };
+            },
+          };
+        },
+      },
+    };
+    const res = await rollupNeuronDaily(env, { now: 1_780_000_000_001 });
+    assert.deepEqual(res, { rolled: true, rows: 42 });
+    // One consistent snapshot stamp (WHERE captured_at = MAX), dated in SQL.
+    assert.match(captured.sql, /INSERT INTO neuron_daily/);
+    assert.match(captured.sql, /SELECT MAX\(captured_at\) FROM neurons/);
+    assert.match(captured.sql, /date\(captured_at \/ 1000, 'unixepoch'\)/);
+    // Idempotent intra-day re-run.
+    assert.match(
+      captured.sql,
+      /ON CONFLICT\(netuid, uid, snapshot_date\) DO UPDATE/,
+    );
+    assert.deepEqual(captured.params, [1_780_000_000_001]);
+  });
+  test("no-ops cleanly without a DB binding (cron isolation)", async () => {
+    assert.deepEqual(await rollupNeuronDaily({}), {
+      rolled: false,
+      reason: "no-db",
+    });
+  });
+});
+
+describe("history builders", () => {
+  test("buildNeuronHistory shapes a per-UID series (live-shaped points + date)", () => {
+    const out = buildNeuronHistory([dailyRow()], 7, 3, { window: "30d" });
+    assert.equal(out.netuid, 7);
+    assert.equal(out.uid, 3);
+    assert.equal(out.window, "30d");
+    assert.equal(out.point_count, 1);
+    assert.equal(out.points[0].snapshot_date, "2026-06-20");
+    assert.equal(out.points[0].stake_tao, 456.7);
+    assert.equal(out.points[0].validator_permit, true); // formatNeuron coerces 0/1
+  });
+  test("buildSubnetHistory shapes per-day aggregates", () => {
+    const out = buildSubnetHistory(
+      [
+        {
+          snapshot_date: "2026-06-20",
+          neuron_count: 256,
+          validator_count: 64,
+          total_stake_tao: 1000,
+          total_emission_tao: 12.3,
+        },
+      ],
+      7,
+      { window: "90d" },
+    );
+    assert.equal(out.point_count, 1);
+    assert.equal(out.points[0].neuron_count, 256);
+    assert.equal(out.points[0].validator_count, 64);
+  });
+});
+
+describe("history endpoints (via the Worker dispatch)", () => {
+  test("GET /subnets/{n}/neurons/{u}/history returns a 200 series + applies a date cutoff", async () => {
+    const captured = {};
+    const env = historyEnv([dailyRow()], captured);
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/neurons/3/history?window=7d",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.uid, 3);
+    assert.equal(body.data.points[0].snapshot_date, "2026-06-20");
+    // A bounded window binds a snapshot_date cutoff + the row cap.
+    assert.match(
+      captured.sql,
+      /FROM neuron_daily WHERE netuid = \? AND uid = \?/,
+    );
+    assert.match(captured.sql, /snapshot_date >= \?/);
+    assert.ok(captured.params.includes(MAX_HISTORY_POINTS));
+  });
+  test("an unsupported ?window is a 400, never a silent coerce", async () => {
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/neurons/3/history?window=400d",
+      ),
+      historyEnv([]),
+      ctx,
+    );
+    assert.equal(res.status, 400);
+  });
+  test("GET /subnets/{n}/history returns per-day aggregates", async () => {
+    const env = historyEnv([
+      {
+        snapshot_date: "2026-06-20",
+        neuron_count: 256,
+        validator_count: 64,
+        total_stake_tao: 1000,
+        total_emission_tao: 12.3,
+      },
+    ]);
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/history?window=90d",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.points[0].neuron_count, 256);
+  });
+  test("?window=all omits the cutoff (full history, still bounded by the row cap)", async () => {
+    const captured = {};
+    const env = historyEnv([dailyRow()], captured);
+    await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/neurons/3/history?window=all",
+      ),
+      env,
+      ctx,
+    );
+    assert.doesNotMatch(captured.sql, /snapshot_date >= \?/);
+    assert.ok(captured.params.includes(MAX_HISTORY_POINTS));
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -99,6 +99,14 @@ import {
   buildNeuronDetail,
 } from "../src/metagraph-neurons.mjs";
 import {
+  rollupNeuronDaily,
+  buildNeuronHistory,
+  buildSubnetHistory,
+  parseHistoryWindow,
+  NEURON_DAILY_READ_COLUMNS,
+  MAX_HISTORY_POINTS,
+} from "../src/neuron-history.mjs";
+import {
   ACCOUNT_EVENT_COLUMNS,
   buildAccountEvents,
   buildAccountSubnets,
@@ -147,12 +155,15 @@ import {
   MAX_RPC_BODY_BYTES,
   MAX_UPTIME_ROWS,
   MAX_WEBHOOK_BODY_BYTES,
+  NEURON_HISTORY_ROLLUP_CRON,
   PERCENTILES_PATH_PATTERN,
   RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN,
   resolveClientIp,
   RPC_USAGE_BUCKETS,
   SAFE_RPC_METHODS,
+  SUBNET_HISTORY_PATH_PATTERN,
   SUBNET_METAGRAPH_PATH_PATTERN,
+  SUBNET_NEURON_HISTORY_PATH_PATTERN,
   SUBNET_NEURON_PATH_PATTERN,
   SUBNET_VALIDATORS_PATH_PATTERN,
   TRAJECTORY_PATH_PATTERN,
@@ -687,6 +698,12 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
   if (cron === EMBEDDING_SYNC_CRON) {
     return runEmbeddingSync(env, { readArtifact });
   }
+  if (cron === NEURON_HISTORY_ROLLUP_CRON) {
+    // Once/day: snapshot the current `neurons` tier into the dated neuron_daily
+    // history table (block-explorer Tier-1, #1345). Its own minute so the
+    // ~33k-row INSERT...SELECT never piles onto the probe/prune/fast crons.
+    return rollupNeuronDaily(env);
+  }
   return runHealthProber(env, ctx);
 }
 
@@ -940,6 +957,29 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       );
     }
     // Per-UID metagraph (#1304/#1305): computed live from the neurons D1 tier.
+    const neuronHistoryMatch = SUBNET_NEURON_HISTORY_PATH_PATTERN.exec(
+      resolved.url.pathname,
+    );
+    if (neuronHistoryMatch) {
+      return handleNeuronHistory(
+        request,
+        env,
+        Number(neuronHistoryMatch[1]),
+        Number(neuronHistoryMatch[2]),
+        resolved.url,
+      );
+    }
+    const subnetHistoryMatch = SUBNET_HISTORY_PATH_PATTERN.exec(
+      resolved.url.pathname,
+    );
+    if (subnetHistoryMatch) {
+      return handleSubnetHistory(
+        request,
+        env,
+        Number(subnetHistoryMatch[1]),
+        resolved.url,
+      );
+    }
     const metagraphMatch = SUBNET_METAGRAPH_PATH_PATTERN.exec(
       resolved.url.pathname,
     );
@@ -2441,6 +2481,88 @@ async function handleSubnetValidators(request, env, netuid, url) {
         env,
         `/metagraph/subnets/${netuid}/validators.json`,
         data.captured_at,
+      ),
+    },
+    "short",
+  );
+}
+
+// ---- Per-UID + per-subnet metagraph HISTORY (block-explorer Tier-1, #1345) --
+// Served from the dated neuron_daily rollup tier (D1). Cold/absent store → 200
+// with empty points (never 404), consistent with the live metagraph tiers.
+
+// GET /api/v1/subnets/{netuid}/neurons/{uid}/history?window=7d|30d|90d|1y|all
+// Per-UID time series (one point per snapshot_date, newest first, bounded).
+async function handleNeuronHistory(request, env, netuid, uid, url) {
+  const validationError = validateQueryParams(url, ["window"]);
+  if (validationError) return analyticsQueryError(validationError);
+  const { label, days, error } = parseHistoryWindow(
+    url.searchParams.get("window"),
+  );
+  if (error) return analyticsQueryError(error);
+  const params = [netuid, uid];
+  let sql = `SELECT ${NEURON_DAILY_READ_COLUMNS} FROM neuron_daily WHERE netuid = ? AND uid = ?`;
+  if (days != null) {
+    // Cutoff computed in JS and bound as a plain YYYY-MM-DD (idx_neuron_daily_uid_date covers it).
+    const cutoff = new Date(Date.now() - days * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
+    sql += " AND snapshot_date >= ?";
+    params.push(cutoff);
+  }
+  sql += " ORDER BY snapshot_date DESC LIMIT ?";
+  params.push(MAX_HISTORY_POINTS);
+  const rows = await d1All(env, sql, params);
+  const data = buildNeuronHistory(rows, netuid, uid, { window: label });
+  return envelopeResponse(
+    request,
+    {
+      data,
+      meta: await metagraphMeta(
+        env,
+        `/metagraph/subnets/${netuid}/neurons/${uid}/history.json`,
+        data.points[0]?.captured_at ?? null,
+      ),
+    },
+    "short",
+  );
+}
+
+// GET /api/v1/subnets/{netuid}/history?window=7d|30d|90d|1y|all
+// Per-subnet daily aggregates over time (count + totals) for a history sparkline,
+// without shipping every UID's row.
+async function handleSubnetHistory(request, env, netuid, url) {
+  const validationError = validateQueryParams(url, ["window"]);
+  if (validationError) return analyticsQueryError(validationError);
+  const { label, days, error } = parseHistoryWindow(
+    url.searchParams.get("window"),
+  );
+  if (error) return analyticsQueryError(error);
+  const params = [netuid];
+  let sql =
+    "SELECT snapshot_date, COUNT(*) AS neuron_count, " +
+    "SUM(validator_permit) AS validator_count, " +
+    "SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao " +
+    "FROM neuron_daily WHERE netuid = ?";
+  if (days != null) {
+    const cutoff = new Date(Date.now() - days * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
+    sql += " AND snapshot_date >= ?";
+    params.push(cutoff);
+  }
+  sql += " GROUP BY snapshot_date ORDER BY snapshot_date DESC LIMIT ?";
+  params.push(MAX_HISTORY_POINTS);
+  const rows = await d1All(env, sql, params);
+  const data = buildSubnetHistory(rows, netuid, { window: label });
+  return envelopeResponse(
+    request,
+    {
+      data,
+      meta: await metagraphMeta(
+        env,
+        `/metagraph/subnets/${netuid}/history.json`,
+        null,
       ),
     },
     "short",

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -18,6 +18,11 @@ export const EMBEDDING_SYNC_CRON = "37 3 * * *";
 // ~5 min WITHOUT running the (heavier) health probe. Must match a wrangler.jsonc
 // `triggers.crons` entry.
 export const EVENTS_LOAD_CRON = "*/3 * * * *";
+// Daily neuron-history rollup (#1345 Tier-1): snapshots the current `neurons`
+// table into the dated neuron_daily table once a day, on its own minute (distinct
+// from the probe/prune/embed/fast crons) so the ~33k-row INSERT...SELECT runs
+// exactly once/day, not on every tick. Must match a wrangler.jsonc cron entry.
+export const NEURON_HISTORY_ROLLUP_CRON = "47 5 * * *";
 // Trend windows for /api/v1/subnets/{netuid}/health/trends and
 // /api/v1/health/trends.
 export const RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN =
@@ -40,6 +45,12 @@ export const SUBNET_NEURON_PATH_PATTERN =
   /^\/api\/v1\/subnets\/(\d+)\/neurons\/(\d+)$/;
 export const SUBNET_VALIDATORS_PATH_PATTERN =
   /^\/api\/v1\/subnets\/(\d+)\/validators$/;
+// Per-UID + per-subnet metagraph HISTORY (block-explorer Tier-1, #1345): time
+// series read from the neuron_daily rollup tier.
+export const SUBNET_NEURON_HISTORY_PATH_PATTERN =
+  /^\/api\/v1\/subnets\/(\d+)\/neurons\/(\d+)\/history$/;
+export const SUBNET_HISTORY_PATH_PATTERN =
+  /^\/api\/v1\/subnets\/(\d+)\/history$/;
 // Account entity routes (#1347): computed live from the account_events + neurons
 // D1 tiers. SS58 addresses are base58 (no 0/O/I/l), 47-48 chars.
 export const ACCOUNT_PATH_PATTERN =

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -115,8 +115,14 @@
   "triggers": {
     // */3 = fast drain of R2-staged chain-event/neuron batches into D1 (#1346
     // Option A, ~5-min ingestion); */15 = health probe; 0 = hourly prune/rollup;
-    // 37 3 = daily embedding sync.
-    "crons": ["*/3 * * * *", "*/15 * * * *", "0 * * * *", "37 3 * * *"],
+    // 37 3 = daily embedding sync; 47 5 = daily neuron-history rollup (#1345).
+    "crons": [
+      "*/3 * * * *",
+      "*/15 * * * *",
+      "0 * * * *",
+      "37 3 * * *",
+      "47 5 * * *",
+    ],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite
   // for enabling METAGRAPH_ENABLE_RPC_PROXY). 100 requests / 60s per client IP;


### PR DESCRIPTION
Closes #1484

## What
Turns the (now-fresh) per-UID snapshot into **history** — the block-explorer foundation.

- **Rollup** (`src/neuron-history.mjs`, dedicated daily cron `47 5 UTC`): single atomic `INSERT INTO neuron_daily SELECT ... FROM neurons WHERE captured_at = MAX(...)` — one consistent stamp, dated in SQL, `ON CONFLICT DO UPDATE` (idempotent intra-day).
- **Migration 0011** `neuron_daily` (shape mirrors `neurons` + snapshot_date; 4 covering indexes) — **applied to prod**.
- **Endpoints** (live D1, cold→empty 200): `/subnets/{n}/neurons/{u}/history?window=` and `/subnets/{n}/history?window=` (per-day aggregates for sparklines).

## Design decisions (validated/corrected)
- **Shared health DB**, not a separate one: D1 can't do cross-DB `INSERT...SELECT`, so co-location keeps the rollup a single atomic statement. The 90-day prune (PR-A2) bounds it ~0.7GB ≪ 10GB cap.
- **History-specific window parser** (7d/30d/90d/1y/all) — not `analyticsWindow` (only 7d/30d).
- Results bounded by `MAX_HISTORY_POINTS`.

## Tests
11 new (rollup SQL, builders, endpoints, window validation). **Full suite: 1560 passed.** Prettier + build + contract-drift clean.

## Follow-ups
- PR-A1b: OpenAPI/catalog registration of the 2 routes (typed schemas).
- PR-A2: R2 cold archive (>90d) + the 90-day prune.