### PR TITLE
fix(submission): reject blank netuid in intake instead of coercing to 0

### DIFF
--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -233,7 +233,7 @@ export function buildIssueIntakeReport({
   const errors = [...fieldErrors];
   const manual_reasons = [];
 
-  const netuid = Number(fields.netuid);
+  const netuid = parseNetuidField(fields.netuid);
   if (
     !Number.isInteger(netuid) ||
     !native.subnets.some((subnet) => subnet.netuid === netuid)
@@ -479,7 +479,7 @@ export function buildEndpointStatusReportIntakeReport({
   const manual_reasons = [
     "status reports trigger review or re-probes and cannot set observed health",
   ];
-  const netuid = Number(fields.netuid);
+  const netuid = parseNetuidField(fields.netuid);
   const activeNetuid = native.subnets.some(
     (subnet) => subnet.netuid === netuid,
   );
@@ -1691,6 +1691,16 @@ export function parseIssueFields(body) {
 
 export function issueFieldParseErrors(fields) {
   return fields?.[FIELD_PARSE_ERRORS] || [];
+}
+
+// Parse an intake `netuid` field. A bare `Number()` coerces a blank/whitespace
+// field to 0, which is a *valid* integer and (since Finney exposes the root
+// subnet, netuid 0) would silently attribute an empty-netuid submission to
+// subnet 0. Same `Number("") === 0` trap fetch-metagraph.mjs::parseNetuidSubset
+// guards against — only an all-digit value is accepted; anything else is NaN.
+export function parseNetuidField(value) {
+  const raw = String(value ?? "").trim();
+  return /^\d+$/.test(raw) ? Number(raw) : NaN;
 }
 
 export function normalizeKind(value) {

--- a/tests/parse-netuid-field.test.mjs
+++ b/tests/parse-netuid-field.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { parseNetuidField } from "../scripts/submission-policy.mjs";
+
+describe("parseNetuidField", () => {
+  test("accepts an all-digit netuid string", () => {
+    assert.equal(parseNetuidField("7"), 7);
+    assert.equal(parseNetuidField("0"), 0);
+    assert.equal(parseNetuidField(" 42 "), 42);
+  });
+
+  test('a blank/whitespace field is NaN, not 0 (the Number("")===0 trap)', () => {
+    // A bare Number("") / Number("  ") is 0 — a valid integer that, since Finney
+    // exposes the root subnet (netuid 0), would silently attribute an empty
+    // submission to subnet 0. parseNetuidField must reject it.
+    assert.ok(Number.isNaN(parseNetuidField("")));
+    assert.ok(Number.isNaN(parseNetuidField("   ")));
+    assert.ok(Number.isNaN(parseNetuidField(null)));
+    assert.ok(Number.isNaN(parseNetuidField(undefined)));
+  });
+
+  test("rejects non-digit, negative, and decimal values", () => {
+    assert.ok(Number.isNaN(parseNetuidField("abc")));
+    assert.ok(Number.isNaN(parseNetuidField("-1")));
+    assert.ok(Number.isNaN(parseNetuidField("3.5")));
+    assert.ok(Number.isNaN(parseNetuidField("_No response_")));
+  });
+});


### PR DESCRIPTION
## Summary

The two intake builders parsed `netuid` with `Number(fields.netuid)`, so a blank/whitespace field coerced to `0` — a valid integer that, because Finney exposes the root subnet (netuid 0), silently attributed an empty-netuid submission to subnet 0.

This adds a shared `parseNetuidField` helper (only an all-digit value is accepted; anything else is `NaN`), matching the `Number("")===0` guard already in `fetch-metagraph.mjs::parseNetuidSubset`, and uses it at both intake sites.

## Changes

- `scripts/submission-policy.mjs`: add `parseNetuidField`; use it in `buildIssueIntakeReport` and `buildEndpointStatusReportIntakeReport`.
- `tests/parse-netuid-field.test.mjs`: regression tests (digit strings accepted; blank/whitespace/null/non-digit/negative/decimal -> NaN).

## Validation

```
npx vitest run tests/parse-netuid-field.test.mjs   # 3 passed
npx prettier --write … && npx eslint …              # clean
```

Closes #1719.
