### PR TITLE
fix(events): bound staged gap recovery batches

### DIFF
--- a/.github/workflows/refresh-events.yml
+++ b/.github/workflows/refresh-events.yml
@@ -75,10 +75,32 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      - name: Check staged event drains are clear
+        id: pending
+        run: |
+          set +e
+          pending=0
+          for key in \
+            events/account-events-pending.json \
+            events/blocks-pending.json \
+            events/extrinsics-pending.json; do
+            npx wrangler r2 object get "metagraphed-artifacts/${key}" --file="/tmp/${key##*/}" --remote >/dev/null 2>&1
+            status=$?
+            if [ "$status" -eq 0 ]; then
+              echo "${key} is still pending; skip this producer tick so the Worker can drain it"
+              pending=1
+            fi
+          done
+          echo "skip=${pending}" >> "$GITHUB_OUTPUT"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       # substrate-interface is PINNED to an exact, verified version: this step runs
       # with Cloudflare secrets in scope, so we never auto-pull a future (possibly
       # compromised) release from PyPI. Bump deliberately after re-verifying.
       - name: Poll finney events (first-party, public RPC, no key)
+        if: steps.pending.outputs.skip != '1'
         run: uv run --with substrate-interface==1.8.1 python scripts/fetch-events.py
         env:
           # Chain RPC endpoint, behind a SECRET so the private archive node's URL is
@@ -96,13 +118,17 @@ jobs:
           # Cap on gap recovery (non-sensitive → a VARIABLE, not a secret). Default
           # 300 = prune horizon, correct for PUBLIC RPC. Once EVENTS_RPC_URL points at
           # the ARCHIVE node, set the `EVENTS_MAX_LOOKBACK` repo variable high (e.g.
-          # 1000000) so a long scheduler gap is recovered in full.
+          # 1000000) so a long scheduler gap is recovered over bounded batches.
           EVENTS_MAX_LOOKBACK: ${{ vars.EVENTS_MAX_LOOKBACK || '300' }}
+          # Producer-side cap: one staged object covers at most this many blocks;
+          # cursor recovery continues on later ticks after pending objects drain.
+          EVENTS_BATCH_BLOCKS: ${{ vars.EVENTS_BATCH_BLOCKS || '250' }}
           # Emit a ::warning:: (and webhook alert, if configured) when the cursor
           # falls within a window of the public-RPC prune horizon.
           METAGRAPH_ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}
 
       - name: Sign staged chain-event batch
+        if: steps.pending.outputs.skip != '1'
         run: node scripts/sign-staged-neurons.mjs dist/account-events.json
         env:
           METAGRAPH_STAGING_SIGNING_KEY: ${{ secrets.METAGRAPH_STAGING_SIGNING_KEY }}
@@ -110,6 +136,7 @@ jobs:
       # Stage to R2 (the token's existing R2 permission); the Worker loads it into
       # D1 through its binding (loadStagedEvents) — no API-token D1 permission.
       - name: Stage events to R2 for the Worker to load into D1
+        if: steps.pending.outputs.skip != '1'
         run: npx wrangler r2 object put metagraphed-artifacts/events/account-events-pending.json --file=dist/account-events.json --remote
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -122,11 +149,13 @@ jobs:
       # fast-load cron (no API-token D1 permission). INSERT OR IGNORE on
       # block_number makes overlapping windows idempotent.
       - name: Sign staged block batch
+        if: steps.pending.outputs.skip != '1'
         run: node scripts/sign-staged-neurons.mjs dist/blocks.json
         env:
           METAGRAPH_STAGING_SIGNING_KEY: ${{ secrets.METAGRAPH_STAGING_SIGNING_KEY }}
 
       - name: Stage blocks to R2 for the Worker to load into D1
+        if: steps.pending.outputs.skip != '1'
         run: npx wrangler r2 object put metagraphed-artifacts/events/blocks-pending.json --file=dist/blocks.json --remote
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -140,11 +169,13 @@ jobs:
       # permission). INSERT OR IGNORE on (block_number, extrinsic_index) makes
       # overlapping windows idempotent.
       - name: Sign staged extrinsic batch
+        if: steps.pending.outputs.skip != '1'
         run: node scripts/sign-staged-neurons.mjs dist/extrinsics.json
         env:
           METAGRAPH_STAGING_SIGNING_KEY: ${{ secrets.METAGRAPH_STAGING_SIGNING_KEY }}
 
       - name: Stage extrinsics to R2 for the Worker to load into D1
