### PR TITLE
fix(release): require package sources match tag

### DIFF
--- a/scripts/validate-client-release.sh
+++ b/scripts/validate-client-release.sh
@@ -31,16 +31,20 @@ if release_tag_commit="$(git rev-parse "$release_tag^{commit}" 2>/dev/null)"; th
     echo "::error::GITHUB_SHA is required for release-please-triggered releases."
     exit 1
   fi
-  # The publish dispatches on --ref main, so by the time this runs main may have
-  # advanced past the release-please tag (e.g. other PRs merged in the gap). Strict
-  # SHA-equality would spuriously fail then. Require instead that the tag is an
-  # ANCESTOR of the workflow commit: it must be a real release-please tag on this
-  # branch's history (a forged/divergent tag fails), while tolerating later commits.
+  # The publish workflow is dispatched on --ref main, so main may have
+  # advanced after release-please created the tag. Accept that only when the
+  # package sources being built are byte-for-byte identical to the tagged
+  # release tree; otherwise an older release tag/version could publish newer,
+  # untagged code.
   if ! git merge-base --is-ancestor "$release_tag_commit" "$GITHUB_SHA" 2>/dev/null; then
     echo "::error::Release tag $release_tag ($release_tag_commit) is not an ancestor of the workflow commit $GITHUB_SHA — refusing a tag that is not on this branch's history."
     exit 1
   fi
-  echo "Tag $release_tag is on the workflow commit's history; continuing."
+  if ! git diff --quiet "$release_tag_commit" "$GITHUB_SHA" -- packages/client; then
+    echo "::error::Release tag $release_tag ($release_tag_commit) does not match the @jsonbored/metagraphed sources at workflow commit $GITHUB_SHA; refusing to publish untagged package contents."
+    exit 1
+  fi
+  echo "Tag $release_tag is on the workflow commit's history and package sources match; continuing."
 elif [ "${RELEASE_PLEASE_TRIGGERED:-}" = "true" ]; then
   echo "::error::Release tag is required for release-please-triggered releases: $release_tag"
   exit 1

--- a/scripts/validate-python-release.sh
+++ b/scripts/validate-python-release.sh
@@ -31,16 +31,20 @@ if release_tag_commit="$(git rev-parse "$release_tag^{commit}" 2>/dev/null)"; th
     echo "::error::GITHUB_SHA is required for release-please-triggered releases."
     exit 1
   fi
-  # The publish dispatches on --ref main, so by the time this runs main may have
-  # advanced past the release-please tag (e.g. other PRs merged in the gap). Strict
-  # SHA-equality would spuriously fail then. Require instead that the tag is an
-  # ANCESTOR of the workflow commit: it must be a real release-please tag on this
-  # branch's history (a forged/divergent tag fails), while tolerating later commits.
+  # The publish workflow is dispatched on --ref main, so main may have
+  # advanced after release-please created the tag. Accept that only when the
+  # package sources being built are byte-for-byte identical to the tagged
+  # release tree; otherwise an older release tag/version could publish newer,
+  # untagged code.
   if ! git merge-base --is-ancestor "$release_tag_commit" "$GITHUB_SHA" 2>/dev/null; then
     echo "::error::Release tag $release_tag ($release_tag_commit) is not an ancestor of the workflow commit $GITHUB_SHA — refusing a tag that is not on this branch's history."
     exit 1
   fi
-  echo "Tag $release_tag is on the workflow commit's history; continuing."
+  if ! git diff --quiet "$release_tag_commit" "$GITHUB_SHA" -- python; then
+    echo "::error::Release tag $release_tag ($release_tag_commit) does not match the metagraphed Python sources at workflow commit $GITHUB_SHA; refusing to publish untagged package contents."
+    exit 1
+  fi
+  echo "Tag $release_tag is on the workflow commit's history and package sources match; continuing."
 elif [ "${RELEASE_PLEASE_TRIGGERED:-}" = "true" ]; then
   echo "::error::Release tag is required for release-please-triggered releases: $release_tag"
   exit 1


### PR DESCRIPTION
### Motivation
- The release validators previously accepted a release tag if its commit was merely an ancestor of the workflow `GITHUB_SHA`, which allowed builds on a later `main` commit to be published under an older release tag and broke release source integrity. 
- The intent is to preserve the tolerance for `main` advancing while ensuring the packaged artifacts are exactly the same as the tagged release tree.

### Description
- Keep the existing ancestry check but add a byte-for-byte source-tree comparison using `git diff --quiet` to `scripts/validate-client-release.sh` for the `packages/client` tree. 
- Apply the same `git diff --quiet` guard to `scripts/validate-python-release.sh` for the `python` tree. 
- Emit a clear `::error::` and refuse publishing when the package sources differ between the release tag commit and the workflow commit.
- Only the two validator scripts were modified to enforce source equality before allowing a release-please-triggered publish.

### Testing
- Ran shell syntax checks with `bash -n scripts/validate-client-release.sh scripts/validate-python-release.sh` which succeeded. 
- Executed a temporary git-repository reproduction that created a tag, made later changes in the package trees, and verified both validators now reject publishing when sources differ, which succeeded. 
- Ran `git diff --check` to ensure no whitespace or diff issues, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a398707bcf0832c89b84476fa41f3fa)