### PR TITLE
fix(ci): align Python route classifier with canonical direct-submission policy

### DIFF
--- a/scripts/classify-validation-route.py
+++ b/scripts/classify-validation-route.py
@@ -4,7 +4,9 @@
 Reads ``changed-files.txt`` (one path per line, produced by the merge-base diff in
 the classify-validation-route composite action) and decides:
 
-  * ``mode=ugc``   — the PR is a single community candidate/provider submission
+  * ``mode=ugc``   — the PR is a community direct submission with no classifier
+                     errors: a single candidate, a single provider, or an atomic
+                     provider+candidate pair
                      (registry/{candidates,providers}/community/<slug>.json). The
                      checks job runs the light submission preflight only.
   * ``mode=full``  — everything else. The full build + contract/schema/safety
@@ -41,15 +43,25 @@ touched_community = [
 ]
 errors = []
 submission_files = candidate_files + provider_files
+# An atomic provider+candidate PAIR (one of each) is a valid debut shape: a
+# first-time team registers its provider and lands its first surface in one PR.
+is_pair = len(candidate_files) == 1 and len(provider_files) == 1
 if not submission_files and not touched_community:
     scope = "normal-pr"
 else:
-    scope = "direct-provider" if len(provider_files) == 1 else "direct-candidate"
-    if len(submission_files) != 1:
+    if is_pair:
+        scope = "direct-pair"
+    elif len(provider_files) == 1:
+        scope = "direct-provider"
+    else:
+        scope = "direct-candidate"
+    # Allowed shapes: exactly one candidate, exactly one provider, OR the atomic
+    # pair. Anything else is out-of-shape (mirrors classifyPrScope).
+    if len(submission_files) != 1 and not is_pair:
         errors.append(
             {
                 "category": "unsupported-shape",
-                "message": "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/community/*.json file",
+                "message": "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/community/*.json file, or an atomic provider+candidate pair (one of each)",
             }
         )
     unrelated = [
@@ -64,7 +76,9 @@ else:
                 "message": "direct submissions cannot change other files: " + ", ".join(unrelated),
             }
         )
-mode = "ugc" if scope in {"direct-candidate", "direct-provider"} else "full"
+# Mirrors scripts/ci-validate-route.mjs: any non-normal-pr scope with no classifier
+# errors takes the light ugc lane; an error (any shape/tampering issue) forces full.
+mode = "ugc" if scope != "normal-pr" and not errors else "full"
 report = {
     "schema_version": 1,
     "mode": mode,

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -500,6 +500,66 @@ describe("Metagraphed submission gate policy", () => {
     assert.equal(scope.errors.length, 0);
   });
 
+  test("python classify-validation-route stays in sync with classifyPrScope (#1577)", () => {
+    // The Python pre-`npm ci` classifier must agree with the canonical JS policy:
+    // an atomic pair is direct-pair (no error), and any classifier error forces
+    // mode=full instead of the light ugc lane.
+    const python = ["python3", "python"].find((bin) => {
+      try {
+        execFileSync(bin, ["--version"], { stdio: "ignore" });
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    if (!python) return; // no interpreter on this runner — CI provides python3
+
+    const scriptPath = path.resolve("scripts/classify-validation-route.py");
+    const runPython = (files) => {
+      const dir = mkdtempSync(path.join(tmpdir(), "classify-route-"));
+      try {
+        writeFileSync(
+          path.join(dir, "changed-files.txt"),
+          files.join("\n") + "\n",
+        );
+        return JSON.parse(
+          execFileSync(python, [scriptPath], { cwd: dir, encoding: "utf8" }),
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    };
+
+    const expect = (files) => {
+      const js = classifyPrScope(files);
+      return {
+        scope: js.scope,
+        mode:
+          js.scope !== "normal-pr" && js.errors.length === 0 ? "ugc" : "full",
+        errorCount: js.errors.length,
+      };
+    };
+
+    const pairFiles = [
+      "registry/candidates/community/acme.json",
+      "registry/providers/community/acme.json",
+    ];
+    const pairPy = runPython(pairFiles);
+    const pairJs = expect(pairFiles);
+    assert.equal(pairPy.scope, "direct-pair");
+    assert.equal(pairPy.scope, pairJs.scope);
+    assert.equal(pairPy.mode, "ugc");
+    assert.equal(pairPy.errors.length, 0);
+
+    const errorFiles = ["registry/candidates/community/acme.json", "README.md"];
+    const errorPy = runPython(errorFiles);
+    const errorJs = expect(errorFiles);
+    assert.equal(errorPy.mode, "full");
+    assert.equal(errorPy.mode, errorJs.mode);
+    assert.ok(errorPy.errors.length >= 1);
+    assert.equal(errorPy.errors.length, errorJs.errorCount);
+  });
+
   test("still blocks a direct submission bundled with unrelated files", () => {
     const scope = classifyPrScope([
       "registry/candidates/community/allways-docs-example.json",


### PR DESCRIPTION
## Summary

The Python pre-`npm ci` route classifier in `scripts/classify-validation-route.py` had drifted from the canonical direct-submission classifier in `scripts/submission-policy.mjs` (`classifyPrScope`) / `scripts/ci-validate-route.mjs`. This realigns it (#1577):

1. **Atomic provider+candidate pair** (one `registry/candidates/community/*.json` + one `registry/providers/community/*.json`) now classifies as `scope="direct-pair"` with no shape error — matching the JS debut-pair lane. Previously it was flagged out-of-shape.
2. **Mode now gates on classifier errors**: any direct submission that produces errors routes to `mode="full"` (the full validation suite) instead of staying on the light `ugc` lane. Mirrors `ci-validate-route.mjs`: `mode = scope !== "normal-pr" && errors.length === 0 ? "ugc" : "full"`.

## Changes

- `scripts/classify-validation-route.py`: add `direct-pair` scope + pair-aware shape check; derive `mode` from scope **and** error presence; docstring updated.
- `tests/submission-gate.test.mjs`: regression test runs the Python classifier and asserts parity with `classifyPrScope` for the atomic-pair (`direct-pair`/`ugc`) and error (`full`) cases. Skips gracefully if no interpreter; CI provides `python3`.

## Validation

Verified Python output matches `classifyPrScope` + the `ci-validate-route` mode rule across pair / error / single-candidate / single-provider / normal-pr / two-candidate shapes:

```
printf 'registry/candidates/community/acme.json\nregistry/providers/community/acme.json\n' > changed-files.txt
python3 scripts/classify-validation-route.py   # scope="direct-pair", mode="ugc", errors=[]

printf 'registry/candidates/community/acme.json\nREADME.md\n' > changed-files.txt
python3 scripts/classify-validation-route.py   # mode="full" (classifier errors present)
```

`npx prettier --write` + `npx eslint` clean; `py_compile` clean.

Closes #1577.
