### PR TITLE
fix(api): await envelopeResponse so the per-response D1-fallback cache guard works

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, test } from "vitest";
 import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
@@ -365,6 +367,71 @@ describe("analytics edge cache", () => {
       "a D1 fallback response must not poison the edge cache",
     );
     assert.equal(cache.store.size, 0);
+  });
+
+  // Regression for #1760: the four D1-backed analytics handlers tag a degraded
+  // response into the D1_FALLBACK_RESPONSES WeakSet so withEdgeCache can refuse to
+  // cache it (the per-response cold-D1 poison guard). That guard is only reachable
+  // if `envelopeResponse` — which is async — is AWAITED at the tag site: a missing
+  // await tags the *Promise*, and withEdgeCache checks the awaited Response, which
+  // never matches, leaving the per-response guard inert (masked only by the coarser
+  // module-level generation counter). Pin the awaits in the source so a regression
+  // is caught even where the two guards happen to coincide in the harness.
+  test("REGRESSION #1760: every analytics handler awaits envelopeResponse at its fallback-tag site", () => {
+    const source = readFileSync(
+      fileURLToPath(new URL("../workers/api.mjs", import.meta.url)),
+      "utf8",
+    );
+    // The bare `const response = envelopeResponse(` form is the bug: the response
+    // is a Promise the WeakSet can never match. Only the awaited form is allowed
+    // anywhere a response is bound for tagging.
+    assert.equal(
+      /const response = envelopeResponse\(/.test(source),
+      false,
+      "an un-awaited `const response = envelopeResponse(...)` cannot be tagged into the D1-fallback WeakSet",
+    );
+    // The four analytics handlers each tag their degraded response. Each
+    // `markD1FallbackResponse(response)` must operate on a real (awaited) Response.
+    assert.equal(
+      (source.match(/\? markD1FallbackResponse\(response\)/g) || []).length,
+      4,
+      "all four analytics handlers tag their fallback response",
+    );
+  });
+
+  // Exercises the WeakSet tag path end-to-end across all four handlers: each is
+  // forced into a D1 fallback and the degraded response must not be cached. Because
+  // the response is now the awaited Response (not a Promise), markD1FallbackResponse
+  // tags the object withEdgeCache actually inspects.
+  test("REGRESSION #1760: a degraded D1 response is refused by the edge cache across all four handlers", async () => {
+    originalCaches = globalThis.caches;
+    const routes = [
+      "https://api.metagraph.sh/api/v1/health/trends",
+      "https://api.metagraph.sh/api/v1/subnets/7/health/trends",
+      "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles?window=7d",
+      "https://api.metagraph.sh/api/v1/subnets/7/health/incidents?window=7d",
+    ];
+    for (const url of routes) {
+      const cache = mockCaches();
+      cache.install();
+      const queries = [];
+      const env = analyticsEnv(queries, {
+        d1Error: new Error("D1 unavailable"),
+      });
+      const res = await handleRequest(new Request(url), env, ctx);
+      await Promise.resolve();
+      assert.equal(
+        res.status,
+        200,
+        `${url}: degraded fallback still serves 200`,
+      );
+      assert.deepEqual(
+        cache.putKeys,
+        [],
+        `${url}: a D1 fallback response must not poison the edge cache`,
+      );
+      assert.equal(cache.store.size, 0, `${url}: nothing cached`);
+    }
   });
 
   test("transparency: the cached body equals the uncached body for the same handler", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -2552,7 +2552,7 @@ async function handleBulkHealthTrends(
       windows,
       windowDays: HEALTH_TREND_WINDOWS,
     });
-    const response = envelopeResponse(
+    const response = await envelopeResponse(
       request,
       {
         data,
@@ -2626,7 +2626,7 @@ async function handleHealthTrends(request, env, netuid, url, ctx = {}) {
       observedAt: meta?.last_run_at || null,
       windows,
     });
-    const response = envelopeResponse(
+    const response = await envelopeResponse(
       request,
       {
         data,
@@ -2838,7 +2838,7 @@ async function handleHealthPercentiles(request, env, netuid, url, ctx = {}) {
       observedAt: meta?.last_run_at || null,
       rows,
     });
-    const response = envelopeResponse(
+    const response = await envelopeResponse(
       request,
       {
         data,
@@ -2927,7 +2927,7 @@ async function handleHealthIncidents(request, env, netuid, url, ctx = {}) {
       incidentRows,
       maxIncidents: MAX_INCIDENT_ROWS,
     });
-    const response = envelopeResponse(
+    const response = await envelopeResponse(
       request,
       {
         data,


### PR DESCRIPTION
## Summary

`envelopeResponse()` is async (`workers/responses.mjs:67`), but four D1-backed analytics handlers bound its result **without `await`** and passed the resulting Promise to `markD1FallbackResponse()`:

- `handleBulkHealthTrends` (`workers/api.mjs`)
- `handleHealthTrends`
- `handleHealthPercentiles`
- `handleHealthIncidents`

That tagged a **Promise** into the `D1_FALLBACK_RESPONSES` WeakSet, while `withEdgeCache` inspects the **awaited Response** (`!D1_FALLBACK_RESPONSES.has(response)`). The two never match, so the per-response cold-D1 cache-poison guard was inert — a degraded/empty D1 fallback could be seeded at the edge. It was masked today only by the coarser module-level generation counter (`d1FallbackGeneration`), which happens to trip on the same D1 failure.

## Fix

Add `await` to the `envelopeResponse(...)` call at all four fallback-tag sites so `markD1FallbackResponse()` tags the real `Response` the cache actually checks. The `return hasD1FallbackRows(...) ? markD1FallbackResponse(response) : response` lines are unchanged and now operate on the awaited Response. Each enclosing function was already `async` (they're awaited via `withEdgeCache`'s `buildResponse()`).

## Test

Added two regression tests to `tests/analytics-edge-cache.test.mjs`:
1. A source assertion pinning the awaits — no bare `const response = envelopeResponse(` form, and all four `markD1FallbackResponse(response)` tag sites present. Verified it fails if any `await` is removed.
2. An end-to-end check that a forced D1 fallback is refused by the edge cache across all four handlers.

Note: isolating the WeakSet path from the module-level generation counter purely through the `handleRequest` interface is infeasible — `markD1FallbackRows` (which bumps the counter) and the row tagging always coincide within one request. The source assertion is therefore what pins the per-response guard's correctness.

## Validation checklist

- `npx vitest run tests/analytics-edge-cache.test.mjs tests/analytics.test.mjs` — 59 passed
- `npx prettier --check workers/api.mjs tests/analytics-edge-cache.test.mjs` — clean
- `npx eslint workers/api.mjs tests/analytics-edge-cache.test.mjs` — clean
- Regression test verified to fail when an `await` is reverted, pass when restored

Closes #1760