### PR TITLE
chore(ci): hide + swap chain RPC via a SUBTENSOR_RPC_URL secret

### DIFF
--- a/.github/workflows/refresh-events.yml
+++ b/.github/workflows/refresh-events.yml
@@ -81,6 +81,11 @@ jobs:
       - name: Poll finney events (first-party, public RPC, no key)
         run: uv run --with substrate-interface==1.8.1 python scripts/fetch-events.py
         env:
+          # Chain RPC endpoint, behind a SECRET so the private archive node's URL is
+          # never exposed in the repo or run logs once we switch to it (ADR 0012 /
+          # #1349). Falls back to the public finney endpoint when the secret is unset,
+          # so swapping = set/clear the one `SUBTENSOR_RPC_URL` secret — no code change.
+          EVENTS_RPC_URL: ${{ secrets.SUBTENSOR_RPC_URL || 'wss://entrypoint-finney.opentensor.ai:443' }}
           # Bounded overlap: ~250 blocks ≈ 50 min of chain is re-scanned every
           # run so staged-but-not-yet-loaded event batches can be regenerated if
           # the single pending R2 object is overwritten before the Worker drains it.
@@ -88,10 +93,11 @@ jobs:
           # Highest block already staged; the poller resumes from cursor+1 to recover
           # a coalescing gap (bounded by EVENTS_MAX_LOOKBACK) and uses it for lag/health.
           EVENTS_CURSOR: ${{ steps.cursor.outputs.block }}
-          # Cap on gap recovery. Default (unset) = prune horizon, correct for PUBLIC
-          # RPC. When EVENTS_RPC_URL points at the ARCHIVE node (ADR 0012 / #1349),
-          # raise this (e.g. "1000000") so a long scheduler gap is recovered in full.
-          # EVENTS_MAX_LOOKBACK: "1000000"
+          # Cap on gap recovery (non-sensitive → a VARIABLE, not a secret). Default
+          # 300 = prune horizon, correct for PUBLIC RPC. Once EVENTS_RPC_URL points at
+          # the ARCHIVE node, set the `EVENTS_MAX_LOOKBACK` repo variable high (e.g.
+          # 1000000) so a long scheduler gap is recovered in full.
+          EVENTS_MAX_LOOKBACK: ${{ vars.EVENTS_MAX_LOOKBACK || '300' }}
           # Emit a ::warning:: (and webhook alert, if configured) when the cursor
           # falls within a window of the public-RPC prune horizon.
           METAGRAPH_ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}

--- a/.github/workflows/refresh-metagraph.yml
+++ b/.github/workflows/refresh-metagraph.yml
@@ -39,6 +39,11 @@ jobs:
       # Taostats source (#1348). No Taostats, no API key.
       - name: Fetch per-UID metagraph (Bittensor SDK)
         run: uvx --from bittensor==10.4.0 python scripts/fetch-metagraph-native.py
+        env:
+          # Same hidden chain-RPC secret as the events poller (ADR 0012 / #1349).
+          # Unset → the script defaults to "finney"; set it to the private node URL
+          # to route the metagraph fetch through our own infra without exposing it.
+          SUBTENSOR_RPC_URL: ${{ secrets.SUBTENSOR_RPC_URL }}
 
       - name: Upload unsigned neuron snapshot
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/scripts/fetch-metagraph-native.py
+++ b/scripts/fetch-metagraph-native.py
@@ -65,7 +65,12 @@ def _at(arr, i):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--network", default="finney")
+    # Default from the SUBTENSOR_RPC_URL env (the hidden chain-RPC secret; ADR 0012)
+    # so the metagraph fetch routes through our own node without exposing its URL;
+    # falls back to "finney" when unset. An explicit --network still overrides.
+    parser.add_argument(
+        "--network", default=os.environ.get("SUBTENSOR_RPC_URL") or "finney"
+    )
     args = parser.parse_args()
 
     s = bt.SubtensorApi(network=args.network)


### PR DESCRIPTION
Makes the chain RPC endpoint a single, hidden, swappable knob — so when we cut over to the private archive node (ADR 0012 / #1749), its URL is never exposed. Refs #1349.

**Why a secret, not a variable:** a repo variable is visible in settings/logs; a **secret** is masked in Actions logs and hidden in the repo. The private node URL belongs in a secret.

**Changes (behavior unchanged until the secret is set — public fallback everywhere):**
- **`refresh-events.yml`**: `EVENTS_RPC_URL: ${{ secrets.SUBTENSOR_RPC_URL || '<public finney>' }}`. Also promoted `EVENTS_MAX_LOOKBACK` from a hardcoded/commented value to a repo **variable** (non-sensitive — raise it once on the archive for full gap recovery).
- **`refresh-metagraph.yml` + `fetch-metagraph-native.py`**: `--network` now defaults from the same `SUBTENSOR_RPC_URL` env (else `"finney"`); an explicit `--network` still overrides.

**Switching to your node = set one secret** (`SUBTENSOR_RPC_URL`) + optionally the `EVENTS_MAX_LOOKBACK` variable. The Railway streamer + manual backfills read the same value via their own env/`--network`.

**Verification:** `fetch-metagraph-native.py` parses; prettier clean; `validate-workflows.mjs` → all 16 workflows valid. The workflows only run on schedule/dispatch, so this PR's CI just validates the YAML.