### PR TITLE
docs(skill): rename skill to metagraphed and correct the linked-issue policy

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: contributing-to-metagraphed
+name: metagraphed
 description: >-
   Use when writing, validating, or preparing ANY contribution or pull request to the
   JSONbored/metagraphed repo — adding/enriching a subnet's public surfaces (the most common
@@ -50,20 +50,19 @@ Most contributions are **Path A**. Do **not** mix the two in one PR.
 The Gittensory Gate is **not advisory**. Once your checks settle, for a **contributor** PR (you are
 not the repo owner or an automation bot) it takes a one-shot disposition:
 
-| Situation                                                                                                                                                         | Gate action                             |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| Content **verified** (owner-matched, fresh, grounded) + **both** AI reviewers confidently approve (≥0.9) + CI green + mergeable-clean + a valid linked issue      | **auto-approve → MERGE**                |
-| A **deterministic fail** — duplicate surface, placeholder, private/localhost URL, secret, dead `source_url`                                                       | **CLOSE** (one-shot)                    |
-| **Every** reviewer returns a clear reject                                                                                                                         | **CLOSE** (one-shot)                    |
-| **No linked issue** (repo hard-rule)                                                                                                                              | **CLOSE / fail** — link a tracked issue |
-| Any CI check failed                                                                                                                                               | **CLOSE** (cites the failing check)     |
-| Legitimate but **uncertain** — a reviewer wanted merge but under 0.9, a reviewer said `manual`, reviewers split, owner-mismatch, stale repo, unfetchable evidence | **MANUAL** (held, not closed)           |
-| CI still pending / unverified fork run                                                                                                                            | **no action** — waits                   |
+| Situation                                                                                                                                                         | Gate action                         |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| Content **verified** (owner-matched, fresh, grounded) + **both** AI reviewers confidently approve (≥0.9) + CI green + mergeable-clean                             | **auto-approve → MERGE**            |
+| A **deterministic fail** — duplicate surface, placeholder, private/localhost URL, secret, dead `source_url`                                                       | **CLOSE** (one-shot)                |
+| **Every** reviewer returns a clear reject                                                                                                                         | **CLOSE** (one-shot)                |
+| Any CI check failed                                                                                                                                               | **CLOSE** (cites the failing check) |
+| Legitimate but **uncertain** — a reviewer wanted merge but under 0.9, a reviewer said `manual`, reviewers split, owner-mismatch, stale repo, unfetchable evidence | **MANUAL** (held, not closed)       |
+| CI still pending / unverified fork run                                                                                                                            | **no action** — waits               |
 
 So a flawed contributor PR is **closed, not coached** — recovery means fixing the problem and opening
-a **fresh** PR. **Verified + green + a real linked issue ⇒ merged; a clear adverse signal ⇒ closed;
-genuine uncertainty ⇒ held for a human.** (Owner / automation-bot PRs are exempt from auto-close — but
-assume you are a contributor.)
+a **fresh** PR. **Verified + green ⇒ merged; a clear adverse signal ⇒ closed; genuine uncertainty ⇒
+held for a human.** (Owner / automation-bot PRs are exempt from auto-close — but assume you are a
+contributor.)
 
 ---
 
@@ -86,9 +85,11 @@ assume you are a contributor.)
 5. **Public-safe only.** No secrets, PATs, wallet/hotkey/coldkey paths, private/localhost URLs, or
    validator-local data anywhere — in files, commits, or PR text. `auth` fields are _placeholders_
    (`Bearer <token>`), never real credentials.
