### PR TITLE
feat(registry): add SN74 Gittensor public dashboard candidate

### DIFF
--- a/registry/candidates/community/community-sn-74-dashboard-gittensor-io.json
+++ b/registry/candidates/community/community-sn-74-dashboard-gittensor-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-74-dashboard-gittensor-io",
+      "kind": "dashboard",
+      "name": "Gittensor public dashboard",
+      "netuid": 74,
+      "provider": "gittensor",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://gittensor.io/",
+      "source_urls": ["https://gittensor.io/"],
+      "state": "schema-valid",
+      "url": "https://gittensor.io/dashboard"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "carlh7777",
+    "submitted_by_url": "https://github.com/carlh7777"
+  }
+}


### PR DESCRIPTION
## Pick The Right Template

Use the matching PR template so the submission gate can classify your PR
correctly:

- [x] [Direct subnet/interface candidate](?template=direct-candidate.md): one
  `registry/candidates/community/*.json` file only.
- [ ] [Provider/operator profile](?template=provider-profile.md): one
  `registry/providers/community/*.json` file only.
- [ ] [Backend/code change](?template=backend-code.md): scripts, schemas,
  contracts, workflows, or registry generator logic.
- [ ] [Docs-only change](?template=docs-only.md): README or docs edits only.

For direct UGC submissions, do not edit generated `public/metagraph/**`
artifacts, native snapshots, scripts, workflows, package files, or multiple
candidate/provider files.

## Summary

Community submission for **Subnet 74 (Gittensor)** — public `dashboard` surface.

Adds exactly one candidate file for the unauthenticated Gittensor web dashboard linked from the official site navigation. Closes the overlay gap noted in `registry/subnets/gittensor.json` (“No verified dashboard surface yet”). Related to surface enrichment epic #427.

## Template Used

Direct subnet/interface candidate (`direct-candidate.md`)

## Candidate

- **Netuid:** 74
- **Kind:** `dashboard`
- **Public URL:** https://gittensor.io/dashboard
- **Source URL:** https://gittensor.io/
- **Provider/operator:** `gittensor`

## Checklist

- [x] This PR changes exactly one `registry/candidates/community/*.json` file.
- [x] I generated the file with `npm run candidate:new` or matched
      `docs/examples/submissions/direct-candidate.json`.
- [x] The submitted URL is public and safe for read-only probes.
- [x] The source URL publicly supports the interface claim.
- [x] This does not require authentication.
- [x] This does not duplicate an existing Metagraphed surface or candidate.
- [x] This does not include secrets, wallet/PAT data, private URLs, private
      dashboards, validator internals, or generated artifacts.

## Validation

Verified `https://gittensor.io/dashboard` returns HTTP 200 and is linked from the official `https://gittensor.io/` site navigation.

```bash
npm run validate:candidate -- registry/candidates/community/community-sn-74-dashboard-gittensor-io.json
npm run submission:pr -- --changed-files <changed-files.txt>
npm run validate:intake
npm run scan:public-safety