### PR TITLE
fix(contracts): declare call_args + fee_tao + spec_version in the API schema

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1624,7 +1624,7 @@ export interface components {
          * @enum {unknown}
          */
         BittensorNetwork: "finney" | "test" | "local";
-        /** @description One finalized block header from the first-party blocks D1 tier (#1345 block explorer). author/parent_hash are best-effort (nullable); observed_at is the block time. */
+        /** @description One finalized block header from the first-party blocks D1 tier (#1345 block explorer). author/parent_hash are best-effort (nullable); spec_version is the runtime version at the block (nullable); observed_at is the block time. */
         Block: {
             author?: string | null;
             block_hash?: string | null;
@@ -1634,6 +1634,7 @@ export interface components {
             /** Format: date-time */
             observed_at?: string | null;
             parent_hash?: string | null;
+            spec_version?: number | null;
         };
         /** @description Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file). */
         BlockDetailArtifact: {
@@ -2223,13 +2224,15 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
-        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
+        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
         Extrinsic: {
             block_number: number | null;
+            call_args?: Record<string, never> | unknown[] | null;
             call_function?: string | null;
             call_module?: string | null;
             extrinsic_hash?: string | null;
             extrinsic_index: number | null;
+            fee_tao?: number | null;
             /** Format: date-time */
             observed_at?: string | null;
             signer?: string | null;
@@ -5612,7 +5615,8 @@ export interface operations {
                      *           "event_count": 1,
                      *           "extrinsic_count": 1,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
-                     *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1"
+                     *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                     *           "spec_version": 1
                      *         },
                      *         "ref": "example",
                      *         "schema_version": 1
@@ -7647,10 +7651,12 @@ export interface operations {
                      *       "data": {
                      *         "extrinsic": {
                      *           "block_number": 5000000,
+                     *           "call_args": {},
                      *           "call_function": "example",
                      *           "call_module": "example",
                      *           "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "extrinsic_index": 1,
+                     *           "fee_tao": 0.5,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
                      *           "signer": "example",
                      *           "success": false

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1267,7 +1267,7 @@
       },
       "Block": {
         "additionalProperties": false,
-        "description": "One finalized block header from the first-party blocks D1 tier (#1345 block explorer). author/parent_hash are best-effort (nullable); observed_at is the block time.",
+        "description": "One finalized block header from the first-party blocks D1 tier (#1345 block explorer). author/parent_hash are best-effort (nullable); spec_version is the runtime version at the block (nullable); observed_at is the block time.",
         "properties": {
           "author": {
             "type": [
@@ -1309,6 +1309,12 @@
           "parent_hash": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "spec_version": {
+            "type": [
+              "integer",
               "null"
             ]
           }
@@ -3726,11 +3732,18 @@
       },
       "Extrinsic": {
         "additionalProperties": false,
-        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
+        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
         "properties": {
           "block_number": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "call_args": {
+            "type": [
+              "object",
+              "array",
               "null"
             ]
           },
@@ -3755,6 +3768,12 @@
           "extrinsic_index": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "fee_tao": {
+            "type": [
+              "number",
               "null"
             ]
           },
@@ -13810,7 +13829,8 @@
                       "event_count": 1,
                       "extrinsic_count": 1,
                       "observed_at": "2026-06-01T00:00:00.000Z",
-                      "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1"
+                      "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                      "spec_version": 1
                     },
                     "ref": "example",
                     "schema_version": 1
@@ -16927,10 +16947,12 @@
                   "data": {
                     "extrinsic": {
                       "block_number": 5000000,
+                      "call_args": {},
                       "call_function": "example",
                       "call_module": "example",
                       "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                       "extrinsic_index": 1,
+                      "fee_tao": 0.5,
                       "observed_at": "2026-06-01T00:00:00.000Z",
                       "signer": "example",
                       "success": false

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1624,7 +1624,7 @@ export interface components {
          * @enum {unknown}
          */
         BittensorNetwork: "finney" | "test" | "local";
-        /** @description One finalized block header from the first-party blocks D1 tier (#1345 block explorer). author/parent_hash are best-effort (nullable); observed_at is the block time. */
+        /** @description One finalized block header from the first-party blocks D1 tier (#1345 block explorer). author/parent_hash are best-effort (nullable); spec_version is the runtime version at the block (nullable); observed_at is the block time. */
         Block: {
             author?: string | null;
             block_hash?: string | null;
@@ -1634,6 +1634,7 @@ export interface components {
             /** Format: date-time */
             observed_at?: string | null;
             parent_hash?: string | null;
+            spec_version?: number | null;
         };
         /** @description Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file). */
         BlockDetailArtifact: {
@@ -2223,13 +2224,15 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
-        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
+        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
         Extrinsic: {
             block_number: number | null;
+            call_args?: Record<string, never> | unknown[] | null;
             call_function?: string | null;
             call_module?: string | null;
             extrinsic_hash?: string | null;
             extrinsic_index: number | null;
+            fee_tao?: number | null;
             /** Format: date-time */
             observed_at?: string | null;
             signer?: string | null;
@@ -5612,7 +5615,8 @@ export interface operations {
                      *           "event_count": 1,
                      *           "extrinsic_count": 1,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
-                     *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1"
+                     *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                     *           "spec_version": 1
                      *         },
                      *         "ref": "example",
                      *         "schema_version": 1
@@ -7647,10 +7651,12 @@ export interface operations {
                      *       "data": {
                      *         "extrinsic": {
                      *           "block_number": 5000000,
+                     *           "call_args": {},
                      *           "call_function": "example",
                      *           "call_module": "example",
                      *           "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "extrinsic_index": 1,
+                     *           "fee_tao": 0.5,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
                      *           "signer": "example",
                      *           "success": false

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -1253,7 +1253,7 @@
       },
       "Block": {
         "additionalProperties": false,
-        "description": "One finalized block header from the first-party blocks D1 tier (#1345 block explorer). author/parent_hash are best-effort (nullable); observed_at is the block time.",
+        "description": "One finalized block header from the first-party blocks D1 tier (#1345 block explorer). author/parent_hash are best-effort (nullable); spec_version is the runtime version at the block (nullable); observed_at is the block time.",
         "properties": {
           "author": {
             "type": [
@@ -1295,6 +1295,12 @@
           "parent_hash": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "spec_version": {
+            "type": [
+              "integer",
               "null"
             ]
           }
@@ -3712,11 +3718,18 @@
       },
       "Extrinsic": {
         "additionalProperties": false,
-        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
+        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
         "properties": {
           "block_number": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "call_args": {
+            "type": [
+              "object",
+              "array",
               "null"
             ]
           },
@@ -3741,6 +3754,12 @@
           "extrinsic_index": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "fee_tao": {
+            "type": [
+              "number",
               "null"
             ]
           },

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1604,7 +1604,7 @@
       "Block": {
         "type": "object",
         "additionalProperties": false,
-        "description": "One finalized block header from the first-party blocks D1 tier (#1345 block explorer). author/parent_hash are best-effort (nullable); observed_at is the block time.",
+        "description": "One finalized block header from the first-party blocks D1 tier (#1345 block explorer). author/parent_hash are best-effort (nullable); spec_version is the runtime version at the block (nullable); observed_at is the block time.",
         "required": ["block_number"],
         "properties": {
           "block_number": { "type": ["integer", "null"] },
@@ -1613,6 +1613,7 @@
           "author": { "type": ["string", "null"] },
           "extrinsic_count": { "type": ["integer", "null"] },
           "event_count": { "type": ["integer", "null"] },
+          "spec_version": { "type": ["integer", "null"] },
           "observed_at": { "type": ["string", "null"], "format": "date-time" }
         }
       },
@@ -1651,7 +1652,7 @@
       "Extrinsic": {
         "type": "object",
         "additionalProperties": false,
-        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
+        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
         "required": ["block_number", "extrinsic_index"],
         "properties": {
           "block_number": { "type": ["integer", "null"] },
@@ -1660,6 +1661,8 @@
           "signer": { "type": ["string", "null"] },
           "call_module": { "type": ["string", "null"] },
           "call_function": { "type": ["string", "null"] },
+          "call_args": { "type": ["object", "array", "null"] },
+          "fee_tao": { "type": ["number", "null"] },
           "success": { "type": ["boolean", "null"] },
           "observed_at": { "type": ["string", "null"], "format": "date-time" }
         }

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -92,12 +92,14 @@ test("formatBlock maps a D1 row to an API block (ISO time)", () => {
     author: "5Author",
     extrinsic_count: 4,
     event_count: 12,
+    spec_version: 201,
     observed_at: 1750000000000,
   });
   assert.equal(out.block_number, 1000);
   assert.equal(out.block_hash, "0xhash");
   assert.equal(out.author, "5Author");
   assert.equal(out.extrinsic_count, 4);
+  assert.equal(out.spec_version, 201);
   assert.equal(out.observed_at, new Date(1750000000000).toISOString());
 });
 

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -105,6 +105,8 @@ test("formatExtrinsic maps a D1 row to an API extrinsic (ISO time, bool success)
     signer: "5Signer",
     call_module: "SubtensorModule",
     call_function: "add_stake",
+    call_args: '[{"name":"hotkey","value":"5H..."}]',
+    fee_tao: 0.0125,
     success: 1,
     observed_at: 1750000000000,
   });
@@ -114,8 +116,38 @@ test("formatExtrinsic maps a D1 row to an API extrinsic (ISO time, bool success)
   assert.equal(out.signer, "5Signer");
   assert.equal(out.call_module, "SubtensorModule");
   assert.equal(out.call_function, "add_stake");
+  assert.deepEqual(out.call_args, [{ name: "hotkey", value: "5H..." }]);
+  assert.equal(out.fee_tao, 0.0125);
   assert.equal(out.success, true);
   assert.equal(out.observed_at, new Date(1750000000000).toISOString());
+});
+
+test("formatExtrinsic parses call_args (array, object, parse-failure->null)", () => {
+  // Substrate call args are canonically a LIST of {name,value} descriptors.
+  const arr = formatExtrinsic({
+    block_number: 1,
+    extrinsic_index: 0,
+    call_args: '[{"name":"netuid","value":1}]',
+  });
+  assert.deepEqual(arr.call_args, [{ name: "netuid", value: 1 }]);
+  // An object payload is also tolerated.
+  const obj = formatExtrinsic({
+    block_number: 1,
+    extrinsic_index: 0,
+    call_args: '{"netuid":1}',
+  });
+  assert.deepEqual(obj.call_args, { netuid: 1 });
+  // Malformed JSON -> null (never throws).
+  const bad = formatExtrinsic({
+    block_number: 1,
+    extrinsic_index: 0,
+    call_args: "not-json",
+  });
+  assert.equal(bad.call_args, null);
+  // Absent -> null; fee_tao absent -> null.
+  const sparse = formatExtrinsic({ block_number: 1, extrinsic_index: 0 });
+  assert.equal(sparse.call_args, null);
+  assert.equal(sparse.fee_tao, null);
 });
 
 test("formatExtrinsic normalizes success (0->false, null->null)", () => {


### PR DESCRIPTION
Closes #1843

## Problem

Migrations 0015/0016/0017 added `call_args` + `fee_tao` to the `extrinsics` table and `spec_version` to `blocks`. `formatExtrinsic`/`formatBlock` already read and emit all three (`src/extrinsics.mjs:97-98,119-121`, `src/blocks.mjs:104`). But the closed (`additionalProperties: false`) `Extrinsic` and `Block` schema components never declared them — so the live `/api/v1/extrinsics(/{ref})` and `/api/v1/blocks(/{ref})` responses emit fields the published contract forbids, and typed SDK clients generated from `openapi.json` never see them.

`validate:contract-drift` passed today only because the schema source and the generated `openapi.json` were wrong *in agreement* (`grep "fee_tao" schemas/ public/` → zero matches before this PR).

## Fix

- **`Extrinsic`**: add `call_args` (`["object","array","null"]` — Substrate call args are canonically a **list** of `{name,value}` descriptors, so an object-only type would itself be a drift) and `fee_tao` (`["number","null"]`).
- **`Block`**: add `spec_version` (`["integer","null"]`).
- All three are **optional** (`formatExtrinsic`/`formatBlock` can emit `null`).
- Regenerated `openapi.json`, `api-components.schema.json`, and `types` (`npm run build`).
- Tests: `formatBlock` surfaces `spec_version`; `formatExtrinsic` surfaces `fee_tao` and `call_args` across the array, object, and JSON-parse-failure→`null` branches.

## Verification

- `node scripts/validate-contract-drift.mjs` → passed
- `node scripts/validate-schemas.mjs` → passed
- `vitest run tests/blocks.test.mjs tests/extrinsics.test.mjs tests/contracts.test.mjs tests/invariants-contracts.test.mjs` → 64 passed
- prettier clean
- No migration (columns already exist); `contracts.json`/`api-index.json` unchanged (field additions only touch component schemas).

Part of #1345 (explorer robustness wave).