### PR TITLE
fix(enrichment): drop source-repo and website from VALUE_PRIORITY

### DIFF
--- a/scripts/enrichment-issues.mjs
+++ b/scripts/enrichment-issues.mjs
@@ -28,21 +28,25 @@ const API_BASE =
 const TRACKER = 427;
 const LABELS = ["gittensor:priority", "good first issue", "help wanted"];
 const LIMIT = Number(getOpt("--limit", "20"));
-// Default to the operational gaps (the remaining volume); identity gaps
-// (source-repo/website) are nearly exhausted by the existing tracker issues.
+// Operational gaps only — identity surfaces (source-repo/website) are
+// machine-promoted automatically from SubnetIdentitiesV3 chain data and injected
+// into every overlay via generateBaselineOverlaySet. Issuing contributor tasks for
+// them produces farming PRs that add no signal; the native-chain probe already
+// covers that surface kind for any subnet that has registered identity on-chain.
 const KINDS = getOpt("--kinds", "openapi,subnet-api,data-artifact,sse")
   .split(",")
   .map((k) => k.trim())
   .filter(Boolean);
 
 // Highest agent value first — a callable API + its spec beat artifacts/streams.
+// source-repo and website are intentionally absent: those are machine-promoted
+// from native-chain data; contributor submissions duplicate what the build already
+// injects automatically (see validate:surface native-chain dedup gate).
 const VALUE_PRIORITY = [
   "subnet-api",
   "openapi",
   "data-artifact",
   "sse",
-  "source-repo",
-  "website",
   "docs",
   "sdk",
 ];


### PR DESCRIPTION
## Summary

- Removes `"source-repo"` and `"website"` from `VALUE_PRIORITY` in `scripts/enrichment-issues.mjs`.
- Updates the comment above `KINDS` to explain why identity surfaces are excluded from the enrichment pipeline.
- The default `--kinds` flag already excluded both (`openapi,subnet-api,data-artifact,sse`) — this change aligns `VALUE_PRIORITY` (used for sorting which gap to lead the issue with) with the same invariant, so neither kind can rank as the primary gap even if `--kinds` is widened.

## Why

`source-repo` and `website` surfaces are machine-promoted automatically from SubnetIdentitiesV3 on-chain data via `generateBaselineOverlaySet` and injected into every overlay by `augmentManualOverlaysWithBaseline`. Issuing enrichment contributor tasks for these kinds produces farming PRs that submit URLs the build pipeline already handles — the new native-chain dedup gate in `validate:surface` (PR #1820) hard-rejects them. Keeping them in `VALUE_PRIORITY` would let them silently resurface if `--kinds` were ever widened. Removing them closes that gap structurally.

The old comment said "identity gaps (source-repo/website) are nearly exhausted" — replaced with the precise reason: they are machine-promoted and not a valid contributor target.