### PR TITLE
fix(mcp): ensure consistent pagination for search_subnets and find_su…

### DIFF
--- a/registry/candidates/community/community-sn-74-data-artifact-gittensor-prices-api-gittensor-io.json
+++ b/registry/candidates/community/community-sn-74-data-artifact-gittensor-prices-api-gittensor-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-74-data-artifact-gittensor-prices-api-gittensor-io",
+      "kind": "data-artifact",
+      "name": "Gittensor TAO and Alpha token prices",
+      "netuid": 74,
+      "provider": "gittensor",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.gittensor.io/swagger",
+      "source_urls": ["https://api.gittensor.io/swagger"],
+      "state": "schema-valid",
+      "url": "https://api.gittensor.io/dash/prices"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "carlh7777",
+    "submitted_by_url": "https://github.com/carlh7777"
+  }
+}


### PR DESCRIPTION
## Pick The Right Template

Use the matching PR template so the submission gate can classify your PR
correctly:

- [x] [Direct subnet/interface candidate](?template=direct-candidate.md): one
  `registry/candidates/community/*.json` file only.
- [ ] [Provider/operator profile](?template=provider-profile.md): one
  `registry/providers/community/*.json` file only.
- [ ] [Backend/code change](?template=backend-code.md): scripts, schemas,
  contracts, workflows, or registry generator logic.
- [ ] [Docs-only change](?template=docs-only.md): README or docs edits only.

For direct UGC submissions, do not edit generated `public/metagraph/**`
artifacts, native snapshots, scripts, workflows, package files, or multiple
candidate/provider files.

## Summary

Community submission for **Subnet 74 (Gittensor)** — public `data-artifact` surface.

Adds exactly one candidate file for the unauthenticated token prices API (`/dash/prices`) documented in the public OpenAPI spec. Returns cached TAO and Alpha token price data as JSON. Related to surface enrichment epic #427.

## Template Used

Direct subnet/interface candidate (`direct-candidate.md`)

## Candidate

- **Netuid:** 74
- **Kind:** `data-artifact`
- **Public URL:** https://api.gittensor.io/dash/prices
- **Source URL:** https://api.gittensor.io/swagger
- **Provider/operator:** `gittensor`

## Checklist

- [x] This PR changes exactly one `registry/candidates/community/*.json` file.
- [x] I generated the file with `npm run candidate:new` or matched
      `docs/examples/submissions/direct-candidate.json`.
- [x] The submitted URL is public and safe for read-only probes.
- [x] The source URL publicly supports the interface claim.
- [x] This does not require authentication.
- [x] This does not duplicate an existing Metagraphed surface or candidate.
- [x] This does not include secrets, wallet/PAT data, private URLs, private
      dashboards, validator internals, or generated artifacts.

## Validation

Verified `https://api.gittensor.io/dash/prices` returns HTTP 200 with `application/json` and is listed in the live Swagger spec under Dashboard → `GET /dash/prices`.

```bash
npm run validate:candidate -- registry/candidates/community/community-sn-74-data-artifact-gittensor-prices-api-gittensor-io.json
npm run submission:pr -- --changed-files <changed-files.txt>
npm run validate:intake
npm run scan:public-safety