### PR TITLE
fix(contracts): substitute all 8 route tokens in artifactPathFromTemplate

### DIFF
--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2186,9 +2186,13 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
 export function artifactPathFromTemplate(template, params = {}) {
   return template
     .replace("{netuid}", String(params.netuid ?? ""))
+    .replace("{uid}", String(params.uid ?? ""))
+    .replace("{ss58}", String(params.ss58 ?? ""))
     .replace("{slug}", String(params.slug ?? ""))
     .replace("{date}", String(params.date ?? ""))
-    .replace("{surface_id}", String(params.surface_id ?? ""));
+    .replace("{surface_id}", String(params.surface_id ?? ""))
+    .replace("{ref}", String(params.ref ?? ""))
+    .replace("{hash}", String(params.hash ?? ""));
 }
 
 export function compileRoutePattern(pathTemplate) {

--- a/tests/invariants-contracts.test.mjs
+++ b/tests/invariants-contracts.test.mjs
@@ -242,17 +242,43 @@ describe("contracts — compileRoutePattern per token type", () => {
   });
 
   test("artifactPathFromTemplate substitutes every supported token", () => {
+    // All eight tokens compileRoutePattern captures must also be substituted here:
+    // netuid, uid, ss58, slug, date, surface_id, ref, hash.
     assert.equal(
       artifactPathFromTemplate(
-        "/metagraph/subnets/{netuid}/{slug}/{date}/{surface_id}.json",
-        { netuid: 7, slug: "x", date: "2026-06-06", surface_id: "sid" },
+        "/m/{netuid}/{uid}/{ss58}/{slug}/{date}/{surface_id}/{ref}/{hash}.json",
+        {
+          netuid: 7,
+          uid: 3,
+          ss58: "5Hk",
+          slug: "x",
+          date: "2026-06-06",
+          surface_id: "sid",
+          ref: "1234",
+          hash: "0xabc",
+        },
       ),
-      "/metagraph/subnets/7/x/2026-06-06/sid.json",
+      "/m/7/3/5Hk/x/2026-06-06/sid/1234/0xabc.json",
     );
-    // A missing param substitutes the empty string (never "undefined").
+    // Real routes that carry the previously-unsubstituted tokens.
     assert.equal(
-      artifactPathFromTemplate("/metagraph/subnets/{netuid}.json", {}),
-      "/metagraph/subnets/.json",
+      artifactPathFromTemplate(
+        "/metagraph/subnets/{netuid}/neurons/{uid}.json",
+        { netuid: 7, uid: 3 },
+      ),
+      "/metagraph/subnets/7/neurons/3.json",
+    );
+    assert.equal(
+      artifactPathFromTemplate("/metagraph/extrinsics/{hash}.json", {
+        hash: "0xdeadbeef",
+      }),
+      "/metagraph/extrinsics/0xdeadbeef.json",
+    );
+    // A missing param substitutes the empty string (never "undefined") — also
+    // exercises the `?? ""` fallback for the newly-added tokens.
+    assert.equal(
+      artifactPathFromTemplate("/m/{uid}/{ss58}/{ref}/{hash}.json", {}),
+      "/m////.json",
     );
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1686.

`compileRoutePattern` captures eight route tokens — `netuid, uid, ss58, slug, date, surface_id, ref, hash` — and `workers/api.mjs` feeds the captured groups into `artifactPathFromTemplate(entry.artifact_path, params)`. But that helper only substituted four (`netuid, slug, date, surface_id`), so `{uid}`, `{ss58}`, `{ref}`, `{hash}` leaked through literally:

```js
artifactPathFromTemplate("/metagraph/subnets/{netuid}/neurons/{uid}.json", { netuid: 7, uid: 3 })
// → "/metagraph/subnets/7/neurons/{uid}.json"   (wrong; expected .../neurons/3.json)
```

Routes carrying these tokens exist in the catalog (`/metagraph/subnets/{netuid}/neurons/{uid}.json`, `/metagraph/accounts/{ss58}.json`, `/metagraph/blocks/{ref}.json`, `/metagraph/extrinsics/{hash}.json`). A real contract divergence between the pattern compiler and the path substituter.

## What Changed

- Add the four missing substitutions (`{uid}`, `{ss58}`, `{ref}`, `{hash}`) so all eight `compileRoutePattern` tokens are handled, with the same `?? ""` fallback.
- Extend the invariants test (it claimed to cover "every supported token" while exercising only four) to all eight, plus real neuron/extrinsic routes and the empty-param fallback.
- Pure runtime helper — no schema/OpenAPI change; `npm run build` produces no artifact diff.

## Template Used

- backend-code

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none)

## Validation

- [x] `vitest run tests/invariants-contracts.test.mjs` (16 passed)
- [x] `npm run build` → no contract-drift / artifact changes
- [x] `prettier --check` + `eslint` on changed files
- [x] `git diff --check`