### PR TITLE
ci(smithery): verify CLI before publish

### DIFF
--- a/.github/workflows/smithery-publish.yml
+++ b/.github/workflows/smithery-publish.yml
@@ -62,9 +62,42 @@ jobs:
             || { echo "::error::$SMITHERY_MCP_URL did not return a valid MCP initialize — aborting publish"; exit 1; }
 
       - name: Install Smithery CLI
-        # Pinned (not @latest) for reproducible, supply-chain-reviewable runs;
-        # bump deliberately when adopting a newer CLI.
-        run: npm install -g smithery@1.2.0
+        # Keep the secret-bearing publish step from trusting a lockless, mutable
+        # npm resolution directly. Fetch the pinned package tarball, verify the
+        # bytes npm selected, install without lifecycle scripts, then require
+        # registry signatures for the installed package graph before any
+        # SMITHERY_API_KEY-bearing process runs.
+        run: |
+          set -euo pipefail
+          npm pack --json smithery@1.2.0 > /tmp/smithery-pack.json
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const crypto = require("node:crypto");
+          const [pack] = JSON.parse(fs.readFileSync("/tmp/smithery-pack.json", "utf8"));
+          if (!pack?.filename || !pack?.integrity) {
+            throw new Error(`missing npm pack integrity metadata: ${JSON.stringify(pack)}`);
+          }
+          const [algorithm, expected] = pack.integrity.split("-");
+          if (algorithm !== "sha512" || !expected) {
+            throw new Error(`unexpected npm pack integrity: ${pack.integrity}`);
+          }
+          const actual = crypto
+            .createHash(algorithm)
+            .update(fs.readFileSync(pack.filename))
+            .digest("base64");
+          if (actual !== expected) {
+            throw new Error(`integrity mismatch for ${pack.filename}`);
+          }
+          fs.writeFileSync("/tmp/smithery-tarball", pack.filename);
+          console.log(`verified ${pack.filename} with ${algorithm}`);
+          NODE
+          mkdir -p /tmp/smithery-cli
+          tarball="$(pwd)/$(cat /tmp/smithery-tarball)"
+          cd /tmp/smithery-cli
+          npm init -y >/dev/null
+          npm install --ignore-scripts "$tarball"
+          npm audit signatures
+          echo "/tmp/smithery-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Publish to Smithery
         env:


### PR DESCRIPTION
### Motivation
- A supply-chain risk was identified where the workflow ran `npm install -g smithery@1.2.0` at runtime and then invoked the installed binary with `SMITHERY_API_KEY`, which could expose the release secret if the package or its dependencies were compromised.
- The goal is to prevent executing unverified, runtime-resolved npm code in the secret-bearing publish step while preserving the existing publish behavior.

### Description
- Replaces the direct `npm install -g smithery@1.2.0` step with an install flow that runs `npm pack --json smithery@1.2.0`, verifies the npm-provided `integrity` (sha512) against the downloaded tarball, and fails on any mismatch.
- Installs the verified tarball into an isolated temporary project with `npm install --ignore-scripts`, runs `npm audit signatures` to require registry signature checks, and adds the local `node_modules/.bin` path to `GITHUB_PATH` instead of performing a global install.
- Leaves the preflight MCP initialize probe and the `smithery mcp publish` invocation intact so the publish behavior is unchanged after the CLI is verified.

### Testing
- Ran `npm run validate:workflows`, which validated the repository workflow files successfully.
- Ran `npm run scan:public-safety`, which completed and reported no public-safety findings.
- Local diffs and workflow validation were inspected to ensure the modified step conforms to the repository workflow checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c6fe58984832c8361936e2822439c)