### PR TITLE
feat(registry): add SN17 404-GEN Blender add-on SDK candidate

### DIFF
--- a/registry/subnets/sn-17.json
+++ b/registry/subnets/sn-17.json
@@ -1,19 +1,35 @@
 {
-  "schema_version": 1,
-  "netuid": 17,
-  "name": "404—GEN",
-  "slug": "sn-17",
-  "status": "active",
   "categories": [],
+  "contact": "404@404.xyz",
   "curation": {
     "level": "candidate-discovered",
     "review_state": "unreviewed"
   },
-  "surfaces": [],
+  "name": "404—GEN",
+  "netuid": 17,
+  "schema_version": 1,
+  "slug": "sn-17",
   "social": {
     "x": "https://x.com/404gen_"
   },
-  "contact": "404@404.xyz",
   "source_repo": "https://github.com/404-Repo/404-gen-subnet",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-17-404-gen-sdk",
+      "kind": "sdk",
+      "name": "404-GEN Blender add-on",
+      "provider": "404-gen",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dripsmvcp"
+      },
+      "source_urls": ["https://github.com/404-Repo/404-gen-subnet"],
+      "url": "https://github.com/404-Repo/404-gen-blender-add-on"
+    }
+  ],
   "website_url": "https://www.404.xyz/"
 }


### PR DESCRIPTION
## Summary

Adds **one** community-data surface: the official **404-GEN Blender add-on** as an `sdk` surface for **Subnet 17 (404—GEN)**, in the single-file subnet layout (`registry/subnets/sn-17.json`).

- `url`: `https://github.com/404-Repo/404-gen-blender-add-on` — the official Blender integration published by the 404-GEN team (`404-Repo` org) that generates 3D assets from SN17 directly inside Blender. Public, not archived, actively maintained.
- `source_url`: `https://github.com/404-Repo/404-gen-subnet` — the subnet's source repository, which the add-on README links as its "Project Repo", proving the add-on belongs to the same official project/team.
- `provider`: `404-gen` — already a registered SN17 team profile.
- Distinct developer surface from the subnet's recorded `source_repo`; SN17 has no `sdk` surface yet, so this is not a duplicate.

Migrates off the retired `registry/candidates/community/` intake path (which now fails `validate:intake`). Single file changed, no generated artifacts.

## Validation

- `npm run surface:add` → surface written, reachable + public-safe
- `npm run build` → passed
- `npm run validate` → passed (1172 surfaces)
- `npm run validate:intake` → passed
- `npm run validate:contract-drift` → passed
- `npm run format:check` → clean

## Checklist

- [x] Exactly one `registry/subnets/<slug>.json` changed, nothing else
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public `url` + `source_url` that proves the claim
- [x] Auto-review `kind` (`sdk`), `auth_required: false`, `public_safe: true`, active netuid (17), registered provider (`404-gen`)
- [x] Conventional Commit; no AI attribution

Closes #1748