### PR TITLE
fix(smoke): fail fast on unsubstituted route placeholders + PR-time substitution test

### DIFF
--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { API_ROUTES } from "../src/contracts.mjs";
 import { MCP_TOOLS } from "../src/mcp-server.mjs";
 
@@ -7,306 +9,331 @@ const baseUrl = normalizeBaseUrl(
   process.env.METAGRAPH_LIVE_BASE_URL || DEFAULT_BASE_URL,
 );
 const timeoutMs = Number(process.env.METAGRAPH_LIVE_SMOKE_TIMEOUT_MS || 15000);
-const healthDate = await discoverHealthHistoryDate();
-const apiChecks = API_ROUTES.map((route) => ({
-  route: route.path,
-  url: apiRouteUrl(route.path, healthDate),
-}));
-const rawArtifactChecks = [
-  "/metagraph/openapi.json",
-  "/metagraph/r2-manifest.json",
-  "/metagraph/subnets/7.json",
-  // Current-state health artifacts are retired (410); the durable daily
-  // history snapshot is the live raw health artifact still served from R2.
-  `/metagraph/health/history/${healthDate}.json`,
-  "/metagraph/candidates.json",
-  "/metagraph/review-queue.json",
-];
-const results = [];
 
-for (const check of apiChecks) {
-  const result = await fetchJson(check.url);
-  assert.equal(result.status, 200, `${check.route}: expected HTTP 200`);
-  assertHeader(result, "access-control-allow-origin", "*", check.route);
-  assert.ok(result.headers.get("etag"), `${check.route}: missing ETag`);
-  assert.ok(
-    result.headers.get("x-metagraph-contract-version"),
-    `${check.route}: missing contract version header`,
-  );
-  assert.equal(result.body?.ok, true, `${check.route}: expected ok envelope`);
-  assert.equal(
-    result.body?.schema_version,
-    1,
-    `${check.route}: expected schema_version 1`,
-  );
-  assert.ok(result.body?.data, `${check.route}: expected data payload`);
-  assert.ok(result.body?.meta, `${check.route}: expected meta payload`);
-  results.push({
-    path: new URL(check.url).pathname,
-    route: check.route,
-    status: result.status,
-    source: result.body.meta.source || null,
-  });
+// Only fire the live smoke when this file is executed directly (npm run
+// smoke:live). Importing it for the PR-time substitution unit test must not hit
+// the network.
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  await runLiveSmoke();
 }
 
