### PR TITLE
chore: add .gittensory.yml to scope the Gittensory Gate

### DIFF
--- a/.gittensory.yml
+++ b/.gittensory.yml
@@ -1,0 +1,28 @@
+# Gittensory Gate scope manifest for metagraphed.
+#
+# wantedPaths  — patterns that signal this PR is a community data contribution
+#                (auto-adjudicate: merge/close/escalate on the gate's rules).
+# blockedPaths — if ANY changed file matches here the PR is NOT a community
+#                data submission (hold for human review / do not auto-merge).
+#
+# Aligns with the paths: filter in .github/workflows/publish-cloudflare.yml so
+# the gate's adjudication scope exactly tracks what a merged data PR publishes.
+
+wantedPaths:
+  - "registry/subnets/**"
+  - "registry/providers/**"
+  - "registry/candidates/community/**"
+  - "registry/reviews/**"
+  - "registry/adapters/**"
+
+blockedPaths:
+  - "src/**"
+  - "scripts/**"
+  - "workers/**"
+  - "schemas/**"
+  - "tests/**"
+  - "migrations/**"
+  - "packages/**"
+  - "public/**"
+  - ".github/**"
+  - ".claude/**"


### PR DESCRIPTION
Closes #1773

## What

Adds a `.gittensory.yml` at the repo root so the Gittensory Gate's adjudication scope is explicit, reviewable, and portable rather than falling back to dashboard defaults.

## Scope rules

**`wantedPaths`** — the 5 human-input registry directories that `publish-cloudflare.yml` already gates on as contributor data:
- `registry/subnets/**`, `registry/providers/**`, `registry/candidates/community/**`, `registry/reviews/**`, `registry/adapters/**`

**`blockedPaths`** — all maintainer-internal areas:
- `src/**`, `scripts/**`, `workers/**`, `schemas/**`, `tests/**`, `migrations/**`, `packages/**`, `public/**`, `.github/**`, `.claude/**`

A PR that touches any blocked path cannot be auto-merged as a community submission — it holds for human review. A PR that touches only wantedPaths is adjudicated by the gate as normal.

## Alignment

This exactly tracks the `paths:` filter in `.github/workflows/publish-cloudflare.yml`, keeping a single coherent definition of "what a community data PR looks like" across both the deploy trigger and the review gate.