### PR TITLE
feat(intake): surface:add auto-scaffolds a community provider stub for debut providers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,22 +41,23 @@ Skipping the rebuild trips `validate:contract-drift` in CI. Schemas are the sour
 
 Surfaces live in **one file per subnet**: `registry/subnets/<slug>.json` → its `surfaces[]` array. A community contribution **adds a surface to that one file** — `npm run surface:add` writes it with `authority: "community"` and `review.state: "community-submitted"`. There is no per-surface candidate file anymore (recreating `registry/candidates/community/*.json` is rejected by CI), so you can't farm one surface per PR: **one subnet = one file = one PR.**
 
-> Change **only** the one `registry/subnets/<slug>.json` — no generated artifacts. First-time provider? Add `registry/providers/community/<slug>.json` in the same PR (`npm run provider:new`); provider identity still gets reviewed before it's trusted.
+> Change **only** the one `registry/subnets/<slug>.json` — no generated artifacts. First-time provider? Pass `--provider-name` + `--provider-url` and `surface:add` scaffolds the `registry/providers/community/<slug>.json` stub for you in the same PR (or run `npm run provider:new`); provider identity still gets reviewed before it's trusted.
 
 Add a surface locally — three steps:
 
 ```bash
 # 1. Find the provider slug for the team/operator behind this surface.
-#    (No match? Register one in the same PR with `npm run provider:new`.)
 npm run providers:list
 
-# 2. Append the surface to the subnet's file with a REAL --provider slug (a
-#    placeholder like "community" is not a registered provider and fails validation).
+# 2. Append the surface to the subnet's file with a REAL --provider slug.
+#    Debut provider? Add --provider-name + --provider-url and surface:add also
+#    scaffolds registry/providers/community/<slug>.json so the PR validates in one shot.
 npm run surface:add -- \
   --netuid 7 --kind docs \
   --url https://docs.example.com \
   --source-url https://github.com/example/project \
   --provider <provider-slug> --submitted-by <github-login> --write
+  # debut provider: --provider-name "Example Team" --provider-url https://example.com
 
 # 3. Check it before pushing — a fast local pre-check (schema + provider slug +
 #    review-state + real subnet name) without the full build (CI runs full validate).

--- a/scripts/surface-add.mjs
+++ b/scripts/surface-add.mjs
@@ -9,6 +9,10 @@
 //     --url https://docs.example.com \
 //     --source-url https://github.com/example/project \
 //     --provider <provider-slug> --submitted-by <github-login> --write
+//
+// Debut provider (slug not registered yet)? Add --provider-name "<Team>" and
+// --provider-url <https://public-site> and surface:add also scaffolds
+// registry/providers/community/<slug>.json so the PR validates in one shot.
 import path from "node:path";
 import {
   isJsonContentType,
@@ -48,6 +52,13 @@ const name = valueAfter("--name");
 const authRequired = parseBoolean(valueAfter("--auth-required") || "false");
 const rateLimitNotes = valueAfter("--rate-limit-notes") || "";
 const notes = valueAfter("--notes") || "";
+// Debut-provider auto-scaffold inputs (only used when --provider isn't registered).
+const providerName = valueAfter("--provider-name");
+const providerUrl = normalizePublicUrl(valueAfter("--provider-url"));
+const providerKind = valueAfter("--provider-kind") || "subnet-team";
+const providerGithub = valueAfter("--provider-github")
+  ? normalizePublicUrl(valueAfter("--provider-github"))
+  : null;
 
 const native = await loadNativeSnapshot();
 const subnet = native.subnets.find((entry) => entry.netuid === netuid);
@@ -68,15 +79,44 @@ if (!document) {
   );
 }
 
-// Provider must be a registered slug to pass validate:surface + CI. Warn (don't
-// fail) so a debut provider added in the same PR still works.
+// Provider must be a registered slug to pass validate:surface + CI. For a debut
+// provider, auto-scaffold a registry/providers/community/<slug>.json stub in the
+// same PR so the contributor never hits the unregistered-provider failure. The
+// website_url is only stored (never fetched), so normalizePublicUrl's synchronous
+// safety check (it rejects localhost/private hosts) is sufficient.
 const providerIds = new Set((await loadProviders()).map((entry) => entry.id));
+const providerFilePath = path.join(
+  repoRoot,
+  "registry/providers/community",
+  `${provider}.json`,
+);
+let providerStub = null;
 if (!providerIds.has(provider)) {
-  console.warn(
-    `Warning: provider "${provider}" is not a registered slug, so this surface will ` +
-      "FAIL `npm run validate:surface` and CI. Pick one with `npm run providers:list`, " +
-      "or register it with `npm run provider:new` in the same PR.",
-  );
+  if (!providerName || !providerUrl) {
+    fail(
+      `Provider "${provider}" is not registered. Add --provider-name "<Team Name>" ` +
+        "and --provider-url <https://public-site> so surface:add scaffolds " +
+        `registry/providers/community/${provider}.json in the same PR, ` +
+        "or pick an existing slug with `npm run providers:list`.",
+    );
+  }
+  providerStub = {
+    schema_version: 1,
+    submission: {
+      submitted_by: submittedBy,
+      submitted_by_url: `https://github.com/${submittedBy}`,
+    },
+    provider: {
+      schema_version: 1,
+      id: provider,
+      name: providerName,
+      kind: providerKind,
+      website_url: providerUrl,
+      ...(providerGithub ? { github_url: providerGithub } : {}),
+      authority: "community",
+      public_notes: "",
+    },
+  };
 }
 
 const surfaces = Array.isArray(document.surfaces) ? document.surfaces : [];
