### PR TITLE
ci(worker): add a PR-time worker bundle-size budget gate

### DIFF
--- a/.claude/skills/contributing-to-metagraphed/reference.md
+++ b/.claude/skills/contributing-to-metagraphed/reference.md
@@ -76,8 +76,9 @@ under `public/` after a fresh build — only CONTRACT artifacts are gated; DATA 
 out-of-band by `readme-catalog-refresh.yml`) · `validate` · `validate:schemas` · `validate:api` ·
 `validate:mcp` · `validate:ai` · `validate:openapi` · `validate:types` · `validate:artifact-budgets` ·
 `validate:docs` · `validate:intake` · `validate:surface` · `validate:workflows` ·
-`cloudflare:verify:dry-run` · r2/kv dry-runs · `worker:deploy:dry-run` · `scan:public-safety` ·
-`validate:private-boundary`.
+`cloudflare:verify:dry-run` · r2/kv dry-runs · `worker:deploy:dry-run` · `worker:bundle:budget`
+(gzip-measures the `wrangler deploy --dry-run` Worker bundle against a budget so an over-1MiB bundle
+fails at PR time, not at the Cloudflare deploy) · `scan:public-safety` · `validate:private-boundary`.
 
 Codecov is configured in `codecov.yml`; run `npm run test:coverage` unsharded locally (CI shards +
 merges, so a single shard under-reports).

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -253,6 +253,9 @@ jobs:
       - name: Worker deploy dry-run
         run: npm run worker:deploy:dry-run
 
+      - name: Worker bundle-size budget
+        run: npm run worker:bundle:budget
+
       - name: Public-safety scan
         run: npm run scan:public-safety
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "cloudflare:verify:dry-run": "node scripts/cloudflare-verify.mjs",
     "worker:test": "node scripts/worker-test.mjs",
     "worker:deploy:dry-run": "node scripts/worker-deploy-dry-run.mjs",
+    "worker:bundle:budget": "node scripts/worker-bundle-budget.mjs",
     "smoke:live": "node scripts/smoke-live-api.mjs",
     "lint": "eslint .",
     "format:check": "prettier --check .",

