### PR TITLE
docs(events): record chain-ingestion architecture (ADR 0012) + fix false poller docs

### DIFF
--- a/.github/workflows/refresh-events.yml
+++ b/.github/workflows/refresh-events.yml
@@ -50,15 +50,16 @@ jobs:
       - name: Install
         run: npm ci
 
-      # Read the durable high-water cursor (highest block previously staged) from
-      # R2 before polling. The window alone is a FIXED look-back: if the scheduler
-      # coalesces/drops runs for longer than the window, blocks older than
-      # head-window are never fetched and silently lost. The cursor closes that gap
-      # — the scan resumes from cursor+1 (capped by the window floor). A cold start
-      # (no object yet) is fine: `get` fails, we leave EVENTS_CURSOR blank, and the
-      # poller falls back to the window floor. `|| true` so a missing object (or a
-      # transient R2 blip) never fails the run; the window floor still makes the
-      # poll correct, just without long-gap recovery for this one tick.
+      # Read the high-water cursor (highest block previously staged) from R2 before
+      # polling. NOTE: the poller scans only a FIXED recent window (head-window..head)
+      # and does NOT resume from the cursor — compute_from_block clamps to the window
+      # floor by design; the cursor is passed for lag/health accounting only (it warns
+      # when the poller nears the prune horizon). So when the scheduler coalesces/drops
+      # runs for longer than ~window blocks, the blocks between runs are lost — they are
+      # pruned before a later run could reach them. This is the bootstrap tier;
+      # complete, gap-free ingestion is the self-hosted archive indexer (ADR 0012 /
+      # #1349). A cold start (no object yet) is fine: `get` fails, EVENTS_CURSOR stays
+      # blank. `|| true` so a missing object or transient R2 blip never fails the run.
       - name: Read event cursor from R2
         id: cursor
         run: |

