### PR TITLE
feat(events): archive-ready cursor-driven gap recovery (ADR 0012)

### DIFF
--- a/.github/workflows/refresh-events.yml
+++ b/.github/workflows/refresh-events.yml
@@ -51,15 +51,14 @@ jobs:
         run: npm ci
 
       # Read the high-water cursor (highest block previously staged) from R2 before
-      # polling. NOTE: the poller scans only a FIXED recent window (head-window..head)
-      # and does NOT resume from the cursor — compute_from_block clamps to the window
-      # floor by design; the cursor is passed for lag/health accounting only (it warns
-      # when the poller nears the prune horizon). So when the scheduler coalesces/drops
-      # runs for longer than ~window blocks, the blocks between runs are lost — they are
-      # pruned before a later run could reach them. This is the bootstrap tier;
-      # complete, gap-free ingestion is the self-hosted archive indexer (ADR 0012 /
-      # #1349). A cold start (no object yet) is fine: `get` fails, EVENTS_CURSOR stays
-      # blank. `|| true` so a missing object or transient R2 blip never fails the run.
+      # polling. The poller scans `min(window-floor, cursor+1) .. head` (ADR 0012): it
+      # always re-scans the overlap window AND extends back to cursor+1 to recover a
+      # scheduler-coalescing gap, bounded by EVENTS_MAX_LOOKBACK. On PUBLIC RPC that
+      # bound is the prune horizon (gaps wider than it are already pruned — best-effort,
+      # lossy by construction); pointed at the ARCHIVE node (ADR 0012 / #1349) with a
+      # high EVENTS_MAX_LOOKBACK, recovery is COMPLETE. A cold start (no object yet) is
+      # fine: `get` fails, EVENTS_CURSOR stays blank → window floor. `|| true` so a
+      # missing object or transient R2 blip never fails the run.
       - name: Read event cursor from R2
         id: cursor
         run: |
@@ -86,8 +85,13 @@ jobs:
           # run so staged-but-not-yet-loaded event batches can be regenerated if
           # the single pending R2 object is overwritten before the Worker drains it.
           EVENTS_WINDOW: "250"
-          # Highest block already staged; used for lag/health accounting only.
+          # Highest block already staged; the poller resumes from cursor+1 to recover
+          # a coalescing gap (bounded by EVENTS_MAX_LOOKBACK) and uses it for lag/health.
           EVENTS_CURSOR: ${{ steps.cursor.outputs.block }}
+          # Cap on gap recovery. Default (unset) = prune horizon, correct for PUBLIC
+          # RPC. When EVENTS_RPC_URL points at the ARCHIVE node (ADR 0012 / #1349),
+          # raise this (e.g. "1000000") so a long scheduler gap is recovered in full.
+          # EVENTS_MAX_LOOKBACK: "1000000"
           # Emit a ::warning:: (and webhook alert, if configured) when the cursor
           # falls within a window of the public-RPC prune horizon.
           METAGRAPH_ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}

--- a/docs/adr/0012-chain-data-ingestion.md
+++ b/docs/adr/0012-chain-data-ingestion.md
@@ -1,8 +1,9 @@
 # ADR 0012 — Chain-data ingestion: bootstrap poller → self-hosted archive indexer
 
