### PR TITLE
fix(icon): resolve icons via page <link rel=icon> (website-only gap)

### DIFF
--- a/src/icon-proxy.mjs
+++ b/src/icon-proxy.mjs
@@ -4,22 +4,30 @@
 //   GET /api/v1/icon?host={domain}&size={px}&theme={light|dark}
 //   -> 200 image/png|x-icon (square, cached) | 404 when no source resolves
 //
-// SSRF SAFETY: sources are the fixed favicon aggregators (DuckDuckGo, Google) PLUS the
-// host's own well-known favicon paths (apple-touch-icon / favicon.ico) — the aggregators
-// are bot-blocked from Worker egress, so the direct same-host fetch is what actually
-// resolves most hosts. Fetching the host directly is safe here because `host` is
-// validated to a plain public DNS name (no IP literals, no localhost/.local/.internal),
-// the Cloudflare Worker runtime cannot reach private/internal addresses, and only an
-// image/* response of sane size is ever returned. Results are cached in R2 (immutable)
-// so repeat loads are a single edge read.
+// Resolution order: (1) the host's OWN page-declared icon via <link rel="icon"> scraped
+// from its HTML root — what actually resolves most real sites; (2) the favicon
+// aggregators (DuckDuckGo, Google), usually bot-blocked from Worker egress; (3) the
+// host's well-known favicon paths (apple-touch-icon / favicon.ico).
+// SSRF SAFETY: `host` is validated to a plain public DNS name (no IP literals, no
+// localhost/.local/.internal); page-declared icon URLs are re-validated the same way
+// (public host, http(s) only) so a hostile page cannot redirect us at an internal
+// target; the Worker runtime cannot reach private/internal addresses; the page fetch is
+// size-capped and only an image/* response of sane size is ever returned. Results are
+// cached in R2 (immutable) so repeat loads are a single edge read.
 const ICON_CACHE_PREFIX = "icon-cache";
 const MAX_SIZE = 256;
 const DEFAULT_SIZE = 64;
 const MIN_ICON_BYTES = 100; // reject empty / 1x1 placeholder responses
 const MAX_ICON_BYTES = 256 * 1024; // bound Worker memory and R2 object size
+const MAX_HTML_BYTES = 256 * 1024; // cap the page fetch when scraping <link rel=icon>
+const MAX_PAGE_ICONS = 4; // most page-declared icons we will try
 const FETCH_TIMEOUT_MS = 3000;
 const CACHE_CONTROL = "public, max-age=2592000, immutable"; // 30d, per contract
 const BLOCKED_TLDS = new Set(["localhost", "local", "internal"]);
