### PR TITLE
fix(publish): make smoke:live resolve D1-tier detail routes + compare

### DIFF
--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -343,14 +343,28 @@ async function discoverHealthHistoryDate() {
 }
 
 function apiRouteUrl(routePath, date) {
+  // D1-tier detail routes carry id placeholders beyond {netuid}/{slug}/{date}.
+  // Substitute constant, dependency-free sample ids that resolve to a live 200:
+  // uid 0 always exists; an all-zero hash / block 0 hit the cold→null wrapper
+  // (still a 200 envelope); the accounts route requires a checksum-valid SS58, so
+  // use the canonical dev address (Alice) rather than an arbitrary string (which
+  // 404s on the checksum). Without these, the smoke step requests literal-
+  // placeholder URLs that match no route and 404 (#1682).
   const route = routePath
     .replace("{netuid}", "7")
     .replace("{slug}", "allways")
-    .replace("{date}", date);
+    .replace("{date}", date)
+    .replace("{uid}", "0")
+    .replace("{hash}", `0x${"0".repeat(64)}`)
+    .replace("{ref}", "0")
+    .replace("{ss58}", "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM");
   const url = new URL(route, baseUrl);
   if (routePath === "/api/v1/subnets") {
     url.searchParams.set("limit", "3");
     url.searchParams.set("sort", "netuid");
+  } else if (routePath === "/api/v1/compare") {
+    // compare requires `netuids` — a bare GET is a 400 (#1682).
+    url.searchParams.set("netuids", "7");
   } else if (
     [
       "/api/v1/surfaces",


### PR DESCRIPTION
## Summary

The **Publish Cloudflare Backend** workflow has been chronically red at the **Smoke live API** step. The data publish (`refresh` → `r2:upload` → `kv:publish`) succeeds first — only the post-publish smoke verification fails, so it is a false-red, but it masks real publish failures and reads as a broken pipeline.

`scripts/smoke-live-api.mjs` iterates every `API_ROUTES` entry asserting HTTP 200, but `apiRouteUrl()`:
- substituted only `{netuid}`/`{slug}`/`{date}`, so the newer D1-tier detail routes requested **literal-placeholder** URLs that match no route and 404 — `subnets/{netuid}/neurons/{uid}` (+ `/history`), `accounts/{ss58}` (+ `/events`, `/subnets`), `blocks/{ref}`, `extrinsics/{hash}`;
- provided no params for `/api/v1/compare` (added in #1664), which **400s** without its required `netuids`.

`smoke:live` fails at the first 404, so the compare 400 was masked behind the neurons 404 — both had to be fixed for the suite to pass.

Closes #1682

## What Changed

`scripts/smoke-live-api.mjs` only:
- `apiRouteUrl()` substitutes the remaining placeholders with **constant, dependency-free** sample ids: `{uid}`→`0`, `{hash}`→`0x`+64 zeros, `{ref}`→`0`, `{ss58}`→`5C4hrfjw9D…` (the canonical dev/Alice address — the accounts route requires a valid SS58 **checksum**, so an arbitrary string 404s).
- adds a `/api/v1/compare` case setting `netuids=7`, mirroring the existing `/api/v1/subnets` `limit`/`sort` special-casing.

No production code, endpoint contract, schema, or publish-pipeline config changes — test harness only.

## Validation

- [x] **`smoke:live` run against `https://api.metagraph.sh` → `status: passed`** (74 API routes + 6 raw artifacts + 23 MCP tools + AI enabled, exit 0) — the exact check the publish workflow runs.
- [x] Each substitution independently confirmed `200` + truthy envelope on live; the literal-placeholder forms confirmed `404`.
- [x] `prettier --check` · `eslint` clean.

> Note: `smoke:live` only runs in the publish workflow (against the live API), not in `Validate` CI, so PR CI won't exercise it — it was verified locally against live prod as above.