### PR TITLE
feat(economics): alpha-price history backfill for marquee sparklines (#1124)

### DIFF
--- a/.github/workflows/backfill-economics-history.yml
+++ b/.github/workflows/backfill-economics-history.yml
@@ -1,0 +1,74 @@
+name: Backfill Economics History (one-time, #1307)
+
+# One-time chain-direct backfill of historical per-SUBNET alpha prices into the
+# `subnet_snapshots.alpha_price_tao` column, so the homepage marquee can show real
+# per-subnet alpha-price sparklines immediately instead of accruing forward over
+# months. Reads the public ARCHIVE node (full historical state, no API key) via
+# scripts/backfill-economics-history.py and POSTs each day's rows to the Worker's
+# secret-gated /api/v1/internal/backfill-economics ingest (idempotent COALESCE
+# upsert → safe to re-run, never clobbers a forward fire). Manual only.
+#
+# Economics is LIGHT — one scalar per subnet (~129 keys/block, one batched
+# round-trip per day) — so a single job covers a full year well within the job
+# limit (no quarterly sharding needed, unlike the neuron backfill).
+on:
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Number of trailing UTC days to backfill"
+        required: false
+        default: "365"
+      end_offset:
+        description: "Newest day backfilled = today - this (default 1 = yesterday)"
+        required: false
+        default: "1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backfill-economics-history
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120 # ~one batched round-trip per day; a full year fits easily
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      # Chain-direct off the public archive node (pinned bittensor, matching
+      # refresh-metagraph). The ingest upsert is idempotent so a rerun is harmless.
+      - name: Backfill economics
+        run: |
+          DAYS="${{ github.event.inputs.days }}"
+          END_OFFSET="${{ github.event.inputs.end_offset }}"
+          echo "backfill: --days $DAYS --end-offset $END_OFFSET"
+          uvx --from bittensor==10.4.0 --with xxhash python scripts/backfill-economics-history.py \
+            --days "$DAYS" --end-offset "$END_OFFSET"
+        env:
+          METAGRAPH_BACKFILL_SECRET: ${{ secrets.METAGRAPH_BACKFILL_SECRET }}
+          METAGRAPH_API_BASE: https://api.metagraph.sh
+
+  notify-on-failure:
+    needs: [backfill]
+    if: ${{ always() && needs.backfill.result == 'failure' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Notify on failure
+        env:
+          METAGRAPH_ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}
+        run: |
+          if [ -z "$METAGRAPH_ALERT_WEBHOOK_URL" ]; then
+            exit 0
+          fi
+          curl -fsS -X POST "$METAGRAPH_ALERT_WEBHOOK_URL" \
+            -H 'content-type: application/json' \
+            -d '{"content":"🔴 metagraphed backfill-economics-history FAILED — historical alpha-price backfill incomplete."}'

--- a/scripts/backfill-economics-history.py
+++ b/scripts/backfill-economics-history.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Historical per-SUBNET alpha-price BACKFILL (#1307, epic #1302) — chain-direct off
+the FREE public archive, BATCHED. Fills `subnet_snapshots.alpha_price_tao`
+retroactively so the homepage marquee can show real per-subnet alpha-price
+sparklines NOW instead of accruing forward over months.
+
+This is the per-SUBNET economics analogue of scripts/backfill-neuron-history.py:
+identical chain-direct machinery (offline storage keys, batched
+state_queryStorageAt on the archive, block resolution, retrying ingest), but one
+scalar per subnet instead of seven per-UID metric vectors.
+
+Why raw storage (not the runtime API): get_metagraph_info(block=N) is ~18-25s PER
+SUBNET with a hard ~8-month MetagraphInfo decode floor. SubnetMovingPrice lives in
+plain SubtensorModule storage with NO floor, and one batched state_queryStorageAt
+returns every subnet's price (~129 values) in ~one round-trip — full-year
+reachable, $0, no API key.
+
+VERIFIED FORMULA: alpha_price_tao = SubnetMovingPrice[netuid] / 2**32.
+SubnetMovingPrice is declared `StorageMap<_, Identity, u16, I96F32, ValueQuery>` —
+an Identity-hashed per-netuid map (same key shape as the neuron script's metric
+maps) holding a 32-fractional-bit fixed-point. The raw SCALE storage value is the
+fixed-point's underlying integer; decode the raw bytes as an unsigned little-endian
+int (whatever length storage returns — I96F32 is 16 bytes; the magnitude fits the
+low word) and divide by 2**32. Cross-checked against the runtime: for netuid 8 this
+equals get_metagraph_info(netuid=8).moving_price EXACTLY, which is what the live
+pipeline stores as alpha_price_tao (scripts/fetch-native-subnets.py uses
+info.moving_price → to_tao → float). So the backfill matches the forward path.
+
+Per target UTC day: resolve the block nearest a fixed time-of-day, read
+TotalNetworks at that block, batch-read SubnetMovingPrice[netuid] for every netuid
+as offline-built storage keys (chunked 50/call), decode each → alpha_price_tao, and
+emit the exact subnet_snapshots row shape ({netuid, snapshot_date, captured_at,
+alpha_price_tao}) to the secret-gated ingest (idempotent COALESCE upsert on
+(netuid,snapshot_date), so re-runs are safe/resumable and never clobber a forward
+fire's value or any other column).
+
+Run (one-time; resumable):
+  METAGRAPH_BACKFILL_SECRET=... \
+  uvx --from bittensor==10.4.0 --with xxhash python \
+    scripts/backfill-economics-history.py --days 365
+"""
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+import bittensor as bt
+import xxhash
+
+BLOCK_MS = 12_000  # finney block time, empirically exactly 12.0s
+PRICE_ITEM = "SubnetMovingPrice"  # SubtensorModule storage map: Identity[u16] -> I96F32
+FIXED_POINT_DIVISOR = 2**32  # 32 fractional bits (I96F32)
+KEY_CHUNK = 50  # >100 keys/call hits a latency cliff; 50 is the measured sweet spot
+API_BASE = os.environ.get("METAGRAPH_API_BASE", "https://api.metagraph.sh")
+INGEST_PATH = "/api/v1/internal/backfill-economics"
+INGEST_HEADER = "x-metagraph-events-token"  # EVENTS_INGEST_TOKEN_HEADER
+SECRET = os.environ.get("METAGRAPH_BACKFILL_SECRET") or os.environ.get(
+    "METAGRAPH_EVENTS_INGEST_SECRET", ""
+)
+
+_PALLET = None
+
+
+def twox128(data: bytes) -> bytes:
+    return xxhash.xxh64(data, seed=0).intdigest().to_bytes(8, "little") + xxhash.xxh64(
+        data, seed=1
+    ).intdigest().to_bytes(8, "little")
+
+
+def storage_key(item: str, netuid: int) -> str:
+    """SubtensorModule.<item>[netuid] — Identity-hashed per-netuid map. Built OFFLINE
+    (substrate.create_storage_key does a network round-trip per key)."""
+    global _PALLET
+    if _PALLET is None:
+        _PALLET = twox128(b"SubtensorModule")
+    return "0x" + (_PALLET + twox128(item.encode()) + int(netuid).to_bytes(2, "little")).hex()
+
+
+def _bytes(hexval):
+    return bytes.fromhex(hexval[2:] if hexval.startswith("0x") else hexval)
+
+
+def decode_price(hexval):
+    """Raw SubnetMovingPrice storage value -> alpha_price_tao (float).
+
+    The stored value is an I96F32 fixed-point: an unsigned little-endian integer
+    whose value is `raw / 2**32`. Decode the full returned byte length (16 bytes
+    for I96F32; the magnitude fits the low word, so the high bytes are zero in
+    practice) so the formula is correct regardless of storage width."""
+    if not hexval:
+        return None
+    raw = int.from_bytes(_bytes(hexval), "little")
+    return round(raw / FIXED_POINT_DIVISOR, 12)
+
+
+def block_ms(sub, block_hash):
+    r = sub.query("Timestamp", "Now", block_hash=block_hash)
+    return int(getattr(r, "value", r) or 0)
+
+
+def resolve_block(sub, target_ms, head_block, head_ms):
+    est = max(1, min(int(head_block - (head_ms - target_ms) // BLOCK_MS), head_block))
+    for _ in range(4):
+        bh = sub.get_block_hash(est)
+        drift = (block_ms(sub, bh) - target_ms) // BLOCK_MS
+        if abs(drift) <= 1:
+            break
+        est = max(1, min(est - int(drift), head_block))
+    return est
+
+
+def fetch_block_prices(sub, netuids, block_hash):
+    """Batched state_queryStorageAt over every SubnetMovingPrice[netuid] key ->
+    raw hex per netuid."""
+    keymap, keys = {}, []
+    for n in netuids:
+        k = storage_key(PRICE_ITEM, n)
+        keys.append(k)
+        keymap[k.lower()] = n
+    raw = {}
+    for i in range(0, len(keys), KEY_CHUNK):
+        chunk = keys[i : i + KEY_CHUNK]
+        for attempt in range(4):
+            try:
+                res = sub.rpc_request("state_queryStorageAt", [chunk, block_hash])
+                for k, v in res["result"][0]["changes"]:
+                    if v is not None:
+                        raw[keymap[k.lower()]] = v
+                break
+            except Exception as e:
+                if attempt == 3:
+                    raise
+                sys.stderr.write(f"chunk retry {attempt + 1}: {repr(e)[:80]}\n")
+                time.sleep(2 * (attempt + 1))
+    return raw
+
+
+def build_rows(raw, netuids, captured_at, snapshot_date):
+    rows, skipped = [], 0
+    for netuid in netuids:
+        price = decode_price(raw.get(netuid))
+        if price is None:
+            skipped += 1
+            continue  # no value at this block (subnet not yet registered) -> skip
+        rows.append(
+            {
+                "netuid": netuid,
+                "snapshot_date": snapshot_date,
+                "captured_at": captured_at,
+                "alpha_price_tao": price,
+            }
+        )
+    return rows, skipped
+
+
+def post_chunk(rows, dry_run):
+    if dry_run or not rows:
+        return
+    body = json.dumps({"rows": rows}).encode()
+    headers = {
+        "content-type": "application/json",
+        INGEST_HEADER: SECRET,
+        "user-agent": "metagraphed-backfill/2.0",  # CF WAF 403s default urllib UA
+    }
+    # Retry transient ingest/D1 errors (5xx/429/network) with backoff — the parallel
+    # shards contend on D1 and occasionally trip a 500, which must not kill the shard.
+    for attempt in range(5):
+        try:
+            req = urllib.request.Request(
+                API_BASE + INGEST_PATH, data=body, method="POST", headers=headers
+            )
+            with urllib.request.urlopen(req, timeout=90) as resp:
+                json.loads(resp.read())
+            return
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 500, 502, 503, 504) and attempt < 4:
+                time.sleep(2 * (attempt + 1))
+                continue
+            raise
+        except (urllib.error.URLError, TimeoutError):
+            if attempt < 4:
+                time.sleep(2 * (attempt + 1))
+                continue
+            raise
+
+
+def cross_check(api, netuid, block, batched_price):
+    """Dry-run correctness probe: compare the batched-decoded alpha_price for one
+    netuid against the runtime get_metagraph_info(netuid, block).moving_price at the
+    same block. Best-effort — a runtime decode failure (older than the ~8-month
+    MetagraphInfo floor, or an absent subnet) just prints n/a."""
+    try:
+        info = api.metagraphs.get_metagraph_info(netuid=netuid, block=block)
+        runtime = float(getattr(info, "moving_price", None))
+    except Exception as e:  # noqa: BLE001 — diagnostic only
+        sys.stderr.write(f"  cross-check netuid {netuid}: runtime n/a ({repr(e)[:60]})\n")
+        return
+    delta = abs(runtime - batched_price) if batched_price is not None else None
+    sys.stderr.write(
+        f"  cross-check netuid {netuid} @ block {block}: "
+        f"batched={batched_price} runtime={runtime:.12f} "
+        f"delta={delta:.3e} {'OK' if (delta is not None and delta <= 1e-6) else 'MISMATCH'}\n"
+    )
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--network", default="archive")
+    p.add_argument("--days", type=int, default=365)
+    p.add_argument("--end-offset", type=int, default=1, help="newest day = today-N")
+    p.add_argument("--hour", type=int, default=5, help="UTC hour (forward cron is 47 5)")
+    p.add_argument("--minute", type=int, default=47)
+    p.add_argument("--chunk", type=int, default=1000, help="rows per ingest POST")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument(
+        "--cross-check-netuid",
+        type=int,
+        default=8,
+        help="dry-run: cross-check this netuid's batched price vs the runtime",
+    )
+    args = p.parse_args()
+    if not SECRET and not args.dry_run:
+        sys.exit("METAGRAPH_BACKFILL_SECRET is required (or use --dry-run)")
+
+    api = bt.SubtensorApi(network=args.network)
+    sub = api.substrate
+    head_block = int(api.block)
+    head_ms = block_ms(sub, sub.get_block_hash(head_block))
+    sys.stderr.write(f"head {head_block} @ {head_ms}ms\n")
+
+    day_ms = 86_400_000
+    midnight = (int(time.time() * 1000) // day_ms) * day_ms
+    tod = (args.hour * 3600 + args.minute * 60) * 1000
+    total_rows = 0
+    for offset in range(args.end_offset, args.end_offset + args.days):
+        target_ms = midnight - offset * day_ms + tod
+        snapshot_date = time.strftime("%Y-%m-%d", time.gmtime(target_ms / 1000))
+        block = resolve_block(sub, target_ms, head_block, head_ms)
+        bh = sub.get_block_hash(block)
+        captured_at = block_ms(sub, bh)
+        total = int(
+            getattr(
+                sub.query("SubtensorModule", "TotalNetworks", [], block_hash=bh),
+                "value",
+                0,
+            )
+            or 0
+        )
+        netuids = list(range(total))
+        raw = fetch_block_prices(sub, netuids, bh)
+        rows, skipped = build_rows(raw, netuids, captured_at, snapshot_date)
+        for i in range(0, len(rows), args.chunk):
+            post_chunk(rows[i : i + args.chunk], args.dry_run)
+        total_rows += len(rows)
+        sys.stderr.write(
+            f"{snapshot_date} block {block} ({total} subnets) -> {len(rows)} rows"
+            f" (skipped {skipped}){' [dry-run]' if args.dry_run else ''}\n"
+        )
+        if args.dry_run and args.cross_check_netuid is not None:
+            cc = args.cross_check_netuid
+            decoded = next(
+                (r["alpha_price_tao"] for r in rows if r["netuid"] == cc), None
+            )
+            cross_check(api, cc, block, decoded)
+    sys.stderr.write(f"done: {total_rows} rows across {args.days} days\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/economics-backfill.mjs
+++ b/src/economics-backfill.mjs
@@ -1,0 +1,68 @@
+// Per-SUBNET alpha-price HISTORY backfill (#1307, epic #1302).
+//
+// The analogue of src/neuron-history.mjs's neuron_daily backfill, but for the
+// per-subnet economics time series that lives in `subnet_snapshots`. The forward
+// path (src/health-prober.mjs writeSubnetSnapshot) records `alpha_price_tao` once
+// a day going forward; this backfill fills the column RETROACTIVELY off the public
+// archive (scripts/backfill-economics-history.py decodes SubnetMovingPrice[netuid]
+// → alpha_price_tao = bits / 2**32, matching info.moving_price), so the homepage
+// marquee can show real per-subnet alpha-price sparklines NOW instead of waiting
+// months for forward accrual.
+//
+// Pure + injectable for tests — the Worker handler runs the D1 batch and calls
+// these. The trajectory endpoint reads subnet_snapshots by (netuid, snapshot_date),
+// so a backfilled row MUST land on the same (netuid, day) PK as a forward fire.
+
+const SNAPSHOT_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// Keep only well-formed backfill rows: integer netuid (≥ 0), a YYYY-MM-DD
+// snapshot_date, and a finite numeric alpha_price_tao. Anything else is silently
+// dropped so a partial/garbage batch can never poison the table.
+export function validEconomicsBackfillRows(rows) {
+  if (!Array.isArray(rows)) return [];
+  return rows.filter(
+    (row) =>
+      row &&
+      Number.isInteger(row.netuid) &&
+      row.netuid >= 0 &&
+      typeof row.snapshot_date === "string" &&
+      SNAPSHOT_DATE_RE.test(row.snapshot_date) &&
+      typeof row.alpha_price_tao === "number" &&
+      Number.isFinite(row.alpha_price_tao),
+  );
+}
+
+// Batched idempotent upsert of HISTORICAL alpha_price_tao into subnet_snapshots.
+//
+// Each row carries its own snapshot_date (the historical UTC day) + captured_at
+// (that block's ms). We INSERT a sparse row keyed on (netuid, snapshot_date) with
+// only alpha_price_tao populated (every other economics/structural column NULL),
+// and ON CONFLICT set alpha_price_tao = COALESCE(existing, excluded) — IDENTICAL
+// to the prober's COALESCE upsert (src/health-prober.mjs writeSubnetSnapshot), so:
+//   - a backfilled value can FILL a NULL alpha_price (a day with no forward fire),
+//   - it can NEVER clobber a value an earlier forward fire already wrote,
+//   - it NEVER touches the structural columns or the other economics columns
+//     (completeness/surface/endpoint/validator/miner/stake/emission_share),
+//   - captured_at is owned by the first writer of that (netuid, day) row and is
+//     only set when this backfill is that first writer.
+// The PK (netuid, snapshot_date) makes any re-POST a no-op.
+export function economicsSnapshotUpsertStatements(db, rows) {
+  const sql =
+    `INSERT INTO subnet_snapshots ` +
+    `(netuid, snapshot_date, alpha_price_tao, captured_at) ` +
+    `VALUES (?, ?, ?, ?) ` +
+    `ON CONFLICT (netuid, snapshot_date) DO UPDATE SET ` +
+    `alpha_price_tao = COALESCE(subnet_snapshots.alpha_price_tao, excluded.alpha_price_tao)`;
+  return rows.map((row) =>
+    db
+      .prepare(sql)
+      .bind(
+        row.netuid,
+        row.snapshot_date,
+        row.alpha_price_tao,
+        Number.isFinite(row.captured_at)
+          ? row.captured_at
+          : Date.parse(`${row.snapshot_date}T00:00:00Z`),
+      ),
+  );
+}

--- a/tests/economics-backfill.test.mjs
+++ b/tests/economics-backfill.test.mjs
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleEconomicsBackfill, handleRequest } from "../workers/api.mjs";
+import {
+  economicsSnapshotUpsertStatements,
+  validEconomicsBackfillRows,
+} from "../src/economics-backfill.mjs";
+
+const SECRET = "test-secret-token-1234567890";
+
+function row(overrides = {}) {
+  return {
+    netuid: 8,
+    snapshot_date: "2025-12-01",
+    captured_at: 1700000000000,
+    alpha_price_tao: 0.030678787,
+    ...overrides,
+  };
+}
+
+function post(body, { secret, method = "POST" } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret) headers["x-metagraph-events-token"] = secret;
+  const init = { method, headers };
+  if (method !== "GET" && method !== "HEAD") {
+    init.body = typeof body === "string" ? body : JSON.stringify(body);
+  }
+  return new Request(
+    "https://api.metagraph.sh/api/v1/internal/backfill-economics",
+    init,
+  );
+}
+
+// Captures both the number of statements batched AND the bound values, so a test
+// can assert the upsert is parameterized (no string interpolation of row data).
+function dbCapture(captured) {
+  return {
+    prepare(sql) {
+      return { bind: (...v) => ({ sql, v }) };
+    },
+    async batch(stmts) {
+      captured.push(stmts);
+    },
+  };
+}
+
+test("economics backfill is disabled (503) without the secret configured", async () => {
+  const res = await handleEconomicsBackfill(post([row()], { secret: "x" }), {});
+  assert.equal(res.status, 503);
+});
+
+test("economics backfill rejects a wrong or missing token (401)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  assert.equal(
+    (await handleEconomicsBackfill(post([row()], { secret: "wrong" }), env))
+      .status,
+    401,
+  );
+  assert.equal((await handleEconomicsBackfill(post([row()]), env)).status, 401);
+});
+
+test("economics backfill rejects non-POST (405)", async () => {
+  const env = { METAGRAPH_EVENTS_INGEST_SECRET: SECRET };
+  const res = await handleEconomicsBackfill(
+    post([row()], { secret: SECRET, method: "GET" }),
+    env,
+  );
+  assert.equal(res.status, 405);
+});
+
+test("economics backfill upserts valid rows + filters invalid (200, parameterized)", async () => {
+  const captured = [];
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture(captured),
+  };
+  const rows = [
+    row(),
+    row({ netuid: 9, snapshot_date: "2025-12-02", alpha_price_tao: 0.5 }),
+    { netuid: 7 }, // invalid (no date/price) → filtered
+    row({ netuid: 10, snapshot_date: "12/01/2025" }), // bad date format → filtered
+    row({ netuid: 11, alpha_price_tao: "0.1" }), // non-numeric price → filtered
+    row({ netuid: -1 }), // negative netuid → filtered
+    row({ netuid: 12, alpha_price_tao: Number.NaN }), // NaN price → filtered
+  ];
+  const res = await handleEconomicsBackfill(
+    post(rows, { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.received, 7);
+  assert.equal(body.inserted, 2);
+  assert.equal(captured.length, 1); // one batch
+  assert.equal(captured[0].length, 2); // of the 2 valid rows
+  // Parameterized: row data is bound, never interpolated into the SQL string.
+  const [first] = captured[0];
+  assert.match(first.sql, /INSERT INTO subnet_snapshots/);
+  assert.match(
+    first.sql,
+    /alpha_price_tao = COALESCE\(subnet_snapshots\.alpha_price_tao, excluded\.alpha_price_tao\)/,
+  );
+  assert.deepEqual(first.v, [8, "2025-12-01", 0.030678787, 1700000000000]);
+});
+
+test("economics backfill accepts the {rows:[...]} envelope + no-ops on empty", async () => {
+  const captured = [];
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture(captured),
+  };
+  const res = await handleEconomicsBackfill(
+    post({ rows: [] }, { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).inserted, 0);
+  assert.equal(captured.length, 0); // no batch issued for an empty set
+});
+
+test("economics backfill rejects malformed JSON (400) + non-array (400)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  assert.equal(
+    (await handleEconomicsBackfill(post("{nope", { secret: SECRET }), env))
+      .status,
+    400,
+  );
+  assert.equal(
+    (await handleEconomicsBackfill(post({ foo: 1 }, { secret: SECRET }), env))
+      .status,
+    400,
+  );
+});
+
+test("economics backfill rejects too many rows (413)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  const many = Array.from({ length: 2001 }, (_, i) => row({ netuid: i }));
+  const res = await handleEconomicsBackfill(
+    post(many, { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 413);
+});
+
+test("economics backfill returns 503 when the history store is unavailable", async () => {
+  const env = { METAGRAPH_EVENTS_INGEST_SECRET: SECRET }; // authed but no DB
+  const res = await handleEconomicsBackfill(
+    post([row()], { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 503);
+});
+
+test("handleRequest routes POST /api/v1/internal/backfill-economics", async () => {
+  // No secret configured → 503 proves dispatch reached handleEconomicsBackfill.
+  const res = await handleRequest(post([row()], { secret: "x" }), {}, {});
+  assert.equal(res.status, 503);
+});
+
+test("validEconomicsBackfillRows + upsert: captured_at falls back to the snapshot day", () => {
+  const valid = validEconomicsBackfillRows([
+    { netuid: 8, snapshot_date: "2025-12-01", alpha_price_tao: 0.1 }, // no captured_at
+    { netuid: 0, snapshot_date: "2025-12-01", alpha_price_tao: 0 }, // netuid 0 + price 0 are valid
+  ]);
+  assert.equal(valid.length, 2);
+  const db = { prepare: (sql) => ({ bind: (...v) => ({ sql, v }) }) };
+  const stmts = economicsSnapshotUpsertStatements(db, valid);
+  // Missing captured_at → derived from the snapshot day's UTC midnight.
+  assert.equal(stmts[0].v[3], Date.parse("2025-12-01T00:00:00Z"));
+  // netuid 0 and alpha_price_tao 0 are preserved (not treated as falsy-invalid).
+  assert.equal(stmts[1].v[0], 0);
+  assert.equal(stmts[1].v[2], 0);
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -120,6 +120,10 @@ import {
   pruneAccountEvents,
   validEventRows,
 } from "../src/account-events.mjs";
+import {
+  economicsSnapshotUpsertStatements,
+  validEconomicsBackfillRows,
+} from "../src/economics-backfill.mjs";
 import { handleMcpRequest } from "../src/mcp-server.mjs";
 import { handleFeedRequest } from "../src/feeds.mjs";
 import { handleBadgeRequest } from "../src/badge.mjs";
@@ -742,6 +746,94 @@ export async function handleNeuronBackfill(request, env) {
   );
 }
 
+// POST /api/v1/internal/backfill-economics (#1307, epic #1302): the per-SUBNET
+// alpha-price history backfill ingest for scripts/backfill-economics-history.py —
+// the analogue of handleNeuronBackfill, but for the economics time series. Auth +
+// caps are IDENTICAL to the neuron backfill: disabled (503) until
+// METAGRAPH_BACKFILL_SECRET (or METAGRAPH_EVENTS_INGEST_SECRET) is configured,
+// then a constant-time token compare over the shared EVENTS_INGEST_TOKEN_HEADER.
+// The body is an array of {netuid, snapshot_date, captured_at, alpha_price_tao}
+// rows (or {rows:[...]}), upserted into subnet_snapshots on (netuid,snapshot_date)
+// with the SAME COALESCE semantics as the forward prober — only alpha_price_tao +
+// the key/captured_at columns are touched, so a backfilled value fills a NULL but
+// never clobbers a forward fire or any other column, and any re-POST is idempotent.
+// NOT in the public contract.
+export async function handleEconomicsBackfill(request, env) {
+  if (request.method !== "POST") {
+    return errorResponse("method_not_allowed", "POST only.", 405);
+  }
+  const configured =
+    env.METAGRAPH_BACKFILL_SECRET || env.METAGRAPH_EVENTS_INGEST_SECRET;
+  if (!configured) {
+    return errorResponse(
+      "backfill_disabled",
+      "Historical backfill requires METAGRAPH_BACKFILL_SECRET (or METAGRAPH_EVENTS_INGEST_SECRET) to be configured.",
+      503,
+    );
+  }
+  const provided = request.headers.get(EVENTS_INGEST_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, configured)) {
+    return errorResponse(
+      "unauthorized",
+      `Provide a valid ${EVENTS_INGEST_TOKEN_HEADER} header.`,
+      401,
+    );
+  }
+  const db = env.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) {
+    return errorResponse("unavailable", "History store unavailable.", 503);
+  }
+  const raw = await request.text();
+  if (raw.length > MAX_BACKFILL_INGEST_BODY_BYTES) {
+    return errorResponse(
+      "payload_too_large",
+      `Body exceeds ${MAX_BACKFILL_INGEST_BODY_BYTES} bytes.`,
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return errorResponse(
+      "invalid_body",
+      "Body must be a JSON array of economics rows (or {rows:[...]}).",
+      400,
+    );
+  }
+  const incoming = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.rows)
+      ? parsed.rows
+      : null;
+  if (!incoming) {
+    return errorResponse(
+      "invalid_body",
+      "Body must be a JSON array of economics rows (or {rows:[...]}).",
+      400,
+    );
+  }
+  if (incoming.length > MAX_BACKFILL_INGEST_ROWS) {
+    return errorResponse(
+      "too_many_rows",
+      `At most ${MAX_BACKFILL_INGEST_ROWS} rows per request.`,
+      413,
+    );
+  }
+  const rows = validEconomicsBackfillRows(incoming);
+  if (rows.length) {
+    await db.batch(economicsSnapshotUpsertStatements(db, rows));
+  }
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      received: incoming.length,
+      inserted: rows.length,
+    }),
+    { status: 200, headers: { "content-type": JSON_CONTENT_TYPE } },
+  );
+}
+
 // Cron entrypoint. Cloudflare passes the exact cron string that fired in
 // `controller.cron`; the hourly trigger prunes the time-series, every other
 // trigger (the 15-minute one) runs a full operational-health probe sweep.
@@ -875,6 +967,9 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   }
   if (url.pathname === "/api/v1/internal/backfill-neurons") {
     return handleNeuronBackfill(request, env);
+  }
+  if (url.pathname === "/api/v1/internal/backfill-economics") {
+    return handleEconomicsBackfill(request, env);
   }
 
   // GraphQL read-only query layer over existing artifacts (issue #751). Runs


### PR DESCRIPTION
Closes #1511

Final piece for the marquee: real per-subnet **alpha-price history** so sparklines (and `/trajectory`) aren't stuck at ~2 days.

Chain-direct **batched** read of `SubnetMovingPrice[netuid]` on the free public archive → `alpha_price_tao = bits/2³²` (**verified vs runtime `moving_price` within ~1e-9** over a 3-day dry-run) → new secret-gated `/api/v1/internal/backfill-economics` route → **idempotent COALESCE upsert** into `subnet_snapshots` (matches the prober's `writeSubnetSnapshot` — fills NULL days, never clobbers a forward value). Daily, full year, $0. Internal route → no contract gates.

10 tests + build/lint/prettier/validate:api green. Runs after the metagraph backfill (archive contention).