-for (const artifactPath of rawArtifactChecks) {
-  const result = await fetchJson(`${baseUrl}${artifactPath}`);
-  assert.equal(result.status, 200, `${artifactPath}: expected HTTP 200`);
-  assertHeader(result, "access-control-allow-origin", "*", artifactPath);
-  assert.ok(result.headers.get("etag"), `${artifactPath}: missing ETag`);
-  assert.ok(
-    result.headers.get("x-metagraph-artifact-source"),
-    `${artifactPath}: missing artifact source header`,
-  );
-  assert.ok(
-    result.headers.get("x-metagraph-storage-tier"),
-    `${artifactPath}: missing storage tier header`,
-  );
-  assert.equal(
-    typeof result.body,
-    "object",
-    `${artifactPath}: expected JSON artifact body`,
-  );
-  results.push({
-    path: artifactPath,
-    route: artifactPath,
-    status: result.status,
-    source: result.headers.get("x-metagraph-artifact-source"),
-    storage_tier: result.headers.get("x-metagraph-storage-tier"),
-  });
-}
+async function runLiveSmoke() {
+  const healthDate = await discoverHealthHistoryDate();
+  const apiChecks = API_ROUTES.map((route) => ({
+    route: route.path,
+    url: apiRouteUrl(route.path, healthDate),
+  }));
+  const rawArtifactChecks = [
+    "/metagraph/openapi.json",
+    "/metagraph/r2-manifest.json",
+    "/metagraph/subnets/7.json",
+    // Current-state health artifacts are retired (410); the durable daily
+    // history snapshot is the live raw health artifact still served from R2.
+    `/metagraph/health/history/${healthDate}.json`,
+    "/metagraph/candidates.json",
+    "/metagraph/review-queue.json",
+  ];
+  const results = [];
 
-const invalidQuery = await fetchJson(`${baseUrl}/api/v1/subnets?limit=0`);
-assert.equal(invalidQuery.status, 400, "invalid query should return HTTP 400");
-assert.equal(
-  invalidQuery.body?.error?.code,
-  "invalid_query",
-  "invalid query should return invalid_query error",
-);
-
-// Subnet slug aliases resolve to the netuid (e.g. allways → 7).
-const slugAlias = await fetchJson(`${baseUrl}/api/v1/subnets/allways`);
-assert.equal(
-  slugAlias.status,
-  200,
-  "slug alias /api/v1/subnets/allways should resolve",
-);
-assert.equal(
-  slugAlias.body?.data?.subnet?.netuid,
-  7,
-  "allways slug should resolve to netuid 7",
-);
-
-// RPC proxy is enabled in production: a non-allowlisted method must be refused
-// (proves the proxy is live and the read-only allowlist holds, with no
-// dependency on a live upstream), and a safe read method must not report
-// "disabled". (The enable gate runs before the method check, so a disabled
-// proxy would 501 here rather than 403.)
-const blockedRpcProxy = await fetchJson(`${baseUrl}/rpc/v1/finney`, {
-  method: "POST",
-  headers: {
-    "content-type": "application/json",
-  },
-  body: JSON.stringify({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "author_submitExtrinsic",
-    params: [],
-  }),
-});
-assert.equal(
-  blockedRpcProxy.status,
-  403,
-  "enabled RPC proxy must refuse non-allowlisted methods",
-);
-assert.equal(
-  blockedRpcProxy.body?.error?.code,
-  "rpc_method_blocked",
-  "blocked RPC method should return rpc_method_blocked",
-);
-
-const safeRpcProxy = await fetchJson(`${baseUrl}/rpc/v1/finney`, {
-  method: "POST",
-  headers: {
-    "content-type": "application/json",
-  },
-  body: JSON.stringify({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "system_health",
-    params: [],
-  }),
-});
-assert.notEqual(
-  safeRpcProxy.status,
-  501,
-  "enabled RPC proxy must not report rpc_proxy_disabled",
-);
-
-// The /wss route is WebSocket-only and cannot be HTTP-proxied; it must return a
-// clean client error, never a 500.
-const wssRpcProxy = await fetchJson(`${baseUrl}/rpc/v1/finney/wss`, {
-  method: "POST",
-  headers: {
-    "content-type": "application/json",
-  },
-  body: JSON.stringify({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "system_health",
-    params: [],
-  }),
-});
-assert.equal(
-  wssRpcProxy.status,
-  400,
-  "the /wss RPC route must be rejected with a clean 400, not 500",
-);
-assert.equal(
-  wssRpcProxy.body?.error?.code,
-  "rpc_websocket_unsupported",
-  "the /wss RPC route should return rpc_websocket_unsupported",
-);
-
-// Remote MCP server: the JSON-RPC handshake must work and expose every tool,
-// and a representative tools/call must resolve real registry data.
-const mcpInit = await fetchJson(`${baseUrl}/mcp`, {
-  method: "POST",
-  headers: { "content-type": "application/json" },
-  body: JSON.stringify({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "initialize",
-    params: { protocolVersion: "2025-06-18" },
-  }),
-});
-assert.equal(mcpInit.status, 200, "POST /mcp initialize must return HTTP 200");
-assert.equal(
-  mcpInit.body?.result?.serverInfo?.name,
-  "metagraphed",
-  "MCP initialize must identify the metagraphed server",
-);
-
-const mcpTools = await fetchJson(`${baseUrl}/mcp`, {
-  method: "POST",
-  headers: { "content-type": "application/json" },
-  body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
-});
-assert.equal(
-  mcpTools.body?.result?.tools?.length,
-  MCP_TOOLS.length,
-  `MCP tools/list must expose all ${MCP_TOOLS.length} tools`,
-);
-
-const mcpCall = await fetchJson(`${baseUrl}/mcp`, {
-  method: "POST",
-  headers: { "content-type": "application/json" },
-  body: JSON.stringify({
-    jsonrpc: "2.0",
-    id: 3,
-    method: "tools/call",
-    params: { name: "list_subnet_apis", arguments: { netuid: 7 } },
-  }),
-});
-assert.equal(
-  mcpCall.body?.result?.isError,
-  false,
-  "MCP list_subnet_apis(7) must succeed against live data",
-);
-assert.ok(
-  mcpCall.body?.result?.structuredContent?.service_count >= 1,
-  "MCP list_subnet_apis(7) must return at least one service",
-);
-
-// AI routes (semantic search + /ask). Tolerant of the kill-switch: a 503
-// ai_unavailable is an accepted "disabled" state; when enabled we validate the
-// envelope shape (results may be empty if the embedding index is still cold).
-let aiStatus = "disabled";
-const semantic = await fetchJson(
-  `${baseUrl}/api/v1/search/semantic?q=image%20generation&limit=5`,
-);
-if (semantic.status === 200) {
-  aiStatus = "enabled";
-  assert.equal(
-    semantic.body?.ok,
-    true,
-    "semantic search must return an ok envelope",
-  );
-  assert.ok(
-    Array.isArray(semantic.body?.data?.results),
-    "semantic search must return a results array",
-  );
-
-  const ask = await fetchJson(`${baseUrl}/api/v1/ask`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ question: "Which subnets expose a public API?" }),
-  });
-  assert.equal(ask.status, 200, "ask must return HTTP 200 when AI is enabled");
-  assert.equal(
-    typeof ask.body?.data?.answer,
-    "string",
-    "ask must return an answer string",
-  );
-  assert.ok(
-    Array.isArray(ask.body?.data?.citations),
-    "ask must return a citations array",
-  );
-} else {
-  assert.equal(
-    semantic.status,
-    503,
-    "semantic search must be 200 (enabled) or 503 (disabled)",
-  );
-  assert.equal(semantic.body?.error?.code, "ai_unavailable");
-}
-
-// AI-crawler access regression check: Cloudflare's "Block AI bots" zone setting
-// once served 403s to AI user-agents on the exact endpoints built for them
-// (llms.txt, agent-catalog) — fatal for an AI-native registry, and invisible to
-// default-UA checks. Assert agent UAs are never blocked again.
-const AI_USER_AGENTS = [
-  "Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)",
-  "Claude-User/1.0",
-  "GPTBot/1.2",
-];
-for (const userAgent of AI_USER_AGENTS) {
-  for (const path of ["/llms.txt", "/api/v1/agent-catalog"]) {
-    const response = await fetch(`${baseUrl}${path}`, {
-      headers: { "user-agent": userAgent },
-      signal: AbortSignal.timeout(timeoutMs),
+  for (const check of apiChecks) {
+    const result = await fetchJson(check.url);
+    assert.equal(result.status, 200, `${check.route}: expected HTTP 200`);
+    assertHeader(result, "access-control-allow-origin", "*", check.route);
+    assert.ok(result.headers.get("etag"), `${check.route}: missing ETag`);
+    assert.ok(
+      result.headers.get("x-metagraph-contract-version"),
+      `${check.route}: missing contract version header`,
+    );
+    assert.equal(result.body?.ok, true, `${check.route}: expected ok envelope`);
+    assert.equal(
+      result.body?.schema_version,
+      1,
+      `${check.route}: expected schema_version 1`,
+    );
+    assert.ok(result.body?.data, `${check.route}: expected data payload`);
+    assert.ok(result.body?.meta, `${check.route}: expected meta payload`);
+    results.push({
+      path: new URL(check.url).pathname,
+      route: check.route,
+      status: result.status,
+      source: result.body.meta.source || null,
     });
-    await response.body?.cancel?.();
-    assert.notEqual(
-      response.status,
-      403,
-      `${path}: AI agent UA "${userAgent}" is blocked (403) — the Cloudflare AI-bot block has regressed`,
+  }
+
+  for (const artifactPath of rawArtifactChecks) {
+    const result = await fetchJson(`${baseUrl}${artifactPath}`);
+    assert.equal(result.status, 200, `${artifactPath}: expected HTTP 200`);
+    assertHeader(result, "access-control-allow-origin", "*", artifactPath);
+    assert.ok(result.headers.get("etag"), `${artifactPath}: missing ETag`);
+    assert.ok(
+      result.headers.get("x-metagraph-artifact-source"),
+      `${artifactPath}: missing artifact source header`,
+    );
+    assert.ok(
+      result.headers.get("x-metagraph-storage-tier"),
+      `${artifactPath}: missing storage tier header`,
     );
     assert.equal(
-      response.status,
-      200,
-      `${path}: expected 200 for AI agent UA "${userAgent}", got ${response.status}`,
+      typeof result.body,
+      "object",
+      `${artifactPath}: expected JSON artifact body`,
     );
+    results.push({
+      path: artifactPath,
+      route: artifactPath,
+      status: result.status,
+      source: result.headers.get("x-metagraph-artifact-source"),
+      storage_tier: result.headers.get("x-metagraph-storage-tier"),
+    });
   }
-}
 
-console.log(
-  JSON.stringify(
-    {
-      base_url: baseUrl,
-      status: "passed",
-      api_route_count: apiChecks.length,
-      raw_artifact_count: rawArtifactChecks.length,
-      mcp_tool_count: MCP_TOOLS.length,
-      ai_status: aiStatus,
-      ai_crawler_access: "unblocked",
-      health_history_date: healthDate,
-      checked_paths: results,
+  const invalidQuery = await fetchJson(`${baseUrl}/api/v1/subnets?limit=0`);
+  assert.equal(
+    invalidQuery.status,
+    400,
+    "invalid query should return HTTP 400",
+  );
+  assert.equal(
+    invalidQuery.body?.error?.code,
+    "invalid_query",
+    "invalid query should return invalid_query error",
+  );
+
+  // Subnet slug aliases resolve to the netuid (e.g. allways → 7).
+  const slugAlias = await fetchJson(`${baseUrl}/api/v1/subnets/allways`);
+  assert.equal(
+    slugAlias.status,
+    200,
+    "slug alias /api/v1/subnets/allways should resolve",
+  );
+  assert.equal(
+    slugAlias.body?.data?.subnet?.netuid,
+    7,
+    "allways slug should resolve to netuid 7",
+  );
+
+  // RPC proxy is enabled in production: a non-allowlisted method must be refused
+  // (proves the proxy is live and the read-only allowlist holds, with no
+  // dependency on a live upstream), and a safe read method must not report
+  // "disabled". (The enable gate runs before the method check, so a disabled
+  // proxy would 501 here rather than 403.)
+  const blockedRpcProxy = await fetchJson(`${baseUrl}/rpc/v1/finney`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
     },
-    null,
-    2,
-  ),
-);
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "author_submitExtrinsic",
+      params: [],
+    }),
+  });
+  assert.equal(
+    blockedRpcProxy.status,
+    403,
+    "enabled RPC proxy must refuse non-allowlisted methods",
+  );
+  assert.equal(
+    blockedRpcProxy.body?.error?.code,
+    "rpc_method_blocked",
+    "blocked RPC method should return rpc_method_blocked",
+  );
+
+  const safeRpcProxy = await fetchJson(`${baseUrl}/rpc/v1/finney`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "system_health",
+      params: [],
+    }),
+  });
+  assert.notEqual(
+    safeRpcProxy.status,
+    501,
+    "enabled RPC proxy must not report rpc_proxy_disabled",
+  );
+
+  // The /wss route is WebSocket-only and cannot be HTTP-proxied; it must return a
+  // clean client error, never a 500.
+  const wssRpcProxy = await fetchJson(`${baseUrl}/rpc/v1/finney/wss`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "system_health",
+      params: [],
+    }),
+  });
+  assert.equal(
+    wssRpcProxy.status,
+    400,
+    "the /wss RPC route must be rejected with a clean 400, not 500",
+  );
+  assert.equal(
+    wssRpcProxy.body?.error?.code,
+    "rpc_websocket_unsupported",
+    "the /wss RPC route should return rpc_websocket_unsupported",
+  );
+
+  // Remote MCP server: the JSON-RPC handshake must work and expose every tool,
+  // and a representative tools/call must resolve real registry data.
+  const mcpInit = await fetchJson(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-06-18" },
+    }),
+  });
+  assert.equal(
+    mcpInit.status,
+    200,
+    "POST /mcp initialize must return HTTP 200",
+  );
+  assert.equal(
+    mcpInit.body?.result?.serverInfo?.name,
+    "metagraphed",
+    "MCP initialize must identify the metagraphed server",
+  );
+
+  const mcpTools = await fetchJson(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+  });
+  assert.equal(
+    mcpTools.body?.result?.tools?.length,
+    MCP_TOOLS.length,
+    `MCP tools/list must expose all ${MCP_TOOLS.length} tools`,
+  );
+
+  const mcpCall = await fetchJson(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "list_subnet_apis", arguments: { netuid: 7 } },
+    }),
+  });
+  assert.equal(
+    mcpCall.body?.result?.isError,
+    false,
+    "MCP list_subnet_apis(7) must succeed against live data",
+  );
+  assert.ok(
+    mcpCall.body?.result?.structuredContent?.service_count >= 1,
+    "MCP list_subnet_apis(7) must return at least one service",
+  );
+
+  // AI routes (semantic search + /ask). Tolerant of the kill-switch: a 503
+  // ai_unavailable is an accepted "disabled" state; when enabled we validate the
+  // envelope shape (results may be empty if the embedding index is still cold).
+  let aiStatus = "disabled";
+  const semantic = await fetchJson(
+    `${baseUrl}/api/v1/search/semantic?q=image%20generation&limit=5`,
+  );
+  if (semantic.status === 200) {
+    aiStatus = "enabled";
+    assert.equal(
+      semantic.body?.ok,
+      true,
+      "semantic search must return an ok envelope",
+    );
+    assert.ok(
+      Array.isArray(semantic.body?.data?.results),
+      "semantic search must return a results array",
+    );
+
+    const ask = await fetchJson(`${baseUrl}/api/v1/ask`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ question: "Which subnets expose a public API?" }),
+    });
+    assert.equal(
+      ask.status,
+      200,
+      "ask must return HTTP 200 when AI is enabled",
+    );
+    assert.equal(
+      typeof ask.body?.data?.answer,
+      "string",
+      "ask must return an answer string",
+    );
+    assert.ok(
+      Array.isArray(ask.body?.data?.citations),
+      "ask must return a citations array",
+    );
+  } else {
+    assert.equal(
+      semantic.status,
+      503,
+      "semantic search must be 200 (enabled) or 503 (disabled)",
+    );
+    assert.equal(semantic.body?.error?.code, "ai_unavailable");
+  }
+
+  // AI-crawler access regression check: Cloudflare's "Block AI bots" zone setting
+  // once served 403s to AI user-agents on the exact endpoints built for them
+  // (llms.txt, agent-catalog) — fatal for an AI-native registry, and invisible to
+  // default-UA checks. Assert agent UAs are never blocked again.
+  const AI_USER_AGENTS = [
+    "Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)",
+    "Claude-User/1.0",
+    "GPTBot/1.2",
+  ];
+  for (const userAgent of AI_USER_AGENTS) {
+    for (const path of ["/llms.txt", "/api/v1/agent-catalog"]) {
+      const response = await fetch(`${baseUrl}${path}`, {
+        headers: { "user-agent": userAgent },
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      await response.body?.cancel?.();
+      assert.notEqual(
+        response.status,
+        403,
+        `${path}: AI agent UA "${userAgent}" is blocked (403) — the Cloudflare AI-bot block has regressed`,
+      );
+      assert.equal(
+        response.status,
+        200,
+        `${path}: expected 200 for AI agent UA "${userAgent}", got ${response.status}`,
+      );
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        base_url: baseUrl,
+        status: "passed",
+        api_route_count: apiChecks.length,
+        raw_artifact_count: rawArtifactChecks.length,
+        mcp_tool_count: MCP_TOOLS.length,
+        ai_status: aiStatus,
+        ai_crawler_access: "unblocked",
+        health_history_date: healthDate,
+        checked_paths: results,
+      },
+      null,
+      2,
+    ),
+  );
+}
 
 async function discoverHealthHistoryDate() {
   // Current-state health is live-only — the static /metagraph/health/latest.json
@@ -342,7 +369,7 @@ async function discoverHealthHistoryDate() {
   });
 }
 
