### PR TITLE
docs(readme): add Smithery listing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The Bittensor subnet integration registry. For every subnet it answers: **what d
 [![MCP](https://img.shields.io/badge/MCP-api.metagraph.sh%2Fmcp-7c3aed)](https://api.metagraph.sh/mcp)
 [![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-7c3aed)](https://registry.modelcontextprotocol.io/v0/servers?search=metagraphed)
 [![mcp.so](https://img.shields.io/badge/mcp.so-listed-f97316)](https://mcp.so/server/metagraphed---bittensor-subnet-registry/JSONbored)
+[![smithery badge](https://smithery.ai/badge/metagraphed/metagraphed)](https://smithery.ai/servers/metagraphed/metagraphed)
 [![npm](https://img.shields.io/npm/v/@jsonbored/metagraphed?logo=npm&label=npm)](https://www.npmjs.com/package/@jsonbored/metagraphed)
 [![PyPI](https://img.shields.io/pypi/v/metagraphed?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/metagraphed/)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue)](./LICENSE)


### PR DESCRIPTION
Adds the [Smithery](https://smithery.ai/servers/metagraphed/metagraphed) badge to the badge row (now: MCP endpoint · MCP Registry · mcp.so · Smithery). Doubles as Smithery's 'Link to Smithery' verification backlink — once merged, re-run the Smithery verification check to clear it.