### PR TITLE
feat(history): R2 cold archive + 90-day prune — completes the history retention architecture (#1345)

### DIFF
--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -76,6 +76,98 @@ export async function rollupNeuronDaily(env, { now = Date.now() } = {}) {
   return { rolled: true, rows: res?.meta?.changes ?? null };
 }
 
+// D1 keeps a bounded hot window; older days live only in the R2 cold archive
+// (written BEFORE any prune). 90 days serves every 7d/30d/90d query from D1 with
+// zero R2 fallthrough while keeping the table ~0.7GB — far under D1's 10GB cap.
+export const NEURON_DAILY_RETENTION_DAYS = 90;
+
+// R2 cold-archive key: one immutable gzip-NDJSON object per subnet per UTC day.
+export function coldArchiveKey(netuid, day) {
+  return `metagraph/history/cold/netuid=${netuid}/${day}.ndjson.gz`;
+}
+
+// gzip a string via the Workers-native CompressionStream (no deps; also present
+// in the Node test runtime).
+async function gzipString(text) {
+  const stream = new Blob([text])
+    .stream()
+    .pipeThrough(new CompressionStream("gzip"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+async function latestRolledDay(db) {
+  const res = await db
+    .prepare("SELECT MAX(snapshot_date) AS day FROM neuron_daily")
+    .bind()
+    .all();
+  return res?.results?.[0]?.day ?? null;
+}
+
+/**
+ * Archive a day's neuron_daily snapshot to the R2 cold tier — one immutable
+ * gzip-NDJSON object per subnet (coldArchiveKey), so a per-subnet as-of read
+ * beyond the D1 hot window is a single small GET. Defaults to the latest rolled
+ * day (the one the rollup just wrote). Returns {archived, day, subnets, rows}.
+ * Caller .catch-isolates it; the prune is gated on its success.
+ */
+export async function archiveNeuronDaily(env, { day, db, bucket } = {}) {
+  const database = db || env?.METAGRAPH_HEALTH_DB;
+  const r2 = bucket || env?.METAGRAPH_ARCHIVE;
+  if (!database?.prepare || !r2?.put) {
+    return { archived: false, reason: "no-binding" };
+  }
+  const targetDay = day || (await latestRolledDay(database));
+  if (!targetDay) return { archived: false, reason: "no-data" };
+  const res = await database
+    .prepare(
+      `SELECT ${ROLLUP_COLUMNS.join(", ")}, snapshot_date FROM neuron_daily ` +
+        "WHERE snapshot_date = ? ORDER BY netuid, uid",
+    )
+    .bind(targetDay)
+    .all();
+  const rows = res?.results ?? [];
+  if (rows.length === 0) {
+    return { archived: false, reason: "no-rows", day: targetDay };
+  }
+  const byNetuid = new Map();
+  for (const row of rows) {
+    let group = byNetuid.get(row.netuid);
+    if (!group) byNetuid.set(row.netuid, (group = []));
+    group.push(row);
+  }
+  let subnets = 0;
+  for (const [netuid, subnetRows] of byNetuid) {
+    const ndjson = subnetRows.map((r) => JSON.stringify(r)).join("\n") + "\n";
+    await r2.put(coldArchiveKey(netuid, targetDay), await gzipString(ndjson), {
+      httpMetadata: {
+        contentType: "application/x-ndjson",
+        contentEncoding: "gzip",
+        cacheControl: "public, max-age=31536000, immutable",
+      },
+    });
+    subnets += 1;
+  }
+  return { archived: true, day: targetDay, subnets, rows: rows.length };
+}
+
+/**
+ * Prune neuron_daily rows older than the retention window from D1. The caller
+ * gates this on a successful archive so a day is never deleted before it exists
+ * in the R2 cold tier. Returns {pruned, cutoff, rows}.
+ */
+export async function pruneNeuronDaily(env, { now = Date.now() } = {}) {
+  const db = env?.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) return { pruned: false, reason: "no-db" };
+  const cutoff = new Date(now - NEURON_DAILY_RETENTION_DAYS * 86_400_000)
+    .toISOString()
+    .slice(0, 10);
+  const res = await db
+    .prepare("DELETE FROM neuron_daily WHERE snapshot_date < ?")
+    .bind(cutoff)
+    .run();
+  return { pruned: true, cutoff, rows: res?.meta?.changes ?? null };
+}
+
 // SELECT list for reading a neuron_daily row back as a live-shaped neuron
 // (formatNeuron consumes NEURON_COLUMNS) plus the history-specific snapshot_date.
 export const NEURON_DAILY_READ_COLUMNS = `snapshot_date, ${NEURON_COLUMNS}`;

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -3,6 +3,10 @@ import { describe, test } from "vitest";
 import {
   parseHistoryWindow,
   rollupNeuronDaily,
+  archiveNeuronDaily,
+  pruneNeuronDaily,
+  coldArchiveKey,
+  NEURON_DAILY_RETENTION_DAYS,
   buildNeuronHistory,
   buildSubnetHistory,
   HISTORY_WINDOWS,
@@ -211,5 +215,81 @@ describe("history endpoints (via the Worker dispatch)", () => {
     );
     assert.doesNotMatch(captured.sql, /snapshot_date >= \?/);
     assert.ok(captured.params.includes(MAX_HISTORY_POINTS));
+  });
+});
+
+describe("R2 cold archive + prune (PR-A2)", () => {
+  test("archiveNeuronDaily writes one immutable gzip object per subnet under the cold key", async () => {
+    const day = "2026-06-20";
+    const rows = [
+      { netuid: 7, uid: 0, snapshot_date: day, stake_tao: 1 },
+      { netuid: 7, uid: 1, snapshot_date: day, stake_tao: 2 },
+      { netuid: 12, uid: 0, snapshot_date: day, stake_tao: 3 },
+    ];
+    const db = {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              all: () =>
+                Promise.resolve({
+                  results: sql.includes("MAX(snapshot_date)")
+                    ? [{ day }]
+                    : rows,
+                }),
+            };
+          },
+        };
+      },
+    };
+    const puts = [];
+    const bucket = {
+      put: (key, body, opts) => {
+        puts.push({ key, opts, size: body.byteLength });
+        return Promise.resolve();
+      },
+    };
+    const res = await archiveNeuronDaily({}, { db, bucket });
+    assert.equal(res.archived, true);
+    assert.equal(res.day, day);
+    assert.equal(res.subnets, 2); // netuid 7 + 12 → one object each
+    assert.equal(res.rows, 3);
+    assert.deepEqual(
+      puts.map((p) => p.key).sort(),
+      [coldArchiveKey(7, day), coldArchiveKey(12, day)].sort(),
+    );
+    assert.equal(puts[0].opts.httpMetadata.contentEncoding, "gzip");
+    assert.match(puts[0].opts.httpMetadata.cacheControl, /immutable/);
+    assert.ok(puts[0].size > 0, "gzip body is non-empty");
+  });
+
+  test("archiveNeuronDaily no-ops without bindings", async () => {
+    assert.equal((await archiveNeuronDaily({})).archived, false);
+  });
+
+  test("pruneNeuronDaily deletes below the 90-day retention cutoff", async () => {
+    const cap = {};
+    const db = {
+      prepare(sql) {
+        cap.sql = sql;
+        return {
+          bind(...p) {
+            cap.params = p;
+            return { run: () => Promise.resolve({ meta: { changes: 5 } }) };
+          },
+        };
+      },
+    };
+    const now = Date.parse("2026-06-22T00:00:00Z");
+    const res = await pruneNeuronDaily({ METAGRAPH_HEALTH_DB: db }, { now });
+    assert.equal(res.pruned, true);
+    assert.equal(res.rows, 5);
+    assert.match(cap.sql, /DELETE FROM neuron_daily WHERE snapshot_date < \?/);
+    const expectedCutoff = new Date(
+      now - NEURON_DAILY_RETENTION_DAYS * 86_400_000,
+    )
+      .toISOString()
+      .slice(0, 10);
+    assert.deepEqual(cap.params, [expectedCutoff]);
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -100,6 +100,8 @@ import {
 } from "../src/metagraph-neurons.mjs";
 import {
   rollupNeuronDaily,
+  archiveNeuronDaily,
+  pruneNeuronDaily,
   buildNeuronHistory,
   buildSubnetHistory,
   parseHistoryWindow,
@@ -699,10 +701,22 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
     return runEmbeddingSync(env, { readArtifact });
   }
   if (cron === NEURON_HISTORY_ROLLUP_CRON) {
-    // Once/day: snapshot the current `neurons` tier into the dated neuron_daily
-    // history table (block-explorer Tier-1, #1345). Its own minute so the
-    // ~33k-row INSERT...SELECT never piles onto the probe/prune/fast crons.
-    return rollupNeuronDaily(env);
+    // Once/day (#1345): snapshot the current `neurons` tier into the dated
+    // neuron_daily table, archive that day to the R2 cold tier, then prune D1 to
+    // the 90-day hot window. Archive runs BEFORE prune and the prune is GATED on
+    // a confirmed archive, so a day is never dropped from D1 before it exists in
+    // R2. Its own cron minute so the ~33k-row work never piles onto the
+    // probe/prune/fast crons; each step is .catch-isolated.
+    const rolled = await rollupNeuronDaily(env).catch(() => ({
+      rolled: false,
+    }));
+    const archived = await archiveNeuronDaily(env).catch(() => ({
+      archived: false,
+    }));
+    const pruned = archived.archived
+      ? await pruneNeuronDaily(env).catch(() => ({ pruned: false }))
+      : { pruned: false, reason: "archive-not-confirmed" };
+    return { rolled, archived, pruned };
   }
   return runHealthProber(env, ctx);
 }


### PR DESCRIPTION
Closes #1490

Completes the R2/history architecture. The daily rollup cron now runs **rollup → archive → prune** (gated):
- **archiveNeuronDaily** — each day's snapshot to R2 cold, one immutable gzip-NDJSON object per subnet per UTC day (`metagraph/history/cold/netuid=N/DATE.ndjson.gz`, via `CompressionStream`).
- **pruneNeuronDaily** — trims D1 to a **90-day hot window**.
- Archive runs **before** prune, prune **gated** on a confirmed archive → a day is never dropped from D1 before it's durable in R2. Each step `.catch`-isolated.

Bounds `neuron_daily` ~0.7 GB (≪ 10 GB cap); full history lives forever in R2. **No new routes/schemas/migration** (reuses the #1485 table).

**Deferred (PR-A2b):** deep-read fallthrough serving >90d from R2 — there's a 90-day runway before any data ages out, so it's not yet functionally needed.

14 history tests (incl. archive/prune) + **full suite 1563 green**; prettier + build clean.