### PR TITLE
fix(submission): route flat provider profiles through gate

### DIFF
--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -48,7 +48,7 @@ atomic provider+candidate **pair** (one of each):
 
 ```text
 registry/candidates/community/<slug>.json
-registry/providers/community/<slug>.json
+registry/providers/<slug>.json
 ```
 
 The atomic pair is the **debut lane**: a first-time team registers its provider

--- a/scripts/classify-validation-route.py
+++ b/scripts/classify-validation-route.py
@@ -5,8 +5,9 @@ Reads ``changed-files.txt`` (one path per line, produced by the merge-base diff 
 the classify-validation-route composite action) and decides:
 
   * ``mode=ugc``   — the PR is a single community candidate/provider submission
-                     (registry/{candidates,providers}/community/<slug>.json). The
-                     checks job runs the light submission preflight only.
+                     (registry/candidates/community/<slug>.json or
+                     registry/providers/<slug>.json). The checks job runs the
+                     light submission preflight only.
   * ``mode=full``  — everything else. The full build + contract/schema/safety
                      suite runs (and the test job runs the test suite).
 
@@ -29,27 +30,43 @@ changed_files = sorted(
     .splitlines()
     if file.strip()
 )
-candidate_pattern = re.compile(r"^registry/candidates/community/[a-z0-9][a-z0-9-]*\.json$")
-provider_pattern = re.compile(r"^registry/providers/community/[a-z0-9][a-z0-9-]*\.json$")
-candidate_files = [file for file in changed_files if candidate_pattern.fullmatch(file)]
+candidate_pattern = re.compile(
+    r"^registry/candidates/community/[a-z0-9][a-z0-9-]*\.json$"
+)
+provider_pattern = re.compile(r"^registry/providers/[a-z0-9][a-z0-9-]*\.json$")
+candidate_files = [
+    file for file in changed_files if candidate_pattern.fullmatch(file)
+]
 provider_files = [file for file in changed_files if provider_pattern.fullmatch(file)]
 touched_community = [
     file
     for file in changed_files
     if file.startswith("registry/candidates/community/")
-    or file.startswith("registry/providers/community/")
+    or (
+        file.startswith("registry/providers/")
+        and not file.startswith("registry/providers/community/")
+    )
 ]
 errors = []
 submission_files = candidate_files + provider_files
 if not submission_files and not touched_community:
     scope = "normal-pr"
 else:
-    scope = "direct-provider" if len(provider_files) == 1 else "direct-candidate"
-    if len(submission_files) != 1:
+    is_pair = len(candidate_files) == 1 and len(provider_files) == 1
+    if is_pair:
+        scope = "direct-pair"
+    else:
+        scope = "direct-provider" if len(provider_files) == 1 else "direct-candidate"
+    if len(submission_files) != 1 and not is_pair:
         errors.append(
             {
                 "category": "unsupported-shape",
-                "message": "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/community/*.json file",
+                "message": (
+                    "direct submissions must change exactly one "
+                    "registry/candidates/community/*.json or "
+                    "registry/providers/*.json file, or an atomic "
+                    "provider+candidate pair (one of each)"
+                ),
             }
         )
     unrelated = [
@@ -64,7 +81,11 @@ else:
                 "message": "direct submissions cannot change other files: " + ", ".join(unrelated),
             }
         )
