### PR TITLE
feat(api): add ?q= search to the /api/v1/subnets list endpoint

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -11425,6 +11425,7 @@ export interface operations {
                 domain?: "agents" | "compute" | "data" | "finance" | "inference" | "media" | "prediction" | "privacy" | "robotics" | "science" | "search" | "security" | "storage" | "training";
                 status?: "active" | "inactive";
                 subnet_type?: "root" | "application";
+                q?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -748,6 +748,12 @@
           }
         },
         {
+          "name": "q",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -23054,6 +23054,14 @@
           },
           {
             "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11425,6 +11425,7 @@ export interface operations {
                 domain?: "agents" | "compute" | "data" | "finance" | "inference" | "media" | "prediction" | "privacy" | "robotics" | "science" | "search" | "security" | "storage" | "training";
                 status?: "active" | "inactive";
                 subnet_type?: "root" | "application";
+                q?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -575,6 +575,7 @@ export const API_QUERY_COLLECTIONS = {
       status: enumSchema(QUERY_ENUMS.subnetStatus),
       subnet_type: enumSchema(QUERY_ENUMS.subnetType),
     },
+    search: ["name", "slug"],
     sort: [
       "block",
       "candidate_count",

--- a/tests/subnets-query.test.mjs
+++ b/tests/subnets-query.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { applyQueryFilters } from "../workers/list-query.mjs";
+
+// A subset of the /api/v1/subnets index row shape (name + slug are the
+// searchable keys; both are projected onto every index row).
+const blob = {
+  subnets: [
+    { netuid: 1, name: "Apex", slug: "apex" },
+    { netuid: 4, name: "Targon", slug: "targon" },
+    { netuid: 64, name: "Chutes", slug: "chutes" },
+  ],
+};
+
+test("subnets collection searches by name (case-insensitive)", () => {
+  const url = new URL("https://x/api/v1/subnets?q=targ");
+  const { data } = applyQueryFilters(blob, url, "subnets", []);
+  assert.deepEqual(
+    data.subnets.map((s) => s.netuid),
+    [4],
+  );
+});
+
+test("subnets collection searches by slug", () => {
+  const url = new URL("https://x/api/v1/subnets?q=chutes");
+  const { data } = applyQueryFilters(blob, url, "subnets", []);
+  assert.deepEqual(
+    data.subnets.map((s) => s.netuid),
+    [64],
+  );
+});
+
+test("subnets collection returns no rows when q matches neither name nor slug", () => {
+  const url = new URL("https://x/api/v1/subnets?q=nonesuch");
+  const { data } = applyQueryFilters(blob, url, "subnets", []);
+  assert.equal(data.subnets.length, 0);
+});
+
+test("subnets collection passes the blob through unchanged with no query", () => {
+  const url = new URL("https://x/api/v1/subnets");
+  const { data } = applyQueryFilters(blob, url, "subnets", []);
+  assert.equal(data.subnets.length, 3);
+});


### PR DESCRIPTION
## Summary

`/api/v1/subnets` is the flagship list endpoint, yet it was the only query collection without a `?q=` free-text search parameter. Every other subnet-shaped collection already supports it — `/api/v1/economics` searches `name`/`slug` over the same rows, and `profiles`, `sources`, `candidates`, `enrichment-queue`, etc. all declare `search`. Callers enumerating subnets by name or slug had to pull the entire list and filter client-side. This closes that gap.

## What Changed

- `src/contracts.mjs`: declare `search: ["name", "slug"]` on the `subnets` query collection. Both fields are already projected onto every subnet index row, so this auto-wires the documented `q` parameter into the OpenAPI / api-index contracts and routes through the existing `searchRows` substring path — no new query-handling code.
- Regenerated committed derived artifacts via `npm run build`: `public/metagraph/openapi.json`, `public/metagraph/api-index.json`, `public/metagraph/types.d.ts`, `generated/metagraphed-api.d.ts`.
- `tests/subnets-query.test.mjs`: covers `?q=` matching by name and by slug, the no-match case, and the no-query passthrough.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts (`npm run build`), not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed (`r2-manifest.json` reverted).
- [x] Public API/OpenAPI/schema changes are intentional and documented — the new `q` param mirrors the existing `economics`/`profiles`/`sources` collections over identical rows.

## Validation

- [x] `npm run validate`
- [x] `npm run validate:types`
- [x] `npm run validate:generated-client`
- [x] Full `vitest run` suite green — 1918 tests, incl. the new `tests/subnets-query.test.mjs`
- [x] `git diff --check`
- [x] Committed `public/` artifacts verified fresh after `npm run build` (clean `git status`, excluding `r2-manifest.json`)
