### PR TITLE
docs(adr): index + fix stale statuses + cross-link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,5 +100,6 @@ Callable surface with documented limits? Add an optional structured `rate_limit`
 - [`docs/submission-gate.md`](docs/submission-gate.md) — full community submission contract.
 - [`docs/curation-playbook.md`](docs/curation-playbook.md) — what to curate and in what order.
 - [`docs/api-stability.md`](docs/api-stability.md) — API/contract stability guarantees.
+- [`docs/adr/`](docs/adr/) — architecture decision records (why the system is built this way); [`RELEASING.md`](RELEASING.md) — the release runbook.
 
 By contributing you agree your work is released under the repository's [AGPL-3.0 License](LICENSE) — or Apache-2.0 for contributions to the client SDKs under `packages/client/` and `python/`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,9 @@
 # Releasing
 
 How metagraphed ships. Most of it is automatic — the only steps that need a
-manual trigger are the MCP registry listings. This is a reference, not a process
-to follow on every change.
+manual trigger are the MCP registry listings. This is the operational runbook (a
+reference, not a per-change checklist); the channel policy and rationale live in
+[ADR 0005](docs/adr/0005-release-process.md).
 
 ## Automatic — no action needed
 

--- a/docs/adr/0003-ai-native-layer.md
+++ b/docs/adr/0003-ai-native-layer.md
@@ -1,6 +1,6 @@
 # ADR 0003 — AI-native layer (agent catalog, llms.txt, remote MCP server)
 
-- **Status:** Accepted — implementing. AI-1 (agent catalog + llms.txt), AI-2 (MCP server), and AI-3 (semantic search + `/ask`) shipped.
+- **Status:** Accepted — implemented. AI-1 (agent catalog + llms.txt), AI-2 (MCP server), and AI-3 (semantic search + `/ask`) all shipped; the remote MCP server is now listed in the canonical MCP Registry, Smithery, and mcp.so. Later AI-native phases are tracked in issues, not this ADR.
 - **Date:** 2026-06-10
 - **Relates to:** ADR 0001 (R2-only data artifacts), ADR 0002 (live operational health).
 

--- a/docs/adr/0006-provenance-tiered-storage.md
+++ b/docs/adr/0006-provenance-tiered-storage.md
@@ -1,6 +1,6 @@
 # ADR 0006 — Provenance-tiered storage: git for human inputs, R2/D1 for machine data
 
-Status: proposed (2026-06-14)
+Status: Accepted (partial), 2026-06-14 — step 1 (#571) shipped; steps 2–4 pending.
 
 Refines [ADR 0001](0001-r2-only-data-artifacts.md). Builds on
 [ADR 0002](0002-live-operational-health.md).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,29 @@
+# Architecture Decision Records
+
+Why metagraphed is built the way it is. Each ADR captures one significant
+decision — its context, the choice made, and the consequences — so the reasoning
+survives even when the code moves on. Skim these before proposing a structural
+change.
+
+| ADR                                       | Decision                                                                                       | Status                                                                                      |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [0001](0001-r2-only-data-artifacts.md)    | R2-only data artifacts; commit inputs + contract, self-sufficient publish                      | Accepted · implemented (publish trigger superseded by [0007](0007-event-driven-publish.md)) |
+| [0002](0002-live-operational-health.md)   | Live operational health — 15-min cron prober → D1/KV → served live                             | Accepted · implemented                                                                      |
+| [0003](0003-ai-native-layer.md)           | AI-native layer — agent catalog, `llms.txt`, remote MCP server                                 | Accepted · implemented (AI-1–AI-3; later AI phases tracked in issues)                       |
+| [0004](0004-candidate-trust-model.md)     | Candidate → verified-surface trust model                                                       | Accepted                                                                                    |
+| [0005](0005-release-process.md)           | Release-channel policy (npm / PyPI / hosted) — runbook in [`RELEASING.md`](../../RELEASING.md) | Accepted                                                                                    |
+| [0006](0006-provenance-tiered-storage.md) | Provenance-tiered storage — git for human inputs, R2/D1 for machine data                       | Accepted (partial) · step 1 (#571) shipped, steps 2–4 pending                               |
+| [0007](0007-event-driven-publish.md)      | Event-driven data publish + daily floor (replaces the 6h cron)                                 | Accepted · implemented (#1250)                                                              |
+
+## Keeping these current
+
+ADRs are **immutable records of a decision at a point in time** — don't rewrite an
+accepted one when reality moves. Instead:
+
+- **A decision is replaced** → write a new ADR and set the old one's status to
+  _Superseded by ADR-NNNN_ (see 0001 → 0007).
+- **A decision lands or stalls** → update only its **Status** line, and the row
+  above, so this index reflects reality at a glance.
+
+New ADR: copy the header shape (Title · Status · Date · Context · Decision ·
+Consequences), take the next number, and add a row here.


### PR DESCRIPTION
**Audit verdict: keep all 7 ADRs** — they're well-formed decision records (the *why* code can't capture). The real problems were (a) **zero discoverability** (nothing linked to `docs/adr/`) and (b) **two drifted statuses**.

## Changes
- **`docs/adr/README.md` (new)** — index table: each ADR's decision + current status at a glance, with a *"keeping these current"* note (ADRs are immutable — supersede + update the Status line, don't silently rewrite). This is the fix for "scattered."
- **0003** status `implementing` → `implemented` (AI-1–AI-3 all shipped; the MCP server is now in the canonical registry + Smithery + mcp.so; later AI phases are tracked in issues, not this ADR).
- **0006** status `proposed` → `Accepted (partial)` (step 1 #571 shipped; steps 2–4 pending).
- **Cross-linked the release docs**: `RELEASING.md` (runbook) ↔ `ADR 0005` (channel policy) — so the two don't drift or confuse.
- **`CONTRIBUTING.md` → "Deeper docs"** now points at `docs/adr/` + `RELEASING.md`.

Docs-only; no code/contract impact.