+// A real-ish UA — DuckDuckGo/Google's favicon endpoints and some origins bot-block
+// the default Worker user-agent (a cause of the prod 404s).
+const BROWSER_UA =
+  "Mozilla/5.0 (compatible; MetagraphedIconBot/1.0; +https://metagraph.sh)";
 
 function normalizeHost(input) {
   const host = String(input ?? "")
@@ -143,13 +151,120 @@ async function boundedArrayBuffer(res) {
   return out.buffer;
 }
 
-// Resolution order: the favicon-aggregator services first (they parse the page and
-// return the best icon), then the host's OWN well-known favicon paths as a fallback.
-// The aggregators are frequently bot-blocked from Cloudflare Worker egress, so the
-// direct same-host paths are what actually resolve most subnets. Fetching the host
-// directly is SSRF-safe here: `host` is validated to a public DNS name (no IP
-// literals / localhost / private TLDs) and the Worker runtime cannot reach private/
-// internal addresses; we additionally only accept an image/* response.
+// Extract icon hrefs from raw HTML: every <link> whose rel contains "icon" (icon /
+// shortcut icon / apple-touch-icon / mask-icon). A small targeted regex — NOT a general
+// HTML parser — over a size-capped page head. Pure + exported for tests; runs identically
+// in node + the Worker (Cloudflare's HTMLRewriter is unavailable in the unit-test
+// runtime, so the tested path IS the prod path).
+export function extractIconHrefs(html) {
+  if (typeof html !== "string" || !html) return [];
+  const attr = (tag, name) => {
+    const m = new RegExp(
+      `\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s">]+))`,
+      "i",
+    ).exec(tag);
+    return m ? (m[2] ?? m[3] ?? m[4] ?? "") : "";
+  };
+  const hrefs = [];
+  const linkRe = /<link\b[^>]*>/gi;
+  let m;
+  while ((m = linkRe.exec(html)) !== null) {
+    const tag = m[0];
+    if (!attr(tag, "rel").toLowerCase().includes("icon")) continue;
+    const href = attr(tag, "href").trim();
+    if (href) hrefs.push(href);
+  }
+  return hrefs;
+}
+
+// Resolve page-declared hrefs to absolute, SSRF-safe http(s) URLs against the host.
+// Rejects non-public hostnames (IP literals / private / localhost) so a hostile page
+// cannot point us at an internal target. Deduped + capped.
+function resolveIconUrls(hrefs, host) {
+  const base = `https://${host}/`;
+  const out = [];
+  const seen = new Set();
+  for (const href of hrefs) {
+    let abs;
+    try {
+      abs = new URL(href, base);
+    } catch {
+      continue;
+    }
+    if (abs.protocol !== "https:" && abs.protocol !== "http:") continue;
+    if (!normalizeHost(abs.hostname)) continue; // SSRF: public DNS names only
+    const s = abs.toString();
+    if (seen.has(s)) continue;
+    seen.add(s);
+    out.push(s);
+    if (out.length >= MAX_PAGE_ICONS) break;
+  }
+  return out;
+}
+
+async function boundedText(res, max) {
+  const reader = res.body?.getReader?.();
+  if (!reader) {
+    const t = await res.text();
+    return t.length > max ? t.slice(0, max) : t;
+  }
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      chunks.push(value);
+      if (total >= max) {
+        await reader.cancel();
+        break;
+      }
+    }
+  } finally {
+    reader.releaseLock?.();
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder("utf-8").decode(out);
+}
+
+// Fetch the host's HTML root and return its declared <link rel="icon"> URLs. THIS is
+// what resolves most real sites: the favicon aggregators are bot-blocked from Worker
+// egress and many sites serve no favicon at a literal root path, but nearly all declare
+// one in the page <head>. Best-effort — any failure yields [] and the caller falls back.
+async function pageDeclaredIconSources(host) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(`https://${host}/`, {
+      headers: {
+        accept: "text/html,application/xhtml+xml",
+        "user-agent": BROWSER_UA,
+      },
+      redirect: "follow",
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timeout));
+    if (!res.ok || !(res.headers.get("content-type") || "").includes("html")) {
+      await res.body?.cancel?.();
+      return [];
+    }
+    const html = await boundedText(res, MAX_HTML_BYTES);
+    return resolveIconUrls(extractIconHrefs(html), host);
+  } catch {
+    return [];
+  }
+}
+
+// Fallback sources, tried after the page-declared icons: the favicon aggregators
+// (frequently bot-blocked from Worker egress) then the host's OWN well-known favicon
+// paths. Fetching the host directly is SSRF-safe here: `host` is validated to a public
+// DNS name (no IP literals / localhost / private TLDs) and the Worker runtime cannot
+// reach private/internal addresses; we additionally only accept an image/* response.
 function faviconSources(host, size) {
   return [
     `https://icons.duckduckgo.com/ip3/${host}.ico`,
@@ -229,21 +344,20 @@ export async function handleIconProxy(request, env, url, options = {}) {
     }
   }
 
-  for (const src of faviconSources(host, size)) {
+  // Page-declared <link rel="icon"> first (the real fix), then aggregators + well-known
+  // paths. Follow redirects (favicons often 30x to a CDN); no cf.cacheEverything (it
+  // forced caching of redirect/non-200 responses and broke resolution) — successful
+  // icons are cached in R2 below.
+  const sources = [
+    ...(await pageDeclaredIconSources(host)),
+    ...faviconSources(host, size),
+  ];
+  for (const src of sources) {
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
       const res = await fetch(src, {
-        // A real-ish UA — DuckDuckGo/Google's favicon endpoints bot-block the
-        // default Worker user-agent (the cause of the prod 404s). Follow redirects
-        // (favicons often 30x to a CDN). Dropped `cf.cacheEverything`, which forced
-        // caching of the services' redirect/non-200 responses and broke resolution;
-        // successful icons are cached in R2 below.
-        headers: {
-          accept: "image/*",
-          "user-agent":
-            "Mozilla/5.0 (compatible; MetagraphedIconBot/1.0; +https://metagraph.sh)",
-        },
+        headers: { accept: "image/*", "user-agent": BROWSER_UA },
         redirect: "follow",
         signal: controller.signal,
       }).finally(() => clearTimeout(timeout));

--- a/tests/icon-proxy.test.mjs
+++ b/tests/icon-proxy.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test, vi } from "vitest";
-import { handleIconProxy } from "../src/icon-proxy.mjs";
+import { handleIconProxy, extractIconHrefs } from "../src/icon-proxy.mjs";
 
 const PNG = new Uint8Array(200).fill(1).buffer; // >100 bytes -> not a placeholder
 
@@ -99,6 +99,80 @@ test("rejects too-small (placeholder) responses -> 404", async () => {
       }),
   });
   assert.equal(res.status, 404);
