### PR TITLE
fix(health): report last_ok as null for a never-OK subnet, not the 1970 epoch

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -345,8 +345,12 @@ function summarizeGroup(rows) {
     degraded_count: counts.degraded,
     failed_count: counts.failed,
     unknown_count: counts.unknown,
-    last_checked: iso(lastChecked) || null,
-    last_ok: iso(lastOk) || null,
+    // Guard the 0 sentinel before iso(): iso(0) is the truthy epoch string
+    // "1970-01-01T00:00:00.000Z", so `iso(0) || null` would report a fake last_ok
+    // for a subnet whose surfaces have never probed OK. (last_checked is always
+    // set from runAt, but guard it the same way for symmetry.)
+    last_checked: lastChecked ? iso(lastChecked) : null,
+    last_ok: lastOk ? iso(lastOk) : null,
     avg_latency_ms: latencies.length
       ? Math.round(latencies.reduce((s, v) => s + v, 0) / latencies.length)
       : null,

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -1404,6 +1404,35 @@ describe("summarizeGroup / rollupStatus via per-subnet rollup", () => {
     assert.equal(subnet.last_checked, new Date(5000).toISOString());
   });
 
+  test("a zero checked-at timestamp reports last_checked null, not the epoch", async () => {
+    // Same 0-sentinel guard as last_ok, on the last_checked field: with the
+    // clock at the Unix epoch every row's checked_at_ms is 0, so lastChecked
+    // stays 0. `iso(0)` is the truthy "1970-01-01T00:00:00.000Z", so the field
+    // must be guarded (`lastChecked ? iso(lastChecked) : null`) to report null.
+    const kv = makeKv();
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 0,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => [buildSurface("z1", 13)],
+        probeSurface: async () => ({
+          status: "unknown",
+          classification: null,
+          latency_ms: null,
+        }),
+        probeOptions: {},
+      },
+    );
+    const subnet = kv
+      .json(KV_HEALTH_CURRENT)
+      .subnets.find((s) => s.netuid === 13);
+    assert.equal(subnet.last_checked, null);
+    assert.equal(subnet.last_ok, null);
+  });
+
   test("mixed ok+failed subnet rolls up to degraded with avg latency", async () => {
     const kv = makeKv();
     await runHealthProber(

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -1397,9 +1397,10 @@ describe("summarizeGroup / rollupStatus via per-subnet rollup", () => {
     assert.equal(subnet.status, "unknown");
     assert.equal(subnet.unknown_count, 2);
     assert.equal(subnet.avg_latency_ms, null);
-    // No surface ever went ok → lastOk stays at the 0 epoch sentinel (iso(0)),
-    // which is truthy so the `|| null` fallback does not fire.
-    assert.equal(subnet.last_ok, new Date(0).toISOString());
+    // No surface ever went ok → last_ok is null ("never"), not the 1970 epoch.
+    // (iso(0) is the truthy string "1970-01-01T00:00:00.000Z", so the old
+    // `iso(lastOk) || null` reported a fabricated last-healthy timestamp here.)
+    assert.equal(subnet.last_ok, null);
     assert.equal(subnet.last_checked, new Date(5000).toISOString());
   });
 


### PR DESCRIPTION
## Summary

- A subnet whose surfaces have **never** probed OK is reported with `last_ok: "1970-01-01T00:00:00.000Z"` in `health:current` instead of `null`.

## What Changed

`summarizeGroup` (the per-subnet rollup the cron prober writes to KV) seeds `lastOk` to `0` and only advances it on a truthy `row.last_ok_ms`:

```js
let lastOk = 0;
for (const row of rows) {
  if (row.last_ok_ms && row.last_ok_ms > lastOk) lastOk = row.last_ok_ms;
}
// ...
last_ok: iso(lastOk) || null,   // iso(0) === "1970-01-01T00:00:00.000Z" (truthy!)
```

For an all-down subnet `lastOk` stays `0`, and `iso(0)` returns the **truthy** epoch string, so the `|| null` fallback never fires. Consumers reading `last_ok` see a fabricated "last healthy at Jan 1 1970" rather than "never."

The sibling `summarizeRows` in `health-serving.mjs` already handles this correctly (it seeds its accumulator to `null`), so the two rollups disagreed on the same field. Fix: guard the `0` sentinel before `iso()` — `lastOk ? iso(lastOk) : null` — and apply the same guard to `last_checked` for symmetry (it is always set from `runAt` in practice, so its behavior is unchanged).

The existing `all-unknown subnet` test asserted the buggy epoch value (its comment even noted the `iso(0)` truthiness); it now asserts `null`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none — only fixes a fabricated value already in the contract)

## Validation

- [x] `npm run lint` / `npm run format:check` — clean
- [x] `npx vitest run tests/health-prober.test.mjs tests/health-serving.test.mjs` — 190 passed
- [x] `git diff --check`