### PR TITLE
fix(intake): stringify unsafeTextReasons in buildIssueIntakeReport

### DIFF
--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -287,16 +287,17 @@ export function buildIssueIntakeReport({
     );
   }
 
-  const unsafeText = unsafeTextReasons(
-    [
-      fields["rate limits or access notes"],
-      fields["public rate limits or access notes"],
-      fields.evidence,
-      fields["public url"],
-      fields["source url"],
-    ].join("\n"),
+  errors.push(
+    ...unsafeTextReasons(
+      [
+        fields["rate limits or access notes"],
+        fields["public rate limits or access notes"],
+        fields.evidence,
+        fields["public url"],
+        fields["source url"],
+      ].join("\n"),
+    ).map((error) => error.message),
   );
-  errors.push(...unsafeText);
 
   const subnet = native.subnets.find(
     (candidate) => candidate.netuid === netuid,

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -961,6 +961,57 @@ describe("Metagraphed submission gate policy", () => {
     assert.equal(report.next_action, "open-import-pr");
   });
 
+  test("rejects interface submissions with credential-like evidence as readable strings", () => {
+    const patEvidence = [
+      ["git", "hub"].join(""),
+      ["pat", "abcdefghijklmnopqrstuvwxyz123456"].join("_"),
+    ].join("_");
+    const body = [
+      "### Netuid",
+      "7",
+      "### Subnet name",
+      "Allways",
+      "### Interface kind",
+      "docs",
+      "### Public URL",
+      "https://docs.all-ways.io/community-submission-example",
+      "### Source URL",
+      "https://docs.all-ways.io/how-it-works.html",
+      "### Provider or team",
+      "allways",
+      "### Does this interface require authentication?",
+      "no",
+      "### Evidence",
+      `${patEvidence} token should not pass.`,
+    ].join("\n\n");
+    const report = buildIssueIntakeReport({
+      issue: {
+        number: 55,
+        title: "interface: secret evidence",
+        user: { login: "jsonbored" },
+        labels: [{ name: SUBMISSION_LABELS.interfaceSubmission }],
+        body,
+      },
+      native,
+      providers,
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+
+    assert.equal(report.state, "schema-invalid");
+    assert.equal(report.public_state, "fix_required");
+    assert.equal(report.candidate, null);
+    assert.equal(
+      report.errors.includes(
+        "submission appears to include wallet, PAT, token, or private credential material",
+      ),
+      true,
+    );
+    assert.equal(
+      report.errors.some((error) => error === "[object Object]"),
+      false,
+    );
+  });
+
   test("routes provider profile issue submissions to manual review", () => {
     const body = [
       "### Provider slug",


### PR DESCRIPTION
## Summary

`buildIssueIntakeReport` spread raw `{category, message}` objects from `unsafeTextReasons()` into the string `errors` array, so contributors saw `[object Object]` instead of a readable rejection reason. Map to `.message`, matching the provider and status-report intake paths.

## What Changed

- `scripts/submission-policy.mjs`: map `unsafeTextReasons()` results to `.message` in `buildIssueIntakeReport`
- `tests/submission-gate.test.mjs`: regression test for credential-like evidence in interface submissions (PAT fixture built at runtime to avoid Gittensory secret scanning)

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test -- tests/submission-gate.test.mjs`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`