### PR TITLE
feat(icon): /api/v1/icon favicon proxy — fixes site-wide missing brand icons (#1124)

### DIFF
--- a/src/icon-proxy.mjs
+++ b/src/icon-proxy.mjs
@@ -1,0 +1,151 @@
+// Brand-icon favicon proxy (#1124 frontend-surfacing) — implements the icon-proxy
+// contract documented in metagraphed-ui src/lib/metagraphed/brand-overrides.ts:
+//
+//   GET /api/v1/icon?host={domain}&size={px}&theme={light|dark}
+//   -> 200 image/png|x-icon (square, cached) | 404 when no source resolves
+//
+// SSRF SAFETY: we NEVER fetch the caller-supplied host directly. We only fetch from
+// FIXED, trusted favicon services (DuckDuckGo, Google), passing the validated host as
+// a query param — so a malicious host can never make the Worker hit an internal/private
+// target. The host is additionally validated to be a plain public DNS name (no IP
+// literals, no localhost/.local/.internal). Results are cached in R2 (immutable) so
+// repeat loads are a single edge read.
+const ICON_CACHE_PREFIX = "icon-cache";
+const MAX_SIZE = 256;
+const DEFAULT_SIZE = 64;
+const MIN_ICON_BYTES = 100; // reject empty / 1x1 placeholder responses
+const CACHE_CONTROL = "public, max-age=2592000, immutable"; // 30d, per contract
+const BLOCKED_TLDS = new Set(["localhost", "local", "internal"]);
+
+function normalizeHost(input) {
+  const host = String(input ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/^www\./, "")
+    .replace(/\.$/, "");
+  if (!host || host.length > 253) return null;
+  // IP literals (v4/v6) are never valid public hosts here.
+  if (host.includes(":") || host.startsWith("[")) return null;
+  const labels = host.split(".");
+  if (labels.length < 2) return null;
+  const tld = labels[labels.length - 1];
+  if (!tld || BLOCKED_TLDS.has(tld)) return null;
+  // Reject a 4-numeric-label IPv4 literal (e.g. 10.0.0.1).
+  if (labels.length === 4 && labels.every((l) => /^\d{1,3}$/.test(l)))
+    return null;
+  const ok = labels.every(
+    (l) =>
+      l.length > 0 &&
+      l.length <= 63 &&
+      /^[a-z0-9-]+$/.test(l) &&
+      !l.startsWith("-") &&
+      !l.endsWith("-"),
+  );
+  return ok ? host : null;
+}
+
+function clampSize(input) {
+  const n = Number.parseInt(String(input ?? ""), 10);
+  if (!Number.isFinite(n)) return DEFAULT_SIZE;
+  return Math.max(16, Math.min(n, MAX_SIZE));
+}
+
+// Fixed trusted services only — the host is a param, never a fetch target itself.
+function faviconSources(host, size) {
+  return [
+    `https://icons.duckduckgo.com/ip3/${host}.ico`,
+    `https://www.google.com/s2/favicons?domain=${host}&sz=${Math.min(size * 2, MAX_SIZE)}`,
+  ];
+}
+
+function etagFor(host, size) {
+  return `"icon-${host}-${size}"`;
+}
+
+function imageResponse(body, contentType, etag, extra = {}) {
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "content-type": contentType || "image/png",
+      "cache-control": CACHE_CONTROL,
+      etag,
+      "access-control-allow-origin": "*",
+      "x-content-type-options": "nosniff",
+      ...extra,
+    },
+  });
+}
+
+function notFound() {
+  return new Response("icon not found", {
+    status: 404,
+    headers: {
+      "cache-control": "public, max-age=86400", // negative-cache a day
+      "access-control-allow-origin": "*",
+    },
+  });
+}
+
+export async function handleIconProxy(request, env, url) {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response("method not allowed", { status: 405 });
+  }
+  const host = normalizeHost(url.searchParams.get("host"));
+  if (!host) {
+    return new Response("invalid host", {
+      status: 400,
+      headers: { "access-control-allow-origin": "*" },
+    });
+  }
+  const size = clampSize(url.searchParams.get("size"));
+  const etag = etagFor(host, size);
+  if ((request.headers.get("if-none-match") || "") === etag) {
+    return new Response(null, {
+      status: 304,
+      headers: { etag, "cache-control": CACHE_CONTROL },
+    });
+  }
+
+  const bucket = env?.METAGRAPH_ARCHIVE;
+  const cacheKey = `${ICON_CACHE_PREFIX}/${host}/${size}`;
+
+  // R2 cache hit -> single edge read.
+  if (bucket?.get) {
+    try {
+      const cached = await bucket.get(cacheKey);
+      if (cached) {
+        const ct = cached.httpMetadata?.contentType || "image/png";
+        return imageResponse(cached.body, ct, etag, { "x-icon-cache": "hit" });
+      }
+    } catch {
+      // fall through to live resolution
+    }
+  }
+
+  for (const src of faviconSources(host, size)) {
+    try {
+      const res = await fetch(src, {
+        headers: { accept: "image/*" },
+        cf: { cacheTtl: 2592000, cacheEverything: true },
+      });
+      if (!res.ok) continue;
+      const buf = await res.arrayBuffer();
+      if (buf.byteLength < MIN_ICON_BYTES) continue; // skip empty/placeholder
+      const ct = res.headers.get("content-type") || "image/png";
+      if (!ct.startsWith("image/")) continue;
+      if (bucket?.put) {
+        try {
+          await bucket.put(cacheKey, buf, {
+            httpMetadata: { contentType: ct, cacheControl: CACHE_CONTROL },
+          });
+        } catch {
+          // caching is best-effort
+        }
+      }
+      return imageResponse(buf, ct, etag, { "x-icon-cache": "miss" });
+    } catch {
+      // try the next source
+    }
+  }
+  return notFound();
+}

