### PR TITLE
feat(schema): add community-seeded curation level for contributor-created subnet files

### DIFF
--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -346,6 +346,7 @@
           "enum": [
             "native",
             "candidate-discovered",
+            "community-seeded",
             "machine-verified",
             "maintainer-reviewed",
             "adapter-backed"

--- a/scripts/subnet-new.mjs
+++ b/scripts/subnet-new.mjs
@@ -64,7 +64,7 @@ const document = {
   slug: `sn-${netuid}`,
   status: subnet.status === "inactive" ? "inactive" : "active",
   categories: [],
-  curation: { level: "candidate-discovered", review_state: "unreviewed" },
+  curation: { level: "community-seeded", review_state: "unreviewed" },
   surfaces: [],
 };
 


### PR DESCRIPTION
## Summary

- Adds `"community-seeded"` to the `curation.level` enum in `schemas/subnet-manifest.schema.json`, positioned between `"candidate-discovered"` and `"machine-verified"`.
- Updates `scripts/subnet-new.mjs` to default new subnet scaffolds to `"community-seeded"` instead of `"candidate-discovered"`.

## Why

`"candidate-discovered"` implies the machine identified the subnet via an automated discovery run. A file created via `npm run subnet:new` — initiated by a human contributor who found an enrichment gap — is not machine-discovered; it is community-seeded. Using the same level conflates two distinct provenance signals and makes the curation tier ladder ambiguous.

The new level slots cleanly into the existing progression:

    native → candidate-discovered → community-seeded → machine-verified → maintainer-reviewed → adapter-backed

Schema-only change: `curation.level` is not projected into any API route response type. `openapi.json`, `types.d.ts`, and `contracts.json` are unchanged; `validate:contract-drift` passes.

## Validation

```
npm run build              # passes; only r2-manifest.json (excluded from drift) differs
npm run validate:contract-drift   # passes
npm run validate:surface   # passes on all 99 existing subnet files
```