### PR TITLE
enrich(registry): add Targon inventory API surface (SN4)

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 73,
+  "surface_count": 74,
   "surfaces": [
     {
       "auth_required": false,
@@ -155,6 +155,24 @@
       "surface_id": "opentensor-lite-wss",
       "surface_key": "srf-dcf48d017826dc4b",
       "url": "wss://lite.chain.opentensor.ai:443"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 4,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "targon",
+      "public_safe": true,
+      "subnet_name": "Targon",
+      "subnet_slug": "sn-4",
+      "surface_id": "sn-4-targon-subnet-api",
+      "surface_key": "srf-40be5162d95eb737",
+      "url": "https://api.targon.com/tha/v2/inventory"
     },
     {
       "auth_required": false,

--- a/registry/subnets/targon.json
+++ b/registry/subnets/targon.json
@@ -15,7 +15,7 @@
   "docs_url": "https://docs.targon.com/",
   "dashboard_url": null,
   "website_url": "https://targon.com/",
-  "notes": "Reviewed overlay for SN4 using the official Targon website, docs, Intel whitepaper, and source repository. No public API, OpenAPI schema, SSE stream, or standalone data artifact is verified yet.",
+  "notes": "Reviewed overlay for SN4 using the official Targon website, docs, Intel whitepaper, and source repository. Community-submitted public inventory API surface (https://api.targon.com/tha/v2/inventory) pending maintainer review. No machine-readable OpenAPI schema, SSE stream, or standalone data artifact is verified yet.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -24,8 +24,8 @@
     "source_count": 6,
     "gap_notes": [
       "Official website, docs, Intel whitepaper, and source repository are verified live.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
+      "Community-submitted public subnet API endpoint pending maintainer review (https://api.targon.com/tha/v2/inventory).",
+      "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
     ]
@@ -105,6 +105,25 @@
         "timeout_ms": 10000
       },
       "notes": "Official Targon source repository."
+    },
+    {
+      "id": "sn-4-targon-subnet-api",
+      "name": "Targon inventory API",
+      "kind": "subnet-api",
+      "url": "https://api.targon.com/tha/v2/inventory",
+      "provider": "targon",
+      "authority": "community",
+      "auth_required": false,
+      "public_safe": true,
+      "source_urls": ["https://docs.targon.com/api/inventory"],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "notes": "Public inventory endpoint from the official Targon API. Returns a JSON catalogue of available compute resource types and pricing. No machine-readable OpenAPI spec captured yet.",
+      "review": { "state": "community-submitted", "submitted_by": "nickmopen" }
     }
   ],
   "social": { "x": "https://x.com/targoncompute" },

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -1072,18 +1072,18 @@ test("public artifacts are internally consistent", () => {
   );
   assert.equal(
     callableAgentServices.length,
-    95,
+    96,
     "agent-catalog callable-service count must stay deterministic",
   );
   assert.equal(
     callableWithoutSchema.length,
-    45,
+    46,
     "schema projection should reduce callable services without schema artifacts",
   );
   assert.equal(
     callableWithoutSchema.filter((service) => service.kind === "subnet-api")
       .length,
-    5,
+    6,
     "schema projection should leave only explicitly uncaptured/unknown subnet APIs without schemas",
   );
   assert.equal(


### PR DESCRIPTION
## Summary

- Adds a community-submitted `subnet-api` surface for SN4 Targon: `GET https://api.targon.com/tha/v2/inventory`
- Returns a public JSON catalogue of compute resource types, GPU specs, and hourly pricing — no auth required
- Source: https://docs.targon.com/api/inventory
- Only `registry/subnets/targon.json` is changed

## Verification

URL resolves and returns JSON:
```
curl https://api.targon.com/tha/v2/inventory
# → [{"name":"cpu-small","display_name":"CPU Server - Small",...}]
```

Closes #682