### PR TITLE
fix(health): pick latency percentiles by nearest rank, not floor(q*N)+1

### DIFF
--- a/src/health-sql.mjs
+++ b/src/health-sql.mjs
@@ -44,8 +44,16 @@ export function latencyStatColumns({
   includeMinMax = true,
 } = {}) {
   const avg = `AVG(CASE WHEN ${OK_LATENCY} THEN latency_ms END)`;
-  const pick = (q, name) =>
-    `MAX(CASE WHEN rn = CAST(${q} * lat_cnt AS INTEGER) + 1 THEN latency_ms END) AS ${name}`;
+  // Nearest-rank order statistic: the value at 1-based ordinal position
+  // ceil(q * N) among the N ok-latency rows. `CAST(x AS INTEGER)` truncates
+  // toward zero (= floor for the non-negative q*N), so add 1 only when there is
+  // a fractional part — that is ceil. The previous `floor(q*N) + 1` overshot by
+  // one whenever q*N was an integer (e.g. N=100 → p50/p95/p99 picked ranks
+  // 51/96/100 instead of 50/95/99).
+  const pick = (q, name) => {
+    const pos = `${q} * lat_cnt`;
+    return `MAX(CASE WHEN rn = CAST(${pos} AS INTEGER) + (${pos} > CAST(${pos} AS INTEGER)) THEN latency_ms END) AS ${name}`;
+  };
   const columns = [
     `MAX(lat_cnt) AS latency_samples`,
     `${roundedAvg ? `CAST(ROUND(${avg}) AS INTEGER)` : avg} AS avg_latency_ms`,

--- a/tests/health-sql.test.mjs
+++ b/tests/health-sql.test.mjs
@@ -36,6 +36,26 @@ describe("health-sql latency builders", () => {
     assert.ok(!cols.includes("CAST(ROUND("));
   });
 
+  test("latencyStatColumns picks percentiles by nearest rank (ceil), not floor+1", () => {
+    const cols = latencyStatColumns();
+    // ceil(q*N): truncate toward zero, then add 1 only on a fractional part.
+    // The old floor(q*N)+1 overshot by one whenever q*N was an integer (the
+    // common case, e.g. N=100 → p50/p95/p99 hit ranks 51/96/100, not 50/95/99).
+    for (const q of ["0.5", "0.95", "0.99"]) {
+      assert.ok(
+        cols.includes(
+          `CAST(${q} * lat_cnt AS INTEGER) + (${q} * lat_cnt > CAST(${q} * lat_cnt AS INTEGER))`,
+        ),
+        `percentile ${q} must select the nearest-rank (ceil) position`,
+      );
+    }
+    // The off-by-one `floor(q*N) + 1` form must be gone.
+    assert.ok(
+      !/CAST\([0-9.]+ \* lat_cnt AS INTEGER\) \+ 1\b/.test(cols),
+      "must not use the floor+1 rank that overshoots at integer boundaries",
+    );
+  });
+
   test("latencyStatColumns honours roundedAvg and includeMinMax options", () => {
     assert.ok(latencyStatColumns({ roundedAvg: true }).includes("CAST(ROUND("));
     const noMinMax = latencyStatColumns({ includeMinMax: false });


### PR DESCRIPTION
## Summary

- The latency p50/p95/p99 order statistics select rank `CAST(q * lat_cnt AS INTEGER) + 1` = `floor(q·N) + 1`, which overshoots the nearest-rank position `ceil(q·N)` by one **whenever `q·N` is an integer** — the common case.
- For a surface with exactly N=100 ok-latency samples, p50/p95/p99 pick ranks **51 / 96 / 100** instead of **50 / 95 / 99** (p99 returns the max), biasing every reported percentile one sample too high.

Fixes #1526

## Detail

`rn` is the 1-based `ROW_NUMBER()` over ok-latency rows, `lat_cnt` their count. Nearest-rank picks position `ceil(q·N)`:
- N=100: ceil → 50 / 95 / 99; code's `floor+1` → 51 / 96 / 100.
- Non-integer `q·N` (e.g. N=10, q=0.95 → 9.5): `floor+1` = `ceil` = 10 — identical, so only the round-count case is wrong.

## What Changed

- `src/health-sql.mjs` — `latencyStatColumns()` picks `ceil(q·N)`: `CAST(x AS INTEGER)` truncates toward zero (= floor for non-negative `q·N`), so add 1 only when there's a fractional part:
  ```sql
  rn = CAST(q * lat_cnt AS INTEGER) + (q * lat_cnt > CAST(q * lat_cnt AS INTEGER))
  ```
  Non-integer cases are unchanged; no new SQL functions (matches the existing CAST-only style). Feeds the percentiles route and the trends/rollup latency tail.
- `tests/health-sql.test.mjs` — assert the nearest-rank expression is emitted for p50/p95/p99 and the off-by-one `floor+1` form is gone.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No OpenAPI/schema surface changes — latency percentile selection only.

## Validation

- [x] `npx vitest run tests/health-sql.test.mjs` — 6 passed (new case fails on the pre-fix `floor+1`).
- [x] `npx vitest run tests/rpc-usage.test.mjs tests/analytics.test.mjs tests/health-serving.test.mjs` — 12 + 158 passed (the SQL-shape mocks are unaffected).
- [x] `npx prettier --check` + `npx eslint` on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
