### PR TITLE
feat(events): stream blocks + extrinsics in realtime (#1345 Option B)

### DIFF
--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -41,6 +41,13 @@ from substrateinterface import SubstrateInterface
 
 RPC = os.environ.get("EVENTS_RPC_URL", "wss://entrypoint-finney.opentensor.ai:443")
 INGEST_URL = os.environ.get("EVENTS_INGEST_URL")
+# Block-explorer ingest (#1345 Option B) — same host as the events endpoint, so it
+# is derived: only EVENTS_INGEST_URL must be set (overridable for odd routings).
+BLOCKS_INGEST_URL = os.environ.get("BLOCKS_INGEST_URL") or (
+    INGEST_URL.replace("/internal/events", "/internal/blocks")
+    if INGEST_URL
+    else None
+)
 SECRET = os.environ.get("METAGRAPH_EVENTS_INGEST_SECRET")
 TOKEN_HEADER = "x-metagraph-events-token"
 PUSH_TIMEOUT = 15
@@ -62,14 +69,12 @@ _fe = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_fe)
 extract = _fe.extract
 
-# TODO(#1345 block explorer, Option B): this realtime streamer only POSTs
-# account_events to the events ingest endpoint (/api/v1/internal/events). The
-# block-explorer `blocks` tier is currently filled by the CI poller
-# (fetch-events.py emits the blocks sidecar → R2 → loadStagedBlocks) only. To
-# stream blocks in realtime too we'd need (1) a blocks ingest endpoint mirroring
-# handleEventIngest + (2) a per-head emit here using _fe.block_extras(s, bn, bh,
-# len(events)). Deliberately deferred for the first slice — the CI poller is the
-# backstop and INSERT OR IGNORE on block_number makes any future overlap free.
+# Block-explorer realtime (#1345 Option B): besides account_events, each finalized
+# head also emits its `blocks` row + `extrinsics` rows (via _fe.block_extras +
+# _fe.extrinsics_for_block) POSTed to /api/v1/internal/blocks. This closes the
+# blocks/extrinsics realtime gap the coalesced CI poller alone left (~58%; #1749);
+# the CI poller stays the self-healing backstop and INSERT OR IGNORE on the PKs
+# makes the overlap free.
 
 _stop = False
 
@@ -85,7 +90,10 @@ signal.signal(signal.SIGINT, _handle_signal)
 
 
 def decode_head(s, block_number):
-    """Decode the SubtensorModule events of one finalized block → ingest rows."""
+    """Decode one finalized block → account_events + block/extrinsic rows (#1345 B).
+
+    Returns {"events": [...], "block": {...}|None, "extrinsics": [...]}.
+    """
     block_hash = s.get_block_hash(block_number)
     # Read the block's timestamp AT THIS block_hash. Querying Timestamp.Now
     # without a block_hash resolves at the chain's current best block, which
@@ -97,10 +105,9 @@ def decode_head(s, block_number):
         head_ts = int(s.query("Timestamp", "Now", block_hash=block_hash).value)
     except Exception:
         head_ts = None
-    rows = []
-    for event_index, ev in enumerate(
-        s.query("System", "Events", block_hash=block_hash)
-    ):
+    events = s.query("System", "Events", block_hash=block_hash)
+    event_rows = []
+    for event_index, ev in enumerate(events):
         v = ev.value if isinstance(ev.value, dict) else {}
         e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
         if e.get("module_id") != "SubtensorModule":
@@ -108,7 +115,7 @@ def decode_head(s, block_number):
         ent = extract(e.get("event_id"), e.get("attributes"))
         if ent is None:
             continue