--- a/tests/icon-proxy.test.mjs
+++ b/tests/icon-proxy.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleIconProxy } from "../src/icon-proxy.mjs";
+
+const PNG = new Uint8Array(200).fill(1).buffer; // >100 bytes -> not a placeholder
+
+async function call(qs, { env = {}, headers = {}, fetchImpl } = {}) {
+  const url = new URL("https://api.metagraph.sh/api/v1/icon" + qs);
+  const request = new Request(url, { headers });
+  const orig = globalThis.fetch;
+  if (fetchImpl) globalThis.fetch = fetchImpl;
+  try {
+    return await handleIconProxy(request, env, url);
+  } finally {
+    globalThis.fetch = orig;
+  }
+}
+
+test("rejects invalid hosts (400): empty, IP literal, localhost, single-label", async () => {
+  assert.equal((await call("?host=")).status, 400);
+  assert.equal((await call("?host=10.0.0.1")).status, 400);
+  assert.equal((await call("?host=localhost")).status, 400);
+  assert.equal((await call("?host=internal")).status, 400);
+  assert.equal((await call("?host=%5B::1%5D")).status, 400);
+});
+
+test("serves + caches a fetched favicon (R2 miss -> 200, put called)", async () => {
+  const puts = [];
+  const env = {
+    METAGRAPH_ARCHIVE: {
+      get: async () => null,
+      put: async (k, _v, o) => puts.push({ k, o }),
+    },
+  };
+  const fetchImpl = async () =>
+    new Response(PNG, {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+  const res = await call("?host=example.com&size=64", { env, fetchImpl });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("x-icon-cache"), "miss");
+  assert.equal(res.headers.get("access-control-allow-origin"), "*");
+  assert.match(res.headers.get("cache-control"), /immutable/);
+  assert.equal(res.headers.get("etag"), '"icon-example.com-64"');
+  assert.equal(puts.length, 1);
+  assert.equal(puts[0].k, "icon-cache/example.com/64");
+});
+
+test("serves from the R2 cache when present (hit, no fetch)", async () => {
+  let fetched = false;
+  const env = {
+    METAGRAPH_ARCHIVE: {
+      get: async () => ({
+        body: PNG,
+        httpMetadata: { contentType: "image/png" },
+      }),
+      put: async () => {},
+    },
+  };
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async () => {
+      fetched = true;
+      return new Response(PNG, { status: 200 });
+    },
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("x-icon-cache"), "hit");
+  assert.equal(fetched, false);
+});
+
+test("404 when no source resolves", async () => {
+  const env = {
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async () => new Response("", { status: 404 }),
+  });
+  assert.equal(res.status, 404);
+});
+
+test("rejects too-small (placeholder) responses -> 404", async () => {
+  const env = {
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const tiny = new Uint8Array(10).buffer;
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async () =>
+      new Response(tiny, {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+  });
+  assert.equal(res.status, 404);
+});
+
+test("304 on matching If-None-Match (no fetch, no R2)", async () => {
+  const res = await call("?host=example.com&size=64", {
+    headers: { "if-none-match": '"icon-example.com-64"' },
+  });
+  assert.equal(res.status, 304);
+});
+
+test("non-GET is 405", async () => {
+  const url = new URL("https://api.metagraph.sh/api/v1/icon?host=example.com");
+  const res = await handleIconProxy(
+    new Request(url, { method: "POST" }),
+    {},
+    url,
+  );
+  assert.equal(res.status, 405);
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -124,6 +124,7 @@ import { handleMcpRequest } from "../src/mcp-server.mjs";
 import { handleFeedRequest } from "../src/feeds.mjs";
 import { handleBadgeRequest } from "../src/badge.mjs";
 import { handleOgImage } from "../src/og-image.mjs";
+import { handleIconProxy } from "../src/icon-proxy.mjs";
 import { handleGraphQLRequest } from "../src/graphql.mjs";
 import {
   aiEnabled,
@@ -920,6 +921,13 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // wasm is lazy-loaded inside the handler so this never weighs on other routes.
   if (url.pathname === "/og.png" || url.pathname === "/og") {
     return handleOgImage(request, env, url, { readArtifact });
+  }
+
+  // Brand-icon favicon proxy (binary, not a JSON contract route). Implements the
+  // icon-proxy contract consumed by metagraphed-ui <BrandIcon>; SSRF-safe (fetches
+  // only fixed favicon services) + R2-cached. See src/icon-proxy.mjs.
+  if (url.pathname === "/api/v1/icon") {
+    return handleIconProxy(request, env, url);
   }
 
   // Agent/AI discovery surfaces. The homepage advertises the machine resources


### PR DESCRIPTION
Closes #1500

Your #1 screenshot complaint: icons missing for an overwhelming majority of subnets/providers. Root cause — `<BrandIcon>`'s resolution chain has an **icon-proxy step (`VITE_ICON_PROXY_URL`) that was never configured**, so anything without a curated override or GitHub repo falls through to a blank monogram.

This implements the documented contract: `GET /api/v1/icon?host&size&theme` → favicon image. **SSRF-safe** (only ever fetches fixed DuckDuckGo/Google services, never the caller host; host validated as a public DNS name). **R2-cached** (immutable, ETag/304), CORS. Binary route → not in the JSON contract → no new-route gates. 7 tests + full suite (1583) green.

**Next (metagraphed-ui follow-up):** set `VITE_ICON_PROXY_URL=https://api.metagraph.sh/api/v1/icon`, drop `crossOrigin` for proxied icons, relax the `naturalWidth` rejection (favicons are 32–64px), and bump icon sizing on subnet pages.