-- **Status:** Proposed (recommended) — pending ratification + infrastructure
-  provisioning. The measured problem and the bootstrap's limits are facts; the
-  target architecture is the recommended decision.
+- **Status:** Accepted — ratified 2026-06-24 (the self-hosted archive node is being
+  provisioned). The bootstrap poller is now archive-ready (cursor-driven gap
+  recovery, #1749) and stays as the interim tier until the continuous indexer is
+  live.
 - **Date:** 2026-06-24
 - **Relates to:** ADR 0010 (chain-direct block explorer — this is the Phase-2
   ingestion it deferred), ADR 0006 (provenance-tiered storage), and the
@@ -41,31 +42,30 @@ extra coverage any window/cursor tweak can buy is ~50 blocks per run, against
 130–1,025-block gaps. The disease is a scheduler we don't control plus a node that
 prunes — not the scan logic.
 
-## Decision (proposed)
+## Decision
 
 Treat the public-RPC + GitHub-cron poller as the **bootstrap tier only**, and make
-the durable ingestion a **continuously-running, first-party indexer against an
-archive node** — the own-the-core direction already chosen for the infrastructure
-program:
+the durable ingestion a **continuously-running, first-party indexer against a
+self-hosted archive node** — the own-the-core direction:
 
 - **Continuous indexer** — a long-running service (not a cron job) that follows the
   finalized head block-by-block from a durable cursor. No scheduler to coalesce ⇒
   **zero trigger gaps**.
-- **Archive node** — retains full historical state ⇒ **no prune wall** ⇒ complete
-  history and arbitrary backfill. Self-hosted (own-the-core) is the recommended
-  end state; a **managed archive RPC** (≈$50–200/mo) is the lower-ops alternative
-  and an acceptable first step.
+- **Self-hosted archive node** — retains full historical state ⇒ **no prune wall** ⇒
+  complete history and arbitrary backfill. (A managed archive RPC is the lower-ops
+  fallback, but self-hosting is the chosen end state.)
 - **Provenance-tiered sink** (ADR 0006) — Postgres in the own-the-core plan, D1
   today — written with the same idempotent keys, so the serving layer is unchanged.
 
-**Migration.** The indexer supersedes `fetch-events.py` + `refresh-events.yml`; the
-bootstrap is retired once the indexer is live and has backfilled the recent window.
-Until then the bootstrap stays (best-effort, gappy) and its docs must state the
-limitation honestly — no cursor-recovery claim it does not implement.
+**Resolved (2026-06-24):** self-hosted archive node (not managed RPC); build now
+(the node is being provisioned).
 
-**Open sub-decisions (why this is Proposed, not Accepted):** self-hosted archive
-node vs managed archive RPC (control vs cost/ops); and build now vs fold into the
-broader own-the-core migration.
+**Migration / interim.** The bootstrap poller is made **archive-ready now** (#1749):
+`compute_from_block` does cursor-driven gap recovery bounded by `EVENTS_MAX_LOOKBACK`
+(default = prune horizon for public RPC; raise it once `EVENTS_RPC_URL` points at the
+archive ⇒ complete gap recovery on the existing pipeline). The continuous indexer
+then supersedes `fetch-events.py` + `refresh-events.yml`, reusing this module's decode
+functions; the bootstrap is retired once the indexer is live and has backfilled.
 
 ## Consequences
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,7 +18,7 @@ change.
 | [0009](0009-autonomous-review-gate.md)      | Autonomous contributor review gate (the Gittensory Gate)                                                                | Accepted · in use                                                                                                |
 | [0010](0010-chain-direct-block-explorer.md) | Chain-direct block explorer + first-party event indexer                                                                 | Accepted (partial) · ingestion/serving shipped, deep history pending infra                                       |
 | [0011](0011-retire-submission-preflight.md) | Retire the metagraphed-side submission preflight (the gate is external; `validate-surface`/`validate-intake` own shape) | Accepted · implemented                                                                                           |
-| [0012](0012-chain-data-ingestion.md)        | Chain-data ingestion — bootstrap poller → self-hosted archive indexer (gap-free, prune-proof)                           | Proposed · bootstrap loses ~58% to cron-coalescing + RPC pruning; durable fix is infra                           |
+| [0012](0012-chain-data-ingestion.md)        | Chain-data ingestion — bootstrap poller → self-hosted archive indexer (gap-free, prune-proof)                           | Accepted · poller made archive-ready (cursor recovery); continuous indexer is the end state                      |
 
 ## Keeping these current
 

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -9,22 +9,24 @@ Worker's loadStagedEvents bulk-loads it into D1 with INSERT OR IGNORE keyed
 (block_number, event_index) — idempotent, so an overlapping window re-inserts
 harmlessly.
 
-Recent-window scan (BOOTSTRAP tier — ADR 0012): each run re-scans a fixed
-`head - EVENTS_WINDOW + 1 .. head`. compute_from_block clamps to that window floor
-and does NOT chase the cursor (see its docstring + the tests for why). The
-EVENTS_CURSOR the workflow reads from R2 is retained for lag/health accounting
-only (see _emit_lag_alert) — NOT for gap recovery. After a successful stage the
-workflow advances the cursor to `events-cursor.json` (the max block scanned this
-run, written below).
+Recent-window scan + cursor-driven gap recovery (ADR 0012): each run scans
+`compute_from_block(cursor, head, window, max_lookback) .. head` — the overlap
+window floor `head - EVENTS_WINDOW + 1` (always re-scanned; idempotent), extended
+back to `cursor + 1` when the scheduler coalesced runs for longer than the window,
+so the gap since the last staged block is recovered (bounded by
+EVENTS_MAX_LOOKBACK). After a successful stage the workflow advances the cursor to
+`events-cursor.json`.
 
-LIMITATION — this is a best-effort live-forward tier, not complete history. When
-GitHub's scheduler coalesces/drops runs for longer than ~EVENTS_WINDOW blocks
-(observed: the */5 cron collapses to ~1.5-4.5h), blocks produced between runs but
-older than the window are never fetched, and public nodes prune them (~300 blocks)
-before any later run could reach them — so they are permanently lost (measured:
-~58% of the block range). Gap-free, complete ingestion is the self-hosted
-continuous indexer against an archive node (ADR 0012 / #1349); this poller is the
-bootstrap for it.
+SOURCE MATTERS — completeness depends on whether old blocks are still fetchable:
+  - PUBLIC RPC (the $0 bootstrap): nodes prune state at ~300 blocks AND GitHub
+    coalesces the */5 cron to ~1.5-4.5h, so gaps wider than the prune horizon are
+    gone before a later run reaches them. EVENTS_MAX_LOOKBACK defaults to the prune
+    horizon (no point scanning past it). This tier is best-effort and lossy by
+    construction (measured: ~58% of the block range).
+  - ARCHIVE node (ADR 0012 / #1349 — the durable target): retains every block, so
+    pointing EVENTS_RPC_URL at it and raising EVENTS_MAX_LOOKBACK makes the cursor
+    recovery COMPLETE — any coalescing gap is back-filled in full. The continuous
+    indexer is the eventual low-latency end state.
 
 Run:  uv run --with substrate-interface python scripts/fetch-events.py
 Env:  EVENTS_RPC_URL        public finney WS endpoint (default below)
@@ -90,6 +92,12 @@ EXTRINSICS_OUT = os.environ.get("EXTRINSICS_JSON", "dist/extrinsics.json")
 # head, the poller is losing the race against pruning and blocks between the prune
 # horizon and the cursor can no longer be re-fetched. Surfaced as a workflow alert.
 PRUNE_HORIZON = int(os.environ.get("EVENTS_PRUNE_HORIZON", "300"))
+# Upper bound on cursor-driven gap recovery: one run never scans more than this
+# many blocks back from the head. Default = PRUNE_HORIZON — against PUBLIC RPC there
+# is no point reaching past the prune wall (those blocks are gone). Against an
+# ARCHIVE node (ADR 0012) set EVENTS_MAX_LOOKBACK high so a long scheduler gap is
+# recovered in full; the archive still holds every block.
+MAX_LOOKBACK = int(os.environ.get("EVENTS_MAX_LOOKBACK", str(PRUNE_HORIZON)))
 
 
 def _parse_cursor(raw):
@@ -110,21 +118,34 @@ def _parse_cursor(raw):
     return n if n >= 0 else None
 
 
-def compute_from_block(cursor, head, window):
+def compute_from_block(cursor, head, window, max_lookback=PRUNE_HORIZON):
     """First block to scan this run — the testable core of the cursor logic.
 
-    Always re-scan the bounded overlap window: `head - window + 1`, clamped to
-    >= 0. The workflow stages events to R2 and the Worker imports that pending
-    object into D1 asynchronously, so a promoted cursor only proves that a range
-    was staged, not that it was durably loaded. Re-scanning the overlap every run
-    lets a later run recreate a recent staged batch if the single pending R2
-    object was overwritten before the Worker drained it; D1 uses idempotent
-    inserts, so duplicated overlap rows are harmless.
+    Returns the EARLIER of the overlap floor and `cursor + 1`, bounded below by the
+    lookback limit:
 
-    The cursor is still useful for lag/health accounting, but it must not move
-    the start block ahead of the overlap floor.
+      - **Overlap floor** `head - window + 1` is ALWAYS re-scanned. The workflow
+        stages events to R2 and the Worker imports that pending object into D1
+        asynchronously, so a promoted cursor only proves a range was staged, not
+        durably loaded; re-scanning the overlap lets a later run recreate a recent
+        staged batch if the single pending R2 object was overwritten before the
+        Worker drained it (D1 inserts are idempotent, so the duplicate is harmless).
+      - **`cursor + 1`** extends the scan back when the scheduler coalesced/dropped
+        runs for longer than the window, so the GAP since the last staged block is
+        recovered instead of silently lost. (Start never moves *ahead* of the
+        overlap floor — `min` keeps the overlap re-scan intact.)
+      - **`head - max_lookback`** bounds how far back one run reaches. Default is
+        the prune horizon: against PUBLIC RPC there is no point scanning past the
+        prune wall (those blocks are gone). Against an ARCHIVE node (ADR 0012) raise
+        EVENTS_MAX_LOOKBACK so a long coalescing gap is recovered in full.
+
+    Cold cursor (None) → just the overlap floor.
     """
-    return max(0, head - window + 1)
+    floor = max(0, head - window + 1)
+    if cursor is None:
+        return floor
+    earliest = max(0, head - max_lookback)
+    return max(earliest, min(floor, cursor + 1))
 
 
 def _ss58(v):
@@ -433,7 +454,7 @@ def main():
             "finalized head timestamp is required for account_events"
         ) from e
     cursor = _parse_cursor(os.environ.get("EVENTS_CURSOR"))
-    start = compute_from_block(cursor, head_bn, WINDOW)
+    start = compute_from_block(cursor, head_bn, WINDOW, MAX_LOOKBACK)
     _emit_lag_alert(head_bn, cursor)
 
     rows = []

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -27,6 +27,7 @@ compute_from_block = _fe.compute_from_block
 _parse_cursor = _fe._parse_cursor
 _block_author = _fe._block_author
 AURA_ENGINE_ID = _fe.AURA_ENGINE_ID
+PRUNE_HORIZON = _fe.PRUNE_HORIZON
 
 
 class ComputeFromBlockTest(unittest.TestCase):
@@ -54,16 +55,31 @@ class ComputeFromBlockTest(unittest.TestCase):
         )
         self.assertLess(self.floor(), cursor + 1)
 
-    def test_stale_cursor_older_than_window_is_capped_at_floor(self):
-        # A cursor far older than the window must NOT trigger a whole-chain rescan;
-        # the floor wins, bounding the scan to `window` blocks.
-        stale = self.HEAD - 5_000  # gap (5000) >> window (250)
+    def test_stale_cursor_recovers_back_to_the_lookback_bound(self):
+        # A cursor far older than the lookback bound: recover the gap, but only as
+        # far back as `head - max_lookback` (default = prune horizon — no point
+        # reaching past the public-RPC prune wall). NOT capped at the window floor
+        # (we DO recover beyond the overlap), and NOT the ancient cursor + 1.
+        stale = self.HEAD - 5_000  # gap (5000) >> lookback (PRUNE_HORIZON)
         got = compute_from_block(stale, self.HEAD, self.WINDOW)
-        self.assertEqual(got, self.floor())
-        # And the scan span never exceeds `window` blocks.
-        self.assertLessEqual(self.HEAD - got + 1, self.WINDOW)
-        # Importantly we did NOT resume from the ancient cursor+1.
-        self.assertNotEqual(got, stale + 1)
+        self.assertEqual(got, self.HEAD - PRUNE_HORIZON)
+        self.assertLess(got, self.floor())  # recovered earlier than the overlap
+        self.assertNotEqual(got, stale + 1)  # but bounded — not the ancient cursor
+
+    def test_archive_lookback_recovers_the_full_gap(self):
+        # Against an archive (no prune wall), a high max_lookback recovers the WHOLE
+        # coalescing gap: the scan resumes from cursor + 1.
+        stale = self.HEAD - 5_000
+        got = compute_from_block(stale, self.HEAD, self.WINDOW, 10_000_000)
+        self.assertEqual(got, stale + 1)
+
+    def test_gap_within_lookback_resumes_from_cursor(self):
+        # A gap wider than the window but inside the lookback bound is fully
+        # recovered from cursor + 1 — not just the overlap floor.
+        cursor = self.HEAD - (PRUNE_HORIZON - 20)
+        got = compute_from_block(cursor, self.HEAD, self.WINDOW)
+        self.assertEqual(got, cursor + 1)
+        self.assertLess(got, self.floor())
 
     def test_cursor_ahead_of_head_reorg_uses_floor(self):
         # Reorg / clock skew left the cursor at or past the head → re-scan the
@@ -94,8 +110,8 @@ class ComputeFromBlockTest(unittest.TestCase):
     def test_never_negative_near_genesis(self):
         # Window larger than the head must clamp the floor to 0, never go negative.
         self.assertEqual(compute_from_block(None, 5, 250), 0)
-        # With a low cursor near genesis we still use the overlap floor because
-        # staging is not proof of D1 persistence.
+        # A low cursor near genesis clamps to 0 too (the floor is already 0 and the
+        # lookback bound never pushes the start negative).
         self.assertEqual(compute_from_block(2, 5, 250), 0)
         self.assertGreaterEqual(compute_from_block(2, 5, 250), 0)
         # A None cursor with head 0 and any window clamps to 0 (not -249).


### PR DESCRIPTION
Prep for the self-hosted archive node (ADR 0012 ratified — node being provisioned). Refs #1749, #1349.

**The unlock:** against the public RPC, cursor-recovery was useless (gaps are pruned before a later run reaches them — that's why it was shelved). Against an **archive node** (no prune wall) it becomes *complete*: a coalescing gap is back-filled in full. This PR makes the existing poller archive-ready so the moment the node is live, it's gap-free with two env flips — no rewrite.

**Changes (pure, fully tested):**
- `compute_from_block` → `max(head - max_lookback, min(window-floor, cursor+1))`: always re-scans the overlap (staged-but-not-loaded resilience preserved) **and** extends back to `cursor+1` to recover a gap, bounded by `EVENTS_MAX_LOOKBACK`.
- **`EVENTS_MAX_LOOKBACK`** (new) defaults to the prune horizon — correct/safe for the current public RPC (bounded ~300-block scan, no pruned-block spam). Flip `EVENTS_RPC_URL`→archive + raise this ⇒ complete recovery.
- Tests: rewrote the stale-cursor case, added archive-mode + within-bound recovery → **16 pass** (`python3 scripts/test_fetch_events.py`).
- **ADR 0012 → Accepted** (own-the-core ratified); docs/comments corrected to describe the real behavior; workflow documents the knob.

**What's next (needs the node live, so not in this PR):** the continuous indexer (reuses these decode fns), a historical backfill once the archive exists, and the double-`get_block` dedupe (an RPC-shape change I'll verify against the archive rather than ship untested). Tracked in #1749.

Docs + a pure-function change; no schema/contract impact.