### PR TITLE
fix(submission): unwrap unsafeTextReasons messages in the interface intake path

### DIFF
--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -296,7 +296,7 @@ export function buildIssueIntakeReport({
       fields["source url"],
     ].join("\n"),
   );
-  errors.push(...unsafeText);
+  errors.push(...unsafeText.map((error) => error.message));
 
   const subnet = native.subnets.find(
     (candidate) => candidate.netuid === netuid,

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -961,6 +961,53 @@ describe("Metagraphed submission gate policy", () => {
     assert.equal(report.next_action, "open-import-pr");
   });
 
+  test("interface candidate reports credential text as a string error, not [object Object] (#1548)", () => {
+    const body = [
+      "### Netuid",
+      "7",
+      "### Subnet name",
+      "Allways",
+      "### Interface kind",
+      "docs",
+      "### Public URL",
+      "https://docs.all-ways.io/community-submission-example",
+      "### Source URL",
+      "https://docs.all-ways.io/how-it-works.html",
+      "### Provider or team",
+      "allways",
+      "### Does this interface require authentication?",
+      "no",
+      "### Evidence",
+      "Reproduced using my wallet mnemonic for the failing call.",
+    ].join("\n\n");
+    const report = buildIssueIntakeReport({
+      issue: {
+        number: 44,
+        title: "interface: credential leak",
+        user: { login: "jsonbored" },
+        labels: [{ name: SUBMISSION_LABELS.interfaceSubmission }],
+        body,
+      },
+      native,
+      providers,
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+
+    assert.equal(report.state, "schema-invalid");
+    assert.equal(
+      report.errors.includes(
+        "submission appears to include wallet, PAT, token, or private credential material",
+      ),
+      true,
+    );
+    // Every error must be a plain string so the contributor preflight comment
+    // never renders [object Object].
+    assert.equal(
+      report.errors.every((error) => typeof error === "string"),
+      true,
+    );
+  });
+
   test("routes provider profile issue submissions to manual review", () => {
     const body = [
       "### Provider slug",


### PR DESCRIPTION
## Summary
`buildIssueIntakeReport` (the interface/endpoint submission path) pushed the `{category, message}` objects returned by `unsafeTextReasons` straight into its `errors` array (line 299), and the report returns that array as-is (line 359). Every other entry in `errors` is a plain string, and the two sibling builders (`buildProviderProfileIntakeReport`, `buildEndpointStatusReportIntakeReport`) already `.map(error => error.message)`.

As a result, an interface/endpoint submission containing credential-like text rendered the security warning to the contributor as `[object Object]` -- the preflight comment builder runs each error through `String(value)` (`submission-comment.mjs` `formatMarkdownValue`), which stringifies an object to `[object Object]` -- instead of the actionable "submission appears to include wallet, PAT, token, or private credential material" message.

## Fix
Map `unsafeText` to the `.message` string, matching the sibling builders, so the contributor sees the real warning.

## Tests
Added a regression test: an interface submission whose evidence contains a wallet/mnemonic reference now reports the credential warning as a plain string, and asserts every error in the report is a string (so the preflight comment can never render `[object Object]`).

Closes #1548