### PR TITLE
fix(health): surface swallowed D1 errors so a silent outage can't recur

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -737,8 +737,12 @@ export async function rollupDailyUptime(env, overrides = {}) {
       days.map(({ date, start, end }) => stmt.bind(start, end, date, runAt)),
     );
     return { rolled: true, days: days.map((d) => d.date) };
-  } catch {
-    return { rolled: false };
+  } catch (error) {
+    // Don't swallow silently: a failing INSERT here (e.g. a missing column from
+    // un-applied schema migration) freezes the daily uptime rollup invisibly.
+    // Surface the reason so the hourly cron's result is diagnosable.
+    console.error("[rollupDailyUptime]", String(error?.message ?? error));
+    return { rolled: false, error: String(error?.message ?? error) };
   }
 }
 

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -1752,6 +1752,7 @@ describe("rollupDailyUptime (durable daily history)", () => {
     };
     assert.deepEqual(await rollupDailyUptime({ METAGRAPH_HEALTH_DB: db }), {
       rolled: false,
+      error: "d1 unavailable",
     });
   });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -2619,7 +2619,16 @@ async function d1All(env, sql, params) {
       d1TimeoutMs(env),
     );
     return result?.results || [];
-  } catch {
+  } catch (error) {
+    // Surface the failure instead of silently degrading to []. A swallowed
+    // "no such column" here (prod schema drift) dark-served the uptime tier for
+    // days before anyone noticed — log it so the next failure is diagnosable.
+    console.error(
+      "[d1All]",
+      String(error?.message ?? error),
+      "·",
+      String(sql).slice(0, 120),
+    );
     return markD1FallbackRows([]);
   }
 }


### PR DESCRIPTION
## Why
The uptime tier was dark on **every** subnet detail page for ~3 days. Root cause: prod \`surface_uptime_daily\` was missing migration 0007's latency columns (migration-tracking drift), so the handler's SELECT and the rollup's INSERT both errored with "no such column" — but **both errors were swallowed silently** (\`d1All\` → \`[]\`, \`rollupDailyUptime\` → \`{ rolled: false }\`), so nothing surfaced in logs.

(The data side is already fixed in prod — 0007 columns applied + backfilled. This PR prevents the *class* of silent failure from recurring.)

## Change
- **`d1All`**: `console.error` the failure (still returns the fallback rows — no behavior change).
- **`rollupDailyUptime`**: `console.error` + return `{ rolled: false, error }` so the hourly cron result is diagnosable.

## Checks
`tests/health-prober.test.mjs` 74 passing (assertion updated to expect the surfaced error) · prettier clean.