### PR TITLE
test(artifacts): assert agent-catalog callable-service invariants instead of a frozen count

### DIFF
--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -1070,25 +1070,26 @@ test("public artifacts are internally consistent", () => {
   const callableWithoutSchema = callableAgentServices.filter(
     (service) => !service.schema_artifact,
   );
-  assert.equal(
-    callableAgentServices.length,
-    95,
-    "agent-catalog callable-service count must stay deterministic",
+  // The callable-service population grows with every community surface addition,
+  // so we assert the schema-projection invariants rather than freezing an
+  // absolute count (a frozen count red-flagged legitimate single-file data PRs
+  // for every callable surface added). The concrete projection behaviour is
+  // pinned per-surface below (SN7/56/110/64).
+  assert.ok(
+    callableAgentServices.length > 0,
+    "agent-catalog must project callable services",
   );
-  assert.equal(
-    callableWithoutSchema.length,
-    45,
-    "schema projection should reduce callable services without schema artifacts",
+  assert.ok(
+    callableWithoutSchema.length > 0 &&
+      callableWithoutSchema.length < callableAgentServices.length,
+    "same-origin schema projection should reduce — but not eliminate — callable services without schema artifacts",
   );
-  assert.equal(
-    callableWithoutSchema.filter((service) => service.kind === "subnet-api")
-      .length,
-    5,
-    "schema projection should leave only explicitly uncaptured/unknown subnet APIs without schemas",
-  );
-  assert.equal(
-    callableWithoutSchema.filter((service) => service.kind === "sse").length,
-    1,
+  assert.ok(
+    callableAgentServices
+      .filter((service) => service.kind === "sse")
+      .every(
+        (service) => service.schema_source?.match !== "same-origin-openapi",
+      ),
     "SSE streams should not inherit same-origin OpenAPI schemas implicitly",
   );
   const serviceById = (catalog, surfaceId) =>


### PR DESCRIPTION
## Summary

The `public artifacts are internally consistent` test in `tests/artifacts.test.mjs` pinned **absolute population counts** of callable agent-catalog services (`95 / 45 / 5 / 1`). The `test` job rebuilds the catalog from the registry, so **any** contribution adding an `auth_required: false` (callable) surface shifts the totals and reds CI — e.g. a two-surface SN19/BlockMachine enrichment ([#1586](https://github.com/JSONbored/metagraphed/pull/1586)) pushes the total `95 → 97` and fails at `97 !== 95`.

Data contributions may edit **only** their one `registry/subnets/<slug>.json`, so this hand-bumped snapshot (last bumped by maintainers in #1211, #1639) structurally blocks the **autonomous contributor lane** for callable surfaces — the most common contribution type — since the gate auto-merges only on green CI. It is the only hard-coded absolute population count in the file; every other count assertion is relational or a floor.

## Change

Replace the four frozen pins with schema-projection **invariants** (matching the file convention). The concrete projection behaviour is already pinned per-surface just below (SN7 same-origin inherit, SN7 SSE no-inherit, SN56 schema-url, SN110 same-origin, SN64 not-captured), so no logic coverage is lost:

| before | after |
|---|---|
| `callable === 95` | `callable > 0` |
| `noSchema === 45` | `0 < noSchema < total` |
| `subnet-api noSchema === 5` | dropped (frozen snapshot, no invariant behind it) |
| `sse noSchema === 1` | no callable SSE inherits a same-origin OpenAPI schema (the real intent) |

## Verification

Reproduced locally (build + count): baseline `95/45/5/1`, with #1586 surfaces `97/46/5/1`.

- target test on baseline registry → passes
- target test with #1586 surfaces applied (the prior failure) → passes
- full `tests/artifacts.test.mjs` (20 tests) → passes; prettier-clean

Unblocks [#1586](https://github.com/JSONbored/metagraphed/pull/1586) (after rebase) and every future callable-surface contribution.

Closes #1797