### PR TITLE
feat(history): backfill 1yr of metagraph history + 400-day D1 retention (#1345 Phase 1)

### DIFF
--- a/.github/workflows/backfill-neuron-history.yml
+++ b/.github/workflows/backfill-neuron-history.yml
@@ -1,0 +1,73 @@
+name: Backfill Neuron History (one-time, #1345)
+
+# One-time chain-direct backfill of historical per-UID metagraph snapshots into the
+# `neuron_daily` tier, so the history endpoints serve a real time-series immediately
+# instead of accruing forward over months. Reads the public ARCHIVE node (full
+# historical state, no API key) via scripts/backfill-neuron-history.py and POSTs each
+# day's rows to the Worker's secret-gated /api/v1/internal/backfill-neurons ingest
+# (idempotent upsert → safe to re-run). Manual only.
+#
+# Sharded into 4 quarters because a full year (~365 days x ~100 subnets) exceeds the
+# 6h job limit; each shard runs ~a quarter in parallel. days_per_shard*4 days total.
+on:
+  workflow_dispatch:
+    inputs:
+      days_per_shard:
+        description: "Days each of the 4 shards backfills (4 x this = total)"
+        required: false
+        default: "92"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backfill-neuron-history
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 350 # ~a quarter of subnet-days at ~0.7s/subnet
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      # Chain-direct off the public archive node (pinned bittensor, matching
+      # refresh-metagraph). Each shard covers a contiguous, non-overlapping day range;
+      # the ingest upsert is idempotent so a rerun or overlap is harmless.
+      - name: Backfill shard ${{ matrix.shard }}
+        run: |
+          DAYS="${{ github.event.inputs.days_per_shard }}"
+          END_OFFSET=$(( ${{ matrix.shard }} * DAYS + 1 ))
+          echo "shard ${{ matrix.shard }}: --days $DAYS --end-offset $END_OFFSET"
+          uvx --from bittensor==10.4.0 python scripts/backfill-neuron-history.py \
+            --days "$DAYS" --end-offset "$END_OFFSET"
+        env:
+          METAGRAPH_EVENTS_INGEST_SECRET: ${{ secrets.METAGRAPH_EVENTS_INGEST_SECRET }}
+          METAGRAPH_API_BASE: https://api.metagraph.sh
+
+  notify-on-failure:
+    needs: [backfill]
+    if: ${{ always() && needs.backfill.result == 'failure' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Notify on failure
+        env:
+          METAGRAPH_ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}
+        run: |
+          if [ -z "$METAGRAPH_ALERT_WEBHOOK_URL" ]; then
+            exit 0
+          fi
+          curl -fsS -X POST "$METAGRAPH_ALERT_WEBHOOK_URL" \
+            -H 'content-type: application/json' \
+            -d '{"content":"🔴 metagraphed backfill-neuron-history FAILED — historical metagraph backfill incomplete."}'

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,7 +26,9 @@ export default [
       globals: {
         AbortController: "readonly",
         AbortSignal: "readonly",
+        Blob: "readonly",
         Buffer: "readonly",
+        CompressionStream: "readonly",
         Headers: "readonly",
         Request: "readonly",
         Response: "readonly",

--- a/scripts/backfill-neuron-history.py
+++ b/scripts/backfill-neuron-history.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Historical per-UID metagraph BACKFILL (#1345 Phase 1) — chain-direct off the
+public ARCHIVE node, no API key. Fills `neuron_daily` retroactively so the history
+endpoints serve a real time-series NOW instead of accruing forward over months.
+
+For each target UTC day it resolves the block nearest a fixed time-of-day (the
+forward rollup's cron minute, so backfilled and live rows line up), then per subnet
+calls the per-subnet runtime API `get_metagraph_info(netuid, block=N)` (the bulk
+`get_all_metagraphs_info` is HEAD-only — it errors at historical blocks) plus a
+`ValidatorTrust` storage read at that block hash, emitting the EXACT
+`NEURON_INSERT_COLUMNS` + `snapshot_date` shape the Worker's
+`/api/v1/internal/backfill-neurons` ingest expects (idempotent upsert on
+(netuid,uid,snapshot_date), so re-runs are safe/resumable).
+
+Units match scripts/fetch-metagraph-native.py (verified vs Taostats, #1348):
+  stake_tao/emission_tao = float(Balance, alpha-denominated)
+  consensus/incentive/dividends = on-chain 0..1 floats
+  validator_trust = SubtensorModule u16 (0..65535) / 65535
+  rank = derived (1-based, incentive desc); trust = 0.0 (dead in dTAO)
+
+Why archive: events/metagraph at block N live in STATE at that block's hash, which a
+pruned public node discards (~256 blocks). archive.chain.opentensor.ai retains full
+historical state (verified). dTAO launched ~block 4,920,351 (2025-02-13); the past
+year is entirely post-dTAO so units are consistent.
+
+Run (one-time; resumable):
+  METAGRAPH_EVENTS_INGEST_SECRET=... \
+  uv run --with bittensor python scripts/backfill-neuron-history.py --days 365
+"""
+import argparse
+import ipaddress
+import json
+import os
+import sys
+import time
+import urllib.request
+
+import bittensor as bt
+
+BLOCK_MS = 12_000  # finney block time, empirically exactly 12.0s
+API_BASE = os.environ.get("METAGRAPH_API_BASE", "https://api.metagraph.sh")
+INGEST_PATH = "/api/v1/internal/backfill-neurons"
+INGEST_HEADER = "x-metagraph-events-token"  # EVENTS_INGEST_TOKEN_HEADER
+SECRET = os.environ.get("METAGRAPH_EVENTS_INGEST_SECRET", "")
+
+
+def to_float(value):
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def u16_ratio(value):
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return None
+    return round(n / 65535, 9)
+
+
+def fmt_axon(axon):
+    if not isinstance(axon, dict):
+        return None
+    ip = axon.get("ip") or 0
+    port = axon.get("port") or 0
+    if not ip:
+        return None
+    try:
+        host = str(ipaddress.ip_address(int(ip)))
+    except (ValueError, TypeError):
+        return None
+    return f"{host}:{port}" if port else host
+
+
+def _at(arr, i):
+    return arr[i] if i < len(arr) else None
+
+
+def block_ms(s, block_hash):
+    """Timestamp.Now (epoch ms) at a block hash."""
+    r = s.substrate.query("Timestamp", "Now", block_hash=block_hash)
+    return int(getattr(r, "value", r) or 0)
+
+
+def resolve_block(s, target_ms, head_block, head_ms):
+    """Block whose timestamp is closest to target_ms (estimate + refine)."""
+    est = head_block - (head_ms - target_ms) // BLOCK_MS
+    est = max(1, min(int(est), head_block))
+    for _ in range(4):
+        bh = s.substrate.get_block_hash(est)
+        ts = block_ms(s, bh)
+        drift = (ts - target_ms) // BLOCK_MS
+        if abs(drift) <= 1:
+            break
+        est = max(1, min(est - int(drift), head_block))
+    return est
+
+
+def storage_vec(s, netuid, name, block_hash):
+    try:
+        r = s.substrate.query("SubtensorModule", name, [netuid], block_hash=block_hash)
+        return list(getattr(r, "value", r) or [])
+    except Exception:
+        return []
+
+
+def subnet_rows(info, netuid, vtrust_vec, snapshot_date, captured_at, block):
+    hotkeys = list(getattr(info, "hotkeys", []) or [])
+    n = len(hotkeys)
+    if not n:
+        return []
+    coldkeys = list(getattr(info, "coldkeys", []) or [])
+    active = list(getattr(info, "active", []) or [])
+    permits = list(getattr(info, "validator_permit", []) or [])
+    consensus = list(getattr(info, "consensus", []) or [])
+    incentives = list(getattr(info, "incentives", []) or [])
+    dividends = list(getattr(info, "dividends", []) or [])
+    emission = list(getattr(info, "emission", []) or [])
+    stake = list(getattr(info, "total_stake", []) or [])
+    axons = list(getattr(info, "axons", []) or [])
+    reg_at = list(getattr(info, "block_at_registration", []) or [])
+    immunity = int(getattr(info, "immunity_period", 0) or 0)
+    rows = []
+    for uid in range(n):
+        reg = _at(reg_at, uid)
+        rows.append(
+            {
+                "netuid": netuid,
+                "uid": uid,
+                "hotkey": _at(hotkeys, uid),
+                "coldkey": _at(coldkeys, uid),
+                "active": 1 if _at(active, uid) else 0,
+                "validator_permit": 1 if _at(permits, uid) else 0,
+                "rank": None,
+                "trust": 0.0,
+                "validator_trust": u16_ratio(_at(vtrust_vec, uid)),
+                "consensus": to_float(_at(consensus, uid)),
+                "incentive": to_float(_at(incentives, uid)),
+                "dividends": to_float(_at(dividends, uid)),
+                "emission_tao": to_float(_at(emission, uid)),
+                "stake_tao": to_float(_at(stake, uid)),
+                "registered_at_block": reg,
+                "is_immunity_period": 1
+                if (reg is not None and block - reg < immunity)
+                else 0,
+                "axon": fmt_axon(_at(axons, uid)),
+                "block_number": block,
+                "captured_at": captured_at,
+                "snapshot_date": snapshot_date,
+            }
+        )
+    # Derive Taostats-style rank: 1-based by incentive desc (null when no incentive).
+    for pos, row in enumerate(
+        sorted(
+            (r for r in rows if r["incentive"]),
+            key=lambda r: (-r["incentive"], r["uid"]),
+        ),
+        start=1,
+    ):
+        row["rank"] = float(pos)
+    return [r for r in rows if r["hotkey"]]
+
+
+def post_chunk(rows, dry_run):
+    if dry_run or not rows:
+        return len(rows)
+    body = json.dumps({"rows": rows}).encode()
+    req = urllib.request.Request(
+        API_BASE + INGEST_PATH,
+        data=body,
+        method="POST",
+        headers={
+            "content-type": "application/json",
+            INGEST_HEADER: SECRET,
+            # CF WAF 403s the default Python-urllib UA (same gotcha as the streamer).
+            "user-agent": "metagraphed-backfill/1.0",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        json.loads(resp.read())
+    return len(rows)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--network", default="archive")
+    p.add_argument("--days", type=int, default=365, help="how many days back to fill")
+    p.add_argument("--end-offset", type=int, default=1, help="newest day = today-N")
+    p.add_argument("--hour", type=int, default=5, help="UTC hour to sample (cron 47 5)")
+    p.add_argument("--minute", type=int, default=47)
+    p.add_argument("--chunk", type=int, default=1500, help="rows per ingest POST")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    if not SECRET and not args.dry_run:
+        sys.exit("METAGRAPH_EVENTS_INGEST_SECRET is required (or use --dry-run)")
+
+    s = bt.SubtensorApi(network=args.network)
+    head_block = int(s.block)
+    head_ms = block_ms(s, s.substrate.get_block_hash(head_block))
+    sys.stderr.write(f"head block {head_block} @ {head_ms}ms; archive={args.network}\n")
+
+    day_ms = 86_400_000
+    now_ms = int(time.time() * 1000)
+    midnight = (now_ms // day_ms) * day_ms
+    tod = (args.hour * 3600 + args.minute * 60) * 1000
+
+    total_rows = 0
+    for offset in range(args.end_offset, args.end_offset + args.days):
+        target_ms = midnight - offset * day_ms + tod
+        snapshot_date = time.strftime("%Y-%m-%d", time.gmtime(target_ms / 1000))
+        block = resolve_block(s, target_ms, head_block, head_ms)
+        bh = s.substrate.get_block_hash(block)
+        captured_at = block_ms(s, bh)
+        total = int(
+            getattr(
+                s.substrate.query("SubtensorModule", "TotalNetworks", [], block_hash=bh),
+                "value",
+                0,
+            )
+            or 0
+        )
+        pending, day_rows = [], 0
+        for netuid in range(total):
+            try:
+                info = s.metagraphs.get_metagraph_info(netuid=netuid, block=block)
+            except Exception:
+                continue
+            vtrust = storage_vec(s, netuid, "ValidatorTrust", bh)
+            rows = subnet_rows(info, netuid, vtrust, snapshot_date, captured_at, block)
+            pending.extend(rows)
+            day_rows += len(rows)
+            while len(pending) >= args.chunk:
+                post_chunk(pending[: args.chunk], args.dry_run)
+                pending = pending[args.chunk :]
+        if pending:
+            post_chunk(pending, args.dry_run)
+        total_rows += day_rows
+        sys.stderr.write(
+            f"{snapshot_date} block {block} ({total} subnets) -> {day_rows} rows"
+            f"{' [dry-run]' if args.dry_run else ''}\n"
+        )
+
+    sys.stderr.write(f"done: {total_rows} rows across {args.days} days\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -77,9 +77,12 @@ export async function rollupNeuronDaily(env, { now = Date.now() } = {}) {
 }
 
 // D1 keeps a bounded hot window; older days live only in the R2 cold archive
-// (written BEFORE any prune). 90 days serves every 7d/30d/90d query from D1 with
-// zero R2 fallthrough while keeping the table ~0.7GB — far under D1's 10GB cap.
-export const NEURON_DAILY_RETENTION_DAYS = 90;
+// (written BEFORE any prune). 400 days (~13 months) keeps a ROLLING 1-year history
+// permanently D1-served — "1 year ago" is always ≤ 400 days old, so every
+// 7d/30d/90d/1y query is answered from D1 with zero R2 fallthrough. At the measured
+// ~7.8 MB/day this caps the table ~3.1 GB — comfortably under D1's 10 GB limit.
+// Only >13-month deep history ages into the R2 cold tier (served later by PR-A2b).
+export const NEURON_DAILY_RETENTION_DAYS = 400;
 
 // R2 cold-archive key: one immutable gzip-NDJSON object per subnet per UTC day.
 export function coldArchiveKey(netuid, day) {
@@ -166,6 +169,53 @@ export async function pruneNeuronDaily(env, { now = Date.now() } = {}) {
     .bind(cutoff)
     .run();
   return { pruned: true, cutoff, rows: res?.meta?.changes ?? null };
+}
+
+// Backfill ingest (#1345 Phase 1): batched idempotent upsert of HISTORICAL
+// neuron_daily rows produced by scripts/backfill-neuron-history.py. Each row already
+// carries its own snapshot_date (the historical UTC day) + captured_at (that block's
+// ms); updated_at is stamped server-side. Same column set + ON CONFLICT target as the
+// forward rollup, so a backfilled row is byte-identical to a rolled one and any
+// re-POST is a no-op upsert on the (netuid,uid,snapshot_date) PK. Column list + bind
+// order are both driven off `cols`, so they cannot drift apart.
+export function neuronDailyUpsertStatements(
+  db,
+  rows,
+  { now = Date.now() } = {},
+) {
+  const cols = [...ROLLUP_COLUMNS, "snapshot_date"];
+  const setClause = ROLLUP_COLUMNS.filter((c) => c !== "netuid" && c !== "uid")
+    .map((c) => `${c} = excluded.${c}`)
+    .concat("updated_at = excluded.updated_at")
+    .join(", ");
+  const placeholders = cols.map(() => "?").join(", ");
+  const sql =
+    `INSERT INTO neuron_daily (${cols.join(", ")}, updated_at) ` +
+    `VALUES (${placeholders}, ?) ` +
+    `ON CONFLICT(netuid, uid, snapshot_date) DO UPDATE SET ${setClause}`;
+  return rows.map((row) =>
+    db.prepare(sql).bind(...cols.map((c) => row[c] ?? null), now),
+  );
+}
+
+const SNAPSHOT_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// Keep only well-formed backfill rows: integer netuid+uid, a YYYY-MM-DD
+// snapshot_date, and a non-empty hotkey (mirrors the forward path, which drops
+// null-hotkey UIDs). Anything else is silently dropped so a partial/garbage batch
+// can never poison the table.
+export function validNeuronDailyRows(rows) {
+  if (!Array.isArray(rows)) return [];
+  return rows.filter(
+    (row) =>
+      row &&
+      Number.isInteger(row.netuid) &&
+      Number.isInteger(row.uid) &&
+      typeof row.snapshot_date === "string" &&
+      SNAPSHOT_DATE_RE.test(row.snapshot_date) &&
+      typeof row.hotkey === "string" &&
+      row.hotkey.length > 0,
+  );
 }
 
 // SELECT list for reading a neuron_daily row back as a live-shaped neuron

--- a/tests/neuron-backfill.test.mjs
+++ b/tests/neuron-backfill.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleNeuronBackfill, handleRequest } from "../workers/api.mjs";
+
+const SECRET = "test-secret-token-1234567890";
+
+function row(overrides = {}) {
+  return {
+    netuid: 7,
+    uid: 1,
+    hotkey: "5Hk",
+    coldkey: "5Co",
+    active: 1,
+    validator_permit: 0,
+    rank: null,
+    trust: 0.0,
+    validator_trust: 0.5,
+    consensus: 0.1,
+    incentive: 0.2,
+    dividends: 0.0,
+    emission_tao: 1.5,
+    stake_tao: 100.0,
+    registered_at_block: 1000,
+    is_immunity_period: 0,
+    axon: "1.2.3.4:8091",
+    block_number: 8000000,
+    captured_at: 1700000000000,
+    snapshot_date: "2025-12-01",
+    ...overrides,
+  };
+}
+
+function post(body, { secret, method = "POST" } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret) headers["x-metagraph-events-token"] = secret;
+  const init = { method, headers };
+  if (method !== "GET" && method !== "HEAD") {
+    init.body = typeof body === "string" ? body : JSON.stringify(body);
+  }
+  return new Request(
+    "https://api.metagraph.sh/api/v1/internal/backfill-neurons",
+    init,
+  );
+}
+
+function dbCapture(captured) {
+  return {
+    prepare(sql) {
+      return { bind: (...v) => ({ sql, v }) };
+    },
+    async batch(stmts) {
+      captured.push(stmts.length);
+    },
+  };
+}
+
+test("backfill is disabled (503) without the secret configured", async () => {
+  const res = await handleNeuronBackfill(post([row()], { secret: "x" }), {});
+  assert.equal(res.status, 503);
+});
+
+test("backfill rejects a wrong or missing token (401)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  assert.equal(
+    (await handleNeuronBackfill(post([row()], { secret: "wrong" }), env))
+      .status,
+    401,
+  );
+  assert.equal((await handleNeuronBackfill(post([row()]), env)).status, 401);
+});
+
+test("backfill rejects non-POST (405)", async () => {
+  const env = { METAGRAPH_EVENTS_INGEST_SECRET: SECRET };
+  const res = await handleNeuronBackfill(
+    post([row()], { secret: SECRET, method: "GET" }),
+    env,
+  );
+  assert.equal(res.status, 405);
+});
+
+test("backfill upserts valid rows + filters invalid (200, parameterized)", async () => {
+  const captured = [];
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture(captured),
+  };
+  const rows = [
+    row(),
+    row({ uid: 2, snapshot_date: "2025-12-02" }),
+    { netuid: 7, uid: 3 }, // invalid (no snapshot_date/hotkey) → filtered
+    row({ hotkey: "", uid: 4 }), // invalid (empty hotkey) → filtered
+    row({ snapshot_date: "12/01/2025", uid: 5 }), // invalid date format → filtered
+  ];
+  const res = await handleNeuronBackfill(post(rows, { secret: SECRET }), env);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.received, 5);
+  assert.equal(body.inserted, 2);
+  assert.deepEqual(captured, [2]); // one batch of the 2 valid rows
+});
+
+test("backfill accepts the {rows:[...]} envelope + no-ops on empty", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  const res = await handleNeuronBackfill(
+    post({ rows: [] }, { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).inserted, 0);
+});
+
+test("backfill rejects malformed JSON (400) + non-array (400)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  assert.equal(
+    (await handleNeuronBackfill(post("{nope", { secret: SECRET }), env)).status,
+    400,
+  );
+  assert.equal(
+    (await handleNeuronBackfill(post({ foo: 1 }, { secret: SECRET }), env))
+      .status,
+    400,
+  );
+});
+
+test("backfill rejects too many rows (413)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  const many = Array.from({ length: 2001 }, (_, i) => row({ uid: i }));
+  const res = await handleNeuronBackfill(post(many, { secret: SECRET }), env);
+  assert.equal(res.status, 413);
+});
+
+test("backfill returns 503 when the history store is unavailable", async () => {
+  const env = { METAGRAPH_EVENTS_INGEST_SECRET: SECRET }; // authed but no DB
+  const res = await handleNeuronBackfill(
+    post([row()], { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 503);
+});
+
+test("handleRequest routes POST /api/v1/internal/backfill-neurons", async () => {
+  // No secret configured → 503 proves dispatch reached handleNeuronBackfill.
+  const res = await handleRequest(post([row()], { secret: "x" }), {}, {});
+  assert.equal(res.status, 503);
+});

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -7,6 +7,8 @@ import {
   pruneNeuronDaily,
   coldArchiveKey,
   NEURON_DAILY_RETENTION_DAYS,
+  neuronDailyUpsertStatements,
+  validNeuronDailyRows,
   buildNeuronHistory,
   buildSubnetHistory,
   HISTORY_WINDOWS,
@@ -291,5 +293,68 @@ describe("R2 cold archive + prune (PR-A2)", () => {
       .toISOString()
       .slice(0, 10);
     assert.deepEqual(cap.params, [expectedCutoff]);
+  });
+
+  test("retention window covers a rolling 1-year history (>= 365 days)", () => {
+    assert.ok(
+      NEURON_DAILY_RETENTION_DAYS >= 365,
+      "1y window must stay D1-served",
+    );
+  });
+});
+
+describe("backfill ingest helpers (#1345 Phase 1)", () => {
+  test("validNeuronDailyRows keeps well-formed rows, drops the rest", () => {
+    const good = {
+      netuid: 7,
+      uid: 1,
+      snapshot_date: "2025-12-01",
+      hotkey: "5Hk",
+    };
+    const rows = validNeuronDailyRows([
+      good,
+      { netuid: 7, uid: 2, snapshot_date: "2025-12-01" }, // no hotkey
+      { netuid: 7, uid: 3, snapshot_date: "bad", hotkey: "5Hk" }, // bad date
+      { netuid: 7, uid: "x", snapshot_date: "2025-12-01", hotkey: "5Hk" }, // uid not int
+      { uid: 4, snapshot_date: "2025-12-01", hotkey: "5Hk" }, // no netuid
+      { netuid: 7, uid: 5, snapshot_date: "2025-12-01", hotkey: "" }, // empty hotkey
+    ]);
+    assert.deepEqual(rows, [good]);
+    assert.deepEqual(validNeuronDailyRows("nope"), []);
+  });
+
+  test("neuronDailyUpsertStatements upserts with the rollup column set + ON CONFLICT", () => {
+    const cap = [];
+    const db = {
+      prepare(sql) {
+        return {
+          bind(...v) {
+            cap.push({ sql, v });
+            return { sql, v };
+          },
+        };
+      },
+    };
+    const now = 1700000000000;
+    const stmts = neuronDailyUpsertStatements(
+      db,
+      [{ netuid: 7, uid: 1, snapshot_date: "2025-12-01", hotkey: "5Hk" }],
+      { now },
+    );
+    assert.equal(stmts.length, 1);
+    const { sql, v } = cap[0];
+    assert.match(sql, /INSERT INTO neuron_daily/);
+    assert.match(sql, /snapshot_date/);
+    assert.match(
+      sql,
+      /ON CONFLICT\(netuid, uid, snapshot_date\) DO UPDATE SET/,
+    );
+    assert.doesNotMatch(sql, /netuid = excluded/); // PK columns never in SET
+    assert.doesNotMatch(sql, /uid = excluded/);
+    assert.match(sql, /updated_at = excluded\.updated_at/);
+    // updated_at (now) is the last bound param; missing fields bind as null.
+    assert.equal(v[v.length - 1], now);
+    assert.ok(v.includes("5Hk") && v.includes("2025-12-01"));
+    assert.ok(v.includes(null)); // unspecified columns → null, not undefined
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -102,6 +102,8 @@ import {
   rollupNeuronDaily,
   archiveNeuronDaily,
   pruneNeuronDaily,
+  neuronDailyUpsertStatements,
+  validNeuronDailyRows,
   buildNeuronHistory,
   buildSubnetHistory,
   parseHistoryWindow,
@@ -147,6 +149,8 @@ import {
   INCIDENTS_PATH_PATTERN,
   JSON_CONTENT_TYPE,
   MAX_ASK_BODY_BYTES,
+  MAX_BACKFILL_INGEST_BODY_BYTES,
+  MAX_BACKFILL_INGEST_ROWS,
   MAX_BULK_TREND_ROWS,
   MAX_EVENTS_INGEST_BODY_BYTES,
   MAX_EVENTS_INGEST_ROWS,
@@ -645,6 +649,89 @@ export async function handleEventIngest(request, env) {
   });
 }
 
+// POST /api/v1/internal/backfill-neurons (#1345 Phase 1): the historical metagraph
+// backfill ingest for scripts/backfill-neuron-history.py. Disabled (503) until
+// METAGRAPH_EVENTS_INGEST_SECRET is configured (reuses the internal-ingest secret +
+// header — same trust boundary); then a constant-time token compare. The body is an
+// array of neuron_daily rows (or {rows:[...]}), each carrying its own snapshot_date,
+// upserted with the SAME column set + ON CONFLICT target as the forward rollup, so a
+// backfilled row is byte-identical to a rolled one and any re-POST is idempotent on
+// (netuid,uid,snapshot_date). NOT in the public contract.
+export async function handleNeuronBackfill(request, env) {
+  if (request.method !== "POST") {
+    return errorResponse("method_not_allowed", "POST only.", 405);
+  }
+  const configured = env.METAGRAPH_EVENTS_INGEST_SECRET;
+  if (!configured) {
+    return errorResponse(
+      "backfill_disabled",
+      "Historical backfill requires METAGRAPH_EVENTS_INGEST_SECRET to be configured.",
+      503,
+    );
+  }
+  const provided = request.headers.get(EVENTS_INGEST_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, configured)) {
+    return errorResponse(
+      "unauthorized",
+      `Provide a valid ${EVENTS_INGEST_TOKEN_HEADER} header.`,
+      401,
+    );
+  }
+  const db = env.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) {
+    return errorResponse("unavailable", "History store unavailable.", 503);
+  }
+  const raw = await request.text();
+  if (raw.length > MAX_BACKFILL_INGEST_BODY_BYTES) {
+    return errorResponse(
+      "payload_too_large",
+      `Body exceeds ${MAX_BACKFILL_INGEST_BODY_BYTES} bytes.`,
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return errorResponse(
+      "invalid_body",
+      "Body must be a JSON array of neuron_daily rows (or {rows:[...]}).",
+      400,
+    );
+  }
+  const incoming = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.rows)
+      ? parsed.rows
+      : null;
+  if (!incoming) {
+    return errorResponse(
+      "invalid_body",
+      "Body must be a JSON array of neuron_daily rows (or {rows:[...]}).",
+      400,
+    );
+  }
+  if (incoming.length > MAX_BACKFILL_INGEST_ROWS) {
+    return errorResponse(
+      "too_many_rows",
+      `At most ${MAX_BACKFILL_INGEST_ROWS} rows per request.`,
+      413,
+    );
+  }
+  const rows = validNeuronDailyRows(incoming);
+  if (rows.length) {
+    await db.batch(neuronDailyUpsertStatements(db, rows));
+  }
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      received: incoming.length,
+      inserted: rows.length,
+    }),
+    { status: 200, headers: { "content-type": JSON_CONTENT_TYPE } },
+  );
+}
+
 // Cron entrypoint. Cloudflare passes the exact cron string that fired in
 // `controller.cron`; the hourly trigger prunes the time-series, every other
 // trigger (the 15-minute one) runs a full operational-health probe sweep.
@@ -775,6 +862,9 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // finalized-head streamer (#1361). POST-only; runs before the read-only gate.
   if (url.pathname === "/api/v1/internal/events") {
     return handleEventIngest(request, env);
+  }
+  if (url.pathname === "/api/v1/internal/backfill-neurons") {
+    return handleNeuronBackfill(request, env);
   }
 
   // GraphQL read-only query layer over existing artifacts (issue #751). Runs

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -129,6 +129,14 @@ export const WEBHOOK_SUBSCRIPTION_TOKEN_HEADER =
 export const EVENTS_INGEST_TOKEN_HEADER = "x-metagraph-events-token";
 export const MAX_EVENTS_INGEST_BODY_BYTES = 262144; // 256 KB
 export const MAX_EVENTS_INGEST_ROWS = 500;
+// Internal historical backfill ingest (#1345 Phase 1): batched neuron_daily
+// upserts from the chain-direct backfill script (scripts/backfill-neuron-history.py).
+// Reuses METAGRAPH_EVENTS_INGEST_SECRET + EVENTS_INGEST_TOKEN_HEADER (same internal
+// trust boundary — no new secret). Caps are wider than the event ingest because a
+// metagraph row is wider and a subnet-day is up to ~256 rows; the script chunks well
+// under these and the PK upsert makes any re-POST idempotent.
+export const MAX_BACKFILL_INGEST_BODY_BYTES = 1_048_576; // 1 MiB
+export const MAX_BACKFILL_INGEST_ROWS = 2_000;
 // Caps on the R2-staged chain-event drain (loadStagedEvents, #1346). Unlike the
 // single bounded HTTP body above, a staged file is produced by the CI poller and
 // can grow large on a backfill or a stuck window. The byte cap guards against


### PR DESCRIPTION
Closes #1494

**Phase 1 of the full block-history vision** — serve a real ~1-year metagraph time-series **now** instead of accruing forward over months. Empirically grounded: `archive.chain.opentensor.ai` retains full historical *state* (verified — read real `System.Events` + per-subnet metagraph at block 4M), so this is **$0 chain-direct**.

### What ships
- **`scripts/backfill-neuron-history.py`** — chain-direct backfill off the public **archive** node (no API key). For each past day: resolve the block nearest a fixed UTC time, then per-subnet `get_metagraph_info(netuid, block=N)` + `ValidatorTrust` at that block hash (the bulk `get_all_metagraphs_info` is HEAD-only — errors historically). Emits the exact `neuron_daily` row shape; POSTs chunked idempotent batches.
- **`POST /api/v1/internal/backfill-neurons`** (`handleNeuronBackfill`) — secret-gated (reuses the internal-ingest secret + header, no new secret), batched `INSERT…ON CONFLICT` via `neuronDailyUpsertStatements` (same column set + PK target as the forward rollup → backfilled rows are byte-identical, re-runs idempotent). **NOT in the public contract.**
- **Retention 90 → 400 days** — a *rolling* 1-year history is **permanently D1-served** ("1 year ago" is always ≤400 days old), so every 7d/30d/90d/1y query stays hot. ~3.1 GB ≪ D1's 10 GB cap; only >13-month deep history ages into the R2 cold tier.
- **`backfill-neuron-history.yml`** — one-time manual dispatch, 4-quarter matrix (a full year exceeds a single 6h Action).
- **`eslint.config.mjs`** — declare `Blob` + `CompressionStream` (PR-A2's `gzipString` used them; main was lint-dirty).

### To run it after merge
Dispatch the workflow (needs `METAGRAPH_EVENTS_INGEST_SECRET` — already set). The existing history endpoints then serve the backfilled year with no further changes.

Internal route → no public-contract/new-route gates. **27 history+backfill tests + full suite (1575) green**; build, lint, prettier clean. Full block/event history (since-dTAO, Iceberg + R2 SQL) is **Phase 2**.