### PR TITLE
feat(intake): surface:add live-verifies URLs + auto-fills openapi schema fields

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -895,6 +895,65 @@ export async function isUnsafeResolvedUrl(value, resolver = lookup) {
   return (await resolvePublicUrlAddresses(value, resolver)).length === 0;
 }
 
+const SAFE_FETCH_REDIRECT_CODES = new Set([301, 302, 303, 307, 308]);
+
+// SSRF-safe outbound GET: re-validates EVERY hop — the initial URL AND each
+// redirect Location — against isUnsafeResolvedUrl before connecting, so a public
+// host can't 30x-redirect into a private/internal address (169.254.169.254,
+// localhost, …). `redirect: "follow"` would bypass the guard; this follows
+// manually, bounded by maxRedirects. Returns exactly one of:
+//   { ok: true,  response, status, url }  final non-redirect 2xx response
+//   { ok: false, response, status, url }  final non-redirect non-2xx response
+//   { ok: false, unsafe: true, url }      a hop resolved to a private/unsafe addr
+//   { ok: false, error }                  network error / timeout / too many redirects
+// The caller owns response.body (read or cancel it).
+export async function safeFetch(
+  url,
+  {
+    accept = "*/*",
+    maxRedirects = 5,
+    timeoutMs = 12000,
+    resolver = lookup,
+  } = {},
+) {
+  let target = url;
+  for (let hop = 0; hop <= maxRedirects; hop += 1) {
+    if (await isUnsafeResolvedUrl(target, resolver)) {
+      return { ok: false, unsafe: true, url: target };
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    let response;
+    try {
+      response = await fetch(target, {
+        method: "GET",
+        redirect: "manual",
+        signal: controller.signal,
+        headers: { "user-agent": "metagraphed/0.0", accept },
+      });
+    } catch (error) {
+      return {
+        ok: false,
+        error: error.name === "AbortError" ? "timeout" : error.message,
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+    const location = response.headers.get("location");
+    if (SAFE_FETCH_REDIRECT_CODES.has(response.status) && location) {
+      await response.body?.cancel();
+      try {
+        target = new URL(location, target).toString();
+      } catch {
+        return { ok: false, error: "invalid redirect location" };
+      }
+      continue;
+    }
+    return { ok: response.ok, response, status: response.status, url: target };
+  }
+  return { ok: false, error: "too many redirects" };
+}
+
 function isUnsafeHostname(host) {
   if (
     !host ||

--- a/scripts/surface-add.mjs
+++ b/scripts/surface-add.mjs
@@ -11,6 +11,8 @@
 //     --provider <provider-slug> --submitted-by <github-login> --write
 import path from "node:path";
 import {
+  isJsonContentType,
+  isUnsafeResolvedUrl,
   listJsonFiles,
   loadNativeSnapshot,
   loadProviders,
@@ -26,6 +28,10 @@ import { normalizeGitHubLogin } from "./submission-policy.mjs";
 
 const args = process.argv.slice(2);
 const write = args.includes("--write");
+// Live verification is ON by default — it probes the real URLs so a contributor
+// finds out NOW (not after a closed PR) that a surface is dead/private, and it
+// fills openapi schema fields from the live spec. --skip-verify for offline work.
+const skipVerify = args.includes("--skip-verify");
 const netuid = Number(valueAfter("--netuid"));
 const kind = valueAfter("--kind");
 const url = normalizePublicUrl(valueAfter("--url"));
@@ -97,6 +103,10 @@ const surface = {
   ...(notes ? { notes } : {}),
 };
 
+const findings = skipVerify
+  ? ["skipped (--skip-verify)"]
+  : await verifyAndEnrich(surface);
+
 document.surfaces = [...surfaces, surface];
 
 if (write) {
@@ -108,10 +118,143 @@ console.log(
     mode: write ? "write" : "dry-run",
     subnet_file: path.relative(repoRoot, filePath),
     surface_count: document.surfaces.length,
+    verification: findings,
     surface,
     next: "Link a tracked issue (Closes #N) and open a PR that changes ONLY this file.",
   }),
 );
+
+// Live verification with real information: hard-fail on a private/unsafe URL (so
+// public_safe:true is never a lie), warn on anything not reachable right now, and
+// for openapi auto-discover the spec → set schema_url/schema_status + name from
+// the live title (closing the gap where a hand-added openapi surface had no schema
+// fields and failed CI). Network-dependent; --skip-verify bypasses it offline.
+async function verifyAndEnrich(target) {
+  const checks = [
+    ["url", target.url],
+    ...target.source_urls.map((value) => ["source_url", value]),
+  ];
+  for (const [label, value] of checks) {
+    if (await isUnsafeResolvedUrl(value)) {
+      fail(
+        `${label} resolves to a private/unsafe address and cannot be a public surface: ${value}`,
+      );
+    }
+  }
+  const out = [];
+  const urlProbe = await probeUrl(target.url);
+  if (!urlProbe.ok) {
+    out.push(
+      `WARN url not reachable right now (${urlProbe.detail}) — confirm it is public + live before merging.`,
+    );
+  }
+  for (const value of target.source_urls) {
+    const probe = await probeUrl(value);
+    if (!probe.ok) {
+      out.push(
+        `WARN source_url not reachable right now (${probe.detail}): ${value} — it must independently prove the claim.`,
+      );
+    }
+  }
+  if (target.kind === "openapi") {
+    const spec = await fetchOpenApi(target.url);
+    if (spec) {
+      target.schema_url = spec.schemaUrl;
+      target.schema_status = "machine-readable";
+      if (!name && spec.document.info?.title) {
+        target.name = `${subnet.name} ${spec.document.info.title}`;
+      }
+      const paths = spec.document.paths
+        ? Object.keys(spec.document.paths).length
+        : 0;
+      out.push(
+        `OK openapi spec verified (${spec.document.info?.title || "untitled"}, ${paths} paths) → schema_url + schema_status set.`,
+      );
+    } else {
+      out.push(
+        `WARN openapi: no machine-readable OpenAPI/Swagger JSON found at ${target.url}. CI's full validate REQUIRES schema_status:"machine-readable" — point --url at the spec (e.g. .../openapi.json) or use a different --kind.`,
+      );
+    }
+  }
+  if (out.length === 0) out.push("OK reachable + public-safe.");
+  return out;
+}
+
+async function probeUrl(target) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 12000);
+  try {
+    const response = await fetch(target, {
+      method: "GET",
+      redirect: "follow",
+      signal: controller.signal,
+      headers: { "user-agent": "metagraphed-surface-add/0.0", accept: "*/*" },
+    });
+    await response.body?.cancel();
+    return response.ok
+      ? { ok: true }
+      : { ok: false, detail: `HTTP ${response.status}` };
+  } catch (error) {
+    return {
+      ok: false,
+      detail: error.name === "AbortError" ? "timeout" : error.message,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchOpenApi(target) {
+  const candidates = [target];
+  try {
+    const parsed = new URL(target);
+    for (const suffix of [
+      "/openapi.json",
+      "/swagger.json",
+      "/api-json",
+      "/docs-json",
+    ]) {
+      candidates.push(`${parsed.origin}${suffix}`);
+    }
+  } catch {
+    // invalid URL — validation elsewhere reports it
+  }
+  for (const candidate of [...new Set(candidates)]) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 12000);
+    try {
+      const response = await fetch(candidate, {
+        method: "GET",
+        redirect: "follow",
+        signal: controller.signal,
+        headers: {
+          "user-agent": "metagraphed-surface-add/0.0",
+          accept: "application/json",
+        },
+      });
+      if (
+        !response.ok ||
+        !isJsonContentType(response.headers.get("content-type"))
+      ) {
+        await response.body?.cancel();
+        continue;
+      }
+      const document = JSON.parse(await response.text());
+      const looksOpenApi =
+        document &&
+        typeof document === "object" &&
+        (typeof document.openapi === "string" ||
+          typeof document.swagger === "string" ||
+          Boolean(document.paths));
+      if (looksOpenApi) return { document, schemaUrl: candidate };
+    } catch {
+      // try the next candidate
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  return null;
+}
 
 async function resolveSubnetFile(targetNetuid) {
   const files = await listJsonFiles(path.join(repoRoot, "registry/subnets"));

--- a/scripts/surface-add.mjs
+++ b/scripts/surface-add.mjs
@@ -20,6 +20,7 @@ import {
   readJson,
   registrySurfaceKey,
   repoRoot,
+  safeFetch,
   slugify,
   stableStringify,
   writeRepositoryJson,
@@ -181,27 +182,17 @@ async function verifyAndEnrich(target) {
 }
 
 async function probeUrl(target) {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 12000);
-  try {
-    const response = await fetch(target, {
-      method: "GET",
-      redirect: "follow",
-      signal: controller.signal,
-      headers: { "user-agent": "metagraphed-surface-add/0.0", accept: "*/*" },
-    });
-    await response.body?.cancel();
-    return response.ok
-      ? { ok: true }
-      : { ok: false, detail: `HTTP ${response.status}` };
-  } catch (error) {
-    return {
-      ok: false,
-      detail: error.name === "AbortError" ? "timeout" : error.message,
-    };
-  } finally {
-    clearTimeout(timer);
+  // safeFetch re-checks every redirect hop, so a public host can't redirect into
+  // a private address to defeat the public-safe guard.
+  const result = await safeFetch(target, { accept: "*/*" });
+  if (result.unsafe) {
+    return { ok: false, detail: "redirects to a private/unsafe address" };
   }
+  if (result.error) return { ok: false, detail: result.error };
+  await result.response?.body?.cancel();
+  return result.ok
+    ? { ok: true }
+    : { ok: false, detail: `HTTP ${result.status}` };
 }
 
 async function fetchOpenApi(target) {
@@ -220,37 +211,27 @@ async function fetchOpenApi(target) {
     // invalid URL — validation elsewhere reports it
   }
   for (const candidate of [...new Set(candidates)]) {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 12000);
+    const result = await safeFetch(candidate, { accept: "application/json" });
+    if (
+      !result.ok ||
+      !result.response ||
+      !isJsonContentType(result.response.headers.get("content-type"))
+    ) {
+      await result.response?.body?.cancel();
+      continue;
+    }
     try {
-      const response = await fetch(candidate, {
-        method: "GET",
-        redirect: "follow",
-        signal: controller.signal,
-        headers: {
-          "user-agent": "metagraphed-surface-add/0.0",
-          accept: "application/json",
-        },
-      });
-      if (
-        !response.ok ||
-        !isJsonContentType(response.headers.get("content-type"))
-      ) {
-        await response.body?.cancel();
-        continue;
-      }
-      const document = JSON.parse(await response.text());
+      const document = JSON.parse(await result.response.text());
       const looksOpenApi =
         document &&
         typeof document === "object" &&
         (typeof document.openapi === "string" ||
           typeof document.swagger === "string" ||
           Boolean(document.paths));
-      if (looksOpenApi) return { document, schemaUrl: candidate };
+      // result.url is the final URL after safe redirects — the real spec location.
+      if (looksOpenApi) return { document, schemaUrl: result.url };
     } catch {
-      // try the next candidate
-    } finally {
-      clearTimeout(timer);
+      // not JSON / not a spec — try the next candidate
     }
   }
   return null;

--- a/tests/safe-fetch.test.mjs
+++ b/tests/safe-fetch.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test, vi } from "vitest";
+import { safeFetch } from "../scripts/lib.mjs";
+
+// IP-literal URLs so isUnsafeResolvedUrl never needs DNS: 1.1.1.1 / 8.8.8.8 are
+// public (safe); 169.254.169.254 (link-local, the classic cloud-metadata SSRF
+// target) + 127.0.0.1 are private (unsafe). fetch is stubbed, so no network.
+function mockResponse({
+  status = 200,
+  location = null,
+  contentType = "application/json",
+  body = "{}",
+}) {
+  const headers = new Map();
+  if (location) headers.set("location", location);
+  if (contentType) headers.set("content-type", contentType);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (key) => headers.get(String(key).toLowerCase()) ?? null },
+    text: async () => body,
+    body: { cancel: async () => {} },
+  };
+}
+
+describe("safeFetch SSRF guard", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  test("does NOT follow a redirect into a private address", async () => {
+    const calls = [];
+    vi.stubGlobal("fetch", async (url) => {
+      calls.push(String(url));
+      return mockResponse({
+        status: 302,
+        location: "http://169.254.169.254/latest/meta-data/",
+      });
+    });
+
+    const result = await safeFetch("http://1.1.1.1/");
+
+    assert.equal(result.ok, false);
+    assert.equal(result.unsafe, true);
+    // The private redirect target must never be requested.
+    assert.deepEqual(calls, ["http://1.1.1.1/"]);
+    assert.ok(!calls.some((u) => u.includes("169.254.169.254")));
+  });
+
+  test("rejects an initial private URL without fetching it", async () => {
+    const calls = [];
+    vi.stubGlobal("fetch", async (url) => {
+      calls.push(String(url));
+      return mockResponse({ status: 200 });
+    });
+
+    const result = await safeFetch("http://127.0.0.1:8080/admin");
+
+    assert.equal(result.unsafe, true);
+    assert.deepEqual(calls, []); // never connected
+  });
+
+  test("follows a redirect between public addresses and returns the final URL", async () => {
+    const calls = [];
+    vi.stubGlobal("fetch", async (url) => {
+      calls.push(String(url));
+      return String(url) === "http://1.1.1.1/"
+        ? mockResponse({ status: 301, location: "http://8.8.8.8/spec.json" })
+        : mockResponse({ status: 200, body: '{"openapi":"3.0.0"}' });
+    });
+
+    const result = await safeFetch("http://1.1.1.1/", {
+      accept: "application/json",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 200);
+    assert.equal(result.url, "http://8.8.8.8/spec.json");
+    assert.deepEqual(calls, ["http://1.1.1.1/", "http://8.8.8.8/spec.json"]);
+    assert.equal(await result.response.text(), '{"openapi":"3.0.0"}');
+  });
+
+  test("returns the final non-2xx response for a direct public URL", async () => {
+    vi.stubGlobal("fetch", async () => mockResponse({ status: 404 }));
+    const result = await safeFetch("http://1.1.1.1/missing");
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 404);
+  });
+});


### PR DESCRIPTION
## Summary
Makes community surface contributions idiot-proof and **verified with real information at add-time** — a contributor finds out a surface is dead/private/mis-kinded *before* opening a PR, not after the gate closes it.

`npm run surface:add` now (on by default):
- **Probes `--url` and `--source-url` live** — **hard-fails** on a private/unsafe address (so `public_safe: true` is never a lie), **warns** with the real HTTP status/error when something isn't reachable right now.
- **openapi auto-enrich** — auto-discovers the spec (the `--url` + common `/openapi.json`, `/swagger.json`, `/api-json`, `/docs-json` paths), sets `schema_url` + `schema_status: "machine-readable"`, and names the surface from the live spec title. **Closes a real gap:** a hand-added `openapi` surface previously had no schema fields and failed full-CI `validate`.
- `--skip-verify` bypasses all network checks for offline work.

## Verified
- `--skip-verify` → `verification: ["skipped (--skip-verify)"]`
- live openapi (petstore) dry-run → `schema_url` + `schema_status` set, name "Apex Swagger Petstore - OpenAPI 3.0" (13 paths), `verification: ["OK openapi spec verified …"]`
- lint + format clean. (Isolated CLI script — not imported elsewhere.)

## Notes
- This is "remaining win #1" (idiot-proof contributions). Reuses `isUnsafeResolvedUrl` / `isJsonContentType` from `lib.mjs`.
- The `contributing-to-metagraphed` skill will get `--skip-verify` + the live-verify behavior in the final skill pass (deferred to migration-end, per plan).