### PR TITLE
fix(ci): sync classify-validation-route.py with the canonical classifier

### DIFF
--- a/scripts/classify-validation-route.py
+++ b/scripts/classify-validation-route.py
@@ -44,12 +44,19 @@ submission_files = candidate_files + provider_files
 if not submission_files and not touched_community:
     scope = "normal-pr"
 else:
-    scope = "direct-provider" if len(provider_files) == 1 else "direct-candidate"
-    if len(submission_files) != 1:
+    # Mirror classifyPrScope in scripts/submission-policy.mjs: a lone candidate, a
+    # lone provider, OR an atomic provider+candidate pair (one of each) are the
+    # only in-shape direct submissions.
+    is_pair = len(candidate_files) == 1 and len(provider_files) == 1
+    if is_pair:
+        scope = "direct-pair"
+    else:
+        scope = "direct-provider" if len(provider_files) == 1 else "direct-candidate"
+    if len(submission_files) != 1 and not is_pair:
         errors.append(
             {
                 "category": "unsupported-shape",
-                "message": "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/community/*.json file",
+                "message": "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/community/*.json file, or an atomic provider+candidate pair (one of each)",
             }
         )
     unrelated = [
@@ -64,7 +71,10 @@ else:
                 "message": "direct submissions cannot change other files: " + ", ".join(unrelated),
             }
         )
-mode = "ugc" if scope in {"direct-candidate", "direct-provider"} else "full"
+# Mirror ci-validate-route.mjs: route to the light ugc preflight only for an
+# in-shape direct submission with no errors; anything errored (e.g. an unrelated
+# file → generated-artifact-tampering) must get the full validation suite.
+mode = "ugc" if scope != "normal-pr" and not errors else "full"
 report = {
     "schema_version": 1,
     "mode": mode,

--- a/scripts/test_classify_validation_route.py
+++ b/scripts/test_classify_validation_route.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Unit tests for classify-validation-route.py.
+
+The script mirrors the canonical classifier in scripts/submission-policy.mjs
+(tested in tests/submission-gate.test.mjs) and must stay in sync with it. Like
+test_fetch_events.py these are stdlib `unittest` only (zero deps), runnable BOTH:
+
+    python3 scripts/test_classify_validation_route.py
+    python3 -m unittest scripts.test_classify_validation_route
+    python3 -m pytest scripts/test_classify_validation_route.py  # if available
+
+classify-validation-route.py does all its work at module top level (reading
+changed-files.txt and writing validate-route.json), so we exercise it as a
+subprocess in a temp cwd rather than importing it.
+"""
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+_SCRIPT = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "classify-validation-route.py"
+)
+
+
+def classify(files):
+    """Run the classifier over `files` and return the validate-route.json report."""
+    with tempfile.TemporaryDirectory() as d:
+        (pathlib.Path(d) / "changed-files.txt").write_text(
+            "\n".join(files) + "\n", encoding="utf-8"
+        )
+        env = {k: v for k, v in os.environ.items() if k != "GITHUB_OUTPUT"}
+        subprocess.run(
+            [sys.executable, _SCRIPT], cwd=d, env=env, check=True,
+            capture_output=True, text=True,
+        )
+        return json.loads(
+            (pathlib.Path(d) / "validate-route.json").read_text(encoding="utf-8")
+        )
+
+
+class ClassifyValidationRouteTest(unittest.TestCase):
+    def test_atomic_provider_candidate_pair_is_direct_pair(self):
+        # The canonical classifier allows a debut provider + first surface together
+        # (tests/submission-gate.test.mjs asserts scope === "direct-pair").
+        report = classify(
+            [
+                "registry/candidates/community/acme.json",
+                "registry/providers/community/acme.json",
+            ]
+        )
+        self.assertEqual(report["scope"], "direct-pair")
+        self.assertEqual(report["errors"], [])
+        self.assertEqual(report["mode"], "ugc")
+
+    def test_lone_candidate_and_lone_provider(self):
+        cand = classify(["registry/candidates/community/acme.json"])
+        self.assertEqual(cand["scope"], "direct-candidate")
+        self.assertEqual(cand["mode"], "ugc")
+        prov = classify(["registry/providers/community/acme.json"])
+        self.assertEqual(prov["scope"], "direct-provider")
+        self.assertEqual(prov["mode"], "ugc")
+
+    def test_normal_pr(self):
+        report = classify(["src/feeds.mjs", "README.md"])
+        self.assertEqual(report["scope"], "normal-pr")
+        self.assertEqual(report["mode"], "full")
+
+    def test_direct_submission_with_unrelated_file_routes_to_full(self):
+        # A direct submission that also touches an unrelated file is tampering and
+        # must get the FULL validation suite, not the light ugc preflight.
+        report = classify(
+            ["registry/candidates/community/acme.json", "src/evil.mjs"]
+        )
+        self.assertEqual(report["scope"], "direct-candidate")
+        self.assertTrue(
+            any(e["category"] == "generated-artifact-tampering" for e in report["errors"])
+        )
+        self.assertEqual(report["mode"], "full")
+
+    def test_two_candidates_is_unsupported_shape(self):
+        report = classify(
+            [
+                "registry/candidates/community/a.json",
+                "registry/candidates/community/b.json",
+            ]
+        )
+        self.assertTrue(
+            any(e["category"] == "unsupported-shape" for e in report["errors"])
+        )
+        self.assertEqual(report["mode"], "full")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1566.

`scripts/classify-validation-route.py` runs before `npm ci` to pick a PR's CI route (`mode=ugc` light preflight vs `mode=full`). Its docstring says it mirrors the canonical `classifyPrScope` in `scripts/submission-policy.mjs` ("keep the two in sync"), but it had drifted in two ways:

1. **No `direct-pair` shape.** The canonical allows an atomic provider+candidate pair (one of each) as `scope: "direct-pair"` with no error — a tested contract (`tests/submission-gate.test.mjs:479`). The Python set `scope="direct-provider"` and pushed a spurious `unsupported-shape` error because `len(submission_files)==2 != 1`.
2. **`mode` ignored errors.** The canonical (`scripts/ci-validate-route.mjs`) gates `mode = scope !== "normal-pr" && errors.length === 0 ? "ugc" : "full"`. The Python derived `mode` from `scope` alone, so a direct submission that also touched an unrelated file (a `generated-artifact-tampering` error) was routed to the light `ugc` preflight instead of the full validation suite.

## What Changed

- Recognize `direct-pair` (one candidate + one provider) with no error, mirroring `classifyPrScope`.
- Gate `mode="ugc"` on `scope != "normal-pr" and not errors`, so any errored/tampering submission gets full validation.
- Added `scripts/test_classify_validation_route.py` (zero-dep stdlib `unittest`, same style as `test_fetch_events.py`) covering direct-pair, lone candidate/provider, normal-pr, tampering→full, and unsupported-shape.

## Template Used

- backend-code

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none)

## Validation

- [x] `python3 scripts/test_classify_validation_route.py` (5 passed)
- [x] `python3 -m py_compile` on both files
- [x] `git diff --check`