### PR TITLE
fix(list): sort null/missing values last regardless of direction

### DIFF
--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -113,6 +113,44 @@ describe("list-query pagination order", () => {
   });
 });
 
+describe("list-query null/missing sort ordering", () => {
+  // Rows whose sort field is null/missing must sort LAST in both directions,
+  // matching sortSubnets() in src/mcp-server.mjs so the REST list and MCP list
+  // agree on identical data.
+  const data = {
+    subnets: [
+      { netuid: 1, emission_share: 0.05 },
+      { netuid: 2 }, // missing emission_share
+      { netuid: 3, emission_share: 0.09 },
+      { netuid: 4, emission_share: null },
+    ],
+  };
+
+  test("ascending keeps real values ordered with null/missing last", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/economics?sort=emission_share&order=asc"),
+      "economics",
+    );
+    assert.deepEqual(
+      result.data.subnets.map((r) => r.netuid),
+      [1, 3, 2, 4],
+    );
+  });
+
+  test("descending still keeps null/missing last (not first)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/economics?sort=emission_share&order=desc"),
+      "economics",
+    );
+    assert.deepEqual(
+      result.data.subnets.map((r) => r.netuid),
+      [3, 1, 2, 4],
+    );
+  });
+});
+
 describe("list-query numeric range filters", () => {
   const data = {
     subnets: [

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -168,7 +168,21 @@ function sortRows(rows, params) {
     return rows;
   }
   const direction = params.get("order") === "desc" ? -1 : 1;
-  return [...rows].sort((a, b) => compareValues(a[key], b[key]) * direction);
+  return [...rows].sort((a, b) => {
+    const av = a[key];
+    const bv = b[key];
+    // Missing/null values sort LAST regardless of direction, matching
+    // sortSubnets() in src/mcp-server.mjs — otherwise a null would flip between
+    // first (asc) and last (desc), so the REST list and the MCP list disagree on
+    // identical data (e.g. ?sort=emission_share with unpriced subnets).
+    const aNull = av === null || av === undefined;
+    const bNull = bv === null || bv === undefined;
+    if (aNull || bNull) {
+      if (aNull && bNull) return 0;
+      return aNull ? 1 : -1;
+    }
+    return compareValues(av, bv) * direction;
+  });
 }
 
 function compareValues(a, b) {


### PR DESCRIPTION
## Summary

The REST list sorter (`sortRows`/`compareValues` in `workers/list-query.mjs`) handled `null`/missing sort values inconsistently with the MCP list sorter (`sortSubnets` in `src/mcp-server.mjs`): a missing value collapsed to `""`, so its position **flipped with direction** (front on `asc`, back on `desc`). For identical data, the REST list and MCP list disagreed.

This makes `sortRows` place `null`/missing **last regardless of direction**, matching `sortSubnets`.

## Changes

- `workers/list-query.mjs`: `sortRows` now sorts null/undefined values last in both directions; non-null comparison still uses `compareValues * direction`.
- `tests/list-query.test.mjs`: regression tests over `/api/v1/economics?sort=emission_share` asserting null/missing rows stay last for both `asc` and `desc`.

## Validation

```
npx vitest run tests/list-query.test.mjs   # 16 passed
npx prettier --write … && npx eslint …      # clean
```

Closes #1716.
