### PR TITLE
test(artifacts): assert every PUBLIC_ARTIFACTS path resolves to an explicit storage tier

### DIFF
--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -6,7 +6,7 @@ export const ARTIFACT_STORAGE_TIERS = {
 
 export const R2_STAGING_RELATIVE_ROOT = "dist/metagraph-r2/metagraph";
 
-const R2_ONLY_PATTERNS = [
+export const R2_ONLY_PATTERNS = [
   /^adapters\/[^/]+\.json$/,
   /^candidates\.json$/,
   /^candidates\/(?:\d+|\{netuid\})\.json$/,
@@ -159,7 +159,7 @@ const R2_ONLY_PATTERNS = [
 // Committed to git (and mirrored to R2): the low-churn, consumer-facing API
 // contract plus the small coverage "shop window". These only change when the
 // API/schema changes — exactly what belongs in version control.
-const DUAL_PATTERNS = [
+export const DUAL_PATTERNS = [
   /^api-index\.json$/,
   // r2-manifest.json: the publish MANIFEST (what's in R2 + per-artifact hashes),
   // read by the upload/kv/verify pipeline — kept committed as publish

--- a/tests/artifact-tiering-explicit.test.mjs
+++ b/tests/artifact-tiering-explicit.test.mjs
@@ -1,0 +1,80 @@
+// Tiering invariant for the public artifact registry. artifactStorageTier*()
+// returns the `git` tier for ANY path that matches NEITHER R2_ONLY_PATTERNS nor
+// DUAL_PATTERNS — a silent default, not an opt-in (the #998 mis-tiering
+// landmine: review/profile-completeness.json was committed as `git` only because
+// it was absent from both lists, which broke the reproducibility gate). That was
+// only ever caught reactively. This test makes it deterministic: every
+// PUBLIC_ARTIFACTS path must resolve to an EXPLICIT R2-only or dual pattern, so a
+// new artifact that falls through to the default-git fallback fails here at PR
+// time instead of in a production refresh.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { PUBLIC_ARTIFACTS } from "../src/contracts.mjs";
+import {
+  DUAL_PATTERNS,
+  R2_ONLY_PATTERNS,
+  artifactRelativePath,
+} from "../src/artifact-storage.mjs";
+
+// Concrete sample values for the path-template tokens, mirroring
+// scripts/smoke-live-api.mjs so a templated path resolves to a real-shaped
+// relative path before pattern matching (the patterns also accept the literal
+// `{token}` form, but substituting proves a *concrete* request path tiers
+// explicitly too).
+const TOKEN_SAMPLES = {
+  "{netuid}": "7",
+  "{slug}": "allways",
+  "{date}": "2026-06-24",
+  "{surface_id}": "allways-rest-api",
+  "{uid}": "0",
+  "{ss58}": "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM",
+  "{ref}": "0",
+  "{hash}": `0x${"0".repeat(64)}`,
+};
+
+function substituteTemplate(path) {
+  let resolved = path;
+  for (const [token, sample] of Object.entries(TOKEN_SAMPLES)) {
+    resolved = resolved.split(token).join(sample);
+  }
+  return resolved;
+}
+
+function matchesExplicitTier(relativePath) {
+  return (
+    R2_ONLY_PATTERNS.some((pattern) => pattern.test(relativePath)) ||
+    DUAL_PATTERNS.some((pattern) => pattern.test(relativePath))
+  );
+}
+
+describe("PUBLIC_ARTIFACTS storage tiering is explicit", () => {
+  test("every artifact path matches an explicit R2-only or dual pattern", () => {
+    const fellThroughToGit = [];
+    for (const entry of PUBLIC_ARTIFACTS) {
+      const relativePath = artifactRelativePath(substituteTemplate(entry.path));
+      if (!matchesExplicitTier(relativePath)) {
+        fellThroughToGit.push(`${entry.id} (${entry.path})`);
+      }
+    }
+    assert.equal(
+      fellThroughToGit.length,
+      0,
+      `These PUBLIC_ARTIFACTS paths match NO explicit R2_ONLY_PATTERNS or ` +
+        `DUAL_PATTERNS entry and only resolve to the default-git fallback in ` +
+        `src/artifact-storage.mjs — add an explicit pattern (the #998 ` +
+        `mis-tiering landmine):\n  ${fellThroughToGit.join("\n  ")}`,
+    );
+  });
+
+  // Sanity-check the assertion DIRECTION: a path that matches neither pattern
+  // list (the default-git fallback) must be reported, so a real fall-through is
+  // never a false pass.
+  test("a path outside both pattern lists is detected as default-git", () => {
+    assert.equal(
+      matchesExplicitTier(
+        artifactRelativePath("/metagraph/not-a-real-artifact.json"),
+      ),
+      false,
+    );
+  });
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -31,6 +31,14 @@ export default defineConfig({
       // lcov for the Codecov upload (codecov/codecov-action reads
       // coverage/lcov.info); json-summary/text for local + CI readouts.
       reporter: ["text", "json-summary", "lcov"],
+      // Only the in-process scripts are listed. The heavily-exercised build
+      // scripts (scripts/build-artifacts.mjs and its siblings) are intentionally
+      // coverage-invisible: the artifact-build tests run them via execFileSync as
+      // a child process, so the in-process V8 collector never sees those lines.
+      // Adding them to `include` would report a misleading ~0% and risk tripping
+      // the floors below. If their coverage is ever wanted, add targeted unit
+      // tests of their pure helpers (imported in-process) rather than the
+      // execFileSync entrypoint.
       include: [
         "src/**/*.mjs",
         "workers/**/*.mjs",


### PR DESCRIPTION
## Summary

`artifactStorageTier*()` in `src/artifact-storage.mjs` returns the `git` tier for **any** path that matches neither `R2_ONLY_PATTERNS` nor `DUAL_PATTERNS` — a silent default, not an opt-in. That is the #998 mis-tiering landmine (e.g. `review/profile-completeness.json` was committed as `git` only because it was absent from both lists, breaking the reproducibility gate), and it was only ever caught reactively in a production refresh.

This makes it deterministic:

- Export `R2_ONLY_PATTERNS` + `DUAL_PATTERNS` from `src/artifact-storage.mjs`.
- Add `tests/artifact-tiering-explicit.test.mjs`: it imports `PUBLIC_ARTIFACTS`, substitutes sample concrete values for the path-template tokens (mirroring `scripts/smoke-live-api.mjs`), and asserts every artifact path matches an **explicit** R2-only or dual pattern — failing with the offending path(s) if any only resolves via the default-git fallback. A direction-check test confirms a path outside both lists is correctly reported as default-git.

For the build-artifacts coverage gap, `build-artifacts.mjs` is **not** added to `coverage.include` — the artifact-build tests run it via `execFileSync` as a child process, so the in-process V8 collector never sees those lines; including it would report a misleading ~0% and risk tripping the coverage floors. Instead the `vitest.config.mjs` coverage comment is extended to document this explicitly, with a note to add targeted unit tests of its pure helpers if coverage is ever wanted.

No generated artifacts change (the patterns were already used internally; only their `export` visibility changed).

## Validation checklist

- `npx vitest run tests/artifact-tiering-explicit.test.mjs` — 2 passed
- `npx vitest run tests/artifact-storage-paths.test.mjs tests/storage-read-artifact.test.mjs tests/invariants-contracts.test.mjs` — 28 passed (no regression from the new exports)
- Direction sanity-checked: removing an explicit pattern makes the corresponding `PUBLIC_ARTIFACTS` path no longer match, i.e. the assertion would fail on a real fall-through
- `npx prettier --check` on all changed files — clean
- `npx eslint` on all changed files — clean

Closes #1768