@@ -112,6 +152,9 @@ document.surfaces = [...surfaces, surface];
 
 if (write) {
   await writeRepositoryJson(filePath, document);
+  if (providerStub) {
+    await writeRepositoryJson(providerFilePath, providerStub);
+  }
 }
 
 console.log(
@@ -121,7 +164,17 @@ console.log(
     surface_count: document.surfaces.length,
     verification: findings,
     surface,
-    next: "Link a tracked issue (Closes #N) and open a PR that changes ONLY this file.",
+    ...(providerStub
+      ? {
+          provider_stub: {
+            file: path.relative(repoRoot, providerFilePath),
+            provider: providerStub.provider,
+          },
+        }
+      : {}),
+    next: providerStub
+      ? "Debut provider scaffolded — open a PR with BOTH this subnet file and the new registry/providers/community file. Link a tracked issue (Closes #N)."
+      : "Link a tracked issue (Closes #N) and open a PR that changes ONLY this file.",
   }),
 );
 


### PR DESCRIPTION
## Why
This is the friction that broke several open surface PRs (SN44 Score, SN124 Swarm, SN120 Affine, SN50 Synth): `surface:add` only **warned** when `--provider` wasn't a registered slug, so the PR then failed `validate:surface` in CI. Decision: **auto-scaffold the provider stub** (idiot-proof, one shot).

## What
For a **debut provider** (slug not yet registered), `surface:add` now also writes `registry/providers/community/<slug>.json` in the same run:
- New flags: `--provider-name`, `--provider-url` (required to scaffold), `--provider-kind` (default `subnet-team`), `--provider-github` (optional).
- Unregistered provider **without** name/url now **hard-fails with the exact fix** instead of warning and slipping an invalid surface to CI.
- The stub mirrors `provider:new`'s schema-valid shape. `website_url` is only stored (never fetched), so `normalizePublicUrl`'s synchronous safety check suffices.
- **No `validate:surface` change needed** — it reads `registry/providers/community` via `loadProviders()`, so the stub registers the slug.
- `CONTRIBUTING.md` updated for the one-shot debut-provider flow.

## Verified (end-to-end)
- Write test → `apex.json` + the stub written → `validate:surface` ✅ (provider resolves) + `validate:schemas` ✅ (stub valid) → reverted clean.
- Debut without name/url → fails with guidance; existing provider → unaffected.
- Full suite ✅ 1940, lint + format clean.

## Note
The resulting surface PR legitimately touches **two** files (the subnet file + the provider stub) — the surface PR template (PR #3) already documents this shape.