### PR TITLE
fix(icon-proxy): TTL the allowlist memo, bodyless HEAD, shorter negative-cache on transient failure

### DIFF
--- a/src/icon-proxy.mjs
+++ b/src/icon-proxy.mjs
@@ -24,6 +24,12 @@ const MIN_ICON_BYTES = 100; // reject empty / 1x1 placeholder responses
 const MAX_ICON_BYTES = 256 * 1024; // bound Worker memory and R2 object size
 const FETCH_TIMEOUT_MS = 3000;
 const CACHE_CONTROL = "public, max-age=2592000, immutable"; // 30d, per contract
+// Negative-cache windows split by cause: a structurally-invalid / non-allowlisted
+// host is a stable "no" (cache a day), but an allowlisted host whose upstream
+// aggregators *transiently* failed must retry soon — otherwise one bad minute
+// blackholes a real icon for 24h. (#1124 frontend-surfacing freshness audit.)
+const NEGATIVE_CACHE_STABLE = "public, max-age=86400"; // 24h — won't resolve
+const NEGATIVE_CACHE_TRANSIENT = "public, max-age=600"; // 10m — retry soon
 const BLOCKED_TLDS = new Set(["localhost", "local", "internal"]);
 // A real-ish UA — DuckDuckGo/Google's favicon endpoints bot-block the default Worker
 // user-agent (a cause of the prod 404s).
@@ -173,25 +179,32 @@ function etagFor(host, size) {
   return `"icon-${host}-${size}"`;
 }
 
