### PR TITLE
fix(webhooks): continue the delivery round when the parked snapshot is truncated

### DIFF
--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -786,12 +786,15 @@ export async function dispatchWithRedelivery({
       if (result.status === "delivered") {
         if (wasParked) await safeDelete(key); // recovered → clear the prior park
       } else if (result.status === "failed" && result.retryable) {
-        await park(
-          key,
-          wasParked ? await safeGet(key) : null,
-          result,
-          freshBody,
-        );
+        // Read the prior record straight from KV, not via `wasParked`: the parked
+        // snapshot is capped at `redeliveryListLimit` and KV lists
+        // lexicographically, so a still-parked key sorting past the cap is absent
+        // from the snapshot. Trusting `wasParked` there would re-park it as a
+        // brand-new record (round reset to 1, backoff + first_failed_at reset), so
+        // a chronically-failing endpoint with a large backlog never reaches the
+        // dead-letter cap. safeGet returns null on a genuine miss, so the healthy
+        // "nothing parked yet" path still parks at round 1.
+        await park(key, await safeGet(key), result, freshBody);
       }
     }
   }

--- a/tests/webhooks-redelivery.test.mjs
+++ b/tests/webhooks-redelivery.test.mjs
@@ -254,6 +254,64 @@ describe("dispatchWithRedelivery", () => {
     assert.equal(record.first_failed_at, T0); // preserved across rounds
   });
 
+  test("Phase 1 re-park continues the round even when the parked snapshot is truncated by redeliveryListLimit", async () => {
+    // KV lists lexicographically and the parked snapshot is capped at
+    // redeliveryListLimit. A still-parked key sorting past the cap is absent from
+    // the snapshot, so `wasParked` is false — but the record still exists in KV.
+    // The re-park must continue its round, not reset it to 1.
+    const map = new Map();
+    const limitStore = {
+      async listKeys(prefix, opts = {}) {
+        let ks = [...map.keys()].filter((k) => k.startsWith(prefix)).sort();
+        if (opts.limit) ks = ks.slice(0, opts.limit);
+        return ks;
+      },
+      async get(k) {
+        return map.has(k) ? JSON.parse(map.get(k)) : null;
+      },
+      async put(k, v) {
+        map.set(k, JSON.stringify(v));
+      },
+      async delete(k) {
+        map.delete(k);
+      },
+    };
+    const eid = await webhookEventId(JSON.stringify(event7));
+    const targetKey = deliveryStorageKey("sub-7", eid);
+    map.set(
+      targetKey,
+      JSON.stringify({
+        subscription_id: "sub-7",
+        event_id: eid,
+        round: 2,
+        state: "pending",
+        first_failed_at: "2026-06-20T00:00:00.000Z",
+        body: JSON.stringify(event7),
+        next_attempt_at: T0,
+      }),
+    );
+    // A decoy that sorts before targetKey ("sub-0" < "sub-7") fills the 1-slot
+    // snapshot, truncating targetKey away.
+    map.set(`${WEBHOOK_DELIVERY_PREFIX}sub-0:${"z".repeat(32)}`, "{}");
+
+    await dispatchWithRedelivery({
+      subscriptions: [SUB],
+      event: event7,
+      store: limitStore,
+      fetchFn: fail503,
+      now: () => "2026-06-22T00:00:05.000Z",
+      maxAttempts: 1,
+      redeliveryBaseMs: 1000,
+      redeliveryMaxMs: 60_000,
+      maxRounds: 5,
+      redeliveryListLimit: 1,
+    });
+
+    const record = JSON.parse(map.get(targetKey));
+    assert.equal(record.round, 3); // continued, not reset to 1
+    assert.equal(record.first_failed_at, "2026-06-20T00:00:00.000Z"); // preserved
+  });
+
   test("does NOT park a deterministic 4xx failure", async () => {
     store = makeStore();
     const { delivered } = await run({


### PR DESCRIPTION
## Summary

Closes #1559.

`dispatchWithRedelivery` snapshots the parked-delivery backlog with `safeListKeys(WEBHOOK_DELIVERY_PREFIX, redeliveryListLimit)` (cap 256) and infers "was this already parked?" from that snapshot. Cloudflare KV lists keys **lexicographically**, so once the backlog exceeds the cap, a still-parked delivery whose key sorts past the cap is absent from the snapshot. When that event is re-published while the endpoint is still failing, Phase 1 re-parked it as a brand-new record:

```js
park(key, wasParked ? await safeGet(key) : null, ...)
```

`wasParked` is false (truncated away), so `existing` is null and `nextDeliveryRecord` resets `round` to 1, resets the exponential backoff to `baseMs`, and resets `first_failed_at` to now. A chronically-failing endpoint with a large backlog then **never reaches the dead-letter cap** (`round >= maxRounds`) and its backoff is pinned at `baseMs` — defeating the bounded-backoff and dead-letter guarantees this module documents.

## What Changed

- `src/webhooks.mjs` — Phase 1 re-park reads the prior record straight from KV (`await safeGet(key)`) instead of gating on the truncated snapshot. `safeGet` returns null on a genuine miss, so the healthy "nothing parked yet" path still parks at round 1; the delivered-branch fast path (no blind writes) is unchanged.
- `tests/webhooks-redelivery.test.mjs` — regression test with a limit-respecting store + a decoy key that truncates the target away; asserts the round continues (3) and `first_failed_at` is preserved.

Verified locally: with no truncation the round continues to 3; pre-fix under truncation it reset to 1; post-fix it continues to 3 with `first_failed_at` preserved. No schema/OpenAPI/artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] Independently exercised dispatchWithRedelivery with a truncating store (round 1 pre-fix vs 3 post-fix; first_failed_at preserved).
- [x] `git diff --check`
- Full `npm run worker:test` / `test:coverage` runs in CI.

## Template Used

- Backend/code change