### PR TITLE
fix(backfill): batched raw-storage — 176x faster, free, full-year (#1345)

### DIFF
--- a/.github/workflows/backfill-neuron-history.yml
+++ b/.github/workflows/backfill-neuron-history.yml
@@ -49,7 +49,7 @@ jobs:
           DAYS="${{ github.event.inputs.days_per_shard }}"
           END_OFFSET=$(( ${{ matrix.shard }} * DAYS + 1 ))
           echo "shard ${{ matrix.shard }}: --days $DAYS --end-offset $END_OFFSET"
-          uvx --from bittensor==10.4.0 python scripts/backfill-neuron-history.py \
+          uvx --from bittensor==10.4.0 --with xxhash python scripts/backfill-neuron-history.py \
             --days "$DAYS" --end-offset "$END_OFFSET"
         env:
           METAGRAPH_BACKFILL_SECRET: ${{ secrets.METAGRAPH_BACKFILL_SECRET }}

--- a/scripts/backfill-neuron-history.py
+++ b/scripts/backfill-neuron-history.py
@@ -1,31 +1,31 @@
 #!/usr/bin/env python3
-"""Historical per-UID metagraph BACKFILL (#1345 Phase 1) — chain-direct off the
-public ARCHIVE node, no API key. Fills `neuron_daily` retroactively so the history
-endpoints serve a real time-series NOW instead of accruing forward over months.
+"""Historical per-UID metagraph BACKFILL (#1345 Phase 1) — chain-direct off the FREE
+public archive, BATCHED. Fills `neuron_daily` retroactively so the history endpoints
+serve a real time-series NOW instead of accruing forward over months.
 
-For each target UTC day it resolves the block nearest a fixed time-of-day (the
-forward rollup's cron minute, so backfilled and live rows line up), then per subnet
-calls the per-subnet runtime API `get_metagraph_info(netuid, block=N)` (the bulk
-`get_all_metagraphs_info` is HEAD-only — it errors at historical blocks) plus a
-`ValidatorTrust` storage read at that block hash, emitting the EXACT
-`NEURON_INSERT_COLUMNS` + `snapshot_date` shape the Worker's
-`/api/v1/internal/backfill-neurons` ingest expects (idempotent upsert on
+Why batched raw storage (not the runtime API): get_metagraph_info(block=N) is ~18-25s
+PER SUBNET and the MetagraphInfo runtime struct has a hard ~8-month decode floor. The
+per-netuid metric VECTORS live in plain SubtensorModule storage with NO such floor, and
+one batched `state_queryStorageAt` returns all 129 subnets' 7 metric vectors (~903
+values) in ~13s PER BLOCK — ~176x faster, full-year reachable, $0, no API key.
+
+Per target UTC day: resolve the block nearest a fixed time-of-day, then for every
+subnet fetch Active, ValidatorPermit, Consensus, Incentive, Dividends, Emission,
+ValidatorTrust as offline-built storage keys (chunked 50/call), SCALE-decode the Vecs,
+and emit the exact `neuron_daily` row shape to the secret-gated ingest (idempotent on
 (netuid,uid,snapshot_date), so re-runs are safe/resumable).
 
-Units match scripts/fetch-metagraph-native.py (verified vs Taostats, #1348):
-  stake_tao/emission_tao = float(Balance, alpha-denominated)
-  consensus/incentive/dividends = on-chain 0..1 floats
-  validator_trust = SubtensorModule u16 (0..65535) / 65535
-  rank = derived (1-based, incentive desc); trust = 0.0 (dead in dTAO)
-
-Why archive: events/metagraph at block N live in STATE at that block's hash, which a
-pruned public node discards (~256 blocks). archive.chain.opentensor.ai retains full
-historical state (verified). dTAO launched ~block 4,920,351 (2025-02-13); the past
-year is entirely post-dTAO so units are consistent.
+Units match scripts/fetch-metagraph-native.py: consensus/incentive/dividends/
+validator_trust = u16/65535; emission_tao = u64/1e9; rank derived (1-based incentive
+desc); trust = 0.0 (dead in dTAO). hotkey/coldkey/registered_at_block/axon come from a
+one-shot CURRENT-snapshot overlay (get_all_metagraphs_info at head) applied to all
+backfilled rows — accurate for stable UIDs (documented approximation). stake_tao is
+DEFERRED (null): per-UID dTAO stake is runtime-only (childkey/TaoWeight math, not a raw
+read); it accrues daily forward via the live rollup.
 
 Run (one-time; resumable):
   METAGRAPH_BACKFILL_SECRET=... \
-  uv run --with bittensor python scripts/backfill-neuron-history.py --days 365
+  uv run --with bittensor --with xxhash python scripts/backfill-neuron-history.py --days 365
 """
 import argparse
 import ipaddress
@@ -36,8 +36,19 @@ import time
 import urllib.request
 
 import bittensor as bt
+import xxhash
 
 BLOCK_MS = 12_000  # finney block time, empirically exactly 12.0s
+METRIC_VECTORS = (
+    "Active",
+    "ValidatorPermit",
+    "Consensus",
+    "Incentive",
+    "Dividends",
+    "Emission",
+    "ValidatorTrust",
+)
+KEY_CHUNK = 50  # >100 keys/call hits a latency cliff; 50 is the measured sweet spot
 API_BASE = os.environ.get("METAGRAPH_API_BASE", "https://api.metagraph.sh")
 INGEST_PATH = "/api/v1/internal/backfill-neurons"
 INGEST_HEADER = "x-metagraph-events-token"  # EVENTS_INGEST_TOKEN_HEADER
@@ -45,22 +56,60 @@ SECRET = os.environ.get("METAGRAPH_BACKFILL_SECRET") or os.environ.get(
     "METAGRAPH_EVENTS_INGEST_SECRET", ""
 )
 
-
-def to_float(value):
-    if value is None:
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
+_PALLET = None
 
 
-def u16_ratio(value):
-    try:
-        n = int(value)
-    except (TypeError, ValueError):
-        return None
-    return round(n / 65535, 9)
+def twox128(data: bytes) -> bytes:
+    return xxhash.xxh64(data, seed=0).intdigest().to_bytes(8, "little") + xxhash.xxh64(
+        data, seed=1
+    ).intdigest().to_bytes(8, "little")
+
+
+def storage_key(item: str, netuid: int) -> str:
+    """SubtensorModule.<item>[netuid] — Identity-hashed per-netuid map. Built OFFLINE
+    (substrate.create_storage_key does a network round-trip per key)."""
+    global _PALLET
+    if _PALLET is None:
+        _PALLET = twox128(b"SubtensorModule")
+    return "0x" + (_PALLET + twox128(item.encode()) + int(netuid).to_bytes(2, "little")).hex()
+
+
+def read_compact(b, i):
+    """SCALE compact-length prefix -> (value, next_index)."""
+    b0 = b[i]
+    mode = b0 & 0b11
+    if mode == 0:
+        return b0 >> 2, i + 1
+    if mode == 1:
+        return int.from_bytes(b[i : i + 2], "little") >> 2, i + 2
+    if mode == 2:
+        return int.from_bytes(b[i : i + 4], "little") >> 2, i + 4
+    n = (b0 >> 2) + 4
+    return int.from_bytes(b[i + 1 : i + 1 + n], "little"), i + 1 + n
+
+
+def _bytes(hexval):
+    return bytes.fromhex(hexval[2:] if hexval.startswith("0x") else hexval)
+
+
+def decode_vec_uint(hexval, size):
+    if not hexval:
+        return []
+    b = _bytes(hexval)
+    n, i = read_compact(b, 0)
+    return [int.from_bytes(b[i + k * size : i + (k + 1) * size], "little") for k in range(n)]
+
+
+def decode_vec_bool(hexval):
+    if not hexval:
+        return []
+    b = _bytes(hexval)
+    n, i = read_compact(b, 0)
+    return [b[i + k] != 0 for k in range(n)]
+
+
+def u16_ratio(v):
+    return round(int(v) / 65535, 9) if v is not None else None
 
 
 def fmt_axon(axon):
@@ -77,98 +126,149 @@ def fmt_axon(axon):
     return f"{host}:{port}" if port else host
 
 
-def _at(arr, i):
-    return arr[i] if i < len(arr) else None
-
-
-def block_ms(s, block_hash):
-    """Timestamp.Now (epoch ms) at a block hash."""
-    r = s.substrate.query("Timestamp", "Now", block_hash=block_hash)
+def block_ms(sub, block_hash):
+    r = sub.query("Timestamp", "Now", block_hash=block_hash)
     return int(getattr(r, "value", r) or 0)
 
 
-def resolve_block(s, target_ms, head_block, head_ms):
-    """Block whose timestamp is closest to target_ms (estimate + refine)."""
-    est = head_block - (head_ms - target_ms) // BLOCK_MS
-    est = max(1, min(int(est), head_block))
+def resolve_block(sub, target_ms, head_block, head_ms):
+    est = max(1, min(int(head_block - (head_ms - target_ms) // BLOCK_MS), head_block))
     for _ in range(4):
-        bh = s.substrate.get_block_hash(est)
-        ts = block_ms(s, bh)
-        drift = (ts - target_ms) // BLOCK_MS
+        bh = sub.get_block_hash(est)
+        drift = (block_ms(sub, bh) - target_ms) // BLOCK_MS
         if abs(drift) <= 1:
             break
         est = max(1, min(est - int(drift), head_block))
     return est
 
 
-def storage_vec(s, netuid, name, block_hash):
-    try:
-        r = s.substrate.query("SubtensorModule", name, [netuid], block_hash=block_hash)
-        return list(getattr(r, "value", r) or [])
-    except Exception:
-        return []
-
-
-def subnet_rows(info, netuid, vtrust_vec, snapshot_date, captured_at, block):
-    hotkeys = list(getattr(info, "hotkeys", []) or [])
-    n = len(hotkeys)
-    if not n:
-        return []
-    coldkeys = list(getattr(info, "coldkeys", []) or [])
-    active = list(getattr(info, "active", []) or [])
-    permits = list(getattr(info, "validator_permit", []) or [])
-    consensus = list(getattr(info, "consensus", []) or [])
-    incentives = list(getattr(info, "incentives", []) or [])
-    dividends = list(getattr(info, "dividends", []) or [])
-    emission = list(getattr(info, "emission", []) or [])
-    stake = list(getattr(info, "total_stake", []) or [])
-    axons = list(getattr(info, "axons", []) or [])
-    reg_at = list(getattr(info, "block_at_registration", []) or [])
-    immunity = int(getattr(info, "immunity_period", 0) or 0)
-    rows = []
-    for uid in range(n):
-        reg = _at(reg_at, uid)
-        rows.append(
-            {
-                "netuid": netuid,
-                "uid": uid,
-                "hotkey": _at(hotkeys, uid),
-                "coldkey": _at(coldkeys, uid),
-                "active": 1 if _at(active, uid) else 0,
-                "validator_permit": 1 if _at(permits, uid) else 0,
-                "rank": None,
-                "trust": 0.0,
-                "validator_trust": u16_ratio(_at(vtrust_vec, uid)),
-                "consensus": to_float(_at(consensus, uid)),
-                "incentive": to_float(_at(incentives, uid)),
-                "dividends": to_float(_at(dividends, uid)),
-                "emission_tao": to_float(_at(emission, uid)),
-                "stake_tao": to_float(_at(stake, uid)),
-                "registered_at_block": reg,
-                "is_immunity_period": 1
-                if (reg is not None and block - reg < immunity)
-                else 0,
-                "axon": fmt_axon(_at(axons, uid)),
-                "block_number": block,
-                "captured_at": captured_at,
-                "snapshot_date": snapshot_date,
+def build_overlay(api):
+    """One-shot current snapshot -> {netuid: {uid: {hotkey, coldkey, reg, immunity, axon}}}."""
+    overlay = {}
+    infos = api.metagraphs.get_all_metagraphs_info(all_mechanisms=True)
+    for info in infos:
+        nu = int(info.netuid)
+        mechid = int(getattr(info, "mechid", 0) or 0)
+        if nu in overlay and mechid != 0:
+            continue
+        hotkeys = list(getattr(info, "hotkeys", []) or [])
+        coldkeys = list(getattr(info, "coldkeys", []) or [])
+        axons = list(getattr(info, "axons", []) or [])
+        reg_at = list(getattr(info, "block_at_registration", []) or [])
+        immunity = int(getattr(info, "immunity_period", 0) or 0)
+        uids = {}
+        for uid in range(len(hotkeys)):
+            uids[uid] = {
+                "hotkey": hotkeys[uid] if uid < len(hotkeys) else None,
+                "coldkey": coldkeys[uid] if uid < len(coldkeys) else None,
+                "reg": reg_at[uid] if uid < len(reg_at) else None,
+                "immunity": immunity,
+                "axon": fmt_axon(axons[uid]) if uid < len(axons) else None,
             }
-        )
-    # Derive Taostats-style rank: 1-based by incentive desc (null when no incentive).
-    for pos, row in enumerate(
-        sorted(
-            (r for r in rows if r["incentive"]),
-            key=lambda r: (-r["incentive"], r["uid"]),
-        ),
-        start=1,
-    ):
-        row["rank"] = float(pos)
-    return [r for r in rows if r["hotkey"]]
+        overlay[nu] = uids
+    return overlay
+
+
+def fetch_block_metrics(sub, netuids, block_hash):
+    """Batched state_queryStorageAt over every (netuid, metric) key -> raw hex per pair."""
+    keymap, keys = {}, []
+    for n in netuids:
+        for item in METRIC_VECTORS:
+            k = storage_key(item, n)
+            keys.append(k)
+            keymap[k.lower()] = (n, item)
+    raw = {}
+    for i in range(0, len(keys), KEY_CHUNK):
+        chunk = keys[i : i + KEY_CHUNK]
+        for attempt in range(4):
+            try:
+                res = sub.rpc_request("state_queryStorageAt", [chunk, block_hash])
+                for k, v in res["result"][0]["changes"]:
+                    if v is not None:
+                        raw[keymap[k.lower()]] = v
+                break
+            except Exception as e:
+                if attempt == 3:
+                    raise
+                sys.stderr.write(f"chunk retry {attempt + 1}: {repr(e)[:80]}\n")
+                time.sleep(2 * (attempt + 1))
+    return raw
+
+
+def build_rows(raw, overlay, netuids, block, captured_at, snapshot_date):
+    rows, skipped = [], 0
+    for netuid in netuids:
+        emission = decode_vec_uint(raw.get((netuid, "Emission")), 8)
+        n = len(emission)
+        if not n:
+            continue
+        consensus = decode_vec_uint(raw.get((netuid, "Consensus")), 2)
+        incentive = decode_vec_uint(raw.get((netuid, "Incentive")), 2)
+        dividends = decode_vec_uint(raw.get((netuid, "Dividends")), 2)
+        vtrust = decode_vec_uint(raw.get((netuid, "ValidatorTrust")), 2)
+        active = decode_vec_bool(raw.get((netuid, "Active")))
+        vpermit = decode_vec_bool(raw.get((netuid, "ValidatorPermit")))
+        ov = overlay.get(netuid, {})
+        subnet_rows = []
+        for uid in range(n):
+            ident = ov.get(uid)
+            if not ident or not ident.get("hotkey"):
+                skipped += 1
+                continue  # no identity overlay -> ingest would reject (needs hotkey)
+            reg = ident.get("reg")
+            immunity = ident.get("immunity") or 0
+            subnet_rows.append(
+                {
+                    "netuid": netuid,
+                    "uid": uid,
+                    "hotkey": ident["hotkey"],
+                    "coldkey": ident.get("coldkey"),
+                    "active": 1 if (uid < len(active) and active[uid]) else 0,
+                    "validator_permit": 1
+                    if (uid < len(vpermit) and vpermit[uid])
+                    else 0,
+                    "rank": None,
+                    "trust": 0.0,
+                    "validator_trust": u16_ratio(vtrust[uid])
+                    if uid < len(vtrust)
+                    else None,
+                    "consensus": u16_ratio(consensus[uid])
+                    if uid < len(consensus)
+                    else None,
+                    "incentive": u16_ratio(incentive[uid])
+                    if uid < len(incentive)
+                    else None,
+                    "dividends": u16_ratio(dividends[uid])
+                    if uid < len(dividends)
+                    else None,
+                    "emission_tao": round(emission[uid] / 1e9, 9),
+                    "stake_tao": None,  # deferred: runtime-only in dTAO
+                    "registered_at_block": reg,
+                    "is_immunity_period": 1
+                    if (reg is not None and block - reg < immunity)
+                    else 0,
+                    "axon": ident.get("axon"),
+                    "block_number": block,
+                    "captured_at": captured_at,
+                    "snapshot_date": snapshot_date,
+                }
+            )
+        # Derive rank: 1-based by incentive desc (null when no incentive).
+        for pos, row in enumerate(
+            sorted(
+                (r for r in subnet_rows if r["incentive"]),
+                key=lambda r: (-r["incentive"], r["uid"]),
+            ),
+            start=1,
+        ):
+            row["rank"] = float(pos)
+        rows.extend(subnet_rows)
+    return rows, skipped
 
 
 def post_chunk(rows, dry_run):
     if dry_run or not rows:
-        return len(rows)
+        return
     body = json.dumps({"rows": rows}).encode()
     req = urllib.request.Request(
         API_BASE + INGEST_PATH,
@@ -177,75 +277,64 @@ def post_chunk(rows, dry_run):
         headers={
             "content-type": "application/json",
             INGEST_HEADER: SECRET,
-            # CF WAF 403s the default Python-urllib UA (same gotcha as the streamer).
-            "user-agent": "metagraphed-backfill/1.0",
+            "user-agent": "metagraphed-backfill/2.0",  # CF WAF 403s default urllib UA
         },
     )
     with urllib.request.urlopen(req, timeout=60) as resp:
         json.loads(resp.read())
-    return len(rows)
 
 
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("--network", default="archive")
-    p.add_argument("--days", type=int, default=365, help="how many days back to fill")
+    p.add_argument("--days", type=int, default=365)
     p.add_argument("--end-offset", type=int, default=1, help="newest day = today-N")
-    p.add_argument("--hour", type=int, default=5, help="UTC hour to sample (cron 47 5)")
+    p.add_argument("--hour", type=int, default=5, help="UTC hour (forward cron is 47 5)")
     p.add_argument("--minute", type=int, default=47)
     p.add_argument("--chunk", type=int, default=1500, help="rows per ingest POST")
     p.add_argument("--dry-run", action="store_true")
     args = p.parse_args()
-
     if not SECRET and not args.dry_run:
         sys.exit("METAGRAPH_BACKFILL_SECRET is required (or use --dry-run)")
 
-    s = bt.SubtensorApi(network=args.network)
-    head_block = int(s.block)
-    head_ms = block_ms(s, s.substrate.get_block_hash(head_block))
-    sys.stderr.write(f"head block {head_block} @ {head_ms}ms; archive={args.network}\n")
+    api = bt.SubtensorApi(network=args.network)
+    sub = api.substrate
+    head_block = int(api.block)
+    head_ms = block_ms(sub, sub.get_block_hash(head_block))
+    sys.stderr.write(f"head {head_block} @ {head_ms}ms; building identity overlay...\n")
+    overlay = build_overlay(api)
+    sys.stderr.write(f"overlay: {len(overlay)} subnets\n")
 
     day_ms = 86_400_000
-    now_ms = int(time.time() * 1000)
-    midnight = (now_ms // day_ms) * day_ms
+    midnight = (int(time.time() * 1000) // day_ms) * day_ms
     tod = (args.hour * 3600 + args.minute * 60) * 1000
-
     total_rows = 0
     for offset in range(args.end_offset, args.end_offset + args.days):
         target_ms = midnight - offset * day_ms + tod
         snapshot_date = time.strftime("%Y-%m-%d", time.gmtime(target_ms / 1000))
-        block = resolve_block(s, target_ms, head_block, head_ms)
-        bh = s.substrate.get_block_hash(block)
-        captured_at = block_ms(s, bh)
+        block = resolve_block(sub, target_ms, head_block, head_ms)
+        bh = sub.get_block_hash(block)
+        captured_at = block_ms(sub, bh)
         total = int(
             getattr(
-                s.substrate.query("SubtensorModule", "TotalNetworks", [], block_hash=bh),
+                sub.query("SubtensorModule", "TotalNetworks", [], block_hash=bh),
                 "value",
                 0,
             )
             or 0
         )
-        pending, day_rows = [], 0
-        for netuid in range(total):
-            try:
-                info = s.metagraphs.get_metagraph_info(netuid=netuid, block=block)
-            except Exception:
-                continue
-            vtrust = storage_vec(s, netuid, "ValidatorTrust", bh)
-            rows = subnet_rows(info, netuid, vtrust, snapshot_date, captured_at, block)
-            pending.extend(rows)
-            day_rows += len(rows)
-            while len(pending) >= args.chunk:
-                post_chunk(pending[: args.chunk], args.dry_run)
-                pending = pending[args.chunk :]
-        if pending:
-            post_chunk(pending, args.dry_run)
-        total_rows += day_rows
-        sys.stderr.write(
-            f"{snapshot_date} block {block} ({total} subnets) -> {day_rows} rows"
-            f"{' [dry-run]' if args.dry_run else ''}\n"
+        netuids = list(range(total))
+        raw = fetch_block_metrics(sub, netuids, bh)
+        rows, skipped = build_rows(
+            raw, overlay, netuids, block, captured_at, snapshot_date
         )
-
+        for i in range(0, len(rows), args.chunk):
+            post_chunk(rows[i : i + args.chunk], args.dry_run)
+        total_rows += len(rows)
+        sys.stderr.write(
+            f"{snapshot_date} block {block} ({total} subnets) -> {len(rows)} rows"
+            f" (skipped {skipped}){' [dry-run]' if args.dry_run else ''}\n"
+        )
     sys.stderr.write(f"done: {total_rows} rows across {args.days} days\n")
 
 


### PR DESCRIPTION
Closes #1498

The per-subnet runtime backfill was ~18–25s/subnet (infeasible) with a hard ~8-month decode floor. **Batched `state_queryStorageAt`** against the free public archive returns all 129 subnets' 7 metric vectors (~903 values) in **~13s/block** → daily full-year in ~1.5–2h, **$0, no key, no runtime floor**, and it shards across CI runners.

**Verified correct**: offline-built keys are byte-identical to the SDK, and decoded values match `get_metagraph_info` exactly on non-zero UIDs (consensus 0.964049744 vs 0.96405; emission 143.011704417 vs 143.011704417). Dry-run: all 129 subnets, ~30k rows/day.

`stake_tao` is the one deferred field (per-UID dTAO stake is runtime-only — childkey/TaoWeight math, not a raw read); it accrues daily forward via the live rollup. hotkey/coldkey from a one-shot current-snapshot overlay. Python-only change (+ `--with xxhash`); no JS/route changes, ingest tests unaffected.