### PR TITLE
feat(chain): fees + spec_version + extended SubtensorModule coverage

### DIFF
--- a/migrations/0016_extrinsic_fee_tao.sql
+++ b/migrations/0016_extrinsic_fee_tao.sql
@@ -1,0 +1,10 @@
+-- Block explorer extrinsic depth (#1815): store the fee paid per extrinsic so
+-- detail pages can show exact cost and network-wide fee analytics can be
+-- derived (total fees per block, fee trends over time).
+--
+-- fee_tao is the `actual_fee` from TransactionPayment.TransactionFeePaid,
+-- converted from rao to TAO. Nullable: inherents and extrinsics that do not
+-- pay a fee store null. Applied as an idempotent ALTER (nullable column never
+-- breaks existing rows or the INSERT OR IGNORE load path).
+
+ALTER TABLE extrinsics ADD COLUMN fee_tao REAL;

--- a/migrations/0017_block_spec_version.sql
+++ b/migrations/0017_block_spec_version.sql
@@ -1,0 +1,11 @@
+-- Block explorer block depth (#1817): store the runtime spec_version for each
+-- block so developers can determine which runtime version was active for any
+-- given block range, debug historical transactions against the correct schema,
+-- and filter/annotate by runtime era.
+--
+-- spec_version is the `specVersion` from get_block_runtime_version(). Nullable:
+-- best-effort only — the field is null when the RPC call fails or the block is
+-- pruned. Applied as an idempotent ALTER (nullable column never breaks existing
+-- rows or the INSERT OR IGNORE load path).
+
+ALTER TABLE blocks ADD COLUMN spec_version INTEGER;

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -227,6 +227,48 @@ def _transfer(a):  # Balances.Transfer: [from, to, amount] or {from, to, amount}
     return {"hotkey": _ss58(sender), "coldkey": _ss58(recipient), "amount_tao": _tao(amount)}
 
 
+def _net(a):  # NetworkAdded/NetworkRemoved: {netuid, ...} or [netuid, ...]
+    netuid = a.get("netuid") if isinstance(a, dict) else (a[0] if len(a) > 0 else None)
+    return {"netuid": _idx(netuid)}
+
+
+def _delegate_added(a):  # DelegateAdded: {coldkey, hotkey, take} or [coldkey, hotkey, ...]
+    if isinstance(a, dict):
+        ck, hk = a.get("coldkey"), a.get("hotkey")
+    else:
+        ck = a[0] if len(a) > 0 else None
+        hk = a[1] if len(a) > 1 else None
+    return {"coldkey": _ss58(ck), "hotkey": _ss58(hk)}
+
+
+def _take_changed(a):  # TakeDecreased/TakeIncreased: {hotkey, coldkey, ...} or [hotkey, coldkey, ...]
+    if isinstance(a, dict):
+        hk, ck = a.get("hotkey"), a.get("coldkey")
+    else:
+        hk = a[0] if len(a) > 0 else None
+        ck = a[1] if len(a) > 1 else None
+    return {"hotkey": _ss58(hk), "coldkey": _ss58(ck)}
+
+
+def _hotkey_swapped(a):  # HotkeySwapped: {coldkey, old_hotkey, new_hotkey} or [coldkey, old_hotkey, new_hotkey]
+    if isinstance(a, dict):
+        ck, hk = a.get("coldkey"), a.get("new_hotkey")
+    else:
+        ck = a[0] if len(a) > 0 else None
+        hk = a[2] if len(a) > 2 else None
+    return {"coldkey": _ss58(ck), "hotkey": _ss58(hk)}
+
+
+def _coldkey_swap(a):  # ColdkeySwapScheduled: {old_coldkey, new_coldkey, ...} or [old_coldkey, new_coldkey, ...]
+    if isinstance(a, dict):
+        old_ck, new_ck = a.get("old_coldkey"), a.get("new_coldkey")
+    else:
+        old_ck = a[0] if len(a) > 0 else None
+        new_ck = a[1] if len(a) > 1 else None
+    # old_coldkey as coldkey (primary actor), new_coldkey as hotkey (target)
+    return {"coldkey": _ss58(old_ck), "hotkey": _ss58(new_ck)}
+
+
 EXTRACTORS = {
     "NeuronRegistered": _registered,
     "StakeAdded": _stake,
@@ -235,6 +277,16 @@ EXTRACTORS = {
     "AxonServed": _axon,
     "WeightsSet": _weights,
     "RootClaimed": _root,
+    # Subnet lifecycle (#1816)
+    "NetworkAdded": _net,
+    "NetworkRemoved": _net,
+    # Delegation (#1816)
+    "DelegateAdded": _delegate_added,
+    "TakeDecreased": _take_changed,
+    "TakeIncreased": _take_changed,
+    # Key rotation (#1816)
+    "HotkeySwapped": _hotkey_swapped,
+    "ColdkeySwapScheduled": _coldkey_swap,
     # Balances pallet — native TAO transfers between accounts (#1814)
     "Transfer": _transfer,
 }
@@ -298,6 +350,11 @@ def block_extras(s, bn, bh, event_count):
         extrinsic_count = len(s.get_block(block_hash=bh)["extrinsics"])
     except Exception:
         extrinsic_count = None
+    try:
+        rt = s.get_block_runtime_version(block_hash=bh)
+        spec_version = rt.get("specVersion") or rt.get("spec_version") if isinstance(rt, dict) else None
+    except Exception:
+        spec_version = None
     return {
         "block_number": bn,
         "block_hash": str(bh),
@@ -305,6 +362,7 @@ def block_extras(s, bn, bh, event_count):
         "author": _block_author(s, bh, header),
         "extrinsic_count": extrinsic_count,
         "event_count": event_count,
+        "spec_version": spec_version,
     }
 
 
@@ -358,6 +416,42 @@ def _extrinsic_call(value):
         return (None, None, None)
 
 
+def _fee_map(events):
+    """Map extrinsic_index -> fee_tao from TransactionPayment.TransactionFeePaid events.
+
+    Substrate emits one TransactionPayment.TransactionFeePaid per fee-paying extrinsic
+    (fields: who, actual_fee, tip). Inherents and unsigned extrinsics do not emit it.
+    Correlated by extrinsic_idx (same ApplyExtrinsic phase as ExtrinsicSuccess/Failed).
+    NEVER raises.
+    """
+    out = {}
+    try:
+        for ev in events:
+            v = ev.value if isinstance(ev.value, dict) else {}
+            if v.get("phase") != "ApplyExtrinsic":
+                continue
+            e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
+            if e.get("module_id") != "TransactionPayment":
+                continue
+            if e.get("event_id") != "TransactionFeePaid":
+                continue
+            idx = v.get("extrinsic_idx")
+            if not isinstance(idx, int) or idx < 0:
+                continue
+            attrs = e.get("attributes")
+            if isinstance(attrs, dict):
+                fee_rao = attrs.get("actual_fee")
+            elif isinstance(attrs, list) and len(attrs) > 1:
+                fee_rao = attrs[1]  # [who, actual_fee, tip]
+            else:
+                fee_rao = None
+            if fee_rao is not None:
+                out[idx] = _tao(fee_rao)
+    except Exception:
+        return out
+    return out
+
+
 def _extrinsic_success_map(events):
     """Map extrinsic_index -> success(1/0) from the block's already-decoded events.
 
@@ -409,6 +503,7 @@ def extrinsics_for_block(s, bn, bh, events):
     except Exception:
         return rows
     success_map = _extrinsic_success_map(events)
+    fee_map = _fee_map(events)
     for extrinsic_index, ext in enumerate(extrinsics):
         try:
             value = ext.value if ext is not None else None
@@ -426,6 +521,7 @@ def extrinsics_for_block(s, bn, bh, events):
                     "call_function": call_function,
                     "call_args": call_args,
                     "success": success_map.get(extrinsic_index),
+                    "fee_tao": fee_map.get(extrinsic_index),
                 }
             )
         except Exception:

--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -20,6 +20,7 @@ export const BLOCK_INSERT_COLUMNS = [
   "author",
   "extrinsic_count",
   "event_count",
+  "spec_version",
   "observed_at",
 ];
 
@@ -44,13 +45,13 @@ export function validBlockRows(rows) {
 }
 
 // Build parameterized INSERT OR IGNORE statements for blocks rows, chunked under
-// D1's 100-bound-param limit (7 cols x 14 = 98). Idempotent on block_number (the
+// D1's 100-bound-param limit (8 cols x 12 = 96). Idempotent on block_number (the
 // primary key). Values are ALWAYS bound, never interpolated — a tampered payload
 // can only fail, never inject. Mirrors eventInsertStatements (#1346).
 export function blockInsertStatements(db, rows) {
   const cols = BLOCK_INSERT_COLUMNS;
   const colList = cols.join(",");
-  const ROWS_PER_STMT = 14;
+  const ROWS_PER_STMT = 12;
   const statements = [];
   for (let i = 0; i < rows.length; i += ROWS_PER_STMT) {
     const chunk = rows.slice(i, i + ROWS_PER_STMT);
@@ -90,7 +91,7 @@ export async function pruneBlocks(env, overrides = {}) {
 // ---- Block API builders ----------------------------------------------------
 // The columns the block handlers SELECT for a block row.
 export const BLOCK_READ_COLUMNS =
-  "block_number, block_hash, parent_hash, author, extrinsic_count, event_count, observed_at";
+  "block_number, block_hash, parent_hash, author, extrinsic_count, event_count, spec_version, observed_at";
 
 // One D1 blocks row → a clean API block object. Null-safe on junk/sparse rows.
 export function formatBlock(row) {
@@ -102,6 +103,7 @@ export function formatBlock(row) {
     author: row.author ?? null,
     extrinsic_count: row.extrinsic_count ?? null,
     event_count: row.event_count ?? null,
+    spec_version: row.spec_version ?? null,
     observed_at: toIso(row.observed_at),
   };
 }

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -22,6 +22,7 @@ export const EXTRINSIC_INSERT_COLUMNS = [
   "call_function",
   "call_args",
   "success",
+  "fee_tao",
   "observed_at",
 ];
 
@@ -46,14 +47,14 @@ export function validExtrinsicRows(rows) {
 }
 
 // Build parameterized INSERT OR IGNORE statements for extrinsics rows, chunked
-// under D1's 100-bound-param limit (9 cols x 11 = 99). Idempotent on
+// under D1's 100-bound-param limit (10 cols x 10 = 100). Idempotent on
 // (block_number, extrinsic_index) (the primary key). Values are ALWAYS bound,
 // never interpolated — a tampered payload can only fail, never inject. Mirrors
 // blockInsertStatements (#1345).
 export function extrinsicInsertStatements(db, rows) {
   const cols = EXTRINSIC_INSERT_COLUMNS;
   const colList = cols.join(",");
-  const ROWS_PER_STMT = 11;
+  const ROWS_PER_STMT = 10;
   const statements = [];
   for (let i = 0; i < rows.length; i += ROWS_PER_STMT) {
     const chunk = rows.slice(i, i + ROWS_PER_STMT);
@@ -95,7 +96,7 @@ export async function pruneExtrinsics(env, overrides = {}) {
 // ---- Extrinsic API builders ------------------------------------------------
 // The columns the extrinsic handlers SELECT for an extrinsic row.
 export const EXTRINSIC_READ_COLUMNS =
-  "block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args, success, observed_at";
+  "block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args, success, fee_tao, observed_at";
 
 // One D1 extrinsics row → a clean API extrinsic object. Null-safe on junk/sparse
 // rows. success is normalized to a boolean (null when undeterminable).
@@ -118,6 +119,7 @@ export function formatExtrinsic(row) {
     call_function: row.call_function ?? null,
     call_args,
     success: row.success == null ? null : row.success === 1,
+    fee_tao: row.fee_tao ?? null,
     observed_at: toIso(row.observed_at),
   };
 }

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -23,6 +23,7 @@ test("BLOCK_INSERT_COLUMNS is the stable load contract (#1345)", () => {
     "author",
     "extrinsic_count",
     "event_count",
+    "spec_version",
     "observed_at",
   ]);
 });
@@ -58,13 +59,13 @@ test("blockInsertStatements builds chunked parameterized INSERT OR IGNORE", () =
     observed_at: 1,
   }));
   const stmts = blockInsertStatements(db, rows);
-  // 30 rows / 14 per statement = 3 statements
+  // 30 rows / 12 per statement = 3 statements (12, 12, 6)
   assert.equal(stmts.length, 3);
   assert.ok(prepared[0].startsWith("INSERT OR IGNORE INTO blocks ("));
   assert.ok(prepared[0].includes("VALUES (?"));
-  // Every value is BOUND (7 cols x 14 rows = 98 params on a full chunk).
-  assert.equal(stmts[0].v.length, 7 * 14);
-  // All seven columns appear in the column list.
+  // Every value is BOUND (8 cols x 12 rows = 96 params on a full chunk, <=100).
+  assert.equal(stmts[0].v.length, 8 * 12);
+  // All eight columns appear in the column list.
   for (const col of BLOCK_INSERT_COLUMNS) {
     assert.ok(prepared[0].includes(col), `missing ${col}`);
   }
@@ -79,8 +80,8 @@ test("blockInsertStatements binds missing fields as null (never interpolates)", 
   const [stmt] = blockInsertStatements(db, [
     { block_number: 7, block_hash: "0x7", observed_at: 9 },
   ]);
-  // parent_hash, author, extrinsic_count, event_count default to null.
-  assert.deepEqual(stmt.v, [7, "0x7", null, null, null, null, 9]);
+  // parent_hash, author, extrinsic_count, event_count, spec_version default to null.
+  assert.deepEqual(stmt.v, [7, "0x7", null, null, null, null, null, 9]);
 });
 
 test("formatBlock maps a D1 row to an API block (ISO time)", () => {

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -25,6 +25,7 @@ test("EXTRINSIC_INSERT_COLUMNS is the stable load contract (#1345)", () => {
     "call_function",
     "call_args",
     "success",
+    "fee_tao",
     "observed_at",
   ]);
 });
@@ -71,13 +72,13 @@ test("extrinsicInsertStatements builds chunked parameterized INSERT OR IGNORE", 
     observed_at: 1,
   }));
   const stmts = extrinsicInsertStatements(db, rows);
-  // 30 rows / 12 per statement = 3 statements (12, 12, 6)
+  // 30 rows / 10 per statement = 3 statements (10, 10, 10)
   assert.equal(stmts.length, 3);
   assert.ok(prepared[0].startsWith("INSERT OR IGNORE INTO extrinsics ("));
   assert.ok(prepared[0].includes("VALUES (?"));
-  // Every value is BOUND (9 cols x 11 rows = 99 params on a full chunk, <=100).
-  assert.equal(stmts[0].v.length, 9 * 11);
-  // All nine columns appear in the column list.
+  // Every value is BOUND (10 cols x 10 rows = 100 params on a full chunk, <=100).
+  assert.equal(stmts[0].v.length, 10 * 10);
+  // All ten columns appear in the column list.
   for (const col of EXTRINSIC_INSERT_COLUMNS) {
     assert.ok(prepared[0].includes(col), `missing ${col}`);
   }
@@ -92,8 +93,8 @@ test("extrinsicInsertStatements binds missing fields as null (never interpolates
   const [stmt] = extrinsicInsertStatements(db, [
     { block_number: 7, extrinsic_index: 2, observed_at: 9 },
   ]);
-  // extrinsic_hash, signer, call_module, call_function, call_args, success default to null.
-  assert.deepEqual(stmt.v, [7, 2, null, null, null, null, null, null, 9]);
+  // extrinsic_hash, signer, call_module, call_function, call_args, success, fee_tao default to null.
+  assert.deepEqual(stmt.v, [7, 2, null, null, null, null, null, null, null, 9]);
 });
 
 test("formatExtrinsic maps a D1 row to an API extrinsic (ISO time, bool success)", () => {


### PR DESCRIPTION
Closes #1815, #1816, #1817. Part of #1345.

## Changes

### Transaction fees (#1815)

- **Migration 0016** — `ALTER TABLE extrinsics ADD COLUMN fee_tao REAL` (nullable, applied to prod D1)
- `_fee_map()` scans `TransactionPayment.TransactionFeePaid` events by `extrinsic_idx` (same `ApplyExtrinsic` phase as success/failure events) and converts `actual_fee` from rao → TAO; handles both dict and positional-list attribute forms
- `extrinsics_for_block()` now emits `fee_tao` on every row (null for inherents and unsigned extrinsics)
- `EXTRINSIC_INSERT_COLUMNS`: 10 cols; `ROWS_PER_STMT`: 10 (10 × 10 = 100 ≤ D1 limit)
- `formatExtrinsic()` exposes `fee_tao` in the API response

### Runtime spec_version (#1817)

- **Migration 0017** — `ALTER TABLE blocks ADD COLUMN spec_version INTEGER` (nullable, applied to prod D1)
- `block_extras()` calls `get_block_runtime_version(block_hash)` and stores `specVersion`; best-effort — null on any RPC failure, never raises
- `BLOCK_INSERT_COLUMNS`: 8 cols; `ROWS_PER_STMT`: 12 (8 × 12 = 96 ≤ D1 limit)
- `formatBlock()` exposes `spec_version` in the API response

### SubtensorModule event coverage (#1816)

New extractors in `EXTRACTORS` (all handle both dict + positional-list attribute forms, never raise, null fields on shape drift):

| Event | hotkey | coldkey | netuid |
|---|---|---|---|
| `NetworkAdded` | — | — | ✓ |
| `NetworkRemoved` | — | — | ✓ |
| `DelegateAdded` | delegate hotkey | delegator coldkey | — |
| `TakeDecreased` | hotkey | coldkey | — |
| `TakeIncreased` | hotkey | coldkey | — |
| `HotkeySwapped` | new_hotkey | coldkey | — |
| `ColdkeySwapScheduled` | new_coldkey | old_coldkey | — |

`backfill-events.py` inherits all changes via `importlib` — no duplicate code.

## Migrations

Both applied to prod D1:
```sql
ALTER TABLE extrinsics ADD COLUMN fee_tao REAL;
ALTER TABLE blocks ADD COLUMN spec_version INTEGER;
```

## Test plan

- [x] 1996/1996 JS tests pass
- [x] 29/29 Python tests pass
- [ ] After merge: confirm `fee_tao` appears on `Balances.transfer_keep_alive` extrinsics; confirm `spec_version` on new block rows