### PR TITLE
fix(validate): reject community surfaces that duplicate native-chain promoted candidates

### DIFF
--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -13,6 +13,7 @@ import {
   classifyNativeName,
   listJsonFiles,
   loadProviders,
+  normalizePublicUrl,
   readJson,
   repoRoot,
 } from "./lib.mjs";
@@ -32,6 +33,44 @@ const providerIds = new Set(
 // contributor template already omits these kinds; this closes the hand-crafted
 // PR gap) without touching the probe-derived endpoint pipeline. See issue #1680.
 const BASE_LAYER_KINDS = new Set(["subtensor-rpc", "subtensor-wss", "archive"]);
+
+// Build the set of (netuid, normalized-url) keys for native-chain candidates that
+// are already machine-promoted (classification live or redirected). A community
+// surface duplicating one of these adds no signal — the build pipeline injects it
+// automatically via generateBaselineOverlaySet / augmentManualOverlaysWithBaseline.
+// Loaded here at start-up so the per-surface loop stays O(1). Silently skipped
+// when the generated artifacts are absent (fresh clone, offline run).
+const LIVE_CLASSIFICATIONS = new Set(["live", "redirected"]);
+const nativeChainLiveKeys = new Set();
+try {
+  const publicSources = await readJson(
+    path.join(
+      repoRoot,
+      "registry/candidates/generated/public-sources.json",
+    ),
+  );
+  const promotions = await readJson(
+    path.join(repoRoot, "registry/verification/promotions.json"),
+  );
+  const classificationById = new Map(
+    (promotions.results || []).map((r) => [r.candidate_id, r.classification]),
+  );
+  for (const candidate of publicSources.candidates || []) {
+    if (
+      candidate.source_tier === "native-chain" &&
+      LIVE_CLASSIFICATIONS.has(classificationById.get(candidate.id))
+    ) {
+      const normalized = normalizePublicUrl(candidate.url);
+      if (normalized) {
+        nativeChainLiveKeys.add(
+          `${candidate.kind}|${candidate.netuid}|${normalized}`,
+        );
+      }
+    }
+  }
+} catch {
+  // Candidate data unavailable — skip the native-chain dedup check.
+}
 
 const fileArgs = process.argv.slice(2).filter((arg) => !arg.startsWith("--"));
 const files =
@@ -79,6 +118,24 @@ for (const file of files) {
         `${label}: a community surface must carry review.state ` +
           '(e.g. "community-submitted"). Use `npm run surface:add`.',
       );
+    }
+    if (
+      surface.authority === "community" &&
+      surface.url &&
+      nativeChainLiveKeys.size > 0
+    ) {
+      const normalized = normalizePublicUrl(surface.url);
+      if (
+        normalized &&
+        nativeChainLiveKeys.has(`${surface.kind}|${document.netuid}|${normalized}`)
+      ) {
+        errors.push(
+          `${label}: "${surface.url}" is already machine-promoted from on-chain ` +
+            "SubnetIdentitiesV3 — this surface adds no new signal (the build pipeline " +
+            "injects it automatically). Submit a surface the machine cannot discover: " +
+            "openapi, subnet-api, sse, data-artifact, or sdk.",
+        );
+      }
     }
     if (BASE_LAYER_KINDS.has(surface.kind) && document.netuid !== 0) {
       errors.push(

--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -44,10 +44,7 @@ const LIVE_CLASSIFICATIONS = new Set(["live", "redirected"]);
 const nativeChainLiveKeys = new Set();
 try {
   const publicSources = await readJson(
-    path.join(
-      repoRoot,
-      "registry/candidates/generated/public-sources.json",
-    ),
+    path.join(repoRoot, "registry/candidates/generated/public-sources.json"),
   );
   const promotions = await readJson(
     path.join(repoRoot, "registry/verification/promotions.json"),
@@ -127,7 +124,9 @@ for (const file of files) {
       const normalized = normalizePublicUrl(surface.url);
       if (
         normalized &&
-        nativeChainLiveKeys.has(`${surface.kind}|${document.netuid}|${normalized}`)
+        nativeChainLiveKeys.has(
+          `${surface.kind}|${document.netuid}|${normalized}`,
+        )
       ) {
         errors.push(
           `${label}: "${surface.url}" is already machine-promoted from on-chain ` +


### PR DESCRIPTION
## Summary

- Loads `registry/candidates/generated/public-sources.json` + `registry/verification/promotions.json` at validate:surface start-up and builds a Set of `(kind, netuid, normalized-url)` keys for every native-chain candidate already machine-promoted with `classification: live` or `redirected`.
- Any community surface whose `(kind, netuid, normalizedUrl)` matches a key in that Set fails validation with an actionable message directing the contributor toward surfaces the machine cannot discover: openapi, subnet-api, sse, data-artifact, sdk.
- Keyed on `kind` so a kind-correction (same URL, different kind — e.g. native-chain `website` → contributor `dashboard`) is still accepted.
- Silently skips the check when candidate artifacts are absent (fresh clone, offline) so no build is red-lined without data.

## Why

`generateBaselineOverlaySet` auto-promotes native-chain candidates that are `live`/`redirected` and `augmentManualOverlaysWithBaseline` injects them into every manual overlay. Contributors submitting `source-repo` or `website` surfaces for subnets where the machine already has those URLs at full confidence add no new signal — and the enrichment issue buffer was generating tasks for those exact gaps, producing farming PRs with zero incremental value.

## Validation

```
npm run validate:surface   # passes on all 99 existing subnet files (404 surfaces)
```

The check is exercised by any future contributor PR that submits a URL already in the native-chain + live/redirected Set — validate:surface (called at `.github/workflows/validate.yml:239`) will reject it in CI.