### PR TITLE
fix(build): preserve committed run_prefix in local manifest writes

### DIFF
--- a/scripts/r2-manifest.mjs
+++ b/scripts/r2-manifest.mjs
@@ -24,9 +24,17 @@ const fullManifestPath = path.join(
   "r2-manifest.json",
 );
 const r2StagingRoot = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT);
-const manifest = write ? null : await readJson(manifestPath);
+// Always read the committed manifest. In write mode, when neither
+// METAGRAPH_RUN_ID nor METAGRAPH_BUILD_TIMESTAMP is set (local dev), reuse
+// the committed manifest's generated_at as the runId so the run_prefix stays
+// stable and never shows 1970 epoch timestamps.
+const manifest = await readJson(manifestPath).catch(() => null);
+const buildGeneratedAt =
+  process.env.METAGRAPH_RUN_ID || process.env.METAGRAPH_BUILD_TIMESTAMP
+    ? buildTimestamp()
+    : (manifest?.generated_at ?? new Date().toISOString());
 const fullManifest = write
-  ? await buildManifest()
+  ? await buildManifest(buildGeneratedAt)
   : existsSync(r2StagingRoot)
     ? await buildManifest(manifest.generated_at)
     : await readJson(fullManifestPath).catch(() => null);


### PR DESCRIPTION
## Root cause

`r2-manifest.mjs --write` called `buildManifest()` with no argument, which defaulted to `buildTimestamp()` → `"1970-01-01T00:00:00.000Z"` when neither `METAGRAPH_BUILD_TIMESTAMP` nor `METAGRAPH_RUN_ID` was set. Every local `npm run build` overwrote `public/metagraph/r2-manifest.json` with `runs/1970-01-01T00-00-00-000Z/` keys.

## Fix

In write mode, read the existing committed manifest before building. When no CI env var is set, use the committed manifest's `generated_at` as the `generatedAt` fallback. Priority order:

1. `METAGRAPH_RUN_ID` — CI, unique per deploy (unchanged)
2. `METAGRAPH_BUILD_TIMESTAMP` — CI reproducibility (unchanged)
3. **Committed manifest's `generated_at`** — local dev: run_prefix stays stable between builds
4. `new Date().toISOString()` — first build, no committed manifest yet

Artifact sha256s are still recomputed from real file contents on every write, so the manifest remains accurate when build outputs change.

## Effect

- Local `npm run build` no longer produces a 1970 diff in `r2-manifest.json`
- CI is unaffected (`METAGRAPH_RUN_ID` overrides everything as before)
- `METAGRAPH_BUILD_TIMESTAMP` still controls the run prefix when set

## Test plan

- [x] `tests/artifacts.test.mjs > r2 manifest dry-run reuses the committed timestamp` — passes (METAGRAPH_BUILD_TIMESTAMP still respected)
- [x] `tests/artifacts.test.mjs > committed R2 manifest does not use fallback history keys` — passes
- [x] 1996/1996 tests pass
- [x] `node scripts/r2-manifest.mjs --write` locally produces `runs/2026-06-18T00-00-00-000Z/` (real date, not 1970)