### PR TITLE
fix(openapi-sample): bound self-refs routed through oneOf/anyOf/allOf

### DIFF
--- a/src/openapi-sample.mjs
+++ b/src/openapi-sample.mjs
@@ -112,21 +112,42 @@ function resolveRef(ref, components) {
 
 // Sample a JSON-Schema (2020-12 subset used by the metagraphed contract) into a
 // concrete, valid instance. `components` is the bundle's components.schemas map.
-export function sampleFromSchema(schema, components, name = "", depth = 0) {
+// `seenRefs` tracks the $refs resolved along the current descent path (see the
+// $ref branch) and is threaded through every recursive call; callers leave it
+// at its default.
+export function sampleFromSchema(
+  schema,
+  components,
+  name = "",
+  depth = 0,
+  seenRefs = null,
+) {
   if (!schema || typeof schema !== "object") return null;
   if (schema.$ref) {
     // Bound self-referential schemas. The object and array branches grow
-    // `depth` as they descend, but only the array branch had a MAX_DEPTH guard,
-    // so a required self-referential property (a linked list / tree node)
-    // recursed through $ref until the stack overflowed. A self-reference always
-    // routes back through here, so guard at this chokepoint — without changing
-    // `depth`, so non-cyclic schemas still sample exactly as before.
+    // `depth` as they descend, so an object/array self-reference (a linked list
+    // / tree node) trips this MAX_DEPTH guard. But the allOf/oneOf/anyOf and
+    // $ref branches recurse WITHOUT growing `depth`, so a self-reference routed
+    // purely through composition keywords (e.g. `Node: { oneOf: [$ref Node] }`)
+    // never advanced `depth` and recursed until the stack overflowed.
     if (depth >= MAX_DEPTH) return null;
+    // Cut a non-advancing cycle: if this same $ref recurs at the same `depth` we
+    // already passed through on this path, no progress is being made. Keying by
+    // depth (not the ref alone) preserves depth-advancing object/array
+    // self-refs, which keep descending until the MAX_DEPTH guard above — so
+    // non-cyclic schemas still sample exactly as before.
+    const refKey = `${schema.$ref}@${depth}`;
+    if (seenRefs?.has(refKey)) return null;
+    // Copy onto a fresh set (seenRefs is null on the entry call) so sibling
+    // branches keep independent paths and this $ref is only seen below here.
+    const nextSeen = new Set(seenRefs ?? []);
+    nextSeen.add(refKey);
     return sampleFromSchema(
       resolveRef(schema.$ref, components),
       components,
       name,
       depth,
+      nextSeen,
     );
   }
   if ("const" in schema) return schema.const;
@@ -137,7 +158,7 @@ export function sampleFromSchema(schema, components, name = "", depth = 0) {
     let merged = {};
     let scalar;
     for (const sub of schema.allOf) {
-      const part = sampleFromSchema(sub, components, name, depth);
+      const part = sampleFromSchema(sub, components, name, depth, seenRefs);
       if (part && typeof part === "object" && !Array.isArray(part)) {
         merged = { ...merged, ...part };
       } else if (part !== null && part !== undefined) {
@@ -151,7 +172,7 @@ export function sampleFromSchema(schema, components, name = "", depth = 0) {
     const pick =
       variants.find((variant) => pickType(variant.type) !== "null") ||
       variants[0];
-    return sampleFromSchema(pick, components, name, depth);
+    return sampleFromSchema(pick, components, name, depth, seenRefs);
   }
 
   const type = pickType(schema.type);
@@ -164,7 +185,13 @@ export function sampleFromSchema(schema, components, name = "", depth = 0) {
     const includeOptional = depth < OPTIONAL_DEPTH;
     for (const [key, propSchema] of Object.entries(props)) {
       if (!required.has(key) && !includeOptional) continue;
-      out[key] = sampleFromSchema(propSchema, components, key, depth + 1);
+      out[key] = sampleFromSchema(
+        propSchema,
+        components,
+        key,
+        depth + 1,
+        seenRefs,
+      );
     }
     // Pure map object (additionalProperties is a schema, no named props): show
     // one representative entry so the shape is visible.
@@ -179,6 +206,7 @@ export function sampleFromSchema(schema, components, name = "", depth = 0) {
         components,
         "example",
         depth + 1,
+        seenRefs,
       );
     }
     return out;
@@ -186,7 +214,15 @@ export function sampleFromSchema(schema, components, name = "", depth = 0) {
 
   if (type === "array") {
     if (depth >= MAX_DEPTH) return [];
-    return [sampleFromSchema(schema.items || {}, components, name, depth + 1)];
+    return [
+      sampleFromSchema(
+        schema.items || {},
+        components,
+        name,
+        depth + 1,
+        seenRefs,
+      ),
+    ];
   }
 
   if (type === "string") {

--- a/tests/openapi-sample.test.mjs
+++ b/tests/openapi-sample.test.mjs
@@ -255,6 +255,28 @@ describe("sampleFromSchema", () => {
     assert.doesNotThrow(() => sampleFromSchema(selfArr.Tree, selfArr, "Tree"));
   });
 
+  test("bounds recursion: self-refs routed through oneOf/anyOf/allOf don't overflow", () => {
+    // A self-reference whose only hop is a composition keyword never grows
+    // `depth`, so the MAX_DEPTH budget alone can't break it — the $ref must
+    // also detect a non-advancing cycle.
+    for (const kw of ["oneOf", "anyOf", "allOf"]) {
+      const cyclic = {
+        Node: { [kw]: [{ $ref: "#/components/schemas/Node" }] },
+      };
+      assert.doesNotThrow(
+        () => sampleFromSchema(cyclic.Node, cyclic, "Node"),
+        `${kw} self-ref should be bounded`,
+      );
+    }
+
+    // Mutual recursion through composition keywords is likewise bounded.
+    const mutual = {
+      A: { oneOf: [{ $ref: "#/components/schemas/B" }] },
+      B: { oneOf: [{ $ref: "#/components/schemas/A" }] },
+    };
+    assert.doesNotThrow(() => sampleFromSchema(mutual.A, mutual, "A"));
+  });
+
   test("a sampled instance validates against its own schema (round-trip)", () => {
     const ajv = new Ajv2020({ strict: false, validateFormats: true });
     addFormats(ajv);


### PR DESCRIPTION
## Summary

- `sampleFromSchema` overflows the stack on a self-referential schema whose cycle is routed purely through a composition keyword (`oneOf` / `anyOf` / `allOf`), e.g. `Node: { oneOf: [{ $ref: "#/components/schemas/Node" }] }`.

_(Revised resubmission of #1554, which was auto-closed as `changes-requested`. See "Re: the prior review note" below — the flagged line is verified correct, and I've made it explicit so it reads unambiguously.)_

## What Changed

- The `MAX_DEPTH` recursion guard only fires when `depth` advances, and `depth` is incremented **only** in the object-property and array-items branches. The `$ref`, `allOf`, and `oneOf`/`anyOf` branches all recurse without growing `depth`, so a cycle that never touches an object/array level never trips the guard and recurses until the stack overflows. (The object/array self-ref paths fixed earlier are unaffected — they advance `depth` and still bottom out at `MAX_DEPTH`.)
- Fix: thread a per-descent-path `seenRefs` set through every recursive call and cut the cycle when the same `$ref` recurs at the **same** `depth` (no progress made). Keying by `ref@depth` (not the ref alone) deliberately preserves depth-advancing object/array self-refs, so **non-cyclic schemas sample byte-for-byte as before** — `validate:contract-drift` and `validate:openapi-examples` are unchanged.
- Added a regression test covering `oneOf`/`anyOf`/`allOf` self-references and mutual composition recursion.

Repro (each throws `RangeError: Maximum call stack size exceeded` before the fix, returns a bounded value after):

```js
for (const kw of ["oneOf", "anyOf", "allOf"]) {
  const comps = { Node: { [kw]: [{ $ref: "#/components/schemas/Node" }] } };
  sampleFromSchema({ $ref: "#/components/schemas/Node" }, comps);
}
```

## Re: the prior review note

The earlier automated review flagged `new Set(seenRefs)` as a TypeError when `seenRefs` is null (the default). That's not the case — per the ECMAScript spec the `Set` constructor ignores a `null`/`undefined` iterable and returns an empty set, so `new Set(null)` does **not** throw. The existing `$ref` unit test exercises the default `seenRefs=null` path, and `validate:contract-drift` regenerates the entire OpenAPI document through every `$ref` with that default — both pass. To remove any ambiguity I've made the entry path explicit anyway: `new Set(seenRefs ?? [])` and `seenRefs?.has(...)`. Behavior is identical.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No OpenAPI output change — verified via `validate:contract-drift`.)

## Validation

- [x] `validate:contract-drift` — passed (no drift)
- [x] `validate:openapi-examples` — passed (73/73)
- [x] `npm run validate:openapi` — passed
- [x] `npm run format:check` / `eslint` — clean
- [x] `vitest run tests/openapi-sample.test.mjs` — 19/19 passed
- [x] `git diff --check` — clean

## Template Used

- backend-code.md
