### PR TITLE
fix(ci): keep rpc secrets out of python dependency steps

### DIFF
--- a/.github/workflows/refresh-events.yml
+++ b/.github/workflows/refresh-events.yml
@@ -75,17 +75,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-      # substrate-interface is PINNED to an exact, verified version: this step runs
-      # with Cloudflare secrets in scope, so we never auto-pull a future (possibly
-      # compromised) release from PyPI. Bump deliberately after re-verifying.
+      # substrate-interface is PINNED to an exact, verified version. Keep hidden
+      # RPC endpoints out of this PyPI execution boundary; the poller uses its
+      # public finney default unless a trusted local/manual run sets EVENTS_RPC_URL.
       - name: Poll finney events (first-party, public RPC, no key)
         run: uv run --with substrate-interface==1.8.1 python scripts/fetch-events.py
         env:
-          # Chain RPC endpoint, behind a SECRET so the private archive node's URL is
-          # never exposed in the repo or run logs once we switch to it (ADR 0012 /
-          # #1349). Falls back to the public finney endpoint when the secret is unset,
-          # so swapping = set/clear the one `SUBTENSOR_RPC_URL` secret — no code change.
-          EVENTS_RPC_URL: ${{ secrets.SUBTENSOR_RPC_URL || 'wss://entrypoint-finney.opentensor.ai:443' }}
           # Bounded overlap: ~250 blocks ≈ 50 min of chain is re-scanned every
           # run so staged-but-not-yet-loaded event batches can be regenerated if
           # the single pending R2 object is overwritten before the Worker drains it.
@@ -94,9 +89,7 @@ jobs:
           # a coalescing gap (bounded by EVENTS_MAX_LOOKBACK) and uses it for lag/health.
           EVENTS_CURSOR: ${{ steps.cursor.outputs.block }}
           # Cap on gap recovery (non-sensitive → a VARIABLE, not a secret). Default
-          # 300 = prune horizon, correct for PUBLIC RPC. Once EVENTS_RPC_URL points at
-          # the ARCHIVE node, set the `EVENTS_MAX_LOOKBACK` repo variable high (e.g.
-          # 1000000) so a long scheduler gap is recovered in full.
+          # 300 = prune horizon, correct for the public RPC used by CI.
           EVENTS_MAX_LOOKBACK: ${{ vars.EVENTS_MAX_LOOKBACK || '300' }}
           # Emit a ::warning:: (and webhook alert, if configured) when the cursor
           # falls within a window of the public-RPC prune horizon.

--- a/.github/workflows/refresh-metagraph.yml
+++ b/.github/workflows/refresh-metagraph.yml
@@ -36,14 +36,11 @@ jobs:
       # First-party chain-direct fetch (pinned bittensor, matching sync-subnets):
       # get_all_metagraphs_info for the per-UID core + SubtensorModule.ValidatorTrust
       # storage; rank is derived from incentive. Units parity-verified vs the prior
-      # Taostats source (#1348). No Taostats, no API key.
+      # Taostats source (#1348). No Taostats, no API key. Keep secrets out of this
+      # PyPI execution boundary; pass --network explicitly for trusted local/manual
+      # runs, but CI uses the public finney default.
       - name: Fetch per-UID metagraph (Bittensor SDK)
         run: uvx --from bittensor==10.4.0 python scripts/fetch-metagraph-native.py
-        env:
-          # Same hidden chain-RPC secret as the events poller (ADR 0012 / #1349).
-          # Unset → the script defaults to "finney"; set it to the private node URL
-          # to route the metagraph fetch through our own infra without exposing it.
-          SUBTENSOR_RPC_URL: ${{ secrets.SUBTENSOR_RPC_URL }}
 
       - name: Upload unsigned neuron snapshot
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -63,9 +60,9 @@ jobs:
         with:
           persist-credentials: false
 
-      # Keep the secret-bearing job in a fresh workspace. The unpinned PyPI
-      # execution boundary above can only pass the JSON data artifact forward, not
-      # mutated repository scripts, shell startup files, or node_modules.
+      # Keep the signing secret in a fresh workspace. The PyPI execution boundary
+      # above can only pass the JSON data artifact forward, not mutated repository
+      # scripts, shell startup files, node_modules, or hidden RPC endpoints.
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/scripts/fetch-metagraph-native.py
+++ b/scripts/fetch-metagraph-native.py
@@ -65,12 +65,9 @@ def _at(arr, i):
 
 def main():
     parser = argparse.ArgumentParser()
-    # Default from the SUBTENSOR_RPC_URL env (the hidden chain-RPC secret; ADR 0012)
-    # so the metagraph fetch routes through our own node without exposing its URL;
-    # falls back to "finney" when unset. An explicit --network still overrides.
-    parser.add_argument(
-        "--network", default=os.environ.get("SUBTENSOR_RPC_URL") or "finney"
-    )
+    # CI must not put hidden RPC URLs in this PyPI execution boundary. Trusted
+    # local/manual runs may still choose an alternate endpoint explicitly.
+    parser.add_argument("--network", default="finney")
     args = parser.parse_args()
 
     s = bt.SubtensorApi(network=args.network)


### PR DESCRIPTION
### Motivation
- Scheduled CI steps previously injected `SUBTENSOR_RPC_URL`/`EVENTS_RPC_URL` into steps that run unpinned/pinned PyPI boundaries (`uvx`/`uv run`), which exposes a hidden archive RPC URL to package build/install hooks and third-party runtime code and creates a supply-chain information-leak. 
- The intent of the change is to preserve the original security boundary so only trusted code paths (manual/local runs) may supply private RPC endpoints while CI uses the public `finney` default.

### Description
- Removed the `SUBTENSOR_RPC_URL` environment from the `refresh-metagraph` step that runs `uvx --from bittensor==10.4.0 python scripts/fetch-metagraph-native.py` so the CI PyPI execution boundary no longer receives the secret. 
- Removed the secret-derived `EVENTS_RPC_URL` assignment from the `refresh-events` step that runs `uv run --with substrate-interface==1.8.1 python scripts/fetch-events.py` so the poller uses its public `finney` default in CI. 
- Updated `scripts/fetch-metagraph-native.py` to default `--network` to `"finney"` instead of reading `os.environ.get("SUBTENSOR_RPC_URL")`, preserving an explicit `--network` override for trusted local/manual runs. 
- Adjusted workflow comments to document the preserved boundary and the intended local/manual override path without placing hidden RPC endpoints into the Python dependency execution environment.

### Testing
- Ran `npm run validate:workflows` and it succeeded. 
- Ran `npm run scan:public-safety` and it succeeded. 
- Ran `npm run format:check` (via `prettier --check`) on the modified files and it succeeded. 
- Ran `python3 -m py_compile scripts/fetch-metagraph-native.py scripts/fetch-events.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cac300170832cb9062dc023b5a856)