-        rows.append(
+        event_rows.append(
             {
                 "block_number": block_number,
                 "event_index": event_index,
@@ -121,22 +128,29 @@ def decode_head(s, block_number):
                 "observed_at": head_ts if head_ts else None,
             }
         )
-    return rows
+    # Block-explorer block + extrinsic rows (#1345 Option B). The _fe helpers are
+    # best-effort (never raise); the caller supplies observed_at (the same block
+    # timestamp the events use). A None block row / empty extrinsics is fine — the
+    # Worker's validators drop incomplete rows before they touch D1.
+    block_row = _fe.block_extras(s, block_number, block_hash, len(events))
+    if block_row is not None:
+        block_row["observed_at"] = head_ts
+    extrinsic_rows = _fe.extrinsics_for_block(s, block_number, block_hash, events)
+    for xrow in extrinsic_rows:
+        xrow["observed_at"] = head_ts
+    return {"events": event_rows, "block": block_row, "extrinsics": extrinsic_rows}
 
 
-def push(rows):
-    """POST rows to the ingest endpoint. Returns True on success; logs WARN +
-    returns False on a transient network failure (the CI poller backstop covers
-    the gap). A TLS/certificate verification failure is NOT a transient blip —
-    it's logged at ERROR and the process exits, so a possible MITM on the
-    secret-bearing POST is surfaced (Railway restarts a transient one; a persistent
-    one crash-loops to the retry cap + goes visibly down) rather than silently
-    swallowed."""
-    if not rows:
-        return True
+def push(url, payload):
+    """POST a JSON payload to an ingest endpoint. Returns True on success; logs WARN
+    + returns False on a transient network failure (the CI poller backstop covers
+    the gap). A TLS/certificate verification failure is NOT a transient blip — it's
+    logged at ERROR and the process exits, so a possible MITM on the secret-bearing
+    POST is surfaced (Railway restarts a transient one; a persistent one crash-loops
+    to the retry cap + goes visibly down) rather than silently swallowed."""
     req = urllib.request.Request(
-        INGEST_URL,
-        data=json.dumps(rows).encode(),
+        url,
+        data=json.dumps(payload).encode(),
         method="POST",
         headers={
             "content-type": "application/json",
@@ -208,14 +222,29 @@ def run():
                 if _stop:
                     return True  # non-None return cancels the subscription
                 bn = obj["header"]["number"]
-                rows = decode_head(s, bn)
-                ok = push(rows)
+                decoded = decode_head(s, bn)
+                event_rows = decoded["events"]
+                # account_events → /internal/events
+                ok = push(INGEST_URL, event_rows) if event_rows else True
+                # blocks + extrinsics → /internal/blocks (#1345 Option B)
+                block_payload = {
+                    "blocks": [decoded["block"]] if decoded["block"] else [],
+                    "extrinsics": decoded["extrinsics"],
+                }
+                if block_payload["blocks"] or block_payload["extrinsics"]:
+                    ok = push(BLOCKS_INGEST_URL, block_payload) and ok
                 stats["blocks"] += 1
-                stats["events"] += len(rows)
+                stats["events"] += len(event_rows)
                 stats["latest"] = bn
                 if not ok:
                     stats["push_fail"] += 1
-                log.debug("block %s: %d events %s", bn, len(rows), "ok" if ok else "FAIL")
+                log.debug(
+                    "block %s: %d events, %d extrinsics %s",
+                    bn,
+                    len(event_rows),
+                    len(decoded["extrinsics"]),
+                    "ok" if ok else "FAIL",
+                )
                 if stats["blocks"] % SUMMARY_EVERY == 0:
                     log.info(
                         "healthy · %d blocks · %d events · latest=#%s · push_failures=%d",

--- a/tests/block-ingest.test.mjs
+++ b/tests/block-ingest.test.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleBlockIngest, handleRequest } from "../workers/api.mjs";
+
+// Realtime block-explorer ingest (#1345 Option B): POST /api/v1/internal/blocks
+// takes {blocks:[...], extrinsics:[...]} and INSERT OR IGNOREs both into D1 — the
+// streamer's per-head emit that closes the blocks/extrinsics realtime gap (#1749).
+const SECRET = "test-secret-token-1234567890";
+
+function post(body, { secret, method = "POST" } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret) headers["x-metagraph-events-token"] = secret;
+  const init = { method, headers };
+  if (method !== "GET" && method !== "HEAD") {
+    init.body = typeof body === "string" ? body : JSON.stringify(body);
+  }
+  return new Request("https://api.metagraph.sh/api/v1/internal/blocks", init);
+}
+
+function dbCapture(captured, changes = 1) {
+  return {
+    prepare(sql) {
+      return {
+        bind(...v) {
+          return { sql, v };
+        },
+      };
+    },
+    async batch(stmts) {
+      captured.push(stmts.length);
+      return stmts.map(() => ({ meta: { changes } }));
+    },
+  };
+}
+
+const BLOCK = {
+  block_number: 1,
+  block_hash: "0xabc",
+  parent_hash: "0xpar",
+  author: "5Author",
+  extrinsic_count: 2,
+  event_count: 3,
+  observed_at: 1,
+};
+const EXTRINSIC = {
+  block_number: 1,
+  extrinsic_index: 0,
+  extrinsic_hash: "0xe0",
+  signer: "5Signer",
+  call_module: "SubtensorModule",
+  call_function: "set_weights",
+  success: 1,
+  observed_at: 1,
+};
+
+test("block ingest is disabled (503) without the secret configured", async () => {
+  const res = await handleBlockIngest(
+    post({ blocks: [] }, { secret: "x" }),
+    {},
+  );
+  assert.equal(res.status, 503);
+});
+
+test("block ingest rejects a wrong or missing token (401)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  assert.equal(
+    (await handleBlockIngest(post({ blocks: [] }, { secret: "wrong" }), env))
+      .status,
+    401,
+  );
+  assert.equal(
+    (await handleBlockIngest(post({ blocks: [] }), env)).status,
+    401,
+  );
+});
+
+test("block ingest rejects non-POST (405)", async () => {
+  const env = { METAGRAPH_EVENTS_INGEST_SECRET: SECRET };
+  const res = await handleBlockIngest(
+    post({ blocks: [] }, { secret: SECRET, method: "GET" }),
+    env,
+  );
+  assert.equal(res.status, 405);
+});
+
+test("block ingest writes valid blocks + extrinsics (200, counts split)", async () => {
+  const captured = [];
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture(captured),
+  };
+  const res = await handleBlockIngest(
+    post(
+      {
+        blocks: [BLOCK],
+        extrinsics: [EXTRINSIC, { foo: "bar" }], // second is invalid → filtered
+      },
+      { secret: SECRET },
+    ),
+    env,
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.blocks_inserted, 1);
+  assert.equal(body.extrinsics_inserted, 1); // junk row filtered out
+  assert.deepEqual(captured, [2]); // 1 block stmt + 1 extrinsic stmt, one batch
+});
+
+test("block ingest no-ops on an empty payload (200, no batch)", async () => {
+  const captured = [];
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture(captured),
+  };
+  const res = await handleBlockIngest(
+    post({ blocks: [], extrinsics: [] }, { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.blocks_inserted, 0);
+  assert.equal(body.extrinsics_inserted, 0);
+  assert.deepEqual(captured, []); // nothing valid → no db.batch issued
+});
+
+test("block ingest reports actually-inserted rows (INSERT OR IGNORE dup = 0)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([], 0), // all duplicates → meta.changes 0
+  };
+  const res = await handleBlockIngest(
+    post({ blocks: [BLOCK], extrinsics: [EXTRINSIC] }, { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.blocks_inserted, 0);
+  assert.equal(body.extrinsics_inserted, 0);
+});
+
+test("block ingest rejects malformed JSON (400)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  const res = await handleBlockIngest(
+    post("{not json", { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 400);
+});
+
+test("block ingest rejects a non-object body (400)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  // A bare array is not the {blocks, extrinsics} envelope.
+  const res = await handleBlockIngest(post([BLOCK], { secret: SECRET }), env);
+  assert.equal(res.status, 400);
+});
+
+test("block ingest rejects too many rows (413)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  const many = Array.from({ length: 501 }, (_, i) => ({
+    block_number: 1,
+    extrinsic_index: i,
+    observed_at: 1,
+  }));
+  const res = await handleBlockIngest(
+    post({ blocks: [], extrinsics: many }, { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 413);
+});
+
+test("block ingest rejects an oversized body (413)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture([]),
+  };
+  const res = await handleBlockIngest(
+    post("x".repeat(300000), { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 413);
+});
+
+test("block ingest returns 503 when the store is unavailable", async () => {
+  const env = { METAGRAPH_EVENTS_INGEST_SECRET: SECRET }; // authed, no DB
+  const res = await handleBlockIngest(
+    post({ blocks: [] }, { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 503);
+});
+
+test("handleRequest routes POST /api/v1/internal/blocks to the ingest handler", async () => {
+  // No secret configured → 503 proves the dispatch reached handleBlockIngest.
+  const res = await handleRequest(
+    post({ blocks: [] }, { secret: "x" }),
+    {},
+    {},
+  );
+  assert.equal(res.status, 503);
+});
+
+test("handleRequest writes blocks end-to-end with a valid token", async () => {
+  const captured = [];
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: dbCapture(captured),
+  };
+  const res = await handleRequest(
+    post({ blocks: [BLOCK], extrinsics: [EXTRINSIC] }, { secret: SECRET }),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.blocks_inserted, 1);
+  assert.equal(body.extrinsics_inserted, 1);
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -181,6 +181,8 @@ import {
   MAX_ASK_BODY_BYTES,
   MAX_BACKFILL_INGEST_BODY_BYTES,
   MAX_BACKFILL_INGEST_ROWS,
+  MAX_BLOCKS_INGEST_BODY_BYTES,
+  MAX_BLOCKS_INGEST_ROWS,
   MAX_BULK_TREND_ROWS,
   MAX_EVENTS_INGEST_BODY_BYTES,
   MAX_EVENTS_INGEST_ROWS,
@@ -906,6 +908,104 @@ export async function handleEventIngest(request, env) {
   });
 }
 
+// POST /api/v1/internal/blocks (#1345 Option B): the realtime block-explorer ingest
+// path for the finalized-head streamer (#1361). Same auth as /internal/events (the
+// shared METAGRAPH_EVENTS_INGEST_SECRET over EVENTS_INGEST_TOKEN_HEADER). Body is
+// {blocks:[...], extrinsics:[...]}, loaded with the SAME parameterized INSERT OR
+// IGNORE as the staged-batch loaders — idempotent on the PKs (block_number;
+// (block_number, extrinsic_index)). NOT in the public contract. Closes the
+// blocks/extrinsics realtime gap (the coalesced CI poller alone missed ~58%; #1749).
+export async function handleBlockIngest(request, env) {
+  if (request.method !== "POST") {
+    return errorResponse("method_not_allowed", "POST only.", 405);
+  }
+  const configured = env.METAGRAPH_EVENTS_INGEST_SECRET;
+  if (!configured) {
+    return errorResponse(
+      "blocks_ingest_disabled",
+      "Realtime block ingest requires METAGRAPH_EVENTS_INGEST_SECRET to be configured.",
+      503,
+    );
+  }
+  const provided = request.headers.get(EVENTS_INGEST_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, configured)) {
+    return errorResponse(
+      "unauthorized",
+      `Provide a valid ${EVENTS_INGEST_TOKEN_HEADER} header.`,
+      401,
+    );
+  }
+  const db = env.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) {
+    return errorResponse("unavailable", "Block store unavailable.", 503);
+  }
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > MAX_BLOCKS_INGEST_BODY_BYTES) {
+    return errorResponse(
+      "payload_too_large",
+      `Body exceeds ${MAX_BLOCKS_INGEST_BODY_BYTES} bytes.`,
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return errorResponse(
+      "invalid_body",
+      "Body must be a JSON object {blocks:[...], extrinsics:[...]}.",
+      400,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return errorResponse(
+      "invalid_body",
+      "Body must be a JSON object {blocks:[...], extrinsics:[...]}.",
+      400,
+    );
+  }
+  const incomingBlocks = Array.isArray(parsed.blocks) ? parsed.blocks : [];
+  const incomingExtrinsics = Array.isArray(parsed.extrinsics)
+    ? parsed.extrinsics
+    : [];
+  if (
+    incomingBlocks.length > MAX_BLOCKS_INGEST_ROWS ||
+    incomingExtrinsics.length > MAX_BLOCKS_INGEST_ROWS
+  ) {
+    return errorResponse(
+      "too_many_rows",
+      `At most ${MAX_BLOCKS_INGEST_ROWS} rows per array (blocks, extrinsics).`,
+      413,
+    );
+  }
+  // Report rows ACTUALLY inserted (INSERT OR IGNORE on the PKs drops the expected
+  // streamer/poller overlap), summing per-statement D1 meta.changes. Block
+  // statements come first in the batch, then extrinsic statements.
+  const blockStmts = blockInsertStatements(db, validBlockRows(incomingBlocks));
+  const extrinsicStmts = extrinsicInsertStatements(
+    db,
+    validExtrinsicRows(incomingExtrinsics),
+  );
+  let blocksInserted = 0;
+  let extrinsicsInserted = 0;
+  if (blockStmts.length || extrinsicStmts.length) {
+    const results = await db.batch([...blockStmts, ...extrinsicStmts]);
+    results.forEach((result, i) => {
+      const changes = result?.meta?.changes ?? 0;
+      if (i < blockStmts.length) blocksInserted += changes;
+      else extrinsicsInserted += changes;
+    });
+  }
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      blocks_inserted: blocksInserted,
+      extrinsics_inserted: extrinsicsInserted,
+    }),
+    { status: 200, headers: { "content-type": JSON_CONTENT_TYPE } },
+  );
+}
+
 // POST /api/v1/internal/backfill-neurons (#1345 Phase 1): the historical metagraph
 // backfill ingest for scripts/backfill-neuron-history.py. Disabled (503) until the
 // dedicated METAGRAPH_BACKFILL_SECRET is configured (falls back to the events-ingest
