### PR TITLE
feat(events): historical backfill workflow for the block-explorer tiers (#1749)

### DIFF
--- a/.github/workflows/backfill-events.yml
+++ b/.github/workflows/backfill-events.yml
@@ -1,0 +1,108 @@
+name: Backfill Chain Events (historical range)
+
+# One-shot historical backfill (#1749, ADR 0012) for the block-explorer tiers.
+# Scans an explicit [from, to] block range from a WS ARCHIVE (the live streamer +
+# poller only cover recent blocks; older gaps are pruned from public RPC), decodes
+# blocks/extrinsics/account_events with the SAME verified decode as the live poller,
+# and stages them to R2 — the Worker's */3 fast-load cron drains them into D1 via
+# loadStaged* (INSERT OR IGNORE on the PKs → idempotent, so re-running a range or
+# overlapping the live poller is free).
+#
+# Manual only. Size each [from, to] to finish inside the timeout (~1500 blocks is a
+# safe chunk); space chunks ~5 min apart so the Worker drains each pending object
+# before the next overwrites it, then confirm with a D1 gap query and re-run any
+# range that didn't land (idempotent). Defaults to the free OnFinality WS archive;
+# override via the rpc_url input or the SUBTENSOR_RPC_URL secret (e.g. our own node).
+on:
+  workflow_dispatch:
+    inputs:
+      from_block:
+        description: First block to backfill (inclusive)
+        required: true
+      to_block:
+        description: Last block to backfill (inclusive)
+        required: true
+      rpc_url:
+        description: WS archive endpoint (blank → SUBTENSOR_RPC_URL secret, else OnFinality)
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backfill-events
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # No `cache: npm`: this workflow holds Cloudflare secrets, so it must not
+      # consume a shared npm cache another workflow could poison.
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.23.0
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install
+        run: npm ci
+
+      # substrate-interface PINNED to the same verified version as the live poller:
+      # this step runs with Cloudflare secrets in scope, so never auto-pull a future
+      # (possibly compromised) release. Inputs are passed via env (not interpolated
+      # into the run line) to avoid script injection.
+      - name: Backfill the range from the archive
+        run: uv run --with substrate-interface==1.8.1 python scripts/backfill-events.py --from "$FROM_BLOCK" --to "$TO_BLOCK"
+        env:
+          FROM_BLOCK: ${{ inputs.from_block }}
+          TO_BLOCK: ${{ inputs.to_block }}
+          # blank input → the SUBTENSOR_RPC_URL secret → (still blank) the script's
+          # OnFinality default. Set the secret to our own node to backfill from it.
+          SUBTENSOR_RPC_URL: ${{ inputs.rpc_url || secrets.SUBTENSOR_RPC_URL }}
+
+      # Sign + stage all three batches exactly like refresh-events (same HMAC signer,
+      # same R2 token, same pending object names) so the Worker's loadStaged* accepts
+      # and drains them into D1. No cursor advance — backfill does not touch the live
+      # poller's high-water cursor.
+      - name: Sign staged chain-event batch
+        run: node scripts/sign-staged-neurons.mjs dist/account-events.json
+        env:
+          METAGRAPH_STAGING_SIGNING_KEY: ${{ secrets.METAGRAPH_STAGING_SIGNING_KEY }}
+
+      - name: Stage events to R2 for the Worker to load into D1
+        run: npx wrangler r2 object put metagraphed-artifacts/events/account-events-pending.json --file=dist/account-events.json --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Sign staged block batch
+        run: node scripts/sign-staged-neurons.mjs dist/blocks.json
+        env:
+          METAGRAPH_STAGING_SIGNING_KEY: ${{ secrets.METAGRAPH_STAGING_SIGNING_KEY }}
+
+      - name: Stage blocks to R2 for the Worker to load into D1
+        run: npx wrangler r2 object put metagraphed-artifacts/events/blocks-pending.json --file=dist/blocks.json --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Sign staged extrinsic batch
+        run: node scripts/sign-staged-neurons.mjs dist/extrinsics.json
+        env:
+          METAGRAPH_STAGING_SIGNING_KEY: ${{ secrets.METAGRAPH_STAGING_SIGNING_KEY }}
+
+      - name: Stage extrinsics to R2 for the Worker to load into D1
+        run: npx wrangler r2 object put metagraphed-artifacts/events/extrinsics-pending.json --file=dist/extrinsics.json --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/scripts/backfill-events.py
+++ b/scripts/backfill-events.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Historical block-explorer backfill (#1749, ADR 0012) — fills the `blocks` /
+`extrinsics` / `account_events` D1 tiers for a PAST block range from a WS ARCHIVE.
+
+The live streamer (#1754) + the CI poller only cover RECENT blocks; older gaps (the
+~58% the coalesced poller left before the streamer fix) are pruned from public RPC
+and can only be recovered from an archive that retains historical state + block
+bodies. This scans an explicit `[--from, --to]` range and writes the SAME staged
+JSON files (account-events / blocks / extrinsics) the refresh-events sign + stage
+steps load into D1 via the Worker's loadStaged* — INSERT OR IGNORE on the PKs, so
+re-running or overlapping a range is free (idempotent).
+
+Reuses the EXACT verified decode from fetch-events.py (block_extras,
+extrinsics_for_block, extract) — no drift. observed_at is anchored on the current
+finalized head's timestamp (finney is exactly 12.0s/block), the same height-derived
+clock the live poller uses, so no per-block Timestamp query is needed.
+
+The public finney RPC prunes ~300 blocks, so point this at an ARCHIVE. The Subway
+proxy `archive.chain.opentensor.ai` serves raw state over HTTP-JSON-RPC but does NOT
+speak substrate-interface's WS protocol — use a real WS archive. OnFinality's free
+public WSS is the default and is already used by the stake/neuron backfills.
+
+Run:  SUBTENSOR_RPC_URL=wss://bittensor-finney.api.onfinality.io/public-ws \
+      uv run --with substrate-interface==1.8.1 \
+      python scripts/backfill-events.py --from 8474393 --to 8475893
+Env:  SUBTENSOR_RPC_URL   WS archive endpoint (default below)
+Output paths reuse fetch-events.py's ACCOUNT_EVENTS_JSON / BLOCKS_JSON / EXTRINSICS_JSON.
+"""
+import argparse
+import importlib.util
+import json
+import os
+import sys
+
+# Reuse fetch-events.py's verified decode (hyphenated → load by path, same as the
+# streamer + the unit tests do).
+_FE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fetch-events.py")
+_spec = importlib.util.spec_from_file_location("fetch_events_backfill", _FE_PATH)
+_fe = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_fe)
+
+# A real WS archive (full historical state + block bodies). NOT the Subway HTTP
+# proxy — that doesn't speak substrate-interface's WS protocol (#1749).
+DEFAULT_ARCHIVE = "wss://bittensor-finney.api.onfinality.io/public-ws"
+
+
+def main():
+    from substrateinterface import SubstrateInterface
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--from", dest="from_block", type=int, required=True)
+    p.add_argument("--to", dest="to_block", type=int, required=True)
+    args = p.parse_args()
+    if args.from_block < 0 or args.to_block < args.from_block:
+        sys.exit("--from must be >= 0 and <= --to")
+
+    url = os.environ.get("SUBTENSOR_RPC_URL") or DEFAULT_ARCHIVE
+    s = SubstrateInterface(url=url)
+    # Anchor observed_at on the current finalized head's timestamp; finney is exactly
+    # 12.0s/block, so height-derivation matches the live poller's clock with no
+    # per-block Timestamp query (one fewer archive round-trip per block).
+    head = s.get_chain_finalised_head()
+    head_bn = s.get_block_header(block_hash=head)["header"]["number"]
+    head_ts = int(s.query("Timestamp", "Now", block_hash=head).value)
+
+    rows, blocks, extrinsics = [], [], []
+    scanned = skipped = 0
+    for bn in range(args.from_block, args.to_block + 1):
+        observed_at = head_ts - (head_bn - bn) * _fe.BLOCK_MS
+        try:
+            bh = s.get_block_hash(bn)
+            events = s.query("System", "Events", block_hash=bh)
+        except Exception as e:  # transient/shape drift → skip this block, keep going
+            skipped += 1
+            sys.stderr.write(f"block {bn}: skip ({repr(e)[:80]})\n")
+            continue
+        scanned += 1
+        extras = _fe.block_extras(s, bn, bh, len(events))
+        if extras is not None:
+            extras["observed_at"] = observed_at
+            blocks.append(extras)
+        for xrow in _fe.extrinsics_for_block(s, bn, bh, events):
+            xrow["observed_at"] = observed_at
+            extrinsics.append(xrow)
+        # account_events rows — mirrors fetch-events.py main()'s row shape (the
+        # decode helper `extract` is reused; only this assembly is repeated).
+        for event_index, ev in enumerate(events):
+            v = ev.value if isinstance(ev.value, dict) else {}
+            e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
+            if e.get("module_id") != "SubtensorModule":
+                continue
+            ent = _fe.extract(e.get("event_id"), e.get("attributes"))
+            if ent is None:
+                continue
+            rows.append(
+                {
+                    "block_number": bn,
+                    "event_index": event_index,
+                    "event_kind": e.get("event_id"),
+                    "hotkey": ent["hotkey"],
+                    "coldkey": ent["coldkey"],
+                    "netuid": ent["netuid"],
+                    "uid": ent["uid"],
+                    "amount_tao": ent["amount_tao"],
+                    "observed_at": observed_at,
+                }
+            )
+
+    for path, data in (
+        (_fe.OUT, rows),
+        (_fe.BLOCKS_OUT, blocks),
+        (_fe.EXTRINSICS_OUT, extrinsics),
+    ):
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(path, "w") as fh:
+            json.dump(data, fh)
+
+    sys.stderr.write(
+        f"backfill {args.from_block}..{args.to_block} via {url}: "
+        f"scanned {scanned}, skipped {skipped} -> {len(rows)} events, "
+        f"{len(blocks)} blocks, {len(extrinsics)} extrinsics\n"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Recovers the pre-existing `blocks`/`extrinsics` gap (the ~58% the coalesced poller left before the streamer fix #1754) from a WS archive — those blocks are pruned from public RPC, so an archive backfill is the only way back. Refs #1345.

**`scripts/backfill-events.py`** — scans an explicit `[--from, --to]` range, **reusing `fetch-events.py`'s verified decode** (`block_extras`, `extrinsics_for_block`, `extract`), and writes the same staged JSON the existing `refresh-events` sign+stage steps load into D1 via the Worker (`loadStaged*`, INSERT OR IGNORE → idempotent, so re-runs/overlaps are free). `observed_at` is height-derived from the current head (finney = exactly 12 s/block).

**`.github/workflows/backfill-events.yml`** — `workflow_dispatch` (from/to/rpc inputs via env to avoid injection), 30-min timeout. Defaults to the free **OnFinality** WS archive — the Subway proxy `archive.chain.opentensor.ai` serves raw HTTP-JSON-RPC but **doesn't speak substrate-interface's WS protocol** (it hung a test run), so a real WS archive is required. Override via the `rpc_url` input or the `SUBTENSOR_RPC_URL` secret (our own node, later). No cursor touch.

**Verification:** AST-parses; `validate-workflows.mjs` → all 17 valid; prettier clean. After merge I'll dispatch a small range against OnFinality and confirm the D1 gap shrinks before running the full backfill.

Usage: chunk (~1500 blocks/run), space ~5 min so the Worker drains each pending object, verify via the D1 gap query, re-run any range that didn't land.