### PR TITLE
fix(api): size internal-ingest bodies by UTF-8 bytes, not UTF-16 units

### DIFF
--- a/tests/economics-backfill.test.mjs
+++ b/tests/economics-backfill.test.mjs
@@ -152,6 +152,20 @@ test("economics backfill rejects too many rows (413)", async () => {
   assert.equal(res.status, 413);
 });
 
+test("economics backfill sizes the body by UTF-8 bytes, not UTF-16 code units (413)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  // 400k three-byte chars: 400_000 UTF-16 code units (under the 1 MiB byte cap)
+  // but ~1.2 MB of UTF-8 (over it). A code-unit check would wrongly admit it.
+  const res = await handleEconomicsBackfill(
+    post("あ".repeat(400000), { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 413);
+});
+
 test("economics backfill returns 503 when the history store is unavailable", async () => {
   const env = { METAGRAPH_EVENTS_INGEST_SECRET: SECRET }; // authed but no DB
   const res = await handleEconomicsBackfill(

--- a/tests/event-ingest.test.mjs
+++ b/tests/event-ingest.test.mjs
@@ -214,6 +214,21 @@ test("ingest rejects an oversized body (413)", async () => {
   assert.equal(res.status, 413);
 });
 
+test("ingest sizes the body by UTF-8 bytes, not UTF-16 code units (413)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  // 100k three-byte chars: 100_000 UTF-16 code units (under the byte cap) but
+  // ~300_000 UTF-8 bytes (over it). A code-unit check would wrongly let it past
+  // the guard; a byte check rejects it.
+  const res = await handleEventIngest(
+    post("あ".repeat(100000), { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 413);
+});
+
 test("ingest rejects a non-array body (400)", async () => {
   const env = {
     METAGRAPH_EVENTS_INGEST_SECRET: SECRET,

--- a/tests/neuron-backfill.test.mjs
+++ b/tests/neuron-backfill.test.mjs
@@ -142,6 +142,20 @@ test("backfill rejects too many rows (413)", async () => {
   assert.equal(res.status, 413);
 });
 
+test("backfill sizes the body by UTF-8 bytes, not UTF-16 code units (413)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  // 400k three-byte chars: 400_000 UTF-16 code units (under the 1 MiB byte cap)
+  // but ~1.2 MB of UTF-8 (over it). A code-unit check would wrongly admit it.
+  const res = await handleNeuronBackfill(
+    post("あ".repeat(400000), { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 413);
+});
+
 test("backfill returns 503 when the history store is unavailable", async () => {
   const env = { METAGRAPH_EVENTS_INGEST_SECRET: SECRET }; // authed but no DB
   const res = await handleNeuronBackfill(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -645,7 +645,7 @@ export async function handleEventIngest(request, env) {
     return errorResponse("unavailable", "Event store unavailable.", 503);
   }
   const raw = await request.text();
-  if (raw.length > MAX_EVENTS_INGEST_BODY_BYTES) {
+  if (utf8Bytes(raw).length > MAX_EVENTS_INGEST_BODY_BYTES) {
     return errorResponse(
       "payload_too_large",
       `Body exceeds ${MAX_EVENTS_INGEST_BODY_BYTES} bytes.`,
@@ -733,7 +733,7 @@ export async function handleNeuronBackfill(request, env) {
     return errorResponse("unavailable", "History store unavailable.", 503);
   }
   const raw = await request.text();
-  if (raw.length > MAX_BACKFILL_INGEST_BODY_BYTES) {
+  if (utf8Bytes(raw).length > MAX_BACKFILL_INGEST_BODY_BYTES) {
     return errorResponse(
       "payload_too_large",
       `Body exceeds ${MAX_BACKFILL_INGEST_BODY_BYTES} bytes.`,
@@ -821,7 +821,7 @@ export async function handleEconomicsBackfill(request, env) {
     return errorResponse("unavailable", "History store unavailable.", 503);
   }
   const raw = await request.text();
-  if (raw.length > MAX_BACKFILL_INGEST_BODY_BYTES) {
+  if (utf8Bytes(raw).length > MAX_BACKFILL_INGEST_BODY_BYTES) {
     return errorResponse(
       "payload_too_large",
       `Body exceeds ${MAX_BACKFILL_INGEST_BODY_BYTES} bytes.`,


### PR DESCRIPTION
## Summary
Three internal-ingest handlers compared `raw.length` (UTF-16 code units) against their `MAX_*_INGEST_BODY_BYTES` caps, even though the caps and the 413 message are defined in bytes. A body of multi-byte UTF-8 characters could exceed the real byte ceiling while passing the guard.

## Fix
Count UTF-8 bytes via the in-file `utf8Bytes` helper at all three sites (events ingest line 649, history backfill lines 737/825), matching the staged-neuron guard (line 390) and `readBoundedRequestText`.

A 256 KB events cap of 262,144 three-byte characters is ~786 KB but only 262,144 UTF-16 code units (3x the cap) -- under the old check it passed; now it is correctly rejected.

## Tests
Added a regression test in `tests/event-ingest.test.mjs`: a body of 100k three-byte chars (100,000 UTF-16 units, under the cap, but ~300,000 bytes, over it) is now rejected with 413. Existing tests are unchanged.

Closes #1544