### PR TITLE
feat(registry): add SN19 BlockMachine public data-artifact candidate

### DIFF
--- a/registry/candidates/community/community-sn-19-data-artifact-api-blockmachine-io.json
+++ b/registry/candidates/community/community-sn-19-data-artifact-api-blockmachine-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-19-data-artifact-api-blockmachine-io",
+      "kind": "data-artifact",
+      "name": "BlockMachine community data-artifact",
+      "netuid": 19,
+      "provider": "blockmachine",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.blockmachine.io/openapi.json",
+      "source_urls": ["https://api.blockmachine.io/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.blockmachine.io/epochs/latest-finalized"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "minion1227",
+    "submitted_by_url": "https://github.com/minion1227"
+  }
+}


### PR DESCRIPTION
Adds a community candidate for BlockMachine's public, no-auth finalized-epoch
data artifact (https://api.blockmachine.io/epochs/latest-finalized), proven by
the published OpenAPI spec (BlockMachine Registry API v0.1.0).

Part of #1278.

## Summary

Enriches **SN19 (BlockMachine)** with a public `data-artifact` surface, completing #1278
(the `subnet-api` half is PR #1586).

Adds exactly one file —
`registry/candidates/community/community-sn-19-data-artifact-api-blockmachine-io.json`:

- **Netuid:** 19 (BlockMachine)
- **Kind:** `data-artifact`
- **Public URL:** https://api.blockmachine.io/epochs/latest-finalized — verified
  HTTP 200, `application/json`, no authentication (live finalized-epoch snapshot)
- **Source URL:** https://api.blockmachine.io/openapi.json — `BlockMachine Registry API v0.1.0`
- **Provider:** `blockmachine` (registered slug)
- `public_safe: true` · `auth_required: false`

Generated with `npm run candidate:new`. One file, no generated artifacts, no
secrets/PAT/private URLs. Not a duplicate — SN19 has no existing `data-artifact` surface.

Validation run locally:
- `npm run submission:pr` → `submit_pr`, no errors
- `npm run validate:candidate` → passed
- `npm run scan:public-safety` → passed

## Template Used

Direct subnet/interface candidate (one `registry/candidates/community/*.json` file)