### PR TITLE
fix(feeds): clamp length guard by code points, not UTF-16 code units

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -50,11 +50,15 @@ function escapeXml(value) {
 
 function clamp(value, max = 500) {
   const s = stripControl(value).trim();
-  if (s.length <= max) return s;
-  // Truncate by code points, not UTF-16 code units: a plain slice() can sever a
-  // non-BMP character (e.g. an emoji) straddling the boundary into a lone
-  // surrogate, which is invalid in XML and breaks the RSS/Atom feed.
-  return `${[...s].slice(0, max - 1).join("")}…`;
+  // Measure (and truncate) by code points, not UTF-16 code units: a plain
+  // slice() can sever a non-BMP character (e.g. an emoji) straddling the
+  // boundary into a lone surrogate, which is invalid in XML and breaks the
+  // RSS/Atom feed. The length guard must use the same unit, or a string that
+  // fits within `max` code points but has more code units (multiple emoji) gets
+  // spuriously truncated.
+  const points = [...s];
+  if (points.length <= max) return s;
+  return `${points.slice(0, max - 1).join("")}…`;
 }
 
 // Accept an ISO string or epoch-ms; return a normalized ISO string or null.

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -164,6 +164,26 @@ describe("feeds — item builders", () => {
     assert.ok(!loneSurrogate.test(items[0].summary));
   });
 
+  test("registryItems clamp keeps a title that fits in code points but not code units", () => {
+    // 60 ASCII + 3 emoji = 63 code points (well under the 80 cap) but 66 UTF-16
+    // code units. The guard must measure code points, or this gets truncated.
+    const path = "a".repeat(60) + "😀😀😀";
+    assert.equal([...path].length <= 80, true);
+    assert.equal(path.length > 80, false); // sanity: still <= 80 code units here
+    const longer = "a".repeat(75) + "😀😀😀"; // 78 code points, 81 code units
+    assert.equal([...longer].length <= 80, true);
+    assert.equal(longer.length > 80, true); // > 80 code units → old guard truncates
+    const items = registryItems({
+      artifacts: { modified: [{ path: longer }] },
+    });
+    assert.equal(items.length, 1);
+    // The full path survives in the title (not truncated to an ellipsis).
+    assert.ok(
+      items[0].title.includes(longer),
+      "a title within the code-point cap must not be truncated",
+    );
+  });
+
   test("registryItems coverage delta describes only the present side", () => {
     // Partial coverage_delta (candidate_count only) must not emit "+0 surfaces"
     // or "Surfaces undefined→undefined" for the absent surface side.


### PR DESCRIPTION
## Summary

- `clamp` truncates feed titles/summaries by **code points** (the #1445 fix, so an emoji isn't severed into a lone surrogate), but its length **guard** still measured **UTF-16 code units**.
- A string that fits within `max` code points but has more code units (multiple emoji) is spuriously truncated — content that fits gets replaced with an ellipsis.

Fixes #1513

## Reproduction

```js
const path = "a".repeat(75) + "😀😀😀"; // 78 code points (< 80 cap), 81 code units
registryItems({ artifacts: { modified: [{ path }] } })[0].title;
// clamp(path, 80): `81 <= 80` is false -> truncates to 79 code points + "…"
// even though the title is only 78 code points and fits.
```

#1445 fixed the truncation path but left the guard on `s.length`, so the two used different units. Subnet names are user-controlled on-chain identity where emoji are common.

## What Changed

- `src/feeds.mjs` — compute the code-point array once and use it for both the guard and the slice:
  ```js
  const points = [...s];
  if (points.length <= max) return s;
  return `${points.slice(0, max - 1).join("")}…`;
  ```
- `tests/feeds.test.mjs` — add a case asserting a 78-code-point / 81-code-unit title is returned whole (fails on the old code-unit guard). The existing surrogate-pair test still passes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No OpenAPI/schema surface changes — feed string formatting only.

## Validation

- [x] `npx vitest run tests/feeds.test.mjs` — 23 passed (new case fails on the pre-fix code-unit guard).
- [x] `npx prettier --check` + `npx eslint` on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