-function apiRouteUrl(routePath, date) {
+export function apiRouteUrl(routePath, date) {
   // D1-tier detail routes carry id placeholders beyond {netuid}/{slug}/{date}.
   // Substitute constant, dependency-free sample ids that resolve to a live 200:
   // uid 0 always exists; an all-zero hash / block 0 hit the cold→null wrapper
@@ -358,19 +385,24 @@ function apiRouteUrl(routePath, date) {
     .replace("{hash}", `0x${"0".repeat(64)}`)
     .replace("{ref}", "0")
     .replace("{ss58}", "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM");
+  // Guard against the recurring #1682 class: any leftover `{` means a route
+  // placeholder was never substituted, which silently 404s against a live URL
+  // that matches no route. Fail fast with the offending path.
+  if (route.includes("{")) {
+    throw new Error(`unsubstituted placeholder in route ${routePath}`);
+  }
   const url = new URL(route, baseUrl);
   if (routePath === "/api/v1/subnets") {
     url.searchParams.set("limit", "3");
     url.searchParams.set("sort", "netuid");
   } else if (routePath === "/api/v1/compare") {
     // compare requires `netuids` — a bare GET is a 400 (#1682).
-    url.searchParams.set("netuids", "7");
+    url.searchParams.set("netuids", "7,8");
   } else if (
     [
       "/api/v1/surfaces",
       "/api/v1/endpoints",
       "/api/v1/candidates",
-      "/api/v1/health/history/{date}",
       "/api/v1/search",
     ].includes(routePath)
   ) {

--- a/tests/smoke-route-substitution.test.mjs
+++ b/tests/smoke-route-substitution.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { API_ROUTES } from "../src/contracts.mjs";
+import { apiRouteUrl } from "../scripts/smoke-live-api.mjs";
+
+// PR-time guard for the recurring #1682 class: the live smoke substitutes path
+// placeholders ({netuid}/{slug}/{date}/{uid}/{hash}/{ref}/{ss58}) before
+// fetching. A route that grows a new placeholder without a matching
+// substitution would otherwise only blow up at publish time. Assert that
+// apiRouteUrl yields a fully-substituted URL for every registered route.
+describe("smoke route substitution", () => {
+  const sampleDate = "2026-06-24";
+
+  for (const route of API_ROUTES) {
+    test(`${route.path} has no leftover placeholder`, () => {
+      const url = apiRouteUrl(route.path, sampleDate);
+      assert.ok(
+        !url.includes("{"),
+        `${route.path}: apiRouteUrl left an unsubstituted placeholder (${url})`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Summary

`scripts/smoke-live-api.mjs` substitutes path placeholders (`{netuid}`/`{slug}`/`{date}`/`{uid}`/`{hash}`/`{ref}`/`{ss58}`) in `apiRouteUrl` before firing live fetches, but had no guard for a still-unsubstituted `{token}` (the recurring #1682 class) and only ran at publish — never on PRs.

- **Fail fast:** after substitution, `apiRouteUrl` now asserts the resulting path contains no leftover `{` and throws `unsubstituted placeholder in route <path>`. A new route placeholder shipping without a matching substitution now blows up loudly instead of silently 404ing a literal-placeholder URL in production.
- **PR-time unit test:** added `tests/smoke-route-substitution.test.mjs`, which imports `apiRouteUrl` + `API_ROUTES` and asserts substitution over **every** route yields a URL with no `{` remaining. To make the top-level script importable without hitting the network, the live-smoke body is now guarded behind a main-module check (`process.argv[1]` resolves to this file) and `apiRouteUrl` is exported. `npm run smoke:live` behavior is unchanged when run directly.
- **Two nits:** dropped the already-substituted `/api/v1/health/history/{date}` from the `?limit=3` branch, and changed the compare smoke from `netuids=7` to `netuids=7,8`.

The bulk of the line diff is reindentation from wrapping the existing top-level body into `runLiveSmoke()`; the substantive changes are the guard, the export + main-module gate, the new test, and the two nits.

## Validation checklist

- `npx vitest run tests/smoke-route-substitution.test.mjs` — 74 passed (one per route), 3ms, no network calls
- `node --check scripts/smoke-live-api.mjs` — syntax OK
- Direct-run path verified to still fire the smoke (attempts the live fetch when invoked via `node scripts/smoke-live-api.mjs`)
- `npx prettier --check scripts/smoke-live-api.mjs tests/smoke-route-substitution.test.mjs` — clean
- `npx eslint scripts/smoke-live-api.mjs tests/smoke-route-substitution.test.mjs` — clean

Closes #1766