### PR TITLE
chore(enrich): taostats identity gap-fills

### DIFF
--- a/registry/subnets/bitcast.json
+++ b/registry/subnets/bitcast.json
@@ -8,7 +8,9 @@
   "netuid": 93,
   "schema_version": 1,
   "slug": "sn-93",
+  "source_repo": "https://github.com/bitcast-network/bitcast",
   "status": "active",
+  "website_url": "https://stats.bitcast.network/",
   "surfaces": [
     {
       "auth_required": false,


### PR DESCRIPTION
## Taostats identity gap-fills — human review required

These are **third-party** gap-fills sourced from `api.taostats.io/api/subnet/identity/v1`. Provenance note: taostats data is operator-reported and unverified by metagraphed; a human reviewer should confirm each URL exists and belongs to the subnet before merging.

### Changes

| Subnet | SN | Field | Value |
|--------|-----|-------|-------|
| bitcast | 93 | `source_repo` | https://github.com/bitcast-network/bitcast |
| bitcast | 93 | `website_url` | https://stats.bitcast.network/ |

### Methodology

- Compared all 129 taostats identity records against 99 registry/subnets/*.json files
- Filtered to schema-valid fields only (source_repo, website_url, social.x) — fields not in the subnet-manifest schema (logo_url, discord_url, description) were skipped
- Sanitized URLs via `backfilledIdentityUrl` helpers from scripts/lib.mjs
- Discarded fills where registry had a deliberate explicit null (maintainer-reviewed suppression)
- Discarded fills where taostats data appeared erroneous (e.g. SN29 twitter @cacheon_ai belongs to SN14)
- Capped at 25 subnets per run (only 1 subnet has valid fills this run)

Surface validation: 399 surfaces across 99 files — passed.
Lint: passed.