### PR TITLE
fix(webhooks): an explicit empty filter allowlist matches nothing, not all

### DIFF
--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -286,17 +286,23 @@ export function buildChangeEvent({ changelog, pointer } = {}) {
 }
 
 export function eventMatchesFilters(event, filters) {
+  // No filters object (or neither facet present) means "no restriction" — match
+  // every event. A PRESENT facet is an allowlist, including an explicit empty
+  // one: `{kinds: []}` allows zero kinds, so it must match NOTHING, not fall
+  // through to match-all. normalizeFilters preserves an empty array, so a
+  // subscriber can create such a filter and would otherwise be flooded with
+  // every event instead of receiving none.
   if (
     !filters ||
     (filters.netuids === undefined && filters.kinds === undefined)
   ) {
     return true;
   }
-  if (Array.isArray(filters.kinds) && filters.kinds.length > 0) {
+  if (Array.isArray(filters.kinds)) {
     const eventKinds = new Set(event?.change_kinds || []);
     if (!filters.kinds.some((kind) => eventKinds.has(kind))) return false;
   }
-  if (Array.isArray(filters.netuids) && filters.netuids.length > 0) {
+  if (Array.isArray(filters.netuids)) {
     const affected = new Set(event?.affected_netuids || []);
     if (!filters.netuids.some((netuid) => affected.has(netuid))) return false;
   }

--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -330,6 +330,19 @@ describe("buildChangeEvent + eventMatchesFilters", () => {
     assert.equal(eventMatchesFilters(event, { netuids: [7] }), true);
     assert.equal(eventMatchesFilters(event, { netuids: [99] }), false);
   });
+
+  test("an explicit empty allowlist matches nothing (not everything)", () => {
+    // normalizeFilters preserves `[]`, so these are reachable subscriptions.
+    // An empty allowlist allows zero items → no event matches.
+    assert.equal(eventMatchesFilters(event, { kinds: [] }), false);
+    assert.equal(eventMatchesFilters(event, { netuids: [] }), false);
+    assert.equal(eventMatchesFilters(event, { netuids: [], kinds: [] }), false);
+    // An empty allowlist on one facet rejects even when the other would match.
+    assert.equal(
+      eventMatchesFilters(event, { netuids: [7], kinds: [] }),
+      false,
+    );
+  });
 });
 
 // --- signPayload / timingSafeEqual -------------------------------------------


### PR DESCRIPTION
## Summary

- `eventMatchesFilters` guarded each facet with `&& filters.X.length > 0`, so an **explicit empty allowlist** (`{ kinds: [] }` / `{ netuids: [] }`) fell through and matched **every** event.
- `normalizeFilters` preserves an empty array (it only rejects invalid entries, never empties), so such a subscription is reachable — and the subscriber gets the full event firehose instead of nothing.

Fixes #1524

## Why it's wrong

An empty allowlist allows **zero** items → it should match **nothing**. The genuine "no restriction" case is already handled separately (a facet that is `undefined` → early `return true`). Treating an explicit `[]` as also "no restriction" is redundant and surprising for a client that builds `kinds`/`netuids` programmatically and ends up with `[]`.

```js
eventMatchesFilters(event, { kinds: [] });             // before: true  → after: false
eventMatchesFilters(event, { netuids: [] });           // before: true  → after: false
eventMatchesFilters(event, { netuids: [7], kinds: [] }); // before: true → after: false
```

## What Changed

- `src/webhooks.mjs` — drop the `length > 0` guards in `eventMatchesFilters`: a present facet is an allowlist, and an empty one matches nothing (`[].some(...)` is `false` → `return false`). The `undefined`-facet early return still preserves "no filter → match all".
- `tests/webhooks-core.test.mjs` — add a case asserting empty allowlists match nothing. Existing tests (`{}`/`undefined` → match all; populated filters) are unchanged.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No OpenAPI/schema surface changes — webhook delivery filtering only.

## Validation

- [x] `npx vitest run tests/webhooks-core.test.mjs` — 60 passed (new case fails on the pre-fix `length > 0` guards).
- [x] `npx prettier --check` + `npx eslint` on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
