### PR TITLE
ci(validate): retire the ugc fast-lane — every contributor PR runs full validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,18 +14,20 @@ concurrency:
   group: validate-${{ github.ref }}
   cancel-in-progress: true
 
-# The work splits across two parallel jobs that share a runner-free route
-# classification (the classify-validation-route composite action): `test` builds
-# then runs the suite + coverage; `checks` builds then runs lint + the ~20
-# contract / schema / safety validations (and the light UGC submission path).
-# They are independent — no validation needs the test results — so running them
-# on two runners makes the wall-clock max(test, checks) instead of the sum. Both
-# build: the suite's reader tests serve R2-only artifacts (registry-summary.json
-# etc.) that have NO committed fallback and only exist after npm run build, so a
-# fresh runner must stage them; the duplicate ~5s build runs in parallel. Both
-# short-circuit the heavy path for a UGC submission (a single community
-# candidate/provider file): the test job becomes a no-op and checks runs only
-# the submission preflight.
+# Every contributor PR runs the FULL validation — there is NO reduced "UGC"
+# fast-lane. The old lane skipped the safety scans for "single community file"
+# PRs and kept causing a stale-base preflight false-positive; community surfaces
+# now live in one file per subnet (registry/subnets/<slug>.json) and are checked
+# by the same gates as everything else (validate:surface + public-safety +
+# private-boundary, all below).
+#
+# The work splits across two parallel jobs that both build: `test` builds then
+# runs the suite + coverage; `checks` builds then runs lint + the ~20 contract /
+# schema / safety validations. They are independent — no validation needs the
+# test results — so two runners make the wall-clock max(test, checks), not the
+# sum. Both build because the suite's reader tests serve R2-only artifacts
+# (registry-summary.json etc.) that have NO committed fallback and only exist
+# after `npm run build`, so a fresh runner must stage them.
 jobs:
   test:
     name: test
