### PR TITLE
fix(icon): aggregator-only proxy — remove the SSRF surface

### DIFF
--- a/src/icon-proxy.mjs
+++ b/src/icon-proxy.mjs
@@ -204,7 +204,7 @@ function resolveIconUrls(hrefs, host) {
   return out;
 }
 
-function isSafeHttpUrl(value) {
+export function isSafeHttpUrl(value) {
   let url;
   try {
     url = new URL(String(value));
@@ -213,7 +213,7 @@ function isSafeHttpUrl(value) {
   }
   return (
     (url.protocol === "https:" || url.protocol === "http:") &&
-    normalizeHost(url.hostname)
+    normalizeHost(url.hostname) !== null
   );
 }
 

--- a/src/icon-proxy.mjs
+++ b/src/icon-proxy.mjs
@@ -4,30 +4,29 @@
 //   GET /api/v1/icon?host={domain}&size={px}&theme={light|dark}
 //   -> 200 image/png|x-icon (square, cached) | 404 when no source resolves
 //
-// Resolution order: (1) the host's OWN page-declared icon via <link rel="icon"> scraped
-// from its HTML root — what actually resolves most real sites; (2) the favicon
-// aggregators (DuckDuckGo, Google), usually bot-blocked from Worker egress; (3) the
-// host's well-known favicon paths (apple-touch-icon / favicon.ico).
-// SSRF SAFETY: `host` is validated to a plain public DNS name (no IP literals, no
-// localhost/.local/.internal); page-declared icon URLs are re-validated the same way
-// (public host, http(s) only) so a hostile page cannot redirect us at an internal
-// target; the Worker runtime cannot reach private/internal addresses; the page fetch is
-// size-capped and only an image/* response of sane size is ever returned. Results are
-// cached in R2 (immutable) so repeat loads are a single edge read.
+// SSRF SAFETY: this Worker fetches ONLY the fixed favicon-aggregator origins
+// (icons.duckduckgo.com, www.google.com). The requested `host` is passed solely as a
+// path/query parameter to those constant origins — it never becomes the request target
+// itself — so an operator-controlled or DNS-rebound registry host cannot make the proxy
+// initiate outbound requests to arbitrary infrastructure. `host` is additionally
+// validated to a plain public DNS name (no IP literals, no localhost/.local/.internal),
+// and only an image/* response of sane size is ever returned. Results are cached in R2
+// (immutable) so repeat loads are a single edge read.
+//
+// NOTE: we deliberately do NOT fetch the host directly (no <link rel=icon> scrape, no
+// direct /favicon.ico). Those add an SSRF surface for marginal gain — aggregators are
+// often bot-blocked from Worker egress anyway, and the UI's GitHub-avatar fallback
+// (BrandIcon repoUrl) is the real icon source for most subnets.
 const ICON_CACHE_PREFIX = "icon-cache";
 const MAX_SIZE = 256;
 const DEFAULT_SIZE = 64;
 const MIN_ICON_BYTES = 100; // reject empty / 1x1 placeholder responses
 const MAX_ICON_BYTES = 256 * 1024; // bound Worker memory and R2 object size
-const MAX_HTML_BYTES = 256 * 1024; // cap the page fetch when scraping <link rel=icon>
-const MAX_PAGE_ICONS = 4; // most page-declared icons we will try
 const FETCH_TIMEOUT_MS = 3000;
 const CACHE_CONTROL = "public, max-age=2592000, immutable"; // 30d, per contract
-const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
-const MAX_REDIRECTS = 5;
 const BLOCKED_TLDS = new Set(["localhost", "local", "internal"]);
-// A real-ish UA — DuckDuckGo/Google's favicon endpoints and some origins bot-block
-// the default Worker user-agent (a cause of the prod 404s).
+// A real-ish UA — DuckDuckGo/Google's favicon endpoints bot-block the default Worker
+// user-agent (a cause of the prod 404s).
 const BROWSER_UA =
   "Mozilla/5.0 (compatible; MetagraphedIconBot/1.0; +https://metagraph.sh)";
 
@@ -153,163 +152,14 @@ async function boundedArrayBuffer(res) {
   return out.buffer;
 }
 
-// Extract icon hrefs from raw HTML: every <link> whose rel contains "icon" (icon /
-// shortcut icon / apple-touch-icon / mask-icon). A small targeted regex — NOT a general
-// HTML parser — over a size-capped page head. Pure + exported for tests; runs identically
-// in node + the Worker (Cloudflare's HTMLRewriter is unavailable in the unit-test
-// runtime, so the tested path IS the prod path).
-export function extractIconHrefs(html) {
-  if (typeof html !== "string" || !html) return [];
-  const attr = (tag, name) => {
-    const m = new RegExp(
-      `\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s">]+))`,
-      "i",
-    ).exec(tag);
-    return m ? (m[2] ?? m[3] ?? m[4] ?? "") : "";
-  };
-  const hrefs = [];
-  const linkRe = /<link\b[^>]*>/gi;
-  let m;
-  while ((m = linkRe.exec(html)) !== null) {
-    const tag = m[0];
-    if (!attr(tag, "rel").toLowerCase().includes("icon")) continue;
-    const href = attr(tag, "href").trim();
-    if (href) hrefs.push(href);
-  }
-  return hrefs;
-}
-
-// Resolve page-declared hrefs to absolute, SSRF-safe http(s) URLs against the host.
-// Rejects non-public hostnames (IP literals / private / localhost) so a hostile page
-// cannot point us at an internal target. Deduped + capped.
-function resolveIconUrls(hrefs, host) {
-  const base = `https://${host}/`;
-  const out = [];
-  const seen = new Set();
-  for (const href of hrefs) {
-    let abs;
-    try {
-      abs = new URL(href, base);
-    } catch {
-      continue;
-    }
-    if (abs.protocol !== "https:" && abs.protocol !== "http:") continue;
-    if (!normalizeHost(abs.hostname)) continue; // SSRF: public DNS names only
-    const s = abs.toString();
-    if (seen.has(s)) continue;
-    seen.add(s);
-    out.push(s);
-    if (out.length >= MAX_PAGE_ICONS) break;
-  }
-  return out;
-}
-
-export function isSafeHttpUrl(value) {
-  let url;
-  try {
-    url = new URL(String(value));
-  } catch {
-    return false;
-  }
-  return (
-    (url.protocol === "https:" || url.protocol === "http:") &&
-    normalizeHost(url.hostname) !== null
-  );
-}
-
-async function safeFetch(url, init = {}, redirectCount = 0) {
-  if (!isSafeHttpUrl(url)) return null;
-  const res = await fetch(url, { ...init, redirect: "manual" });
-  if (!REDIRECT_STATUSES.has(res.status)) return res;
-
-  const location = res.headers.get("location");
-  if (!location || redirectCount >= MAX_REDIRECTS) {
-    await res.body?.cancel?.();
-    return null;
-  }
-
-  let next;
-  try {
-    next = new URL(location, url).toString();
-  } catch {
-    await res.body?.cancel?.();
-    return null;
-  }
-
-  await res.body?.cancel?.();
-  return safeFetch(next, init, redirectCount + 1);
-}
-
-async function boundedText(res, max) {
-  const reader = res.body?.getReader?.();
-  if (!reader) {
-    const t = await res.text();
-    return t.length > max ? t.slice(0, max) : t;
-  }
-  const chunks = [];
-  let total = 0;
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      total += value.byteLength;
-      chunks.push(value);
-      if (total >= max) {
-        await reader.cancel();
-        break;
-      }
-    }
-  } finally {
-    reader.releaseLock?.();
-  }
-  const out = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    out.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return new TextDecoder("utf-8").decode(out);
-}
-
-// Fetch the host's HTML root and return its declared <link rel="icon"> URLs. THIS is
-// what resolves most real sites: the favicon aggregators are bot-blocked from Worker
-// egress and many sites serve no favicon at a literal root path, but nearly all declare
-// one in the page <head>. Best-effort — any failure yields [] and the caller falls back.
-async function pageDeclaredIconSources(host) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  try {
-    const res = await safeFetch(`https://${host}/`, {
-      headers: {
-        accept: "text/html,application/xhtml+xml",
-        "user-agent": BROWSER_UA,
-      },
-      signal: controller.signal,
-    }).finally(() => clearTimeout(timeout));
-    if (!res) return [];
-    if (!res.ok || !(res.headers.get("content-type") || "").includes("html")) {
-      await res.body?.cancel?.();
-      return [];
-    }
-    const html = await boundedText(res, MAX_HTML_BYTES);
-    return resolveIconUrls(extractIconHrefs(html), host);
-  } catch {
-    return [];
-  }
-}
-
-// Fallback sources, tried after the page-declared icons: the favicon aggregators
-// (frequently bot-blocked from Worker egress) then the host's OWN well-known favicon
-// paths. Fetching the host directly is SSRF-safe here: `host` is validated to a public
-// DNS name (no IP literals / localhost / private TLDs) and the Worker runtime cannot
-// reach private/internal addresses; we additionally only accept an image/* response.
+// FIXED aggregator origins ONLY — the host is a path/query param, never the request
+// target. Do NOT add `https://${host}/...` entries here: fetching a registry-controlled
+// host directly is an SSRF surface (operator-controlled / DNS-rebindable) for marginal
+// gain. The UI's GitHub-avatar fallback covers most subnets.
 function faviconSources(host, size) {
   return [
     `https://icons.duckduckgo.com/ip3/${host}.ico`,
     `https://www.google.com/s2/favicons?domain=${host}&sz=${Math.min(size * 2, MAX_SIZE)}`,
-    `https://${host}/apple-touch-icon.png`,
-    `https://${host}/apple-touch-icon-precomposed.png`,
-    `https://${host}/favicon.ico`,
   ];
 }
 
