### PR TITLE
fix(icon): remove direct host favicon fetches

### DIFF
--- a/src/icon-proxy.mjs
+++ b/src/icon-proxy.mjs
@@ -4,14 +4,11 @@
 //   GET /api/v1/icon?host={domain}&size={px}&theme={light|dark}
 //   -> 200 image/png|x-icon (square, cached) | 404 when no source resolves
 //
-// SSRF SAFETY: sources are the fixed favicon aggregators (DuckDuckGo, Google) PLUS the
-// host's own well-known favicon paths (apple-touch-icon / favicon.ico) — the aggregators
-// are bot-blocked from Worker egress, so the direct same-host fetch is what actually
-// resolves most hosts. Fetching the host directly is safe here because `host` is
-// validated to a plain public DNS name (no IP literals, no localhost/.local/.internal),
-// the Cloudflare Worker runtime cannot reach private/internal addresses, and only an
-// image/* response of sane size is ever returned. Results are cached in R2 (immutable)
-// so repeat loads are a single edge read.
+// SSRF SAFETY: sources are fixed favicon aggregators (DuckDuckGo, Google). The
+// requested host is passed only as a parameter/path segment to those services, never
+// fetched directly by this Worker, so operator-controlled registry hosts cannot make
+// the proxy initiate outbound requests to arbitrary infrastructure. Results are
+// cached in R2 (immutable) so repeat loads are a single edge read.
 const ICON_CACHE_PREFIX = "icon-cache";
 const MAX_SIZE = 256;
 const DEFAULT_SIZE = 64;
@@ -143,20 +140,14 @@ async function boundedArrayBuffer(res) {
   return out.buffer;
 }
 
-// Resolution order: the favicon-aggregator services first (they parse the page and
-// return the best icon), then the host's OWN well-known favicon paths as a fallback.
-// The aggregators are frequently bot-blocked from Cloudflare Worker egress, so the
-// direct same-host paths are what actually resolve most subnets. Fetching the host
-// directly is SSRF-safe here: `host` is validated to a public DNS name (no IP
-// literals / localhost / private TLDs) and the Worker runtime cannot reach private/
-// internal addresses; we additionally only accept an image/* response.
+// Resolution order is limited to fixed favicon-aggregator services. Do not add
+// direct `https://${host}/...` fetches here: allowlisted registry hosts can be
+// operator-controlled or later DNS-rebound, and Workers cannot verify the resolved
+// address before initiating a fetch.
 function faviconSources(host, size) {
   return [
     `https://icons.duckduckgo.com/ip3/${host}.ico`,
     `https://www.google.com/s2/favicons?domain=${host}&sz=${Math.min(size * 2, MAX_SIZE)}`,
-    `https://${host}/apple-touch-icon.png`,
-    `https://${host}/apple-touch-icon-precomposed.png`,
-    `https://${host}/favicon.ico`,
   ];
 }
 
@@ -235,10 +226,9 @@ export async function handleIconProxy(request, env, url, options = {}) {
       const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
       const res = await fetch(src, {
         // A real-ish UA — DuckDuckGo/Google's favicon endpoints bot-block the
-        // default Worker user-agent (the cause of the prod 404s). Follow redirects
-        // (favicons often 30x to a CDN). Dropped `cf.cacheEverything`, which forced
-        // caching of the services' redirect/non-200 responses and broke resolution;
-        // successful icons are cached in R2 below.
+        // default Worker user-agent. Redirects are acceptable here because the
+        // Worker only requests fixed aggregator origins, not registry-controlled
+        // hosts. Successful icons are cached in R2 below.
         headers: {
           accept: "image/*",
           "user-agent":

--- a/tests/icon-proxy.test.mjs
+++ b/tests/icon-proxy.test.mjs
@@ -101,6 +101,30 @@ test("rejects too-small (placeholder) responses -> 404", async () => {
   assert.equal(res.status, 404);
 });
 
+test("never fetches the requested host directly", async () => {
+  const requested = [];
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async (src) => {
+      requested.push(String(src));
+      return new Response("", { status: 404 });
+    },
+  });
+  assert.equal(res.status, 404);
+  assert.deepEqual(requested, [
+    "https://icons.duckduckgo.com/ip3/example.com.ico",
+    "https://www.google.com/s2/favicons?domain=example.com&sz=128",
+  ]);
+  assert.equal(
+    requested.some((src) => src.startsWith("https://example.com/")),
+    false,
+  );
+});
+
 test("304 on matching If-None-Match (no fetch, no R2)", async () => {
   const res = await call("?host=example.com&size=64", {
     env: { METAGRAPH_ICON_ALLOWED_HOSTS: "example.com" },


### PR DESCRIPTION
### Motivation
- Prevent SSRF introduced by fetching `https://{host}/...` directly for allowlisted registry hosts, since `normalizeHost` only does syntactic checks and the Worker cannot verify DNS/resolved addresses before a fetch.
- Limit outbound requests to well-known, fixed favicon aggregator origins so operator-controlled registry hosts cannot cause the Worker to initiate requests to attacker-chosen destinations.

### Description
- Remove direct same-host favicon URLs from `faviconSources` so only fixed aggregator endpoints remain (`icons.duckduckgo.com`, `www.google.com`).
- Update inline SSRF-safety comments to document that the Worker never fetches the requested host directly and explain why direct fetches must not be reintroduced without DNS/address-aware protections.
- Add a regression test `test("never fetches the requested host directly")` in `tests/icon-proxy.test.mjs` that asserts the proxy only requests the aggregator URLs and never `https://{host}/...` for an allowlisted host.
- Minor formatting adjustments to keep lint/Prettier happy.

### Testing
- Ran unit tests with `npm test -- --run tests/icon-proxy.test.mjs` and observed `19 tests passed (19)`.
- Ran style checks with `npm run lint` and `npm run format:check`, and formatting/lint issues were fixed with `prettier --write` so checks now pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b17e99950832c91a9f9b6fc4f4426)