### PR TITLE
fix(streamer): read each block's timestamp at its own block_hash

### DIFF
--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -75,9 +75,19 @@ signal.signal(signal.SIGTERM, _handle_signal)
 signal.signal(signal.SIGINT, _handle_signal)
 
 
-def decode_head(s, block_number, head_ts):
+def decode_head(s, block_number):
     """Decode the SubtensorModule events of one finalized block → ingest rows."""
     block_hash = s.get_block_hash(block_number)
+    # Read the block's timestamp AT THIS block_hash. Querying Timestamp.Now
+    # without a block_hash resolves at the chain's current best block, which
+    # leads the finalized head being processed by ~2-3 blocks — skewing every
+    # event's observed_at into the future (and mis-binning events near a UTC-day
+    # boundary). The events query below already pins block_hash; the timestamp
+    # must use the same one.
+    try:
+        head_ts = int(s.query("Timestamp", "Now", block_hash=block_hash).value)
+    except Exception:
+        head_ts = None
     rows = []
     for event_index, ev in enumerate(
         s.query("System", "Events", block_hash=block_hash)
@@ -189,11 +199,7 @@ def run():
                 if _stop:
                     return True  # non-None return cancels the subscription
                 bn = obj["header"]["number"]
-                try:
-                    head_ts = int(s.query("Timestamp", "Now").value)
-                except Exception:
-                    head_ts = None
-                rows = decode_head(s, bn, head_ts)
+                rows = decode_head(s, bn)
                 ok = push(rows)
                 stats["blocks"] += 1
                 stats["events"] += len(rows)


### PR DESCRIPTION
## Summary

Fixes #1508.

The realtime streamer's finalized-head handler read `Timestamp.Now` with no `block_hash`, which resolves at the chain's current best block — ~2-3 blocks ahead of the finalized head `bn` being decoded. That chain-tip timestamp was then stamped as `observed_at` on every event of block `bn`, skewing it ~24-36s into the future. This corrupts `/health` chain-event freshness (`age_seconds` can read negative), daily rollup binning near UTC-day boundaries, and determinism vs the backstop poller (which computes the correct per-block timestamp).

## What Changed

- `scripts/stream-events.py` — move the timestamp read into `decode_head` and query `Timestamp.Now` at the block's own `block_hash` (the events query already pins that hash), dropping the now-redundant `head_ts` handler argument.

`scripts/stream-events.py` is a long-running service script (not in the JS test/coverage scope and run against a live substrate node). Verified locally with `python -m py_compile`. The fix mirrors the per-block semantics the backstop poller (`fetch-events.py`) already uses.

No schema, OpenAPI, or generated-artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] `python -m py_compile scripts/stream-events.py` — clean
- [x] `git diff --check`

## Template Used

- Backend/code change
