### PR TITLE
feat(registry): add SN74 Gittensor PRs data-artifact candidate

### DIFF
--- a/registry/candidates/community/community-sn-74-data-artifact-gittensor-prs-api-gittensor-io.json
+++ b/registry/candidates/community/community-sn-74-data-artifact-gittensor-prs-api-gittensor-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-74-data-artifact-gittensor-prs-api-gittensor-io",
+      "kind": "data-artifact",
+      "name": "Gittensor pull request records",
+      "netuid": 74,
+      "provider": "gittensor",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.gittensor.io/swagger-json",
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "state": "schema-valid",
+      "url": "https://api.gittensor.io/prs"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "seekmistar01",
+    "submitted_by_url": "https://github.com/seekmistar01"
+  }
+}


### PR DESCRIPTION
## Summary

Adds one community candidate surface for SN74 (Gittensor): the public `https://api.gittensor.io/prs` data-artifact — the subnet's pull-request records — complementing the already-listed `https://api.gittensor.io/issues` candidate so the registry covers both the issues and PRs sides of the Gittensor data artifact.

The endpoint is documented in the Gittensor DAS OpenAPI (`https://api.gittensor.io/swagger-json`, path `/prs`) and currently responds `200 application/json`, no auth, read-only GET.

Closes #1632.

## Submission

- Changes exactly one file: `registry/candidates/community/community-sn-74-data-artifact-gittensor-prs-api-gittensor-io.json`
- One `candidates[0]` entry; `state: schema-valid`
- `submission.submitted_by` / `submitted_by_url` match the PR author (`seekmistar01`)
- Public-safe `url` and `source_url`; no auth, no secrets, no private/validator-local data

## Checklist

- [x] Changes exactly one `registry/candidates/community/*.json` file
- [x] One `candidates[0]` entry only
- [x] `submission.submitted_by` + `submitted_by_url` match the PR author
- [x] Public-safe `url` and `source_url`
- [x] No generated artifacts, secrets, private URLs, wallet data, or validator-local data
- [x] Validates against `schemas/candidate-surface.schema.json` (ajv 2020)
