### PR TITLE
test(coverage): cover the weakest backend modules (storage/og-image/discovery/lib/api)

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1284,6 +1284,19 @@ describe("weightedPickEndpoint", () => {
     assert.equal(picked.id, "b");
   });
 
+  test("returns the final endpoint when randomFn lands exactly on the total (cursor never < 0)", () => {
+    // randomFn() === 1 → cursor = total; subtracting each weight leaves cursor at
+    // exactly 0 after the last endpoint, never < 0, so the loop never returns and
+    // the post-loop fallthrough (return endpoints[len-1]) is taken.
+    const endpoints = [
+      { id: "a", score: 1 },
+      { id: "b", score: 1 },
+      { id: "c", score: 1 },
+    ];
+    const picked = weightedPickEndpoint(endpoints, () => 1);
+    assert.equal(picked.id, "c");
+  });
+
   test("single-endpoint shortcut", () => {
     assert.equal(weightedPickEndpoint([{ id: "solo" }]).id, "solo");
   });

--- a/tests/discovery-conditional.test.mjs
+++ b/tests/discovery-conditional.test.mjs
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   agentToolsResponse,
+  apiCatalogResponse,
   handleBadgeSvgRequest,
   mcpServerCardResponse,
 } from "../workers/request-handlers/discovery.mjs";
