### PR TITLE
fix(events): emit coldkey/hotkey in chain order for TakeIncreased/TakeDecreased

### DIFF
--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -244,12 +244,15 @@ def _delegate_added(a):  # DelegateAdded: {coldkey, hotkey, take} or [coldkey, h
     return {"coldkey": _ss58(ck), "hotkey": _ss58(hk)}
 
 
-def _take_changed(a):  # TakeDecreased/TakeIncreased: {hotkey, coldkey, ...} or [hotkey, coldkey, ...]
+def _take_changed(a):  # TakeDecreased/TakeIncreased: {coldkey, hotkey, take} or [coldkey, hotkey, take]
+    # Subtensor emits these coldkey-first: Event::TakeIncreased(coldkey, hotkey, take)
+    # / TakeDecreased(coldkey, hotkey, take). The variants are positional tuples, so
+    # the list branch must read a[0]=coldkey, a[1]=hotkey (same order as DelegateAdded).
     if isinstance(a, dict):
-        hk, ck = a.get("hotkey"), a.get("coldkey")
+        ck, hk = a.get("coldkey"), a.get("hotkey")
     else:
-        hk = a[0] if len(a) > 0 else None
-        ck = a[1] if len(a) > 1 else None
+        ck = a[0] if len(a) > 0 else None
+        hk = a[1] if len(a) > 1 else None
     return {"hotkey": _ss58(hk), "coldkey": _ss58(ck)}
 
 

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -365,5 +365,32 @@ class StakeAlphaExtractorTest(unittest.TestCase):
         self.assertIsNone(result["alpha_amount"])
 
 
+class TakeDelegateExtractorTest(unittest.TestCase):
+    # Subtensor emits TakeIncreased/TakeDecreased/DelegateAdded coldkey-first:
+    # Event::Take*(coldkey, hotkey, take). The positional list must map a[0] to
+    # coldkey and a[1] to hotkey — not the reverse.
+    def test_take_increased_positional_is_coldkey_first(self):
+        result = _extract("TakeIncreased", [_SS58_A, _SS58_B, 100])
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertEqual(result["hotkey"], _SS58_B)
+
+    def test_take_decreased_positional_is_coldkey_first(self):
+        result = _extract("TakeDecreased", [_SS58_A, _SS58_B, 50])
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertEqual(result["hotkey"], _SS58_B)
+
+    def test_take_changed_named_dict_form(self):
+        result = _extract("TakeIncreased", {"coldkey": _SS58_A, "hotkey": _SS58_B})
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertEqual(result["hotkey"], _SS58_B)
+
+    def test_take_matches_delegate_added_key_order(self):
+        # Identical (coldkey, hotkey, take) shape → identical key mapping.
+        take = _extract("TakeIncreased", [_SS58_A, _SS58_B, 100])
+        delegate = _extract("DelegateAdded", [_SS58_A, _SS58_B, 100])
+        self.assertEqual(take["coldkey"], delegate["coldkey"])
+        self.assertEqual(take["hotkey"], delegate["hotkey"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

`_take_changed` in `scripts/fetch-events.py` decoded the `TakeIncreased` / `TakeDecreased` Subtensor events with the coldkey and hotkey positions reversed, so every such row written to `account_events` stored the two SS58 keys swapped.

## What Changed

Subtensor emits both events coldkey-first:

- `Self::deposit_event(Event::TakeIncreased(coldkey, hotkey, take));` (pallets/subtensor/src/staking/increase_take.rs)
- `Self::deposit_event(Event::TakeDecreased(coldkey, hotkey, take));` (pallets/subtensor/src/staking/decrease_take.rs)

The variants are positional tuples `Take*(T::AccountId, T::AccountId, u16)` with no named fields, so substrate-interface decodes the attributes as a list and the list branch of `_take_changed` runs. It read `a[0]` as the hotkey and `a[1]` as the coldkey -- the reverse of the chain order. Both values are valid SS58 addresses, so `_ss58()` and the shape-drift guard pass and the row is written transposed.

The fix reads `a[0]=coldkey`, `a[1]=hotkey`, matching:
- the structurally identical sibling `_delegate_added` (`DelegateAdded(coldkey, hotkey, take)`), and
- the coldkey-first convention already used by `_stake` and `_moved`.

Added `TakeDelegateExtractorTest` covering the positional form, the named-dict form, and key-order parity with `DelegateAdded`.

Fixes #1840

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes (extractor mapping only).

## Validation

- [x] Verified against the Subtensor source that both events emit `(coldkey, hotkey, take)`.
- [x] `python3 scripts/test_fetch_events.py` covers the new extractor assertions (stdlib unittest, zero deps).
