### PR TITLE
feat(chain): capture Balances.Transfer events in the chain-event index

### DIFF
--- a/scripts/backfill-events.py
+++ b/scripts/backfill-events.py
@@ -168,7 +168,7 @@ def main():
         for event_index, ev in enumerate(events):
             v = ev.value if isinstance(ev.value, dict) else {}
             e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
-            if e.get("module_id") != "SubtensorModule":
+            if e.get("module_id") not in ("SubtensorModule", "Balances"):
                 continue
             ent = _fe.extract(e.get("event_id"), e.get("attributes"))
             if ent is None:

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -216,6 +216,17 @@ def _root(a):  # {coldkey} (named) or [coldkey]
     return {"coldkey": _ss58(ck)}
 
 
+def _transfer(a):  # Balances.Transfer: [from, to, amount] or {from, to, amount}
+    if isinstance(a, dict):
+        sender, recipient, amount = a.get("from"), a.get("to"), a.get("amount")
+    else:
+        sender = a[0] if len(a) > 0 else None
+        recipient = a[1] if len(a) > 1 else None
+        amount = a[2] if len(a) > 2 else None
+    # hotkey = sender, coldkey = recipient (pragmatic reuse of the index columns)
+    return {"hotkey": _ss58(sender), "coldkey": _ss58(recipient), "amount_tao": _tao(amount)}
+
+
 EXTRACTORS = {
     "NeuronRegistered": _registered,
     "StakeAdded": _stake,
@@ -224,6 +235,8 @@ EXTRACTORS = {
     "AxonServed": _axon,
     "WeightsSet": _weights,
     "RootClaimed": _root,
+    # Balances pallet — native TAO transfers between accounts (#1814)
+    "Transfer": _transfer,
 }
 
 
@@ -524,7 +537,7 @@ def main():
         for event_index, ev in enumerate(events):
             v = ev.value if isinstance(ev.value, dict) else {}
             e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
-            if e.get("module_id") != "SubtensorModule":
+            if e.get("module_id") not in ("SubtensorModule", "Balances"):
                 continue
             eid = e.get("event_id")
             ent = extract(eid, e.get("attributes"))

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -212,5 +212,62 @@ class LagAlertNeededTest(unittest.TestCase):
         self.assertFalse(_lag_alert_needed(10_000, 9_000, window=400, horizon=300))
 
 
+_extract = _fe.extract
+_SS58_A = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+_SS58_B = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+_RAO_100 = 100_000_000_000  # 100 TAO in rao
+
+
+class TransferExtractorTest(unittest.TestCase):
+    """Tests for the Balances.Transfer extractor (#1814)."""
+
+    def test_list_form_positional(self):
+        # Older runtimes emit [from, to, amount] as positional list
+        result = _extract("Transfer", [_SS58_A, _SS58_B, _RAO_100])
+        self.assertEqual(result["hotkey"], _SS58_A)
+        self.assertEqual(result["coldkey"], _SS58_B)
+        self.assertAlmostEqual(result["amount_tao"], 100.0)
+        self.assertIsNone(result["netuid"])
+        self.assertIsNone(result["uid"])
+
+    def test_dict_form_named(self):
+        # Newer runtimes emit named-field dict
+        result = _extract("Transfer", {"from": _SS58_A, "to": _SS58_B, "amount": _RAO_100})
+        self.assertEqual(result["hotkey"], _SS58_A)
+        self.assertEqual(result["coldkey"], _SS58_B)
+        self.assertAlmostEqual(result["amount_tao"], 100.0)
+
+    def test_zero_amount(self):
+        result = _extract("Transfer", [_SS58_A, _SS58_B, 0])
+        self.assertAlmostEqual(result["amount_tao"], 0.0)
+
+    def test_invalid_from_gives_null_hotkey(self):
+        result = _extract("Transfer", ["not-an-address", _SS58_B, _RAO_100])
+        self.assertIsNone(result["hotkey"])
+        self.assertEqual(result["coldkey"], _SS58_B)
+
+    def test_invalid_to_gives_null_coldkey(self):
+        result = _extract("Transfer", [_SS58_A, "not-an-address", _RAO_100])
+        self.assertEqual(result["hotkey"], _SS58_A)
+        self.assertIsNone(result["coldkey"])
+
+    def test_missing_amount_gives_null(self):
+        result = _extract("Transfer", [_SS58_A, _SS58_B])
+        self.assertIsNone(result["amount_tao"])
+
+    def test_non_transfer_balances_event_ignored(self):
+        # Balances.Deposit, Balances.Reserved, etc. — no extractor → None
+        self.assertIsNone(_extract("Deposit", [_SS58_A, _RAO_100]))
+        self.assertIsNone(_extract("Reserved", [_SS58_A, _RAO_100]))
+
+    def test_shape_drift_never_raises(self):
+        # Completely wrong shape (empty list) must never raise — all fields null
+        result = _extract("Transfer", [])
+        self.assertIsNotNone(result)
+        self.assertIsNone(result["hotkey"])
+        self.assertIsNone(result["coldkey"])
+        self.assertIsNone(result["amount_tao"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Adds `_transfer` extractor to `EXTRACTORS` in `scripts/fetch-events.py` for `Balances.Transfer` events
- Broadens the per-event module filter from `SubtensorModule`-only to `("SubtensorModule", "Balances")` in both `fetch-events.py` and `backfill-events.py`
- 8 new unit tests in `scripts/test_fetch_events.py`; 29/29 pass

## Schema mapping

`Balances.Transfer` → `account_events` row:

| Chain field | Column | Notes |
|---|---|---|
| `from` | `hotkey` | sender ss58 |
| `to` | `coldkey` | recipient ss58 |
| `amount` | `amount_tao` | `amount / 1e9` |
| — | `event_kind` | `"Transfer"` |
| — | `netuid`, `uid` | `null` |

Handles both positional-list and named-dict attribute forms for runtime compatibility. Shape drift degrades to null fields — never raises.

## Why no schema change

The `account_events` table already accepts arbitrary `event_kind` values. No migration needed.

## Test plan

- [x] 29/29 unit tests pass (`python3 scripts/test_fetch_events.py`)
- [ ] After merge, dispatch a backfill over a range with known transfers and verify `event_kind = "Transfer"` rows land in D1
- [ ] `GET /api/v1/accounts/{ss58}` for an active wallet returns `Transfer` events

Closes #1814