@@ -51,6 +52,62 @@ describe("discovery conditional requests", () => {
     await assertConditional((headers) =>
       handleBadgeSvgRequest(new Request(url, { headers }), {}, new URL(url)),
     );
+  });
+
+  test("badge SVG rejects non-GET/HEAD methods with 405 and an Allow header", async () => {
+    const url = "https://api.metagraph.sh/metagraph/health/badges/7.svg";
+    const res = await handleBadgeSvgRequest(
+      new Request(url, { method: "POST" }),
+      {},
+      new URL(url),
+    );
+    assert.equal(res.status, 405);
+    assert.equal(res.headers.get("allow"), "GET, HEAD, OPTIONS");
+    const body = await res.json();
+    assert.equal(body.error.code, "method_not_allowed");
+  });
+
+  test("api catalog HEAD returns the discovery headers with no body", async () => {
+    const url = "https://api.metagraph.sh/.well-known/api-catalog";
+    const res = apiCatalogResponse(new Request(url, { method: "HEAD" }));
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "application/linkset+json");
+    // HEAD never carries a body, but the discovery Link header is still present.
+    assert.ok(res.headers.get("link"));
+    assert.equal(await res.text(), "");
+  });
+
+  test("api catalog GET returns the RFC 9264 linkset body", async () => {
+    const url = "https://api.metagraph.sh/.well-known/api-catalog";
+    const res = apiCatalogResponse(new Request(url, { method: "GET" }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(Array.isArray(body.linkset));
+    assert.ok(body.linkset[0]["service-desc"]);
+  });
+
+  test("MCP server card returns 404 when the static asset is unavailable", async () => {
+    // ASSETS missing the card -> the handler degrades to a 404 not_found.
+    const url = "https://api.metagraph.sh/.well-known/mcp/server-card.json";
+    const envMiss = {
+      ASSETS: {
+        fetch: async () => new Response("not found", { status: 404 }),
+      },
+    };
+    const res = await mcpServerCardResponse(
+      new Request(url, { method: "GET" }),
+      envMiss,
+    );
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.error.code, "not_found");
+
+    // No ASSETS binding at all -> same 404 path (asset === null).
+    const resNoBinding = await mcpServerCardResponse(
+      new Request(url, { method: "GET" }),
+      {},
+    );
+    assert.equal(resNoBinding.status, 404);
   });
 
   test("MCP server card honors If-None-Match lists and the * wildcard", async () => {

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -1424,6 +1424,17 @@ describe("deriveAuthDetail (#746)", () => {
       }).token_url,
       "https://auth.example.com/token",
     );
+    // Swagger-2 top-level authorizationUrl (no tokenUrl, no flows) is the last
+    // fallback in oauthTokenUrl().
+    assert.equal(
+      deriveAuthDetail({
+        o: {
+          type: "oauth2",
+          authorizationUrl: "https://auth.example.com/authorize",
+        },
+      }).token_url,
+      "https://auth.example.com/authorize",
+    );
   });
 
   test("ignores non-object scheme entries and unknown scheme types", () => {

--- a/tests/load-staged-blocks-extrinsics.test.mjs
+++ b/tests/load-staged-blocks-extrinsics.test.mjs
@@ -1,0 +1,317 @@
+// Block-explorer staged-batch loaders (#1345): loadStagedBlocks +
+// loadStagedExtrinsics drain the R2-staged sidecar into D1. They mirror
+// loadStagedEvents EXACTLY (HMAC-authenticated envelope, byte/row caps,
+// write-D1-first / shrink-R2-after progressive drain, delete-on-success), so
+// these tests mirror tests/load-staged-events.test.mjs.
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { test } from "vitest";
+import { loadStagedBlocks, loadStagedExtrinsics } from "../workers/api.mjs";
+import {
+  MAX_STAGED_BLOCKS_BYTES,
+  MAX_STAGED_BLOCK_ROWS,
+  MAX_STAGED_EXTRINSICS_BYTES,
+  MAX_STAGED_EXTRINSIC_ROWS,
+} from "../workers/config.mjs";
+
+const SIGNING_KEY = "test-staged-secret";
+const BLOCKS_KEY = "events/blocks-pending.json";
+const EXTRINSICS_KEY = "events/extrinsics-pending.json";
+
+function signed(rows, key = SIGNING_KEY) {
+  return {
+    schema_version: 1,
+    hmac_sha256: createHmac("sha256", key)
+      .update(JSON.stringify(rows))
+      .digest("hex"),
+    rows,
+  };
+}
+
+function blockRow(n) {
+  return { block_number: n, block_hash: `0x${n.toString(16)}`, observed_at: 1 };
+}
+
+function extrinsicRow(n) {
+  return { block_number: n, extrinsic_index: 0, observed_at: 1 };
+}
+
+// Mirrors mockEnv/archiveEnv in load-staged-events.test.mjs.
+function makeEnv({
+  object,
+  get,
+  put,
+  delete: del,
+  signingKey = SIGNING_KEY,
+  batchThrows = false,
+  prepared = [],
+  batches = [],
+} = {}) {
+  return {
+    METAGRAPH_STAGING_SIGNING_KEY: signingKey,
+    METAGRAPH_ARCHIVE: {
+      get: get || (async () => object ?? null),
+      put: put || (async () => {}),
+      delete: del || (async () => {}),
+    },
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        prepared.push(sql);
+        return { bind: (...v) => ({ sql, v }) };
+      },
+      async batch(stmts) {
+        if (batchThrows) throw new Error("d1 down");
+        batches.push(stmts.length);
+      },
+    },
+  };
+}
+
+// Each loader gets the same matrix of cases, parameterized by its key + sigil.
+const cases = [
+  {
+    name: "blocks",
+    load: loadStagedBlocks,
+    key: BLOCKS_KEY,
+    row: blockRow,
+    maxBytes: MAX_STAGED_BLOCKS_BYTES,
+    maxRows: MAX_STAGED_BLOCK_ROWS,
+    insertTable: "INSERT OR IGNORE INTO blocks (",
+  },
+  {
+    name: "extrinsics",
+    load: loadStagedExtrinsics,
+    key: EXTRINSICS_KEY,
+    row: extrinsicRow,
+    maxBytes: MAX_STAGED_EXTRINSICS_BYTES,
+    maxRows: MAX_STAGED_EXTRINSIC_ROWS,
+    insertTable: "INSERT OR IGNORE INTO extrinsics (",
+  },
+];
+
+for (const c of cases) {
+  test(`loadStaged${c.name} no-ops without bindings`, async () => {
+    const r = await c.load({});
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "unavailable");
+  });
+
+  test(`loadStaged${c.name} no-ops when nothing is staged`, async () => {
+    const deleted = [];
+    const env = makeEnv({ object: null, delete: async (k) => deleted.push(k) });
+    const r = await c.load(env);
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "none");
+    assert.deepEqual(deleted, []);
+  });
+
+  test(`loadStaged${c.name} skips an over-byte-cap file without parsing or deleting it`, async () => {
+    let jsonCalled = false;
+    const deleted = [];
+    const env = makeEnv({
+      object: {
+        size: c.maxBytes + 1,
+        async json() {
+          jsonCalled = true;
+          return [];
+        },
+      },
+      delete: async (k) => deleted.push(k),
+    });
+    const r = await c.load(env);
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "too_large");
+    assert.equal(r.size, c.maxBytes + 1);
+    assert.equal(jsonCalled, false, "never materialized the oversized body");
+    assert.deepEqual(deleted, [], "must NOT delete — that would drop rows");
+  });
+
+  test(`loadStaged${c.name} deletes + bails on unparseable JSON`, async () => {
+    const deleted = [];
+    const env = makeEnv({
+      object: {
+        size: 16,
+        async json() {
+          throw new Error("bad json");
+        },
+      },
+      delete: async (k) => deleted.push(k),
+    });
+    const r = await c.load(env);
+    assert.equal(r.reason, "parse_failed");
+    assert.deepEqual(deleted, [c.key]);
+  });
+
+  test(`loadStaged${c.name} rejects an unsigned envelope`, async () => {
+    const deleted = [];
+    const batches = [];
+    const env = makeEnv({
+      object: {
+        size: 16,
+        async json() {
+          return c.row(1); // raw rows, not an envelope
+        },
+      },
+      delete: async (k) => deleted.push(k),
+      batches,
+    });
+    const r = await c.load(env);
+    assert.equal(r.reason, "unauthenticated");
+    assert.equal(batches.length, 0);
+    assert.deepEqual(deleted, [c.key]);
+  });
+
+  test(`loadStaged${c.name} rejects a bad HMAC`, async () => {
+    const deleted = [];
+    const batches = [];
+    const envelope = signed([c.row(1)]);
+    envelope.hmac_sha256 = "0".repeat(64);
+    const env = makeEnv({
+      object: {
+        size: 16,
+        async json() {
+          return envelope;
+        },
+      },
+      delete: async (k) => deleted.push(k),
+      batches,
+    });
+    const r = await c.load(env);
+    assert.equal(r.reason, "unauthenticated");
+    assert.equal(batches.length, 0);
+    assert.deepEqual(deleted, [c.key]);
+  });
+
+  test(`loadStaged${c.name} deletes + bails when no rows survive validation`, async () => {
+    const deleted = [];
+    const batches = [];
+    // A valid HMAC over garbage rows -> validRows is empty -> "empty".
+    const env = makeEnv({
+      object: {
+        size: 16,
+        async json() {
+          return signed([{ nope: true }]);
+        },
+      },
+      delete: async (k) => deleted.push(k),
+      batches,
+    });
+    const r = await c.load(env);
+    assert.equal(r.reason, "empty");
+    assert.equal(batches.length, 0);
+    assert.deepEqual(deleted, [c.key]);
+  });
+
+  test(`loadStaged${c.name} loads signed rows via parameterized batches + deletes the file`, async () => {
+    const deleted = [];
+    const prepared = [];
+    const batches = [];
+    const rows = Array.from({ length: 5 }, (_, i) => c.row(1000 + i));
+    const env = makeEnv({
+      object: {
+        size: 256,
+        async json() {
+          return signed(rows);
+        },
+      },
+      delete: async (k) => deleted.push(k),
+      prepared,
+      batches,
+    });
+    const r = await c.load(env);
+    assert.equal(r.ok, true);
+    assert.equal(r.rows, 5);
+    assert.equal(r.remaining, undefined);
+    assert.ok(prepared[0].startsWith(c.insertTable));
+    assert.ok(prepared[0].includes("VALUES (?"));
+    assert.equal(batches.length, 1);
+    assert.deepEqual(deleted, [c.key], "file deleted only after a full drain");
+  });
+
+  test(`loadStaged${c.name} caps rows/tick + leaves the remainder in R2 (not deleted)`, async () => {
+    const N = c.maxRows + 3;
+    const rows = Array.from({ length: N }, (_, i) => c.row(1000 + i));
+    const puts = [];
+    const deleted = [];
+    const env = makeEnv({
+      object: {
+        size: 1024,
+        async json() {
+          return signed(rows);
+        },
+      },
+      put: async (key, body) => puts.push({ key, body }),
+      delete: async (k) => deleted.push(k),
+    });
+    const r = await c.load(env);
+    assert.equal(r.ok, true);
+    assert.equal(r.rows, c.maxRows);
+    assert.equal(r.remaining, 3);
+    assert.deepEqual(
+      deleted,
+      [],
+      "must NOT delete while rows are un-persisted",
+    );
+    assert.equal(puts.length, 1, "remainder rewritten for the next tick");
+    assert.equal(puts[0].key, c.key);
+    const remainder = JSON.parse(puts[0].body);
+    assert.equal(remainder.rows.length, 3, "exactly the un-loaded rows kept");
+    assert.match(remainder.hmac_sha256, /^[a-f0-9]{64}$/);
+  });
+
+  test(`loadStaged${c.name} drains a >cap file across ticks without dropping rows`, async () => {
+    const N = c.maxRows + 3;
+    const all = Array.from({ length: N }, (_, i) => c.row(1000 + i));
+    let stored = JSON.stringify(signed(all));
+    const env = makeEnv({
+      get: async () =>
+        stored == null
+          ? null
+          : {
+              size: stored.length,
+              async json() {
+                return JSON.parse(stored);
+              },
+            },
+      put: async (_key, body) => {
+        stored = body;
+      },
+      delete: async () => {
+        stored = null;
+      },
+    });
+    const t1 = await c.load(env);
+    assert.equal(t1.rows, c.maxRows);
+    assert.equal(t1.remaining, 3);
+    assert.notEqual(stored, null, "remainder stays in R2 after tick 1");
+    const t2 = await c.load(env);
+    assert.equal(t2.rows, 3);
+    assert.equal(t2.remaining, undefined);
+    assert.equal(
+      stored,
+      null,
+      "object deleted only after the last row drained",
+    );
+    assert.equal(t1.rows + t2.rows, N, "every row loaded across ticks");
+  });
+
+  test(`loadStaged${c.name} leaves the file intact if a D1 batch throws (no drop on crash)`, async () => {
+    const puts = [];
+    const deleted = [];
+    const rows = Array.from({ length: 5 }, (_, i) => c.row(1000 + i));
+    const env = makeEnv({
+      object: {
+        size: 256,
+        async json() {
+          return signed(rows);
+        },
+      },
+      put: async (key, body) => puts.push({ key, body }),
+      delete: async (k) => deleted.push(k),
+      batchThrows: true,
+    });
+    await assert.rejects(c.load(env));
+    assert.deepEqual(puts, [], "no remainder written on failure");
+    assert.deepEqual(deleted, [], "object NOT deleted — re-drains next tick");
+  });
+}

