### PR TITLE
chore(hooks): repo Claude hook to keep the contract + skill fresh

### DIFF
--- a/.claude/hooks/skill-reminder.sh
+++ b/.claude/hooks/skill-reminder.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# PostToolUse (Edit|Write|MultiEdit) reminder for metagraphed.
+#
+# When a fundamental file changes, nudge to keep the generated contract and the
+# contributing-to-metagraphed skill in sync — the two things we've repeatedly
+# forgotten and red-mained / shipped stale. Advisory only: always exits 0, never
+# blocks an edit. Reads the hook payload (tool_input.file_path) on stdin.
+command -v jq >/dev/null 2>&1 || exit 0
+f=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+[ -z "$f" ] && exit 0
+
+m=""
+case "$f" in
+  */schemas/*)
+    m="schemas/ changed → run npm run build + commit public/metagraph/{openapi.json,types.d.ts,contracts.json,api-index.json} (validate:contract-drift gates this)."
+    ;;
+esac
+case "$f" in
+  */schemas/* | */scripts/build-artifacts.mjs | */scripts/submission-policy.mjs | */scripts/validate-intake.mjs | */scripts/surface-add.mjs | */scripts/subnet-new.mjs | */scripts/lib.mjs | */workers/api.mjs | */.github/workflows/validate.yml)
+    m="${m:+$m | }fundamental change → update .claude/skills/contributing-to-metagraphed (SKILL.md + reference.md) if the contributor flow, gates, or schema changed."
+    ;;
+esac
+[ -z "$m" ] && exit 0
+
+jq -cn --arg m "$m" '{systemMessage:("metagraphed: "+$m), hookSpecificOutput:{hookEventName:"PostToolUse", additionalContext:("metagraphed reminder: "+$m)}}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": ["Bash(gh pr merge:*)"]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/skill-reminder.sh\"",
+            "timeout": 10,
+            "statusMessage": "metagraphed contract/skill freshness check"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -199,11 +199,16 @@ vite.config.ts.timestamp-*
 .vite/
 
 # Claude Code session directory (local, per-developer) — but version-control the
-# shared project slash commands in .claude/commands/ (e.g. /lineage-discovery) and
-# the committed contributor skill in .claude/skills/ (read by Claude Code + Codex).
+# shared project slash commands in .claude/commands/ (e.g. /lineage-discovery),
+# the committed contributor skill in .claude/skills/ (read by Claude Code + Codex),
+# and the shared repo hooks/settings in .claude/settings.json + .claude/hooks/
+# (e.g. the contract/skill freshness reminder). Personal overrides go in the
+# gitignored .claude/settings.local.json.
 .claude/*
 !.claude/commands/
 !.claude/skills/
+!.claude/settings.json
+!.claude/hooks/
 
 # Python bytecode (scripts/classify-validation-route.py — the CI route classifier)
 __pycache__/


### PR DESCRIPTION
## Summary
Adds a committed Claude Code hook for this repo that nudges on the two things we've repeatedly shipped stale (contract drift, skill staleness).

**PostToolUse (`Edit|Write|MultiEdit`) — advisory, non-blocking:**
- Edit under `schemas/` → reminder to `npm run build` + commit `public/metagraph/{openapi.json,types.d.ts,contracts.json,api-index.json}` (or `validate:contract-drift` reds CI).
- Edit a fundamental file (`schemas/`, `scripts/build-artifacts.mjs`, `submission-policy.mjs`, `validate-intake.mjs`, `surface-add.mjs`, `subnet-new.mjs`, `lib.mjs`, `workers/api.mjs`, `.github/workflows/validate.yml`) → reminder to update the `contributing-to-metagraphed` skill if the flow/gates/schema changed.

## Files
- `.claude/hooks/skill-reminder.sh` — `jq`-guarded (no-ops if `jq` absent), always `exit 0`, emits a reminder only for matching paths (verified via pipe-test: schemas→both, workers/api→skill, unrelated→silent).
- `.claude/settings.json` — wires the hook (merged with the existing `gh pr merge` allow).
- `.gitignore` — allowlists `.claude/settings.json` + `.claude/hooks/` (same pattern as `.claude/skills/`), so the hook applies in every checkout/worktree. Personal overrides → the gitignored `.claude/settings.local.json`.

## Notes
- Committed (shared) so it works everywhere you touch metagraphed, not just one worktree. If you'd rather it be local-only, move it to `.claude/settings.local.json`.
- Claude Code's settings watcher only picks up new hook files on next session / after opening `/hooks`, so it won't fire in the session that created it.