-6. **Link a tracked issue.** The gate hard-fails a PR with no linked issue. Put `Closes #<n>` (or a
-   `Refs #<n>`) in the PR body. For surface work, the per-subnet enrichment issues under
-   [epic #427](https://github.com/JSONbored/metagraphed/issues/427) are the linkable home.
+6. **Link an issue when one exists (optional).** A linked issue is **not required** — a PR with no
+   linked issue is judged on its own merit and is **never** closed for the missing link. When an issue
+   does track the work, reference it (`Closes #<n>` / `Refs #<n>`) in the PR body and the gate verifies
+   the PR against that issue's intent. For surface work, the per-subnet enrichment issues under
+   [epic #427](https://github.com/JSONbored/metagraphed/issues/427) are the natural home to link.
 7. **Schema is the contract — regenerate + commit (Path B).** Editing `schemas/` means
    `npm run build` then committing `openapi.json` + types/clients in the same PR, or
    `validate:contract-drift` fails CI.
@@ -192,13 +193,14 @@ submission lane.)
   `registry/subnets/<slug>.json`.
 - **Commit (Conventional):** `feat(registry): add SN43 Example subnet-api surface (#<issue>)`.
 - **PR body:** fill `.github/pull_request_template.md` honestly — a real Summary, the `url` +
-  `source_url` proof, the validation commands you ran, and **`Closes #<issue>`**. No AI attribution.
+  `source_url` proof, the validation commands you ran, and **`Closes #<issue>`** if an issue tracks
+  this (optional — not required). No AI attribution.
 
 ### Phase A5 — Let the gate adjudicate
 
-Watch `Validate` and `Gittensory Gate` go green. Verified + green + linked issue → merged. A
-deterministic fail (dup / dead source / private URL) or a clear reject → closed; fix and open a fresh
-PR. Genuine uncertainty → held for a human — don't open a duplicate.
+Watch `Validate` and `Gittensory Gate` go green. Verified + green → merged. A deterministic fail
+(dup / dead source / private URL) or a clear reject → closed; fix and open a fresh PR. Genuine
+uncertainty → held for a human — don't open a duplicate.
 
 ---
 
@@ -253,9 +255,9 @@ clean `npm run build` (see the build-gotchas note in `reference.md`).
 
 ### Phase B5 — Commit + PR
 
-Conventional Commit (no AI attribution), `Closes #<issue>`, fill the PR template with the validation
-commands you actually ran. Sync with `main` if it moved (`git fetch upstream && git rebase
-upstream/main`) — a base conflict closes a contributor PR.
+Conventional Commit (no AI attribution); `Closes #<issue>` if an issue tracks the work (optional); fill
+the PR template with the validation commands you actually ran. Sync with `main` if it moved
+(`git fetch upstream && git rebase upstream/main`) — a base conflict closes a contributor PR.
 
 ---
 
@@ -268,7 +270,7 @@ upstream/main`) — a base conflict closes a contributor PR.
       `review.state: community-submitted`; `public_safe: true`; no health/`verification`/secrets set by hand.
 - [ ] Not a duplicate of an existing surface or an open PR; not the same surface re-titled by `kind`.
 - [ ] `npm run validate:surface` + `npm run scan:public-safety` clean.
-- [ ] Conventional Commit (no AI attribution); PR template filled; **`Closes #<issue>`** present.
+- [ ] Conventional Commit (no AI attribution); PR template filled; **`Closes #<issue>`** if an issue tracks it (optional).
 
 **Path B (code/schema):**
 
@@ -276,7 +278,7 @@ upstream/main`) — a base conflict closes a contributor PR.
 - [ ] Regenerated + committed: `npm run build` artifacts (OpenAPI/types/contracts) as applicable.
 - [ ] `git diff --check` clean · `lint` + `format:check` clean · `npm run validate` green ·
       `npm run test:coverage` green · the focused `validate:*` for what you touched green.
-- [ ] Branch current with `main`; Conventional Commit (no AI attribution); PR template filled; `Closes #<issue>`.
+- [ ] Branch current with `main`; Conventional Commit (no AI attribution); PR template filled; `Closes #<issue>` if an issue tracks it (optional).
 
 If every box is checked, the PR has the best chance of a one-shot approve-and-merge. If any box can't
 be checked, **keep working — don't push.**

--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -90,23 +90,24 @@ merges, so a single shard under-reports).
 The review gate is **gittensory** (the old "reviewbot" was converged into gittensory 2026-06-22). It
 posts `Gittensory Gate` + `Gittensory Context` checks and acts on **contributor** PRs with autonomy:
 
