### PR TITLE
docs(readme): add mcp.so listing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The Bittensor subnet integration registry. For every subnet it answers: **what d
 
 [![Website](https://img.shields.io/badge/website-metagraph.sh-111?logo=cloudflare&logoColor=white)](https://metagraph.sh)
 [![MCP](https://img.shields.io/badge/MCP-api.metagraph.sh%2Fmcp-7c3aed)](https://api.metagraph.sh/mcp)
+[![mcp.so](https://img.shields.io/badge/mcp.so-listed-f97316)](https://mcp.so/server/metagraphed---bittensor-subnet-registry/JSONbored)
 [![npm](https://img.shields.io/npm/v/@jsonbored/metagraphed?logo=npm&label=npm)](https://www.npmjs.com/package/@jsonbored/metagraphed)
 [![PyPI](https://img.shields.io/pypi/v/metagraphed?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/metagraphed/)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue)](./LICENSE)


### PR DESCRIPTION
Adds a badge for the live [mcp.so](https://mcp.so/server/metagraphed---bittensor-subnet-registry/JSONbored) community MCP-directory listing, next to the existing MCP-endpoint badge.

(Held the canonical `registry.modelcontextprotocol.io` badge for a follow-up — that listing is currently stale at v0.1.0 vs server.json 1.3.0; will badge it once bumped.)