### PR TITLE
fix(api): gate neuron daily rollup on complete metagraph snapshot

### DIFF
--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -51,11 +51,37 @@ function toIso(ms) {
   return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
 }
 
+// True when no subnet represented at the latest captured_at stamp still carries
+// older captured_at rows — the signature of a mid-batch loadStagedNeurons run.
+export async function neuronsSnapshotReadyForDailyRollup(db) {
+  if (!db?.prepare) return false;
+  try {
+    const result = await db
+      .prepare(
+        `SELECT 1 AS partial
+         FROM neurons n_latest
+         WHERE n_latest.captured_at = (SELECT MAX(captured_at) FROM neurons)
+           AND EXISTS (
+             SELECT 1 FROM neurons n_old
+             WHERE n_old.netuid = n_latest.netuid
+               AND n_old.captured_at < n_latest.captured_at
+           )
+         LIMIT 1`,
+      )
+      .bind()
+      .all();
+    return (result?.results?.length ?? 0) === 0;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Daily rollup: snapshot the current `neurons` table into `neuron_daily` for the
  * captured UTC day. A single atomic INSERT...SELECT in the health DB:
- *  - WHERE captured_at = MAX(captured_at): one consistent snapshot stamp, so a
- *    concurrent partial load can't bleed two stamps into a single day.
+ *  - Pre-check: skip when any refreshed subnet still has mixed captured_at stamps
+ *    (a concurrent loadStagedNeurons mid-batch would corrupt the daily row).
+ *  - WHERE captured_at = MAX(captured_at): one consistent snapshot stamp.
  *  - snapshot_date = the UTC day of that captured_at, computed in SQL.
  *  - ON CONFLICT(netuid,uid,snapshot_date) DO UPDATE: intra-day re-runs are
  *    idempotent (the row reflects the last capture that UTC day).
@@ -65,6 +91,9 @@ function toIso(ms) {
 export async function rollupNeuronDaily(env, { now = Date.now() } = {}) {
   const db = env?.METAGRAPH_HEALTH_DB;
   if (!db?.prepare) return { rolled: false, reason: "no-db" };
+  if (!(await neuronsSnapshotReadyForDailyRollup(db))) {
+    return { rolled: false, reason: "incomplete-snapshot" };
+  }
   const cols = ROLLUP_COLUMNS.join(", ");
   const setClause = ROLLUP_COLUMNS.filter((c) => c !== "netuid" && c !== "uid")
     .map((c) => `${c} = excluded.${c}`)

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -3,6 +3,7 @@ import { describe, test } from "vitest";
 import {
   parseHistoryWindow,
   rollupNeuronDaily,
+  neuronsSnapshotReadyForDailyRollup,
   archiveNeuronDaily,
   archivePrunableNeuronDaily,
   pruneNeuronDaily,
@@ -19,6 +20,39 @@ import {
 import { handleRequest, handleScheduled } from "../workers/api.mjs";
 import { NEURON_HISTORY_ROLLUP_CRON } from "../workers/config.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+const ctx = { waitUntil: (promise) => promise };
+
+function isPartialNeuronsSnapshotProbe(sql) {
+  return sql.includes("FROM neurons n_latest") && sql.includes("n_old");
+}
+
+function rollupDb({ run, partialSnapshot = false, onRun } = {}) {
+  return {
+    prepare(sql) {
+      return {
+        bind(...params) {
+          return {
+            all: () => {
+              if (isPartialNeuronsSnapshotProbe(sql)) {
+                return Promise.resolve({
+                  results: partialSnapshot ? [{ partial: 1 }] : [],
+                });
+              }
+              return Promise.resolve({ results: [] });
+            },
+            run: () => {
+              onRun?.(sql, params);
+              return run
+                ? run(sql, params)
+                : Promise.resolve({ meta: { changes: 42 } });
+            },
+          };
+        },
+      };
+    },
+  };
+}
 
 // A neuron_daily read row (NEURON_DAILY_READ_COLUMNS shape: snapshot_date + the
 // live neuron columns) — formatNeuron consumes the same fields.
@@ -65,8 +99,6 @@ function historyEnv(rows, captured = {}) {
   };
 }
 
-const ctx = { waitUntil: (p) => p };
-
 describe("parseHistoryWindow", () => {
   test("accepts the documented windows + defaults", () => {
     assert.deepEqual(parseHistoryWindow("7d"), { label: "7d", days: 7 });
@@ -103,21 +135,32 @@ describe("isValidSnapshotDate", () => {
   });
 });
 
+describe("neuronsSnapshotReadyForDailyRollup", () => {
+  test("returns true when no subnet mixes latest and older captured_at stamps", async () => {
+    const env = rollupDb();
+    assert.equal(await neuronsSnapshotReadyForDailyRollup(env), true);
+  });
+
+  test("returns false when a subnet still has mixed captured_at stamps", async () => {
+    const env = rollupDb({ partialSnapshot: true });
+    assert.equal(await neuronsSnapshotReadyForDailyRollup(env), false);
+  });
+
+  test("returns false without a DB binding", async () => {
+    assert.equal(await neuronsSnapshotReadyForDailyRollup(null), false);
+  });
+});
+
 describe("rollupNeuronDaily", () => {
   test("issues a single INSERT...SELECT with a consistent captured_at snapshot + idempotent upsert", async () => {
     const captured = {};
     const env = {
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
+      METAGRAPH_HEALTH_DB: rollupDb({
+        onRun: (sql, params) => {
           captured.sql = sql;
-          return {
-            bind(...params) {
-              captured.params = params;
-              return { run: () => Promise.resolve({ meta: { changes: 42 } }) };
-            },
-          };
+          captured.params = params;
         },
-      },
+      }),
     };
     const res = await rollupNeuronDaily(env, { now: 1_780_000_000_001 });
     assert.deepEqual(res, { rolled: true, rows: 42 });
@@ -139,15 +182,23 @@ describe("rollupNeuronDaily", () => {
     });
   });
 
+  test("skips rollup when the live neurons table has a partial snapshot load", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: rollupDb({ partialSnapshot: true }),
+    };
+    assert.deepEqual(await rollupNeuronDaily(env, { now: 1 }), {
+      rolled: false,
+      reason: "incomplete-snapshot",
+    });
+  });
+
   test("reports rows:null when the run result omits meta.changes", async () => {
     // A run() that returns no `.meta.changes` must surface rows:null, exercising
     // the `?? null` fallback rather than leaking undefined.
     const env = {
-      METAGRAPH_HEALTH_DB: {
-        prepare() {
-          return { bind: () => ({ run: () => Promise.resolve({}) }) };
-        },
-      },
+      METAGRAPH_HEALTH_DB: rollupDb({
+        run: () => Promise.resolve({}),
+      }),
     };
     const res = await rollupNeuronDaily(env, { now: 1 });
     assert.equal(res.rolled, true);
@@ -222,16 +273,10 @@ describe("rollupNeuronDaily idempotency invariant (#1345)", () => {
     // at best, a drift risk at worst).
     const seen = [];
     const env = {
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
-          seen.push(sql);
-          return {
-            bind: () => ({
-              run: () => Promise.resolve({ meta: { changes: 5 } }),
-            }),
-          };
-        },
-      },
+      METAGRAPH_HEALTH_DB: rollupDb({
+        onRun: (sql) => seen.push(sql),
+        run: () => Promise.resolve({ meta: { changes: 5 } }),
+      }),
     };
     await rollupNeuronDaily(env, { now: 1 });
     await rollupNeuronDaily(env, { now: 2 });
@@ -648,6 +693,9 @@ describe("handleScheduled rollup cron (#1345)", () => {
                 return Promise.resolve({ meta: { changes: 1 } });
               },
               all: () => {
+                if (isPartialNeuronsSnapshotProbe(sql)) {
+                  return Promise.resolve({ results: [] });
+                }
                 if (sql.includes("MAX(snapshot_date)")) {
                   return Promise.resolve({ results: [{ day: latestDay }] });
                 }
@@ -696,6 +744,9 @@ describe("handleScheduled rollup cron (#1345)", () => {
             return {
               run: () => Promise.resolve({ meta: { changes: 1 } }),
               all: () => {
+                if (isPartialNeuronsSnapshotProbe(sql)) {
+                  return Promise.resolve({ results: [] });
+                }
                 if (sql.includes("MAX(snapshot_date)")) {
                   return Promise.resolve({ results: [{ day: latestDay }] });
                 }
@@ -752,6 +803,9 @@ describe("handleScheduled rollup cron (#1345)", () => {
                 return Promise.resolve({ meta: { changes: 1 } });
               },
               all: () => {
+                if (isPartialNeuronsSnapshotProbe(sql)) {
+                  return Promise.resolve({ results: [] });
+                }
                 if (sql.includes("MAX(snapshot_date)")) {
                   return Promise.resolve({ results: [{ day: latestDay }] });
                 }

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -148,6 +148,33 @@ describe("neuronsSnapshotReadyForDailyRollup", () => {
 
   test("returns false without a DB binding", async () => {
     assert.equal(await neuronsSnapshotReadyForDailyRollup(null), false);
+    assert.equal(await neuronsSnapshotReadyForDailyRollup({}), false);
+  });
+
+  test("returns false when the completeness probe throws", async () => {
+    const db = {
+      prepare() {
+        return {
+          bind() {
+            return { all: () => Promise.reject(new Error("D1 down")) };
+          },
+        };
+      },
+    };
+    assert.equal(await neuronsSnapshotReadyForDailyRollup(db), false);
+  });
+
+  test("returns true when the probe response omits results", async () => {
+    const db = {
+      prepare() {
+        return {
+          bind() {
+            return { all: () => Promise.resolve({}) };
+          },
+        };
+      },
+    };
+    assert.equal(await neuronsSnapshotReadyForDailyRollup(db), true);
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1287,6 +1287,14 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
     // for deletion, so a day is never dropped from D1 before it exists in R2. Its
     // own cron minute so the ~33k-row work never piles onto the probe/prune/fast
     // crons; each step is .catch-isolated.
+    //
+    // Drain any pending R2-staged neuron snapshot BEFORE rolling up so the daily
+    // row is taken against a fully loaded metagraph, not a concurrent */3 load
+    // mid-batch. rollupNeuronDaily also skips when mixed captured_at stamps remain.
+    const staged = await loadStagedNeurons(env).catch(() => ({
+      ok: false,
+      reason: "load-error",
+    }));
     const rolled = await rollupNeuronDaily(env).catch(() => ({
       rolled: false,
     }));
@@ -1302,7 +1310,7 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
       archived.archived && archivedPrunable.archived
         ? await pruneNeuronDaily(env).catch(() => ({ pruned: false }))
         : { pruned: false, reason: "archive-not-confirmed" };
-    return { rolled, archived, archivedPrunable, pruned };
+    return { staged, rolled, archived, archivedPrunable, pruned };
   }
   return runHealthProber(env, ctx);
 }


### PR DESCRIPTION
### Summary

Prevent corrupted `neuron_daily` rows when the daily metagraph rollup runs
while `loadStagedNeurons()` is mid-batch. The rollup uses
`WHERE captured_at = MAX(captured_at)`; during a concurrent load some neurons
already carry the new stamp while others on the same subnet still have the old
one, producing an incomplete daily snapshot that persists via
`ON CONFLICT DO UPDATE`.

### What Changed

- **`neuronsSnapshotReadyForDailyRollup()`** (`src/neuron-history.mjs`): new
  pre-check that detects any subnet with rows at the latest `captured_at` that
  also still has older rows for the same `netuid` (partial-load signature).
- **`rollupNeuronDaily()`**: skips rollup with
  `{ rolled: false, reason: "incomplete-snapshot" }` when the check fails.
- **`NEURON_HISTORY_ROLLUP_CRON` handler** (`workers/api.mjs`): calls
  `loadStagedNeurons()` before `rollupNeuronDaily()` so any pending R2-staged
  snapshot is fully drained before the daily snapshot is taken. Returns `staged`
  in the cron payload for observability.
- **Tests** (`tests/neuron-history.test.mjs`):
  - Unit tests for the completeness probe
  - Rollup skip on incomplete snapshot
  - Cron test mocks updated for the new probe query

### Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.
      *(No contract change — internal cron/rollup behavior only.)*

### Validation

- [x] `npm test -- tests/neuron-history.test.mjs` (39/39 pass)
- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run worker:test`

### Test plan

- [x] Completeness probe returns true when no mixed stamps exist
- [x] Completeness probe returns false when a subnet has latest + older rows
- [x] `rollupNeuronDaily` skips with `incomplete-snapshot` when probe fails
- [x] Daily rollup cron still archives and prunes when snapshot is complete
- [ ] Manual: confirm rollup cron at 05:47 UTC drains staged neurons before rolling up
