### PR TITLE
fix(security): lock down event backfill archive source

### DIFF
--- a/.github/workflows/backfill-events.yml
+++ b/.github/workflows/backfill-events.yml
@@ -12,7 +12,7 @@ name: Backfill Chain Events (historical range)
 # safe chunk); space chunks ~5 min apart so the Worker drains each pending object
 # before the next overwrites it, then confirm with a D1 gap query and re-run any
 # range that didn't land (idempotent). Defaults to the free OnFinality WS archive;
-# override via the rpc_url input or the SUBTENSOR_RPC_URL secret (e.g. our own node).
+# override only via the maintainer-controlled SUBTENSOR_RPC_URL secret (e.g. our own node).
 on:
   workflow_dispatch:
     inputs:
@@ -22,10 +22,6 @@ on:
       to_block:
         description: Last block to backfill (inclusive)
         required: true
-      rpc_url:
-        description: WS archive endpoint (blank → SUBTENSOR_RPC_URL secret, else OnFinality)
-        required: false
-        default: ""
 
 permissions:
   contents: read
@@ -66,9 +62,10 @@ jobs:
         env:
           FROM_BLOCK: ${{ inputs.from_block }}
           TO_BLOCK: ${{ inputs.to_block }}
-          # blank input → the SUBTENSOR_RPC_URL secret → (still blank) the script's
-          # OnFinality default. Set the secret to our own node to backfill from it.
-          SUBTENSOR_RPC_URL: ${{ inputs.rpc_url || secrets.SUBTENSOR_RPC_URL }}
+          # Secret only → (still blank) the script's OnFinality default. Set the
+          # secret to our own archive to backfill from it; workflow callers cannot
+          # choose an endpoint for a production-signed staging batch.
+          SUBTENSOR_RPC_URL: ${{ secrets.SUBTENSOR_RPC_URL }}
 
       # Sign + stage all three batches exactly like refresh-events (same HMAC signer,
       # same R2 token, same pending object names) so the Worker's loadStaged* accepts

--- a/scripts/backfill-events.py
+++ b/scripts/backfill-events.py
@@ -32,6 +32,7 @@ import json
 import os
 import sys
 import time
+from urllib.parse import urlsplit, urlunsplit
 
 # Reuse fetch-events.py's verified decode (hyphenated → load by path, same as the
 # streamer + the unit tests do).
@@ -43,6 +44,50 @@ _spec.loader.exec_module(_fe)
 # A real WS archive (full historical state + block bodies). NOT the Subway HTTP
 # proxy — that doesn't speak substrate-interface's WS protocol (#1749).
 DEFAULT_ARCHIVE = "wss://bittensor-finney.api.onfinality.io/public-ws"
+FINNEY_GENESIS_HASH = (
+    "0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03"
+)
+TRUSTED_ARCHIVE_URLS = frozenset([DEFAULT_ARCHIVE])
+
+
+def _normalize_url(url):
+    parts = urlsplit((url or "").strip())
+    if parts.scheme not in {"ws", "wss"} or not parts.netloc:
+        raise ValueError("SUBTENSOR_RPC_URL must be a ws:// or wss:// archive URL")
+    host = (parts.hostname or "").lower()
+    netloc = host
+    if parts.port is not None:
+        netloc = f"{host}:{parts.port}"
+    return urlunsplit((parts.scheme.lower(), netloc, parts.path.rstrip("/"), "", ""))
+
+
+def _trusted_archive_urls():
+    extra = os.environ.get("BACKFILL_TRUSTED_ARCHIVE_URLS", "")
+    urls = list(TRUSTED_ARCHIVE_URLS) + [u for u in extra.split(",") if u.strip()]
+    return frozenset(_normalize_url(u) for u in urls)
+
+
+def _select_archive_url():
+    selected = _normalize_url(os.environ.get("SUBTENSOR_RPC_URL") or DEFAULT_ARCHIVE)
+    trusted = _trusted_archive_urls()
+    if selected not in trusted:
+        allowed = ", ".join(sorted(trusted))
+        raise ValueError(
+            "SUBTENSOR_RPC_URL is not trusted for production backfill; "
+            f"allowed: {allowed}"
+        )
+    return selected
+
+
+def _verify_finney_chain(substrate):
+    genesis = substrate.get_block_hash(0)
+    if str(genesis).strip().lower() != FINNEY_GENESIS_HASH:
+        raise ValueError("archive endpoint is not finney mainnet: genesis hash mismatch")
+
+
+def _header_number(substrate, block_hash):
+    header = substrate.get_block_header(block_hash=block_hash)["header"]
+    return int(header["number"])
 
 
 def main():
@@ -55,7 +100,10 @@ def main():
     if args.from_block < 0 or args.to_block < args.from_block:
         sys.exit("--from must be >= 0 and <= --to")
 
-    url = os.environ.get("SUBTENSOR_RPC_URL") or DEFAULT_ARCHIVE
+    try:
+        url = _select_archive_url()
+    except ValueError as e:
+        sys.exit(str(e))
     s = SubstrateInterface(url=url)
     # Free archives (OnFinality) rate-limit (JSON-RPC -32029 "Too Many Requests")
     # under rapid block-by-block scanning. Wrap the RPC layer so EVERY call backs off