-function imageResponse(body, contentType, etag, extra = {}) {
-  return new Response(body, {
-    status: 200,
-    headers: {
-      "content-type": contentType || "image/png",
-      "cache-control": CACHE_CONTROL,
-      etag,
-      "access-control-allow-origin": "*",
-      "x-content-type-options": "nosniff",
-      ...extra,
-    },
-  });
+// A HEAD must carry the same status + headers as the GET but no body (mirrors the
+// discovery handler's `request.method === "HEAD" ? null : ...`). We pass the GET's
+// byte length through so HEAD still advertises an accurate content-length.
+function imageResponse(body, contentType, etag, extra = {}, head = false) {
+  const byteLength =
+    body && typeof body === "object" && "byteLength" in body
+      ? body.byteLength
+      : null;
+  const headers = {
+    "content-type": contentType || "image/png",
+    "cache-control": CACHE_CONTROL,
+    etag,
+    "access-control-allow-origin": "*",
+    "x-content-type-options": "nosniff",
+    ...extra,
+  };
+  if (head && byteLength != null)
+    headers["content-length"] = String(byteLength);
+  return new Response(head ? null : body, { status: 200, headers });
 }
 
-function notFound() {
-  return new Response("icon not found", {
+function notFound(cacheControl = NEGATIVE_CACHE_STABLE) {
+  return new Response(null, {
     status: 404,
     headers: {
-      "cache-control": "public, max-age=86400", // negative-cache a day
+      "cache-control": cacheControl,
       "access-control-allow-origin": "*",
     },
   });
@@ -201,6 +214,7 @@ export async function handleIconProxy(request, env, url, options = {}) {
   if (request.method !== "GET" && request.method !== "HEAD") {
     return new Response("method not allowed", { status: 405 });
   }
+  const isHead = request.method === "HEAD";
   const host = normalizeHost(url.searchParams.get("host"));
   if (!host) {
     return new Response("invalid host", {
@@ -208,9 +222,11 @@ export async function handleIconProxy(request, env, url, options = {}) {
       headers: { "access-control-allow-origin": "*" },
     });
   }
-  const allowlist = await iconHostAllowlist(env, options);
+  const now = typeof options.now === "number" ? options.now : Date.now();
+  const allowlist = await iconHostAllowlist(env, options, now);
   if (!allowlist.has(host)) {
-    return notFound();
+    // Stable "no": this host isn't (yet) a registered surface. Cache a full day.
+    return notFound(NEGATIVE_CACHE_STABLE);
   }
 
   const size = clampSize(url.searchParams.get("size"));
@@ -225,13 +241,22 @@ export async function handleIconProxy(request, env, url, options = {}) {
   const bucket = env?.METAGRAPH_ARCHIVE;
   const cacheKey = `${ICON_CACHE_PREFIX}/${host}/${size}`;
 
-  // R2 cache hit -> single edge read.
+  // R2 cache hit -> single edge read. A HEAD short-circuits to a bodyless 200 but
+  // still wants an accurate content-length, so prefer R2's stored object size and
+  // release the body stream we won't send.
   if (bucket?.get) {
     try {
       const cached = await bucket.get(cacheKey);
       if (cached) {
         const ct = cached.httpMetadata?.contentType || "image/png";
-        return imageResponse(cached.body, ct, etag, { "x-icon-cache": "hit" });
+        const extra = { "x-icon-cache": "hit" };
+        if (isHead) {
+          if (typeof cached.size === "number")
+            extra["content-length"] = String(cached.size);
+          await cached.body?.cancel?.();
+          return imageResponse(null, ct, etag, extra, true);
+        }
+        return imageResponse(cached.body, ct, etag, extra);
       }
     } catch {
       // fall through to live resolution
@@ -242,6 +267,12 @@ export async function handleIconProxy(request, env, url, options = {}) {
   // Worker UA); follow redirects (the aggregators 30x to their own CDNs); no
   // cf.cacheEverything (it forced caching of redirect/non-200 responses and broke
   // resolution) — successful icons are cached in R2 below.
+  //
+  // Track whether any source *transiently* failed (network error / timeout / abort,
+  // or a 5xx upstream) vs. a clean negative (4xx / non-image). An allowlisted host
+  // that only saw transient failures must be retried soon, so it gets the short
+  // negative-cache window; a clean negative is a stable "no" and keeps 24h.
+  let transient = false;
   for (const src of faviconSources(host, size)) {
     try {
       const controller = new AbortController();
@@ -251,7 +282,10 @@ export async function handleIconProxy(request, env, url, options = {}) {
         redirect: "follow",
         signal: controller.signal,
       }).finally(() => clearTimeout(timeout));
-      if (!res.ok) continue;
+      if (!res.ok) {
+        if (res.status >= 500) transient = true; // upstream blip, not a real "no"
+        continue;
+      }
       const ct = res.headers.get("content-type") || "image/png";
       if (!ct.startsWith("image/")) {
         await res.body?.cancel?.();
@@ -268,10 +302,13 @@ export async function handleIconProxy(request, env, url, options = {}) {
           // caching is best-effort
         }
       }
-      return imageResponse(buf, ct, etag, { "x-icon-cache": "miss" });
+      return imageResponse(buf, ct, etag, { "x-icon-cache": "miss" }, isHead);
     } catch {
-      // try the next source
+      // A thrown fetch is a network error / timeout / abort — transient.
+      transient = true;
     }
   }
-  return notFound();
+  // Allowlisted host, every source failed: short window if it was transient (retry
+  // soon), full day if every source gave a clean negative.
+  return notFound(transient ? NEGATIVE_CACHE_TRANSIENT : NEGATIVE_CACHE_STABLE);
 }

--- a/tests/icon-proxy.test.mjs
+++ b/tests/icon-proxy.test.mjs
@@ -4,9 +4,12 @@ import { handleIconProxy } from "../src/icon-proxy.mjs";
 
 const PNG = new Uint8Array(200).fill(1).buffer; // >100 bytes -> not a placeholder
 
-async function call(qs, { env = {}, headers = {}, fetchImpl, options } = {}) {
+async function call(
+  qs,
+  { env = {}, headers = {}, method = "GET", fetchImpl, options } = {},
+) {
   const url = new URL("https://api.metagraph.sh/api/v1/icon" + qs);
-  const request = new Request(url, { headers });
+  const request = new Request(url, { method, headers });
   const orig = globalThis.fetch;
   if (fetchImpl) globalThis.fetch = fetchImpl;
   try {
@@ -259,7 +262,88 @@ test("memoizes the artifact allowlist per env (readArtifact not re-read)", async
     options: { readArtifact },
     fetchImpl,
   });
-  assert.equal(reads, before); // second call served from the WeakMap memo
+  assert.equal(reads, before); // second call served from the TTL memo
+});
+
+test("re-reads the artifact allowlist after the memo TTL expires", async () => {
+  let reads = 0;
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const readArtifact = async () => {
+    reads += 1;
+    return { ok: true, data: {} };
+  };
+  const fetchImpl = async () =>
+    new Response(PNG, {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+  const t0 = 1_000_000;
+  await call("?host=example.com", {
+    env,
+    options: { readArtifact, now: t0 },
+    fetchImpl,
+  });
+  const afterFirst = reads;
+  // Within the TTL window -> memo hit, no re-read.
+  await call("?host=example.com", {
+    env,
+    options: { readArtifact, now: t0 + 60_000 },
+    fetchImpl,
+  });
+  assert.equal(reads, afterFirst, "within TTL: no re-read");
+  // Past the 5-minute TTL -> the memo is stale, artifacts are re-read so a
+  // newly-published host would now resolve.
+  await call("?host=example.com", {
+    env,
+    options: { readArtifact, now: t0 + 300_001 },
+    fetchImpl,
+  });
+  assert.equal(reads > afterFirst, true, "past TTL: artifacts re-read");
+});
+
+test("a host published after the first memo resolves once the TTL lapses", async () => {
+  let published = false;
+  const env = {
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  // The allowlist artifact starts empty, then a new surface appears.
+  const readArtifact = async (_e, path) => {
+    if (!path.endsWith("subnets.json")) return { ok: false, data: null };
+    return published
+      ? { ok: true, data: { url: "https://fresh.example" } }
+      : { ok: true, data: {} };
+  };
+  const fetchImpl = async () =>
+    new Response(PNG, {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+  const t0 = 2_000_000;
+  // Not yet published -> 404 (not allowlisted), and the empty memo is cached.
+  const before = await call("?host=fresh.example", {
+    env,
+    options: { readArtifact, now: t0 },
+    fetchImpl,
+  });
+  assert.equal(before.status, 404);
+  published = true;
+  // Still inside the TTL -> served from the stale (empty) memo, still 404.
+  const stillStale = await call("?host=fresh.example", {
+    env,
+    options: { readArtifact, now: t0 + 10_000 },
+    fetchImpl,
+  });
+  assert.equal(stillStale.status, 404);
+  // Past the TTL -> memo refreshes, the new host resolves.
+  const fresh = await call("?host=fresh.example", {
+    env,
+    options: { readArtifact, now: t0 + 300_001 },
+    fetchImpl,
+  });
+  assert.equal(fresh.status, 200);
 });
 
 test("artifact read errors fail closed (host still allowed via configured env)", async () => {
@@ -421,6 +505,104 @@ test("skips a non-image content-type and cancels its body", async () => {
   });
   assert.equal(res.status, 404);
   assert.equal(canceled, true);
+});
+
+test("HEAD on an R2 hit returns a bodyless 200 with matching headers", async () => {
+  let bodyCanceled = false;
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: {
+      get: async () => ({
+        body: {
+          cancel: async () => {
+            bodyCanceled = true;
+          },
+        },
+        size: 200,
+        httpMetadata: { contentType: "image/png" },
+      }),
+      put: async () => {},
+    },
+  };
+  const res = await call("?host=example.com&size=64", { env, method: "HEAD" });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("x-icon-cache"), "hit");
+  assert.equal(res.headers.get("content-type"), "image/png");
+  assert.equal(res.headers.get("etag"), '"icon-example.com-64"');
+  assert.equal(res.headers.get("content-length"), "200"); // R2 object size
+  assert.match(res.headers.get("cache-control"), /immutable/);
+  assert.equal(await res.text(), ""); // no body streamed
+  assert.equal(bodyCanceled, true); // the R2 body stream was released
+});
+
+test("HEAD on a live miss returns a bodyless 200 advertising the byte length", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const res = await call("?host=example.com", {
+    env,
+    method: "HEAD",
+    fetchImpl: async () =>
+      new Response(PNG, {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("x-icon-cache"), "miss");
+  assert.equal(res.headers.get("content-length"), "200"); // PNG byteLength
+  assert.equal(await res.text(), "");
+});
+
+test("non-allowlisted host negative-caches for a full day (stable no)", async () => {
+  const res = await call("?host=attacker.example.com", {
+    env: { METAGRAPH_ICON_ALLOWED_HOSTS: "example.com" },
+  });
+  assert.equal(res.status, 404);
+  assert.match(res.headers.get("cache-control"), /max-age=86400/);
+});
+
+test("allowlisted host, clean 404 from every aggregator -> 24h negative cache", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async () => new Response("", { status: 404 }),
+  });
+  assert.equal(res.status, 404);
+  assert.match(res.headers.get("cache-control"), /max-age=86400/);
+});
+
+test("allowlisted host, thrown upstream error -> short transient negative cache", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async () => {
+      throw new Error("connection reset");
+    },
+  });
+  assert.equal(res.status, 404);
+  // 10-minute window, NOT the 24h stable one — a real icon retries soon.
+  assert.match(res.headers.get("cache-control"), /max-age=600/);
+});
+
+test("allowlisted host, 5xx from an aggregator -> short transient negative cache", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async () => new Response("", { status: 503 }),
+  });
+  assert.equal(res.status, 404);
+  assert.match(res.headers.get("cache-control"), /max-age=600/);
 });
 
 test("aborts a hung upstream fetch via the timeout controller", async () => {


### PR DESCRIPTION
## Summary

Fixes three freshness bugs in the brand-icon favicon proxy (`src/icon-proxy.mjs`),
surfaced by the **2026-06 gap audit** (no tracking issue). All keep the
aggregator-only fetch model — no host-derived or redirect fetches are added; the
proxy still hits only the fixed DuckDuckGo / Google favicon origins.

- **Bodyless HEAD.** `HEAD` requests previously read and returned the full R2 /
  upstream image body. They now short-circuit to a bodyless `200` carrying the
  same headers (etag, cache-control, content-type) plus an accurate
  `content-length`, mirroring `workers/request-handlers/discovery.mjs`. The R2
  body stream is released rather than streamed.

- **Negative-cache split by cause.** An allowlisted host that hit a *transient*
  aggregator failure was negative-cached for 24h, blackholing a real icon for a
  day after one bad minute. The window is now split: a structurally-invalid /
  non-allowlisted host keeps the 24h stable window (`max-age=86400`), but an
  allowlisted host whose upstreams *threw* (network error / timeout / abort) or
  returned `5xx` gets a short `max-age=600` window so it retries soon. Clean
  negatives (4xx / non-image) remain stable.

- **Allowlist memo TTL.** The per-isolate allowlist memo TTL (the third audit
  item) was already addressed on `main`. This PR threads an injectable clock
  through `handleIconProxy` so the TTL expiry is unit-testable, and adds explicit
  coverage proving a host published after the first memo resolves once the TTL
  lapses.

## Validation

- `npm run build` — all steps passed (no contract drift; the only build-time
  churn was the local `r2-manifest.json` timestamp, which is unrelated to this
  change and was not committed).
- `npx vitest run tests/icon-proxy.test.mjs` — 27 passed (added cases for TTL
  expiry, post-TTL host resolution, HEAD bodyless on both R2-hit and live-miss,
  and the transient-vs-stable negative-cache split for thrown / 5xx / clean-404).
- `npx vitest run tests/worker-runtime.test.mjs` — 41 passed (route-level
  regression).
- `npx prettier --check` + `npx eslint` on both changed files — clean.