@@ -36,122 +38,27 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Classify validation route
-        id: route
-        shell: bash
-        env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
-        run: |
-          # Keep route classification in the trusted workflow instead of a
-          # checkout-local action/script. Pull request contents are untrusted and
-          # must not be able to force the reduced UGC lane.
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
-              git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
-              git diff --name-only --diff-filter=d "$BASE_SHA"..."$HEAD_SHA" > submitted-artifact-files.txt
-            else
-              git fetch origin "$BASE_REF"
-              git diff --name-only "origin/$BASE_REF"...HEAD > changed-files.txt
-              git diff --name-only --diff-filter=d "origin/$BASE_REF"...HEAD > submitted-artifact-files.txt
-            fi
-          else
-            : > changed-files.txt
-            : > submitted-artifact-files.txt
-          fi
-
-          python3 - <<'PY_ROUTE'
-          import json
-          import os
-          import pathlib
-          import re
-
-          changed_files = sorted(
-              file.strip().replace("\\", "/").removeprefix("./")
-              for file in pathlib.Path("changed-files.txt").read_text(encoding="utf-8").splitlines()
-              if file.strip()
-          )
-          candidate_pattern = re.compile(r"^registry/candidates/community/[a-z0-9][a-z0-9-]*\.json$")
-          provider_pattern = re.compile(r"^registry/providers/community/[a-z0-9][a-z0-9-]*\.json$")
-          candidate_files = [file for file in changed_files if candidate_pattern.fullmatch(file)]
-          provider_files = [file for file in changed_files if provider_pattern.fullmatch(file)]
-          touched_community = [
-              file
-              for file in changed_files
-              if file.startswith("registry/candidates/community/")
-              or file.startswith("registry/providers/community/")
-          ]
-          errors = []
-          submission_files = candidate_files + provider_files
-          # Atomic debut pair: one candidate + one provider (and nothing else) so a
-          # first-time team lands its provider + first surface in one PR. Mirrors
-          # classifyPrScope in scripts/submission-policy.mjs.
-          is_pair = len(candidate_files) == 1 and len(provider_files) == 1
-          if not submission_files and not touched_community:
-              scope = "normal-pr"
-          else:
-              if is_pair:
-                  scope = "direct-pair"
-              elif len(provider_files) == 1:
-                  scope = "direct-provider"
-              else:
-                  scope = "direct-candidate"
-              if len(submission_files) != 1 and not is_pair:
-                  errors.append({"category": "unsupported-shape"})
-              unrelated = [
-                  file
-                  for file in changed_files
-                  if not candidate_pattern.fullmatch(file) and not provider_pattern.fullmatch(file)
-              ]
-              if unrelated:
-                  errors.append({"category": "generated-artifact-tampering"})
-          mode = "ugc" if scope in {"direct-candidate", "direct-provider", "direct-pair"} and not errors else "full"
-          report = {
-              "schema_version": 1,
-              "mode": mode,
-              "scope": scope,
-              "changed_files": changed_files,
-              "candidate_files": candidate_files,
-              "provider_files": provider_files,
-              "errors": errors,
-          }
-          pathlib.Path("validate-route.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
-          output_path = os.environ.get("GITHUB_OUTPUT")
-          if output_path:
-              with open(output_path, "a", encoding="utf-8") as output:
-                  output.write(f"mode={mode}\n")
-                  output.write(f"scope={scope}\n")
-          print(json.dumps(report, indent=2))
-          PY_ROUTE
-
       - name: Setup Node
-        if: steps.route.outputs.mode == 'full'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.23.0
           cache: npm
 
       - name: Install
-        if: steps.route.outputs.mode == 'full'
         run: npm ci
 
       # Stage artifacts before the suite: the reader tests serve R2-only
       # artifacts that have NO committed fallback (dist/metagraph-r2/metagraph/*,
-      # e.g. registry-summary.json), which only exist after a build — exactly as
-      # the checks job and the old single job do.
+      # e.g. registry-summary.json), which only exist after a build.
       - name: Build artifacts
-        if: steps.route.outputs.mode == 'full'
         env:
           METAGRAPH_PRESERVE_PROBE_HEALTH: "1"
         run: npm run build
 
       - name: Prepare test reports dir
-        if: steps.route.outputs.mode == 'full'
         run: mkdir -p reports/junit
 
       - name: Test (with coverage gate)
-        if: steps.route.outputs.mode == 'full'
         env:
           VITEST_JUNIT_PATH: reports/junit/vitest.xml
         run: npm run test:coverage
@@ -161,7 +68,6 @@ jobs:
       # local backstop. Runs on PRs AND main pushes (main = the comparison base);
       # the upload failing never fails CI (the gate is Codecov's own status).
       - name: Upload coverage to Codecov
-        if: steps.route.outputs.mode == 'full'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -169,7 +75,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload Vitest results to Codecov
-        if: ${{ !cancelled() && steps.route.outputs.mode == 'full' }}
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -186,94 +92,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Classify validation route
-        id: route
+      # Compute the deletion-filtered list of files this PR submits, inline in the
+      # trusted workflow (PR contents are untrusted). It feeds ONLY the
+      # reproducible-artifact verifier below, which diff-scopes its check to the
+      # files actually changed. There is no reduced lane to forge — every PR runs
+      # the full validation regardless of this list.
+      - name: Compute submitted files
         shell: bash
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
         run: |
-          # Keep route classification in the trusted workflow instead of a
-          # checkout-local action/script. Pull request contents are untrusted and
-          # must not be able to force the reduced UGC lane.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
-              git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
               git diff --name-only --diff-filter=d "$BASE_SHA"..."$HEAD_SHA" > submitted-artifact-files.txt
             else
               git fetch origin "$BASE_REF"
-              git diff --name-only "origin/$BASE_REF"...HEAD > changed-files.txt
               git diff --name-only --diff-filter=d "origin/$BASE_REF"...HEAD > submitted-artifact-files.txt
             fi
           else
-            : > changed-files.txt
             : > submitted-artifact-files.txt
           fi
-
-          python3 - <<'PY_ROUTE'
-          import json
-          import os
-          import pathlib
-          import re
-
-          changed_files = sorted(
-              file.strip().replace("\\", "/").removeprefix("./")
-              for file in pathlib.Path("changed-files.txt").read_text(encoding="utf-8").splitlines()
-              if file.strip()
-          )
-          candidate_pattern = re.compile(r"^registry/candidates/community/[a-z0-9][a-z0-9-]*\.json$")
-          provider_pattern = re.compile(r"^registry/providers/community/[a-z0-9][a-z0-9-]*\.json$")
-          candidate_files = [file for file in changed_files if candidate_pattern.fullmatch(file)]
-          provider_files = [file for file in changed_files if provider_pattern.fullmatch(file)]
-          touched_community = [
-              file
-              for file in changed_files
-              if file.startswith("registry/candidates/community/")
-              or file.startswith("registry/providers/community/")
-          ]
-          errors = []
-          submission_files = candidate_files + provider_files
-          # Atomic debut pair: one candidate + one provider (and nothing else) so a
-          # first-time team lands its provider + first surface in one PR. Mirrors
-          # classifyPrScope in scripts/submission-policy.mjs.
-          is_pair = len(candidate_files) == 1 and len(provider_files) == 1
-          if not submission_files and not touched_community:
-              scope = "normal-pr"
-          else:
-              if is_pair:
-                  scope = "direct-pair"
-              elif len(provider_files) == 1:
-                  scope = "direct-provider"
-              else:
-                  scope = "direct-candidate"
-              if len(submission_files) != 1 and not is_pair:
-                  errors.append({"category": "unsupported-shape"})
-              unrelated = [
-                  file
-                  for file in changed_files
-                  if not candidate_pattern.fullmatch(file) and not provider_pattern.fullmatch(file)
-              ]
-              if unrelated:
-                  errors.append({"category": "generated-artifact-tampering"})
-          mode = "ugc" if scope in {"direct-candidate", "direct-provider", "direct-pair"} and not errors else "full"
-          report = {
-              "schema_version": 1,
-              "mode": mode,
-              "scope": scope,
-              "changed_files": changed_files,
-              "candidate_files": candidate_files,
-              "provider_files": provider_files,
-              "errors": errors,
-          }
-          pathlib.Path("validate-route.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
-          output_path = os.environ.get("GITHUB_OUTPUT")
-          if output_path:
-              with open(output_path, "a", encoding="utf-8") as output:
-                  output.write(f"mode={mode}\n")
-                  output.write(f"scope={scope}\n")
-          print(json.dumps(report, indent=2))
-          PY_ROUTE
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -284,29 +124,7 @@ jobs:
       - name: Install
         run: npm ci
 
-      # --- UGC submission path (a single community candidate/provider file) ---
-      - name: Run UGC submission preflight
-        if: steps.route.outputs.mode == 'ugc'
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: npm run submission:pr -- --changed-files changed-files.txt --out submission-report.json --submitter "$PR_AUTHOR"
-
-      - name: Validate UGC intake templates
-        if: steps.route.outputs.mode == 'ugc'
-        run: npm run validate:intake
-
-      - name: Public-safety scan for UGC submission
-        if: steps.route.outputs.mode == 'ugc'
-        run: npm run scan:public-safety
-
-      - name: Validate private boundary for UGC submission
-        if: steps.route.outputs.mode == 'ugc'
-        run: npm run validate:private-boundary
-
-      # --- Full validation path ---
       - name: Lint + format
-        if: steps.route.outputs.mode == 'full'
         run: |
           npm run lint
           npm run format:check
@@ -317,7 +135,6 @@ jobs:
       # This is the gate CONTRIBUTING.md references — without it a stale or
       # hand-edited committed contract could land on main undetected.
       - name: Validate committed contract (drift)
-        if: steps.route.outputs.mode == 'full'
         run: |
           npm run validate:contract-drift
           npm run validate:schema-enums
@@ -326,21 +143,18 @@ jobs:
           npm run validate:committed-seed
 
       - name: Build artifacts
-        if: steps.route.outputs.mode == 'full'
         env:
           METAGRAPH_PRESERVE_PROBE_HEALTH: "1"
         run: npm run build
 
       - name: Verify submitted public artifacts are reproducible
-        if: steps.route.outputs.mode == 'full' && github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request'
         run: node scripts/ci-verify-submitted-artifacts.mjs --changed-files submitted-artifact-files.txt
 
       - name: Validate registry
-        if: steps.route.outputs.mode == 'full'
         run: npm run validate
 
       - name: Generate R2 manifest
-        if: steps.route.outputs.mode == 'full'
         run: npm run r2:manifest
 
       # #1025: committed derived artifacts under public/ must match a fresh
@@ -359,7 +173,6 @@ jobs:
       # on every publish (and by the r2:manifest step above), so its committed
       # copy is a best-effort lockfile, not a served/contract surface.
       - name: Verify committed derived artifacts are fresh
-        if: steps.route.outputs.mode == 'full'
         run: |
           # Only CONTRACT artifacts are gated here — openapi.json / types.d.ts /
           # contracts.json / api-index.json / operational-surfaces.json — because they
@@ -387,35 +200,27 @@ jobs:
           echo "All committed derived artifacts under public/ match a fresh build."
 
       - name: Validate JSON schemas
-        if: steps.route.outputs.mode == 'full'
         run: npm run validate:schemas
 
       - name: Validate Worker API
-        if: steps.route.outputs.mode == 'full'
         run: npm run validate:api
 
       - name: Validate MCP server
-        if: steps.route.outputs.mode == 'full'
         run: npm run validate:mcp
 
       - name: Validate AI routes
-        if: steps.route.outputs.mode == 'full'
         run: npm run validate:ai
 
       - name: Validate OpenAPI
-        if: steps.route.outputs.mode == 'full'
         run: npm run validate:openapi
 
       - name: Validate generated API types
-        if: steps.route.outputs.mode == 'full'
         run: npm run validate:types
 
       - name: Validate artifact size budgets
-        if: steps.route.outputs.mode == 'full'
         run: npm run validate:artifact-budgets
 
       - name: Validate documentation contracts
-        if: steps.route.outputs.mode == 'full'
         run: npm run validate:docs
 
       # NOTE: the README subnet catalog is intentionally NOT gated here. It is a
@@ -428,36 +233,28 @@ jobs:
       # catalogs + public/datasets — DATA artifacts are not PR-gated.)
 
       - name: Validate intake templates
-        if: steps.route.outputs.mode == 'full'
         run: npm run validate:intake
 
       - name: Validate registry subnet files
-        if: steps.route.outputs.mode == 'full'
         run: npm run validate:surface
 
       - name: Validate workflows
-        if: steps.route.outputs.mode == 'full'
         run: npm run validate:workflows
 
       - name: Validate Cloudflare config
-        if: steps.route.outputs.mode == 'full'
         run: npm run cloudflare:verify:dry-run
 
       - name: Validate R2 manifest
-        if: steps.route.outputs.mode == 'full'
         run: |
           npm run r2:manifest:dry-run
           npm run r2:download:dry-run
           npm run kv:publish:dry-run
 
       - name: Worker deploy dry-run
-        if: steps.route.outputs.mode == 'full'
         run: npm run worker:deploy:dry-run
 
       - name: Public-safety scan
-        if: steps.route.outputs.mode == 'full'
         run: npm run scan:public-safety
 
       - name: Validate private boundary
-        if: steps.route.outputs.mode == 'full'
         run: npm run validate:private-boundary

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -112,23 +112,24 @@ for (const workflow of workflows) {
     );
   }
   if (workflow === "validate.yml") {
-    // Route classification must stay in this trusted workflow. Running a
-    // checkout-local action/script would let pull requests forge `mode=ugc` and
-    // skip full validation. The deletion-filtered verification is consumed back
-    // in this workflow.
+    // There is NO reduced "ugc" lane to forge — every PR runs the full
+    // validation. The only PR-derived input is the deletion-filtered submitted-
+    // file list, computed inline in this trusted workflow (a checkout-local
+    // action could be PR-controlled) and consumed only to diff-scope the
+    // reproducible-artifact verifier.
     check(
       !content.includes("uses: ./.github/actions/classify-validation-route"),
       workflow,
       "validate workflow must not route CI through PR-controlled local actions",
     );
     check(
-      content.includes("git diff --name-only ") &&
-        content.includes("> changed-files.txt") &&
+      content.includes("git diff --name-only") &&
         content.includes("--diff-filter=d") &&
         content.includes("> submitted-artifact-files.txt") &&
-        content.includes("python3 - <<'PY_ROUTE'"),
+        !content.includes("PY_ROUTE") &&
+        !content.includes("mode=ugc"),
       workflow,
-      "validate workflow must compute routing diffs and classify the route inline from trusted workflow code",
+      "validate workflow must compute the submitted-artifact diff inline and run no reduced ugc lane",
     );
     check(
       content.includes("--changed-files submitted-artifact-files.txt"),


### PR DESCRIPTION
## Why
The CI route classifier sorted single-community-file PRs into a reduced **`ugc`** lane that **skipped the safety scans** and kept tripping a stale-base preflight false-positive. With community surfaces now living in **one file per subnet** (`registry/subnets/<slug>.json`), there's no reason for a separate lane — the full path already runs `validate:surface` + `scan:public-safety` + `validate:private-boundary`.

This is migration cleanup #1 of a series: the backend moved to single-file surfaces, but the contributor pipeline (CI lanes, templates, the candidate scripts) still drove the retired candidate lane. Decision: **full-mode for all.**

## What
- Remove the inline `PY_ROUTE` classifier and **every `if: steps.route.outputs.mode == 'full'` gate** from both jobs. The `test` job always builds + tests; the `checks` job always runs the full validation.
- Drop the candidate-shaped `ugc` steps (the `submission:pr` preflight + the `ugc`-only copies of `validate:intake` / public-safety / private-boundary — the full path keeps those).
- Keep a minimal inline **Compute submitted files** step (deletion-filtered `git diff`) feeding only the reproducible-artifact verifier. No reduced lane = nothing for an untrusted PR to forge.
- Update `validate-workflows.mjs` to assert the new shape (inline submitted-file diff; no `PY_ROUTE` / no `mode=ugc`).

## Verified
- `validate:workflows` ✅ (18 workflows)
- full test suite ✅ (1929/1929), lint + format clean

## Follow-ups (separate PRs)
Retire the candidate lane dead code (`intake-import-pr`/`intake-validation` workflows, `direct-candidate.md`, candidate scripts/examples, trim `validate-intake.mjs`); consolidate issue/PR templates to the single "Add a surface" model; `surface:add` provider auto-scaffold; wire `review.state`.