### PR TITLE
feat(feeds): optional ?tag= filter to narrow a feed to one tag

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -9,6 +9,13 @@
 //   /api/v1/feeds/incidents[.rss|.atom|.json]
 //   /api/v1/feeds/subnets/{netuid}[.rss|.atom|.json]
 // Format precedence: explicit .rss/.atom/.json suffix > Accept header > JSON Feed.
+//
+// Optional `?tag=<tag>` narrows a feed to items carrying that tag, so a single
+// feed URL can serve a focused subscription (e.g. ?tag=incident, ?tag=coverage,
+// ?tag=artifact). Item tags: registry items carry "registry" + one of
+// "subnet"/"artifact"/"coverage" + the change verb (added/removed/renamed/
+// modified); incident items carry "incident", "sn<netuid>", and
+// "ongoing"/"resolved". An unknown tag yields an empty (but valid) feed.
 
 const SITE_URL = "https://metagraph.sh";
 const API_URL = "https://api.metagraph.sh";
@@ -199,6 +206,14 @@ function sortAndCap(items) {
   return [...items]
     .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
     .slice(0, FEED_MAX_ITEMS);
+}
+
+// Optional `?tag=` filter: keep only items whose tags array includes the value.
+// A falsy/absent tag is a no-op (the whole feed). The tag is only ever compared,
+// never rendered into the feed body, so it needs no escaping.
+function filterByTag(items, tag) {
+  if (!tag) return items;
+  return items.filter((item) => (item.tags || []).includes(tag));
 }
 
 function jsonFeed(meta, items) {
@@ -394,6 +409,7 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
     updatedSource = changelog?.generated_at;
   }
 
+  items = filterByTag(items, url.searchParams.get("tag"));
   items = sortAndCap(items);
   const meta = {
     title,
@@ -438,4 +454,5 @@ export const __test = {
   rssFeed,
   atomFeed,
   escapeXml,
+  filterByTag,
 };

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -10,8 +10,15 @@ import {
 import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 
-const { registryItems, incidentItems, jsonFeed, rssFeed, atomFeed, escapeXml } =
-  __test;
+const {
+  registryItems,
+  incidentItems,
+  jsonFeed,
+  rssFeed,
+  atomFeed,
+  escapeXml,
+  filterByTag,
+} = __test;
 
 const CHANGELOG = {
   generated_at: "2026-06-15T00:00:00.000Z",
@@ -216,6 +223,39 @@ describe("feeds — item builders", () => {
   });
 });
 
+describe("feeds — filterByTag", () => {
+  const items = [
+    { id: "a", tags: ["registry", "subnet", "added"] },
+    { id: "b", tags: ["registry", "coverage"] },
+    { id: "c", tags: ["incident", "sn7", "ongoing"] },
+  ];
+
+  test("a null/empty tag is a no-op (returns the input)", () => {
+    assert.equal(filterByTag(items, null), items);
+    assert.equal(filterByTag(items, ""), items);
+    assert.equal(filterByTag(items, undefined), items);
+  });
+
+  test("keeps only items carrying the tag", () => {
+    assert.deepEqual(
+      filterByTag(items, "incident").map((i) => i.id),
+      ["c"],
+    );
+    assert.deepEqual(
+      filterByTag(items, "registry").map((i) => i.id),
+      ["a", "b"],
+    );
+  });
+
+  test("an unknown tag yields an empty list", () => {
+    assert.deepEqual(filterByTag(items, "nope"), []);
+  });
+
+  test("an item with no tags array is safely skipped", () => {
+    assert.deepEqual(filterByTag([{ id: "x" }], "incident"), []);
+  });
+});
+
 describe("feeds — serializers", () => {
   const meta = {
     title: "t",
@@ -345,6 +385,40 @@ describe("feeds — handleFeedRequest", () => {
     const parsed = JSON.parse(text);
     assert.equal(parsed.items.length, 0);
     assert.ok(parsed.title && parsed.feed_url);
+  });
+
+  test("?tag= narrows the registry feed to matching items", async () => {
+    const { res, text } = await feed("/api/v1/feeds/registry?tag=coverage");
+    assert.equal(res.status, 200);
+    const parsed = JSON.parse(text);
+    assert.ok(parsed.items.length > 0);
+    assert.ok(parsed.items.every((i) => i.id.startsWith("registry:coverage")));
+  });
+
+  test("?tag= on a per-subnet feed keeps only that tag across both sources", async () => {
+    const { text } = await feed("/api/v1/feeds/subnets/7?tag=incident");
+    const parsed = JSON.parse(text);
+    assert.ok(parsed.items.length > 0);
+    assert.ok(parsed.items.every((i) => i.id.startsWith("incident:")));
+  });
+
+  test("an unknown ?tag= yields a valid but empty feed", async () => {
+    const { res, text } = await feed(
+      "/api/v1/feeds/registry?tag=does-not-exist",
+    );
+    assert.equal(res.status, 200);
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.items.length, 0);
+    assert.ok(parsed.title && parsed.feed_url);
+  });
+
+  test("no ?tag= returns the full feed (filter is a no-op)", async () => {
+    const all = await feed("/api/v1/feeds/registry");
+    const tagged = await feed("/api/v1/feeds/registry?tag=registry");
+    const allItems = JSON.parse(all.text).items.length;
+    const taggedItems = JSON.parse(tagged.text).items.length;
+    // Every registry item carries the "registry" tag, so the two match.
+    assert.equal(taggedItems, allItems);
   });
 });
 


### PR DESCRIPTION
## Summary

- Add an optional `?tag=<tag>` query param to the content feeds so a single feed URL can serve a focused subscription (e.g. incidents-only, coverage-only) without a new route.

## What Changed

Every feed item already carries a `tags` array, but subscribers could only take the whole feed:
- registry items → `["registry", "subnet"|"artifact"|"coverage", <change verb>]`
- incident items → `["incident", "sn<netuid>", "ongoing"|"resolved"]`

`?tag=` keeps only items whose `tags` include the value, applied to all three feed kinds (`registry`, `incidents`, merged per-subnet) before sort/cap:

```
GET /api/v1/feeds/registry?tag=coverage      # only coverage-delta items
GET /api/v1/feeds/incidents.rss?tag=ongoing  # only ongoing incidents
GET /api/v1/feeds/subnets/7?tag=incident     # only incidents for sn7
```

Backward-compatible: an absent/empty tag is a no-op (the full feed); an unknown tag yields a valid but empty feed. The tag is only ever compared (`Array.includes`), never rendered into the feed body, so it needs no escaping.

One file (`src/feeds.mjs`): a small pure `filterByTag` helper + one handler line. No contract churn — feed query params are not in the OpenAPI/schemas.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none — additive optional query param, feeds aren't in the OpenAPI)

## Validation

- [x] `npm run lint` / `npm run format:check` — clean
- [x] `npx vitest run tests/feeds.test.mjs` — 31 passed (filterByTag unit tests cover all branches; handler tests cover registry, per-subnet, unknown-tag, and no-tag paths)
- [x] 100% branch coverage of the changed lines (verified via lcov BRDA)
- [x] `git diff --check`