### PR TITLE
docs(adr): record three undocumented decisions (0008–0010)

### DIFF
--- a/docs/adr/0008-subnet-data-model.md
+++ b/docs/adr/0008-subnet-data-model.md
@@ -1,0 +1,60 @@
+# ADR 0008 — Subnet data model: one file per subnet, trust + review as fields
+
+- **Status:** Accepted — implemented (#1678 + the surface-model migration).
+- **Date:** 2026-06-24
+- **Relates to:** ADR 0004 (candidate → verified-surface trust model — the
+  machine-verification axis this separates from human review) and ADR 0006
+  (provenance-tiered storage — git holds these human inputs).
+
+## Context
+
+A contribution adds a _surface_ (a public API, doc, schema, RPC, or dashboard) to
+a subnet. The earlier layout spread this across the tree: providers were split by
+trust into `registry/providers/` vs `registry/community/`, and surfaces were
+proposed as per-candidate files. Two problems followed:
+
+- **PR-splitting farms.** One surface per file, plus trust-by-directory, invited
+  many tiny redundant PRs — the same surface re-submitted as a different `kind`,
+  or one PR per surface — noise the review gate then had to auto-close.
+- **Trust and review were encoded by _location_.** Moving a surface between trust
+  tiers meant moving files, and there was no clean place to record a _human_
+  review decision distinct from machine probe results.
+
+## Decision
+
+One subnet is **one file** — `registry/subnets/<slug>.json`, holding a
+`surfaces[]` list. Trust and governance are **fields on each surface, not
+directories**:
+
+- **`authority`** — provenance/trust tier: `official`, `registry-observed`,
+  `provider-claimed`, `community`, `native-chain`. Providers likewise live in a
+  single flat `registry/providers/<slug>.json`; trust is the `authority` field,
+  not the directory (#1678).
+- **`review`** — the **human governance axis**:
+  `{ state: community-submitted | maintainer-reviewed | rejected, … }`. This is
+  deliberately **separate from machine verification** — probe-derived
+  health/freshness is a live overlay (ADR 0002), never a stored, hand-set field.
+  A surface can be `maintainer-reviewed` (human) yet `unknown` health (machine),
+  and vice versa.
+
+A data contribution therefore edits **exactly one** `registry/subnets/<slug>.json`,
+appending surface(s) with `authority: "community"` and
+`review.state: "community-submitted"` — and nothing else.
+
+Base-layer network endpoints (`subtensor-rpc`/`subtensor-wss`/`archive`) are the
+one carve-out: maintainer-curated infra on `root.json` (netuid 0), not the
+contributor surface lane.
+
+## Consequences
+
+- **One merge per subnet.** Adding several surfaces for a subnet is one diff, one
+  review, one merge — and the autonomous gate (ADR 0009) validates a single
+  file's diff.
+- **Trust is data.** Promotion between tiers is a field change — machine-checkable
+  — not a file move. The display layer reads `authority`/`review` directly.
+- **Human and machine signals never conflate.** `review.state` records what a
+  maintainer decided; health/verification stays a probe overlay (probe-derived
+  only, per ADR 0002).
+- **Trade-off:** large subnets accrue large single files. Accepted — they stay
+  diff-reviewable, and one-file-per-subnet is what makes the autonomous gate
+  tractable.

--- a/docs/adr/0009-autonomous-review-gate.md
+++ b/docs/adr/0009-autonomous-review-gate.md
@@ -1,0 +1,46 @@
+# ADR 0009 — Autonomous contributor review gate (the Gittensory Gate)
+
+- **Status:** Accepted — in use.
+- **Date:** 2026-06-22
+- **Relates to:** ADR 0008 (the one-file-per-subnet model the gate validates) and
+  [`docs/submission-gate.md`](../submission-gate.md) (the operational contract
+  this records the rationale for).
+
+## Context
+
+The contributor flywheel produces a steady stream of data PRs (new surfaces for
+subnets). A maintainer cannot review each one, and a human pre-gate would be the
+very bottleneck the flywheel exists to remove. The decision is **how a contributor
+PR gets merged without a human in the loop — safely.**
+
+## Decision
+
+Contributor data PRs are adjudicated by an **external AI review gate** (Gittensory,
+a separate repo + GitHub App) that is the **sole adjudicator** — the maintainer is
+**not** in the loop before or after merge. metagraphed itself **pre-gates nothing**
+(its CI emits advisory flags only; trust/provenance is display-only). The
+disposition is deterministic at the edges and conservative in the middle:
+
+- **Auto-CLOSE** on a deterministic fail — duplicate, dead/private `source_url`, a
+  secret, **no linked issue**, a clear reviewer reject, or red CI.
+- **Auto-MERGE** only when content is verified (owner-matched, fresh) with **both
+  AI reviewers ≥ 0.9**, CI green, mergeable-clean, and a valid linked issue.
+- **Hold for a human** only when genuinely uncertain.
+
+The default posture is **close-when-in-doubt**: a redundant or unprovable PR costs
+the contributor a re-submission, not the registry its integrity.
+
+## Consequences
+
+- **Throughput without a maintainer bottleneck** — the flywheel scales; recovery
+  from an auto-close is a fresh PR, not a negotiation.
+- **The gate is the contract.** Contributors (and AI tools) must get a PR _right
+  before pushing_ — one focused subnet file (ADR 0008), a public `url` plus an
+  independent `source_url` that proves it, and a linked issue. See
+  [`docs/submission-gate.md`](../submission-gate.md) and the
+  `contributing-to-metagraphed` skill for the checklist.
+- **metagraphed stays adjudication-free** — no manual pre-escalation, no stored
+  trust gating; the gate lives outside this repo and is configured there.
+- **Trade-off:** an external adjudicator is a dependency, and a wrong auto-close is
+  possible — accepted because the cost is a re-submit and the default protects the
+  registry over any single contribution.

--- a/docs/adr/0010-chain-direct-block-explorer.md
+++ b/docs/adr/0010-chain-direct-block-explorer.md
@@ -1,0 +1,47 @@
+# ADR 0010 — Chain-direct block explorer + first-party event indexer
+
+- **Status:** Accepted (partial) — first-party ingestion + serving shipped
+  (#1345 vertical slices: blocks, extrinsics, account events; Aura block-author
+  decode). Deep history (#1519 R2 SQL, #1349 archive RPC) is pending the
+  self-hosted infrastructure.
+- **Date:** 2026-06-23
+- **Relates to:** ADR 0006 (provenance-tiered storage — D1 for dynamic data) and
+  ADR 0002 (the existing probe / RPC-pool plane this reuses).
+
+## Context
+
+Developers and agents want chain-level context — recent blocks, extrinsics, an
+account's activity, per-UID metagraph history — alongside the registry's
+operational data. metagraphed had none of it first-party, and leaning on a
+third-party indexer (Taostats) makes the explorer a dependency with its own
+freshness, rate limits, and cost.
+
+## Decision
+
+Build a **first-party, chain-direct indexer** as the spine, with Taostats demoted
+to **backfill / fallback only**:
+
+- A poller (`scripts/fetch-events.py`, substrate-interface against public finney
+  RPC) decodes a recent window of finalized blocks into the `blocks`,
+  `extrinsics`, and `account_events` D1 tiers (migrations 0013 / 0014 / 0009),
+  bulk-loaded idempotently. Block author is decoded from the **Aura PreRuntime
+  digest** (slot → `Aura.Authorities[slot % n]`, ss58).
+- **D1 holds the hot window** — recent blocks/events the public node still retains
+  state for. It is bounded and self-pruning.
+- **Deep history is a separate, infra-gated phase** — R2 Iceberg + R2 SQL (#1519)
+  and an archive RPC (#1349) for full-history queries, landing with the
+  self-hosted infrastructure (own-the-core / rent-the-edge).
+
+## Consequences
+
+- **No third-party dependency for the live explorer.** `/api/v1/blocks`,
+  `/extrinsics`, and `/accounts/{ss58}` are first-party and fresh; Taostats is a
+  fallback, not the source of truth.
+- **Bounded by public-RPC state pruning.** The hot window is small — the public
+  node discards old state (~hundreds of blocks), so a full historical backfill
+  needs the archive (Phase 2). This is _why_ entity-history depth is staged and
+  why the live backfill of older block authors is limited.
+- **Reuses the data plane** — D1 + the publish/serve path (ADR 0006), not a new
+  store.
+- **The frontend is staged too** — universal search is live; account/extrinsic
+  entity pages pair with the deep backend (#1350).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,15 +5,18 @@ decision — its context, the choice made, and the consequences — so the reaso
 survives even when the code moves on. Skim these before proposing a structural
 change.
 
-| ADR                                       | Decision                                                                                       | Status                                                                                      |
-| ----------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [0001](0001-r2-only-data-artifacts.md)    | R2-only data artifacts; commit inputs + contract, self-sufficient publish                      | Accepted · implemented (publish trigger superseded by [0007](0007-event-driven-publish.md)) |
-| [0002](0002-live-operational-health.md)   | Live operational health — 15-min cron prober → D1/KV → served live                             | Accepted · implemented                                                                      |
-| [0003](0003-ai-native-layer.md)           | AI-native layer — agent catalog, `llms.txt`, remote MCP server                                 | Accepted · implemented (AI-1–AI-3; later AI phases tracked in issues)                       |
-| [0004](0004-candidate-trust-model.md)     | Candidate → verified-surface trust model                                                       | Accepted                                                                                    |
-| [0005](0005-release-process.md)           | Release-channel policy (npm / PyPI / hosted) — runbook in [`RELEASING.md`](../../RELEASING.md) | Accepted                                                                                    |
-| [0006](0006-provenance-tiered-storage.md) | Provenance-tiered storage — git for human inputs, R2/D1 for machine data                       | Accepted (partial) · step 1 (#571) shipped, steps 2–4 pending                               |
-| [0007](0007-event-driven-publish.md)      | Event-driven data publish + daily floor (replaces the 6h cron)                                 | Accepted · implemented (#1250)                                                              |
+| ADR                                         | Decision                                                                                       | Status                                                                                      |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [0001](0001-r2-only-data-artifacts.md)      | R2-only data artifacts; commit inputs + contract, self-sufficient publish                      | Accepted · implemented (publish trigger superseded by [0007](0007-event-driven-publish.md)) |
+| [0002](0002-live-operational-health.md)     | Live operational health — 15-min cron prober → D1/KV → served live                             | Accepted · implemented                                                                      |
+| [0003](0003-ai-native-layer.md)             | AI-native layer — agent catalog, `llms.txt`, remote MCP server                                 | Accepted · implemented (AI-1–AI-3; later AI phases tracked in issues)                       |
+| [0004](0004-candidate-trust-model.md)       | Candidate → verified-surface trust model                                                       | Accepted                                                                                    |
+| [0005](0005-release-process.md)             | Release-channel policy (npm / PyPI / hosted) — runbook in [`RELEASING.md`](../../RELEASING.md) | Accepted                                                                                    |
+| [0006](0006-provenance-tiered-storage.md)   | Provenance-tiered storage — git for human inputs, R2/D1 for machine data                       | Accepted (partial) · step 1 (#571) shipped, steps 2–4 pending                               |
+| [0007](0007-event-driven-publish.md)        | Event-driven data publish + daily floor (replaces the 6h cron)                                 | Accepted · implemented (#1250)                                                              |
+| [0008](0008-subnet-data-model.md)           | Subnet data model — one file per subnet; `authority` + `review` as fields                      | Accepted · implemented (#1678 + surface migration)                                          |
+| [0009](0009-autonomous-review-gate.md)      | Autonomous contributor review gate (the Gittensory Gate)                                       | Accepted · in use                                                                           |
+| [0010](0010-chain-direct-block-explorer.md) | Chain-direct block explorer + first-party event indexer                                        | Accepted (partial) · ingestion/serving shipped, deep history pending infra                  |
 
 ## Keeping these current
 


### PR DESCRIPTION
Following the ADR gap audit — these three significant decisions had an *operational* doc but no *decision record* (the why + tradeoffs). Drafted from the code + history; **left open for your review** since they encode your rationale (review the Decision/Consequences before merging).

| ADR | Decision | Grounded in |
| --- | --- | --- |
| **0008** | Subnet data model — one file per subnet; `authority` + `review` as fields, not directories | the #1678 flatten + surface migration; real enums (`official`/`registry-observed`/`provider-claimed`/`community`/`native-chain`; `community-submitted`/`maintainer-reviewed`/`rejected`) |
| **0009** | Autonomous contributor review gate (Gittensory) — external AI gate is sole adjudicator; auto-merge/close/hold + close-when-in-doubt | `docs/submission-gate.md` + CLAUDE.md disposition matrix |
| **0010** | Chain-direct block explorer + first-party event indexer (*partial*) — poller → D1 hot window, Taostats as fallback, deep history infra-gated | migrations 0013/0014/0009, the Aura author decode, #1345/#1519/#1349 |

Each follows the existing ADR shape (Status · Date · Relates-to · Context · Decision · Consequences) and is added to `docs/adr/README.md`. Docs-only.

**Check the rationale, not just the prose** — if any Decision/Consequence misstates your actual reasoning, tell me and I'll correct it before this merges.