--- a/scripts/worker-bundle-budget.mjs
+++ b/scripts/worker-bundle-budget.mjs
@@ -1,0 +1,96 @@
+// PR-time guard on the compiled Worker bundle size. Cloudflare rejects a Worker
+// whose script + bound modules exceed 1 MiB gzipped, but that limit is only
+// enforced at deploy time — i.e. post-merge. This gate reproduces the deploy-side
+// bundling locally via `wrangler deploy --dry-run` (no network/auth required),
+// gzip-measures the produced Worker JS + wasm modules (NOT the ./public assets,
+// which don't count against the Worker script limit), and fails the build if the
+// total crosses the budget. Mirrors the metagraphed-ui ci.yml bundle-budget gate
+// in spirit: a soft warn well below the hard ceiling, a hard fail comfortably
+// under Cloudflare's 1 MiB limit. Both thresholds are tunable via env vars.
+import { spawnSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { gzipSync } from "node:zlib";
+import os from "node:os";
+import path from "node:path";
+import { repoRoot } from "./lib.mjs";
+
+const KIB = 1024;
+
+// Cloudflare's hard ceiling is 1 MiB (1024 KiB) gzipped. Warn early, fail before
+// the ceiling so a regression is caught at PR time rather than at deploy.
+const WARN_KIB = Number(process.env.WORKER_BUNDLE_WARN_KIB ?? "920");
+const FAIL_KIB = Number(process.env.WORKER_BUNDLE_FAIL_KIB ?? "980");
+
+if (!Number.isFinite(WARN_KIB) || !Number.isFinite(FAIL_KIB)) {
+  console.error("Invalid WORKER_BUNDLE_WARN_KIB/WORKER_BUNDLE_FAIL_KIB value.");
+  process.exit(1);
+}
+
+const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "worker-bundle-"));
+
+try {
+  const result = spawnSync(
+    "npx",
+    ["wrangler", "deploy", "--dry-run", "--outdir", outDir],
+    { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+
+  if (result.status !== 0) {
+    console.error("wrangler deploy --dry-run failed:");
+    console.error(result.stdout ?? "");
+    console.error(result.stderr ?? "");
+    process.exit(1);
+  }
+
+  // The deployable Worker bundle is the produced JS entry plus any bound wasm
+  // modules. Source maps (.map) and asset metadata (README.md) are not uploaded
+  // to the Worker, so they're excluded from the measurement.
+  const entries = await fs.readdir(outDir);
+  const moduleFiles = entries
+    .filter((name) => name.endsWith(".js") || name.endsWith(".wasm"))
+    .sort();
+
+  if (moduleFiles.length === 0) {
+    console.error(`No Worker modules found in dry-run output (${outDir}).`);
+    process.exit(1);
+  }
+
+  let totalGzip = 0;
+  const rows = [];
+  for (const name of moduleFiles) {
+    const bytes = await fs.readFile(path.join(outDir, name));
+    const gzip = gzipSync(bytes, { level: 9 }).length;
+    totalGzip += gzip;
+    rows.push({ name, gzip });
+  }
+
+  const totalKib = totalGzip / KIB;
+  for (const row of rows) {
+    console.log(`  ${row.name}: ${(row.gzip / KIB).toFixed(1)} KiB gzipped`);
+  }
+  console.log(
+    `Worker bundle: ${totalKib.toFixed(1)} KiB gzipped ` +
+      `(warn ${WARN_KIB} KiB, fail ${FAIL_KIB} KiB, Cloudflare limit 1024 KiB).`,
+  );
+
+  if (totalKib >= FAIL_KIB) {
+    console.error(
+      `Worker bundle ${totalKib.toFixed(1)} KiB exceeds the ${FAIL_KIB} KiB ` +
+        `budget. Trim the Worker entry (workers/api.mjs) or its dependencies ` +
+        `before this reaches Cloudflare's 1024 KiB deploy limit.`,
+    );
+    process.exit(1);
+  }
+
+  if (totalKib >= WARN_KIB) {
+    console.warn(
+      `::warning::Worker bundle ${totalKib.toFixed(1)} KiB is within ` +
+        `${(FAIL_KIB - totalKib).toFixed(1)} KiB of the ${FAIL_KIB} KiB fail ` +
+        `budget. Keep an eye on the Worker bundle size.`,
+    );
+  }
+
+  console.log("Worker bundle budget check passed.");
+} finally {
+  await fs.rm(outDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

There is no CI gate on the compiled Worker bundle size. Cloudflare rejects a Worker whose script + bound modules exceed **1 MiB gzipped**, but that limit is only enforced at deploy time — i.e. post-merge. An over-budget bundle passes all of CI today and would only fail at the Cloudflare deploy.

This adds a PR-time gate:

- **`scripts/worker-bundle-budget.mjs`** reproduces the deploy-side bundling via `wrangler deploy --dry-run --outdir <tmp>` (no network/auth required), gzip-measures the produced Worker JS + wasm modules (excluding `./public` assets, which don't count against the Worker script limit), and asserts the total against a budget.
- Budget: **warn 920 KiB, fail 980 KiB** — comfortably under Cloudflare's 1024 KiB ceiling, and above the current bundle. Both tunable via `WORKER_BUNDLE_WARN_KIB` / `WORKER_BUNDLE_FAIL_KIB`.
- Exposed as `npm run worker:bundle:budget` and wired into `.github/workflows/validate.yml` right after the existing `worker:deploy:dry-run` step.
- Skill reference (`reference.md`) validator list updated.

The current Worker bundle measures **881.2 KiB gzipped** (resvg wasm 517.1 + api.js 336.5 + yoga wasm 27.6) — the OG-image resvg wasm is the dominant cost, which is exactly the kind of thing this gate now guards against drifting past 1 MiB.

## Validation

Exact commands run locally (Node, no network/auth):

```
npx wrangler deploy --dry-run --outdir /tmp/wbundle   # exits 0, no auth needed
npm run worker:bundle:budget                          # -> 881.2 KiB gzipped, "passed", exit 0
WORKER_BUNDLE_FAIL_KIB=800 npm run worker:bundle:budget  # -> exit 1 (fail path verified)
WORKER_BUNDLE_WARN_KIB=850 npm run worker:bundle:budget  # -> ::warning:: annotation (warn path verified)
npx prettier --check scripts/worker-bundle-budget.mjs package.json .github/workflows/validate.yml .claude/skills/contributing-to-metagraphed/reference.md  # all pass
npx eslint scripts/worker-bundle-budget.mjs           # exit 0
```

The gate is deterministic (gzip level 9 of a fixed dry-run bundle) and runs without network or auth.

Closes #1765
