### PR TITLE
fix(graphql): fall back to the default page on limit:0 instead of clamping to 1

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -233,8 +233,18 @@ export function maxComplexityRule(max) {
 
 // --- Pagination ---
 
+const DEFAULT_PAGE_LIMIT = 20;
+const MAX_PAGE_LIMIT = 100;
+
 function paginate(items, limit, cursor, keyFn) {
-  const safeLimit = Math.min(Math.max(1, limit ?? 20), 100);
+  // A missing/blank/<1 limit falls back to the default — it must NOT clamp UP to
+  // 1. An explicit `limit: 0` reaching `Math.max(1, …)` would return a single
+  // result, which reads to an agent as "this registry knows one subnet" (the same
+  // reasoning as clampLimit in src/mcp-server.mjs and src/ai-search.mjs).
+  const safeLimit =
+    typeof limit === "number" && Number.isFinite(limit) && limit >= 1
+      ? Math.min(MAX_PAGE_LIMIT, Math.floor(limit))
+      : DEFAULT_PAGE_LIMIT;
   let start = 0;
   if (cursor) {
     const idx = items.findIndex((item) => String(keyFn(item)) === cursor);

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -412,6 +412,27 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     assert.equal(body.data.subnets.total, 3);
   });
 
+  test("subnets limit:0 falls back to the default page (not clamped up to 1)", async () => {
+    const env = fakeArtifactEnv({
+      "/metagraph/subnets.json": {
+        subnets: [
+          { netuid: 1, name: "A", slug: "a" },
+          { netuid: 2, name: "B", slug: "b" },
+          { netuid: 3, name: "C", slug: "c" },
+        ],
+      },
+    });
+    for (const limit of [0, -5]) {
+      const { status, body } = await gql(
+        `{ subnets(limit: ${limit}) { items { netuid } total } }`,
+        env,
+      );
+      assert.equal(status, 200);
+      assert.equal(body.data.subnets.items.length, 3, `limit:${limit}`);
+      assert.equal(body.data.subnets.total, 3);
+    }
+  });
+
   test("subnet resolves a single subnet by netuid", async () => {
     const env = fakeArtifactEnv({
       "/metagraph/subnets/7.json": {


### PR DESCRIPTION
## Summary

Closes #1545.

`paginate()` in the GraphQL layer clamped the page size with `Math.min(Math.max(1, limit ?? 20), 100)`, so an explicit `limit: 0` (or any negative) was clamped **up to 1** — the query returned a single item instead of the default page.

The codebase already established and documented the opposite convention. From `clampLimit` in `src/mcp-server.mjs`:

> A missing/blank/<1 limit falls back to the default — it must NOT clamp UP to 1. `Math.max(1, …)` would return a single result, which reads to an agent as "this registry knows one subnet" (see the same fix in `src/ai-search.mjs`).

The GraphQL read layer is agent-facing with the same failure mode, but still used the `Math.max(1, …)` anti-pattern.

## What Changed

- `src/graphql.mjs` — `paginate()` now treats a non-finite / `< 1` limit as "use the default" (20); a valid limit is floored and upper-clamped to 100. Behaviour for normal limits is unchanged.
- Test: `subnets(limit: 0)` and `limit: -5` now return the full default page (3 of 3 fixture rows), not 1.

No schema, OpenAPI, or generated-artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] Verified the new clamp across limit = 0, -5, null, undefined, NaN (→ 20), 1/2/100 (unchanged), 1000 (→ 100), 3.9 (→ 3).
- [x] `git diff --check`
- Full `npm run worker:test` / `test:coverage` suite runs in CI.

## Template Used

- Backend/code change