### PR TITLE
feat(schema): give CompareArtifact a real per-entry sub-schema

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1784,11 +1784,37 @@ export interface components {
             requested_netuids?: number[];
             schema_version: number;
             source: string;
-            subnets: {
-                [key: string]: unknown;
-            }[];
+            subnets: components["schemas"]["CompareSubnetEntry"][];
         } & {
             [key: string]: unknown;
+        };
+        /** @description One subnet's side-by-side entry in GET /api/v1/compare (composeCompareData). structure/economics/health are present only when their dimension is requested, and each is null when the subnet is not found or that tier has no row. */
+        CompareSubnetEntry: {
+            economics?: {
+                alpha_price_tao?: number | null;
+                emission_share?: number | null;
+                miner_count?: number;
+                miner_readiness?: number | null;
+                open_slots?: number | null;
+                registration_allowed?: boolean;
+                registration_cost_tao?: number | null;
+                total_stake_tao?: number | null;
+                validator_count?: number;
+            } | null;
+            found: boolean;
+            health?: {
+                avg_latency_ms?: number | null;
+                ok_count?: number;
+                surface_count?: number;
+            } | null;
+            name: string | null;
+            netuid: number;
+            slug: string | null;
+            structure?: {
+                completeness_score?: number | null;
+                operational_interface_count?: number;
+                surface_count?: number;
+            } | null;
         };
         ContractsArtifact: components["schemas"]["ArtifactBase"] & ({
             artifacts: components["schemas"]["ArtifactContractEntry"][];
@@ -5941,7 +5967,12 @@ export interface operations {
                      *         "schema_version": 1,
                      *         "source": "live-cron-prober",
                      *         "subnets": [
-                     *           {}
+                     *           {
+                     *             "found": false,
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "slug": "example-subnet"
+                     *           }
                      *         ]
                      *       },
                      *       "meta": {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1971,8 +1971,7 @@
           },
           "subnets": {
             "items": {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/components/schemas/CompareSubnetEntry"
             },
             "type": "array"
           }
@@ -1981,6 +1980,140 @@
           "schema_version",
           "source",
           "subnets"
+        ],
+        "type": "object"
+      },
+      "CompareSubnetEntry": {
+        "additionalProperties": false,
+        "description": "One subnet's side-by-side entry in GET /api/v1/compare (composeCompareData). structure/economics/health are present only when their dimension is requested, and each is null when the subnet is not found or that tier has no row.",
+        "properties": {
+          "economics": {
+            "additionalProperties": false,
+            "properties": {
+              "alpha_price_tao": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "emission_share": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "miner_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "miner_readiness": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "open_slots": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "registration_allowed": {
+                "type": "boolean"
+              },
+              "registration_cost_tao": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "total_stake_tao": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "validator_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "found": {
+            "type": "boolean"
+          },
+          "health": {
+            "additionalProperties": false,
+            "properties": {
+              "avg_latency_ms": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "ok_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "slug": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "structure": {
+            "additionalProperties": false,
+            "properties": {
+              "completeness_score": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "operational_interface_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "netuid",
+          "name",
+          "slug",
+          "found"
         ],
         "type": "object"
       },
@@ -14188,7 +14321,12 @@
                     "schema_version": 1,
                     "source": "live-cron-prober",
                     "subnets": [
-                      {}
+                      {
+                        "found": false,
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "slug": "example-subnet"
+                      }
                     ]
                   },
                   "meta": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1784,11 +1784,37 @@ export interface components {
             requested_netuids?: number[];
             schema_version: number;
             source: string;
-            subnets: {
-                [key: string]: unknown;
-            }[];
+            subnets: components["schemas"]["CompareSubnetEntry"][];
         } & {
             [key: string]: unknown;
+        };
+        /** @description One subnet's side-by-side entry in GET /api/v1/compare (composeCompareData). structure/economics/health are present only when their dimension is requested, and each is null when the subnet is not found or that tier has no row. */
+        CompareSubnetEntry: {
+            economics?: {
+                alpha_price_tao?: number | null;
+                emission_share?: number | null;
+                miner_count?: number;
+                miner_readiness?: number | null;
+                open_slots?: number | null;
+                registration_allowed?: boolean;
+                registration_cost_tao?: number | null;
+                total_stake_tao?: number | null;
+                validator_count?: number;
+            } | null;
+            found: boolean;
+            health?: {
+                avg_latency_ms?: number | null;
+                ok_count?: number;
+                surface_count?: number;
+            } | null;
+            name: string | null;
+            netuid: number;
+            slug: string | null;
+            structure?: {
+                completeness_score?: number | null;
+                operational_interface_count?: number;
+                surface_count?: number;
+            } | null;
         };
         ContractsArtifact: components["schemas"]["ArtifactBase"] & ({
             artifacts: components["schemas"]["ArtifactContractEntry"][];
@@ -5941,7 +5967,12 @@ export interface operations {
                      *         "schema_version": 1,
                      *         "source": "live-cron-prober",
                      *         "subnets": [
-                     *           {}
+                     *           {
+                     *             "found": false,
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "slug": "example-subnet"
+                     *           }
                      *         ]
                      *       },
                      *       "meta": {

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -1957,8 +1957,7 @@
           },
           "subnets": {
             "items": {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/components/schemas/CompareSubnetEntry"
             },
             "type": "array"
           }
@@ -1967,6 +1966,140 @@
           "schema_version",
           "source",
           "subnets"
+        ],
+        "type": "object"
+      },
+      "CompareSubnetEntry": {
+        "additionalProperties": false,
+        "description": "One subnet's side-by-side entry in GET /api/v1/compare (composeCompareData). structure/economics/health are present only when their dimension is requested, and each is null when the subnet is not found or that tier has no row.",
+        "properties": {
+          "economics": {
+            "additionalProperties": false,
+            "properties": {
+              "alpha_price_tao": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "emission_share": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "miner_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "miner_readiness": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "open_slots": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "registration_allowed": {
+                "type": "boolean"
+              },
+              "registration_cost_tao": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "total_stake_tao": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "validator_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "found": {
+            "type": "boolean"
+          },
+          "health": {
+            "additionalProperties": false,
+            "properties": {
+              "avg_latency_ms": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "ok_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "slug": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "structure": {
+            "additionalProperties": false,
+            "properties": {
+              "completeness_score": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "operational_interface_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "netuid",
+          "name",
+          "slug",
+          "found"
         ],
         "type": "object"
       },

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -19,10 +19,55 @@
           },
           "subnets": {
             "type": "array",
-            "items": { "type": "object", "additionalProperties": true }
+            "items": { "$ref": "#/components/schemas/CompareSubnetEntry" }
           }
         },
         "additionalProperties": true
+      },
+      "CompareSubnetEntry": {
+        "type": "object",
+        "description": "One subnet's side-by-side entry in GET /api/v1/compare (composeCompareData). structure/economics/health are present only when their dimension is requested, and each is null when the subnet is not found or that tier has no row.",
+        "required": ["netuid", "name", "slug", "found"],
+        "additionalProperties": false,
+        "properties": {
+          "netuid": { "type": "integer", "minimum": 0 },
+          "name": { "type": ["string", "null"] },
+          "slug": { "type": ["string", "null"] },
+          "found": { "type": "boolean" },
+          "structure": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "completeness_score": { "type": ["number", "null"] },
+              "surface_count": { "type": "integer", "minimum": 0 },
+              "operational_interface_count": { "type": "integer", "minimum": 0 }
+            }
+          },
+          "economics": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "registration_cost_tao": { "type": ["number", "null"] },
+              "registration_allowed": { "type": "boolean" },
+              "open_slots": { "type": ["integer", "null"] },
+              "emission_share": { "type": ["number", "null"] },
+              "alpha_price_tao": { "type": ["number", "null"] },
+              "validator_count": { "type": "integer", "minimum": 0 },
+              "miner_count": { "type": "integer", "minimum": 0 },
+              "total_stake_tao": { "type": ["number", "null"] },
+              "miner_readiness": { "type": ["number", "null"] }
+            }
+          },
+          "health": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "surface_count": { "type": "integer", "minimum": 0 },
+              "ok_count": { "type": "integer", "minimum": 0 },
+              "avg_latency_ms": { "type": ["number", "null"] }
+            }
+          }
+        }
       },
       "CurationMetadata": {
         "type": "object",


### PR DESCRIPTION
Closes #1673.

## Problem
`CompareArtifact.subnets[]` was `{ type: object, additionalProperties: true }` — the entire `/api/v1/compare` per-subnet payload was uncontracted. The typed client got `{ [k]: unknown }[]`, and `validate:contract-drift` couldn't catch a `composeCompareData` field rename (only `compare.test.mjs` did).

## What
New `CompareSubnetEntry` component mirroring `composeCompareData` **exactly** (verified field-by-field against the live endpoint):
- `netuid` / `name` / `slug` / `found`
- nullable `structure` { completeness_score, surface_count, operational_interface_count }
- nullable `economics` { registration_cost_tao, registration_allowed, open_slots, emission_share, alpha_price_tao, validator_count, miner_count, total_stake_tao, miner_readiness }
- nullable `health` { surface_count, ok_count, avg_latency_ms }

Each sub-object is `additionalProperties: false`, so a future rename now trips `contract-drift`. (Deliberately **not** reusing `SubnetEconomics` — the compare projection has `open_slots` + `miner_readiness`, a different 9-field shape.) Regenerated `openapi.json` + `types.d.ts` + generated client.

## Verified
`validate:schemas/openapi/openapi-examples/types/api` green · `compare.test` (12) · full suite 1950 · no committed-artifact drift.