### PR TITLE
docs(skill): note public-provider-URL and no-committed-datasets rules

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -142,7 +142,9 @@ npm run surface:add -- \
   --source-url https://github.com/example/project/blob/main/README.md \
   --provider <provider-slug> --submitted-by <github-login> --write
   # Debut provider (slug not registered)? Add the team identity and surface:add scaffolds
-  # registry/providers/<slug>.json (flat — trust is the authority field) in the SAME PR:
+  # registry/providers/<slug>.json (flat — trust is the authority field) in the SAME PR.
+  # --provider-url is the provider's website_url and MUST be a public URL (validate
+  # rejects private/localhost), as must any logo/docs/github/team/contact/social URL:
   #   --provider-name "Example Team" --provider-url https://example.com
 ```
 

--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -116,18 +116,18 @@ The gate's private scoring rubric/thresholds must **never** appear in this repo 
 
 ## 4. npm scripts you'll actually use
 
-| Need                                      | Command                                                                                                                                                                                                                    |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Find the data gaps                        | `npm run curation:brief` (`-- --limit 20`, `-- --json`)                                                                                                                                                                    |
-| List / register providers                 | `npm run providers:list` (debut a new provider via `surface:add --provider-name`)                                                                                                                                          |
-| Add a community surface to a subnet file  | `npm run surface:add -- --netuid … --kind … --url … --source-url … --provider … --submitted-by … --write` — debut provider: add `--provider-name "…" --provider-url …` and it scaffolds the provider stub too              |
-| Scaffold a brand-new subnet file _(new)_  | `npm run subnet:new -- --netuid <n>`                                                                                                                                                                                       |
-| Validate a surface contribution _(new)_   | `npm run validate:surface -- registry/subnets/<slug>.json`                                                                                                                                                                 |
-| Public-safety scan                        | `npm run scan:public-safety`                                                                                                                                                                                               |
-| Code/schema: regenerate the contract      | `npm run build`                                                                                                                                                                                                            |
-| Code/schema: validators                   | `npm run validate` · `validate:schemas` · `validate:api` · `validate:openapi` · `validate:types` · `validate:contract-drift` · `validate:mcp` · `validate:ai` · `validate:docs` · `validate:intake` · `validate:workflows` |
-| Tests / coverage                          | `npm test` · `npm run test:coverage`                                                                                                                                                                                       |
-| Full local pipeline (after a clean build) | `npm run pipeline:check`                                                                                                                                                                                                   |
+| Need                                      | Command                                                                                                                                                                                                                                                     |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Find the data gaps                        | `npm run curation:brief` (`-- --limit 20`, `-- --json`)                                                                                                                                                                                                     |
+| List / register providers                 | `npm run providers:list` (debut a new provider via `surface:add --provider-name`)                                                                                                                                                                           |
+| Add a community surface to a subnet file  | `npm run surface:add -- --netuid … --kind … --url … --source-url … --provider … --submitted-by … --write` — debut provider: add `--provider-name "…" --provider-url …` (the `website_url`, **must be a public URL**) and it scaffolds the provider stub too |
+| Scaffold a brand-new subnet file _(new)_  | `npm run subnet:new -- --netuid <n>`                                                                                                                                                                                                                        |
+| Validate a surface contribution _(new)_   | `npm run validate:surface -- registry/subnets/<slug>.json`                                                                                                                                                                                                  |
+| Public-safety scan                        | `npm run scan:public-safety`                                                                                                                                                                                                                                |
+| Code/schema: regenerate the contract      | `npm run build`                                                                                                                                                                                                                                             |
+| Code/schema: validators                   | `npm run validate` · `validate:schemas` · `validate:api` · `validate:openapi` · `validate:types` · `validate:contract-drift` · `validate:mcp` · `validate:ai` · `validate:docs` · `validate:intake` · `validate:workflows`                                  |
+| Tests / coverage                          | `npm test` · `npm run test:coverage`                                                                                                                                                                                                                        |
+| Full local pipeline (after a clean build) | `npm run pipeline:check`                                                                                                                                                                                                                                    |
 
 > `surface:add`, `subnet:new`, and `validate:surface` are the single-file-model commands. They fully
 > replaced the retired `candidate:new` / `validate:candidate` intake lane — and `surface:add`
@@ -180,6 +180,8 @@ local paths, env dumps, or private notes.
 - Hand-set health/uptime/`verification` (probe-derived only).
 - UI/frontend changes (those belong in metagraphed-ui).
 - Editing the contract by hand without `npm run build` (contract-drift), or stale committed artifacts.
+- Committing generated artifacts — `public/datasets/*` or any `public/metagraph/*` outside the reviewed
+  contract (regenerated on build/deploy; `ci-verify-submitted-artifacts` rejects them).
 
 ---
 


### PR DESCRIPTION
## Summary

Two small accuracy clarifications to the `metagraphed` skill, each grounded in current CI behaviour (the two minor gaps flagged during the skill audit):

- **Public provider URLs (#1753).** A debut provider's `--provider-url` is its `website_url` and **must be a public URL** — `scripts/validate.mjs` (`assertPublicHttpUrl`) rejects private/localhost, as it does for `logo_url`/`docs_url`/`github_url`/`team_url`/`contact_url`/`social.*`. Noted in the Phase A2 `surface:add` snippet (`SKILL.md`) and the §4 provider-debut row (`reference.md`).
- **No committed generated artifacts (#1619).** `public/datasets/*` and any `public/metagraph/*` outside the reviewed contract are regenerated on build/deploy; `scripts/ci-verify-submitted-artifacts.mjs` rejects them. Added to the §7 close-list (`reference.md`).

Global personal copy (`~/.claude/skills/metagraphed/`) kept in sync.

## Verification

`npm run format:check` ✓ · `npm run lint` ✓ · `npm run validate:docs` ✓

_No linked issue (optional, per the gate policy)._