--- a/docs/adr/0012-chain-data-ingestion.md
+++ b/docs/adr/0012-chain-data-ingestion.md
@@ -1,0 +1,81 @@
+# ADR 0012 — Chain-data ingestion: bootstrap poller → self-hosted archive indexer
+
+- **Status:** Proposed (recommended) — pending ratification + infrastructure
+  provisioning. The measured problem and the bootstrap's limits are facts; the
+  target architecture is the recommended decision.
+- **Date:** 2026-06-24
+- **Relates to:** ADR 0010 (chain-direct block explorer — this is the Phase-2
+  ingestion it deferred), ADR 0006 (provenance-tiered storage), and the
+  own-the-core infrastructure program (#1345, #1349, #1519).
+
+## Context
+
+The block explorer's first-party ingestion (ADR 0010) ships today as a **$0
+bootstrap**: a Python poller (`scripts/fetch-events.py`) on a GitHub Actions cron
+(`refresh-events.yml`, `*/5`) decodes a recent window of finalized finney blocks
+over **public** RPC, stages JSON to R2, and the Worker bulk-loads it into D1
+(`blocks` / `extrinsics` / `account_events`). It powers `/api/v1/blocks`,
+`/extrinsics`, and `/accounts/{ss58}` history.
+
+Two **structural** limits have now been measured in production — both
+infrastructural, neither a logic bug:
+
+1. **Trigger coalescing.** GitHub does not honor a `*/5` schedule; it collapses it
+   to roughly **once every 1.5–4.5 hours** (20 consecutive runs observed at 76–265
+   min intervals). So **380–1,325 blocks** are produced between runs.
+2. **Prune wall.** Public finney nodes discard historical state at **~300 blocks**
+   (the #1718 author backfill hit the wall at ~87). The poller re-scans only the
+   last `EVENTS_WINDOW` (250) blocks, and `compute_from_block` deliberately caps at
+   that window floor (it is tested to _not_ chase the cursor). Blocks produced
+   between runs but older than the window are never scanned — and are pruned before
+   any later run could reach them.
+
+**Measured impact:** the `blocks` D1 tier holds 2,500 rows over a 5,953-block span
+— **3,453 blocks (58%) missing**, in regular gaps of 131–769 that track
+(inter-run interval − window). `account_events` and `extrinsics` come from the
+same loop, so they have the **same holes** — `/accounts/{ss58}` history is roughly
+half-complete.
+
+**No poller-code change fixes this.** With window 250 and prune ~300, the most
+extra coverage any window/cursor tweak can buy is ~50 blocks per run, against
+130–1,025-block gaps. The disease is a scheduler we don't control plus a node that
+prunes — not the scan logic.
+
+## Decision (proposed)
+
+Treat the public-RPC + GitHub-cron poller as the **bootstrap tier only**, and make
+the durable ingestion a **continuously-running, first-party indexer against an
+archive node** — the own-the-core direction already chosen for the infrastructure
+program:
+
+- **Continuous indexer** — a long-running service (not a cron job) that follows the
+  finalized head block-by-block from a durable cursor. No scheduler to coalesce ⇒
+  **zero trigger gaps**.
+- **Archive node** — retains full historical state ⇒ **no prune wall** ⇒ complete
+  history and arbitrary backfill. Self-hosted (own-the-core) is the recommended
+  end state; a **managed archive RPC** (≈$50–200/mo) is the lower-ops alternative
+  and an acceptable first step.
+- **Provenance-tiered sink** (ADR 0006) — Postgres in the own-the-core plan, D1
+  today — written with the same idempotent keys, so the serving layer is unchanged.
+
+**Migration.** The indexer supersedes `fetch-events.py` + `refresh-events.yml`; the
+bootstrap is retired once the indexer is live and has backfilled the recent window.
+Until then the bootstrap stays (best-effort, gappy) and its docs must state the
+limitation honestly — no cursor-recovery claim it does not implement.
+
+**Open sub-decisions (why this is Proposed, not Accepted):** self-hosted archive
+node vs managed archive RPC (control vs cost/ops); and build now vs fold into the
+broader own-the-core migration.
+
+## Consequences
+
+- **Complete, gap-free chain data** — both the live-forward series and deep history
+  — independent of GitHub's scheduler and public-RPC pruning.
+- **Infra cost/ops** — an archive node (or managed archive RPC) plus a hosted
+  indexer process. This is the own-the-core tradeoff already on the roadmap.
+- **Interim** — the bootstrap keeps serving a best-effort recent window with known
+  gaps. An optional reliable-trigger bridge (a Cloudflare-cron `workflow_dispatch`)
+  could cut the live-forward loss in the meantime, but it is throwaway once the
+  indexer lands.
+- **Existing gaps are not backfillable now** — the missing blocks are long past the
+  public prune horizon; they return only once an archive source exists.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,6 +18,7 @@ change.
 | [0009](0009-autonomous-review-gate.md)      | Autonomous contributor review gate (the Gittensory Gate)                                                                | Accepted · in use                                                                                                |
 | [0010](0010-chain-direct-block-explorer.md) | Chain-direct block explorer + first-party event indexer                                                                 | Accepted (partial) · ingestion/serving shipped, deep history pending infra                                       |
 | [0011](0011-retire-submission-preflight.md) | Retire the metagraphed-side submission preflight (the gate is external; `validate-surface`/`validate-intake` own shape) | Accepted · implemented                                                                                           |
+| [0012](0012-chain-data-ingestion.md)        | Chain-data ingestion — bootstrap poller → self-hosted archive indexer (gap-free, prune-proof)                           | Proposed · bootstrap loses ~58% to cron-coalescing + RPC pruning; durable fix is infra                           |
 
 ## Keeping these current
 

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -9,15 +9,22 @@ Worker's loadStagedEvents bulk-loads it into D1 with INSERT OR IGNORE keyed
 (block_number, event_index) — idempotent, so an overlapping window re-inserts
 harmlessly.
 
-Durable high-water cursor (#1346 audit fix): the scan no longer starts at a
-FIXED `head - window`. The refresh-events workflow reads the last successfully
-staged block from R2 (events/cursor.json) and passes it as EVENTS_CURSOR; we
-scan `compute_from_block(cursor, head, window) .. head`. So a long gap (GitHub's
-scheduler coalescing/dropping runs for longer than the window) is recovered from
-the cursor instead of silently lost, while EVENTS_WINDOW stays as a generous
-overlap floor that keeps a cold/empty cursor safe and the load idempotent. After
-a successful stage the workflow advances the cursor to `events-cursor.json`
-(the max block scanned this run, written below).
+Recent-window scan (BOOTSTRAP tier — ADR 0012): each run re-scans a fixed
+`head - EVENTS_WINDOW + 1 .. head`. compute_from_block clamps to that window floor
+and does NOT chase the cursor (see its docstring + the tests for why). The
+EVENTS_CURSOR the workflow reads from R2 is retained for lag/health accounting
+only (see _emit_lag_alert) — NOT for gap recovery. After a successful stage the
+workflow advances the cursor to `events-cursor.json` (the max block scanned this
+run, written below).
+
+LIMITATION — this is a best-effort live-forward tier, not complete history. When
+GitHub's scheduler coalesces/drops runs for longer than ~EVENTS_WINDOW blocks
+(observed: the */5 cron collapses to ~1.5-4.5h), blocks produced between runs but
+older than the window are never fetched, and public nodes prune them (~300 blocks)
+before any later run could reach them — so they are permanently lost (measured:
+~58% of the block range). Gap-free, complete ingestion is the self-hosted
+continuous indexer against an archive node (ADR 0012 / #1349); this poller is the
+bootstrap for it.
 
 Run:  uv run --with substrate-interface python scripts/fetch-events.py
 Env:  EVENTS_RPC_URL        public finney WS endpoint (default below)


### PR DESCRIPTION
Closes the documentation/architecture half of #1749 (the infra build is tracked there).

**Why:** auditing the poller surfaced that `scripts/fetch-events.py`'s top docstring + `refresh-events.yml` both claim **cursor-based gap recovery that the code doesn't implement** — `compute_from_block` caps at the window floor by design (and is tested to). That false claim masked a **measured 58% block-loss** in the explorer tier (prod `blocks`: 2,500 rows / 5,953 span; gaps 131–769 tracking the coalesced inter-run interval).

**What this PR does (docs only — no logic change):**
- **ADR 0012 (Proposed)** — records the two *structural* limits (GitHub coalescing `*/5` → 1.5–4.5h; public-RPC prune ~300 blocks), proves no poller-code change can fix them, and proposes the durable architecture: a **continuous first-party indexer against an archive node** (own-the-core). Indexed in `docs/adr/README.md`.
- **Corrects the false docs** in `fetch-events.py` + `refresh-events.yml` to describe the actual window-only behavior + the live-forward limitation honestly.

**Verification:** `python3 scripts/test_fetch_events.py` → 14 tests pass (docstring edit is import-safe); prettier clean.

The architecture *decision* (self-hosted archive node vs managed archive RPC; build now vs later) and the infra build are tracked in #1749 — this PR just makes the docs honest and records the recommended direction.