### PR TITLE
ci: add Publish to Smithery workflow

### DIFF
--- a/.github/workflows/smithery-publish.yml
+++ b/.github/workflows/smithery-publish.yml
@@ -32,6 +32,11 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Deployment environment for the release secret — enables protection rules
+    # (required reviewers, branch restrictions) and lets SMITHERY_API_KEY be
+    # scoped as an environment secret. Configure rules in repo Settings ->
+    # Environments -> smithery.
+    environment: smithery
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/smithery-publish.yml
+++ b/.github/workflows/smithery-publish.yml
@@ -33,6 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: refs/heads/main
+          persist-credentials: false
+
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -51,7 +57,9 @@ jobs:
             || { echo "::error::$SMITHERY_MCP_URL did not return a valid MCP initialize — aborting publish"; exit 1; }
 
       - name: Install Smithery CLI
-        run: npm install -g smithery@latest
+        # Pinned (not @latest) for reproducible, supply-chain-reviewable runs;
+        # bump deliberately when adopting a newer CLI.
+        run: npm install -g smithery@1.2.0
 
       - name: Publish to Smithery
         env:

--- a/.github/workflows/smithery-publish.yml
+++ b/.github/workflows/smithery-publish.yml
@@ -1,0 +1,69 @@
+name: Publish to Smithery
+
+# Re-publishes metagraphed's hosted MCP server to Smithery
+# (https://smithery.ai/servers/metagraphed/metagraphed) so the listing re-scans
+# the live tool set at https://api.metagraph.sh/mcp. It is a remote server, so
+# there is no package artifact — this just re-registers the URL and cuts a new
+# release. Run after shipping MCP tool/metadata changes (mirrors the canonical
+# publish-mcp-registry.yml).
+#
+# Requires a SMITHERY_API_KEY repo secret:
+#   Smithery -> account -> API keys -> Create API key
+#   -> repo Settings -> Secrets and variables -> Actions -> New repository secret.
+# Manual trigger only — run "Publish to Smithery" from the Actions tab. Test once
+# after adding the secret to confirm the CLI's auth picks up SMITHERY_API_KEY.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: smithery-release
+  cancel-in-progress: false
+
+env:
+  SMITHERY_NAMESPACE: metagraphed/metagraphed
+  SMITHERY_MCP_URL: https://api.metagraph.sh/mcp
+
+jobs:
+  publish:
+    # Only from the reviewed default branch.
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Preflight — endpoint answers MCP initialize
+        run: |
+          set -euo pipefail
+          code=$(curl -sS -o /tmp/mcp-init.json -w '%{http_code}' \
+            -X POST "$SMITHERY_MCP_URL" \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json, text/event-stream' \
+            -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smithery-publish-preflight","version":"1.0"}}}')
+          echo "initialize -> HTTP $code"
+          grep -q '"serverInfo"' /tmp/mcp-init.json \
+            || { echo "::error::$SMITHERY_MCP_URL did not return a valid MCP initialize — aborting publish"; exit 1; }
+
+      - name: Install Smithery CLI
+        run: npm install -g smithery@latest
+
+      - name: Publish to Smithery
+        env:
+          # Smithery's standard auth env var (Bearer token for api.smithery.ai).
+          # If `smithery mcp publish` does not pick this up, the run fails with an
+          # auth error — switch to the `smithery auth login` flow then.
+          SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SMITHERY_API_KEY:-}" ]; then
+            echo "::error::SMITHERY_API_KEY secret is not set. Smithery -> API keys -> Create API key, then repo Settings -> Secrets -> Actions."
+            exit 1
+          fi
+          smithery --version || true
+          smithery mcp publish "$SMITHERY_MCP_URL" -n "$SMITHERY_NAMESPACE"


### PR DESCRIPTION
Adds `.github/workflows/smithery-publish.yml` — a manual-trigger workflow that re-publishes the hosted MCP server to **Smithery** (`metagraphed/metagraphed`) so the listing re-scans the live tools at `https://api.metagraph.sh/mcp`. Mirrors the canonical `publish-mcp-registry.yml` (remote server → no package artifact).

**What it does:** preflight (aborts unless the endpoint returns a valid MCP `initialize`) → `npm install -g smithery@latest` → `smithery mcp publish "$URL" -n metagraphed/metagraphed`.

**Before first run:** add a **`SMITHERY_API_KEY`** repo secret (Smithery → API keys → Create API key → repo Settings → Secrets → Actions). Then run it once from the Actions tab to confirm the CLI picks up the key (the docs are slightly loose on CLI CI-auth; the workflow guards + errors clearly if not).

**Safety:** manual `workflow_dispatch` only, `if: main`, one github-owned action (`setup-node`, SHA-pinned to the repo's existing version) so it can't trip the Actions allowlist; everything else is shell.