### PR TITLE
fix(health): block fec0::/10 site-local IPv6 in probe SSRF guards

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -86,6 +86,7 @@ unsafeIpBlocks.addSubnet("64:ff9b:1::", 48, "ipv6");
 unsafeIpBlocks.addSubnet("100::", 64, "ipv6");
 unsafeIpBlocks.addSubnet("fc00::", 7, "ipv6");
 unsafeIpBlocks.addSubnet("fe80::", 10, "ipv6");
+unsafeIpBlocks.addSubnet("fec0::", 10, "ipv6"); // deprecated site-local (RFC 3879)
 unsafeIpBlocks.addSubnet("ff00::", 8, "ipv6");
 
 export function buildEvidenceSubjectNetuidIndex({

--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -62,7 +62,9 @@ const UNSAFE_HOST_PATTERNS = [
   /^0\./,
   /^::1$/,
   /^::$/,
-  /^fe80:/i,
+  // fe80::/10 link-local + fec0::/10 deprecated site-local (RFC 3879) — the whole
+  // fe80::–feff: reserved range, mirroring the webhook guard (issue #1538).
+  /^fe[89a-f][0-9a-f]:/i,
   /^fc00:/i,
   /^fd/i,
 ];

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -150,7 +150,9 @@ function isUnsafeIpAddress(value) {
     host.startsWith("64:ff9b:1:") ||
     host.startsWith("fc") ||
     host.startsWith("fd") ||
-    /^fe[89ab][0-9a-f]:/i.test(host) ||
+    // fe80::/10 link-local + fec0::/10 deprecated site-local (RFC 3879): the whole
+    // fe80::–feff: reserved range, matching the webhook guard (issue #1538).
+    /^fe[89a-f][0-9a-f]:/i.test(host) ||
     host.startsWith("ff")
   );
 }

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -95,6 +95,17 @@ describe("isUnsafePublicUrl", () => {
     }
   });
 
+  test("blocks fec0::/10 deprecated site-local IPv6 (issue #1538)", () => {
+    for (const url of [
+      "http://[fec0::1]/x",
+      "https://[fed0:1:2::3]/x",
+      "http://[feff::1]/x",
+      "http://[fe80::1]/x", // link-local still blocked
+    ]) {
+      assert.equal(isUnsafePublicUrl(url), true, url);
+    }
+  });
+
   test("blocks a private v4 tunnelled inside an IPv6 literal host", () => {
     for (const url of [
       "http://[::ffff:169.254.169.254]/latest", // IPv4-mapped metadata IP

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -94,6 +94,15 @@ describe("workerResolvedUrlSafetyGuard (DNS-aware SSRF)", () => {
     assert.equal(await guard("https://v6.example.com/x"), true);
   });
 
+  test("blocks an fec0::/10 site-local AAAA answer (issue #1538)", async () => {
+    for (const aaaa of ["fec0::1", "fed0:1:2::3", "feff::1"]) {
+      const guard = workerResolvedUrlSafetyGuard({
+        fetchImpl: dohFetch({ "evil.example.com": { AAAA: [aaaa] } }),
+      });
+      assert.equal(await guard("https://evil.example.com/x"), true, aaaa);
+    }
+  });
+
   test("blocks an AAAA answer that tunnels a private v4 (mapped/6to4/NAT64)", async () => {
     // A rebinding answer can hide a loopback/link-local target inside an IPv6
     // literal; the guard must decode the embedded v4 and block it.

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -1517,6 +1517,7 @@ describe("script utility contracts", () => {
     assert.equal(isUnsafeUrl("http://172.16.0.1"), true);
     assert.equal(isUnsafeUrl("http://[fd00::1]"), true);
     assert.equal(isUnsafeUrl("http://[fe80::1]"), true);
+    assert.equal(isUnsafeUrl("http://[fec0::1]"), true); // site-local (issue #1538)
     assert.equal(isUnsafeUrl("http://[::ffff:127.0.0.1]"), true);
     assert.equal(isUnsafeUrl("not a url"), true);
     assert.equal(isUnsafeUrl("https://metagraph.sh"), false);


### PR DESCRIPTION
## Summary

Closes #1538.

The webhook SSRF guard was fixed in #1443 to block the full `fe00::/8` reserved range (link-local `fe80::/10` + deprecated site-local `fec0::/10`). The same fix was never applied to the other three SSRF guards, which still only blocked `fe80::/10` and therefore classified `fec0::/10` site-local addresses as **public/safe** — an SSRF gap (`fec0::/10` is deprecated per RFC 3879 but still a real internal range).

## What Changed

- `src/health-probe-core.mjs` — `UNSAFE_HOST_PATTERNS`: `/^fe80:/i` → `/^fe[89a-f][0-9a-f]:/i` (covers `fe80::`–`feff:`). The pattern still requires an IPv6 segment colon, so hostnames like `fedora.org` are not affected.
- `src/health-prober.mjs` — `isUnsafeIpAddress`: `/^fe[89ab][0-9a-f]:/i` → `/^fe[89a-f][0-9a-f]:/i`, so a literal/DNS-answer `fec0::1` is now blocked.
- `scripts/lib.mjs` — `unsafeIpBlocks`: add `fec0::/10` alongside the existing `fe80::/10`.
- Tests added for each guard (`health-probe-core`, `health-prober` DNS-aware, `script-utils`).

All three guards now cover the same `fe80::`–`feff:` reserved range as the webhook guard. No schema, OpenAPI, or generated-artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] Directly verified all three guards: `isUnsafePublicUrl([fec0::1])`, the prober DNS-aware guard with an `fec0::1` AAAA answer, and `isUnsafeUrl([fec0::1])` all now return unsafe; `fe80::/10`, public hosts, and `fedora.org`-style hostnames are unaffected.
- [x] `git diff --check`
- Full `npm run worker:test` / `test:coverage` suite runs in CI.

## Template Used

- Backend/code change