### PR TITLE
feat(intake): keep base-layer endpoints out of the contributor surface template

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-subnet-surface.yml
+++ b/.github/ISSUE_TEMPLATE/add-subnet-surface.yml
@@ -30,6 +30,7 @@ body:
     id: kind
     attributes:
       label: Surface kind
+      description: "Application/operational surfaces only. Base-layer chain endpoints (RPC/WSS/archive) are maintainer-curated network infrastructure served via the endpoint lane (/api/v1/rpc, the /rpc proxy) — they are not contributor surfaces."
       options:
         - docs
         - website
@@ -42,9 +43,6 @@ body:
         - example
         - sse
         - repo-registry
-        - archive
-        - subtensor-rpc
-        - subtensor-wss
     validations:
       required: true
   - type: input

--- a/scripts/validate-intake.mjs
+++ b/scripts/validate-intake.mjs
@@ -86,7 +86,6 @@ checkIncludes(surfaceTemplate.toLowerCase(), "surface template", [
 ]);
 
 for (const kind of [
-  "archive",
   "website",
   "source-repo",
   "subnet-api",
@@ -98,8 +97,6 @@ for (const kind of [
   "repo-registry",
   "docs",
   "data-artifact",
-  "subtensor-rpc",
-  "subtensor-wss",
 ]) {
   checkIncludes(surfaceTemplate, "surface template", [`- ${kind}`]);
 }


### PR DESCRIPTION
## Why
Base-layer chain endpoints (`subtensor-rpc` / `subtensor-wss` / `archive`) are **maintainer-curated network infrastructure** served via the endpoint lane (the `/rpc` proxy + `/api/v1/rpc/*`), not per-subnet contributor surfaces. They shouldn't be offered as options when a contributor adds a surface.

## What
- Remove the three base-layer kinds from the **"Add a surface"** issue template's `kind` dropdown (+ a note pointing to the endpoint lane).
- Remove them from `validate-intake.mjs`'s kind assertion to match.

## Scope (deliberately contributor-facing only)
The surface **schema keeps** these kinds — `root.json`'s curated Finney base-layer endpoints and the endpoint-artifact pipeline that feeds the **live `/rpc` proxy** are **untouched** (zero proxy risk). The full relocation of those curated endpoints into the native endpoint lane is tracked as a separate **maintainer** issue (it needs health/probe-pipeline rework + byte-identical endpoint-artifact verification under review).

## Verified
- `validate:intake` green, full suite ✅ 1947, lint + format clean.