--- a/tests/og-image.test.mjs
+++ b/tests/og-image.test.mjs
@@ -217,6 +217,112 @@ describe("handleOgImage", () => {
     assert.ok(buf.length > 1000);
   });
 
+  test("falls back to a generic stat line when readArtifact itself throws", async () => {
+    const og = fakeOg();
+    const readArtifactThrows = async () => {
+      throw new Error("registry-summary read blew up");
+    };
+    const res = await handleOgImage(req("GET"), {}, urlFor(), {
+      readArtifact: readArtifactThrows,
+      og: og.og,
+      cache: null,
+    });
+    assert.equal(res.status, 200);
+    // loadStatLine swallowed the throw -> generic ASCII fallback line, no counts
+    assert.doesNotMatch(og.calls.markup, /\d+ subnets/);
+    assert.match(og.calls.markup, /Live health, schemas, and discovery/);
+  });
+
+  test("serves the branded fallback card when workers-og is unavailable (import/destructure throws)", async () => {
+    // deps.og is truthy (so the dynamic import is short-circuited) but accessing
+    // its members throws during destructuring -> the catch on line 190-192 fires.
+    const explodingOg = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("workers-og module evaluation failed");
+        },
+      },
+    );
+    const { assets, requested } = fakeAssets();
+    const { cache, puts } = fakeCache();
+    const res = await handleOgImage(req("GET"), {}, urlFor(), {
+      readArtifact: readSummaryOk,
+      og: explodingOg,
+      cache,
+      assets,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "image/png");
+    assert.equal(await res.text(), "BRANDED-FALLBACK-CARD-1200x630");
+    assert.deepEqual(requested, ["/brand/og-fallback.png"]);
+    // a fallback is never edge-cached
+    assert.equal(puts.length, 0);
+  });
+
+  test("returns 503 when the fallback asset fetch itself throws (no cached blank)", async () => {
+    const og = fakeOg({ failRender: true });
+    const assets = {
+      fetch: async () => {
+        throw new Error("ASSETS subsystem down");
+      },
+    };
+    const res = await handleOgImage(req("GET"), {}, urlFor(), {
+      readArtifact: readSummaryOk,
+      og: og.og,
+      cache: null,
+      assets,
+    });
+    // fallbackResponse swallowed the throw and degraded to the 503 no-store path
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get("cache-control"), "no-store");
+    assert.match(await res.text(), /temporarily unavailable/);
+  });
+
+  test("a HEAD on a cache hit returns the cached headers with no body", async () => {
+    const cachedResponse = new Response("CACHED-PNG", {
+      headers: { "content-type": "image/png", "x-cached": "1" },
+    });
+    const res = await handleOgImage(req("HEAD"), {}, urlFor(), {
+      readArtifact: readSummaryOk,
+      cache: { match: async () => cachedResponse, put: async () => {} },
+    });
+    // HEAD on a cache hit: status + headers from the cached response, empty body
+    assert.equal(res.headers.get("x-cached"), "1");
+    assert.equal(await res.text(), "");
+  });
+
+  test("uses globalThis.caches.default when no cache dep is provided", async () => {
+    const og = fakeOg();
+    const matched = [];
+    const cachedResponse = new Response("GLOBAL-CACHED-PNG", {
+      headers: { "content-type": "image/png" },
+    });
+    const originalCaches = globalThis.caches;
+    globalThis.caches = {
+      default: {
+        match: async (key) => {
+          matched.push(key);
+          return cachedResponse;
+        },
+        put: async () => {},
+      },
+    };
+    try {
+      const res = await handleOgImage(req("GET"), {}, urlFor(), {
+        readArtifact: readSummaryOk,
+        og: og.og,
+        // cache intentionally omitted -> falls back to globalThis.caches.default
+      });
+      assert.equal(await res.text(), "GLOBAL-CACHED-PNG");
+      assert.equal(matched.length, 1);
+      // served from cache, so no render happened
+      assert.equal(og.calls.markup, null);
+    } finally {
+      globalThis.caches = originalCaches;
+    }
+  });
+
   test("serves a cached render on hit without re-rendering", async () => {
     let rendered = false;
     const og = {

--- a/tests/openapi-discovery.test.mjs
+++ b/tests/openapi-discovery.test.mjs
@@ -195,6 +195,19 @@ describe("apiDocsSubdomainOrigins (#1004)", () => {
     }
   });
 
+  test("returns [] for a bare multi-label public suffix with no registrable domain", () => {
+    // A host that is *exactly* a multi-label public suffix (co.uk, com.au) has
+    // no project-owned registrable domain, so clusterSuffixDomain returns null
+    // and no api./docs. origin can be derived.
+    for (const origin of [
+      "https://co.uk",
+      "https://com.au",
+      "https://org.nz",
+    ]) {
+      assert.deepEqual(apiDocsSubdomainOrigins(origin), [], origin);
+    }
+  });
+
   test("returns [] for IP literals, bare hosts, and unparseable input", () => {
     for (const origin of [
       "https://127.0.0.1",

--- a/tests/provenance-elevation.test.mjs
+++ b/tests/provenance-elevation.test.mjs
@@ -152,6 +152,54 @@ describe("computeProvenanceElevations", () => {
     assert.equal(out.length, 0);
   });
 
+  test("sorts multiple elevated netuids ascending and back-fills a missing slug from a later candidate", () => {
+    // Two subnets so the sort comparator (a.netuid - b.netuid) actually runs,
+    // emitted out-of-order to prove the ascending sort. For netuid 1 the first
+    // candidate carries no slug and a later same-netuid candidate supplies it,
+    // exercising the slug back-fill.
+    const candidates = [
+      {
+        id: "b",
+        netuid: 2,
+        kind: "subnet-api",
+        url: "https://api.other.io/",
+        source_type: "github-readme-link",
+        slug: "other",
+      },
+      {
+        id: "a1",
+        netuid: 1,
+        kind: "subnet-api",
+        url: "https://api.acme.ai/",
+        source_type: "github-readme-link",
+        // no slug on the first candidate for netuid 1
+      },
+      {
+        id: "a2",
+        netuid: 1,
+        kind: "openapi",
+        url: "https://api.acme.ai/openapi.json",
+        source_type: "openapi-probe",
+        slug: "acme", // later candidate supplies the slug
+      },
+    ];
+    const out = computeProvenanceElevations({
+      candidates,
+      nativeSubnets,
+      verificationResults: [live("b"), live("a1"), live("a2")],
+    });
+    assert.equal(out.length, 2);
+    // ascending netuid order (input was 2, then 1)
+    assert.deepEqual(
+      out.map((e) => e.netuid),
+      [1, 2],
+    );
+    // slug back-filled onto netuid 1 from the second candidate
+    assert.equal(out[0].slug, "acme");
+    assert.deepEqual(out[0].kinds, ["openapi", "subnet-api"]);
+    assert.equal(out[1].slug, "other");
+  });
+
   test("non-API kinds (docs, website, dashboard) are never elevated", () => {
     const out = computeProvenanceElevations({
       candidates: [

--- a/tests/storage-read-artifact.test.mjs
+++ b/tests/storage-read-artifact.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import { readArtifact, readAsset, readR2 } from "../workers/storage.mjs";
+
+// A git/dual-tier artifact (not in any R2-only pattern) serves ASSETS-first,
+// then falls back to R2. These tests drive that fallback chain and the
+// no-binding guards in readAsset/readR2 directly.
+
+const r2Object = (data) => ({
+  async json() {
+    return data;
+  },
+});
+
+function assetsMiss() {
+  return {
+    async fetch() {
+      return new Response("not found", { status: 404 });
+    },
+  };
+}
+
+function assetsHit(data) {
+  return {
+    async fetch() {
+      return Response.json(data);
+    },
+  };
+}
+
+test("readArtifact falls back to R2 when the static asset misses (git tier line 97)", async () => {
+  const env = {
+    ASSETS: assetsMiss(),
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return r2Object({ from: "r2" });
+      },
+    },
+    // No control binding → latestR2Key uses the default prefix.
+  };
+  const result = await readArtifact(env, "/metagraph/unknown-file.json");
+  assert.equal(result.ok, true);
+  assert.equal(result.source, "r2");
+  assert.deepEqual(result.data, { from: "r2" });
+});
+
+test("readArtifact prefers the static asset for a git/dual tier when it hits", async () => {
+  const env = {
+    ASSETS: assetsHit({ from: "assets" }),
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return r2Object({ from: "r2" });
+      },
+    },
+  };
+  const result = await readArtifact(env, "/metagraph/unknown-file.json");
+  assert.equal(result.ok, true);
+  assert.equal(result.source, "static-assets");
+  assert.deepEqual(result.data, { from: "assets" });
+});
+
+test("readArtifact surfaces the asset error when both tiers miss and the asset was not a 404", async () => {
+  const env = {
+    ASSETS: {
+      async fetch() {
+        return new Response("boom", { status: 500 });
+      },
+    },
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return null; // R2 cold → 404
+      },
+    },
+  };
+  const result = await readArtifact(env, "/metagraph/unknown-file.json");
+  assert.equal(result.ok, false);
+  // asset.status (500) !== 404, so the non-404 asset result wins.
+  assert.equal(result.status, 500);
+  assert.equal(result.code, "artifact_not_found");
+});
+
+test("readAsset returns asset_binding_missing when no ASSETS binding is configured (line 105)", async () => {
+  const result = await readAsset({}, "/metagraph/unknown-file.json", "git");
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 404);
+  assert.equal(result.code, "asset_binding_missing");
+  assert.match(result.message, /No ASSETS binding/);
+});
+
+test("readR2 returns r2_binding_missing when no archive binding is configured", async () => {
+  const result = await readR2({}, "/metagraph/unknown-file.json", "git");
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 404);
+  assert.equal(result.code, "r2_binding_missing");
+});
+
+// ---- R2-preferred dual artifacts (lines 78-87) -----------------------------
+// R2_PREFERRED_DUAL_PATTERNS is currently empty (subnets/coverage moved to plain
+// R2-only), so isR2PreferredDualArtifactPath() never matches a real path. The
+// R2-first-then-asset fallback logic in readArtifact is still live code and is
+// the correct serving path for any future dual artifact that needs fresh
+// per-publish fields. Mock the predicate to true (the tier stays a real "dual")
+// to drive the three branches: R2 hit, asset fallback, and the
+// non-404-wins tiebreak.
+
+test("readArtifact serves R2-first for an R2-preferred dual artifact (R2 hit)", async () => {
+  vi.resetModules();
+  vi.doMock("../src/artifact-storage.mjs", async (importOriginal) => {
+    const actual = await importOriginal();
+    return { ...actual, isR2PreferredDualArtifactPath: () => true };
+  });
+  const { readArtifact: read } = await import("../workers/storage.mjs");
+  const env = {
+    ASSETS: assetsHit({ from: "assets" }),
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return r2Object({ from: "r2-fresh" });
+      },
+    },
+  };
+  const result = await read(env, "/metagraph/contracts.json");
+  assert.equal(result.ok, true);
+  assert.equal(result.source, "r2");
+  assert.deepEqual(result.data, { from: "r2-fresh" });
+  vi.doUnmock("../src/artifact-storage.mjs");
+  vi.resetModules();
+});
+
+test("readArtifact falls back to the committed baseline when R2 is cold for an R2-preferred dual artifact", async () => {
+  vi.resetModules();
+  vi.doMock("../src/artifact-storage.mjs", async (importOriginal) => {
+    const actual = await importOriginal();
+    return { ...actual, isR2PreferredDualArtifactPath: () => true };
+  });
+  const { readArtifact: read } = await import("../workers/storage.mjs");
+  const env = {
+    ASSETS: assetsHit({ from: "committed-baseline" }),
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return null; // R2 cold → 404
+      },
+    },
+  };
+  const result = await read(env, "/metagraph/contracts.json");
+  assert.equal(result.ok, true);
+  assert.equal(result.source, "static-assets");
+  assert.deepEqual(result.data, { from: "committed-baseline" });
+  vi.doUnmock("../src/artifact-storage.mjs");
+  vi.resetModules();
+});
+
+test("readArtifact returns the non-404 R2 error over the asset 404 for an R2-preferred dual artifact", async () => {
+  vi.resetModules();
+  vi.doMock("../src/artifact-storage.mjs", async (importOriginal) => {
+    const actual = await importOriginal();
+    return { ...actual, isR2PreferredDualArtifactPath: () => true };
+  });
+  const { readArtifact: read } = await import("../workers/storage.mjs");
+  const env = {
+    METAGRAPH_R2_TIMEOUT_MS: "5",
+    ASSETS: assetsMiss(), // asset → 404
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        // never resolves → withTimeout rejects → r2 504
+        return new Promise(() => {});
+      },
+    },
+  };
+  const result = await read(env, "/metagraph/contracts.json");
+  assert.equal(result.ok, false);
+  // r2Preferred.status (504) !== 404, so the R2 error wins the tiebreak.
+  assert.equal(result.status, 504);
+  assert.equal(result.code, "r2_timeout");
+  vi.doUnmock("../src/artifact-storage.mjs");
+  vi.resetModules();
+});