-| Condition                                                                                                                                                  | Disposition                          |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| Both AI reviewers confidently approve (**≥0.9**) verified + owner-matched + fresh + netuid-grounded content, CI green, mergeable-clean, valid linked issue | **auto-MERGE**                       |
-| **Deterministic fail** — duplicate surface, placeholder, private/localhost URL, secret, dead `source_url`                                                  | **auto-CLOSE**                       |
-| **Every** reviewer returns a clear reject                                                                                                                  | **auto-CLOSE**                       |
-| **No linked issue** (repo hard-rule)                                                                                                                       | **fail / close** — add `Closes #<n>` |
-| Any CI check failed                                                                                                                                        | **CLOSE** (cites the failing check)  |
-| Legitimate but uncertain — a reviewer < 0.9, a reviewer said `manual`, reviewers split, owner-mismatch, stale repo, unfetchable evidence                   | **MANUAL** (held, never auto-closed) |
-| CI pending / unverified fork run                                                                                                                           | no action — waits                    |
+| Condition                                                                                                                                | Disposition                          |
+| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| Both AI reviewers confidently approve (**≥0.9**) verified + owner-matched + fresh + netuid-grounded content, CI green, mergeable-clean   | **auto-MERGE**                       |
+| **Deterministic fail** — duplicate surface, placeholder, private/localhost URL, secret, dead `source_url`                                | **auto-CLOSE**                       |
+| **Every** reviewer returns a clear reject                                                                                                | **auto-CLOSE**                       |
+| Any CI check failed                                                                                                                      | **CLOSE** (cites the failing check)  |
+| Legitimate but uncertain — a reviewer < 0.9, a reviewer said `manual`, reviewers split, owner-mismatch, stale repo, unfetchable evidence | **MANUAL** (held, never auto-closed) |
+| CI pending / unverified fork run                                                                                                         | no action — waits                    |
 
 **Content bar** (benchmarked strict): official/primary sources wherever possible, 100% verifiable, the
 `url` owner must match the subnet's registered identity, source repo fresh, no prompt-injection in
 fetched or submitted text. Make the `source_url` an _independent_ proof of ownership.
 
-**Hard rule for everyone, including maintainers:** a PR with **no linked issue** fails the gate. This
-also blocks release-please bot PRs unless exempted in the gittensory config (that config lives in the
-gittensory system, **not** in this repo). Don't `--admin`-bypass — the policy is deliberate.
+**Linked issues are optional, not a gate.** A PR with **no linked issue** is judged on its own merit —
+the missing link is **never** a fail/close reason (for contributors or maintainers). When an issue
+tracks the work, link it (`Closes #<n>`) and the gate verifies the PR against that issue's intent,
+clause by clause. (What the gate does with a linked issue is configured in the gittensory system,
+**not** in this repo.)
 
 The gate's private scoring rubric/thresholds must **never** appear in this repo —
 `validate:private-boundary` fails CI if they do. Keep gate heuristics in the gittensory system only.
