### PR TITLE
fix(contracts): substitute all route tokens in artifactPathFromTemplate

### DIFF
--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2184,11 +2184,18 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
 }
 
 export function artifactPathFromTemplate(template, params = {}) {
+  // Substitute every route token compileRoutePattern() captures, in the same
+  // order, so an artifact path can never leak a raw {uid}/{ss58}/{ref}/{hash}
+  // placeholder when one of those routes falls through to the artifact reader.
   return template
-    .replace("{netuid}", String(params.netuid ?? ""))
-    .replace("{slug}", String(params.slug ?? ""))
-    .replace("{date}", String(params.date ?? ""))
-    .replace("{surface_id}", String(params.surface_id ?? ""));
+    .replace(/\{netuid\}/g, String(params.netuid ?? ""))
+    .replace(/\{uid\}/g, String(params.uid ?? ""))
+    .replace(/\{ss58\}/g, String(params.ss58 ?? ""))
+    .replace(/\{slug\}/g, String(params.slug ?? ""))
+    .replace(/\{date\}/g, String(params.date ?? ""))
+    .replace(/\{surface_id\}/g, String(params.surface_id ?? ""))
+    .replace(/\{ref\}/g, String(params.ref ?? ""))
+    .replace(/\{hash\}/g, String(params.hash ?? ""));
 }
 
 export function compileRoutePattern(pathTemplate) {

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -100,6 +100,50 @@ describe("public contract registry", () => {
     );
   });
 
+  test("substitutes every route token compileRoutePattern captures", () => {
+    // Each token the compiler captures must also be substituted by the path
+    // builder, or the route's artifact path leaks a raw placeholder (#1686).
+    const tokenCases = [
+      ["/metagraph/subnets/{netuid}/neurons/{uid}.json", { netuid: 7, uid: 3 }],
+      ["/metagraph/accounts/{ss58}.json", { ss58: "5GrwvaEF" }],
+      ["/metagraph/blocks/{ref}.json", { ref: 123 }],
+      ["/metagraph/extrinsics/{hash}.json", { hash: "0xdeadbeef" }],
+    ];
+    for (const [template, params] of tokenCases) {
+      const resolved = artifactPathFromTemplate(template, params);
+      assert.ok(
+        !/\{[a-z_]+\}/.test(resolved),
+        `unsubstituted token left in ${resolved}`,
+      );
+    }
+    assert.equal(
+      artifactPathFromTemplate(
+        "/metagraph/subnets/{netuid}/neurons/{uid}.json",
+        {
+          netuid: 7,
+          uid: 3,
+        },
+      ),
+      "/metagraph/subnets/7/neurons/3.json",
+    );
+    assert.equal(
+      artifactPathFromTemplate("/metagraph/accounts/{ss58}.json", {
+        ss58: "5GrwvaEF",
+      }),
+      "/metagraph/accounts/5GrwvaEF.json",
+    );
+    assert.equal(
+      artifactPathFromTemplate("/metagraph/blocks/{ref}.json", { ref: 123 }),
+      "/metagraph/blocks/123.json",
+    );
+    assert.equal(
+      artifactPathFromTemplate("/metagraph/extrinsics/{hash}.json", {
+        hash: "0xabc123",
+      }),
+      "/metagraph/extrinsics/0xabc123.json",
+    );
+  });
+
   test("builds contracts, API index, and OpenAPI from one route table", async () => {
     const generatedAt = "1970-01-01T00:00:00.000Z";
     const contracts = buildContractsArtifact(generatedAt);


### PR DESCRIPTION
## Summary

`compileRoutePattern` captures **eight** named route tokens (`netuid, uid, ss58, slug, date, surface_id, ref, hash`), but `artifactPathFromTemplate` only substituted four (`netuid, slug, date, surface_id`). For any route carrying `{uid}`, `{ss58}`, `{ref}`, or `{hash}` — e.g. `/metagraph/subnets/{netuid}/neurons/{uid}.json`, `/metagraph/accounts/{ss58}.json`, `/metagraph/blocks/{ref}.json`, `/metagraph/extrinsics/{hash}.json` — the produced artifact path leaked the raw placeholder.

This closes the contract divergence between the pattern compiler and the path substituter (#1686).

## Changes

- `src/contracts.mjs`: `artifactPathFromTemplate` now substitutes all eight tokens, in the same order `compileRoutePattern` declares them, using global replacement.
- `tests/contracts.test.mjs`: regression test asserting no `{token}` placeholder survives for the four previously-unsubstituted tokens, plus exact-output checks.

## Validation

```
npx vitest run tests/contracts.test.mjs -t "substitutes every route token"   # pass
npx prettier --write src/contracts.mjs tests/contracts.test.mjs
npx eslint src/contracts.mjs tests/contracts.test.mjs                          # clean
```

Closes #1686.
