### PR TITLE
fix(neurons): break validator stake ties by uid for a stable ranking

### DIFF
--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -123,8 +123,11 @@ export async function loadSubnetMetagraph(
 }
 
 export async function loadSubnetValidators(d1, netuid) {
+  // Tie-break equal stake by the unique uid so the ranking is deterministic
+  // across snapshot-replaced captures (without it, SQLite returns tied rows in
+  // arbitrary physical order). Mirrors loadSubnetMetagraph's ORDER BY uid.
   const rows = await d1(
-    `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = 1 ORDER BY stake_tao DESC`,
+    `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? AND validator_permit = 1 ORDER BY stake_tao DESC, uid ASC`,
     [netuid],
   );
   return buildSubnetValidators(rows, netuid);

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -5,6 +5,7 @@ import {
   buildSubnetMetagraph,
   buildSubnetValidators,
   buildNeuronDetail,
+  loadSubnetValidators,
 } from "../src/metagraph-neurons.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
@@ -92,6 +93,47 @@ describe("metagraph-neurons builders", () => {
   test("buildNeuronDetail returns neuron:null for a cold/absent row", () => {
     assert.equal(buildNeuronDetail(null, 7).neuron, null);
     assert.equal(buildNeuronDetail(ROW, 7).neuron.uid, 0);
+  });
+});
+
+describe("metagraph-neurons loaders", () => {
+  // A d1 runner that filters by validator_permit and APPLIES the SQL's ORDER BY
+  // (parsing the real clause), so a missing tie-break would actually reorder the
+  // result — not a circular check that passes regardless.
+  function orderingD1(rows) {
+    return async (sql) => {
+      let r = rows.filter((x) => x.validator_permit === 1);
+      const order = /ORDER BY (.+?)(?:$|\bLIMIT\b)/.exec(sql);
+      if (order) {
+        const keys = order[1]
+          .split(",")
+          .map((part) => part.trim().split(/\s+/));
+        r = [...r].sort((a, b) => {
+          for (const [col, dir] of keys) {
+            const delta = (a[col] - b[col]) * (dir === "DESC" ? -1 : 1);
+            if (delta !== 0) return delta;
+          }
+          return 0;
+        });
+      }
+      return r;
+    };
+  }
+
+  test("loadSubnetValidators ranks by stake, breaking equal-stake ties by uid", async () => {
+    const d1 = orderingD1([
+      { uid: 9, validator_permit: 1, stake_tao: 100 },
+      { uid: 2, validator_permit: 1, stake_tao: 100 }, // tie with uid 9
+      { uid: 5, validator_permit: 1, stake_tao: 250 },
+      { uid: 4, validator_permit: 0, stake_tao: 999 }, // not a validator
+    ]);
+    const data = await loadSubnetValidators(d1, 7);
+    // 250 first; the two 100-stake validators tie → uid ascending (2 before 9).
+    assert.deepEqual(
+      data.validators.map((v) => v.uid),
+      [5, 2, 9],
+    );
+    assert.equal(data.validator_count, 3); // the miner is excluded
   });
 });
 


### PR DESCRIPTION
Closes #1579

## Summary

- `loadSubnetValidators` ranked validators by `ORDER BY stake_tao DESC` with no tie-break, so validators with **equal stake** came back in SQLite's arbitrary physical order — and the `neurons` table is snapshot-replaced each cron, so the ranking of tied validators could change between captures (not stable/reproducible).

## What Changed

```diff
- ... ORDER BY stake_tao DESC
+ ... ORDER BY stake_tao DESC, uid ASC
```

`uid` is unique, so it's a deterministic tie-break — mirroring the sibling `loadSubnetMetagraph`'s `ORDER BY uid`. The loader is shared by the REST `/subnets/{netuid}/validators` route and the `list_subnet_validators` MCP tool, so **both** are stabilized.

Behavioral-only — no I/O-shape or schema change, so no MCP version bump / `server-card.json` regen (verified: a fresh `npm run build` leaves `public/` unchanged).

The new loader test drives a d1 mock that **parses and applies the actual `ORDER BY` clause**, so a missing tie-break genuinely reorders the result (confirmed: the test fails without the fix).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none — output order is now deterministic, shape unchanged)

## Validation

- [x] `npm run lint` / `npm run format:check` — clean
- [x] `npx vitest run` — 1746 passed; the new test fails without the fix (proven)
- [x] Fresh `npm run build` leaves `public/` unchanged (freshness check clean)
- [x] `git diff --check`