-mode = "ugc" if scope in {"direct-candidate", "direct-provider"} else "full"
+mode = (
+    "ugc"
+    if scope in {"direct-candidate", "direct-provider", "direct-pair"}
+    else "full"
+)
 report = {
     "schema_version": 1,
     "mode": mode,

--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -719,7 +719,6 @@ export function classifyPrScope(changedFiles) {
   const touchedCommunityProvider = files.filter(
     (file) =>
       file.startsWith("registry/providers/") &&
-      file !== "registry/providers/" &&
       !file.startsWith("registry/providers/community/"),
   );
   const errors = [];

--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -163,7 +163,7 @@ export const PUBLIC_PREFLIGHT_STATES = new Set([
 export const DIRECT_CANDIDATE_PATTERN =
   /^registry\/candidates\/community\/[a-z0-9][a-z0-9-]*\.json$/;
 export const DIRECT_PROVIDER_PATTERN =
-  /^registry\/providers\/community\/[a-z0-9][a-z0-9-]*\.json$/;
+  /^registry\/providers\/[a-z0-9][a-z0-9-]*\.json$/;
 
 export const SUPPORTED_INTERFACE_KINDS = new Set([
   "archive",
@@ -626,7 +626,7 @@ export function buildPrSubmissionReport({
     // for the candidate's provider checks, so a first-time team can land its
     // debut provider + first surface in one PR. Both files are community-authored
     // and loaded as first-class once merged (loadProviders reads
-    // registry/providers/community/), so the candidate's provider resolves at
+    // registry/providers/), so the candidate's provider resolves at
     // build/serve time without a prior, separately-reviewed provider PR.
     const isPair = provider && scope.scope === "direct-pair";
     const providersForCandidate = isPair ? [...providers, provider] : providers;
@@ -716,8 +716,11 @@ export function classifyPrScope(changedFiles) {
   const touchedCommunityCandidate = files.filter((file) =>
     file.startsWith("registry/candidates/community/"),
   );
-  const touchedCommunityProvider = files.filter((file) =>
-    file.startsWith("registry/providers/community/"),
+  const touchedCommunityProvider = files.filter(
+    (file) =>
+      file.startsWith("registry/providers/") &&
+      file !== "registry/providers/" &&
+      !file.startsWith("registry/providers/community/"),
   );
   const errors = [];
 
@@ -745,7 +748,7 @@ export function classifyPrScope(changedFiles) {
     errors.push({
       category: "unsupported-shape",
       message:
-        "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/community/*.json file, or an atomic provider+candidate pair (one of each)",
+        "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/*.json file, or an atomic provider+candidate pair (one of each)",
     });
   }
 
@@ -1371,7 +1374,7 @@ export function validateCandidateForSubmission({
     // gate accepts and counts as registered. A contributor fix, never a maintainer.
     errors.push({
       category: "provider-not-registered",
-      message: `candidate provider ${candidate.provider || "<missing>"} is not registered — include its registry/providers/community/<id>.json in the same PR`,
+      message: `candidate provider ${candidate.provider || "<missing>"} is not registered — include its registry/providers/<id>.json in the same PR`,
     });
   }
   // Placeholder/example identity URLs (example.com, github.com/username/repo, "deprecated") are never

--- a/scripts/submission-pr.mjs
+++ b/scripts/submission-pr.mjs
@@ -43,7 +43,8 @@ const changedFiles = normalizeChangedFiles(
 // strict DIRECT_*_PATTERN, so ANY removed candidate/provider file is recognized as a deletion.
 const isRemovedDirectFile = (file) =>
   (file.startsWith("registry/candidates/community/") ||
-    file.startsWith("registry/providers/community/")) &&
+    (file.startsWith("registry/providers/") &&
+      !file.startsWith("registry/providers/community/"))) &&
   file.endsWith(".json") &&
   !existsSync(path.join(inputRoot, file));
 const removedDirectFiles = changedFiles.filter(isRemovedDirectFile);

--- a/scripts/surface-add.mjs
+++ b/scripts/surface-add.mjs
@@ -12,7 +12,7 @@
 //
 // Debut provider (slug not registered yet)? Add --provider-name "<Team>" and
 // --provider-url <https://public-site> and surface:add also scaffolds
-// registry/providers/community/<slug>.json so the PR validates in one shot.
+// registry/providers/<slug>.json so the PR validates in one shot.
 import path from "node:path";
 import {
   isJsonContentType,

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -527,6 +527,19 @@ describe("Metagraphed submission gate policy", () => {
     assert.equal(scope.errors.length, 0);
   });
 
+  test("treats a legacy registry/providers/community/ path as a normal PR (post-flatten exclusion)", () => {
+    // Providers were flattened to registry/providers/*.json (#1678); the old
+    // community/ subdir is gone. A path still under that retired subdir is neither
+    // a flat direct-provider file nor a touchedCommunityProvider, so it falls
+    // through to a normal PR (full validation), not the direct-provider lane.
+    const scope = classifyPrScope([
+      "registry/providers/community/legacy-operator.json",
+    ]);
+
+    assert.equal(scope.scope, "normal-pr");
+    assert.equal(scope.providerFiles.length, 0);
+  });
+
   test("still blocks a direct submission bundled with unrelated files", () => {
     const scope = classifyPrScope([
       "registry/candidates/community/allways-docs-example.json",

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -169,6 +169,33 @@ describe("Metagraphed submission gate policy", () => {
     }
   });
 
+  test("routes flat provider profile submissions through the UGC gate", () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), "metagraphed-provider-route-"));
+    try {
+      const changedFilesPath = path.join(tmp, "changed-files.txt");
+      const outputPath = path.join(tmp, "github-output.txt");
+      writeFileSync(
+        changedFilesPath,
+        "registry/providers/example-operator.json\n",
+      );
+
+      execFileSync(
+        process.execPath,
+        ["scripts/ci-validate-route.mjs", "--changed-files", changedFilesPath],
+        {
+          env: { ...process.env, GITHUB_OUTPUT: outputPath },
+          stdio: "pipe",
+        },
+      );
+
+      const output = readFileSync(outputPath, "utf8");
+      assert.match(output, /^mode=ugc$/m);
+      assert.match(output, /^scope=direct-provider$/m);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   test("passes a delete-only candidate PR (removed file) instead of ENOENT-failing the preflight (#candidate-deletion)", () => {
     const tmp = mkdtempSync(path.join(tmpdir(), "metagraphed-del-"));
     try {
@@ -393,7 +420,7 @@ describe("Metagraphed submission gate policy", () => {
     document.submission.submitted_by = "jsonbored";
     document.submission.submitted_by_url = "https://github.com/jsonbored";
     const report = buildPrSubmissionReport({
-      changedFiles: ["registry/providers/community/example-operator.json"],
+      changedFiles: ["registry/providers/example-operator.json"],
       providerDocument: document,
       native,
       providers,
@@ -410,7 +437,7 @@ describe("Metagraphed submission gate policy", () => {
     assert.equal(report.blocking, true);
     assert.equal(
       report.direct_provider_file,
-      "registry/providers/community/example-operator.json",
+      "registry/providers/example-operator.json",
     );
     assert.equal(report.provider.id, "example-operator");
     assert.equal(
@@ -428,7 +455,7 @@ describe("Metagraphed submission gate policy", () => {
     document.provider.website_url = "https://user:pass@example.com";
 
     const report = buildPrSubmissionReport({
-      changedFiles: ["registry/providers/community/credentialed-provider.json"],
+      changedFiles: ["registry/providers/credentialed-provider.json"],
       providerDocument: document,
       native,
       providers,
@@ -455,7 +482,7 @@ describe("Metagraphed submission gate policy", () => {
     document.provider.notes = "github_pat_abcdefghijklmnopqrstuvwxyz123456";
 
     const report = buildPrSubmissionReport({
-      changedFiles: ["registry/providers/community/unsafe-provider.json"],
+      changedFiles: ["registry/providers/unsafe-provider.json"],
       providerDocument: document,
       native,
       providers,
@@ -490,7 +517,7 @@ describe("Metagraphed submission gate policy", () => {
   test("accepts an atomic provider+candidate pair PR (debut lane)", () => {
     const scope = classifyPrScope([
       "registry/candidates/community/allways-docs-example.json",
-      "registry/providers/community/example-operator.json",
+      "registry/providers/example-operator.json",
     ]);
 
     // One candidate + one provider (and nothing else) is the atomic debut pair:
@@ -503,7 +530,7 @@ describe("Metagraphed submission gate policy", () => {
   test("still blocks a direct submission bundled with unrelated files", () => {
     const scope = classifyPrScope([
       "registry/candidates/community/allways-docs-example.json",
-      "registry/providers/community/example-operator.json",
+      "registry/providers/example-operator.json",
       "scripts/build.mjs",
     ]);
 
@@ -538,7 +565,7 @@ describe("Metagraphed submission gate policy", () => {
     const report = buildPrSubmissionReport({
       changedFiles: [
         "registry/candidates/community/community-sn-7-docs-debut.json",
-        "registry/providers/community/example-operator.json",
+        "registry/providers/example-operator.json",
       ],
       candidateDocument: candidateDoc,
       providerDocument: providerDoc,

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -26,6 +26,7 @@ import {
   providerIdentityTokens,
   sameResourceUrl,
   urlOwnerTokens,
+  validateCandidateForSubmission,
 } from "../scripts/submission-policy.mjs";
 import {
   buildNotificationKey,
@@ -538,6 +539,29 @@ describe("Metagraphed submission gate policy", () => {
 
     assert.equal(scope.scope, "normal-pr");
     assert.equal(scope.providerFiles.length, 0);
+  });
+
+  test("validateCandidateForSubmission labels a provider-less candidate <missing>", () => {
+    const result = validateCandidateForSubmission({
+      candidate: {
+        schema_version: 1,
+        netuid: 1,
+        kind: "docs",
+        url: "https://api.acme-labs.io/v1",
+        source_url: "https://api.acme-labs.io/v1",
+      },
+      native: { subnets: [{ netuid: 1 }] },
+      providers: [],
+    });
+
+    assert.equal(
+      result.errors.some((error) =>
+        error.message?.includes(
+          "candidate provider <missing> is not registered",
+        ),
+      ),
+      true,
+    );
   });
 
   test("still blocks a direct submission bundled with unrelated files", () => {


### PR DESCRIPTION
### Motivation
- Flat `registry/providers/*.json` provider profile submissions were being classified as normal PRs and skipped the direct-provider validation that enforces community/provider-claimed authority and public-safe URL checks, creating a policy bypass that weakens provider-trust boundaries.

### Description
- Match the canonical classifier to flat provider files by changing `DIRECT_PROVIDER_PATTERN` to accept `registry/providers/<id>.json` and broaden touched-provider detection in `scripts/submission-policy.mjs` and `scripts/classify-validation-route.py` so flat provider PRs are recognized as direct-provider (including atomic provider+candidate pairs).
- Update the preflight/deletion handling in `scripts/submission-pr.mjs` to treat removed flat provider files the same way the classifier expects, and adjust `scripts/submission-pr.mjs`/`scripts/surface-add.mjs` comments/docs to reference the flat provider path.
- Add regression coverage and test updates in `tests/submission-gate.test.mjs` to assert flat provider profile submissions route through the UGC/direct-provider gate and still trigger provider-specific validation.
- Tidy related references in `docs/submission-gate.md` to reflect the flat provider path and keep the CI route classifier and JS policy in sync.

### Testing
- `python -m py_compile scripts/classify-validation-route.py` succeeded and `npx prettier --check` passed for updated files.
- `npm run build` completed successfully and produced the usual artifacts summary without drift.
- `npm run validate:intake` succeeded (issue intake templates passed) and `npm run validate` completed with registry validation passing.
- `npm test -- tests/submission-gate.test.mjs` ran the submission gate suite and all tests passed (56/56) after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c1b144890832ca2ed976d37c065db)