### PR TITLE
fix(events): don't fire the lag alert when the overlap window covers the prune horizon

### DIFF
--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -402,6 +402,23 @@ def extract(event_id, attrs):
     }
 
 
+def _lag_alert_needed(head_bn, cursor, window=WINDOW, horizon=PRUNE_HORIZON):
+    """True when the cursor is far enough behind the finalized head that un-fetched
+    blocks risk being pruned before the next run.
+
+    No alert on a cold cursor (nothing to lag). And none when the overlap window
+    already covers the whole prune horizon (``horizon - window <= 0``): blocks can
+    then never age out unseen, so the bare ``horizon - window`` threshold would be
+    zero/negative and otherwise fire on every run (even at lag 0).
+    """
+    if cursor is None:
+        return False
+    overlap_floor = horizon - window
+    if overlap_floor <= 0:
+        return False
+    return (head_bn - cursor) >= overlap_floor
+
+
 def _emit_lag_alert(head_bn, cursor):
     """If the cursor is within ~one window of the prune horizon, warn loudly.
 
@@ -410,13 +427,9 @@ def _emit_lag_alert(head_bn, cursor):
     falling behind faster than it can catch up is VISIBLE before blocks are pruned
     out from under it — not silently lost. No-op on a cold cursor (nothing to lag).
     """
-    if cursor is None:
+    if not _lag_alert_needed(head_bn, cursor):
         return
     lag = head_bn - cursor
-    # Alert once the lag is within a window of the prune horizon (i.e. the next
-    # missed/coalesced run could push un-fetched blocks past the prune point).
-    if lag < PRUNE_HORIZON - WINDOW:
-        return
     msg = (
         f"chain-event poller lagging: cursor={cursor} is {lag} blocks behind "
         f"finalized head {head_bn} (prune horizon ~{PRUNE_HORIZON}). Blocks risk "

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -170,5 +170,33 @@ class ParseCursorTest(unittest.TestCase):
         self.assertIsNone(_parse_cursor(-7))
 
 
+_lag_alert_needed = _fe._lag_alert_needed
+
+
+class LagAlertNeededTest(unittest.TestCase):
+    def test_cold_cursor_never_alerts(self):
+        self.assertFalse(_lag_alert_needed(10_000, None, window=256, horizon=300))
+
+    def test_alerts_at_and_above_the_overlap_floor(self):
+        # floor = horizon - window = 44; lag >= 44 alerts, below does not.
+        self.assertFalse(
+            _lag_alert_needed(10_000, 10_000 - 43, window=256, horizon=300)
+        )
+        self.assertTrue(
+            _lag_alert_needed(10_000, 10_000 - 44, window=256, horizon=300)
+        )
+        self.assertTrue(
+            _lag_alert_needed(10_000, 10_000 - 100, window=256, horizon=300)
+        )
+
+    def test_window_ge_horizon_never_alerts(self):
+        # When the overlap window covers the whole prune horizon, blocks can never
+        # age out unseen — must NOT alert (regression: a bare horizon-window
+        # threshold goes <= 0 and would fire every run, even at lag 0).
+        self.assertFalse(_lag_alert_needed(10_000, 10_000, window=300, horizon=300))
+        self.assertFalse(_lag_alert_needed(10_000, 9_000, window=300, horizon=300))
+        self.assertFalse(_lag_alert_needed(10_000, 9_000, window=400, horizon=300))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Fixes #1601.

`_emit_lag_alert` (scripts/fetch-events.py) used the unclamped threshold `PRUNE_HORIZON - WINDOW`:

```python
if lag < PRUNE_HORIZON - WINDOW:
    return
```

`EVENTS_WINDOW` (default 256) and `EVENTS_PRUNE_HORIZON` (default 300) are independent env knobs. With `WINDOW >= PRUNE_HORIZON` the threshold goes `<= 0`, so `lag < threshold` is never true and the alert (a `::warning::` **and** a `METAGRAPH_ALERT_WEBHOOK_URL` POST) fired on every run — even at lag 0. That is exactly the configuration where the overlap window already covers the whole prune horizon, so blocks can never age out unseen and there is nothing to alert about.

## What Changed

- Extracted a pure `_lag_alert_needed(head_bn, cursor, window, horizon)`: no alert on a cold cursor; no alert when `horizon - window <= 0`; otherwise alert when `lag >= horizon - window`.
- `_emit_lag_alert` now delegates to it. (A bare `max(0, …)` clamp is insufficient — it would still fire at lag 0; the `<= 0` case must short-circuit.)
- Added `LagAlertNeededTest` to scripts/test_fetch_events.py.

## Template Used

- backend-code

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none)

## Validation

- [x] `python3 scripts/test_fetch_events.py` (15 passed, incl. new lag-alert tests)
- [x] `python3 -m py_compile` on both files
- [x] `git diff --check`