### PR TITLE
docs(readme): add canonical MCP Registry badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The Bittensor subnet integration registry. For every subnet it answers: **what d
 
 [![Website](https://img.shields.io/badge/website-metagraph.sh-111?logo=cloudflare&logoColor=white)](https://metagraph.sh)
 [![MCP](https://img.shields.io/badge/MCP-api.metagraph.sh%2Fmcp-7c3aed)](https://api.metagraph.sh/mcp)
+[![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-7c3aed)](https://registry.modelcontextprotocol.io/v0/servers?search=metagraphed)
 [![mcp.so](https://img.shields.io/badge/mcp.so-listed-f97316)](https://mcp.so/server/metagraphed---bittensor-subnet-registry/JSONbored)
 [![npm](https://img.shields.io/npm/v/@jsonbored/metagraphed?logo=npm&label=npm)](https://www.npmjs.com/package/@jsonbored/metagraphed)
 [![PyPI](https://img.shields.io/pypi/v/metagraphed?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/metagraphed/)


### PR DESCRIPTION
Now that the canonical registry listing is current at **v1.3.0** (publish-mcp-registry.yml ran successfully 2026-06-24), adds the official `registry.modelcontextprotocol.io` badge next to the MCP-endpoint + mcp.so badges. Completes #377.