### PR TITLE
fix(api): /rpc/usage latency percentiles use nearest-rank, not floor(q*N)+1

### DIFF
--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -3257,8 +3257,8 @@ async function handleRpcUsage(request, env, url) {
            FROM rpc_proxy_events
            WHERE observed_at >= ? AND latency_ms IS NOT NULL
          )
-         SELECT MAX(CASE WHEN rn = CAST(0.50 * cnt AS INTEGER) + 1 THEN latency_ms END) AS p50,
-                MAX(CASE WHEN rn = CAST(0.95 * cnt AS INTEGER) + 1 THEN latency_ms END) AS p95
+         SELECT MAX(CASE WHEN rn = CAST(0.50 * cnt AS INTEGER) + (0.50 * cnt > CAST(0.50 * cnt AS INTEGER)) THEN latency_ms END) AS p50,
+                MAX(CASE WHEN rn = CAST(0.95 * cnt AS INTEGER) + (0.95 * cnt > CAST(0.95 * cnt AS INTEGER)) THEN latency_ms END) AS p95
          FROM ranked`,
         [since],
       ),


### PR DESCRIPTION
## Summary
The latency p50/p95 query for `GET /api/v1/rpc/usage` (`handleRpcUsage`) still used the `floor(q*N) + 1` nearest-rank ordinal, which overshoots by one whenever `q*N` is an integer. The canonical helper `latencyStatColumns` in `src/health-sql.mjs` was corrected to true nearest-rank in #1527, but that fix never reached this hand-rolled copy in `workers/api.mjs`, so the two analytics routes reported percentiles differently for the same kind of data.

## Fix
Mirror the canonical form from `src/health-sql.mjs` - `CAST(q*cnt AS INTEGER)` truncates toward zero (= floor for non-negative `q*cnt`), so add 1 only when there is a fractional part, which is `ceil(q*N)`:

```sql
CAST(0.50 * cnt AS INTEGER) + (0.50 * cnt > CAST(0.50 * cnt AS INTEGER))
```

For `cnt = 100` this now correctly picks ranks 50/95 instead of 51/96.

## Why no new behavioural test
The percentile branch is intentionally mocked in `tests/rpc-usage.test.mjs` (D1 is a stub that returns literal `{ p50, p95 }` for the `ranked` query), so the SQL ranking math isn't executed in-suite. The query still contains `ranked`, so the existing mock matcher and all current assertions are unchanged. The identical formula is already exercised and proven correct by `src/health-sql.mjs`'s percentile tests.

Closes #1542