@@ -382,24 +232,19 @@ export async function handleIconProxy(request, env, url, options = {}) {
     }
   }
 
-  // Page-declared <link rel="icon"> first (the real fix), then aggregators + well-known
-  // paths. Follow only redirects whose next target also passes URL safety checks
-  // (favicons often 30x to a CDN); no cf.cacheEverything (it forced caching of
-  // redirect/non-200 responses and broke resolution) — successful icons are cached
-  // in R2 below.
-  const sources = [
-    ...(await pageDeclaredIconSources(host)),
-    ...faviconSources(host, size),
-  ];
-  for (const src of sources) {
+  // Try each fixed aggregator. A browser-ish UA (the services bot-block the default
+  // Worker UA); follow redirects (the aggregators 30x to their own CDNs); no
+  // cf.cacheEverything (it forced caching of redirect/non-200 responses and broke
+  // resolution) — successful icons are cached in R2 below.
+  for (const src of faviconSources(host, size)) {
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-      const res = await safeFetch(src, {
+      const res = await fetch(src, {
         headers: { accept: "image/*", "user-agent": BROWSER_UA },
+        redirect: "follow",
         signal: controller.signal,
       }).finally(() => clearTimeout(timeout));
-      if (!res) continue;
       if (!res.ok) continue;
       const ct = res.headers.get("content-type") || "image/png";
       if (!ct.startsWith("image/")) {

--- a/src/icon-proxy.mjs
+++ b/src/icon-proxy.mjs
@@ -23,6 +23,8 @@ const MAX_HTML_BYTES = 256 * 1024; // cap the page fetch when scraping <link rel
 const MAX_PAGE_ICONS = 4; // most page-declared icons we will try
 const FETCH_TIMEOUT_MS = 3000;
 const CACHE_CONTROL = "public, max-age=2592000, immutable"; // 30d, per contract
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const MAX_REDIRECTS = 5;
 const BLOCKED_TLDS = new Set(["localhost", "local", "internal"]);
 // A real-ish UA — DuckDuckGo/Google's favicon endpoints and some origins bot-block
 // the default Worker user-agent (a cause of the prod 404s).
@@ -202,6 +204,42 @@ function resolveIconUrls(hrefs, host) {
   return out;
 }
 
+function isSafeHttpUrl(value) {
+  let url;
+  try {
+    url = new URL(String(value));
+  } catch {
+    return false;
+  }
+  return (
+    (url.protocol === "https:" || url.protocol === "http:") &&
+    normalizeHost(url.hostname)
+  );
+}
+
+async function safeFetch(url, init = {}, redirectCount = 0) {
+  if (!isSafeHttpUrl(url)) return null;
+  const res = await fetch(url, { ...init, redirect: "manual" });
+  if (!REDIRECT_STATUSES.has(res.status)) return res;
+
+  const location = res.headers.get("location");
+  if (!location || redirectCount >= MAX_REDIRECTS) {
+    await res.body?.cancel?.();
+    return null;
+  }
+
+  let next;
+  try {
+    next = new URL(location, url).toString();
+  } catch {
+    await res.body?.cancel?.();
+    return null;
+  }
+
+  await res.body?.cancel?.();
+  return safeFetch(next, init, redirectCount + 1);
+}
+
 async function boundedText(res, max) {
   const reader = res.body?.getReader?.();
   if (!reader) {
@@ -241,14 +279,14 @@ async function pageDeclaredIconSources(host) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
-    const res = await fetch(`https://${host}/`, {
+    const res = await safeFetch(`https://${host}/`, {
       headers: {
         accept: "text/html,application/xhtml+xml",
         "user-agent": BROWSER_UA,
       },
-      redirect: "follow",
       signal: controller.signal,
     }).finally(() => clearTimeout(timeout));
+    if (!res) return [];
     if (!res.ok || !(res.headers.get("content-type") || "").includes("html")) {
       await res.body?.cancel?.();
       return [];
@@ -345,9 +383,10 @@ export async function handleIconProxy(request, env, url, options = {}) {
   }
 
   // Page-declared <link rel="icon"> first (the real fix), then aggregators + well-known
-  // paths. Follow redirects (favicons often 30x to a CDN); no cf.cacheEverything (it
-  // forced caching of redirect/non-200 responses and broke resolution) — successful
-  // icons are cached in R2 below.
+  // paths. Follow only redirects whose next target also passes URL safety checks
+  // (favicons often 30x to a CDN); no cf.cacheEverything (it forced caching of
+  // redirect/non-200 responses and broke resolution) — successful icons are cached
+  // in R2 below.
   const sources = [
     ...(await pageDeclaredIconSources(host)),
     ...faviconSources(host, size),
@@ -356,11 +395,11 @@ export async function handleIconProxy(request, env, url, options = {}) {
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-      const res = await fetch(src, {
+      const res = await safeFetch(src, {
         headers: { accept: "image/*", "user-agent": BROWSER_UA },
-        redirect: "follow",
         signal: controller.signal,
       }).finally(() => clearTimeout(timeout));
+      if (!res) continue;
       if (!res.ok) continue;
       const ct = res.headers.get("content-type") || "image/png";
       if (!ct.startsWith("image/")) {

--- a/tests/icon-proxy.test.mjs
+++ b/tests/icon-proxy.test.mjs
@@ -1,10 +1,6 @@
 import assert from "node:assert/strict";
 import { test, vi } from "vitest";
-import {
-  handleIconProxy,
-  extractIconHrefs,
-  isSafeHttpUrl,
-} from "../src/icon-proxy.mjs";
+import { handleIconProxy } from "../src/icon-proxy.mjs";
 
 const PNG = new Uint8Array(200).fill(1).buffer; // >100 bytes -> not a placeholder
 
@@ -105,237 +101,24 @@ test("rejects too-small (placeholder) responses -> 404", async () => {
   assert.equal(res.status, 404);
 });
 
-test("extractIconHrefs parses rel/href variants, ignores non-icon links", () => {
-  const html = `
-    <link rel="icon" href="/a.png">
-    <link rel='shortcut icon' href='/b.ico'>
-    <link rel="apple-touch-icon" href="https://cdn.x.com/c.png">
-    <link rel="stylesheet" href="/styles.css">
-    <link rel="mask-icon" href=/d.svg color=red>`;
-  assert.deepEqual(extractIconHrefs(html), [
-    "/a.png",
-    "/b.ico",
-    "https://cdn.x.com/c.png",
-    "/d.svg",
-  ]);
-  assert.deepEqual(extractIconHrefs(""), []);
-  assert.deepEqual(extractIconHrefs(null), []);
-});
-
-test("resolves an icon declared via <link rel=icon> in the page HTML", async () => {
+test("never fetches the requested host directly (only fixed aggregators)", async () => {
+  const requested = [];
   const env = {
     METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
     METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
   };
-  const fetchImpl = async (u) => {
-    const url = String(u);
-    if (url === "https://example.com/") {
-      return new Response(
-        '<html><head><link rel="icon" href="/brand/icon.png"></head></html>',
-        {
-          status: 200,
-          headers: { "content-type": "text/html; charset=utf-8" },
-        },
-      );
-    }
-    if (url === "https://example.com/brand/icon.png") {
-      return new Response(PNG, {
-        status: 200,
-        headers: { "content-type": "image/png" },
-      });
-    }
-    return new Response("", { status: 404 });
-  };
-  const res = await call("?host=example.com&size=64", { env, fetchImpl });
-  assert.equal(res.status, 200);
-  assert.equal(res.headers.get("content-type"), "image/png");
-});
-
-test("page-declared icon at a private/non-public host is rejected (SSRF)", async () => {
-  const env = {
-    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
-    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
-  };
-  let privateFetched = false;
-  const fetchImpl = async (u) => {
-    const url = String(u);
-    if (url === "https://example.com/") {
-      return new Response(
-        '<html><head><link rel="icon" href="http://localhost/secret.png"></head></html>',
-        { status: 200, headers: { "content-type": "text/html" } },
-      );
-    }
-    if (url.includes("localhost")) {
-      privateFetched = true;
-      return new Response(PNG, {
-        status: 200,
-        headers: { "content-type": "image/png" },
-      });
-    }
-    return new Response("", { status: 404 });
-  };
-  const res = await call("?host=example.com", { env, fetchImpl });
-  assert.equal(privateFetched, false); // never fetched the private target
-  assert.equal(res.status, 404); // nothing else resolves
-});
-
-test("blocks redirects from page-declared icons to private targets (SSRF)", async () => {
-  const env = {
-    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
-    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
-  };
-  let privateFetched = false;
-  const fetchImpl = async (u) => {
-    const url = String(u);
-    if (url === "https://example.com/") {
-      return new Response(
-        '<html><head><link rel="icon" href="https://cdn.example.com/icon.png"></head></html>',
-        { status: 200, headers: { "content-type": "text/html" } },
-      );
-    }
-    if (url === "https://cdn.example.com/icon.png") {
-      return new Response("", {
-        status: 302,
-        headers: { location: "http://127.0.0.1/secret.png" },
-      });
-    }
-    if (url.includes("127.0.0.1")) {
-      privateFetched = true;
-      return new Response(PNG, {
-        status: 200,
-        headers: { "content-type": "image/png" },
-      });
-    }
-    return new Response("", { status: 404 });
-  };
-  const res = await call("?host=example.com", { env, fetchImpl });
-  assert.equal(privateFetched, false);
-  assert.equal(res.status, 404);
-});
-
-test("blocks redirects from the allowlisted page root to private targets (SSRF)", async () => {
-  const env = {
-    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
-    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
-  };
-  let privateFetched = false;
-  const fetchImpl = async (u) => {
-    const url = String(u);
-    if (url === "https://example.com/") {
-      return new Response("", {
-        status: 302,
-        headers: { location: "http://127.0.0.1/" },
-      });
-    }
-    if (url.includes("127.0.0.1")) {
-      privateFetched = true;
-      return new Response(
-        '<html><head><link rel="icon" href="/secret.png"></head></html>',
-        { status: 200, headers: { "content-type": "text/html" } },
-      );
-    }
-    return new Response("", { status: 404 });
-  };
-  const res = await call("?host=example.com", { env, fetchImpl });
-  assert.equal(privateFetched, false);
-  assert.equal(res.status, 404);
-});
-
-test("isSafeHttpUrl: only public-DNS http(s) URLs pass", () => {
-  assert.equal(isSafeHttpUrl("https://example.com/favicon.ico"), true);
-  assert.equal(isSafeHttpUrl("http://example.com/a.png"), true);
-  assert.equal(isSafeHttpUrl("ftp://example.com/a"), false); // non-http(s)
-  assert.equal(isSafeHttpUrl("http://127.0.0.1/a"), false); // private/IP-literal
-  assert.equal(isSafeHttpUrl("http://localhost/a"), false); // single-label
-  assert.equal(isSafeHttpUrl("not a url"), false); // unparseable -> catch
-  assert.equal(isSafeHttpUrl(null), false);
-});
-
-test("follows a SAFE favicon redirect through to the image", async () => {
-  const env = {
-    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
-    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
-  };
-  const fetchImpl = async (u) => {
-    const url = String(u);
-    if (url === "https://example.com/")
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async (src) => {
+      requested.push(String(src));
       return new Response("", { status: 404 });
-    if (url === "https://icons.duckduckgo.com/ip3/example.com.ico") {
-      return new Response("", {
-        status: 302,
-        headers: { location: "https://cdn.example.com/real.png" },
-      });
-    }
-    if (url === "https://cdn.example.com/real.png") {
-      return new Response(PNG, {
-        status: 200,
-        headers: { "content-type": "image/png" },
-      });
-    }
-    return new Response("", { status: 404 });
-  };
-  const res = await call("?host=example.com&size=64", { env, fetchImpl });
-  assert.equal(res.status, 200);
-  assert.equal(res.headers.get("content-type"), "image/png");
-});
-
-test("a redirect with no Location header resolves to nothing (404)", async () => {
-  const env = {
-    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
-    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
-  };
-  const fetchImpl = async (u) =>
-    String(u) === "https://icons.duckduckgo.com/ip3/example.com.ico"
-      ? new Response("", { status: 302 }) // no location header
-      : new Response("", { status: 404 });
-  assert.equal(
-    (await call("?host=example.com", { env, fetchImpl })).status,
-    404,
-  );
-});
-
-test("a redirect loop past the cap resolves to nothing (404)", async () => {
-  const env = {
-    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
-    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
-  };
-  // Every source self-redirects to a safe target → exceeds MAX_REDIRECTS → null.
-  const fetchImpl = async (u) => {
-    const url = String(u);
-    if (
-      url.startsWith("https://example.com") ||
-      url.startsWith("https://icons.duckduckgo.com") ||
-      url.startsWith("https://www.google.com")
-    ) {
-      return new Response("", {
-        status: 308,
-        headers: { location: "https://example.com/loop" },
-      });
-    }
-    return new Response("", { status: 404 });
-  };
-  assert.equal(
-    (await call("?host=example.com", { env, fetchImpl })).status,
-    404,
-  );
-});
-
-test("a redirect to a malformed Location resolves to nothing (404)", async () => {
-  const env = {
-    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
-    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
-  };
-  const fetchImpl = async (u) =>
-    String(u) === "https://icons.duckduckgo.com/ip3/example.com.ico"
-      ? new Response("", {
-          status: 302,
-          headers: { location: "http://foo bar/" },
-        }) // unparseable
-      : new Response("", { status: 404 });
-  assert.equal(
-    (await call("?host=example.com", { env, fetchImpl })).status,
-    404,
-  );
+    },
+  });
+  assert.equal(res.status, 404);
+  assert.deepEqual(requested, [
+    "https://icons.duckduckgo.com/ip3/example.com.ico",
+    "https://www.google.com/s2/favicons?domain=example.com&sz=128",
+  ]);
 });
 
 test("304 on matching If-None-Match (no fetch, no R2)", async () => {

--- a/tests/icon-proxy.test.mjs
+++ b/tests/icon-proxy.test.mjs
@@ -175,6 +175,68 @@ test("page-declared icon at a private/non-public host is rejected (SSRF)", async
   assert.equal(res.status, 404); // nothing else resolves
 });
 
+test("blocks redirects from page-declared icons to private targets (SSRF)", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  let privateFetched = false;
+  const fetchImpl = async (u) => {
+    const url = String(u);
+    if (url === "https://example.com/") {
+      return new Response(
+        '<html><head><link rel="icon" href="https://cdn.example.com/icon.png"></head></html>',
+        { status: 200, headers: { "content-type": "text/html" } },
+      );
+    }
+    if (url === "https://cdn.example.com/icon.png") {
+      return new Response("", {
+        status: 302,
+        headers: { location: "http://127.0.0.1/secret.png" },
+      });
+    }
+    if (url.includes("127.0.0.1")) {
+      privateFetched = true;
+      return new Response(PNG, {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      });
+    }
+    return new Response("", { status: 404 });
+  };
+  const res = await call("?host=example.com", { env, fetchImpl });
+  assert.equal(privateFetched, false);
+  assert.equal(res.status, 404);
+});
+
+test("blocks redirects from the allowlisted page root to private targets (SSRF)", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  let privateFetched = false;
+  const fetchImpl = async (u) => {
+    const url = String(u);
+    if (url === "https://example.com/") {
+      return new Response("", {
+        status: 302,
+        headers: { location: "http://127.0.0.1/" },
+      });
+    }
+    if (url.includes("127.0.0.1")) {
+      privateFetched = true;
+      return new Response(
+        '<html><head><link rel="icon" href="/secret.png"></head></html>',
+        { status: 200, headers: { "content-type": "text/html" } },
+      );
+    }
+    return new Response("", { status: 404 });
+  };
+  const res = await call("?host=example.com", { env, fetchImpl });
+  assert.equal(privateFetched, false);
+  assert.equal(res.status, 404);
+});
+
 test("304 on matching If-None-Match (no fetch, no R2)", async () => {
   const res = await call("?host=example.com&size=64", {
     env: { METAGRAPH_ICON_ALLOWED_HOSTS: "example.com" },

--- a/tests/icon-proxy.test.mjs
+++ b/tests/icon-proxy.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { test, vi } from "vitest";
-import { handleIconProxy, extractIconHrefs } from "../src/icon-proxy.mjs";
+import {
+  handleIconProxy,
+  extractIconHrefs,
+  isSafeHttpUrl,
+} from "../src/icon-proxy.mjs";
 
 const PNG = new Uint8Array(200).fill(1).buffer; // >100 bytes -> not a placeholder
 
@@ -235,6 +239,103 @@ test("blocks redirects from the allowlisted page root to private targets (SSRF)"
   const res = await call("?host=example.com", { env, fetchImpl });
   assert.equal(privateFetched, false);
   assert.equal(res.status, 404);
+});
+
+test("isSafeHttpUrl: only public-DNS http(s) URLs pass", () => {
+  assert.equal(isSafeHttpUrl("https://example.com/favicon.ico"), true);
+  assert.equal(isSafeHttpUrl("http://example.com/a.png"), true);
+  assert.equal(isSafeHttpUrl("ftp://example.com/a"), false); // non-http(s)
+  assert.equal(isSafeHttpUrl("http://127.0.0.1/a"), false); // private/IP-literal
+  assert.equal(isSafeHttpUrl("http://localhost/a"), false); // single-label
+  assert.equal(isSafeHttpUrl("not a url"), false); // unparseable -> catch
+  assert.equal(isSafeHttpUrl(null), false);
+});
+
+test("follows a SAFE favicon redirect through to the image", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const fetchImpl = async (u) => {
+    const url = String(u);
+    if (url === "https://example.com/")
+      return new Response("", { status: 404 });
+    if (url === "https://icons.duckduckgo.com/ip3/example.com.ico") {
+      return new Response("", {
+        status: 302,
+        headers: { location: "https://cdn.example.com/real.png" },
+      });
+    }
+    if (url === "https://cdn.example.com/real.png") {
+      return new Response(PNG, {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      });
+    }
+    return new Response("", { status: 404 });
+  };
+  const res = await call("?host=example.com&size=64", { env, fetchImpl });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("content-type"), "image/png");
+});
+
+test("a redirect with no Location header resolves to nothing (404)", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const fetchImpl = async (u) =>
+    String(u) === "https://icons.duckduckgo.com/ip3/example.com.ico"
+      ? new Response("", { status: 302 }) // no location header
+      : new Response("", { status: 404 });
+  assert.equal(
+    (await call("?host=example.com", { env, fetchImpl })).status,
+    404,
+  );
+});
+
+test("a redirect loop past the cap resolves to nothing (404)", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  // Every source self-redirects to a safe target → exceeds MAX_REDIRECTS → null.
+  const fetchImpl = async (u) => {
+    const url = String(u);
+    if (
+      url.startsWith("https://example.com") ||
+      url.startsWith("https://icons.duckduckgo.com") ||
+      url.startsWith("https://www.google.com")
+    ) {
+      return new Response("", {
+        status: 308,
+        headers: { location: "https://example.com/loop" },
+      });
+    }
+    return new Response("", { status: 404 });
+  };
+  assert.equal(
+    (await call("?host=example.com", { env, fetchImpl })).status,
+    404,
+  );
+});
+
+test("a redirect to a malformed Location resolves to nothing (404)", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const fetchImpl = async (u) =>
+    String(u) === "https://icons.duckduckgo.com/ip3/example.com.ico"
+      ? new Response("", {
+          status: 302,
+          headers: { location: "http://foo bar/" },
+        }) // unparseable
+      : new Response("", { status: 404 });
+  assert.equal(
+    (await call("?host=example.com", { env, fetchImpl })).status,
+    404,
+  );
 });
 
 test("304 on matching If-None-Match (no fetch, no R2)", async () => {


### PR DESCRIPTION
### Motivation
- The page-declared favicon path accepted attacker-controlled `http(s)` URLs that were only syntactically hostname-validated and then fetched with automatic redirects, allowing an allowlisted host to cause server-side requests to internal/private targets (SSRF).
- The intent is to keep the page-scraped favicon behaviour (it improves real-world resolution) while preventing redirect-based SSRF by validating redirect targets before following them.

### Description
- Add `REDIRECT_STATUSES` and `MAX_REDIRECTS` and implement `isSafeHttpUrl()` to ensure a candidate URL is `http(s)` and its hostname passes `normalizeHost()`.
- Add `safeFetch()` which performs `fetch(..., redirect: "manual")`, inspects redirect `Location` headers, revalidates each redirect target with `isSafeHttpUrl()`, caps redirect depth, and cancels blocked redirect bodies.
- Replace the direct `fetch()` usage in `pageDeclaredIconSources()` and the icon-fetch loop in `handleIconProxy()` with `safeFetch()` and skip when it returns no safe response, preserving image validation, size caps, R2 caching, and deduping.
- Add two unit tests to `tests/icon-proxy.test.mjs` covering redirect-based SSRF attempts from a declared icon URL and from the allowlisted page root, ensuring those redirects are blocked.

### Testing
- Ran `npx vitest run tests/icon-proxy.test.mjs` and observed all tests pass (`23 passed`).
- Ran `npm run lint` (`eslint`) and it completed without errors.
- Ran `npm run format:check` (`prettier --check`) and all files matched the project formatter rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b2366d0fc832c84a46fc25e25f01f)