+});
+
+test("extractIconHrefs parses rel/href variants, ignores non-icon links", () => {
+  const html = `
+    <link rel="icon" href="/a.png">
+    <link rel='shortcut icon' href='/b.ico'>
+    <link rel="apple-touch-icon" href="https://cdn.x.com/c.png">
+    <link rel="stylesheet" href="/styles.css">
+    <link rel="mask-icon" href=/d.svg color=red>`;
+  assert.deepEqual(extractIconHrefs(html), [
+    "/a.png",
+    "/b.ico",
+    "https://cdn.x.com/c.png",
+    "/d.svg",
+  ]);
+  assert.deepEqual(extractIconHrefs(""), []);
+  assert.deepEqual(extractIconHrefs(null), []);
+});
+
+test("resolves an icon declared via <link rel=icon> in the page HTML", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const fetchImpl = async (u) => {
+    const url = String(u);
+    if (url === "https://example.com/") {
+      return new Response(
+        '<html><head><link rel="icon" href="/brand/icon.png"></head></html>',
+        {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        },
+      );
+    }
+    if (url === "https://example.com/brand/icon.png") {
+      return new Response(PNG, {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      });
+    }
+    return new Response("", { status: 404 });
+  };
+  const res = await call("?host=example.com&size=64", { env, fetchImpl });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("content-type"), "image/png");
+});
+
+test("page-declared icon at a private/non-public host is rejected (SSRF)", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  let privateFetched = false;
+  const fetchImpl = async (u) => {
+    const url = String(u);
+    if (url === "https://example.com/") {
+      return new Response(
+        '<html><head><link rel="icon" href="http://localhost/secret.png"></head></html>',
+        { status: 200, headers: { "content-type": "text/html" } },
+      );
+    }
+    if (url.includes("localhost")) {
+      privateFetched = true;
+      return new Response(PNG, {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      });
+    }
+    return new Response("", { status: 404 });
+  };
+  const res = await call("?host=example.com", { env, fetchImpl });
+  assert.equal(privateFetched, false); // never fetched the private target
+  assert.equal(res.status, 404); // nothing else resolves
 });
 
 test("304 on matching If-None-Match (no fetch, no R2)", async () => {


### PR DESCRIPTION
Follow-up to #1536/#1537. The favicon proxy still 404'd for many subnet sites (taostats.io, opentensor.ai): aggregators are Worker-egress-blocked and the direct same-host fallback only catches a literal root `/favicon.ico`. But sites **declare** their icon via `<link rel="icon">` in `<head>`.

- **Primary source now:** fetch the host's HTML root (browser UA, size-capped), extract `<link rel=icon|shortcut icon|apple-touch-icon|mask-icon>` hrefs (small targeted regex — portable node+Worker, so the tested path IS the prod path), resolve→absolute, try before aggregators + well-known paths.
- **SSRF preserved:** page-declared URLs re-validated (public DNS host, http(s) only); page fetch size-capped; only image/* of sane size returned.
- Secondary win — most icons already resolve via the GitHub-avatar fallback ([metagraphed-ui #212](https://github.com/JSONbored/metagraphed-ui/pull/212)).

21 tests pass (+3); lint + prettier clean. Will re-verify the live proxy on taostats.io/opentensor.ai after deploy.