### PR TITLE
fix(chain): stop pruning block-explorer tables from the hourly cron

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -1,12 +1,13 @@
 // Chain-event index (#1346, epic #1345): the D1 `account_events` tier — first-party
 // per-entity activity decoded DIRECTLY from finney by scripts/fetch-events.py
 // (substrate System.Events), NOT Taostats. This module holds the load contract,
-// the daily rollup + prune (retention), and the row→API shaping (#1347). Pure +
-// exported for tests; the Worker runs the D1 I/O.
+// the daily rollup, the (currently inactive) prune, and the row→API shaping
+// (#1347). Pure + exported for tests; the Worker runs the D1 I/O.
 
-// Hot window for raw events; rolled into account_events_daily before prune so
-// long-term per-entity history survives (mirrors the 30d surface_checks window).
-export const EVENT_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+// Retention constant kept for tests. pruneAccountEvents is NOT called by the cron
+// — the block explorer requires full historical depth (ADR 0012); prune is
+// deferred to the Postgres migration (#1519).
+export const EVENT_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // reference only
 
 // Columns written to account_events — THE load contract. scripts/fetch-events.py
 // emits rows with exactly these keys; loadStagedEvents binds them in this order.

--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -1,13 +1,14 @@
-// Block explorer hot window (#1345 epic, first vertical slice): the D1 `blocks`
-// tier — first-party per-block headers decoded DIRECTLY from finney by the same
+// Block explorer (#1345 epic, first vertical slice): the D1 `blocks` tier —
+// first-party per-block headers decoded DIRECTLY from finney by the same
 // chain-direct poller (scripts/fetch-events.py) that fills account_events, NOT
 // Taostats. This module holds the load contract, the row→API shaping, and the
-// retention prune. Pure + exported for tests; the Worker runs the D1 I/O.
+// (currently inactive) retention prune. Pure + exported for tests; the Worker
+// runs the D1 I/O.
 
-// Hot window for raw blocks; rows older than this are pruned (mirrors the
-// account_events 90d window). Deep block history is the optional archive-RPC
-// upgrade (#1349).
-export const BLOCK_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+// Retention constant kept for tests. pruneBlocks is NOT called by the cron —
+// the block explorer requires full historical depth (ADR 0012); prune is
+// deferred to the Postgres migration (#1519).
+export const BLOCK_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // reference only
 
 // Columns written to blocks — THE load contract. scripts/fetch-events.py emits
 // rows with exactly these keys; loadStagedBlocks binds them in this order. Values

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -1,14 +1,14 @@
-// Block explorer hot window (#1345 epic, second vertical slice): the D1
-// `extrinsics` tier — first-party per-extrinsic (transaction) records decoded
-// DIRECTLY from finney by the same chain-direct poller (scripts/fetch-events.py)
-// that fills account_events + blocks, NOT Taostats. This module holds the load
-// contract, the row→API shaping, and the retention prune. Pure + exported for
+// Block explorer (#1345 epic, second vertical slice): the D1 `extrinsics` tier —
+// first-party per-extrinsic (transaction) records decoded DIRECTLY from finney by
+// the same chain-direct poller (scripts/fetch-events.py) that fills account_events
+// + blocks, NOT Taostats. This module holds the load contract, the row→API
+// shaping, and the (currently inactive) retention prune. Pure + exported for
 // tests; the Worker runs the D1 I/O.
 
-// Hot window for raw extrinsics; rows older than this are pruned (mirrors the
-// account_events + blocks 90d window). Deep extrinsic history is the optional
-// archive-RPC upgrade (#1349).
-export const EXTRINSIC_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+// Retention constant kept for tests. pruneExtrinsics is NOT called by the cron —
+// the block explorer requires full historical depth (ADR 0012); prune is deferred
+// to the Postgres migration (#1519).
+export const EXTRINSIC_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // reference only
 
 // Columns written to extrinsics — THE load contract. scripts/fetch-events.py
 // emits rows with exactly these keys; loadStagedExtrinsics binds them in this

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -142,10 +142,7 @@ import {
   rollupAccountEventsDaily,
   validEventRows,
 } from "../src/account-events.mjs";
