### PR TITLE
fix(test): date health/trends rows relative to now (de-time-bomb)

### DIFF
--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -982,18 +982,25 @@ describe("worker live health serving", () => {
   });
 
   test("/api/v1/health/trends queries compact all-subnet D1 rows", async () => {
+    // Date the rows relative to "now" so they always fall inside the live 7d
+    // window the handler derives from Date.now() (`day >= now − 7d`). A fixed
+    // calendar date ages out of the window and turns this into a time-bomb that
+    // fails repo-wide the day the clock passes it.
+    const recentDay = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
     const env = createLocalArtifactEnv({
       METAGRAPH_HEALTH_DB: d1With([
         {
           netuid: 8,
-          date: "2026-06-17",
+          date: recentDay,
           total: 10,
           ok_count: 8,
           avg_latency_ms: 30,
         },
         {
           netuid: 7,
-          date: "2026-06-17",
+          date: recentDay,
           total: 5,
           ok_count: 5,
           avg_latency_ms: 20,


### PR DESCRIPTION
## Summary

`tests/health-serving.test.mjs` → "/api/v1/health/trends queries compact all-subnet D1 rows" started failing **repo-wide** (every PR + `main`) on **2026-06-25** with no code change:

```
body.data.windows["7d"].subnets.map(e => e.netuid)
  actual: []   expected: [7, 8]
```

**Root cause:** the all-subnet trends handler derives its 7d window from the real clock (`workers/api.mjs` `handleBulkHealthTrends`: `day >= now − 7·DAY_MS`). The test hardcoded its rows at `2026-06-17` — exactly the 7-day edge on 2026-06-24 (in-window), 8 days back from 2026-06-25 (out of window). A latent date time-bomb that detonated when the clock rolled past it.

**Fix:** date the rows **3 days before `now`** so they always fall inside the window. `formatBulkTrends` pushes one point per data row (no day-padding), so `points[0]` remains the row and every assertion holds.

Closes #1746

## Validation

- [x] `tests/health-serving.test.mjs` → 119/119.
- [x] `eslint` / `prettier` clean.

> Surfaced while running the suite for an unrelated PR; this is independent and unblocks all CI (`main` is currently red on it too).