### PR TITLE
fix(scripts): walk all TaoMarketCap pages when the API omits count

### DIFF
--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -304,9 +304,12 @@ async function discoverFromTaoMarketCap() {
       return;
     }
 
-    expectedCount = Number.isInteger(page.count)
-      ? page.count
-      : offset + (page.results || []).length;
+    // Only bound the loop by total when the API actually reports one. The old
+    // fallback `offset + results.length` equalled the just-advanced offset, so a
+    // response without `count` exited after page 1 even when `page.next` pointed
+    // at more pages. Leave it null and let the `if (!page.next) break` below
+    // (the API's own pagination signal) terminate the walk.
+    expectedCount = Number.isInteger(page.count) ? page.count : null;
     for (const subnet of page.results || []) {
       const netuid = Number(subnet.netuid);
       if (!nativeByNetuid.has(netuid) || subnet.is_active === false) {


### PR DESCRIPTION
## Summary

Fixes #1506.

`discoverFromTaoMarketCap` stops paginating after the first page when the upstream API omits an integer `count`. Its loop is bounded by `while (expectedCount === null || offset < expectedCount)`, and when a page has no `count` it sets `expectedCount = offset + results.length`. After the `offset += limit` advance, that bound equals (or trails) the new offset, so the loop exits — even when `page.next` points at more pages. The `if (!page.next) break` is dead in this path. Result: every TaoMarketCap website/source-repo candidate for subnets beyond the first 100 is silently dropped from the generated `registry/candidates/generated/public-sources.json`.

## What Changed

- `scripts/discover-candidates.mjs` — leave `expectedCount` null when no count is reported, and let the existing `if (!page.next) break` (the API's own pagination signal) terminate the walk. The count bound still applies when the API does report a total.

This is a one-line change to a CLI discovery script (`scripts/discover-candidates.mjs` is not in the test/coverage scope, and the function is not exported / runs against a live API). The fix relies on the loop's pre-existing `page.next` terminator, which is the documented pagination contract.

No schema, OpenAPI, or generated-artifact changes in this PR.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `npx eslint scripts/discover-candidates.mjs` — clean
- [x] `npx prettier --check scripts/discover-candidates.mjs` — clean
- [x] `git diff --check`

## Template Used

- Backend/code change
