### PR TITLE
fix(mcp): a <1 limit falls back to the default, not clamped up to 1

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -327,8 +327,14 @@ function requireString(args, key) {
 }
 
 function clampLimit(value, fallback, max) {
-  if (!Number.isFinite(value)) return fallback;
-  return Math.max(1, Math.min(max, Math.floor(value)));
+  // A missing/blank/<1 limit falls back to the default — it must NOT clamp UP to
+  // 1. tools/call does not enforce the inputSchema `minimum`, so an explicit
+  // limit:0 reaches here; `Math.max(1, …)` would return a single result, which
+  // reads to an agent as "this registry knows one subnet" (see the same fix in
+  // src/ai-search.mjs).
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return Math.min(max, Math.floor(n));
 }
 
 // A search.json document → keywordScore shape: title/slug are identity; subtitle

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -927,6 +927,22 @@ describe("MCP tools (injected deps)", () => {
     assert.equal(res.body.result.structuredContent.count, 0);
   });
 
+  test("search_subnets limit:0 falls back to the default, not a single result", async () => {
+    // tools/call does not enforce inputSchema `minimum:1`, so limit:0 reaches
+    // clampLimit. It must fall back to the default (10), not clamp up to 1 — a
+    // query matching two subnets returns both, not one.
+    const res = await callTool(
+      "search_subnets",
+      { query: "data compute", limit: 0 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.ok(
+      out.results.length >= 2,
+      `expected >=2 results (fallback), got ${out.results.length}`,
+    );
+  });
+
   test("search_subnets requires a non-empty query", async () => {
     const res = await callTool("search_subnets", { query: "   " }, { deps });
     assert.equal(res.body.result.isError, true);


### PR DESCRIPTION
## Summary

- `clampLimit` in `src/mcp-server.mjs` clamped a `<1` limit **up to 1** (`Math.max(1, …)`). The same helper in `src/ai-search.mjs` was already fixed, with a comment: clamping to 1 makes a blank/`<1` limit return a single result, which "read as 'this registry knows one subnet' to agents." The MCP copy kept the pre-fix behavior.

Fixes #1522

## Reachability

`callTool` (`tools/call`) invokes handlers with raw arguments and does **not** enforce the `inputSchema` (`limit` has `minimum: 1`). So an explicit `limit: 0` reaches `clampLimit`:

```
search_subnets({ query: "...", limit: 0 })
  -> clampLimit(0, 10, 50) = Math.max(1, min(50, 0)) = 1   // ONE result instead of the default 10
```

Affects every limit-taking tool: `search_subnets`, `list_subnets`, `find_subnets_by_capability`, `get_best_rpc_endpoint`, `list_enrichment_targets`, `find_subnet_for_task`.

## What Changed

- `src/mcp-server.mjs` — align with the fixed ai-search helper: a non-finite or `<1` limit returns the `fallback` default; never clamps up to 1. Behaviour is unchanged for valid limits (≥1) and for missing limits (already returned fallback).
- `tests/mcp-server.test.mjs` — add a case asserting `search_subnets({ limit: 0 })` returns the default (a 2-subnet query returns both, not one).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No OpenAPI/schema surface changes — MCP result-count behavior only.

## Validation

- [x] `npx vitest run tests/mcp-server.test.mjs` — new case passes (fails on the pre-fix `Math.max(1, …)`); existing limit tests (limit:5, limit:999) unchanged.
- [x] `npx prettier --check` + `npx eslint` on the changed files — clean.
- Note: the pre-existing `POST /mcp tools/call resolves real artifacts from the local env` failure reproduces on `main` unchanged (local-env only; needs built artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