+        if: steps.pending.outputs.skip != '1'
         run: npx wrangler r2 object put metagraphed-artifacts/events/extrinsics-pending.json --file=dist/extrinsics.json --remote
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -155,6 +186,7 @@ jobs:
       # it to R2 for lag/health accounting. The poller still re-scans the bounded
       # overlap window because R2 staging is not proof of asynchronous D1 import.
       - name: Advance event cursor in R2
+        if: steps.pending.outputs.skip != '1'
         run: npx wrangler r2 object put metagraphed-artifacts/events/cursor.json --file=dist/events-cursor.json --remote
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -36,6 +36,7 @@ Env:  EVENTS_RPC_URL        public finney WS endpoint (default below)
                             on a cold start → fall back to the window floor
       ACCOUNT_EVENTS_JSON   events output path (default dist/account-events.json)
       EVENTS_CURSOR_OUT     next-cursor sidecar path (default dist/events-cursor.json)
+      EVENTS_BATCH_BLOCKS   max blocks emitted in one staged batch (default EVENTS_WINDOW)
       BLOCKS_JSON           per-block sidecar path (default dist/blocks.json) — the
                             block-explorer hot window (#1345), staged + loaded into
                             D1 `blocks` the same way the events JSON is
@@ -98,6 +99,11 @@ PRUNE_HORIZON = int(os.environ.get("EVENTS_PRUNE_HORIZON", "300"))
 # ARCHIVE node (ADR 0012) set EVENTS_MAX_LOOKBACK high so a long scheduler gap is
 # recovered in full; the archive still holds every block.
 MAX_LOOKBACK = int(os.environ.get("EVENTS_MAX_LOOKBACK", str(PRUNE_HORIZON)))
+# Producer-side batch guard for cursor recovery. The Worker drains one pending R2
+# object at a time, with byte/row caps; keep each recovery poll bounded so archive
+# mode advances through long gaps over multiple safe staged batches instead of
+# producing one pathological object.
+BATCH_BLOCKS = max(1, int(os.environ.get("EVENTS_BATCH_BLOCKS", str(WINDOW))))
 
 
 def _parse_cursor(raw):
@@ -116,6 +122,21 @@ def _parse_cursor(raw):
     except (TypeError, ValueError):
         return None
     return n if n >= 0 else None
+
+
+def compute_scan_range(cursor, head, window, max_lookback=PRUNE_HORIZON, batch_blocks=None):
+    """Inclusive block range to scan for one staged producer batch.
+
+    The start preserves cursor-driven gap recovery. The end is capped by
+    `batch_blocks` (default: `window`) so a long archive-node recovery is emitted
+    as several bounded staged batches. This keeps each pending R2 object inside the
+    Worker's progressive-drain envelope and lets the workflow promote only the
+    highest block actually staged in this run.
+    """
+    start = compute_from_block(cursor, head, window, max_lookback)
+    limit = window if batch_blocks is None else max(1, int(batch_blocks))
+    end = min(head, start + limit - 1)
+    return start, end
 
 
 def compute_from_block(cursor, head, window, max_lookback=PRUNE_HORIZON):
@@ -454,7 +475,7 @@ def main():
             "finalized head timestamp is required for account_events"
         ) from e
     cursor = _parse_cursor(os.environ.get("EVENTS_CURSOR"))
-    start = compute_from_block(cursor, head_bn, WINDOW, MAX_LOOKBACK)
+    start, end = compute_scan_range(cursor, head_bn, WINDOW, MAX_LOOKBACK, BATCH_BLOCKS)
     _emit_lag_alert(head_bn, cursor)
 
     rows = []
@@ -462,7 +483,7 @@ def main():
     extrinsics = []
     scanned = 0
     skipped = 0
-    for bn in range(start, head_bn + 1):
+    for bn in range(start, end + 1):
         observed_at = head_ts - (head_bn - bn) * BLOCK_MS
         try:
             bh = s.get_block_hash(bn)
@@ -529,19 +550,18 @@ def main():
     with open(EXTRINSICS_OUT, "w") as fh:
         json.dump(extrinsics, fh)
 