@@ -165,8 +166,8 @@ fix(health-serving): stamp merged RPC endpoint observed_at with sweep time (#161
 
 **PR body:** GitHub pre-fills `.github/pull_request_template.md`. Fill it — don't replace it: a real
 `## Summary`, the `url` + `source_url` proof (Path A) or the validation commands you ran (Path B), and
-**`Closes #<issue>`** (the gate hard-fails without a linked issue). No local paths, env dumps, or
-private notes.
+**`Closes #<issue>`** when an issue tracks the work (optional — a missing link never fails a PR). No
+local paths, env dumps, or private notes.
 
 ---
 
@@ -177,7 +178,7 @@ private notes.
 - A duplicate of an existing surface or an open PR; the same surface re-titled by `kind`.
 - Secrets/PATs/wallet paths, private/localhost URLs, real credentials in `auth`.
 - Hand-set health/uptime/`verification` (probe-derived only).
-- No linked issue. UI/frontend changes (those belong in metagraphed-ui).
+- UI/frontend changes (those belong in metagraphed-ui).
 - Editing the contract by hand without `npm run build` (contract-drift), or stale committed artifacts.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 # metagraphed — AI contributor guide
 
 Loaded automatically by AI coding tools: **Codex** reads this `AGENTS.md`; **Claude Code** reads
-`CLAUDE.md` (a symlink to this file) and additionally auto-loads the on-demand skill at
-`.claude/skills/contributing-to-metagraphed/`.
+`CLAUDE.md` (a symlink to this file) and additionally auto-loads the on-demand `metagraphed` skill at
+`.claude/skills/metagraphed/`.
 
 **Before writing ANY contribution or pull request to this repo, read and follow the skill:**
 
-- `.claude/skills/contributing-to-metagraphed/SKILL.md` — the one-shot-PR playbook (phases + checklist)
-- `.claude/skills/contributing-to-metagraphed/reference.md` — exhaustive tables (CI, the gate, the surface schema, validators, style)
+- `.claude/skills/metagraphed/SKILL.md` — the one-shot-PR playbook (phases + checklist)
+- `.claude/skills/metagraphed/reference.md` — exhaustive tables (CI, the gate, the surface schema, validators, style)
 
 That skill is the **single source of truth** for how to contribute here. Keep it updated as the
 process evolves — edits to those files improve both Claude Code and Codex.
@@ -16,19 +16,19 @@ process evolves — edits to those files improve both Claude Code and Codex.
 
 1. **The Gittensory Gate auto-merges and auto-closes — it is not advisory.** A _contributor_ PR is
    **auto-CLOSED** on a deterministic fail (duplicate / dead `source_url` / private URL / secret), a
-   clear reviewer reject, red CI, or **no linked issue**; **auto-MERGED** only when content is verified
-   (owner-matched, fresh) with both AI reviewers ≥0.9, CI green, mergeable-clean, and a valid linked
-   issue; **held for a human** when genuinely uncertain. Make it right before you push — recovery is a
-   fresh PR.
+   clear reviewer reject, or red CI; **auto-MERGED** only when content is verified (owner-matched,
+   fresh) with both AI reviewers ≥0.9, CI green, and mergeable-clean; **held for a human** when
+   genuinely uncertain. Make it right before you push — recovery is a fresh PR.
 2. **Surfaces live in ONE file per subnet.** A data contribution edits **exactly one**
    `registry/subnets/<slug>.json`, appending surface(s) with `authority: "community"` and
    `review.state: "community-submitted"` — and nothing else. **Never** add per-surface candidate
    files, **never** split a subnet's surfaces across multiple PRs, and **never** re-title the same
    surface as a different `kind` (that farm is closed — redundant PRs are auto-closed). Adding several
    surfaces for one subnet in one diff is one merge, the way it should be.
-3. **Prove it and link an issue.** Every surface needs a public `url` **and** a `source_url` that
-   independently proves the subnet publishes it. Every PR needs a tracked issue (`Closes #<n>`) — the
-   gate hard-fails without one.
+3. **Prove it.** Every surface needs a public `url` **and** a `source_url` that independently proves
+   the subnet publishes it. A linked issue is **optional** — when one tracks the work, reference it
+   (`Closes #<n>`) and the gate verifies the PR against it; a PR with no linked issue is judged on its
+   own merit, never closed for the missing link.
 4. **Schema is the contract; regenerate + commit.** Code/schema changes: edit `schemas/`, run
    `npm run build`, commit the regenerated `openapi.json` + types/clients in the same PR, or
    `validate:contract-drift` fails CI. Never hand-edit generated artifacts under `public/`.

--- a/docs/adr/0009-autonomous-review-gate.md
+++ b/docs/adr/0009-autonomous-review-gate.md
@@ -22,10 +22,13 @@ a separate repo + GitHub App) that is the **sole adjudicator** — the maintaine
 disposition is deterministic at the edges and conservative in the middle:
 
 - **Auto-CLOSE** on a deterministic fail — duplicate, dead/private `source_url`, a