@@ -82,11 +130,16 @@ def main():
             return _orig_rpc(method, params, *a, **k)
 
         s.rpc_request = _rpc_request
+    try:
+        _verify_finney_chain(s)
+    except ValueError as e:
+        sys.exit(str(e))
+
     # Anchor observed_at on the current finalized head's timestamp; finney is exactly
     # 12.0s/block, so height-derivation matches the live poller's clock with no
     # per-block Timestamp query (one fewer archive round-trip per block).
     head = s.get_chain_finalised_head()
-    head_bn = s.get_block_header(block_hash=head)["header"]["number"]
+    head_bn = _header_number(s, head)
     head_ts = int(s.query("Timestamp", "Now", block_hash=head).value)
 
     rows, blocks, extrinsics = [], [], []
@@ -95,6 +148,8 @@ def main():
         observed_at = head_ts - (head_bn - bn) * _fe.BLOCK_MS
         try:
             bh = s.get_block_hash(bn)
+            if _header_number(s, bh) != bn:
+                raise ValueError("block header number mismatch")
             events = s.query("System", "Events", block_hash=bh)
         except Exception as e:  # transient/shape drift → skip this block, keep going
             skipped += 1

--- a/scripts/test_backfill_events.py
+++ b/scripts/test_backfill_events.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Unit tests for backfill-events.py trust-boundary helpers."""
+import importlib.util
+import os
+import unittest
+from unittest.mock import patch
+
+_BE_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "backfill-events.py"
+)
+_spec = importlib.util.spec_from_file_location("backfill_events_under_test", _BE_PATH)
+_be = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_be)
+
+
+class ArchiveTrustTest(unittest.TestCase):
+    def test_default_archive_is_selected_when_env_is_blank(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(_be._select_archive_url(), _be.DEFAULT_ARCHIVE)
+
+    def test_untrusted_archive_is_rejected(self):
+        with patch.dict(
+            os.environ,
+            {"SUBTENSOR_RPC_URL": "ws://attacker.invalid/archive"},
+            clear=True,
+        ):
+            with self.assertRaisesRegex(ValueError, "not trusted"):
+                _be._select_archive_url()
+
+    def test_extra_trusted_archive_must_be_maintainer_configured(self):
+        trusted = "wss://archive.example.org/subtensor"
+        with patch.dict(
+            os.environ,
+            {
+                "BACKFILL_TRUSTED_ARCHIVE_URLS": trusted,
+                "SUBTENSOR_RPC_URL": trusted,
+            },
+            clear=True,
+        ):
+            self.assertEqual(_be._select_archive_url(), trusted)
+
+    def test_non_websocket_urls_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "ws:// or wss://"):
+            _be._normalize_url("https://bittensor-finney.api.onfinality.io/public")
+
+
+class ChainVerificationTest(unittest.TestCase):
+    class Substrate:
+        def __init__(self, genesis):
+            self.genesis = genesis
+
+        def get_block_hash(self, block_number):
+            if block_number != 0:
+                raise AssertionError(f"unexpected block lookup: {block_number}")
+            return self.genesis
+
+    def test_finney_genesis_is_accepted(self):
+        _be._verify_finney_chain(self.Substrate(_be.FINNEY_GENESIS_HASH.upper()))
+
+    def test_wrong_genesis_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "genesis hash mismatch"):
+            _be._verify_finney_chain(self.Substrate("0xother"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
### Motivation
- A manual `rpc_url` workflow input allowed a workflow dispatcher to point the backfill at an arbitrary Substrate-compatible endpoint and produce HMAC-signed staging files that the Worker would trust, creating a high-integrity attack path. 
- The change prevents untrusted endpoints from being used for production-signed backfills and enforces chain identity checks before any staged data is produced.

### Description
- Removed the caller-controlled `rpc_url` workflow input and made the backfill job use the maintainer-controlled `SUBTENSOR_RPC_URL` secret (or the script default) so dispatchers cannot select an archive endpoint at runtime. 
- Hardened `scripts/backfill-events.py` with URL normalization and an allowlist: `_normalize_url`, `_trusted_archive_urls`, and `_select_archive_url` reject non-`ws/wss` URLs and endpoints not in the trusted set (extendable via `BACKFILL_TRUSTED_ARCHIVE_URLS`). 
- Added chain verification and consistency checks: `_verify_finney_chain` validates the genesis hash before scanning and a per-block header-number check guards against mismatched/forged blocks. 
- Added regression unit tests in `scripts/test_backfill_events.py` to exercise trusted-url selection, URL-scheme validation, and Finney genesis verification.

### Testing
- Ran `python3 scripts/test_backfill_events.py` and the new tests passed. 
- Ran `python3 scripts/test_fetch_events.py` and all existing tests passed. 
- Ran workflow and repo validators (`npm run validate:workflows`, `npm run lint`, `npm run format:check`, `npm run build`, and `npm run validate`) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb2c4d914832ca600eb6cfc1e7c97)