### PR TITLE
Fix query auth snippet crash on malformed Unicode

### DIFF
--- a/src/integration-snippets.mjs
+++ b/src/integration-snippets.mjs
@@ -75,6 +75,15 @@ function isCredentialSafeUrl(url) {
   }
 }
 
+function encodeQueryCredentialPart(value) {
+  try {
+    return encodeURIComponent(value);
+  } catch (error) {
+    if (error instanceof URIError) return null;
+    throw error;
+  }
+}
+
 // Returns { curl, python, typescript } or null when there is no usable base_url.
 export function generateServiceSnippets(service) {
   const url = service?.base_url;
@@ -97,12 +106,14 @@ export function generateServiceSnippets(service) {
   // spaces and URL-reserved chars (fine inside a header), but unencoded they'd
   // either trip isSnippetSafeUrl's whitespace guard (→ no snippets at all) or
   // corrupt the query string.
-  const requestUrl =
-    auth?.location === "query"
-      ? `${url}${url.includes("?") ? "&" : "?"}${encodeURIComponent(
-          auth.name,
-        )}=${encodeURIComponent(auth.value)}`
-      : url;
+  let requestUrl = url;
+  if (auth?.location === "query") {
+    const encodedName = encodeQueryCredentialPart(auth.name);
+    const encodedValue = encodeQueryCredentialPart(auth.value);
+    if (encodedName !== null && encodedValue !== null) {
+      requestUrl = `${url}${url.includes("?") ? "&" : "?"}${encodedName}=${encodedValue}`;
+    }
+  }
   if (!isSnippetSafeUrl(requestUrl)) return null;
   const header = auth?.location === "header" ? auth : null;
 

--- a/tests/integration-snippets.test.mjs
+++ b/tests/integration-snippets.test.mjs
@@ -168,6 +168,35 @@ describe("generateServiceSnippets structured auth (#746)", () => {
     assert.match(out.curl, /\?api_key=Bearer%20YOUR_API_KEY/);
   });
 
+  test("malformed UTF-16 in query auth is dropped without throwing", () => {
+    let out;
+    assert.doesNotThrow(() => {
+      out = generateServiceSnippets({
+        ...base,
+        auth: {
+          scheme: "api-key",
+          location: "query",
+          name: "\uD800",
+          value_format: "<api-key>",
+        },
+      });
+    });
+    assert.equal(out.curl, "curl -sS 'https://api.example.com/v1'");
+
+    out = generateServiceSnippets({
+      ...base,
+      auth: {
+        scheme: "api-key",
+        location: "query",
+        name: "api_key",
+        value_format: "\uD800",
+      },
+    });
+    assert.ok(out);
+    assert.equal(out.curl, "curl -sS 'https://api.example.com/v1'");
+    assert.doesNotMatch(out.python, /api_key/);
+  });
+
   test("structured auth wins over the scheme-type guess", () => {
     const out = generateServiceSnippets({
       ...base,


### PR DESCRIPTION
### Motivation
- `encodeURIComponent` throws `URIError` on malformed UTF-16 (lone surrogates) and the query-auth encoding added earlier could crash snippet generation and abort builds when upstream OpenAPI securitySchemes contain attacker-controlled names/values. 
- The intent is to avoid throwing on unencodable credential parts while preserving snippet generation for safe cases.

### Description
- Add a helper `encodeQueryCredentialPart` that wraps `encodeURIComponent` and returns `null` for `URIError` so malformed Unicode does not propagate as a synchronous crash. 
- Change query credential URL construction to only append the encoded `name=value` pair when both `encodedName` and `encodedValue` are non-`null`, otherwise keep the plain base URL. 
- Leave header-auth behavior unchanged so header placeholders still appear as before. 
- Add a regression test `malformed UTF-16 in query auth is dropped without throwing` to `tests/integration-snippets.test.mjs` to verify that malformed query auth names/values are tolerated and snippets do not throw.

### Testing
- Ran the integration snippet tests with `npm test -- --run tests/integration-snippets.test.mjs` (Vitest) and all tests passed (`17` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b630d6174832c9f50a25d1394143b)