### PR TITLE
fix(blocks): reject malformed Aura slot digests

### DIFF
--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -200,7 +200,10 @@ def _block_author(s, block_hash, header):
             engine, data = pre[0], pre[1]
             if engine == AURA_ENGINE_ID:
                 hex_data = data[2:] if str(data).startswith("0x") else str(data)
-                slot = int.from_bytes(bytes.fromhex(hex_data)[:8], "little")
+                slot_data = bytes.fromhex(hex_data)
+                if len(slot_data) != 8:
+                    return None
+                slot = int.from_bytes(slot_data, "little")
                 break
         if slot is None:
             return None

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -25,6 +25,8 @@ _spec.loader.exec_module(_fe)
 
 compute_from_block = _fe.compute_from_block
 _parse_cursor = _fe._parse_cursor
+_block_author = _fe._block_author
+AURA_ENGINE_ID = _fe.AURA_ENGINE_ID
 
 
 class ComputeFromBlockTest(unittest.TestCase):
@@ -98,6 +100,37 @@ class ComputeFromBlockTest(unittest.TestCase):
         self.assertGreaterEqual(compute_from_block(2, 5, 250), 0)
         # A None cursor with head 0 and any window clamps to 0 (not -249).
         self.assertEqual(compute_from_block(None, 0, 250), 0)
+
+
+class BlockAuthorTest(unittest.TestCase):
+    class QueryResult:
+        def __init__(self, value):
+            self.value = value
+
+    class Substrate:
+        def query(self, module, storage, block_hash=None):
+            return BlockAuthorTest.QueryResult(["0x00", "0x01", "0x02"])
+
+        def ss58_encode(self, pubkey):
+            return f"5AUTHORITY{pubkey}"
+
+    def header(self, data):
+        return {"digest": {"logs": [{"PreRuntime": [AURA_ENGINE_ID, data]}]}}
+
+    def test_aura_digest_requires_exactly_eight_slot_bytes(self):
+        substrate = self.Substrate()
+        for data in ("0x", "0x01", "0x01000000000000", "0x010000000000000000"):
+            with self.subTest(data=data):
+                self.assertIsNone(
+                    _block_author(substrate, "0xblock", self.header(data))
+                )
+
+    def test_aura_digest_decodes_eight_byte_slot(self):
+        substrate = self.Substrate()
+        self.assertEqual(
+            _block_author(substrate, "0xblock", self.header("0x0100000000000000")),
+            "5AUTHORITY01",
+        )
 
 
 class ParseCursorTest(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- Fix a correctness bug where truncated or empty Aura PreRuntime digest payloads were decoded as small integer slots and could be mapped to a valid-looking block author instead of returning `None` on shape drift.

### Description
- In `scripts/fetch-events.py` the Aura `PreRuntime` digest is now decoded to `slot_data = bytes.fromhex(hex_data)` and rejected unless `len(slot_data) == 8`, returning `None` on mismatch instead of feeding a short byte-string to `int.from_bytes`.
- Added unit tests in `scripts/test_fetch_events.py` that cover empty, truncated (1- and 7-byte), oversized, and valid 8-byte Aura digest payloads against `_block_author`.
- The change preserves the best-effort, non-throwing semantics: malformed data yields `None` and never raises during the poll.

### Testing
- Ran `python3 scripts/test_fetch_events.py` and all tests passed (unit tests covering cursor logic and the new block-author cases).
- Ran `npm run lint -- --max-warnings=0` and the linter passed with no warnings.
- Ran `npm run format:check` and Prettier formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c5cb494ec832c8a7900f95a25fb86)