### PR TITLE
fix(security): block IPv4-embedded IPv6 forms in the SSRF guards

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -8,6 +8,7 @@
 // URL, TextEncoder). The classification + scoring logic is lifted verbatim from
 // the historical build so artifacts stay byte-stable after the extraction
 // (writeJson sorts keys via stableStringify, so only VALUES must match).
+import { ipv6EmbeddedIpv4 } from "./ip-safety.mjs";
 
 export const SUBTENSOR_PROBE_CALLS = [
   { key: "chain_getHeader", method: "chain_getHeader", params: [] },
@@ -83,6 +84,20 @@ export function isUnsafePublicUrl(value) {
     // 172.16.0.0 – 172.31.255.255 (private range).
     if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) {
       return true;
+    }
+    // IPv4 tunnelled inside an IPv6 literal (::ffff:a.b.c.d mapped, ::a.b.c.d
+    // compatible, 2002::/16 6to4, 64:ff9b::/96 NAT64) hides a private/loopback
+    // target — e.g. ::ffff:169.254.169.254 (cloud metadata) — from the prefix
+    // patterns. Re-check the embedded v4 against the same ranges.
+    const embedded = ipv6EmbeddedIpv4(host);
+    if (embedded) {
+      const dotted = embedded.join(".");
+      if (
+        /^172\.(1[6-9]|2\d|3[01])\./.test(dotted) ||
+        UNSAFE_HOST_PATTERNS.some((pattern) => pattern.test(dotted))
+      ) {
+        return true;
+      }
     }
     return UNSAFE_HOST_PATTERNS.some((pattern) => pattern.test(host));
   } catch {

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -22,6 +22,7 @@ import {
   rollupSubnetStatus,
 } from "./health-probe-core.mjs";
 import { latencyStatColumns, rankedChecksCte } from "./health-sql.mjs";
+import { ipv6EmbeddedIpv4 } from "./ip-safety.mjs";
 import {
   KV_HEALTH_CURRENT,
   KV_HEALTH_META,
@@ -116,25 +117,32 @@ function ipv4Octets(value) {
   return octets.every((n) => n !== null) ? octets : null;
 }
 
+function isUnsafeIpv4(octets) {
+  const [a, b, c, d] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 0 && c === 0) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 224 ||
+    (a === 255 && b === 255 && c === 255 && d === 255)
+  );
+}
+
 function isUnsafeIpAddress(value) {
   const host = normalizedHostname(value);
   const v4 = ipv4Octets(host);
-  if (v4) {
-    const [a, b, c, d] = v4;
-    return (
-      a === 0 ||
-      a === 10 ||
-      (a === 100 && b >= 64 && b <= 127) ||
-      a === 127 ||
-      (a === 169 && b === 254) ||
-      (a === 172 && b >= 16 && b <= 31) ||
-      (a === 192 && b === 0 && c === 0) ||
-      (a === 192 && b === 168) ||
-      (a === 198 && (b === 18 || b === 19)) ||
-      a >= 224 ||
-      (a === 255 && b === 255 && c === 255 && d === 255)
-    );
-  }
+  if (v4) return isUnsafeIpv4(v4);
+  // IPv4-mapped (::ffff:a.b.c.d), IPv4-compatible (::a.b.c.d), 6to4 (2002::/16),
+  // and NAT64 (64:ff9b::/96) tunnel a v4 address that the prefix checks below
+  // can't see — re-check the embedded v4 against the same private ranges.
+  const embedded = ipv6EmbeddedIpv4(host);
+  if (embedded && isUnsafeIpv4(embedded)) return true;
   return (
     host === "::" ||
     host === "::1" ||

--- a/src/ip-safety.mjs
+++ b/src/ip-safety.mjs
@@ -1,0 +1,101 @@
+// Shared IPv6 parsing for the SSRF guards in webhooks.mjs and health-prober.mjs.
+// Leaf module: imports nothing, so either guard can use it without an import
+// cycle (mirrors the de-monolith leaf-module discipline in workers/storage.mjs).
+//
+// Several IPv6 textual forms embed an IPv4 address. A guard that only string- or
+// prefix-matches IPv6 cannot see the tunnelled v4, so an attacker reaches a
+// loopback / RFC1918 target it would otherwise block:
+//   ::ffff:127.0.0.1   IPv4-mapped     (::ffff:0:0/96)
+//   ::127.0.0.1        IPv4-compatible (::/96, deprecated)
+//   2002:7f00:1::      6to4            (2002::/16, v4 in the next 32 bits)
+//   64:ff9b::7f00:1    NAT64           (64:ff9b::/96 well-known prefix)
+// The WHATWG URL parser re-serialises the v4 tail into hextets (e.g. [::127.0.0.1]
+// becomes ::7f00:1), so the caller can't string-match it either. We parse to the
+// 16 address bytes and return the embedded v4 octets so the caller can apply its
+// own private-range policy.
+
+// Parse an IPv6 literal to its 16 bytes, or null if it is not a valid IPv6
+// address. Handles "::" zero-compression and an optional trailing dotted-quad
+// IPv4 (the standard x:x:x:x:x:x:d.d.d.d notation). A zone id (%eth0) is ignored.
+export function ipv6ToBytes(value) {
+  let host = String(value || "")
+    .trim()
+    .toLowerCase();
+  if (!host.includes(":")) return null;
+  const zone = host.indexOf("%");
+  if (zone !== -1) host = host.slice(0, zone);
+
+  // At most one "::" run is allowed.
+  const halves = host.split("::");
+  if (halves.length > 2) return null;
+
+  const parseGroups = (segment) => {
+    if (segment === "") return [];
+    const parts = segment.split(":");
+    const bytes = [];
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (part.includes(".")) {
+        // A dotted-quad IPv4 is only valid as the final group.
+        if (i !== parts.length - 1) return null;
+        const octets = part.split(".");
+        if (octets.length !== 4) return null;
+        for (const octet of octets) {
+          if (!/^\d{1,3}$/.test(octet)) return null;
+          const n = Number(octet);
+          if (n > 255) return null;
+          bytes.push(n);
+        }
+        continue;
+      }
+      if (!/^[0-9a-f]{1,4}$/.test(part)) return null;
+      const n = Number.parseInt(part, 16);
+      bytes.push((n >> 8) & 0xff, n & 0xff);
+    }
+    return bytes;
+  };
+
+  const head = parseGroups(halves[0]);
+  if (head === null) return null;
+
+  if (halves.length === 2) {
+    const tail = parseGroups(halves[1]);
+    if (tail === null) return null;
+    const fill = 16 - head.length - tail.length;
+    if (fill < 0) return null;
+    return [...head, ...new Array(fill).fill(0), ...tail];
+  }
+
+  // No "::" — the address must be fully specified.
+  return head.length === 16 ? head : null;
+}
+
+// Return the IPv4 octets [a,b,c,d] embedded in an IPv6 literal for the mapped /
+// compatible / 6to4 / NAT64 forms, or null when the address embeds no IPv4 the
+// caller should re-check. `::` and `::1` embed 0.0.0.0 / 0.0.0.1, which a v4
+// private-range check already rejects, so they need no special-casing here.
+export function ipv6EmbeddedIpv4(value) {
+  const bytes = ipv6ToBytes(value);
+  if (!bytes) return null;
+  const isZero = (start, end) => bytes.slice(start, end).every((b) => b === 0);
+  const v4At = (i) => bytes.slice(i, i + 4);
+
+  // IPv4-mapped ::ffff:0:0/96
+  if (isZero(0, 10) && bytes[10] === 0xff && bytes[11] === 0xff)
+    return v4At(12);
+  // IPv4-compatible ::/96 (the high 96 bits are zero)
+  if (isZero(0, 12)) return v4At(12);
+  // 6to4 2002::/16 — the v4 is the 32 bits after the 2002 prefix
+  if (bytes[0] === 0x20 && bytes[1] === 0x02) return v4At(2);
+  // NAT64 64:ff9b::/96 well-known prefix
+  if (
+    bytes[0] === 0x00 &&
+    bytes[1] === 0x64 &&
+    bytes[2] === 0xff &&
+    bytes[3] === 0x9b &&
+    isZero(4, 12)
+  ) {
+    return v4At(12);
+  }
+  return null;
+}

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -7,6 +7,7 @@
 // They perform NO I/O — KV and fetch are injected by callers — so every branch
 // is unit-testable. Runs unchanged on the Workers runtime and Node 22 (both
 // expose Web Crypto + TextEncoder + URL).
+import { ipv6EmbeddedIpv4 } from "./ip-safety.mjs";
 
 export const WEBHOOK_KV_PREFIX = "webhooks:sub:";
 // Per-(subscription, event) delivery state for at-least-once redelivery: a failed
@@ -78,6 +79,11 @@ function isIpv4Literal(host) {
   });
 }
 
