### PR TITLE
feat(chain): add fee_tao (transaction fees) to the extrinsics tier (#1815)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -2196,13 +2196,17 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
-        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
+        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function/call_args are best-effort (nullable); fee_tao is the actual_fee+tip in TAO from TransactionPayment (null for inherents); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
         Extrinsic: {
             block_number: number | null;
+            /** @description Decoded call arguments as a JSON object; null for inherents or when decode fails. */
+            call_args?: Record<string, never> | null;
             call_function?: string | null;
             call_module?: string | null;
             extrinsic_hash?: string | null;
             extrinsic_index: number | null;
+            /** @description Fee paid for this extrinsic in TAO (actual_fee + tip); null for inherents/unsigned extrinsics. */
+            fee_tao?: number | null;
             /** Format: date-time */
             observed_at?: string | null;
             signer?: string | null;
@@ -7516,10 +7520,12 @@ export interface operations {
                      *       "data": {
                      *         "extrinsic": {
                      *           "block_number": 5000000,
+                     *           "call_args": {},
                      *           "call_function": "example",
                      *           "call_module": "example",
                      *           "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "extrinsic_index": 1,
+                     *           "fee_tao": 0.5,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
                      *           "signer": "example",
                      *           "success": false

--- a/migrations/0016_extrinsic_fee.sql
+++ b/migrations/0016_extrinsic_fee.sql
@@ -1,0 +1,2 @@
+-- Add fee_tao to extrinsics for TransactionPayment.TransactionFeePaid data (#1815)
+ALTER TABLE extrinsics ADD COLUMN fee_tao REAL;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3696,11 +3696,18 @@
       },
       "Extrinsic": {
         "additionalProperties": false,
-        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
+        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function/call_args are best-effort (nullable); fee_tao is the actual_fee+tip in TAO from TransactionPayment (null for inherents); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
         "properties": {
           "block_number": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "call_args": {
+            "description": "Decoded call arguments as a JSON object; null for inherents or when decode fails.",
+            "type": [
+              "object",
               "null"
             ]
           },
@@ -3725,6 +3732,13 @@
           "extrinsic_index": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "fee_tao": {
+            "description": "Fee paid for this extrinsic in TAO (actual_fee + tip); null for inherents/unsigned extrinsics.",
+            "type": [
+              "number",
               "null"
             ]
           },
@@ -16768,10 +16782,12 @@
                   "data": {
                     "extrinsic": {
                       "block_number": 5000000,
+                      "call_args": {},
                       "call_function": "example",
                       "call_module": "example",
                       "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                       "extrinsic_index": 1,
+                      "fee_tao": 0.5,
                       "observed_at": "2026-06-01T00:00:00.000Z",
                       "signer": "example",
                       "success": false

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2196,13 +2196,17 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
-        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
+        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function/call_args are best-effort (nullable); fee_tao is the actual_fee+tip in TAO from TransactionPayment (null for inherents); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
         Extrinsic: {
             block_number: number | null;
+            /** @description Decoded call arguments as a JSON object; null for inherents or when decode fails. */
+            call_args?: Record<string, never> | null;
             call_function?: string | null;
             call_module?: string | null;
             extrinsic_hash?: string | null;
             extrinsic_index: number | null;
+            /** @description Fee paid for this extrinsic in TAO (actual_fee + tip); null for inherents/unsigned extrinsics. */
+            fee_tao?: number | null;
             /** Format: date-time */
             observed_at?: string | null;
             signer?: string | null;
@@ -7516,10 +7520,12 @@ export interface operations {
                      *       "data": {
                      *         "extrinsic": {
                      *           "block_number": 5000000,
+                     *           "call_args": {},
                      *           "call_function": "example",
                      *           "call_module": "example",
                      *           "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "extrinsic_index": 1,
+                     *           "fee_tao": 0.5,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
                      *           "signer": "example",
                      *           "success": false

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3682,11 +3682,18 @@
       },
       "Extrinsic": {
         "additionalProperties": false,
-        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
+        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function/call_args are best-effort (nullable); fee_tao is the actual_fee+tip in TAO from TransactionPayment (null for inherents); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
         "properties": {
           "block_number": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "call_args": {
+            "description": "Decoded call arguments as a JSON object; null for inherents or when decode fails.",
+            "type": [
+              "object",
               "null"
             ]
           },
@@ -3711,6 +3718,13 @@
           "extrinsic_index": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "fee_tao": {
+            "description": "Fee paid for this extrinsic in TAO (actual_fee + tip); null for inherents/unsigned extrinsics.",
+            "type": [
+              "number",
               "null"
             ]
           },

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1639,7 +1639,7 @@
       "Extrinsic": {
         "type": "object",
         "additionalProperties": false,
-        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
+        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function/call_args are best-effort (nullable); fee_tao is the actual_fee+tip in TAO from TransactionPayment (null for inherents); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
         "required": ["block_number", "extrinsic_index"],
         "properties": {
           "block_number": { "type": ["integer", "null"] },
@@ -1648,6 +1648,8 @@
           "signer": { "type": ["string", "null"] },
           "call_module": { "type": ["string", "null"] },
           "call_function": { "type": ["string", "null"] },
+          "call_args": { "description": "Decoded call arguments as a JSON object; null for inherents or when decode fails.", "type": ["object", "null"] },
+          "fee_tao": { "description": "Fee paid for this extrinsic in TAO (actual_fee + tip); null for inherents/unsigned extrinsics.", "type": ["number", "null"] },
           "success": { "type": ["boolean", "null"] },
           "observed_at": { "type": ["string", "null"], "format": "date-time" }
         }

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -388,6 +388,49 @@ def _extrinsic_success_map(events):
     return out
 
 
+def _extrinsic_fee_map(events):
+    """Map extrinsic_index -> fee_tao from TransactionPayment.TransactionFeePaid events.
+
+    TransactionPayment emits one TransactionFeePaid per fee-bearing extrinsic, with
+    phase ApplyExtrinsic + extrinsic_idx. Fields: who (ss58), actual_fee (rao),
+    tip (rao). Best-effort: any malformed event is skipped; an index missing here
+    yields null fee_tao. NEVER raises.
+    """
+    out = {}
+    try:
+        for ev in events:
+            v = ev.value if isinstance(ev.value, dict) else {}
+            if v.get("phase") != "ApplyExtrinsic":
+                continue
+            e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
+            if e.get("module_id") != "TransactionPayment":
+                continue
+            if e.get("event_id") != "TransactionFeePaid":
+                continue
+            idx = v.get("extrinsic_idx")
+            if not isinstance(idx, int) or idx < 0:
+                continue
+            attrs = e.get("attributes") or e.get("event_data") or {}
+            # attrs may be a dict {who, actual_fee, tip} or a list [who, actual_fee, tip]
+            if isinstance(attrs, dict):
+                actual_fee = attrs.get("actual_fee")
+                tip = attrs.get("tip") or 0
+            elif isinstance(attrs, (list, tuple)) and len(attrs) >= 2:
+                actual_fee = attrs[1]
+                tip = attrs[2] if len(attrs) > 2 else 0
+            else:
+                continue
+            if actual_fee is None:
+                continue
+            try:
+                out[idx] = (_tao(actual_fee) or 0) + (_tao(tip) or 0)
+            except Exception:
+                continue
+    except Exception:
+        return out
+    return out
+
+
 def extrinsics_for_block(s, bn, bh, events):
     """Best-effort per-extrinsic records for the `extrinsics` D1 tier (#1345).
 
@@ -409,6 +452,7 @@ def extrinsics_for_block(s, bn, bh, events):
     except Exception:
         return rows
     success_map = _extrinsic_success_map(events)
+    fee_map = _extrinsic_fee_map(events)
     for extrinsic_index, ext in enumerate(extrinsics):
         try:
             value = ext.value if ext is not None else None
@@ -425,6 +469,7 @@ def extrinsics_for_block(s, bn, bh, events):
                     "call_module": call_module,
                     "call_function": call_function,
                     "call_args": call_args,
+                    "fee_tao": fee_map.get(extrinsic_index),
                     "success": success_map.get(extrinsic_index),
                 }
             )

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -212,6 +212,109 @@ class LagAlertNeededTest(unittest.TestCase):
         self.assertFalse(_lag_alert_needed(10_000, 9_000, window=400, horizon=300))
 
 
+_extrinsic_fee_map = _fe._extrinsic_fee_map
+
+
+class ExtrinsicFeeMapTest(unittest.TestCase):
+    """Tests for the _extrinsic_fee_map correlator (#1815)."""
+
+    class Ev:
+        def __init__(self, value):
+            self.value = value
+
+    def _fee_event(self, extrinsic_idx, actual_fee, tip=0):
+        return self.Ev({
+            "phase": "ApplyExtrinsic",
+            "extrinsic_idx": extrinsic_idx,
+            "event": {
+                "module_id": "TransactionPayment",
+                "event_id": "TransactionFeePaid",
+                "attributes": {"who": "5Signer", "actual_fee": actual_fee, "tip": tip},
+            },
+        })
+
+    def test_dict_attrs_maps_fee_to_index(self):
+        ev = self._fee_event(2, 500_000_000)  # 0.5 TAO
+        result = _extrinsic_fee_map([ev])
+        self.assertAlmostEqual(result[2], 0.5)
+
+    def test_tip_is_added_to_actual_fee(self):
+        ev = self._fee_event(0, 1_000_000_000, tip=100_000_000)  # 1 + 0.1 TAO
+        result = _extrinsic_fee_map([ev])
+        self.assertAlmostEqual(result[0], 1.1)
+
+    def test_list_attrs_positional(self):
+        ev = self.Ev({
+            "phase": "ApplyExtrinsic",
+            "extrinsic_idx": 1,
+            "event": {
+                "module_id": "TransactionPayment",
+                "event_id": "TransactionFeePaid",
+                "attributes": ["5Signer", 2_000_000_000, 0],
+            },
+        })
+        result = _extrinsic_fee_map([ev])
+        self.assertAlmostEqual(result[1], 2.0)
+
+    def test_wrong_module_skipped(self):
+        ev = self.Ev({
+            "phase": "ApplyExtrinsic",
+            "extrinsic_idx": 0,
+            "event": {"module_id": "System", "event_id": "TransactionFeePaid", "attributes": {}},
+        })
+        self.assertEqual(_extrinsic_fee_map([ev]), {})
+
+    def test_wrong_phase_skipped(self):
+        ev = self.Ev({
+            "phase": "Initialization",
+            "extrinsic_idx": 0,
+            "event": {
+                "module_id": "TransactionPayment",
+                "event_id": "TransactionFeePaid",
+                "attributes": {"actual_fee": 1_000_000_000, "tip": 0},
+            },
+        })
+        self.assertEqual(_extrinsic_fee_map([ev]), {})
+
+    def test_negative_index_skipped(self):
+        ev = self.Ev({
+            "phase": "ApplyExtrinsic",
+            "extrinsic_idx": -1,
+            "event": {
+                "module_id": "TransactionPayment",
+                "event_id": "TransactionFeePaid",
+                "attributes": {"actual_fee": 1_000_000_000, "tip": 0},
+            },
+        })
+        self.assertEqual(_extrinsic_fee_map([ev]), {})
+
+    def test_missing_actual_fee_skipped(self):
+        ev = self.Ev({
+            "phase": "ApplyExtrinsic",
+            "extrinsic_idx": 0,
+            "event": {
+                "module_id": "TransactionPayment",
+                "event_id": "TransactionFeePaid",
+                "attributes": {"who": "5Signer"},
+            },
+        })
+        self.assertEqual(_extrinsic_fee_map([ev]), {})
+
+    def test_empty_events_returns_empty(self):
+        self.assertEqual(_extrinsic_fee_map([]), {})
+
+    def test_never_raises_on_garbage(self):
+        result = _extrinsic_fee_map([None, "garbage", 42])
+        self.assertIsInstance(result, dict)
+
+    def test_multiple_events_multiple_indices(self):
+        evs = [self._fee_event(0, 1_000_000_000), self._fee_event(3, 500_000_000)]
+        result = _extrinsic_fee_map(evs)
+        self.assertAlmostEqual(result[0], 1.0)
+        self.assertAlmostEqual(result[3], 0.5)
+        self.assertNotIn(1, result)
+
+
 _extract = _fe.extract
 _SS58_A = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
 _SS58_B = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -21,6 +21,7 @@ export const EXTRINSIC_INSERT_COLUMNS = [
   "call_module",
   "call_function",
   "call_args",
+  "fee_tao",
   "success",
   "observed_at",
 ];
@@ -46,14 +47,14 @@ export function validExtrinsicRows(rows) {
 }
 
 // Build parameterized INSERT OR IGNORE statements for extrinsics rows, chunked
-// under D1's 100-bound-param limit (9 cols x 11 = 99). Idempotent on
+// under D1's 100-bound-param limit (10 cols x 9 = 90). Idempotent on
 // (block_number, extrinsic_index) (the primary key). Values are ALWAYS bound,
 // never interpolated — a tampered payload can only fail, never inject. Mirrors
 // blockInsertStatements (#1345).
 export function extrinsicInsertStatements(db, rows) {
   const cols = EXTRINSIC_INSERT_COLUMNS;
   const colList = cols.join(",");
-  const ROWS_PER_STMT = 11;
+  const ROWS_PER_STMT = 9;
   const statements = [];
   for (let i = 0; i < rows.length; i += ROWS_PER_STMT) {
     const chunk = rows.slice(i, i + ROWS_PER_STMT);
@@ -95,7 +96,7 @@ export async function pruneExtrinsics(env, overrides = {}) {
 // ---- Extrinsic API builders ------------------------------------------------
 // The columns the extrinsic handlers SELECT for an extrinsic row.
 export const EXTRINSIC_READ_COLUMNS =
-  "block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args, success, observed_at";
+  "block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args, fee_tao, success, observed_at";
 
 // One D1 extrinsics row → a clean API extrinsic object. Null-safe on junk/sparse
 // rows. success is normalized to a boolean (null when undeterminable).
@@ -117,6 +118,7 @@ export function formatExtrinsic(row) {
     call_module: row.call_module ?? null,
     call_function: row.call_function ?? null,
     call_args,
+    fee_tao: row.fee_tao ?? null,
     success: row.success == null ? null : row.success === 1,
     observed_at: toIso(row.observed_at),
   };

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -24,6 +24,7 @@ test("EXTRINSIC_INSERT_COLUMNS is the stable load contract (#1345)", () => {
     "call_module",
     "call_function",
     "call_args",
+    "fee_tao",
     "success",
     "observed_at",
   ]);
@@ -71,13 +72,13 @@ test("extrinsicInsertStatements builds chunked parameterized INSERT OR IGNORE", 
     observed_at: 1,
   }));
   const stmts = extrinsicInsertStatements(db, rows);
-  // 30 rows / 12 per statement = 3 statements (12, 12, 6)
-  assert.equal(stmts.length, 3);
+  // 30 rows / 9 per statement = 4 statements (9, 9, 9, 3)
+  assert.equal(stmts.length, 4);
   assert.ok(prepared[0].startsWith("INSERT OR IGNORE INTO extrinsics ("));
   assert.ok(prepared[0].includes("VALUES (?"));
-  // Every value is BOUND (9 cols x 11 rows = 99 params on a full chunk, <=100).
-  assert.equal(stmts[0].v.length, 9 * 11);
-  // All nine columns appear in the column list.
+  // Every value is BOUND (10 cols x 9 rows = 90 params on a full chunk, <=100).
+  assert.equal(stmts[0].v.length, 10 * 9);
+  // All ten columns appear in the column list.
   for (const col of EXTRINSIC_INSERT_COLUMNS) {
     assert.ok(prepared[0].includes(col), `missing ${col}`);
   }
@@ -92,8 +93,8 @@ test("extrinsicInsertStatements binds missing fields as null (never interpolates
   const [stmt] = extrinsicInsertStatements(db, [
     { block_number: 7, extrinsic_index: 2, observed_at: 9 },
   ]);
-  // extrinsic_hash, signer, call_module, call_function, call_args, success default to null.
-  assert.deepEqual(stmt.v, [7, 2, null, null, null, null, null, null, 9]);
+  // extrinsic_hash, signer, call_module, call_function, call_args, fee_tao, success default to null.
+  assert.deepEqual(stmt.v, [7, 2, null, null, null, null, null, null, null, 9]);
 });
 
 test("formatExtrinsic maps a D1 row to an API extrinsic (ISO time, bool success)", () => {
@@ -141,6 +142,25 @@ test("formatExtrinsic is null-safe on junk + sparse rows", () => {
   assert.equal(out.extrinsic_hash, null);
   assert.equal(out.signer, null);
   assert.equal(out.observed_at, null);
+});
+
+test("formatExtrinsic passes through fee_tao (numeric and null)", () => {
+  const withFee = formatExtrinsic({
+    block_number: 1,
+    extrinsic_index: 0,
+    fee_tao: 0.000125,
+  });
+  assert.equal(withFee.fee_tao, 0.000125);
+
+  const noFee = formatExtrinsic({ block_number: 1, extrinsic_index: 0 });
+  assert.equal(noFee.fee_tao, null);
+
+  const explicitNull = formatExtrinsic({
+    block_number: 1,
+    extrinsic_index: 0,
+    fee_tao: null,
+  });
+  assert.equal(explicitNull.fee_tao, null);
 });
 
 test("buildExtrinsic wraps a row + is schema-stable when absent (#1345)", () => {
@@ -192,6 +212,7 @@ test("EXTRINSIC_READ_COLUMNS lists the served extrinsic columns", () => {
     "signer",
     "call_module",
     "call_function",
+    "fee_tao",
     "success",
     "observed_at",
   ]) {


### PR DESCRIPTION
## Summary

- Adds `fee_tao` (actual_fee + tip from `TransactionPayment.TransactionFeePaid`) to the extrinsics chain-data tier; migration `0016_extrinsic_fee.sql` adds the column, `_extrinsic_fee_map` in the poller correlates events to extrinsic indices, and the JS load contract + API formatter are updated
- Fixes the missing `call_args` property in the Extrinsic schema (it was omitted from the schema in #1828 even though the code already returns it)
- Contract artifacts regenerated (`npm run build`); `validate:contract-drift` will pass

## Test plan

- [ ] `npx vitest run tests/extrinsics.test.mjs` — 20 tests pass (20 was 19 before; new `formatExtrinsic passes through fee_tao` test added)
- [ ] `python3 scripts/test_fetch_events.py` — 39 tests pass (10 new `ExtrinsicFeeMapTest` cases cover dict/list attrs, wrong-module/phase/index guards, missing-fee skip, garbage tolerance)
- [ ] `migrations/0016_extrinsic_fee.sql` applies cleanly (additive ALTER TABLE; no data migration needed)
- [ ] `public/metagraph/openapi.json` now includes `fee_tao` and `call_args` in the Extrinsic schema

Closes #1815