### PR TITLE
docs(submission-gate): realign the contributor PR-shape contract to the single-file surface model

### DIFF
--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -43,56 +43,42 @@ The stable marker comment is:
 
 ## Direct PR Shape
 
-Direct UGC PRs must change exactly one candidate or provider review file, OR an
-atomic provider+candidate **pair** (one of each):
+A community **surface contribution** changes **exactly one** subnet file — the
+subnet's `registry/subnets/<slug>.json`, appending to its `surfaces[]` array:
 
 ```text
-registry/candidates/community/<slug>.json
-registry/providers/<slug>.json
+registry/subnets/<slug>.json
 ```
 
-The atomic pair is the **debut lane**: a first-time team registers its provider
-and lands its first surface in a single PR. The inline provider counts as
-registered for the candidate's checks, so no prior, separately-reviewed provider
-PR is required. (Submitting a candidate alone that references an unregistered
-provider is a non-terminal `fix_required` asking you to add the provider in the
-same PR — it is never auto-closed.)
+`npm run surface:add` writes the surface with `authority: "community"` and
+`review.state: "community-submitted"`. A first-time provider can debut in the
+**same PR** by adding one `registry/providers/community/<slug>.json` stub
+(`surface:add --provider-name … --provider-url …` scaffolds it, or
+`npm run provider:new`) — provider identity is reviewed before it is trusted.
 
-The file must contain exactly one candidate:
+> The standalone per-candidate-file lane (`registry/candidates/community/*.json`)
+> is **retired** — recreating it is rejected by CI (`validate:intake`). One
+> subnet = one file = one PR; see
+> [CONTRIBUTING → Community submissions](../CONTRIBUTING.md#community-submissions).
+
+The appended `surfaces[]` entry looks like (health/`probe` fields are
+probe-derived and added by the build — never hand-set):
 
 ```json
 {
-  "schema_version": 1,
-  "submission": {
-    "submitted_by": "github-login",
-    "submitted_by_url": "https://github.com/github-login"
-  },
-  "candidates": [
-    {
-      "schema_version": 1,
-      "id": "community-sn-7-docs-example",
-      "netuid": 7,
-      "state": "schema-valid",
-      "name": "Allways community docs example",
-      "kind": "docs",
-      "url": "https://docs.example.com",
-      "source_url": "https://github.com/example/project",
-      "source_urls": ["https://github.com/example/project"],
-      "source_type": "community-pr-intake",
-      "source_tier": "community-docs",
-      "confidence": "medium",
-      "provider": "community",
-      "auth_required": false,
-      "public_safe": true,
-      "rate_limit_notes": "",
-      "rate_limit": {
-        "requests": 60,
-        "window": "60s",
-        "scope": "per-ip"
-      },
-      "review_notes": "Community-submitted public interface candidate."
-    }
-  ]
+  "id": "sn-7-allways-docs-example",
+  "name": "Allways community docs example",
+  "kind": "docs",
+  "url": "https://docs.example.com",
+  "provider": "community",
+  "authority": "community",
+  "auth_required": false,
+  "public_safe": true,
+  "source_urls": ["https://github.com/example/project"],
+  "review": {
+    "state": "community-submitted",
+    "submitted_by": "github-login"
+  }
 }
 ```
 
@@ -136,7 +122,7 @@ Provider profile submissions are review inputs only; they cannot claim official
 authority, directly modify canonical provider manifests, set endpoint health, or
 make any endpoint pool-eligible.
 
-Clean direct candidate PRs for public-safe app-layer surfaces can be
+Clean direct surface PRs for public-safe app-layer surfaces can be
 AI-reviewed by the private Metagraphed gate and merged directly by the GitHub
 App after required public checks pass. Public preflight only decides whether a
 submission is shaped correctly enough for private review; it does not expose AI
@@ -149,7 +135,8 @@ lane until a maintainer reviews the identity claim.
 
 Maintainer automation branches such as `codex/*` are ignored before D1 state,
 labels, comments, AI review, or Discord notifications. Direct UGC examples
-should use normal feature branches and exactly one candidate or provider file.
+should use normal feature branches and the one-file surface shape (one
+`registry/subnets/<slug>.json`, optionally plus a debut provider stub).
 
 ## Supported UGC Types
 

--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -746,8 +746,14 @@ export function classifyPrScope(changedFiles) {
   if (submissionFileCount !== 1 && !isPair) {
     errors.push({
       category: "unsupported-shape",
+      // The standalone community-candidate file lane is retired (validate-intake
+      // rejects registry/candidates/community/*.json); community surfaces now live
+      // in registry/subnets/<slug>.json, added via `npm run surface:add` and
+      // reviewed as a normal PR. This classifier still recognizes the provider /
+      // legacy-candidate direct shapes, so the message describes them accurately
+      // while pointing contributors at the current surface model.
       message:
-        "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/*.json file, or an atomic provider+candidate pair (one of each)",
+        "the per-candidate-file lane (registry/candidates/community/*.json) is retired — add community surfaces to a single registry/subnets/<slug>.json via `npm run surface:add` instead. (A provider profile may still change exactly one registry/providers/*.json file.)",
     });
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #1734 (the enrichment-issue realignment). The per-candidate-file lane (`registry/candidates/community/*.json`) is retired — `validate-intake.mjs` hard-fails it and community surfaces live in `registry/subnets/<slug>.json` — but the **submission gate's contributor-facing contract** still advertised the retired lane:

- `docs/submission-gate.md`'s **"Direct PR Shape"** documented the candidate-file model (with a full candidate-JSON example) as the submission shape.
- `scripts/submission-policy.mjs`'s `classifyPrScope` **`unsupported-shape` error message** told contributors to "change exactly one `registry/candidates/community/*.json`".

A contributor reading either is pointed at a shape CI now rejects.

Closes #1741

## What changed

- **`docs/submission-gate.md`** — "Direct PR Shape" now leads with the surface model: append to one `registry/subnets/<slug>.json` via `npm run surface:add` (`authority: community`, `review.state: community-submitted`), debut provider via `registry/providers/community/`, with a retirement note pointing at `CONTRIBUTING.md`. The candidate-JSON example is replaced with the real `surfaces[]` entry shape (verified against `registry/subnets/allways.json`; build-managed `probe`/health fields omitted). Two follow-on "candidate PR" / "candidate or provider file" mentions realigned to the surface shape.
- **`scripts/submission-policy.mjs`** — the `unsupported-shape` message now names the retired lane + redirects to `surface:add` → `registry/subnets/<slug>.json`, with a code comment explaining the legacy classifier still recognizes the provider/candidate direct shapes.

## Deliberately out of scope (not a behavior change)

`classifyPrScope`'s **classification logic is unchanged**. Surface-edit PRs already classify as `normal-pr` and are adjudicated by the external Gittensory Gate — which is why every open contributor surface PR passes `metagraphed-submission-gate`. The candidate-model preflight is vestigial; migrating it (and its ~1722-line test suite) to the surface model is a separate, disproportionate effort and would risk the working contributor flow. This PR realigns only the stale contributor-facing **text**.

## Validation

- [x] `npm run validate:docs` passes.
- [x] `tests/submission-gate.test.mjs` → 58 passed (classification behavior unchanged — only the message string + docs moved).
- [x] Full `vitest run` → **1951 passed**.
- [x] `prettier --check` · `eslint` clean.