+function isPrivateIpv4Octets(octets) {
+  const dotted = octets.join(".");
+  return PRIVATE_IPV4_PATTERNS.some((pattern) => pattern.test(dotted));
+}
+
 function isLiteralIp(host) {
   return isIpv4Literal(host) || host.includes(":");
 }
@@ -97,6 +103,11 @@ export function isPublicWebhookAddress(value) {
     ) {
       return false;
     }
+    // IPv4-compatible (::a.b.c.d, normalised to ::7f00:1 by the URL parser),
+    // 6to4 (2002::/16), and NAT64 (64:ff9b::/96) tunnel a v4 address past the
+    // prefix checks above — re-check the embedded v4 against the private ranges.
+    const embedded = ipv6EmbeddedIpv4(host);
+    if (embedded && isPrivateIpv4Octets(embedded)) return false;
     return true;
   }
 

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -95,12 +95,25 @@ describe("isUnsafePublicUrl", () => {
     }
   });
 
+  test("blocks a private v4 tunnelled inside an IPv6 literal host", () => {
+    for (const url of [
+      "http://[::ffff:169.254.169.254]/latest", // IPv4-mapped metadata IP
+      "http://[::127.0.0.1]/x", // IPv4-compatible loopback
+      "http://[2002:7f00:1::]/x", // 6to4 loopback
+      "http://[2002:a00:1::]/x", // 6to4 of 10.0.0.1
+      "http://[64:ff9b::a9fe:a9fe]/x", // NAT64 of 169.254.169.254
+    ]) {
+      assert.equal(isUnsafePublicUrl(url), true, url);
+    }
+  });
+
   test("allows public http(s)/ws(s)", () => {
     for (const url of [
       "https://entrypoint-finney.opentensor.ai",
       "http://example.com/api",
       "wss://lite.chain.opentensor.ai:443",
       "https://172.15.0.1/x", // just outside the private 172.16-31 range
+      "https://[2002:808:808::]/x", // 6to4 of public 8.8.8.8 stays allowed
     ]) {
       assert.equal(isUnsafePublicUrl(url), false, url);
     }

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -94,6 +94,22 @@ describe("workerResolvedUrlSafetyGuard (DNS-aware SSRF)", () => {
     assert.equal(await guard("https://v6.example.com/x"), true);
   });
 
+  test("blocks an AAAA answer that tunnels a private v4 (mapped/6to4/NAT64)", async () => {
+    // A rebinding answer can hide a loopback/link-local target inside an IPv6
+    // literal; the guard must decode the embedded v4 and block it.
+    for (const aaaa of [
+      "::ffff:169.254.169.254", // IPv4-mapped link-local (cloud metadata)
+      "::127.0.0.1", // IPv4-compatible loopback
+      "2002:7f00:1::", // 6to4 loopback
+      "64:ff9b::a00:1", // NAT64 of 10.0.0.1
+    ]) {
+      const guard = workerResolvedUrlSafetyGuard({
+        fetchImpl: dohFetch({ "evil.example.com": { AAAA: [aaaa] } }),
+      });
+      assert.equal(await guard("https://evil.example.com/x"), true, aaaa);
+    }
+  });
+
   test("allows a hostname that resolves to a public IP", async () => {
     const guard = workerResolvedUrlSafetyGuard({
       fetchImpl: dohFetch({ "ok.example.com": { A: ["93.184.216.34"] } }),

--- a/tests/ip-safety.test.mjs
+++ b/tests/ip-safety.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { ipv6EmbeddedIpv4, ipv6ToBytes } from "../src/ip-safety.mjs";
+
+describe("ipv6ToBytes", () => {
+  test("returns null for non-IPv6 input", () => {
+    assert.equal(ipv6ToBytes(""), null);
+    assert.equal(ipv6ToBytes(null), null);
+    assert.equal(ipv6ToBytes("127.0.0.1"), null);
+    assert.equal(ipv6ToBytes("example.com"), null);
+  });
+
+  test("expands :: zero-compression to 16 bytes", () => {
+    assert.deepEqual(
+      ipv6ToBytes("::1"),
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+    );
+    assert.deepEqual(ipv6ToBytes("::"), new Array(16).fill(0));
+    assert.deepEqual(
+      ipv6ToBytes("2002:7f00:1::"),
+      [0x20, 0x02, 0x7f, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    );
+  });
+
+  test("parses a trailing dotted-quad IPv4 group", () => {
+    assert.deepEqual(
+      ipv6ToBytes("::ffff:127.0.0.1"),
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 127, 0, 0, 1],
+    );
+  });
+
+  test("parses a fully-specified address without ::", () => {
+    assert.deepEqual(
+      ipv6ToBytes("2606:4700:4700:0:0:0:0:1111"),
+      [0x26, 0x06, 0x47, 0x00, 0x47, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0x11, 0x11],
+    );
+  });
+
+  test("rejects malformed input", () => {
+    assert.equal(ipv6ToBytes("1:2:3::4::5"), null); // two "::" runs
+    assert.equal(ipv6ToBytes("gggg::1"), null); // non-hex group
+    assert.equal(ipv6ToBytes("1:2:3:4:5:6:7"), null); // too few groups, no ::
+    assert.equal(ipv6ToBytes("::1.2.3"), null); // truncated dotted-quad
+    assert.equal(ipv6ToBytes("::1.2.3.999"), null); // octet out of range
+  });
+
+  test("ignores a zone id", () => {
+    assert.deepEqual(ipv6ToBytes("fe80::1%eth0"), ipv6ToBytes("fe80::1"));
+  });
+});
+
+describe("ipv6EmbeddedIpv4", () => {
+  test("extracts the embedded v4 for each tunnelling form", () => {
+    assert.deepEqual(ipv6EmbeddedIpv4("::ffff:127.0.0.1"), [127, 0, 0, 1]); // mapped
+    assert.deepEqual(ipv6EmbeddedIpv4("::ffff:7f00:1"), [127, 0, 0, 1]); // mapped, hex tail
+    assert.deepEqual(ipv6EmbeddedIpv4("::127.0.0.1"), [127, 0, 0, 1]); // compatible
+    assert.deepEqual(ipv6EmbeddedIpv4("::7f00:1"), [127, 0, 0, 1]); // compatible, normalised
+    assert.deepEqual(ipv6EmbeddedIpv4("2002:7f00:1::"), [127, 0, 0, 1]); // 6to4
+    assert.deepEqual(ipv6EmbeddedIpv4("64:ff9b::7f00:1"), [127, 0, 0, 1]); // NAT64
+    assert.deepEqual(
+      ipv6EmbeddedIpv4("::ffff:169.254.169.254"),
+      [169, 254, 169, 254],
+    );
+  });
+
+  test("returns null for a global-unicast address with no embedded v4", () => {
+    assert.equal(ipv6EmbeddedIpv4("2606:4700:4700::1111"), null);
+    assert.equal(ipv6EmbeddedIpv4("fe80::1"), null);
+    assert.equal(ipv6EmbeddedIpv4("fd00::1"), null);
+  });
+
+  test("returns null for non-IPv6 input", () => {
+    assert.equal(ipv6EmbeddedIpv4("8.8.8.8"), null);
+    assert.equal(ipv6EmbeddedIpv4("example.com"), null);
+  });
+});

--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -46,6 +46,26 @@ describe("isPublicWebhookAddress", () => {
     assert.equal(isPublicWebhookAddress("2606:4700:4700::1111"), true);
   });
 
+  test("IPv4 tunnelled inside an IPv6 literal → false", () => {
+    // IPv4-compatible (deprecated); the URL parser re-serialises ::127.0.0.1 to
+    // ::7f00:1, so both spellings must be caught.
+    assert.equal(isPublicWebhookAddress("::127.0.0.1"), false);
+    assert.equal(isPublicWebhookAddress("::7f00:1"), false);
+    assert.equal(isPublicWebhookAddress("::192.168.1.1"), false);
+    // 6to4 (2002::/16) wrapping a private/loopback v4.
+    assert.equal(isPublicWebhookAddress("2002:7f00:1::"), false);
+    assert.equal(isPublicWebhookAddress("2002:a00:1::"), false); // 10.0.0.1
+    // NAT64 (64:ff9b::/96) wrapping a private/loopback v4.
+    assert.equal(isPublicWebhookAddress("64:ff9b::7f00:1"), false);
+    assert.equal(isPublicWebhookAddress("64:ff9b::c0a8:101"), false); // 192.168.1.1
+  });
+
+  test("an IPv6 form wrapping a PUBLIC v4 stays public", () => {
+    // 6to4 / NAT64 of 8.8.8.8 is genuinely routable — don't over-block.
+    assert.equal(isPublicWebhookAddress("2002:808:808::"), true);
+    assert.equal(isPublicWebhookAddress("64:ff9b::808:808"), true);
+  });
+
   test("private IPv4 literals → false", () => {
     assert.equal(isPublicWebhookAddress("10.0.0.1"), false);
     assert.equal(isPublicWebhookAddress("127.0.0.1"), false);
@@ -90,6 +110,14 @@ describe("isPublicWebhookUrl", () => {
 
   test("rejects a private IPv4 literal host", () => {
     assert.equal(isPublicWebhookUrl("https://169.254.169.254/x"), false);
+  });
+
+  test("rejects a v4 loopback tunnelled through an IPv6 literal host", () => {
+    // The URL parser normalises [::127.0.0.1] → [::7f00:1]; the SSRF guard must
+    // still see the embedded loopback rather than treating it as public IPv6.
+    assert.equal(isPublicWebhookUrl("https://[::127.0.0.1]/x"), false);
+    assert.equal(isPublicWebhookUrl("https://[2002:7f00:1::]/x"), false);
+    assert.equal(isPublicWebhookUrl("https://[64:ff9b::7f00:1]/x"), false);
   });
 
   test("allows a public IPv4 literal host", () => {


### PR DESCRIPTION
## Summary

- The webhook, prober, and probe-core SSRF guards each block IPv6 by string-matching prefixes, so they miss the textual forms that **tunnel an IPv4 address inside an IPv6 literal**. A loopback / RFC1918 / link-local target slips past every one of them.

## What Changed

The blind spots, all of which decode to a private/loopback v4 the guards already reject in dotted form:

| Form | Example | Decodes to |
|------|---------|-----------|
| IPv4-mapped | `::ffff:169.254.169.254` | 169.254.169.254 (cloud metadata) |
| IPv4-compatible | `::127.0.0.1` → URL parser re-serialises to `::7f00:1` | 127.0.0.1 |
| 6to4 (`2002::/16`) | `2002:7f00:1::` | 127.0.0.1 |
| NAT64 (`64:ff9b::/96`) | `64:ff9b::a9fe:a9fe` | 169.254.169.254 |

The IPv4-compatible case is the nastiest: the WHATWG URL parser rewrites `[::127.0.0.1]` to `[::7f00:1]`, so a prefix string-match can't catch it even in principle.

Reachable today via:
- a subscriber registering `https://[::127.0.0.1]/` — `isPublicWebhookAddress` returned `true`;
- a DNS-rebinding `AAAA` answer of `::ffff:169.254.169.254` — `isUnsafeIpAddress` returned `false`;
- `isUnsafePublicUrl` (the Worker's literal guard, also the default for `probeUrl` and redirect checks) had the same gap plus a thinner pattern list.

Fix: a new pure leaf module **`src/ip-safety.mjs`** parses an IPv6 literal to its 16 bytes (handling `::` compression and a trailing dotted-quad) and returns any embedded IPv4 octets for the mapped/compatible/6to4/NAT64 forms. Each guard runs that v4 through **its own** private-range policy, so a public address tunnelled the same way (6to4 of `8.8.8.8`) stays allowed — no over-blocking.

Touched guards:
- `src/webhooks.mjs` — `isPublicWebhookAddress`
- `src/health-prober.mjs` — `isUnsafeIpAddress` (factored out `isUnsafeIpv4` so the literal and embedded paths share one range table)
- `src/health-probe-core.mjs` — `isUnsafePublicUrl`

Follows the `fe00::/8` hardening (#1443); defense in depth on top of the curated `public_safe` allowlist. New unit tests cover the parser, the URL-level webhook guard, the DoH-resolved prober guard, and the literal probe-core guard (including the "public v4 stays allowed" cases).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (no artifacts touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none — internal guards only)

## Validation

- [x] `npm run lint` (eslint clean on changed files)
- [x] `npm run format:check` (prettier clean)
- [x] `npm run validate:types` — "Generated API types are current."
- [x] full `npx vitest run` — 1683 passed, incl. new `ip-safety`, webhook, prober, and probe-core SSRF tests
- [x] `git diff --check`