### PR TITLE
perf(api): tighten edge-cache keying, cache aggregating entity handlers, and harden the cron/limits

### DIFF
--- a/src/icon-proxy.mjs
+++ b/src/icon-proxy.mjs
@@ -92,16 +92,22 @@ function collectHosts(value, hosts = new Set()) {
   return hosts;
 }
 
-const allowlistMemo = new WeakMap();
+// In-isolate memo of the derived host allowlist, TTL'd so a newly published
+// provider/subnet host becomes allowed within one interval instead of staying
+// rejected until the isolate recycles. Same {env, value, expiresAt} pattern as
+// the Worker's readHealthMetaKv (#1375); the previous WeakMap had no expiry.
+const ICON_ALLOWLIST_TTL_MS = 300_000; // 5 min
+let allowlistMemo = { env: null, value: null, expiresAt: 0 };
 
-async function iconHostAllowlist(env, options = {}) {
+async function iconHostAllowlist(env, options = {}, now = Date.now()) {
   const configured = String(env?.METAGRAPH_ICON_ALLOWED_HOSTS || "")
     .split(",")
     .map(normalizeHost)
     .filter(Boolean);
   if (!options.readArtifact) return new Set(configured);
-  const cached = allowlistMemo.get(env);
-  if (cached) return cached;
+  if (allowlistMemo.env === env && now < allowlistMemo.expiresAt) {
+    return allowlistMemo.value;
+  }
   const hosts = new Set(configured);
   for (const path of [
     "/metagraph/subnets.json",
@@ -115,7 +121,7 @@ async function iconHostAllowlist(env, options = {}) {
       // Missing artifacts fail closed except for explicit configured hosts.
     }
   }
-  allowlistMemo.set(env, hosts);
+  allowlistMemo = { env, value: hosts, expiresAt: now + ICON_ALLOWLIST_TTL_MS };
   return hosts;
 }
 

--- a/tests/serving-optimizations-edge.test.mjs
+++ b/tests/serving-optimizations-edge.test.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "vitest";
+import { handleRequest, handleScheduled } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+// Coverage for the serving-optimizations PR (#1764): the canonical cache-search
+// now folds a collection's range/csv/array filter params into the static edge
+// cache key, and the hourly maintenance cron .catch-isolates pruneHealthHistory
+// like its sibling prunes. These tests execute exactly those new paths through
+// the public worker surface — the cache-key build for a range-filtered
+// collection, and the prune rejection isolation — without asserting any new
+// behaviour beyond what the handlers already guarantee.
+
+// A minimal stand-in for the Workers `caches.default`: a Map keyed on the
+// request URL (mirrors the edge-cache stub in worker-runtime.test.mjs). The
+// static edge cache calls canonicalCacheSearch to build its key, which is where
+// the new range/csv/array filter folding for the `subnets` collection runs.
+function installMockCaches() {
+  const store = new Map();
+  const putKeys = [];
+  globalThis.caches = {
+    default: {
+      async match(request) {
+        const cached = store.get(request.url);
+        return cached ? cached.clone() : undefined;
+      },
+      async put(request, response) {
+        putKeys.push(request.url);
+        store.set(request.url, response.clone());
+      },
+    },
+  };
+  return { store, putKeys };
+}
+
+const ctx = { waitUntil: (promise) => promise };
+
+let originalCaches;
+afterEach(() => {
+  globalThis.caches = originalCaches;
+});
+
+describe("static edge cache — range-filtered collection key", () => {
+  test("a GET on the range-filtered `subnets` collection folds its filter params into the cache key", async () => {
+    originalCaches = globalThis.caches;
+    const cache = installMockCaches();
+    const env = createLocalArtifactEnv();
+
+    // /api/v1/subnets is static-edge-eligible AND backed by the `subnets` query
+    // collection, whose range_filters (block, tempo, …) drive canonicalCacheSearch
+    // to enumerate `min_<field>`/`max_<field>` params, plus its csv_filters
+    // (netuids) — all of which the new fold must add to the key.
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets?min_tempo=1&max_tempo=99&netuids=7",
+      ),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(res.status, 200);
+
+    // The body was cached under a single static-edge key (the range/csv/array
+    // params were enumerated without throwing — the new fold ran).
+    assert.equal(cache.putKeys.length, 1);
+    const key = cache.putKeys[0];
+    assert.ok(
+      key.includes("min_tempo=1"),
+      "range filter min_<field> folded into the key",
+    );
+    assert.ok(
+      key.includes("max_tempo=99"),
+      "range filter max_<field> folded into the key",
+    );
+  });
+
+  test("an unfiltered GET on the same collection still caches (the fold tolerates absent params)", async () => {
+    originalCaches = globalThis.caches;
+    const cache = installMockCaches();
+    const env = createLocalArtifactEnv();
+
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/subnets"),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(res.status, 200);
+    assert.equal(cache.putKeys.length, 1);
+  });
+});
+
+describe("hourly maintenance cron — pruneHealthHistory isolation", () => {
+  test("a rejecting pruneHealthHistory degrades to a no-op without aborting the cron", async () => {
+    originalCaches = globalThis.caches;
+
+    // A D1 stub whose statements resolve, so the two daily rollups confirm
+    // (rolled: true) and the cron reaches the prune fan-out.
+    const goodStmt = {
+      bind: () => ({ run: () => Promise.resolve({ meta: { changes: 0 } }) }),
+    };
+    const goodDb = {
+      prepare: () => goodStmt,
+      batch: () => Promise.resolve([]),
+    };
+    // A D1 stub whose `prepare` ACCESS throws (a throwing getter). That is the
+    // one way pruneHealthHistory can reject: its `if (!db?.prepare)` guard reads
+    // the property before the try block, so the throw escapes as a rejection
+    // (every actual DB call inside the try is already caught and folded to
+    // { pruned: false }). This proves the new `.catch(() => ({ pruned: false }))`
+    // isolation around it actually fires.
+    const throwingDb = {
+      get prepare() {
+        throw new Error("transient D1 error");
+      },
+      batch: () => Promise.resolve([]),
+    };
+
+    // handleScheduled reads env.METAGRAPH_HEALTH_DB once per consumer, in order:
+    // rollupDailyUptime (1), rollupAccountEventsDaily (2), writeSubnetSnapshot (3),
+    // then pruneHealthHistory (4) — the first member of the prune Promise.all.
+    // Hand pruneHealthHistory the throwing DB so it rejects; everyone before it
+    // gets the working DB so the rollups confirm and the prune fan-out is reached.
+    let dbReads = 0;
+    const env = {
+      get METAGRAPH_HEALTH_DB() {
+        dbReads += 1;
+        return dbReads === 4 ? throwingDb : goodDb;
+      },
+    };
+
+    const result = await handleScheduled({ cron: "0 * * * *" }, env, ctx);
+
+    // The rejection was isolated to a no-op for this tick (not propagated out of
+    // the Promise.all): the cron returns the .catch fallback, not a throw.
+    assert.deepEqual(result, { pruned: false });
+    assert.ok(dbReads >= 4, "the prune fan-out was reached");
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -264,13 +264,31 @@ function isStaticEdgeCacheEligible(matched, network) {
 // per-subnet `subnet-endpoints` variant is small and intentionally excluded.
 const CACHEABLE_OVERLAY_ROUTE_IDS = new Set(["endpoints"]);
 
-function canonicalOverlayCacheSearch(url, matched) {
+// Reduce a request's query string to its canonical, cache-relevant form: keep
+// only the params that actually steer the response body (the collection's
+// filters / search / sort / pagination / projection), single-valued, and emit
+// them in a deterministic order. URLSearchParams.set sorts nothing, but the
+// fixed iteration order below makes `?b=2&a=1` and `?a=1&b=2&unused=x` collapse
+// to the same key — so param order and ignored params stop fragmenting the
+// cache. Routes with no query collection (pure static artifacts) honour no
+// params at all, so their canonical search is the empty string. Shared by both
+// the static edge cache and the live-overlay collection cache.
+function canonicalCacheSearch(url, matched) {
   const config = API_QUERY_COLLECTIONS[matched.queryCollection];
   if (!config) return "";
   const filterNames =
     matched.queryFilterNames?.length > 0
       ? matched.queryFilterNames
       : Object.keys(config.filters);
+  // Range filters expose `min_<field>`/`max_<field>` params; csv/array filters
+  // expose their own param names. All of these change the filtered body, so they
+  // must be part of the cache key (omitting them would collide distinct queries).
+  const rangeNames = (config.range_filters || []).flatMap((field) => [
+    `min_${field}`,
+    `max_${field}`,
+  ]);
+  const csvNames = Object.keys(config.csv_filters || {});
+  const arrayNames = Object.keys(config.array_filters || {});
   const cacheableNames = [
     "q",
     "fields",
@@ -279,6 +297,9 @@ function canonicalOverlayCacheSearch(url, matched) {
     "sort",
     "order",
     ...filterNames,
+    ...csvNames,
+    ...arrayNames,
+    ...rangeNames,
   ];
   const canonicalUrl = new URL("https://edge-cache.metagraph.sh/");
   for (const name of cacheableNames) {
@@ -1236,7 +1257,10 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
       };
     }
     const [pruned] = await Promise.all([
-      pruneHealthHistory(env),
+      // .catch-isolated like every sibling prune below — a rejection here (e.g. a
+      // transient D1 error) must degrade to a no-op for this tick, not abort the
+      // whole Promise.all and discard the snapshot write + the other prunes.
+      pruneHealthHistory(env).catch(() => ({ pruned: false })),
       pruneAccountEvents(env).catch(() => ({ pruned: false })),
       // Block-explorer hot window (#1345): prune `blocks` past the 90d retention
       // on the same hourly maintenance cron. No rollup (the block hot window has
@@ -1580,22 +1604,32 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       resolved.url.pathname,
     );
     if (subnetHistoryMatch) {
-      return handleSubnetHistory(
-        request,
-        env,
-        Number(subnetHistoryMatch[1]),
-        resolved.url,
+      // GROUP BY daily aggregation, deterministic per cron snapshot — edge-cache
+      // on last_run_at like the sibling analytics routes (pathname carries the
+      // netuid, search carries ?window). Cheap single-row lookups stay uncached.
+      return withEdgeCache(request, ctx, env, "subnet-history", () =>
+        handleSubnetHistory(
+          request,
+          env,
+          Number(subnetHistoryMatch[1]),
+          resolved.url,
+        ),
       );
     }
     const metagraphMatch = SUBNET_METAGRAPH_PATH_PATTERN.exec(
       resolved.url.pathname,
     );
     if (metagraphMatch) {
-      return handleSubnetMetagraph(
-        request,
-        env,
-        Number(metagraphMatch[1]),
-        resolved.url,
+      // Full per-subnet metagraph (range read over the neurons tier), deterministic
+      // per cron snapshot — edge-cache on last_run_at; ?validator_permit rides the
+      // search into the key.
+      return withEdgeCache(request, ctx, env, "subnet-metagraph", () =>
+        handleSubnetMetagraph(
+          request,
+          env,
+          Number(metagraphMatch[1]),
+          resolved.url,
+        ),
       );
     }
     const neuronMatch = SUBNET_NEURON_PATH_PATTERN.exec(resolved.url.pathname);
@@ -1611,11 +1645,15 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       resolved.url.pathname,
     );
     if (validatorsMatch) {
-      return handleSubnetValidators(
-        request,
-        env,
-        Number(validatorsMatch[1]),
-        resolved.url,
+      // Validator slice of the metagraph (filtered range read), deterministic per
+      // cron snapshot — edge-cache on last_run_at like the sibling routes.
+      return withEdgeCache(request, ctx, env, "subnet-validators", () =>
+        handleSubnetValidators(
+          request,
+          env,
+          Number(validatorsMatch[1]),
+          resolved.url,
+        ),
       );
     }
     // Account entity routes (#1347): computed live from the account_events +
@@ -2256,7 +2294,7 @@ async function handleApiRequest(
     ? new Request(
         `https://edge-cache.metagraph.sh/${network.id}/${encodeURIComponent(
           contractVersion(env),
-        )}${url.pathname}${url.search}`,
+        )}${url.pathname}${canonicalCacheSearch(url, matched)}`,
       )
     : null;
   // Live-overlay collection cache (the large /api/v1/endpoints index). Excluded
@@ -2280,7 +2318,7 @@ async function handleApiRequest(
       overlayCacheKey = new Request(
         `https://edge-cache.metagraph.sh/overlay/${network.id}/${encodeURIComponent(
           contractVersion(env),
-        )}/${encodeURIComponent(lastRunAt)}${url.pathname}${canonicalOverlayCacheSearch(url, matched)}`,
+        )}/${encodeURIComponent(lastRunAt)}${url.pathname}${canonicalCacheSearch(url, matched)}`,
       );
       const overlayHit = await overlayCache.match(overlayCacheKey);
       if (overlayHit) {
@@ -2949,6 +2987,16 @@ async function handleHealthIncidents(request, env, netuid, url, ctx = {}) {
 // per-subnet route but with no netuid filter, grouped by (netuid, surface_id)
 // and capped. Powers a public status page's "recent incidents" feed. Returns a
 // schema-stable empty payload when D1 is unbound/cold.
+//
+// APPROXIMATE NEAR THE SOURCE-ROW CAP: the inner `recent_checks` CTE truncates
+// to the newest MAX_GLOBAL_INCIDENT_SOURCE_ROWS checks before the gap-island
+// pass runs. An incident whose probe samples straddle that boundary is seen only
+// partially, so its started_at / failed_samples can be clipped (or the incident
+// dropped entirely if too few of its samples survive the LIMIT). This is a
+// best-effort recent-incidents feed for a status page, not an exact audit ledger
+// — the per-subnet /incidents route (no global cap) is the authoritative source
+// for a single subnet. Widening this to an exact bound would mean aggregating
+// from surface_uptime_daily (out of scope here).
 async function handleGlobalIncidents(request, env, url) {
   const { label, days, error } = analyticsWindow(url);
   if (error) {
@@ -2958,6 +3006,9 @@ async function handleGlobalIncidents(request, env, url) {
   const incidentRows = await d1All(
     env,
     `WITH recent_checks AS (
+       -- Source-row cap (LIMIT ?): bounds the gap-island scan, but an incident
+       -- straddling this newest-N boundary is only partially counted (see the
+       -- handler doc-note above — this feed is approximate near the cap).
        SELECT netuid, COALESCE(surface_key, surface_id) AS surface_key, surface_id, checked_at, ok
        FROM surface_checks
        WHERE checked_at >= ?
@@ -4036,7 +4087,7 @@ async function verifyMeta(env) {
 // confirm "callable right now" before wiring.
 async function handleSurfaceVerify(request, env, surfaceId, ctx = {}) {
   if (env.RPC_RATE_LIMITER?.limit) {
-    const clientKey = resolveClientIp(request);
+    const clientKey = `verify:${resolveClientIp(request)}`;
     const { success } = await env.RPC_RATE_LIMITER.limit({ key: clientKey });
     if (!success) {
       return errorResponse(
@@ -4145,7 +4196,7 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
   // (local dev / not yet provisioned) so tests and local runs are unaffected;
   // enforced on Cloudflare where the binding is bound.
   if (env.RPC_RATE_LIMITER?.limit) {
-    const clientKey = resolveClientIp(request);
+    const clientKey = `rpc:${resolveClientIp(request)}`;
     const { success } = await env.RPC_RATE_LIMITER.limit({ key: clientKey });
     if (!success) {
       return errorResponse(
@@ -4575,13 +4626,16 @@ function setRpcRateLimitHeaders(headers) {
 // the edge can cache — every call hits the worker and fans out into one or more
 // artifact reads + query execution. That makes it at least as expensive as the
 // RPC proxy, so it shares the SAME strict limiter binding, bucket strategy
-// (cf-connecting-ip only; see resolveClientIp), policy, and 429 shape. Skipped
-// only when the binding is absent (local dev / CI), matching the RPC/MCP paths.
-// Returns a 429 Response when the caller is over the limit, else null.
+// (cf-connecting-ip only; see resolveClientIp), policy, and 429 shape. The key is
+// namespaced (`gql:`) so each surface draws its own independent 100/60s budget —
+// matching the per-surface x-ratelimit headers each one advertises, instead of a
+// caller's RPC traffic silently consuming the GraphQL budget (or vice versa).
+// Skipped only when the binding is absent (local dev / CI), matching the RPC/MCP
+// paths. Returns a 429 Response when the caller is over the limit, else null.
 async function graphqlRateLimited(request, env) {
   if (!env.RPC_RATE_LIMITER?.limit) return null;
   const { success } = await env.RPC_RATE_LIMITER.limit({
-    key: resolveClientIp(request),
+    key: `gql:${resolveClientIp(request)}`,
   });
   if (success) return null;
   return errorResponse(


### PR DESCRIPTION
Six small, independent serving optimizations from the 2026-06-25 audit (#1755). Behavior-preserving except where noted; no contract/schema change (no build artifacts touched).

### Changes
1. **Static edge-cache key canonicalization** — the static-artifact edge cache keyed on raw `url.search`, so param order / ignored params fragmented the cache. It now uses the same canonicalization the overlay cache used (allowlist + sort + single-value). `canonicalOverlayCacheSearch` is generalized to `canonicalCacheSearch` and shared by both caches. The generalization additionally folds in `csv_filters` / `array_filters` / `min_<f>`/`max_<f>` range param names (the `/api/v1/subnets` index uses all three) so distinct filtered queries can't collide on one key.
2. **Cache the aggregating per-subnet entity handlers** — `handleSubnetHistory`, `handleSubnetMetagraph`, `handleSubnetValidators` run GROUP BY / range aggregations but were dispatched bare. Each is now wrapped in `withEdgeCache` keyed on `last_run_at`, matching the sibling analytics routes (`ctx` threaded through dispatch; pathname carries the netuid, search carries `?window`/`?validator_permit`). Cheap single-row lookups (block/account/extrinsic/neuron) stay uncached. The existing `d1FallbackGeneration` guard in `withEdgeCache` prevents caching a cold/errored D1 read.
3. **Namespace the rate-limit key per endpoint** — RPC proxy, GraphQL, and surface-verify all called `RPC_RATE_LIMITER.limit({key: clientIp})`, sharing one per-IP budget while advertising independent 100/60s headers. The key is now prefixed `rpc:` / `gql:` / `verify:` so each surface draws its own budget matching its headers.
4. **TTL the icon-host allowlist memo** — `src/icon-proxy.mjs` memoized the derived allowlist per-env with no expiry (a new provider/subnet host was rejected until isolate recycle). Replaced the `WeakMap` with the 5-min `{env, value, expiresAt}` TTL pattern used by `readHealthMetaKv`.
5. **`.catch`-isolate the cron `pruneHealthHistory`** — it was the only prune in the maintenance `Promise.all` not `.catch`-isolated, so a rejection aborted the whole tick (discarding the snapshot write + sibling prunes). Now `.catch(() => ({ pruned: false }))` like every sibling, matching the documented isolation invariant.
6. **Global-incidents source-row cap** — `handleGlobalIncidents` gap-islands over a `LIMIT`-truncated set, so an incident straddling the cap is split/miscounted. Documented as approximate near the cap (handler doc-note + inline SQL note); the per-subnet `/incidents` route remains authoritative. Aggregating from `surface_uptime_daily` was out of scope.

## Validation
Ran `npm run build` first (reader tests serve R2-only artifacts), then:

```
npx vitest run tests/analytics-edge-cache.test.mjs tests/analytics.test.mjs \
  tests/api-coverage.test.mjs tests/icon-proxy.test.mjs tests/health-prober.test.mjs \
  tests/metagraph-fetch.test.mjs tests/metagraph-neurons.test.mjs tests/graphql.test.mjs \
  tests/batch-ratelimit.test.mjs tests/rpc-cache.test.mjs tests/neuron-history.test.mjs
# 11 files, 371 tests passed

npx vitest run tests/worker-runtime.test.mjs tests/subnet-overview.test.mjs \
  tests/rpc-failover.test.mjs tests/rpc-usage.test.mjs tests/rpc-network-routing.test.mjs
# 5 files, 87 tests passed

npx prettier --check workers/api.mjs src/icon-proxy.mjs   # clean
npx eslint workers/api.mjs src/icon-proxy.mjs             # clean
```

Closes #1764
