### PR TITLE
feat(coverage): add machine-readable surface kind counts and depth ti…

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -628,6 +628,22 @@ const coverage = {
     mergedSubnets.flatMap((subnet) => subnet.derived_categories || []),
     (tag) => tag,
   ),
+  // Machine-readable surface coverage by kind (issue #1125): how many subnets
+  // expose at least one published surface of each machine-usable kind. These
+  // are the audit numbers the coverage-depth roadmap tracks (e.g. 22/129
+  // openapi, 17/129 subnet-api, 1/129 sse at the June 2026 baseline).
+  machine_readable_surface_kinds: Object.fromEntries(
+    ["openapi", "subnet-api", "sse", "data-artifact", "sdk", "example"].map(
+      (kind) => [
+        kind.replace(/-/g, "_") + "_subnet_count",
+        mergedSubnets.filter((subnet) =>
+          (surfacesByNetuidForCounts.get(subnet.netuid) || []).some(
+            (surface) => surface.kind === kind,
+          ),
+        ).length,
+      ],
+    ),
+  ),
 };
 
 // #1002: superseded_by is computed once above (curatedSurfaceIdByRegistryKey /
@@ -2332,6 +2348,23 @@ const coverageDepthArtifact = buildCoverageDepthArtifact({
   contractVersion,
 });
 await writeJson(artifactFile("coverage-depth.json"), coverageDepthArtifact);
+// Stamp coverage-depth tier summary back into the git-tier coverage.json
+// (issue #1125) so contributors can track the roadmap numbers (agent-ready,
+// machine-usable, tier distribution, top gap codes) without running a full
+// build. coverage.json is the authoritative git-committed summary artifact.
+coverage.coverage_depth = {
+  tier_counts: coverageDepthArtifact.summary.tier_counts,
+  agent_ready_count: coverageDepthArtifact.summary.agent_ready_count,
+  callable_subnet_count: coverageDepthArtifact.summary.callable_subnet_count,
+  average_score: coverageDepthArtifact.summary.average_score,
+  top_gap_codes: Object.entries(
+    coverageDepthArtifact.summary.gap_code_counts || {},
+  )
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([code, count]) => ({ code, count })),
+};
+await writeJson(artifactFile("coverage.json"), coverage);
 
 // --- llms.txt / llms-full.txt (LLM + agent discoverability) ------------------
 // The emerging standard for making a site/API legible to LLMs. Served from the

--- a/scripts/curation-brief.mjs
+++ b/scripts/curation-brief.mjs
@@ -51,6 +51,9 @@ export async function loadCurationSnapshot({ limit = 12 } = {}) {
       surfaces: coverage.surface_count,
       probed_surfaces: coverage.probed_surface_count,
       candidates: coverage.candidate_count,
+      machine_readable_surface_kinds:
+        coverage.machine_readable_surface_kinds || {},
+      coverage_depth: coverage.coverage_depth || null,
     },
     profile_summary: {
       average_completeness_score:
@@ -95,6 +98,39 @@ export async function loadCurationSnapshot({ limit = 12 } = {}) {
   };
 }
 
+function renderMachineReadableKinds(kinds, totalNetuids) {
+  const LABEL = {
+    openapi_subnet_count: "OpenAPI/schema spec",
+    subnet_api_subnet_count: "Subnet API (callable)",
+    sse_subnet_count: "SSE stream",
+    data_artifact_subnet_count: "Data artifact",
+    sdk_subnet_count: "SDK",
+    example_subnet_count: "Example/quickstart",
+  };
+  const total = totalNetuids || "?";
+  return Object.entries(LABEL).map(([key, label]) => {
+    const count = kinds?.[key] ?? "?";
+    return `- ${label}: ${count}/${total} subnets`;
+  });
+}
+
+function renderCoverageDepthSummary(depth) {
+  if (!depth) return [];
+  const tierLines = Object.entries(depth.tier_counts || {})
+    .sort((a, b) => b[1] - a[1])
+    .map(([tier, count]) => `  - ${tier}: ${count}`);
+  const topGaps = (depth.top_gap_codes || [])
+    .map(({ code, count }) => `${code} (${count})`)
+    .join(", ");
+  return [
+    `- Coverage-depth tiers (avg score ${depth.average_score ?? "?"}):`,
+    ...tierLines,
+    `- Agent-ready subnets: ${depth.agent_ready_count ?? "?"}`,
+    `- Callable subnets: ${depth.callable_subnet_count ?? "?"}`,
+    ...(topGaps ? [`- Top gap codes: ${topGaps}`] : []),
+  ];
+}
+
 export function renderCurationBrief(snapshot) {
   const enrichmentSummary = snapshot.enrichment_summary || {};
   const enrichmentQueue = snapshot.enrichment_queue || [];
@@ -112,6 +148,14 @@ export function renderCurationBrief(snapshot) {
     `- Published surfaces/endpoints: ${snapshot.coverage.surfaces}`,
     `- Probed surfaces: ${snapshot.coverage.probed_surfaces}`,
     `- Candidate surfaces: ${snapshot.coverage.candidates}`,
+    "",
+    "### Machine-readable surface coverage",
+    ...renderMachineReadableKinds(
+      snapshot.coverage.machine_readable_surface_kinds,
+      snapshot.coverage.active_netuids,
+    ),
+    ...renderCoverageDepthSummary(snapshot.coverage.coverage_depth),
+    "",
     `- Average profile completeness: ${snapshot.profile_summary.average_completeness_score ?? "unknown"}`,
     `- Profile levels: ${formatCounts(snapshot.profile_summary.by_level)}`,
     `- Identity promotion candidates: ${snapshot.profile_summary.identity_promotion_candidate_count ?? "unknown"}`,


### PR DESCRIPTION
## Summary

- Closes #1125. Adds machine-readable surface kind counts and coverage-depth tier summary to `coverage.json` (the git-committed summary artifact) so the roadmap audit numbers (OpenAPI, subnet-API, SSE, data-artifact coverage per subnet) are trackable without running a full build.

## What Changed

- **`scripts/build-artifacts.mjs`**: Added `machine_readable_surface_kinds` to the `coverage` object at construction time — counts, per published surface kind (`openapi`, `subnet-api`, `sse`, `data-artifact`, `sdk`, `example`), how many subnets expose at least one surface of that kind (the "X/129" numbers the issue cites). After `buildCoverageDepthArtifact` runs, stamps `coverage.coverage_depth` (tier distribution, agent-ready count, callable-subnet count, average score, top gap codes) into `coverage.json` with a second write so the tier scorecard lives in the committed artifact.
- **`scripts/curation-brief.mjs`**: Passes the two new fields through `loadCurationSnapshot` and renders them in the `## Coverage` section of `npm run curation:brief` output via two new helpers (`renderMachineReadableKinds`, `renderCoverageDepthSummary`).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`
