### PR TITLE
fix(scripts): weight array-shaped methods_supported x5 in endpoint score

### DIFF
--- a/scripts/lib/endpoint-artifacts.mjs
+++ b/scripts/lib/endpoint-artifacts.mjs
@@ -521,7 +521,7 @@ function endpointScoreBreakdown(endpoint) {
       Math.min(Object.values(methodSupport).filter(Boolean).length * 5, 20),
     );
   } else if (Array.isArray(methodSupport)) {
-    add("method-support", Math.min(methodSupport.length, 20));
+    add("method-support", Math.min(methodSupport.length * 5, 20));
   }
   if (Number.isFinite(endpoint.latency_ms))
     add("latency", Math.max(0, 20 - Math.round(endpoint.latency_ms / 100)));

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -1969,6 +1969,22 @@ describe("script utility contracts", () => {
     const degradedEndpoint = endpointResources.endpoints.find(
       (endpoint) => endpoint.surface_id === "root-degraded-rpc",
     );
+    // method-support weights each supported method by 5 (capped at 20), and must
+    // do so identically whether methods_supported is object- or array-shaped
+    // (regression: the array branch dropped the x5 multiplier, scoring 5x low).
+    assert.equal(
+      endpointResources.endpoints
+        .find((endpoint) => endpoint.surface_id === "root-rpc")
+        .score_reasons.find((reason) => reason.reason === "method-support")
+        .points,
+      10, // object shape: 2 methods x 5
+    );
+    assert.equal(
+      degradedEndpoint.score_reasons.find(
+        (reason) => reason.reason === "method-support",
+      ).points,
+      5, // array shape: 1 method x 5 (was 1 before the fix)
+    );
     assert.equal(incidents.incidents[0].endpoint_id, failedEndpoint.id);
     assert.equal(
       incidents.incidents[0].surface_key,


### PR DESCRIPTION
## Summary
`endpointScoreBreakdown` scored an array-shaped `methods_supported` as the raw method count (capped at 20), while the object-shaped branch weights each supported method by 5 (`count * 5`, capped at 20). Identical method support therefore scored 5x lower when the field was carried as an array, which can mis-rank endpoints and change `best_endpoint_id` selection.

## Why it is a real bug
Both branches feed the identical `"method-support"` reason and share the same 20-point cap, so they are the same metric. The `Math.min(..., 20)` cap on the array branch is the tell: a raw method count maxes at ~11 (SAFE_RPC_METHODS), so the cap is meaningless unless the value was intended to be `count * 5` (4+ methods -> capped 20), exactly like the object branch. Both shapes reach this scorer (object is the canonical probe output; the array shape is preserved/passed through in the build).

Reproduction (3 supported methods): object `{a:true,b:true,c:true}` -> 15, array `["a","b","c"]` -> 3.

## Fix
Apply the same x5 weight to the array branch.

## Tests
Extended the endpoint-resource test to assert `method-support` points for both shapes: object (`root-rpc`, 2 methods -> 10) and array (`root-degraded-rpc`, 1 method -> 5, was 1 before the fix).

Closes #1558