-  secret, **no linked issue**, a clear reviewer reject, or red CI.
+  secret, a clear reviewer reject, or red CI.
 - **Auto-MERGE** only when content is verified (owner-matched, fresh) with **both
-  AI reviewers ≥ 0.9**, CI green, mergeable-clean, and a valid linked issue.
+  AI reviewers ≥ 0.9**, CI green, and mergeable-clean.
 - **Hold for a human** only when genuinely uncertain.
+
+A linked issue is **optional** — its absence is never a close reason; when one
+exists the gate verifies the PR against the issue's intent.
 
 The default posture is **close-when-in-doubt**: a redundant or unprovable PR costs
 the contributor a re-submission, not the registry its integrity.
@@ -35,9 +38,9 @@ the contributor a re-submission, not the registry its integrity.
 - **Throughput without a maintainer bottleneck** — the flywheel scales; recovery
   from an auto-close is a fresh PR, not a negotiation.
 - **The gate is the contract.** Contributors (and AI tools) must get a PR _right
-  before pushing_ — one focused subnet file (ADR 0008), a public `url` plus an
-  independent `source_url` that proves it, and a linked issue. See [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
-  and the `contributing-to-metagraphed` skill for the checklist.
+  before pushing_ — one focused subnet file (ADR 0008), and a public `url` plus an
+  independent `source_url` that proves it. See [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
+  and the `metagraphed` skill for the checklist.
 - **metagraphed stays adjudication-free** — no manual pre-escalation, no stored
   trust gating; the gate lives outside this repo and is configured there.
 - **Trade-off:** an external adjudicator is a dependency, and a wrong auto-close is

--- a/scripts/surface-add.mjs
+++ b/scripts/surface-add.mjs
@@ -3,7 +3,7 @@
 // model that replaces the per-candidate-file lane (registry/candidates/community).
 // The surface lands with authority:"community" + review.state:"community-submitted";
 // the Gittensory Gate / maintainer review promotes it in place, and the build's
-// prober owns verification/health. See .claude/skills/contributing-to-metagraphed.
+// prober owns verification/health. See .claude/skills/metagraphed.
 //
 //   npm run surface:add -- --netuid 7 --kind docs \
 //     --url https://docs.example.com \


### PR DESCRIPTION
## Summary

Two coupled documentation fixes to the contributor skill / guide.

### 1. Rename the skill `contributing-to-metagraphed` → `metagraphed`

So the repo skill and the on-demand skill share one name. Touches:
- `.claude/skills/contributing-to-metagraphed/` → `.claude/skills/metagraphed/` (dir + `SKILL.md` frontmatter `name`)
- `AGENTS.md` (the auto-load path + the two skill-file links)
- `docs/adr/0009-autonomous-review-gate.md` (skill reference)
- `scripts/surface-add.mjs` (path comment)

`CHANGELOG.md` is left as-is (release-please-generated history).

### 2. Correct the linked-issue policy

The docs claimed a linked issue is **required** and that the gate **hard-fails / auto-closes** a PR without one. That is wrong: **a linked issue is optional.** A PR with no linked issue is judged on its own merit and is **never** closed for the missing link; when an issue exists it is referenced (`Closes #<n>`) and the gate verifies the PR against the issue's intent.

Removed/corrected the false claim in:
- `AGENTS.md` — the gate-disposition sentence + non-negotiable #3
- `SKILL.md` — gate disposition table (dropped the *“No linked issue → CLOSE”* row), non-negotiable #6, Phase A4/A5, both pre-push checklists
- `reference.md` — the §3 gate table + the *“Hard rule for everyone”* paragraph + §6 PR-body + §7 close-list
- `docs/adr/0009-autonomous-review-gate.md` — auto-CLOSE / auto-MERGE bullets + consequences

## Verification

- `npm run format:check` ✓ · `npm run lint` ✓ · `npm run validate:docs` ✓
- No residual `contributing-to-metagraphed` refs (except `CHANGELOG.md` history); no residual *“no linked issue → fail”* claims.

_No linked issue — fittingly, per the policy this PR documents._