### PR TITLE
feat(badge): metric=grade for a one-glyph A–F reliability badge

### DIFF
--- a/src/badge.mjs
+++ b/src/badge.mjs
@@ -8,6 +8,8 @@
 //   metric=readiness   integration readiness 0–100 (default)
 //   metric=uptime      window uptime %, colored by the A–F reliability grade
 //                      (alias: reliability), from the live uptime rollup in D1
+//   metric=grade       the A–F reliability grade letter itself (e.g. "A") —
+//                      same uptime data + color band as uptime, one-glyph message
 //   style=flat-square  square corners, no gradient (default: flat)
 //   label=…            override the left "metagraphed" segment text
 //
@@ -22,11 +24,13 @@ const NA_MESSAGE = "n/a";
 const UNKNOWN_COLOR = "#9f9f9f";
 const NA_CONTENT = { message: NA_MESSAGE, color: UNKNOWN_COLOR };
 
-// metric query value → internal metric ("uptime"/"reliability" are aliases).
+// metric query value → internal metric ("uptime"/"reliability" are aliases;
+// "grade" shares the reliability data but renders the letter grade as the message).
 const BADGE_METRICS = {
   readiness: "readiness",
   uptime: "reliability",
   reliability: "reliability",
+  grade: "grade",
 };
 // Allow-listed render styles; an unknown value falls back to "flat".
 const BADGE_STYLES = new Set(["flat", "flat-square"]);
@@ -210,13 +214,15 @@ async function readinessContent({ target, readArtifact, env }) {
 }
 
 // Reliability: the subnet's netuid, or all of a provider's netuids, scored from
-// the live uptime rollup in one aggregate query. Message is the window uptime %.
+// the live uptime rollup in one aggregate query, colored by the A–F grade band.
+// The message is the window uptime % — or, for metric=grade, the grade letter.
 async function reliabilityContent({
   target,
   readArtifact,
   env,
   db,
   loadReliability,
+  metric,
 }) {
   let netuids = [];
   if (target.kind === "subnet") {
@@ -233,7 +239,10 @@ async function reliabilityContent({
   const rel = netuids.length ? await loadReliability({ db, netuids }) : null;
   return rel
     ? {
-        message: formatUptimePercent(rel.uptime_ratio),
+        message:
+          metric === "grade"
+            ? rel.grade
+            : formatUptimePercent(rel.uptime_ratio),
         color: gradeColor(rel.grade),
       }
     : NA_CONTENT;
@@ -264,8 +273,8 @@ export async function handleBadgeRequest(request, env, url, deps = {}) {
   let content = NA_CONTENT;
   if (target && typeof readArtifact === "function") {
     content =
-      metric === "reliability"
-        ? await reliabilityContent(ctx)
+      metric === "reliability" || metric === "grade"
+        ? await reliabilityContent({ ...ctx, metric })
         : await readinessContent(ctx);
   }
 

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -133,6 +133,7 @@ describe("badge — rendering", () => {
       parseBadgeOptions(sp("metric=reliability")).metric,
       "reliability",
     );
+    assert.equal(parseBadgeOptions(sp("metric=GRADE")).metric, "grade");
     assert.equal(parseBadgeOptions(sp("metric=bogus")).metric, "readiness");
     // style: flat default; flat-square allowed; anything else → flat.
     assert.equal(parseBadgeOptions(sp("")).style, "flat");
@@ -271,6 +272,33 @@ describe("badge — uptime / reliability metric", () => {
       "/api/v1/subnets/7/badge.svg?metric=uptime&label=uptime",
     );
     assert.match(text, /aria-label="uptime: 99\.83%"/);
+  });
+});
+
+describe("badge — grade metric", () => {
+  test("subnet grade renders the A–F letter, colored by the grade band", async () => {
+    const { text } = await badge("/api/v1/subnets/7/badge.svg?metric=grade");
+    assert.match(text, /aria-label="metagraphed: A"/); // the letter itself
+    assert.match(text, /#2ea44f/); // grade A → green
+    assert.ok(!text.includes("99.83")); // not the uptime % rendering
+    assert.ok(!text.includes("/100")); // not the readiness rendering
+  });
+
+  test("provider grade is the rollup grade across its subnets", async () => {
+    const { text } = await badge(
+      "/api/v1/providers/datura/badge.svg?metric=grade",
+    );
+    assert.match(text, /aria-label="metagraphed: D"/);
+    assert.match(text, /#dfb317/); // grade D → yellow
+  });
+
+  test("unknown subnet grade degrades to n/a (gray, still 200)", async () => {
+    const { res, text } = await badge(
+      "/api/v1/subnets/999/badge.svg?metric=grade",
+    );
+    assert.equal(res.status, 200);
+    assert.match(text, /n\/a/);
+    assert.match(text, /#9f9f9f/);
   });
 });
 


### PR DESCRIPTION
Closes #1573

## Summary

- Add `metric=grade` to the badge endpoint: render the A–F reliability **grade letter** (e.g. `A`) as the badge message, for a compact `metagraphed │ A` README badge.

## What Changed

The badge already supports `metric=readiness` (score/100) and `metric=uptime` (window %, colored by the A–F grade). `metric=grade` reuses the **exact same** reliability data load + grade color band as `uptime`, but renders `rel.grade` (the letter) instead of the uptime percent:

```
GET /api/v1/subnets/7/badge.svg?metric=grade     →  metagraphed │ A   (green)
GET /api/v1/providers/datura/badge.svg?metric=grade
```

Single file (`src/badge.mjs`): a `grade` entry in the metric allow-list, a one-line message branch in `reliabilityContent`, and the handler dispatch. Backward-compatible; unknown / no-data still renders `n/a` (200).

Request-time only — no committed artifact or schema derives from badges, so there's no contract churn (verified: a fresh `npm run build` changes nothing under `public/`).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (additive query value; badges aren't in the OpenAPI/schemas)

## Validation

- [x] `npm run lint` / `npm run format:check` — clean
- [x] `npx vitest run` — 1721 passed; new tests cover subnet + provider grade, n/a, and the metric allow-list — 100% branch coverage of the changed lines
- [x] Fresh `npm run build` leaves `public/` unchanged (freshness check clean)
- [x] `git diff --check`