### PR TITLE
fix(ci): let oversized event batches self-heal

### DIFF
--- a/.github/workflows/refresh-events.yml
+++ b/.github/workflows/refresh-events.yml
@@ -80,15 +80,23 @@ jobs:
         run: |
           set +e
           pending=0
+          max_staged_bytes=4194304
           for key in \
             events/account-events-pending.json \
             events/blocks-pending.json \
             events/extrinsics-pending.json; do
-            npx wrangler r2 object get "metagraphed-artifacts/${key}" --file="/tmp/${key##*/}" --remote >/dev/null 2>&1
+            staged_file="/tmp/${key##*/}"
+            rm -f "${staged_file}"
+            npx wrangler r2 object get "metagraphed-artifacts/${key}" --file="${staged_file}" --remote >/dev/null 2>&1
             status=$?
             if [ "$status" -eq 0 ]; then
-              echo "${key} is still pending; skip this producer tick so the Worker can drain it"
-              pending=1
+              size=$(wc -c < "${staged_file}" | tr -d ' ')
+              if [ "${size}" -gt "${max_staged_bytes}" ]; then
+                echo "${key} is ${size} bytes, above the Worker drain cap; allow this producer tick to replace it"
+              else
+                echo "${key} is still pending; skip this producer tick so the Worker can drain it"
+                pending=1
+              fi
             fi
           done
           echo "skip=${pending}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Motivation
- The refresh workflow previously skipped producing/staging/signing and cursor advancement whenever any R2 pending events/blocks/extrinsics object existed, which could permanently stall ingestion if the Worker left an over-byte staged object intact. 
- The Worker enforces byte caps (4 MiB) and deliberately returns `too_large` without deleting such objects, so the producer must be allowed to overwrite oversized pending files to restore self-heal semantics.

### Description
- Update `.github/workflows/refresh-events.yml` to download each staged object and measure its byte size before deciding to skip the producer tick. 
- Add `max_staged_bytes=4194304` and allow the producer to proceed when a staged object's size is greater than that cap, while still skipping when the object is drainable (size <= cap).
- This preserves the guard for drainable pending batches so the Worker can import them, but prevents a single oversized pending object from freezing progress.

### Testing
- Ran `git diff --check` and `npm run validate:workflows`, both completed successfully. 
- Ran targeted JS tests `npm test -- --run tests/load-staged-events.test.mjs tests/load-staged-blocks-extrinsics.test.mjs`, which passed. 
- Ran Python unit tests `python -m unittest scripts/test_fetch_events.py -v`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ccda10b38832c901fe4c0b3b20b55)