### PR TITLE
fix(backfill): retry transient 5xx + monthly stake pass (#1345)

### DIFF
--- a/.github/workflows/backfill-stake-monthly.yml
+++ b/.github/workflows/backfill-stake-monthly.yml
@@ -1,0 +1,73 @@
+name: Backfill Stake Monthly (one-time, #1345)
+
+# One-time MONTHLY backfill of the DEFERRED per-UID `stake_tao` field that the daily
+# backfill (Backfill Neuron History) leaves NULL. Per-UID dTAO stake is runtime-only
+# (childkey/TaoWeight math, not a raw storage read), so it can only come from the slow
+# runtime get_metagraph_info — which also has a hard ~8-month decode floor. A monthly
+# pass over the last ~8 months (~8 blocks x ~129 subnets) is the feasible enrichment.
+#
+# Reads OnFinality's public archive (free, no API key, retains historical state) via
+# scripts/backfill-stake-monthly.py and POSTs each month's complete, stake-included rows
+# to the Worker's secret-gated /api/v1/internal/backfill-neurons ingest. The upsert is
+# idempotent on (netuid,uid,snapshot_date) → those monthly days are overwritten in place
+# with full rows, so a re-run is safe. Manual only.
+#
+# ONE job (NOT a matrix): OnFinality is a single endpoint, and the work is small enough
+# (~8 months x ~5s/subnet) to finish well inside one runner.
+on:
+  workflow_dispatch:
+    inputs:
+      months:
+        description: "Months back to backfill stake (runtime decode floor ~8)"
+        required: false
+        default: "8"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backfill-stake-monthly
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120 # ~8 months x ~129 subnets x ~5s/subnet, plus margin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      # Runtime get_metagraph_info off OnFinality's public archive (pinned bittensor,
+      # matching the daily backfill). One block per month, every subnet, stake included;
+      # the ingest upsert is idempotent so a rerun is harmless.
+      - name: Backfill monthly stake
+        run: |
+          MONTHS="${{ github.event.inputs.months }}"
+          echo "backfilling stake for $MONTHS month(s)"
+          uvx --from bittensor==10.4.0 python scripts/backfill-stake-monthly.py \
+            --months "$MONTHS"
+        env:
+          METAGRAPH_BACKFILL_SECRET: ${{ secrets.METAGRAPH_BACKFILL_SECRET }}
+          METAGRAPH_API_BASE: https://api.metagraph.sh
+
+  notify-on-failure:
+    needs: [backfill]
+    if: ${{ always() && needs.backfill.result == 'failure' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Notify on failure
+        env:
+          METAGRAPH_ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}
+        run: |
+          if [ -z "$METAGRAPH_ALERT_WEBHOOK_URL" ]; then
+            exit 0
+          fi
+          curl -fsS -X POST "$METAGRAPH_ALERT_WEBHOOK_URL" \
+            -H 'content-type: application/json' \
+            -d '{"content":"🔴 metagraphed backfill-stake-monthly FAILED — historical stake_tao backfill incomplete."}'

--- a/scripts/backfill-neuron-history.py
+++ b/scripts/backfill-neuron-history.py
@@ -33,6 +33,7 @@ import json
 import os
 import sys
 import time
+import urllib.error
 import urllib.request
 
 import bittensor as bt
@@ -270,18 +271,31 @@ def post_chunk(rows, dry_run):
     if dry_run or not rows:
         return
     body = json.dumps({"rows": rows}).encode()
-    req = urllib.request.Request(
-        API_BASE + INGEST_PATH,
-        data=body,
-        method="POST",
-        headers={
-            "content-type": "application/json",
-            INGEST_HEADER: SECRET,
-            "user-agent": "metagraphed-backfill/2.0",  # CF WAF 403s default urllib UA
-        },
-    )
-    with urllib.request.urlopen(req, timeout=60) as resp:
-        json.loads(resp.read())
+    headers = {
+        "content-type": "application/json",
+        INGEST_HEADER: SECRET,
+        "user-agent": "metagraphed-backfill/2.0",  # CF WAF 403s default urllib UA
+    }
+    # Retry transient ingest/D1 errors (5xx/429/network) with backoff — the parallel
+    # shards contend on D1 and occasionally trip a 500, which must not kill the shard.
+    for attempt in range(5):
+        try:
+            req = urllib.request.Request(
+                API_BASE + INGEST_PATH, data=body, method="POST", headers=headers
+            )
+            with urllib.request.urlopen(req, timeout=90) as resp:
+                json.loads(resp.read())
+            return
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 500, 502, 503, 504) and attempt < 4:
+                time.sleep(2 * (attempt + 1))
+                continue
+            raise
+        except (urllib.error.URLError, TimeoutError):
+            if attempt < 4:
+                time.sleep(2 * (attempt + 1))
+                continue
+            raise
 
 
 def main():
@@ -291,7 +305,7 @@ def main():
     p.add_argument("--end-offset", type=int, default=1, help="newest day = today-N")
     p.add_argument("--hour", type=int, default=5, help="UTC hour (forward cron is 47 5)")
     p.add_argument("--minute", type=int, default=47)
-    p.add_argument("--chunk", type=int, default=1500, help="rows per ingest POST")
+    p.add_argument("--chunk", type=int, default=1000, help="rows per ingest POST")
     p.add_argument("--dry-run", action="store_true")
     args = p.parse_args()
     if not SECRET and not args.dry_run:

--- a/scripts/backfill-stake-monthly.py
+++ b/scripts/backfill-stake-monthly.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""One-time MONTHLY historical STAKE backfill (#1345 / #1302) — fills the DEFERRED
+`stake_tao` field in `neuron_daily` that scripts/backfill-neuron-history.py leaves NULL.
+
+Why a SEPARATE, slower, monthly pass: per-UID dTAO stake is RUNTIME-only (childkey /
+TaoWeight math), NOT a raw SubtensorModule storage read, so the fast batched
+state_queryStorageAt path the daily backfiller uses cannot produce it. The runtime
+`get_metagraph_info(block=N)` DOES return correct per-UID `total_stake`, but it is
+~5s PER SUBNET and the MetagraphInfo runtime struct has a hard ~8-month decode floor
+(decode TypeError at ~270d+ — the struct didn't exist before then). A monthly pass over
+the last ~8 months is therefore the feasible enrichment: ~8 blocks x ~129 subnets.
+
+For each month offset we resolve the block nearest a fixed UTC time-of-day, then for
+every subnet pull the FULL runtime metagraph and emit the SAME `neuron_daily` row shape
+as the daily backfiller — only now `stake_tao = float(total_stake[uid])` is populated.
+The ingest upsert is idempotent on (netuid,uid,snapshot_date), so these monthly days are
+overwritten in place with complete, stake-included rows (re-runs are safe/resumable).
+
+Units match scripts/fetch-metagraph-native.py exactly:
+  stake_tao / emission_tao = float(Balance, alpha-denominated)
+  consensus / incentive / dividends = runtime 0..1 floats
+  validator_trust = SubtensorModule u16 (0..65535) / 65535
+  trust = 0.0 (dead in dTAO)
+  rank = derived (1-based by incentive desc; null for non-incentivized neurons)
+
+Connection: OnFinality's public archive endpoint — free, no API key, no rate limit,
+retains historical state. In bittensor 10.4.x the metagraph helpers live on
+`api.metagraphs` (NOT api.subnets).
+
+Run (one-time; resumable):
+  METAGRAPH_BACKFILL_SECRET=... \
+  uv run --with bittensor python scripts/backfill-stake-monthly.py --months 8
+"""
+import argparse
+import ipaddress
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+import bittensor as bt
+
+# OnFinality public archive — free, no key, no rate limit, retains historical state.
+NETWORK = "wss://bittensor-finney.api.onfinality.io/public-ws"
+BLOCK_MS = 12_000  # finney block time, empirically exactly 12.0s
+DAYS_PER_MONTH = 30  # month offset m = m*30 days ago (calendar-month precision n/a here)
+API_BASE = os.environ.get("METAGRAPH_API_BASE", "https://api.metagraph.sh")
+INGEST_PATH = "/api/v1/internal/backfill-neurons"
+INGEST_HEADER = "x-metagraph-events-token"  # EVENTS_INGEST_TOKEN_HEADER
+SECRET = os.environ.get("METAGRAPH_BACKFILL_SECRET") or os.environ.get(
+    "METAGRAPH_EVENTS_INGEST_SECRET", ""
+)
+
+
+def to_float(value):
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def u16_ratio(value):
+    """SubtensorModule ValidatorTrust is u16 (0..65535) → 0..1 ratio."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return None
+    return round(n / 65535, 9)
+
+
+def fmt_axon(axon):
+    """axons[uid] = {ip:int, port:int, ...}; ip 0 → not serving."""
+    if not isinstance(axon, dict):
+        return None
+    ip = axon.get("ip") or 0
+    port = axon.get("port") or 0
+    if not ip:
+        return None
+    try:
+        host = str(ipaddress.ip_address(int(ip)))
+    except (ValueError, TypeError):
+        return None
+    return f"{host}:{port}" if port else host
+
+
+def _at(arr, i):
+    return arr[i] if i < len(arr) else None
+
+
+def block_ms(sub, block_hash):
+    r = sub.query("Timestamp", "Now", block_hash=block_hash)
+    return int(getattr(r, "value", r) or 0)
+
+
+def resolve_block(sub, target_ms, head_block, head_ms):
+    """Block whose timestamp is nearest target_ms (≤1 block drift), bisecting from a
+    linear estimate. Mirrors scripts/backfill-neuron-history.py."""
+    est = max(1, min(int(head_block - (head_ms - target_ms) // BLOCK_MS), head_block))
+    for _ in range(4):
+        bh = sub.get_block_hash(est)
+        drift = (block_ms(sub, bh) - target_ms) // BLOCK_MS
+        if abs(drift) <= 1:
+            break
+        est = max(1, min(est - int(drift), head_block))
+    return est
+
+
+def total_networks(sub, block_hash):
+    return int(
+        getattr(
+            sub.query("SubtensorModule", "TotalNetworks", [], block_hash=block_hash),
+            "value",
+            0,
+        )
+        or 0
+    )
+
+
+def validator_trust_vec(sub, netuid, block_hash):
+    """ValidatorTrust isn't carried in MetagraphInfo in dTAO — read it from storage at
+    the historical block (mirrors fetch-metagraph-native.py's storage_vec)."""
+    try:
+        r = sub.query("SubtensorModule", "ValidatorTrust", [netuid], block_hash=block_hash)
+        return list(getattr(r, "value", r) or [])
+    except Exception:
+        return []
+
+
+def build_subnet_rows(info, vtrust_vec, netuid, block, captured_at, snapshot_date):
+    """One subnet's runtime MetagraphInfo → neuron_daily rows, INCLUDING stake_tao.
+    Same row shape as scripts/backfill-neuron-history.py:build_rows, field extraction
+    matching scripts/fetch-metagraph-native.py."""
+    hotkeys = list(getattr(info, "hotkeys", []) or [])
+    n = len(hotkeys)
+    if not n:
+        return []
+    coldkeys = list(getattr(info, "coldkeys", []) or [])
+    active = list(getattr(info, "active", []) or [])
+    permits = list(getattr(info, "validator_permit", []) or [])
+    consensus = list(getattr(info, "consensus", []) or [])
+    incentives = list(getattr(info, "incentives", []) or [])
+    dividends = list(getattr(info, "dividends", []) or [])
+    emission = list(getattr(info, "emission", []) or [])
+    stake = list(getattr(info, "total_stake", []) or [])
+    axons = list(getattr(info, "axons", []) or [])
+    reg_at = list(getattr(info, "block_at_registration", []) or [])
+    immunity = int(getattr(info, "immunity_period", 0) or 0)
+
+    subnet_rows = []
+    for uid in range(n):
+        hotkey = _at(hotkeys, uid)
+        if not hotkey:
+            continue  # ingest rejects null-hotkey rows (mirrors forward path)
+        reg = _at(reg_at, uid)
+        subnet_rows.append(
+            {
+                "netuid": netuid,
+                "uid": uid,
+                "hotkey": hotkey,
+                "coldkey": _at(coldkeys, uid),
+                "active": 1 if _at(active, uid) else 0,
+                "validator_permit": 1 if _at(permits, uid) else 0,
+                "rank": None,  # derived below
+                "trust": 0.0,
+                "validator_trust": u16_ratio(_at(vtrust_vec, uid)),
+                "consensus": to_float(_at(consensus, uid)),
+                "incentive": to_float(_at(incentives, uid)),
+                "dividends": to_float(_at(dividends, uid)),
+                "emission_tao": to_float(_at(emission, uid)),
+                "stake_tao": to_float(_at(stake, uid)),  # THE point of this pass
+                "registered_at_block": reg,
+                "is_immunity_period": 1
+                if (reg is not None and block - reg < immunity)
+                else 0,
+                "axon": fmt_axon(_at(axons, uid)),
+                "block_number": block,
+                "captured_at": captured_at,
+                "snapshot_date": snapshot_date,
+            }
+        )
+    # Derive rank: 1-based by incentive desc (null for non-incentivized neurons),
+    # matching fetch-metagraph-native.py / backfill-neuron-history.py.
+    for pos, row in enumerate(
+        sorted(
+            (r for r in subnet_rows if r["incentive"]),
+            key=lambda r: (-r["incentive"], r["uid"]),
+        ),
+        start=1,
+    ):
+        row["rank"] = float(pos)
+    return subnet_rows
+
+
+def post_chunk(rows, dry_run):
+    if dry_run or not rows:
+        return
+    body = json.dumps({"rows": rows}).encode()
+    headers = {
+        "content-type": "application/json",
+        INGEST_HEADER: SECRET,
+        "user-agent": "metagraphed-backfill/2.0",  # CF WAF 403s default urllib UA
+    }
+    # Retry transient ingest/D1 errors (5xx/429/network) with backoff.
+    for attempt in range(5):
+        try:
+            req = urllib.request.Request(
+                API_BASE + INGEST_PATH, data=body, method="POST", headers=headers
+            )
+            with urllib.request.urlopen(req, timeout=90) as resp:
+                json.loads(resp.read())
+            return
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 500, 502, 503, 504) and attempt < 4:
+                time.sleep(2 * (attempt + 1))
+                continue
+            raise
+        except (urllib.error.URLError, TimeoutError):
+            if attempt < 4:
+                time.sleep(2 * (attempt + 1))
+                continue
+            raise
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--months", type=int, default=8, help="months back (decode floor ~8)")
+    p.add_argument("--hour", type=int, default=5, help="UTC hour (forward cron is 47 5)")
+    p.add_argument("--minute", type=int, default=47)
+    p.add_argument("--chunk", type=int, default=1000, help="rows per ingest POST")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+    if not SECRET and not args.dry_run:
+        sys.exit("METAGRAPH_BACKFILL_SECRET is required (or use --dry-run)")
+
+    # bittensor 10.4.x: metagraph helpers live on api.metagraphs (NOT api.subnets).
+    api = bt.SubtensorApi(network=NETWORK)
+    sub = api.substrate
+    head_block = int(api.block)
+    head_ms = block_ms(sub, sub.get_block_hash(head_block))
+    sys.stderr.write(
+        f"connected {NETWORK}\nhead {head_block} @ {head_ms}ms; "
+        f"backfilling stake for {args.months} month(s)\n"
+    )
+
+    day_ms = 86_400_000
+    midnight = (int(time.time() * 1000) // day_ms) * day_ms
+    tod = (args.hour * 3600 + args.minute * 60) * 1000
+    total_rows = 0
+    for m in range(1, args.months + 1):
+        target_ms = midnight - m * DAYS_PER_MONTH * day_ms + tod
+        snapshot_date = time.strftime("%Y-%m-%d", time.gmtime(target_ms / 1000))
+        block = resolve_block(sub, target_ms, head_block, head_ms)
+        bh = sub.get_block_hash(block)
+        captured_at = block_ms(sub, bh)
+        total = total_networks(sub, bh)
+        rows = []
+        fetched = 0
+        errors = 0
+        for netuid in range(total):
+            try:
+                info = api.metagraphs.get_metagraph_info(netuid=netuid, block=block)
+            except Exception as e:
+                errors += 1
+                sys.stderr.write(
+                    f"  netuid {netuid} @ block {block}: {repr(e)[:120]}\n"
+                )
+                continue
+            if info is None:
+                continue
+            vtrust_vec = validator_trust_vec(sub, netuid, bh)
+            subnet_rows = build_subnet_rows(
+                info, vtrust_vec, netuid, block, captured_at, snapshot_date
+            )
+            rows.extend(subnet_rows)
+            fetched += 1
+        for i in range(0, len(rows), args.chunk):
+            post_chunk(rows[i : i + args.chunk], args.dry_run)
+        total_rows += len(rows)
+        with_stake = sum(1 for r in rows if r["stake_tao"] is not None)
+        sys.stderr.write(
+            f"{snapshot_date} block {block} ({fetched}/{total} subnets, {errors} err)"
+            f" -> {len(rows)} rows ({with_stake} with stake)"
+            f"{' [dry-run]' if args.dry_run else ''}\n"
+        )
+        # Dry-run: print a known-active subnet's top stakes so a human can eyeball that
+        # historical runtime stake is populated and plausible.
+        if args.dry_run:
+            sample = sorted(
+                (r for r in rows if r["netuid"] == 8 and r["stake_tao"]),
+                key=lambda r: -r["stake_tao"],
+            )[:3]
+            for r in sample:
+                sys.stderr.write(
+                    f"    sample netuid 8 uid {r['uid']}: "
+                    f"stake_tao={r['stake_tao']} emission_tao={r['emission_tao']}\n"
+                )
+    sys.stderr.write(f"done: {total_rows} rows across {args.months} month(s)\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #1504

The full-year backfill shards each died ~⅓ through on a transient **HTTP 500 from the ingest** (D1 contention under 4 concurrent shards) — `post_chunk` had no retry, so one 500 crashed the shard. 147 days had landed (idempotent upsert), and the endpoint serves them.

- **Retry-with-backoff** on 5xx/429/network in `post_chunk` (both scripts; 5 attempts, 2–8s) + chunk 1500→1000 to ease D1 batches. A re-run now completes the year.
- **Monthly stake pass** (`backfill-stake-monthly.py` + dispatch-only workflow): fills the one deferred field `stake_tao` for the last ~8 months via the runtime API on OnFinality. Dry-run verified: 129/129 subnets, all rows non-null stake (netuid 8 uid 1 = 1,547,226.74).

Python-only; py_compile clean. After merge: re-run the metagraph backfill (completes the year), then dispatch the stake pass.