### PR TITLE
fix(contracts): expand artifactPathFromTemplate to all 8 route tokens

### DIFF
--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2189,9 +2189,13 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
 export function artifactPathFromTemplate(template, params = {}) {
   return template
     .replace("{netuid}", String(params.netuid ?? ""))
+    .replace("{uid}", String(params.uid ?? ""))
+    .replace("{ss58}", String(params.ss58 ?? ""))
     .replace("{slug}", String(params.slug ?? ""))
     .replace("{date}", String(params.date ?? ""))
-    .replace("{surface_id}", String(params.surface_id ?? ""));
+    .replace("{surface_id}", String(params.surface_id ?? ""))
+    .replace("{ref}", String(params.ref ?? ""))
+    .replace("{hash}", String(params.hash ?? ""));
 }
 
 export function compileRoutePattern(pathTemplate) {

--- a/tests/invariants-contracts.test.mjs
+++ b/tests/invariants-contracts.test.mjs
@@ -249,6 +249,30 @@ describe("contracts — compileRoutePattern per token type", () => {
       ),
       "/metagraph/subnets/7/x/2026-06-06/sid.json",
     );
+    // Block-explorer + account tokens (#1686).
+    assert.equal(
+      artifactPathFromTemplate(
+        "/metagraph/subnets/{netuid}/neurons/{uid}.json",
+        { netuid: 7, uid: 3 },
+      ),
+      "/metagraph/subnets/7/neurons/3.json",
+    );
+    assert.equal(
+      artifactPathFromTemplate("/metagraph/accounts/{ss58}.json", {
+        ss58: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+      }),
+      "/metagraph/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5.json",
+    );
+    assert.equal(
+      artifactPathFromTemplate("/metagraph/blocks/{ref}.json", { ref: "1234" }),
+      "/metagraph/blocks/1234.json",
+    );
+    assert.equal(
+      artifactPathFromTemplate("/metagraph/extrinsics/{hash}.json", {
+        hash: "0xabc",
+      }),
+      "/metagraph/extrinsics/0xabc.json",
+    );
     // A missing param substitutes the empty string (never "undefined").
     assert.equal(
       artifactPathFromTemplate("/metagraph/subnets/{netuid}.json", {}),


### PR DESCRIPTION
Closes #1686

## What

`compileRoutePattern` captures eight named route tokens (`netuid`, `uid`, `ss58`, `slug`, `date`, `surface_id`, `ref`, `hash`), but `artifactPathFromTemplate` only substituted four of them — `netuid`, `slug`, `date`, `surface_id`. The missing four (`uid`, `ss58`, `ref`, `hash`) leaked through literally in any artifact path that used them.

## Fix

Add the four missing `.replace()` calls in `artifactPathFromTemplate`. Extend the invariants test to verify all eight tokens substitute correctly.

## Why it matters

This is currently latent: affected routes (`/blocks/{ref}`, `/extrinsics/{hash}`, `/accounts/{ss58}`, `/subnets/{netuid}/neurons/{uid}`) all have dedicated D1 handlers that fire before the generic artifact-path lookup. But the divergence between pattern compiler and path substituter is a contract bug — the next route that relies on the generic path would silently produce a broken artifact key.