### PR TITLE
fix(graphql): validate provider(id) to block artifact path traversal

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -250,6 +250,16 @@ function paginate(items, limit, cursor, keyFn) {
 
 // --- Resolvers ---
 
+// `provider(id)` interpolates the client-supplied id straight into an artifact
+// path, and readArtifact's static-asset tier resolves it through `new
+// Request("https://assets.local" + path)`, whose URL parser COLLAPSES "../"
+// segments. An id like "../subnets" would therefore escape the providers/
+// namespace and read a different artifact. Constrain the id to the same safe
+// slug charset every other id-bearing artifact path enforces (mcp-server's
+// resourceArtifactPath, get_api_schema). `subnet(netuid)` is Int-typed by the
+// schema so it needs no equivalent guard.
+const VALID_PROVIDER_ID = /^[A-Za-z0-9._:-]+$/;
+
 const rootValue = {
   async subnets({ limit, cursor }, context) {
     const { ok, data } = await readArtifact(
@@ -295,6 +305,7 @@ const rootValue = {
   },
 
   async provider({ id }, context) {
+    if (typeof id !== "string" || !VALID_PROVIDER_ID.test(id)) return null;
     const { ok, data } = await readArtifact(
       context.env,
       `/metagraph/providers/${id}.json`,

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -443,6 +443,43 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     assert.deepEqual(body.data.providers.items[0].netuids, []);
   });
 
+  test("provider resolves a valid slug id from the store", async () => {
+    const env = fakeArtifactEnv({
+      "/metagraph/providers/acme-1.0.json": { id: "acme-1.0", name: "Acme" },
+    });
+    const { status, body } = await gql(
+      '{ provider(id: "acme-1.0") { id name } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.provider.name, "Acme");
+  });
+
+  test("provider rejects a traversal/invalid id without reading any artifact", async () => {
+    // The id is interpolated into the artifact path and the static-asset tier
+    // collapses "../", so an unvalidated id could escape the providers/
+    // namespace. The resolver must reject a non-slug id BEFORE touching storage.
+    let reads = 0;
+    const env = {
+      METAGRAPH_R2_LATEST_PREFIX: "latest/",
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          reads += 1;
+          return null;
+        },
+      },
+    };
+    for (const id of ["../subnets", "../../economics", "a/b", "foo bar", ""]) {
+      const { status, body } = await gql(
+        `{ provider(id: ${JSON.stringify(id)}) { id name } }`,
+        env,
+      );
+      assert.equal(status, 200, id);
+      assert.equal(body.data.provider, null, id);
+    }
+    assert.equal(reads, 0, "no artifact read should happen for an invalid id");
+  });
+
   test("economics returns subnet economics list", async () => {
     const env = fakeArtifactEnv({
       "/metagraph/economics.json": {


### PR DESCRIPTION
## Summary

- The GraphQL `provider(id)` resolver interpolates the client-supplied `id` straight into an artifact path, and the static-asset tier normalises `../`, so a crafted id escapes the `providers/` namespace.

## What Changed

```js
async provider({ id }, context) {
  const { ok, data } = await readArtifact(
    context.env,
    `/metagraph/providers/${id}.json`,   // id is unvalidated
  );
```

`readArtifact`'s static-asset tier resolves the path via `new Request("https://assets.local" + path)`, whose URL parser **collapses `../`**. So `provider(id: "../subnets")` resolves to `/metagraph/subnets.json`, and `provider(id: "../../economics")` to `/metagraph/economics.json` — reading a different public artifact and shaping it as a `Provider`.

Impact is bounded — the R2 tier uses literal keys so it isn't traversable, and only public `.json` artifacts are reachable — but it bypasses the slug validation **every other id-bearing artifact path enforces** (`mcp-server`'s `resourceArtifactPath`, `get_api_schema`, `get_fixture` all gate on `/^[A-Za-z0-9._:-]+$/`).

Fix: constrain `id` to the same charset and return `null` before touching storage on a mismatch. `subnet(netuid)` is `Int!`-typed by the schema, so it needs no equivalent guard.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none — resolver input validation only)

## Validation

- [x] `npm run lint` / `npm run format:check` — clean
- [x] `npx vitest run tests/graphql.test.mjs` — 46 passed (incl. a valid slug resolving + traversal/invalid ids returning null with no artifact read)
- [x] `git diff --check`