### PR TITLE
fix(scripts): bound TaoMarketCap pagination

### DIFF
--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -97,6 +97,9 @@ for (const file of await listJsonFilesRecursive(
 }
 const restoredProviders = new Set();
 const TAOPEDIA_ARTICLE_PROBE_MAX_BYTES = 64 * 1024;
+// TaoMarketCap normally reports a finite `count`, but keep count-less
+// pagination bounded so a malformed `next` chain cannot hang refresh jobs.
+const TAOMARKETCAP_MAX_PAGES = 50;
 
 await discoverFromNativeChainIdentity();
 await discoverFromTaoMarketCap();
@@ -294,7 +297,11 @@ async function discoverFromTaoMarketCap() {
   let offset = 0;
   let expectedCount = null;
 
-  while (expectedCount === null || offset < expectedCount) {
+  for (let pageIndex = 0; pageIndex < TAOMARKETCAP_MAX_PAGES; pageIndex += 1) {
+    if (expectedCount !== null && offset >= expectedCount) {
+      break;
+    }
+
     const pageUrl = `https://api.taomarketcap.com/public/v1/subnets/?limit=${limit}&offset=${offset}`;
     const page = await fetchJson(pageUrl);
     if (!page) {
@@ -364,6 +371,12 @@ async function discoverFromTaoMarketCap() {
       break;
     }
     offset += limit;
+
+    if (pageIndex === TAOMARKETCAP_MAX_PAGES - 1) {
+      warnings.push(
+        `TaoMarketCap pagination exceeded ${TAOMARKETCAP_MAX_PAGES} pages; stopping discovery to avoid an unbounded refresh`,
+      );
+    }
   }
 }
 

--- a/tests/discover-candidates-pagination.test.mjs
+++ b/tests/discover-candidates-pagination.test.mjs
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile("scripts/discover-candidates.mjs", "utf8");
+
+describe("TaoMarketCap discovery pagination", () => {
+  it("keeps count-less pagination bounded by a page cap", () => {
+    expect(source).toContain("const TAOMARKETCAP_MAX_PAGES = 50;");
+    expect(source).toContain(
+      "for (let pageIndex = 0; pageIndex < TAOMARKETCAP_MAX_PAGES; pageIndex += 1)",
+    );
+    expect(source).toContain(
+      "expectedCount !== null && offset >= expectedCount",
+    );
+    expect(source).toContain(
+      "TaoMarketCap pagination exceeded ${TAOMARKETCAP_MAX_PAGES} pages",
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- A recent change left `discoverFromTaoMarketCap()` unbounded when `page.count` is missing, allowing a malicious or malformed stream that always sets `page.next` to keep discovery looping and hang production refresh/publish jobs.
- The discovery step is run during `npm run build` (via `scripts/refresh-candidates.mjs`), so an unbounded walk can impact CI/build availability.

### Description
- Add a defensive page cap constant `TAOMARKETCAP_MAX_PAGES = 50` to `scripts/discover-candidates.mjs` so count-less TaoMarketCap pagination cannot loop indefinitely.
- Replace the unbounded `while (expectedCount === null || offset < expectedCount)` loop with a bounded `for (let pageIndex = 0; pageIndex < TAOMARKETCAP_MAX_PAGES; pageIndex += 1)` loop while preserving the existing `expectedCount` termination when the API reports a total.
- Preserve the `if (!page.next) break` behavior and advance `offset` by `limit` as before, and emit a warning if the defensive page cap is reached.
- Add `tests/discover-candidates-pagination.test.mjs` which asserts the presence of the pagination guard in `scripts/discover-candidates.mjs`.

### Testing
- Ran the unit test with `vitest`: `npm test -- --run tests/discover-candidates-pagination.test.mjs` and it passed.
- Ran code style checks with `npx prettier --check` (and applied `--write` where needed) and `eslint`, both of which completed successfully as part of the automated checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ac8cf7754832cbf65a1a461ecb286)