### PR TITLE
fix(chain): re-enable pruning at 365-day window as D1 safety valve

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -1,13 +1,12 @@
 // Chain-event index (#1346, epic #1345): the D1 `account_events` tier — first-party
 // per-entity activity decoded DIRECTLY from finney by scripts/fetch-events.py
 // (substrate System.Events), NOT Taostats. This module holds the load contract,
-// the daily rollup, the (currently inactive) prune, and the row→API shaping
-// (#1347). Pure + exported for tests; the Worker runs the D1 I/O.
+// the daily rollup, the prune, and the row→API shaping (#1347). Pure + exported
+// for tests; the Worker runs the D1 I/O.
 
-// Retention constant kept for tests. pruneAccountEvents is NOT called by the cron
-// — the block explorer requires full historical depth (ADR 0012); prune is
-// deferred to the Postgres migration (#1519).
-export const EVENT_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // reference only
+// D1 safety-valve: 365-day retention prevents unbounded growth before the
+// Postgres cold tier (#1519) ships. pruneAccountEvents runs in HEALTH_PRUNE_CRON.
+export const EVENT_RETENTION_MS = 365 * 24 * 60 * 60 * 1000;
 
 // Columns written to account_events — THE load contract. scripts/fetch-events.py
 // emits rows with exactly these keys; loadStagedEvents binds them in this order.

--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -2,13 +2,11 @@
 // first-party per-block headers decoded DIRECTLY from finney by the same
 // chain-direct poller (scripts/fetch-events.py) that fills account_events, NOT
 // Taostats. This module holds the load contract, the row→API shaping, and the
-// (currently inactive) retention prune. Pure + exported for tests; the Worker
-// runs the D1 I/O.
+// retention prune. Pure + exported for tests; the Worker runs the D1 I/O.
 
-// Retention constant kept for tests. pruneBlocks is NOT called by the cron —
-// the block explorer requires full historical depth (ADR 0012); prune is
-// deferred to the Postgres migration (#1519).
-export const BLOCK_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // reference only
+// D1 safety-valve: 365-day retention prevents unbounded growth before the
+// Postgres cold tier (#1519) ships. pruneBlocks runs in the HEALTH_PRUNE_CRON.
+export const BLOCK_RETENTION_MS = 365 * 24 * 60 * 60 * 1000;
 
 // Columns written to blocks — THE load contract. scripts/fetch-events.py emits
 // rows with exactly these keys; loadStagedBlocks binds them in this order. Values

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -2,13 +2,12 @@
 // first-party per-extrinsic (transaction) records decoded DIRECTLY from finney by
 // the same chain-direct poller (scripts/fetch-events.py) that fills account_events
 // + blocks, NOT Taostats. This module holds the load contract, the row→API
-// shaping, and the (currently inactive) retention prune. Pure + exported for
-// tests; the Worker runs the D1 I/O.
+// shaping, and the retention prune. Pure + exported for tests; the Worker runs
+// the D1 I/O.
 
-// Retention constant kept for tests. pruneExtrinsics is NOT called by the cron —
-// the block explorer requires full historical depth (ADR 0012); prune is deferred
-// to the Postgres migration (#1519).
-export const EXTRINSIC_RETENTION_MS = 90 * 24 * 60 * 60 * 1000; // reference only
+// D1 safety-valve: 365-day retention prevents unbounded growth before the
+// Postgres cold tier (#1519) ships. pruneExtrinsics runs in the HEALTH_PRUNE_CRON.
+export const EXTRINSIC_RETENTION_MS = 365 * 24 * 60 * 60 * 1000;
 
 // Columns written to extrinsics — THE load contract. scripts/fetch-events.py
 // emits rows with exactly these keys; loadStagedExtrinsics binds them in this

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -139,12 +139,18 @@ import {
 } from "../src/neuron-history.mjs";
 import {
   eventInsertStatements,
+  pruneAccountEvents,
   rollupAccountEventsDaily,
   validEventRows,
 } from "../src/account-events.mjs";
-import { blockInsertStatements, validBlockRows } from "../src/blocks.mjs";
+import {
+  blockInsertStatements,
+  pruneBlocks,
+  validBlockRows,
+} from "../src/blocks.mjs";
 import {
   extrinsicInsertStatements,
+  pruneExtrinsics,
   validExtrinsicRows,
 } from "../src/extrinsics.mjs";
 import {
@@ -759,11 +765,14 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
       // .catch-isolated — a transient D1 error must degrade to a no-op for this
       // tick, not abort the whole Promise.all and discard the snapshot write.
       pruneHealthHistory(env).catch(() => ({ pruned: false })),
-      // blocks / extrinsics / account_events are NOT pruned here — the block
-      // explorer requires full historical depth (ADR 0012). Retention is deferred
-      // to the Postgres migration (#1519) where a cold tier backs older rows
-      // before any D1 prune can run. The prune functions remain in src/ for
-      // tests; removing these calls is the only safe wire-cut.
+      // D1 safety-valve: prune chain-explorer tables at a 365-day window so D1
+      // never hits the 10 GB cap before the Postgres cold tier (#1519) ships.
+      // account_events is safe here — rollupAccountEventsDaily (above) already
+      // aggregated the daily summaries. blocks + extrinsics have no daily rollup
+      // yet, so older raw rows are discarded. All three are .catch-isolated.
+      pruneAccountEvents(env).catch(() => ({ pruned: false })),
+      pruneBlocks(env).catch(() => ({ pruned: false })),
+      pruneExtrinsics(env).catch(() => ({ pruned: false })),
       snapshotPromise,
     ]);
     return pruned;


### PR DESCRIPTION
Closes #1831

## Summary

- `blocks` / `extrinsics` / `account_events` have been growing unbounded since #1806 removed their prune calls to preserve full block-explorer history (ADR 0012)
- With no Postgres cold tier timeline (#1519), D1's 10 GB cap becomes a real risk
- Re-wires all three `prune*` functions into the `HEALTH_PRUNE_CRON` Promise.all at a **365-day** retention window (4× the original 90-day hot window)
- The chain stream started a few weeks ago, so nothing is pruned for ~11 months — by which point #1519 should land or the window can be adjusted
- `account_events`: safe — `rollupAccountEventsDaily` already aggregated daily summaries before prune runs; `blocks` + `extrinsics` have no daily rollup yet so raw rows beyond 365d are dropped

## Changes

- `src/blocks.mjs`, `src/extrinsics.mjs`, `src/account-events.mjs`: bump `*_RETENTION_MS` from 90 to 365 days; update comments
- `workers/api.mjs`: re-import the three prune functions; add them to the `HEALTH_PRUNE_CRON` `Promise.all` with `.catch`-isolation