### PR TITLE
fix(api): list pagination meta only reports desc when a sort was applied

### DIFF
--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -76,3 +76,39 @@ describe("list-query field projection", () => {
     );
   });
 });
+
+describe("list-query pagination order", () => {
+  const data = {
+    subnets: [{ netuid: 3 }, { netuid: 1 }, { netuid: 2 }],
+  };
+
+  test("order=desc without a sort key reports asc (rows are unsorted)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?order=desc"),
+      "subnets",
+    );
+    // sortRows did not run (no sort key) → rows stay in source order …
+    assert.deepEqual(
+      result.data.subnets.map((r) => r.netuid),
+      [3, 1, 2],
+    );
+    // … so meta must not claim a descending order that wasn't applied.
+    assert.equal(result.meta.pagination.sort, null);
+    assert.equal(result.meta.pagination.order, "asc");
+  });
+
+  test("order=desc with a sort key reports desc and sorts", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?sort=netuid&order=desc"),
+      "subnets",
+    );
+    assert.deepEqual(
+      result.data.subnets.map((r) => r.netuid),
+      [3, 2, 1],
+    );
+    assert.equal(result.meta.pagination.sort, "netuid");
+    assert.equal(result.meta.pagination.order, "desc");
+  });
+});

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -160,7 +160,10 @@ function paginateRows(rows, params) {
     cursor,
     limit,
     nextCursor: next < rows.length ? next : null,
-    order: params.get("order") === "desc" ? "desc" : "asc",
+    // sortRows only orders when a `sort` key is present, so without one the rows
+    // are in source order — reporting "desc" here would misdescribe them.
+    order:
+      params.get("sort") && params.get("order") === "desc" ? "desc" : "asc",
     rows: shouldPage ? rows.slice(cursor, next) : rows,
     sort: params.get("sort") || null,
   };


### PR DESCRIPTION
## Summary

Fixes #1502.

`paginateRows` reported `order: "desc"` in the pagination metadata whenever `?order=desc` was present, but `sortRows` only sorts when a `sort` key is given. So `GET /api/v1/subnets?order=desc` (no `sort`) leaves rows in source order while `meta.pagination` claims `{ sort: null, order: "desc" }` — misdescribing an unordered list as descending.

## What Changed

- `workers/list-query.mjs` — gate the reported `order` on the presence of a `sort` key (mirroring `sortRows`): no sort key → `order: "asc"` (the no-op default); `?sort=field&order=desc` still reports `"desc"`.
- `tests/list-query.test.mjs` — tests for both branches (order=desc without sort → asc + unsorted; sort+order=desc → desc + sorted).

No schema, OpenAPI, or generated-artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `npx vitest run tests/list-query.test.mjs` — 6 passed (new order tests fail without the fix)
- [x] `npx prettier --check` + `npx eslint` on changed files — clean
- [x] `git diff --check`

## Template Used

- Backend/code change
