### PR TITLE
refactor(schema): simplify surface review.state to the human-governance axis

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -4103,13 +4103,13 @@ export interface components {
                 window: string;
             };
             rate_limit_notes?: string;
-            /** @description Per-surface review/trust state (single-file contribution model): community-submitted surfaces enter as "community-submitted" and are promoted in place by the Gittensory Gate / maintainer review. Distinct from probe-derived verification (health) and subnet-level curation.review_state. */
+            /** @description Per-surface HUMAN review/governance state (single-file contribution model): a surface enters as "community-submitted"; a maintainer promotes it to "maintainer-reviewed" or marks it "rejected". This is the human-governance axis ONLY — machine verification + freshness (is the surface live or stale) is the separate probe-derived overlay (health, last_verified_at, incidents), and subnet-level curation has its own curation.review_state. */
             review?: {
                 /** @enum {unknown} */
                 confidence?: "low" | "medium" | "high";
                 review_notes?: string;
                 /** @enum {unknown} */
-                state: "community-submitted" | "schema-valid" | "auto-verified" | "maintainer-reviewed" | "stale" | "rejected";
+                state: "community-submitted" | "maintainer-reviewed" | "rejected";
                 submitted_at?: string;
                 submitted_by?: string;
             };

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -11377,7 +11377,7 @@
           },
           "review": {
             "additionalProperties": false,
-            "description": "Per-surface review/trust state (single-file contribution model): community-submitted surfaces enter as \"community-submitted\" and are promoted in place by the Gittensory Gate / maintainer review. Distinct from probe-derived verification (health) and subnet-level curation.review_state.",
+            "description": "Per-surface HUMAN review/governance state (single-file contribution model): a surface enters as \"community-submitted\"; a maintainer promotes it to \"maintainer-reviewed\" or marks it \"rejected\". This is the human-governance axis ONLY — machine verification + freshness (is the surface live or stale) is the separate probe-derived overlay (health, last_verified_at, incidents), and subnet-level curation has its own curation.review_state.",
             "properties": {
               "confidence": {
                 "enum": [
@@ -11392,10 +11392,7 @@
               "state": {
                 "enum": [
                   "community-submitted",
-                  "schema-valid",
-                  "auto-verified",
                   "maintainer-reviewed",
-                  "stale",
                   "rejected"
                 ]
               },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4103,13 +4103,13 @@ export interface components {
                 window: string;
             };
             rate_limit_notes?: string;
-            /** @description Per-surface review/trust state (single-file contribution model): community-submitted surfaces enter as "community-submitted" and are promoted in place by the Gittensory Gate / maintainer review. Distinct from probe-derived verification (health) and subnet-level curation.review_state. */
+            /** @description Per-surface HUMAN review/governance state (single-file contribution model): a surface enters as "community-submitted"; a maintainer promotes it to "maintainer-reviewed" or marks it "rejected". This is the human-governance axis ONLY — machine verification + freshness (is the surface live or stale) is the separate probe-derived overlay (health, last_verified_at, incidents), and subnet-level curation has its own curation.review_state. */
             review?: {
                 /** @enum {unknown} */
                 confidence?: "low" | "medium" | "high";
                 review_notes?: string;
                 /** @enum {unknown} */
-                state: "community-submitted" | "schema-valid" | "auto-verified" | "maintainer-reviewed" | "stale" | "rejected";
+                state: "community-submitted" | "maintainer-reviewed" | "rejected";
                 submitted_at?: string;
                 submitted_by?: string;
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -11355,7 +11355,7 @@
           },
           "review": {
             "additionalProperties": false,
-            "description": "Per-surface review/trust state (single-file contribution model): community-submitted surfaces enter as \"community-submitted\" and are promoted in place by the Gittensory Gate / maintainer review. Distinct from probe-derived verification (health) and subnet-level curation.review_state.",
+            "description": "Per-surface HUMAN review/governance state (single-file contribution model): a surface enters as \"community-submitted\"; a maintainer promotes it to \"maintainer-reviewed\" or marks it \"rejected\". This is the human-governance axis ONLY — machine verification + freshness (is the surface live or stale) is the separate probe-derived overlay (health, last_verified_at, incidents), and subnet-level curation has its own curation.review_state.",
             "properties": {
               "confidence": {
                 "enum": [
@@ -11370,10 +11370,7 @@
               "state": {
                 "enum": [
                   "community-submitted",
-                  "schema-valid",
-                  "auto-verified",
                   "maintainer-reviewed",
-                  "stale",
                   "rejected"
                 ]
               },

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -435,15 +435,12 @@
             "type": "object",
             "additionalProperties": false,
             "required": ["state"],
-            "description": "Per-surface review/trust state (single-file contribution model): community-submitted surfaces enter as \"community-submitted\" and are promoted in place by the Gittensory Gate / maintainer review. Distinct from probe-derived verification (health) and subnet-level curation.review_state.",
+            "description": "Per-surface HUMAN review/governance state (single-file contribution model): a surface enters as \"community-submitted\"; a maintainer promotes it to \"maintainer-reviewed\" or marks it \"rejected\". This is the human-governance axis ONLY — machine verification + freshness (is the surface live or stale) is the separate probe-derived overlay (health, last_verified_at, incidents), and subnet-level curation has its own curation.review_state.",
             "properties": {
               "state": {
                 "enum": [
                   "community-submitted",
-                  "schema-valid",
-                  "auto-verified",
                   "maintainer-reviewed",
-                  "stale",
                   "rejected"
                 ]
               },

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -210,17 +210,10 @@
           "type": "object",
           "additionalProperties": false,
           "required": ["state"],
-          "description": "Per-surface review/trust state for the single-file contribution model: a community-submitted surface enters as \"community-submitted\" and the Gittensory Gate / maintainer review promotes the state in place. Distinct from probe-derived `verification` (health) and the subnet-level `curation.review_state`.",
+          "description": "Per-surface HUMAN review/governance state for the single-file contribution model: a surface enters as \"community-submitted\"; a maintainer promotes it to \"maintainer-reviewed\" or marks it \"rejected\". Human-governance axis ONLY — machine verification + freshness (live or stale) is the separate probe-derived `verification` overlay (health, last_verified_at, incidents); subnet-level curation has its own `curation.review_state`.",
           "properties": {
             "state": {
-              "enum": [
-                "community-submitted",
-                "schema-valid",
-                "auto-verified",
-                "maintainer-reviewed",
-                "stale",
-                "rejected"
-              ]
+              "enum": ["community-submitted", "maintainer-reviewed", "rejected"]
             },
             "submitted_by": {
               "type": "string"


### PR DESCRIPTION
## Why
`review.state` had 6 enum values but only 2 were ever used (`community-submitted`, `maintainer-reviewed`) and **nothing advanced it** — while machine verification + freshness already exist as a live **probe-derived overlay** (health, `last_verified_at`, incidents, the `stale` flag). Conflating human review with machine verification made `review.state` a dead, ambiguous field.

## What
Tighten the enum (in `04-surfaces` + `subnet-manifest`) to the **human-governance axis only**:

`community-submitted` → `maintainer-reviewed` / `rejected`

Machine "is it live / stale / verified" stays the probe overlay; subnet-level curation keeps its own `curation.review_state`. No surface used the dropped values (`schema-valid`/`auto-verified`/`stale`), and the candidate/gate lane's similarly-named `state` values are a **separate field** (untouched).

Regenerated the contract (`openapi.json`, `types.d.ts`, generated client, `api-components` bundle).

## Verified
- `validate:schemas` / `validate:schema-enums` / `validate:surface` green
- full suite ✅ 1940 (1 pre-existing `webhooks-redelivery` ordering flake passes in isolation)

## Frontend
`review.state` rendering in metagraphed-ui will be wired up with the other backend changes once the series lands.