### PR TITLE
feat(intake): retire the community-candidate lane — surface:add is the only path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Live: [metagraph.sh](https://metagraph.sh) · API [api.metagraph.sh](https://api
 Two kinds of contribution, two paths:
 
 - **Code / schema changes** → normal feature PR, run the gates below.
-- **Community data** → one candidate JSON file, see [Community submissions](#community-submissions).
+- **Community data** → add a surface to one subnet file, see [Community submissions](#community-submissions).
 
 ## Setup & gates
 
@@ -34,60 +34,58 @@ Skipping the rebuild trips `validate:contract-drift` in CI. Schemas are the sour
 
 ## Where to start
 
-- **Enrich a subnet** (the best first PR) — we track one scoped task per subnet under the [surface-enrichment epic #427](https://github.com/JSONbored/metagraphed/issues/427). Browse [`good first issue`](https://github.com/JSONbored/metagraphed/labels/good%20first%20issue) + [`help wanted`](https://github.com/JSONbored/metagraphed/labels/help%20wanted): pick a subnet, find its real public API / OpenAPI / data artifact, and submit one candidate file ([Community submissions](#community-submissions) below). Each issue links the exact `candidate:new` command.
+- **Enrich a subnet** (the best first PR) — we track one scoped task per subnet under the [surface-enrichment epic #427](https://github.com/JSONbored/metagraphed/issues/427). Browse [`good first issue`](https://github.com/JSONbored/metagraphed/labels/good%20first%20issue) + [`help wanted`](https://github.com/JSONbored/metagraphed/labels/help%20wanted): pick a subnet, find its real public API / OpenAPI / data artifact, and add it as a surface on the subnet's file ([Community submissions](#community-submissions) below). Each issue links the exact `surface:add` command.
 - **Data gaps** — generate the current curation queue: `npm run curation:brief` (add `-- --limit 20` for more, `-- --json` for machine-readable). Start with profile-light subnets: directory-only entries, missing websites or source repos, public APIs with no OpenAPI metadata yet. See [`docs/curation-playbook.md`](docs/curation-playbook.md).
 
 ## Community submissions
 
-Community data becomes a reviewed **candidate**, not direct registry truth. PR-first is the simplest path:
+Surfaces live in **one file per subnet**: `registry/subnets/<slug>.json` → its `surfaces[]` array. A community contribution **adds a surface to that one file** — `npm run surface:add` writes it with `authority: "community"` and `review.state: "community-submitted"`. There is no per-surface candidate file anymore (recreating `registry/candidates/community/*.json` is rejected by CI), so you can't farm one surface per PR: **one subnet = one file = one PR.**
 
-> Add **exactly one** file — `registry/candidates/community/*.json` (a candidate) **or** `registry/providers/community/*.json` (a provider profile) — and **nothing else**. No generated artifacts. First-time team? Add **both** in one PR (an atomic provider+candidate pair): the inline provider counts as registered for candidate validation, but provider/profile identity still requires maintainer review before it can land.
+> Change **only** the one `registry/subnets/<slug>.json` — no generated artifacts. First-time provider? Add `registry/providers/community/<slug>.json` in the same PR (`npm run provider:new`); provider identity still gets reviewed before it's trusted.
 
-Generate a candidate locally — three steps:
+Add a surface locally — three steps:
 
 ```bash
 # 1. Find the provider slug for the team/operator behind this surface.
 #    (No match? Register one in the same PR with `npm run provider:new`.)
 npm run providers:list
 
-# 2. Generate the candidate with a REAL --provider slug (a placeholder like
-#    "community" is not a registered provider and will fail validation).
-npm run candidate:new -- \
+# 2. Append the surface to the subnet's file with a REAL --provider slug (a
+#    placeholder like "community" is not a registered provider and fails validation).
+npm run surface:add -- \
   --netuid 7 --kind docs \
   --url https://docs.example.com \
   --source-url https://github.com/example/project \
   --provider <provider-slug> --submitted-by <github-login> --write
 
-# 3. Check it before pushing — a fast local pre-check that catches schema +
-#    provider-slug mistakes without the full build (CI runs the full validate).
-npm run validate:candidate -- registry/candidates/community/<your-file>.json
+# 3. Check it before pushing — a fast local pre-check (schema + provider slug +
+#    review-state + real subnet name) without the full build (CI runs full validate).
+npm run validate:surface -- registry/subnets/<slug>.json
 ```
 
-A good candidate PR is small: one public URL, one source URL proving the claim, one active netuid, no generated files. Best kinds (these can be auto-reviewed): `docs`, `website`, `source-repo`, `dashboard`, `openapi`, `subnet-api`, `sse`, `data-artifact`, `sdk`, `example`.
+> New subnet with no file yet? `npm run subnet:new -- --netuid <n> --name "<Real Name>" --write` first — a real `--name` is required (placeholder on-chain identities like "Team TBC" are rejected) — then add your surface to it.
 
-**Higher-trust kinds** (provider/operator profiles, base-layer `subtensor-rpc`/`subtensor-wss`/`archive` endpoints, authenticated or paid APIs, unknown providers, adapter requests, status reports, identity disputes) are also welcome and no longer need a maintainer: they go to the same autonomous reviewer, which scrutinizes identity/evidence harder and, when in doubt, closes or escalates rather than merging. Make the proof airtight (an independent `source_url` proving ownership) and they can merge like any other surface.
+A good surface PR is small: one public `url`, one `source_url` proving the claim, the right `kind`, all on the subnet's single file. Auto-review kinds: `docs`, `website`, `source-repo`, `dashboard`, `openapi`, `subnet-api`, `sse`, `data-artifact`, `sdk`, `example`.
+
+**Higher-trust kinds** (base-layer `subtensor-rpc`/`subtensor-wss`/`archive` endpoints, authenticated or paid APIs, unknown providers, identity disputes) are welcome too — the autonomous reviewer scrutinizes identity/evidence harder and, when in doubt, closes or escalates rather than merging. Make the proof airtight (an independent `source_url` proving ownership).
 
 **Hard boundaries:**
 
-- Health, uptime, latency, incidents, and pool eligibility are **probe-derived only**. Reports can trigger a re-probe; they can never set observed state.
+- Health, uptime, latency, incidents, and pool eligibility are **probe-derived only** — never hand-set them (or a surface's `verification`). The build's prober owns them.
 - No secrets, PATs, wallet paths, private URLs, or validator-local data.
 - Don't invent API/status surfaces a subnet doesn't publish.
-- Schema-valid ≠ accepted. A private review gate makes the final call.
+- Schema-valid ≠ accepted. The review gate makes the final call.
 
 **Accepted vs rejected at a glance** — the visible checklist (the final merge decision is the review gate's):
 
-| ✅ Tends to get accepted                                                                                             | ❌ Gets closed / routed to manual                                                                              |
-| -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| Exactly one `registry/candidates/community/*.json` (or `providers/community/*.json`)                                 | Touches generated artifacts, scripts, or workflows ([#296](https://github.com/JSONbored/metagraphed/pull/296)) |
-| A public `url` **plus** a `source_url` that proves the claim                                                         | `source_url` 404s or doesn't back the claim ([#328](https://github.com/JSONbored/metagraphed/pull/328))        |
-| An auto-review `kind` (docs, website, source-repo, openapi, subnet-api, dashboard, sse, data-artifact, sdk, example) | A surface the subnet already exposes — duplicate ([#90](https://github.com/JSONbored/metagraphed/pull/90))     |
-| `auth_required: false`, `public_safe: true`, an active netuid, a registered provider (or one added in the same PR)   | Secrets/PATs/wallet paths, private/localhost URLs, or unproven ownership claims                                |
+| ✅ Tends to get accepted                                                                                          | ❌ Gets closed / routed to manual                                                                    |
+| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Exactly one `registry/subnets/<slug>.json` changed (+ an optional `providers/community/*.json` for a debut)       | Touches generated artifacts, scripts, or workflows                                                   |
+| A surface with a public `url` **plus** a `source_url` that proves the claim                                       | `source_url` 404s or doesn't back the claim                                                          |
+| `authority: community` + `review.state: community-submitted`, an auto-review `kind`, an active netuid, a provider | A surface the subnet already exposes — duplicate                                                     |
+| `auth_required: false`, `public_safe: true`                                                                       | Secrets/PATs/wallet paths, private/localhost URLs, unproven ownership, or a recreated candidate file |
 
-A clean accepted example to copy: [#87](https://github.com/JSONbored/metagraphed/pull/87).
-
-Prefer issues? Use the `interface-submission`, `profile-correction`, `endpoint-submission`, `provider-submission`, or `status-report` template — an approved issue opens the candidate PR for you. Full contract in [`docs/submission-gate.md`](docs/submission-gate.md).
-
-Callable surface with documented limits? Add an optional structured `rate_limit` — `{ requests, window, burst?, scope?, cost_notes? }` (`requests` + `window` required) — so agents and SDKs can pace calls. It's integration-only: metagraphed never enforces it and it doesn't feed completeness. See the example in [`docs/submission-gate.md`](docs/submission-gate.md).
+Callable surface with documented limits? Add an optional structured `rate_limit` — `{ requests, window, burst?, scope?, cost_notes? }` (`requests` + `window` required) — so agents and SDKs can pace calls. It's integration-only: metagraphed never enforces it and it doesn't feed completeness.
 
 ## Pull requests
 

--- a/scripts/candidate-new.mjs
+++ b/scripts/candidate-new.mjs
@@ -1,149 +1,21 @@
-import path from "node:path";
-import {
-  loadCandidates,
-  loadNativeSnapshot,
-  loadProviders,
-  loadSubnets,
-  normalizePublicUrl,
-  repoRoot,
-  slugify,
-  stableStringify,
-  writeRepositoryJson,
-} from "./lib.mjs";
-import {
-  buildPrSubmissionReport,
-  normalizeGitHubLogin,
-} from "./submission-policy.mjs";
-
-const args = process.argv.slice(2);
-const write = args.includes("--write");
-const netuid = Number(valueAfter("--netuid"));
-const kind = valueAfter("--kind");
-const url = normalizePublicUrl(valueAfter("--url"));
-const sourceUrl = normalizePublicUrl(valueAfter("--source-url"));
-const provider = slugify(valueAfter("--provider") || "community");
-const submittedBy = normalizeGitHubLogin(
-  valueAfter("--submitted-by") || process.env.GITHUB_ACTOR || process.env.USER,
+// RETIRED: the per-surface community-candidate intake lane
+// (registry/candidates/community/*.json) is gone. Surfaces now live in ONE file
+// per subnet — add them directly to registry/subnets/<slug>.json with
+// `npm run surface:add`. This stub points contributors at the new flow instead of
+// recreating the candidate files that the migration removed.
+console.error(
+  [
+    "`candidate:new` is retired — the per-surface candidate lane was migrated into",
+    "single per-subnet files (registry/subnets/<slug>.json).",
+    "",
+    "Add a surface to a subnet instead:",
+    "  npm run surface:add -- --netuid <n> --kind <kind> \\",
+    "    --url <public-url> --source-url <proof-url> \\",
+    "    --provider <provider-slug> --submitted-by <github-login> --write",
+    "",
+    'New subnet with no file yet?  npm run subnet:new -- --netuid <n> --name "<Real Name>" --write',
+    "Validate before pushing:        npm run validate:surface -- registry/subnets/<slug>.json",
+    "See .claude/skills/contributing-to-metagraphed for the full flow.",
+  ].join("\n"),
 );
-const name = valueAfter("--name");
-const authRequired = parseBoolean(valueAfter("--auth-required") || "false");
-const rateLimitNotes = valueAfter("--rate-limit-notes") || "";
-const outArg = valueAfter("--out");
-
-const native = await loadNativeSnapshot();
-const subnet = native.subnets.find((candidate) => candidate.netuid === netuid);
-
-if (!subnet) {
-  fail("--netuid must be an active Finney netuid");
-}
-if (!kind) {
-  fail("--kind is required");
-}
-if (!url) {
-  fail("--url must be a public http(s), wss, or ws URL");
-}
-if (!sourceUrl) {
-  fail("--source-url must be a public http(s), wss, or ws URL");
-}
-if (!submittedBy) {
-  fail("--submitted-by or GITHUB_ACTOR is required");
-}
-if (authRequired === null) {
-  fail("--auth-required must be true or false");
-}
-
-// `provider` must be a registered slug for the candidate to validate (the
-// default placeholder "community" is NOT one). Warn — don't fail — so adding a
-// provider alongside the candidate still works; the contributor can fix it.
-const providerIds = new Set((await loadProviders()).map((entry) => entry.id));
-if (!providerIds.has(provider)) {
-  console.warn(
-    `Warning: provider "${provider}" is not a registered slug, so this candidate will ` +
-      "FAIL `npm run validate:candidate` and CI. Pick a real one with `npm run providers:list`, " +
-      "or register it with `npm run provider:new`.",
-  );
-}
-
-const host = new URL(url).hostname;
-const id = `community-sn-${netuid}-${kind}-${slugify(host)}`;
-const outPath =
-  outArg || path.join(repoRoot, "registry/candidates/community", `${id}.json`);
-const outputPath = path.resolve(outPath);
-const document = {
-  schema_version: 1,
-  submission: {
-    submitted_by: submittedBy,
-    submitted_by_url: `https://github.com/${submittedBy}`,
-  },
-  candidates: [
-    {
-      schema_version: 1,
-      id,
-      netuid,
-      state: "schema-valid",
-      name: name || `${subnet.name} community ${kind}`,
-      kind,
-      url,
-      source_url: sourceUrl,
-      source_urls: [sourceUrl],
-      source_type: "community-pr-intake",
-      source_tier: "community-docs",
-      confidence: "medium",
-      provider,
-      auth_required: authRequired,
-      public_safe: true,
-      rate_limit_notes: rateLimitNotes,
-      review_notes: "Community-submitted public interface candidate.",
-    },
-  ],
-};
-
-const report = buildPrSubmissionReport({
-  changedFiles: [path.relative(repoRoot, outputPath)],
-  candidateDocument: document,
-  submitter: submittedBy,
-  native,
-  providers: await loadProviders(),
-  existingCandidates: await loadCandidates(),
-  existingSubnets: await loadSubnets(),
-});
-
-if (report.blocking) {
-  console.error(stableStringify(report));
-  process.exit(1);
-}
-
-if (write) {
-  await writeRepositoryJson(outputPath, document);
-}
-
-console.log(
-  stableStringify({
-    mode: write ? "write" : "dry-run",
-    output_path: path.relative(repoRoot, outputPath),
-    public_state: report.public_state,
-    next_action: report.next_action,
-    manual_reasons: report.manual_reasons,
-    warnings: report.warnings,
-    candidate: document.candidates[0],
-  }),
-);
-
-function valueAfter(flag) {
-  const index = args.indexOf(flag);
-  return index === -1 ? null : args[index + 1] || null;
-}
-
-function parseBoolean(value) {
-  const normalized = String(value || "")
-    .trim()
-    .toLowerCase();
-  if (["true", "yes", "1"].includes(normalized)) return true;
-  if (["false", "no", "0"].includes(normalized)) return false;
-  return null;
-}
-
-function fail(message) {
-  console.error(message);
-  process.exit(1);
-}
+process.exit(1);

--- a/scripts/validate-intake.mjs
+++ b/scripts/validate-intake.mjs
@@ -77,6 +77,26 @@ const profileCorrectionExample = await readJson(
 );
 const errors = [];
 
+// The per-surface community-candidate intake lane is retired — surfaces now live
+// in ONE file per subnet (registry/subnets/<slug>.json), added with
+// `npm run surface:add`. Reject any recreation of the candidate dir so the
+// migrated-away one-file-per-surface farm can't reopen. Runs in both the UGC and
+// full CI lanes (validate:intake is on both), so a candidate file is always caught.
+try {
+  const retiredDir = path.join(repoRoot, "registry/candidates/community");
+  const retiredFiles = (await fs.readdir(retiredDir)).filter((name) =>
+    name.endsWith(".json"),
+  );
+  if (retiredFiles.length > 0) {
+    errors.push(
+      `registry/candidates/community/ is retired (${retiredFiles.length} file(s): ${retiredFiles.join(", ")}). ` +
+        "Add surfaces to registry/subnets/<slug>.json with `npm run surface:add` instead.",
+    );
+  }
+} catch (error) {
+  if (error.code !== "ENOENT") throw error;
+}
+
 checkIncludes(interfaceTemplate.toLowerCase(), "interface template", [
   "interface-submission",
   "metagraphed-under-review",


### PR DESCRIPTION
## Summary
The per-surface community-candidate lane (`registry/candidates/community/*.json`) was migrated into single per-subnet files in #1639. This closes the lane for good so the one-surface-per-PR farm can't reopen, and points contributors at `surface:add`.

- **`candidate:new` → redirects to `surface:add`** (no more candidate-file creation).
- **`validate:intake` rejects any recreated `registry/candidates/community/*.json`** — it runs in **both** CI lanes (UGC + full), so a candidate file is always caught and blocked.
- **`CONTRIBUTING.md` community-submissions section rewritten** for the single-file `surface:add` flow: one subnet = one file = one PR, a real `--name` is required (placeholder identities like "Team TBC" rejected), surfaces enter as `authority: community` / `review.state: community-submitted`.

## Decisions baked in (per maintainer)
- **Issue→PR auto-import: retire** (PR-only via `surface:add`).
- **CI routing: full mode for all** — the artifact-freshness fix (#1649) makes full-mode safe, and `validate:surface` (wired into CI) gates surface PRs.

## Validation
`validate` · `validate:docs` · `validate:intake` (guard verified to reject a recreated candidate file) · lint · format — green · `npm test` **1925/1925**.

## Follow-up (next layer of the cutover)
Retire the issue→PR auto-import workflows (`intake-import-pr.yml`, `intake-validation.yml`) + the candidate issue/PR templates + `docs/submission-gate.md` + the candidate example files + the now-dead `submission-policy.mjs` candidate path & its tests. (The Gittensory Gate that consumes the submission shape is paused, so this is sequenced carefully.)