### PR TITLE
feat(validate): restrict base-layer endpoint kinds to the root subnet (netuid 0)

### DIFF
--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -26,6 +26,12 @@ const validate = ajv.compile(schema);
 const providerIds = new Set(
   (await loadProviders()).map((provider) => provider.id),
 );
+// Base-layer chain endpoints are maintainer-curated network infrastructure that
+// live ONLY on the root subnet (netuid 0) and feed the /rpc endpoint lane — they
+// are NOT per-subnet contributor surfaces. Enforce the boundary here (the
+// contributor template already omits these kinds; this closes the hand-crafted
+// PR gap) without touching the probe-derived endpoint pipeline. See issue #1680.
+const BASE_LAYER_KINDS = new Set(["subtensor-rpc", "subtensor-wss", "archive"]);
 
 const fileArgs = process.argv.slice(2).filter((arg) => !arg.startsWith("--"));
 const files =
@@ -72,6 +78,13 @@ for (const file of files) {
       errors.push(
         `${label}: a community surface must carry review.state ` +
           '(e.g. "community-submitted"). Use `npm run surface:add`.',
+      );
+    }
+    if (BASE_LAYER_KINDS.has(surface.kind) && document.netuid !== 0) {
+      errors.push(
+        `${label}: base-layer endpoint kind "${surface.kind}" is only allowed on the ` +
+          "root subnet (netuid 0) — these are maintainer-curated network infrastructure " +
+          "(the /rpc endpoint lane), not per-subnet contributor surfaces.",
       );
     }
   }


### PR DESCRIPTION
## Why
Base-layer chain endpoints (`subtensor-rpc` / `subtensor-wss` / `archive`) are maintainer-curated network infrastructure that feed the `/rpc` endpoint lane — not per-subnet contributor surfaces. #1679 removed them from the contributor template (steering); this **enforces** the boundary so a hand-crafted PR can't add one to a regular subnet.

## What
`validate:surface` now rejects those kinds on any subnet except **netuid 0** (root), where they legitimately live today and feed the probe-derived `/rpc` pool.

## Why this instead of relocating (#1680)
The `/rpc` pool eligibility is **probe-derived from the `surfaces` list**, so physically relocating the endpoints out of `root.json` has a **prod-only failure mode green CI can't catch** (the next probe run would empty the pool), and a static pool would violate the "health is probe-derived only" principle for the **mainnet** pool. This guard keeps everything probe-derived and working while closing the contributor-boundary gap — **zero `/rpc` risk**, fully CI-verifiable. Closes #1680.

## Verified
- `validate:surface` passes current data (399 surfaces / 99 files; root's base-layer allowed) and **fires** on a non-root base-layer surface.
- full suite ✅ 1947, lint + format clean.