### PR TITLE
fix(scripts): harden build-network-registry main-module guard against spaced paths

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/shadowbook/Documents/metagraphed/.claude/worktrees/vigilant-swirles-471738/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/shadowbook/Documents/metagraphed/.claude/worktrees/vigilant-swirles-471738/node_modules

--- a/scripts/build-network-registry.mjs
+++ b/scripts/build-network-registry.mjs
@@ -14,6 +14,7 @@
 
 import { existsSync, promises as fs } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import {
   artifactOutputPath,
@@ -293,7 +294,10 @@ export async function buildNetworkRegistry({ prefix, snapshotPath }) {
 // r2-manifest (so the manifest/upload picks the network registries up). A missing
 // snapshot is a skip-with-warning, never a hard failure — testnet data is
 // best-effort and must never block the mainnet publish.
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
   const summaries = [];
   for (const net of NETWORK_REGISTRIES) {
     const snapshotPath = path.join(repoRoot, net.snapshotPath);


### PR DESCRIPTION
## Summary

`scripts/build-network-registry.mjs` guarded its CLI entry with the fragile raw idiom:

```js
if (import.meta.url === `file://${process.argv[1]}`) {
```

On a repo path containing a space (or other URL-special char) — e.g. an agent worktree like `/…/agent worktrees/…` — `import.meta.url` is percent-encoded (`agent%20worktrees`) while `process.argv[1]` is not, so the strings never match. The guard silently no-ops and the testnet-registry build is skipped with no error.

This swaps in the robust form already used by 7 other scripts (e.g. `ci-verify-submitted-artifacts.mjs`, `fetch-metagraph.mjs`, `validate-committed-seed.mjs`):

```js
if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
```

`path` was already imported; this adds `import { fileURLToPath } from "node:url";` (mirroring `generate-client.mjs` / `bundle-schemas.mjs`). Minimal change: one import + the guard line (Prettier wrapped the condition across lines).

## Validation checklist

- `npx prettier --check scripts/build-network-registry.mjs` — pass (after wrapping)
- `npx eslint scripts/build-network-registry.mjs` — pass (exit 0)
- `node --check scripts/build-network-registry.mjs` — syntax OK
- `node -e "import('./scripts/build-network-registry.mjs')"` — imports clean (exports `NETWORK_REGISTRIES`, `buildNetworkRegistry`); guard correctly does NOT fire on import
- Idiom proof: on a synthetic spaced path the OLD idiom returns `false` (the bug) while the NEW idiom returns `true` (fixed)

Closes #1762