-    # Next-cursor sidecar: the highest block we covered this run (the finalized
-    # head we scanned through). The workflow stages the events first, then — only
-    # on a successful stage — promotes this to events/cursor.json in R2. Because
-    # staging and D1 loading are asynchronous, compute_from_block still re-scans
-    # the overlap window every run; the cursor is retained for lag/health alerts,
-    # not as proof that staged rows have already been imported into D1.
-    next_cursor = max(head_bn, cursor) if cursor is not None else head_bn
+    # Next-cursor sidecar: the highest block we covered in THIS bounded batch.
+    # The workflow stages the events first, then — only on a successful stage —
+    # promotes this to events/cursor.json in R2. Long archive recovery therefore
+    # advances over multiple bounded pending objects instead of one oversized
+    # object; compute_from_block still re-scans the overlap window once current.
+    next_cursor = max(end, cursor) if cursor is not None else end
     os.makedirs(os.path.dirname(CURSOR_OUT) or ".", exist_ok=True)
     with open(CURSOR_OUT, "w") as fh:
         json.dump({"block_number": next_cursor}, fh)
 
     sys.stderr.write(
-        f"wrote {len(rows)} events from blocks {start}..{head_bn} "
+        f"wrote {len(rows)} events from blocks {start}..{end} (head={head_bn}) "
         f"(cursor_in={cursor}, scanned {scanned}, skipped {skipped}) -> {OUT}; "
         f"wrote {len(blocks)} block rows -> {BLOCKS_OUT}; "
         f"wrote {len(extrinsics)} extrinsic rows -> {EXTRINSICS_OUT}; "

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -24,6 +24,7 @@ _fe = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_fe)
 
 compute_from_block = _fe.compute_from_block
+compute_scan_range = _fe.compute_scan_range
 _parse_cursor = _fe._parse_cursor
 _block_author = _fe._block_author
 AURA_ENGINE_ID = _fe.AURA_ENGINE_ID
@@ -80,6 +81,19 @@ class ComputeFromBlockTest(unittest.TestCase):
         got = compute_from_block(cursor, self.HEAD, self.WINDOW)
         self.assertEqual(got, cursor + 1)
         self.assertLess(got, self.floor())
+
+    def test_scan_range_caps_long_archive_recovery_to_bounded_batch(self):
+        stale = self.HEAD - 5_000
+        start, end = compute_scan_range(stale, self.HEAD, self.WINDOW, 10_000_000)
+        self.assertEqual(start, stale + 1)
+        self.assertEqual(end, start + self.WINDOW - 1)
+        self.assertLess(end, self.HEAD)
+
+    def test_scan_range_promotes_to_head_when_batch_reaches_head(self):
+        cursor = self.HEAD - 20
+        start, end = compute_scan_range(cursor, self.HEAD, self.WINDOW, 10_000_000)
+        self.assertEqual(start, self.floor())
+        self.assertEqual(end, self.HEAD)
 
     def test_cursor_ahead_of_head_reorg_uses_floor(self):
         # Reorg / clock skew left the cursor at or past the head → re-scan the


### PR DESCRIPTION
### Motivation
- Cursor-driven archive recovery could produce a single oversized staged R2 object that the Worker would skip or only partially drain, and the workflow advanced the cursor after staging which could cause recovered blocks to be lost. 
- The producer and workflow must cooperate so long recovery scans are split into bounded staged batches and the producer does not overwrite pending objects the Worker is still draining.

### Description
- Add a producer-side batch cap `EVENTS_BATCH_BLOCKS` (env) and `BATCH_BLOCKS` (producer default) to limit the number of blocks emitted in a single staged object. 
- Introduce `compute_scan_range(cursor, head, window, max_lookback, batch_blocks)` which preserves the existing cursor-driven start but caps the run to a bounded `end`, and update the poller to iterate `start..end` and write the cursor to the last block actually staged. 
- Update the refresh-events workflow to check for existing pending staged objects and skip the producer tick when any `events/*-pending.json` object still exists, and gate staging/cursor-promotion steps on that check. 
- Add regression tests exercising the bounded scan range (`scripts/test_fetch_events.py`) and keep existing `loadStagedEvents` tests; changes touch `.github/workflows/refresh-events.yml`, `scripts/fetch-events.py`, and `scripts/test_fetch_events.py`.

### Testing
- Ran the new and existing Python unit tests with `python3 scripts/test_fetch_events.py`, all tests passed. 
- Ran the Worker loader tests with `npm test -- tests/load-staged-events.test.mjs`, all tests passed. 
- Ran `npm run validate:workflows`, `npm run format:check`, and `npm run lint`, which passed. 
- Fixed an initial `validate` failure by running `npm run build` (to produce generated artifacts) and then `npm run validate`, after which the full validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cad215364832cb33625f6089fcab5)