-import {
-  blockInsertStatements,
-  validBlockRows,
-} from "../src/blocks.mjs";
+import { blockInsertStatements, validBlockRows } from "../src/blocks.mjs";
 import {
   extrinsicInsertStatements,
   validExtrinsicRows,

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -140,17 +140,14 @@ import {
 import {
   eventInsertStatements,
   rollupAccountEventsDaily,
-  pruneAccountEvents,
   validEventRows,
 } from "../src/account-events.mjs";
 import {
   blockInsertStatements,
-  pruneBlocks,
   validBlockRows,
 } from "../src/blocks.mjs";
 import {
   extrinsicInsertStatements,
-  pruneExtrinsics,
   validExtrinsicRows,
 } from "../src/extrinsics.mjs";
 import {
@@ -762,21 +759,14 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
       };
     }
     const [pruned] = await Promise.all([
-      // .catch-isolated like every sibling prune below — a rejection here (e.g. a
-      // transient D1 error) must degrade to a no-op for this tick, not abort the
-      // whole Promise.all and discard the snapshot write + the other prunes.
+      // .catch-isolated — a transient D1 error must degrade to a no-op for this
+      // tick, not abort the whole Promise.all and discard the snapshot write.
       pruneHealthHistory(env).catch(() => ({ pruned: false })),
-      pruneAccountEvents(env).catch(() => ({ pruned: false })),
-      // Block-explorer hot window (#1345): prune `blocks` past the 90d retention
-      // on the same hourly maintenance cron. No rollup (the block hot window has
-      // no durable daily aggregate yet), so it isn't gated on a rollup like the
-      // events prune; .catch-isolated so it can never break the shared cron.
-      pruneBlocks(env).catch(() => ({ pruned: false })),
-      // Block-explorer extrinsic slice (#1345): prune `extrinsics` past the 90d
-      // retention on the same hourly maintenance cron. No rollup (the extrinsic
-      // hot window has no durable daily aggregate yet), so it isn't gated on a
-      // rollup; .catch-isolated so it can never break the shared cron.
-      pruneExtrinsics(env).catch(() => ({ pruned: false })),
+      // blocks / extrinsics / account_events are NOT pruned here — the block
+      // explorer requires full historical depth (ADR 0012). Retention is deferred
+      // to the Postgres migration (#1519) where a cold tier backs older rows
+      // before any D1 prune can run. The prune functions remain in src/ for
+      // tests; removing these calls is the only safe wire-cut.
       snapshotPromise,
     ]);
     return pruned;


### PR DESCRIPTION
## Summary

- Removes the three `pruneBlocks` / `pruneExtrinsics` / `pruneAccountEvents` calls from the `HEALTH_PRUNE_CRON` handler in `workers/api.mjs`
- Removes the now-unused imports of those three functions from `api.mjs`
- Updates comment blocks in `src/blocks.mjs`, `src/extrinsics.mjs`, and `src/account-events.mjs` to note that the retention constants are reference-only and the prune is deferred

## Why

The block explorer (ADR 0012 / #1345) requires **full historical depth** — a 90-day rolling window defeats the purpose. Historical backfill via `backfill-events.py` writes rows with height-derived `observed_at` timestamps; the old 90-day prune would immediately delete anything older than 90 days on the next hourly cron tick.

Prune is deferred to the Postgres migration (#1519), where a cold tier will archive older rows before any D1 prune can run.

The `pruneBlocks` / `pruneExtrinsics` / `pruneAccountEvents` functions remain in `src/` — they are still imported and exercised by their unit tests. Only the live cron calls are removed.

## Test plan

- [ ] `npm test` — existing prune unit tests still pass (functions unchanged)
- [ ] Confirm no `pruneBlocks` / `pruneExtrinsics` / `pruneAccountEvents` call sites remain in `workers/api.mjs`
- [ ] Deploy to prod; verify the hourly `HEALTH_PRUNE_CRON` fires without errors and D1 block/extrinsic counts do not drop

Closes #1349