@@ -1237,6 +1337,9 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // finalized-head streamer (#1361). POST-only; runs before the read-only gate.
   if (url.pathname === "/api/v1/internal/events") {
     return handleEventIngest(request, env);
+  }
+  if (url.pathname === "/api/v1/internal/blocks") {
+    return handleBlockIngest(request, env);
   }
   if (url.pathname === "/api/v1/internal/backfill-neurons") {
     return handleNeuronBackfill(request, env);

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -149,6 +149,14 @@ export const MAX_EVENTS_INGEST_ROWS = 500;
 // script chunks well under these and the PK upsert makes any re-POST idempotent.
 export const MAX_BACKFILL_INGEST_BODY_BYTES = 1_048_576; // 1 MiB
 export const MAX_BACKFILL_INGEST_ROWS = 2_000;
+// Realtime block-explorer ingest (#1345 Option B): the finalized-head streamer also
+// POSTs the per-block `blocks` row + its `extrinsics` rows to POST
+// /api/v1/internal/blocks, authed by the SAME METAGRAPH_EVENTS_INGEST_SECRET over
+// EVENTS_INGEST_TOKEN_HEADER. Body is {blocks:[...], extrinsics:[...]}; idempotent
+// INSERT OR IGNORE on the PKs. Closes the blocks/extrinsics realtime gap (the
+// coalesced CI poller alone missed ~58% of blocks; #1749).
+export const MAX_BLOCKS_INGEST_BODY_BYTES = 262144; // 256 KB
+export const MAX_BLOCKS_INGEST_ROWS = 500; // cap per array (blocks[], extrinsics[])
 // Caps on the R2-staged chain-event drain (loadStagedEvents, #1346). Unlike the
 // single bounded HTTP body above, a staged file is produced by the CI poller and
 // can grow large on a backfill or a stuck window. The byte cap guards against


### PR DESCRIPTION
Closes the live-forward half of #1749. Refs #1345.

**Diagnosis (proven against prod D1):** the realtime streamer covers `account_events` gap-free (20,203 blocks; every block in a sampled `blocks` gap had events) but **only emits account_events** — blocks/extrinsics were CI-poller-only → the measured ~58% gap. So the right fix is the streamer, not the archive (the archive is for the one-time *historical* backfill).

**Changes:**
- **`POST /api/v1/internal/blocks`** (`handleBlockIngest`) — mirrors `handleEventIngest` exactly: same shared secret + token header, `{blocks:[], extrinsics:[]}` body, reuses the **existing** `validBlockRows`/`validExtrinsicRows` + `block/extrinsicInsertStatements` (INSERT OR IGNORE on the PKs → idempotent with the poller backstop). Internal, not in the public contract.
- **Streamer** — each finalized head now also emits `block_extras` + `extrinsics_for_block` (reusing the verified decode) and POSTs to the derived `/internal/blocks` URL. Result: **all three tiers realtime (~12s) + gap-free**, no archive in the live path.

**Verification:** 13 new tests + the 15 existing events-ingest tests pass (28/28); eslint + prettier clean; streamer AST-parses. Post-merge, the Worker deploys via Workers Builds and the streamer redeploys on Railway (watchPatterns) — I'll confirm the `blocks` gap stops growing via D1.

The single-knob RPC swap (your other point) is a separate small PR coming next.