### PR TITLE
fix(contracts): tier the /api/v1/compare artifact r2 like its sibling live routes

### DIFF
--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -460,7 +460,7 @@
       "id": "compare",
       "path": "/metagraph/compare.json",
       "schema_ref": "#/components/schemas/CompareArtifact",
-      "storage_tier": "git"
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -592,7 +592,7 @@
       "id": "compare",
       "path": "/metagraph/compare.json",
       "schema_ref": "#/components/schemas/CompareArtifact",
-      "storage_tier": "git"
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -58,6 +58,11 @@ const R2_ONLY_PATTERNS = [
   /^extrinsics\.json$/,
   /^extrinsics\/(?:0x[0-9a-fA-F]{64}|\{hash\})\.json$/,
   /^registry\/leaderboards\.json$/,
+  // Cross-subnet comparison (#1664), composed live from registry projections +
+  // the economics tier + D1 at /api/v1/compare — never written as a file. R2-only
+  // like its sibling live routes so the contract maps a schema to the route
+  // without the build expecting a committed/staged artifact.
+  /^compare\.json$/,
   // RPC reverse-proxy usage analytics (B3), computed live from D1 telemetry at
   // /api/v1/rpc/usage — never written as a file.
   /^rpc\/usage\.json$/,


### PR DESCRIPTION
## Summary

The `compare` artifact (`GET /api/v1/compare`, added in #1664) backs a fileless, computed-live route but resolved to the default **`git`** storage tier, because `/metagraph/compare.json` was never added to `R2_ONLY_PATTERNS` in `src/artifact-storage.mjs`. Every other fileless/computed-live route — `registry/leaderboards`, `rpc/usage`, `incidents` — is `r2`-tiered; `compare` was the only outlier:

```
compare                => git      ← was the outlier
registry/leaderboards  => r2
rpc/usage              => r2
incidents              => r2
```

It kept passing CI only because `compare` was also added to the `COMPUTED_ARTIFACTS` skip-list in `scripts/validate-schemas.mjs`, which suppresses the "missing committed file" check — so two parallel sources of truth happened to agree. But the published contract (`contracts.json` + `api-index.json`) advertised `storage_tier: "git"`, i.e. a committed static file at `/metagraph/compare.json` that does not and never will exist. This is the same mis-tiering the codebase documents as a prior incident (the `review/profile-completeness.json` note: *"mis-tiered as git … absent from BOTH pattern lists … #998 v1"*).

Closes #1672

## What Changed

- `src/artifact-storage.mjs`: add `/^compare\.json$/` to `R2_ONLY_PATTERNS`, next to its sibling live routes. The live-only-D1 convention is `R2_ONLY_PATTERNS` **and** `COMPUTED_ARTIFACTS` together; the existing `COMPUTED_ARTIFACTS` entry is kept.
- Regenerated via `npm run build`: `public/metagraph/contracts.json` + `public/metagraph/api-index.json` — `compare`'s `storage_tier` flips `git` → `r2` (one line each). No `openapi.json`/types/client change, since `storage_tier` lives only in the artifact registry, not the OpenAPI component.

A follow-up issue (#1673) tracks tightening the loose `CompareArtifact` response schema, separately.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts (`npm run build`), not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed (`r2-manifest.json` reverted; `compare` is fileless).
- [x] Public API/OpenAPI/schema changes are intentional and documented — a storage-tier correction; no behavior, route, or payload change.

## Validation

- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:contract-drift` · `validate:generated-client` · `validate:artifact-budgets`
- [x] `npm run scan:public-safety` · `git diff --check`
- [x] `npm run lint` · `prettier --check` (changed files)
- [ ] `npm run test:coverage` / `worker:test` — deferred to CI (no code-path/behavior change; storage-tier config + deterministic regenerated artifacts only)