### PR TITLE
feat(registry): add ReadyAI SN33 public health endpoint to subnet surfaces

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 73,
+  "surface_count": 74,
   "surfaces": [
     {
       "auth_required": false,
@@ -587,6 +587,24 @@
       "surface_id": "sn-33-readyai-llms-data-repo",
       "surface_key": "srf-369814c5b1cde9c3",
       "url": "https://github.com/afterpartyai/llms_txt_store"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 33,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "readyai",
+      "public_safe": true,
+      "subnet_name": "ReadyAI",
+      "subnet_slug": "sn-33",
+      "surface_id": "sn-33-readyai-subnet-api",
+      "surface_key": "srf-64549ab07f522cc6",
+      "url": "https://api.readyai.ai/health"
     },
     {
       "auth_required": false,

--- a/registry/subnets/readyai.json
+++ b/registry/subnets/readyai.json
@@ -10,11 +10,7 @@
   ],
   "contact": "david@readyai.ai",
   "curation": {
-    "gap_notes": [
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet."
-    ],
+    "gap_notes": ["No verified SSE/event stream yet."],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T08:35:00.000Z",
@@ -24,7 +20,7 @@
   "docs_url": "https://github.com/afterpartyai/bittensor-conversation-genome-project/blob/main/README.md",
   "name": "ReadyAI",
   "netuid": 33,
-  "notes": "Reviewed overlay for SN33 using the official ReadyAI website, Conversation Genome source repository, README, public Hugging Face dataset, and llms.txt data repository.",
+  "notes": "Reviewed overlay for SN33 using the official ReadyAI website, Conversation Genome source repository, README, public Hugging Face dataset, llms.txt data repository, and the live public OpenAPI and health endpoints. No public SSE surface is verified yet.",
   "schema_version": 1,
   "slug": "sn-33",
   "source_repo": "https://github.com/afterpartyai/bittensor-conversation-genome-project",
@@ -156,6 +152,29 @@
       "schema_url": "https://api.readyai.ai/openapi.json",
       "source_urls": ["https://readyai.ai/docs"],
       "url": "https://api.readyai.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-33-readyai-subnet-api",
+      "kind": "subnet-api",
+      "name": "ReadyAI API health",
+      "notes": "Safe read-only health endpoint documented by the ReadyAI OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "readyai",
+      "public_safe": true,
+      "review": {
+        "confidence": "medium",
+        "state": "community-submitted",
+        "submitted_by": "statxc"
+      },
+      "source_urls": ["https://api.readyai.ai/openapi.json"],
+      "url": "https://api.readyai.ai/health"
     }
   ],
   "website_url": "https://readyai.ai/"

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -1072,7 +1072,7 @@ test("public artifacts are internally consistent", () => {
   );
   assert.equal(
     callableAgentServices.length,
-    95,
+    96,
     "agent-catalog callable-service count must stay deterministic",
   );
   assert.equal(


### PR DESCRIPTION
## Summary

- add the verified SN33 ReadyAI public health endpoint to `registry/subnets/readyai.json`
- keep the change scoped to one subnet surface submission using the current single-file model
- update the ReadyAI profile notes and gap notes so they match the newly verified public OpenAPI and subnet-api surfaces
- leave SSE out of scope because no public ReadyAI SSE endpoint could be verified

Closes #1282

## Template Used

- Subnet surface
