### PR TITLE
fix(health): parseBlockNumber returns null, not NaN, for malformed headers

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -690,15 +690,21 @@ export function parseBlockNumber(header) {
     return null;
   }
   const value = header.number;
+  let block;
   if (typeof value === "number") {
-    return value;
-  }
-  if (typeof value === "string") {
-    return value.startsWith("0x")
+    block = value;
+  } else if (typeof value === "string") {
+    block = value.startsWith("0x")
       ? Number.parseInt(value, 16)
       : Number.parseInt(value, 10);
+  } else {
+    return null;
   }
-  return null;
+  // A real block height is a non-negative integer. Anything else — NaN from a
+  // malformed "0x"/"0xZZ"/empty string, or a non-finite/fractional number —
+  // is unusable and collapses to null, matching this function's other branches
+  // (and so it never leaks NaN past the `??` fallbacks downstream).
+  return Number.isInteger(block) && block >= 0 ? block : null;
 }
 
 // Bounded-concurrency map. Preserves INPUT order in the returned array (callers

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -965,6 +965,20 @@ describe("parseBlockNumber", () => {
     assert.equal(parseBlockNumber({ number: { nested: true } }), null);
     assert.equal(parseBlockNumber({}), null);
   });
+  test("malformed numeric string returns null, not NaN", () => {
+    assert.equal(parseBlockNumber({ number: "0x" }), null);
+    assert.equal(parseBlockNumber({ number: "0xZZ" }), null);
+    assert.equal(parseBlockNumber({ number: "" }), null);
+  });
+  test("non-finite or non-integer number field returns null", () => {
+    assert.equal(parseBlockNumber({ number: NaN }), null);
+    assert.equal(parseBlockNumber({ number: Infinity }), null);
+    assert.equal(parseBlockNumber({ number: 1.5 }), null);
+  });
+  test("genesis block 0 is preserved", () => {
+    assert.equal(parseBlockNumber({ number: 0 }), 0);
+    assert.equal(parseBlockNumber({ number: "0x0" }), 0);
+  });
 });
 
 describe("contentMismatch (remaining branches)", () => {


### PR DESCRIPTION
## Summary
`parseBlockNumber()` is documented and unit-tested to return either a numeric block height or `null` for any unusable input, but it returned `NaN` for a string `number` field that fails to parse - the bare `"0x"` prefix, malformed hex like `"0xZZ"`, or an empty string - and the plain-number branch passed a `NaN`/non-integer `number` straight through.

`NaN` then defeats the `??` block fallbacks downstream (e.g. `live.latest_block ?? endpoint.latest_block ?? null` in `overlayRpcPoolEligibility`, since `NaN` is neither `null` nor `undefined`), leaving the parser reliant on `safeRpcBlockNumber()` to scrub the value later.

## Fix
Normalize every branch to a non-negative integer or `null`, consistent with the function's existing tests and its other branches. Genesis block `0` is preserved.

## Tests
Added cases for malformed numeric strings (`"0x"`, `"0xZZ"`, `""`), non-finite/non-integer numbers (`NaN`, `Infinity`, `1.5`), and the genesis-block boundary (`0`, `"0x0"`). Existing assertions are unchanged and still pass.

Closes #1539