### PR TITLE
fix(api): reject a malformed ?block= on the extrinsics feed instead of silently querying block 0

### DIFF
--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -331,6 +331,63 @@ test("GET /extrinsics?block=<n> scopes the feed to one block (#1345)", async () 
   assert.ok(/WHERE block_number = \?/.test(boundSql));
 });
 
+test("GET /extrinsics?block rejects malformed values instead of querying block 0 (#1615)", async () => {
+  let boundSql;
+  const env = {
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        boundSql = sql;
+        return {
+          bind() {
+            return {
+              async all() {
+                return { results: [] };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+  for (const bad of ["", "abc", "-5", "1.5", "1e3", "0x10", " "]) {
+    boundSql = null;
+    const res = await handleRequest(
+      req(`/api/v1/extrinsics?block=${encodeURIComponent(bad)}`),
+      env,
+      {},
+    );
+    assert.equal(res.status, 400, `?block=${JSON.stringify(bad)} should 400`);
+    const body = await res.json();
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "block");
+    // Crucially, a malformed filter must never reach the DB as block 0.
+    assert.equal(boundSql, null);
+  }
+});
+
+test("GET /extrinsics?block=0 is a valid filter (genesis block, #1615)", async () => {
+  let boundParam;
+  const env = {
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind(...v) {
+            if (/WHERE block_number = \?/.test(sql)) boundParam = v[0];
+            return {
+              async all() {
+                return { results: [] };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+  const res = await handleRequest(req("/api/v1/extrinsics?block=0"), env, {});
+  assert.equal(res.status, 200);
+  assert.equal(boundParam, 0);
+});
+
 test("GET /extrinsics/{hash} returns detail by extrinsic_hash (#1345)", async () => {
   const hash = `0x${"c".repeat(64)}`;
   const env = dbWith({

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -3438,8 +3438,20 @@ async function handleExtrinsics(request, env, url) {
   let sql = `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics`;
   const params = [];
   if (blockParam != null) {
+    // A malformed `block` filter must be rejected, not silently coerced.
+    // clampInt would map "", "abc", "-5", "1.5" to the default 0 and quietly
+    // return block 0's extrinsics as if that were the requested filter. A block
+    // number is a plain non-negative decimal integer; reject anything else
+    // (incl. signs, decimals, "1e3", hex) before it reaches the query.
+    const blockNumber = Number(blockParam);
+    if (!/^\d+$/.test(blockParam) || !Number.isSafeInteger(blockNumber)) {
+      return analyticsQueryError({
+        parameter: "block",
+        message: "block must be a non-negative integer.",
+      });
+    }
     sql += " WHERE block_number = ?";
-    params.push(clampInt(blockParam, 0, 0, Number.MAX_SAFE_INTEGER));
+    params.push(blockNumber);
   }
   sql += " ORDER BY block_number DESC, extrinsic_index DESC LIMIT ? OFFSET ?";
   params.push(limit, offset);


### PR DESCRIPTION
## Summary

- Fixes #1615. `GET /api/v1/extrinsics?block=<n>` silently returned **block 0's**
  extrinsics for any malformed `block` filter (`?block=`, `?block=abc`,
  `?block=-5`, `?block=1.5`). `validateQueryParams` only checks parameter
  *names*, so a bad value flowed into `clampInt(blockParam, 0, …)`, which maps
  non-finite / out-of-range input to its default of `0`. The handler then ran
  `WHERE block_number = 0` and served genesis-block rows as though they matched
  the requested filter — a silently wrong result instead of a `400`.

## What Changed

- `handleExtrinsics` (`workers/api.mjs`) now validates the `block` filter before
  it touches the query: a block number must be a plain non-negative decimal
  integer (`/^\d+$/`) within the safe-integer range. Anything else returns
  `400 invalid_query` (`meta.parameter: "block"`), consistent with the other
  list-route rejections (`analyticsQueryError`).
- `?block=0` remains a valid filter (genesis block); only malformed input is
  rejected.
- Regression tests in `tests/extrinsics.test.mjs`: malformed values
  (`""`, `"abc"`, `"-5"`, `"1.5"`, `"1e3"`, `"0x10"`, `" "`) all `400` and never
  reach the DB; `?block=0` binds `block_number = 0` and returns `200`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (Behavior
      change: a malformed `?block=` now returns `400` instead of silently
      filtering to block 0. No schema/contract surface changes.)

## Validation

- [x] `npm run check`
- [x] `npm run worker:test` (`tests/extrinsics.test.mjs` — 21 passing)
- [x] `git diff --check`

## Template Used

- backend-code.md
