### PR TITLE
fix(scripts): resolve repoRoot via fileURLToPath for Windows

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import { lookup } from "node:dns/promises";
 import { BlockList, isIP } from "node:net";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   ARTIFACT_STORAGE_TIERS,
   R2_STAGING_RELATIVE_ROOT,
@@ -11,7 +12,12 @@ import {
   artifactStorageTierForRelativePath,
 } from "../src/artifact-storage.mjs";
 
-export const repoRoot = new URL("..", import.meta.url).pathname;
+// Resolve to a native filesystem path via fileURLToPath rather than URL.pathname:
+// on Windows `.pathname` is `/C:/…` (a leading slash + percent-encoding), which
+// path.join turns into a broken `C:\C:\…` and decodes nothing, breaking every
+// script that derives a path from repoRoot. fileURLToPath yields the correct
+// platform-native, percent-decoded path on POSIX and Windows alike.
+export const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 export const publicMetagraphRoot = path.join(repoRoot, "public/metagraph");
 export const r2StagingRoot = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT);
 export const generatedSourceRoot = path.join(repoRoot, "dist/metagraph-source");


### PR DESCRIPTION
## Summary

- On Windows, `scripts/lib.mjs` derived `repoRoot` from `new URL(.., import.meta.url).pathname`, which yields `/C:/Users/.../metagraphed/` (a leading slash + percent-encoding). `path.join(repoRoot, ...)` then produced a broken `C:\C:\Users\...` path, so every script that builds a path from `repoRoot` crashed with `ENOENT`.
- This breaks the documented contributor workflow on Windows — e.g. `npm run candidate:new` and `npm run validate:candidate` (the exact commands the enrichment issues ask contributors to run), plus `validate:*`, `build`, and friends.

## What Changed

- Resolve `repoRoot` with `fileURLToPath(new URL(.., import.meta.url))` instead of `URL.pathname`. `fileURLToPath` returns the correct platform-native, percent-decoded path on both POSIX and Windows.
- Behavior is unchanged on Linux/CI: for normal paths `fileURLToPath` returns the same value `.pathname` did, and it additionally decodes percent-encoding (e.g. spaces in a checkout path), so it is strictly more correct.
- Single-line change plus an explanatory comment; no API, schema, or generated-artifact changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none)

## Validation

Ran on Windows (where the bug reproduces):

- [x] `npx eslint scripts/lib.mjs` — clean
- [x] `npx prettier --check scripts/lib.mjs` — clean
- [x] `npx vitest run tests/lib-helpers.test.mjs tests/script-utils.test.mjs` — 149 passed
- [x] `node scripts/validate-candidate.mjs <file>` — now runs (previously crashed with `C:\C:\...` ENOENT)
- [x] `node scripts/candidate-new.mjs ...` — now runs (previously crashed)
- [x] `git diff --check`

## Template Used

- backend-code