### PR TITLE
fix(health-serving): stamp merged RPC endpoint observed_at with the sweep time, not stale last_ok

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -219,7 +219,11 @@ export function mergeRpcEndpoints(staticArtifact, liveRpcPool) {
       archive_support: live.archive_support ?? endpoint.archive_support,
       health_source: "probe-derived",
       health_stale: false,
-      observed_at: live.last_ok || liveRpcPool.last_run_at,
+      // observed_at is when this status was observed, i.e. the sweep time. rpc-pool
+      // rows carry only last_ok (last SUCCESS), so a failing/degraded endpoint's
+      // last_ok is a stale prior-success time — using it would label a fresh
+      // failed observation with an hours-old timestamp. Prefer the run time.
+      observed_at: liveRpcPool.last_run_at || live.last_ok || null,
     };
   });
   return {

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -141,6 +141,31 @@ describe("mergeRpcEndpoints", () => {
     assert.equal(merged.operational_observed_at, "r");
     assert.equal(merged.endpoints.find((e) => e.id === "b").status, "ok"); // no live → static
   });
+
+  test("a failing endpoint's observed_at is the sweep time, not its stale last_ok", () => {
+    const stat = {
+      schema_version: 1,
+      endpoints: [{ id: "a", status: "ok", health_source: "probe-derived" }],
+    };
+    const live = {
+      last_run_at: "2026-06-11T00:00:00Z",
+      endpoints: [
+        {
+          id: "a",
+          status: "failed",
+          classification: "dead",
+          latency_ms: null,
+          // last successful probe was hours ago; the endpoint is failing now.
+          last_ok: "2026-06-10T08:00:00Z",
+        },
+      ],
+    };
+    const a = mergeRpcEndpoints(stat, live).endpoints.find((e) => e.id === "a");
+    // health_stale:false claims a fresh observation, so observed_at must be the
+    // run time — not the stale last-success timestamp.
+    assert.equal(a.health_stale, false);
+    assert.equal(a.observed_at, "2026-06-11T00:00:00Z");
+  });
 });
 
 describe("overlayRpcPoolEligibility", () => {


### PR DESCRIPTION
## Summary

Fixes #1598.

`mergeRpcEndpoints` overlaid live RPC-pool health with:

```js
health_stale: false,
observed_at: live.last_ok || liveRpcPool.last_run_at,
```

rpc-pool endpoint rows carry only `last_ok` (last SUCCESS) — see the prober's `rpcRows` build in `src/health-prober.mjs` (no `last_checked`); the pool object carries `last_run_at` (this sweep). For a `failed`/`degraded` endpoint, `last_ok` is its stale prior-success time, so the overlay reported an hours-old `observed_at` while also asserting `health_stale: false` — a fresh observation labelled with an old timestamp.

## What Changed

- `observed_at: liveRpcPool.last_run_at || live.last_ok || null` — the sweep/run time is the correct freshness source for a probe-derived, non-stale row.
- Added a regression test: a failing endpoint with a stale `last_ok` now reports `observed_at` = the run time.

## Template Used

- backend-code

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none)

## Validation

- [x] `vitest run tests/health-serving.test.mjs` (120 passed, incl. new regression test)
- [x] `prettier --check` + `eslint` on changed files
- [x] `git diff --check`