### PR TITLE
fix(webhooks): make the redelivery sweep order deterministic

### DIFF
--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -574,15 +574,23 @@ export async function deliverChangeEvent({
 // Bounded-concurrency map: drains `items` through at most `concurrency` in-flight
 // `fn` calls. Shared by the fresh fan-out and the redelivery sweep.
 async function mapBounded(items, concurrency, fn) {
-  const queue = [...(items || [])];
-  const results = [];
+  const list = [...(items || [])];
+  // Place each result at its INPUT index, not in completion order — workers
+  // resolve concurrently (and the per-item work does real async I/O: crypto
+  // signing + fetch), so a push-on-complete would return results in a
+  // nondeterministic order. Order-preserving output is what every caller relies
+  // on (the redelivery sweep's per-subscription budget + redelivered sequence).
+  const results = new Array(list.length);
+  let cursor = 0;
   const worker = async () => {
-    while (queue.length > 0) {
-      results.push(await fn(queue.shift()));
+    while (cursor < list.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await fn(list[index]);
     }
   };
   const workers = Array.from(
-    { length: Math.max(1, Math.min(concurrency, queue.length)) },
+    { length: Math.max(1, Math.min(concurrency, list.length)) },
     () => worker(),
   );
   await Promise.all(workers);
@@ -804,8 +812,12 @@ export async function dispatchWithRedelivery({
   // re-attempted this run. Independent keys → concurrent sweep.
   const due = [];
   const dueBySubscription = new Map();
+  // Sweep the parked backlog in a STABLE lexicographic key order — the order KV
+  // itself lists in — so the shared per-run / per-subscription budget always
+  // selects the same records for the same inputs, independent of the injected
+  // store's iteration order or the concurrent get-completion order.
   for (const candidate of (
-    await mapBounded([...parked], concurrency, async (key) => {
+    await mapBounded([...parked].sort(), concurrency, async (key) => {
       const record = await safeGet(key);
       return record &&
         record.state === "pending" &&


### PR DESCRIPTION
## Summary

`tests/webhooks-redelivery.test.mjs:456` ("redelivery sweep honors list, run, and per-subscription budgets") was genuinely flaky — it red-failed two unrelated PRs' CI while ~40 PRs on the same main commit passed it.

**Root cause:** `mapBounded` (`src/webhooks.mjs`) collected results with `results.push(await fn(...))` across concurrent workers — **completion order, not input order**. In `dispatchWithRedelivery`'s Phase 2, the final `mapBounded(due, …)` runs `deliverChangeEvent` per record (real async: HMAC signing + fetch), so the three concurrent deliveries resolved in a nondeterministic order and the `redelivered` sequence flipped. The selected *set* is always correct (2× `sub-7`, 1× `sub-8` under per-run=3 / per-subscription=2); only the order was racy — and the order *is* part of the spec (`src/webhooks.mjs` documents that KV lists keys lexicographically).

Reproduced in-process: **58 / 400 runs (~14.5%)** produced `[sub-7, sub-8, sub-7]` instead of the expected `[sub-7, sub-7, sub-8]`.

Closes #1730

## What changed (`src/webhooks.mjs` only)

- **`mapBounded` is now order-preserving** — each result is placed at its input index instead of pushed on completion. Order-preserving output is what every caller relies on; this is the actual bug.
- **The Phase 2 sweep iterates the parked backlog in stable lexicographic key order** (`[...parked].sort()`) — the order KV itself lists in — so the shared per-run / per-subscription budget selection is deterministic regardless of the injected store's iteration order.

Source fix, not a test relaxation. No schema/contract change.

## Validation

- [x] In-process reproduction: **400/400 runs deterministic** after the fix (was 342/400 + 58 flips before).
- [x] Tight loop `vitest -t "redelivery sweep honors"` ×80 → **0 failures** (the repro loop from the issue).
- [x] `tests/webhooks-redelivery.test.mjs` + `tests/webhooks.test.mjs` → 55 passed.
- [x] **Full `vitest run` → 100 files, 1951 tests passed.**
- [x] `prettier --check` · `eslint` clean.