### PR TITLE
fix(mcp): reject non-numeric limits

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -334,9 +334,9 @@ function clampLimit(value, fallback, max) {
   // limit:0 reaches here; `Math.max(1, …)` would return a single result, which
   // reads to an agent as "this registry knows one subnet" (see the same fix in
   // src/ai-search.mjs).
-  const n = Number(value);
-  if (!Number.isFinite(n) || n < 1) return fallback;
-  return Math.min(max, Math.floor(n));
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
 }
 
 // A search.json document → keywordScore shape: title/slug are identity; subtitle

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -943,6 +943,23 @@ describe("MCP tools (injected deps)", () => {
     );
   });
 
+  test("search_subnets malformed limit values fall back to the default", async () => {
+    // tools/call passes raw JSON arguments to handlers, so clampLimit must not
+    // coerce schema-invalid values like true or "1" into a one-result limit.
+    for (const limit of [true, "1", [1], { toString: null }]) {
+      const res = await callTool(
+        "search_subnets",
+        { query: "data compute", limit },
+        { deps },
+      );
+      const out = res.body.result.structuredContent;
+      assert.ok(
+        out.results.length >= 2,
+        `expected fallback for limit ${JSON.stringify(limit)}, got ${out.results.length}`,
+      );
+    }
+  });
+
   test("search_subnets requires a non-empty query", async () => {
     const res = await callTool("search_subnets", { query: "   " }, { deps });
     assert.equal(res.body.result.isError, true);


### PR DESCRIPTION
### Motivation
- Prevent `clampLimit` from coercing schema-invalid JSON values (e.g. `true`, `"1"`, `[1]`) into numeric limits via `Number(value)`, which recreated the single-result behavior the previous fix intended to remove. 
- Ensure handlers receiving raw `params.arguments` from `tools/call` do not accidentally treat non-number inputs as valid limits and that object shapes which could throw are handled as fallbacks.

### Description
- Change `clampLimit` to only accept real numeric inputs by checking `typeof value === "number"` and then validating `Number.isFinite(value)` and `value >= 1`, returning the `fallback` for any other input. 
- Add a regression test `search_subnets malformed limit values fall back to the default` in `tests/mcp-server.test.mjs` that exercises `limit` values `true`, `"1"`, `[1]`, and `{ toString: null }` to assert they use the fallback limit. 
- Preserve the intended behavior where `limit:0` (and other numeric <1) falls back to the default rather than being clamped up to `1`.

### Testing
- Ran the focused search tests with `npx vitest run tests/mcp-server.test.mjs -t "search_subnets"`, and the search-related tests including the new malformed-limit regression passed. 
- Ran the full test file with `npm test -- tests/mcp-server.test.mjs`, which produced `118 passed, 1 failed`; the single failure is an existing end-to-end local-env artifact expectation (`POST /mcp tools/call resolves real artifacts from the local env` failing on `service_count >= 1`) and is unrelated to the `clampLimit` change. 
- Ran `npx eslint src/mcp-server.mjs tests/mcp-server.test.mjs` and `git diff --check`, both of which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ac78442e4832c96d82486947174e7)