### PR DESCRIPTION
## What

Raises test coverage on the weakest backend modules toward "extensive". **Tests-only** — no source changes, no assertion weakened. Every new test asserts real behavior (error paths, cold-store guards, fallbacks, HMAC auth, edge inputs).

## Before → after coverage (lines / branch)

| File | Before | After |
|------|--------|-------|
| `workers/storage.mjs` | 87.83% / 80% | **100% / 98%** |
| `src/og-image.mjs` | 94.73% / 84.48% | **100% / 89.65%** |
| `workers/request-handlers/discovery.mjs` | 96.34% / 78.94% | **100% / 85.96%** |
| `scripts/lib.mjs` | 96.28% / 89.46% | **96.67% / 89.89%** |
| `workers/api.mjs` | 94.37% / 88.7% | **98.14% / 91.86%** |
| **All files** | **97.4% / 90.86%** | **98.61% / 91.77%** |

## What each test covers

- **storage.mjs** (`tests/storage-read-artifact.test.mjs`, new): `readArtifact` git-tier asset→R2 fallback (L97), the no-binding guards in `readAsset`/`readR2` (L105), and the R2-preferred-dual fallback chain (L78-87) by mocking the currently-empty `isR2PreferredDualArtifactPath` predicate (the branch logic is live code; the pattern array is just empty today).
- **og-image.mjs** (`tests/og-image.test.mjs`): fail-soft paths — `readArtifact` throwing (L114), workers-og import/destructure failure (L191-192), fallback-asset fetch throwing (L74), plus cached-HEAD and `globalThis.caches` branches.
- **discovery.mjs** (`tests/discovery-conditional.test.mjs`): badge 405 (L41), api-catalog HEAD (L268), MCP server-card 404-when-asset-missing (L289).
- **lib.mjs** (`tests/openapi-discovery.test.mjs`, `tests/provenance-elevation.test.mjs`, `tests/lib-helpers.test.mjs`): `apiDocsSubdomainOrigins` bare-public-suffix (L1817), elevation multi-netuid sort + slug back-fill (L1894/L1904), Swagger-2 top-level `authorizationUrl` oauth fallback (L2008).
- **api.mjs** (`tests/load-staged-blocks-extrinsics.test.mjs`, new; `tests/api-coverage.test.mjs`): `loadStagedBlocks` + `loadStagedExtrinsics` end-to-end — HMAC auth, byte/row caps, progressive drain, crash-safety (L680-822) — and the `weightedPickEndpoint` exact-total fallthrough (L5259).

## Intentionally not covered

The IPv4/localhost SSRF guard inside `isPrivateOrLocalHostname`/`parseIpv4Address` (api.mjs L5288, L5293-5294, L5324-5325) is **unreachable via its only caller**: `isSafeRpcEndpointUrl` gates on `TRUSTED_RPC_UPSTREAM_ORIGINS`, which contains only real provider hostnames — never IP literals or localhost. It's dead defensive code given the current allowlist; covering it would require changing production config or adding an export seam with no isolated value.

## Verification

- `npx vitest run --coverage`: **96 files, 1804 tests pass** (was 1762; +42 tests).
- `npm run build`: green. (`public/metagraph/r2-manifest.json` is publish-managed — restored from origin/main, not committed.)
- `npm run lint` (eslint): clean.
- `npx prettier --check` on all touched test files: clean.

Do **not** merge — for human review.