### PR TITLE
fix(test): un-break main — graphql.test.mjs renamed helper (fixtureEnv)

### DIFF
--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -455,7 +455,7 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
   });
 
   test("subnets limit:0 falls back to the default page (not clamped up to 1)", async () => {
-    const env = fakeArtifactEnv({
+    const env = fixtureEnv({
       "/metagraph/subnets.json": {
         subnets: [
           { netuid: 1, name: "A", slug: "a" },


### PR DESCRIPTION
**main is currently RED.** A concurrent-merge collision between #1546 (added the `subnets limit:0` test using `fakeArtifactEnv`) and #1547 (renamed that helper to `fixtureEnv`) left `tests/graphql.test.mjs:458` calling an undefined `fakeArtifactEnv` — failing both the **test** job (`ReferenceError`) and the **checks** job (eslint `no-undef`). Each PR passed CI alone; merged together they broke main. One-line fix: rename the stale call to `fixtureEnv`. graphql.test.mjs 79 pass; eslint + prettier clean.