### PR TITLE
fix(validate): require public provider URLs

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -123,6 +123,13 @@ function assert(condition, message) {
   }
 }
 
+function assertPublicHttpUrl(owner, key, value) {
+  assert(
+    normalizePublicHttpUrl(value),
+    `${owner}: ${key} must be a public HTTP(S) URL`,
+  );
+}
+
 function validateProvider(provider) {
   assert(
     provider.schema_version === 1,
@@ -137,21 +144,18 @@ function validateProvider(provider) {
     providerKinds.has(provider.kind),
     `${provider.id}: invalid provider kind`,
   );
-  assert(
-    isValidUrl(provider.website_url),
-    `${provider.id}: website_url must be a URL`,
-  );
+  assertPublicHttpUrl(provider.id, "website_url", provider.website_url);
   for (const key of ["docs_url", "github_url", "team_url", "contact_url"]) {
     if (provider[key] === undefined) {
       continue;
     }
-    assert(isValidUrl(provider[key]), `${provider.id}: ${key} must be a URL`);
+    assertPublicHttpUrl(provider.id, key, provider[key]);
   }
   if (provider.logo_url !== undefined) {
-    assert(
-      normalizePublicHttpUrl(provider.logo_url),
-      `${provider.id}: logo_url must be a public HTTP(S) URL`,
-    );
+    assertPublicHttpUrl(provider.id, "logo_url", provider.logo_url);
+  }
+  for (const [key, value] of Object.entries(provider.social || {})) {
+    assertPublicHttpUrl(provider.id, `social.${key}`, value);
   }
   assert(
     authorities.has(provider.authority),


### PR DESCRIPTION
### Motivation
- Reinstate repository-side public-safe checks for provider profile URLs so provider records cannot contain credentialed, localhost, link-local, or other non-public targets that would poison generated artifacts.

### Description
- Add `assertPublicHttpUrl(owner, key, value)` which enforces `normalizePublicHttpUrl(value)` for public HTTP(S) normalization and safety.
- Replace `isValidUrl(...)` checks for provider `website_url`, `docs_url`, `github_url`, `team_url`, and `contact_url` with `assertPublicHttpUrl(...)` to require public-safe HTTP(S) URLs.
- Extend the same public-safe validation to `logo_url` and every curated `social.*` entry so logos and social links are also normalized and blocked when unsafe.

### Testing
- Ran `npm run build` which completed successfully. 
- Ran `npm run validate` which completed successfully against the built artifacts. 
- Ran `npm run scan:public-safety` which passed. 
- Performed a targeted negative check by injecting unsafe provider URLs (link-local, credentialed, IPv6 loopback) and confirmed `npm run validate` reported the expected validation errors for those fields. 
- Ran `npx vitest run tests/public-safety.test.mjs` where one DNS-dependent assertion failed in this environment; the failure is due to DNS resolution behavior in the execution environment rather than the new validation logic (other public-safety checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c871082a8832c87aeebf037cc7694)