### PR TITLE
fix(client): silence TS 6.0 baseUrl deprecation so the SDK build/publish works

### DIFF
--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": true
+    "noEmit": true,
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
The `Publish client SDK` run for 0.6.0 failed: `tsup --dts` under typescript 6.0.3 hard-errors (`TS5101` baseUrl deprecated). Adds the compiler-recommended `"ignoreDeprecations": "6.0"` to packages/client/tsconfig.json. Verified locally: build succeeds, dist/index.d.ts includes the current contract (compare, blocks/extrinsics, #1783 derived fields). After merge I'll re-run the publish for 0.6.0 (never tagged/published).