### PR TITLE
feat(registry): add SN15 ORO public data-artifact candidate

### DIFF
--- a/registry/candidates/community/community-sn-15-data-artifact-api-oroagents-com.json
+++ b/registry/candidates/community/community-sn-15-data-artifact-api-oroagents-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-15-data-artifact-api-oroagents-com",
+      "kind": "data-artifact",
+      "name": "ORO community data-artifact",
+      "netuid": 15,
+      "provider": "oro",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.oroagents.com/openapi.json",
+      "source_urls": ["https://api.oroagents.com/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.oroagents.com/v1/public/top"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "minion1227",
+    "submitted_by_url": "https://github.com/minion1227"
+  }
+}


### PR DESCRIPTION
Adds a community candidate for ORO's public, no-auth top-miner data artifact
(https://api.oroagents.com/v1/public/top), proven by the published OpenAPI
spec (ORO API v0.1.0, no global security).

Part of #1280.

## Summary

Enriches **SN15 (ORO)** with a public `data-artifact` surface, completing #1280
(the `subnet-api` half is PR #1584).

Adds exactly one file —
`registry/candidates/community/community-sn-15-data-artifact-api-oroagents-com.json`:

- **Netuid:** 15 (ORO)
- **Kind:** `data-artifact`
- **Public URL:** https://api.oroagents.com/v1/public/top — verified HTTP 200,
  `application/json`, no authentication (current top-miner snapshot)
- **Source URL:** https://api.oroagents.com/openapi.json — `ORO API v0.1.0`, no global security
- **Provider:** `oro` (registered slug)
- `public_safe: true` · `auth_required: false`

Generated with `npm run candidate:new`. One file, no generated artifacts, no
secrets/PAT/private URLs. Not a duplicate — SN15 has no existing `data-artifact` surface.

Validation run locally:
- `npm run submission:pr` → `submit_pr`, no errors
- `npm run validate:candidate` → passed
- `npm run scan:public-safety` → passed

## Template Used

Direct subnet/interface candidate (one `registry/candidates/community/*.json` file)
