### PR TITLE
fix(api): make the degraded /health 503 no-store so the edge cannot pin it

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -235,6 +235,9 @@ describe("/health readiness", () => {
     const res = await handleRequest(req("/health"), env, {});
     assert.equal(res.status, 503);
     assert.equal(res.headers.get("x-metagraph-health"), "degraded");
+    // A transient degraded 503 must not be edge-cached (it would pin the outage
+    // for up to max-age + stale-while-revalidate after recovery).
+    assert.equal(res.headers.get("cache-control"), "no-store");
     const body = await res.json();
     assert.equal(body.status, "degraded");
     assert.equal(body.freshness.stale, true);
@@ -250,6 +253,8 @@ describe("/health readiness", () => {
     const res = await handleRequest(req("/health"), env, {});
     assert.equal(res.status, 200);
     assert.equal((await res.json()).status, "ok");
+    // The healthy path stays edge-cacheable (short profile) for load relief.
+    assert.match(res.headers.get("cache-control"), /max-age=/);
   });
 
   test("reports chain-event index freshness (#1361)", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -4159,6 +4159,14 @@ async function handleHealthRequest(request, env) {
 
   const headers = apiHeaders("short");
   headers.set("x-metagraph-health", stale ? "degraded" : "ok");
+  if (stale) {
+    // The degraded branch is a transient 503; a 503 carrying explicit freshness
+    // (public, max-age=60, stale-while-revalidate=300) is cacheable per RFC 7234,
+    // so a shared/edge cache could keep serving "degraded" for up to ~6 min after
+    // the data recovers. Never cache it — mirror errorResponse in workers/http.mjs.
+    headers.set("cache-control", "no-store");
+    headers.set("x-metagraph-cache-profile", "no-store");
+  }
   return new Response(request.method === "HEAD" ? null : body, {
     status: stale ? 503 : 200,
     headers,


### PR DESCRIPTION
## Summary

Closes #1561.

handleHealthRequest returns the degraded branch as HTTP 503 but with apiHeaders("short") -- public, max-age=60, stale-while-revalidate=300. A 503 carrying explicit freshness is cacheable per RFC 7234, so a shared/edge cache (or browser/proxy) can keep serving "degraded" for up to max-age + stale-while-revalidate (~6 min) after the underlying data recovers -- exactly the failure errorResponse (workers/http.mjs) already guards against (its comment: "a transient 5xx ... would otherwise be served stale ... turning a blip into a multi-minute edge outage"). /health degraded is precisely such a transient 5xx, but it skipped that guard.

## What Changed

- workers/api.mjs -- set cache-control: no-store (+ x-metagraph-cache-profile: no-store) on the degraded (stale -> 503) branch, mirroring errorResponse. The healthy 200 path keeps the short edge-cache profile for load relief.
- tests/api-coverage.test.mjs -- assert the degraded 503 is no-store and the healthy 200 keeps a max-age= profile.

No schema/OpenAPI/artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None in this PR.)

## Validation

- [x] Existing /health tests extended with cache-control assertions (degraded -> no-store; ok -> max-age).
- [x] git diff --check
- Full npm run worker:test / test:coverage runs in CI.

## Template Used

- Backend/code change