### PR TITLE
fix(backfill): dedicated METAGRAPH_BACKFILL_SECRET for ingest auth (#1345)

### DIFF
--- a/.github/workflows/backfill-neuron-history.yml
+++ b/.github/workflows/backfill-neuron-history.yml
@@ -52,7 +52,7 @@ jobs:
           uvx --from bittensor==10.4.0 python scripts/backfill-neuron-history.py \
             --days "$DAYS" --end-offset "$END_OFFSET"
         env:
-          METAGRAPH_EVENTS_INGEST_SECRET: ${{ secrets.METAGRAPH_EVENTS_INGEST_SECRET }}
+          METAGRAPH_BACKFILL_SECRET: ${{ secrets.METAGRAPH_BACKFILL_SECRET }}
           METAGRAPH_API_BASE: https://api.metagraph.sh
 
   notify-on-failure:

--- a/scripts/backfill-neuron-history.py
+++ b/scripts/backfill-neuron-history.py
@@ -24,7 +24,7 @@ historical state (verified). dTAO launched ~block 4,920,351 (2025-02-13); the pa
 year is entirely post-dTAO so units are consistent.
 
 Run (one-time; resumable):
-  METAGRAPH_EVENTS_INGEST_SECRET=... \
+  METAGRAPH_BACKFILL_SECRET=... \
   uv run --with bittensor python scripts/backfill-neuron-history.py --days 365
 """
 import argparse
@@ -41,7 +41,9 @@ BLOCK_MS = 12_000  # finney block time, empirically exactly 12.0s
 API_BASE = os.environ.get("METAGRAPH_API_BASE", "https://api.metagraph.sh")
 INGEST_PATH = "/api/v1/internal/backfill-neurons"
 INGEST_HEADER = "x-metagraph-events-token"  # EVENTS_INGEST_TOKEN_HEADER
-SECRET = os.environ.get("METAGRAPH_EVENTS_INGEST_SECRET", "")
+SECRET = os.environ.get("METAGRAPH_BACKFILL_SECRET") or os.environ.get(
+    "METAGRAPH_EVENTS_INGEST_SECRET", ""
+)
 
 
 def to_float(value):
@@ -196,7 +198,7 @@ def main():
     args = p.parse_args()
 
     if not SECRET and not args.dry_run:
-        sys.exit("METAGRAPH_EVENTS_INGEST_SECRET is required (or use --dry-run)")
+        sys.exit("METAGRAPH_BACKFILL_SECRET is required (or use --dry-run)")
 
     s = bt.SubtensorApi(network=args.network)
     head_block = int(s.block)

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -650,10 +650,11 @@ export async function handleEventIngest(request, env) {
 }
 
 // POST /api/v1/internal/backfill-neurons (#1345 Phase 1): the historical metagraph
-// backfill ingest for scripts/backfill-neuron-history.py. Disabled (503) until
-// METAGRAPH_EVENTS_INGEST_SECRET is configured (reuses the internal-ingest secret +
-// header — same trust boundary); then a constant-time token compare. The body is an
-// array of neuron_daily rows (or {rows:[...]}), each carrying its own snapshot_date,
+// backfill ingest for scripts/backfill-neuron-history.py. Disabled (503) until the
+// dedicated METAGRAPH_BACKFILL_SECRET is configured (falls back to the events-ingest
+// secret; reuses the EVENTS_INGEST_TOKEN_HEADER header); then a constant-time token
+// compare. The body is an array of neuron_daily rows (or {rows:[...]}), each carrying
+// its own snapshot_date,
 // upserted with the SAME column set + ON CONFLICT target as the forward rollup, so a
 // backfilled row is byte-identical to a rolled one and any re-POST is idempotent on
 // (netuid,uid,snapshot_date). NOT in the public contract.
@@ -661,11 +662,12 @@ export async function handleNeuronBackfill(request, env) {
   if (request.method !== "POST") {
     return errorResponse("method_not_allowed", "POST only.", 405);
   }
-  const configured = env.METAGRAPH_EVENTS_INGEST_SECRET;
+  const configured =
+    env.METAGRAPH_BACKFILL_SECRET || env.METAGRAPH_EVENTS_INGEST_SECRET;
   if (!configured) {
     return errorResponse(
       "backfill_disabled",
-      "Historical backfill requires METAGRAPH_EVENTS_INGEST_SECRET to be configured.",
+      "Historical backfill requires METAGRAPH_BACKFILL_SECRET (or METAGRAPH_EVENTS_INGEST_SECRET) to be configured.",
       503,
     );
   }

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -131,10 +131,10 @@ export const MAX_EVENTS_INGEST_BODY_BYTES = 262144; // 256 KB
 export const MAX_EVENTS_INGEST_ROWS = 500;
 // Internal historical backfill ingest (#1345 Phase 1): batched neuron_daily
 // upserts from the chain-direct backfill script (scripts/backfill-neuron-history.py).
-// Reuses METAGRAPH_EVENTS_INGEST_SECRET + EVENTS_INGEST_TOKEN_HEADER (same internal
-// trust boundary — no new secret). Caps are wider than the event ingest because a
-// metagraph row is wider and a subnet-day is up to ~256 rows; the script chunks well
-// under these and the PK upsert makes any re-POST idempotent.
+// Auth via the dedicated METAGRAPH_BACKFILL_SECRET (falls back to the events-ingest
+// secret) over the shared EVENTS_INGEST_TOKEN_HEADER. Caps are wider than the event
+// ingest because a metagraph row is wider and a subnet-day is up to ~256 rows; the
+// script chunks well under these and the PK upsert makes any re-POST idempotent.
 export const MAX_BACKFILL_INGEST_BODY_BYTES = 1_048_576; // 1 MiB
 export const MAX_BACKFILL_INGEST_ROWS = 2_000;
 // Caps on the R2-staged chain-event drain (loadStagedEvents, #1346). Unlike the


### PR DESCRIPTION
Closes #1496

The backfill workflow ([run](https://github.com/JSONbored/metagraphed/actions/runs/27992356112)) failed — `METAGRAPH_EVENTS_INGEST_SECRET` (which the route reused) is on the Worker + Railway but **not** a GitHub Actions secret, and its value can't be read back to copy.

Switch to a **dedicated `METAGRAPH_BACKFILL_SECRET`** — already generated and set on **both** the Worker (`wrangler secret put`) and GitHub Actions (`gh secret set`) — with a fallback to the events-ingest secret. Cleaner isolation than sharing the streamer's credential; header unchanged. Existing route tests pass via the fallback.

Build, lint, prettier, py_compile, 9 backfill tests green. After merge + deploy I re-dispatch the backfill (smoke first).