### PR TITLE
fix(chain): cap staged account event batches

### DIFF
--- a/scripts/backfill-events.py
+++ b/scripts/backfill-events.py
@@ -156,6 +156,16 @@ def main():
             sys.stderr.write(f"block {bn}: skip ({repr(e)[:80]})\n")
             continue
         scanned += 1
+        # account_events rows — mirrors fetch-events.py main()'s row shape. Keep
+        # whole blocks together so backfills do not create staged objects above the
+        # Worker drain cap after high-volume Balances.Transfer bursts.
+        block_event_rows = _fe.event_rows_for_events(bn, events, observed_at)
+        if not _fe._can_append_event_block(rows, block_event_rows):
+            sys.stderr.write(
+                f"event row cap reached before block {bn}; "
+                "rerun from this block for the remaining range\n"
+            )
+            break
         extras = _fe.block_extras(s, bn, bh, len(events))
         if extras is not None:
             extras["observed_at"] = observed_at
@@ -163,29 +173,7 @@ def main():
         for xrow in _fe.extrinsics_for_block(s, bn, bh, events):
             xrow["observed_at"] = observed_at
             extrinsics.append(xrow)
-        # account_events rows — mirrors fetch-events.py main()'s row shape (the
-        # decode helper `extract` is reused; only this assembly is repeated).
-        for event_index, ev in enumerate(events):
-            v = ev.value if isinstance(ev.value, dict) else {}
-            e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
-            if e.get("module_id") not in ("SubtensorModule", "Balances"):
-                continue
-            ent = _fe.extract(e.get("event_id"), e.get("attributes"))
-            if ent is None:
-                continue
-            rows.append(
-                {
-                    "block_number": bn,
-                    "event_index": event_index,
-                    "event_kind": e.get("event_id"),
-                    "hotkey": ent["hotkey"],
-                    "coldkey": ent["coldkey"],
-                    "netuid": ent["netuid"],
-                    "uid": ent["uid"],
-                    "amount_tao": ent["amount_tao"],
-                    "observed_at": observed_at,
-                }
-            )
+        rows.extend(block_event_rows)
 
     for path, data in (
         (_fe.OUT, rows),

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -104,6 +104,10 @@ MAX_LOOKBACK = int(os.environ.get("EVENTS_MAX_LOOKBACK", str(PRUNE_HORIZON)))
 # mode advances through long gaps over multiple safe staged batches instead of
 # producing one pathological object.
 BATCH_BLOCKS = max(1, int(os.environ.get("EVENTS_BATCH_BLOCKS", str(WINDOW))))
+# Keep producer batches below the Worker staged-event row cap (10k) and,
+# indirectly, below its 4 MiB parse-safety byte cap even when high-volume
+# Balances.Transfer events are present. Reserve headroom for the HMAC envelope.
+MAX_EVENT_ROWS = max(1, int(os.environ.get("EVENTS_MAX_EVENT_ROWS", "9000")))
 
 
 def _parse_cursor(raw):
@@ -590,6 +594,52 @@ def extract(event_id, attrs):
     }
 
 
+def event_rows_for_events(bn, events, observed_at):
+    """Extract account_events rows for one block.
+
+    Kept as whole-block units so producer-side row chunking never advances the
+    staged cursor past a partially emitted block. Shape drift on individual events
+    is handled by extract() and skipped, matching the historical inline loop.
+    """
+    rows = []
+    for event_index, ev in enumerate(events):
+        v = ev.value if isinstance(ev.value, dict) else {}
+        e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
+        if e.get("module_id") not in ("SubtensorModule", "Balances"):
+            continue
+        eid = e.get("event_id")
+        ent = extract(eid, e.get("attributes"))
+        if ent is None:
+            continue
+        # Link the event to the extrinsic that emitted it (#1849): the
+        # ApplyExtrinsic-phase extrinsic_idx (the same field _fee_map /
+        # _extrinsic_success_map correlate on). Initialization / Finalization
+        # phase events have no extrinsic — store null.
+        xidx = v.get("extrinsic_idx") if v.get("phase") == "ApplyExtrinsic" else None
+        if not isinstance(xidx, int) or xidx < 0:
+            xidx = None
+        rows.append(
+            {
+                "block_number": bn,
+                "event_index": event_index,
+                "event_kind": eid,
+                "hotkey": ent["hotkey"],
+                "coldkey": ent["coldkey"],
+                "netuid": ent["netuid"],
+                "uid": ent["uid"],
+                "amount_tao": ent["amount_tao"],
+                "alpha_amount": ent["alpha_amount"],
+                "observed_at": observed_at,
+                "extrinsic_index": xidx,
+            }
+        )
+    return rows
+
+
+def _can_append_event_block(rows, block_rows, max_rows=MAX_EVENT_ROWS):
+    """Whether the next block's account_events fit in this staged batch."""
+    return len(rows) + len(block_rows) <= max_rows
+
 def _lag_alert_needed(head_bn, cursor, window=WINDOW, horizon=PRUNE_HORIZON):
     """True when the cursor is far enough behind the finalized head that un-fetched
     blocks risk being pruned before the next run.
@@ -673,6 +723,10 @@ def main():
             sys.stderr.write(f"block {bn}: skip ({repr(e)[:80]})\n")
             continue
         scanned += 1
+        block_event_rows = event_rows_for_events(bn, events, observed_at)
+        if not _can_append_event_block(rows, block_event_rows):
+            end = bn - 1
+            break
         # Block-explorer hot-window record (#1345): best-effort header extras +
         # the decoded event count, observed_at from the same height-derived clock
         # as the events. A None means the extras read failed — skip this block's
@@ -688,37 +742,7 @@ def main():
         for xrow in extrinsics_for_block(s, bn, bh, events):
             xrow["observed_at"] = observed_at
             extrinsics.append(xrow)
-        for event_index, ev in enumerate(events):
-            v = ev.value if isinstance(ev.value, dict) else {}
-            e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
-            if e.get("module_id") not in ("SubtensorModule", "Balances"):
-                continue
-            eid = e.get("event_id")
-            ent = extract(eid, e.get("attributes"))
-            if ent is None:
-                continue
-            # Link the event to the extrinsic that emitted it (#1849): the
-            # ApplyExtrinsic-phase extrinsic_idx (the same field _fee_map /
-            # _extrinsic_success_map correlate on). Initialization / Finalization
-            # phase events have no extrinsic — store null.
-            xidx = v.get("extrinsic_idx") if v.get("phase") == "ApplyExtrinsic" else None
-            if not isinstance(xidx, int) or xidx < 0:
-                xidx = None
-            rows.append(
-                {
-                    "block_number": bn,
-                    "event_index": event_index,
-                    "event_kind": eid,
-                    "hotkey": ent["hotkey"],
-                    "coldkey": ent["coldkey"],
-                    "netuid": ent["netuid"],
-                    "uid": ent["uid"],
-                    "amount_tao": ent["amount_tao"],
-                    "alpha_amount": ent["alpha_amount"],
-                    "observed_at": observed_at,
-                    "extrinsic_index": xidx,
-                }
-            )
+        rows.extend(block_event_rows)
 
     os.makedirs(os.path.dirname(OUT) or ".", exist_ok=True)
     with open(OUT, "w") as fh:

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -29,6 +29,8 @@ _parse_cursor = _fe._parse_cursor
 _block_author = _fe._block_author
 AURA_ENGINE_ID = _fe.AURA_ENGINE_ID
 PRUNE_HORIZON = _fe.PRUNE_HORIZON
+event_rows_for_events = _fe.event_rows_for_events
+_can_append_event_block = _fe._can_append_event_block
 
 
 class ComputeFromBlockTest(unittest.TestCase):
@@ -182,6 +184,37 @@ class ParseCursorTest(unittest.TestCase):
     def test_negative_is_cold(self):
         self.assertIsNone(_parse_cursor("-1"))
         self.assertIsNone(_parse_cursor(-7))
+
+class EventRowBatchCapTest(unittest.TestCase):
+    class Event:
+        def __init__(self, module_id, event_id, attributes):
+            self.value = {
+                "event": {
+                    "module_id": module_id,
+                    "event_id": event_id,
+                    "attributes": attributes,
+                }
+            }
+
+    def test_event_rows_for_events_matches_transfer_shape(self):
+        rows = event_rows_for_events(
+            123,
+            [self.Event("Balances", "Transfer", [_SS58_A, _SS58_B, _RAO_100])],
+            456,
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["block_number"], 123)
+        self.assertEqual(rows[0]["event_index"], 0)
+        self.assertEqual(rows[0]["event_kind"], "Transfer")
+        self.assertEqual(rows[0]["hotkey"], _SS58_A)
+        self.assertEqual(rows[0]["coldkey"], _SS58_B)
+        self.assertAlmostEqual(rows[0]["amount_tao"], 100.0)
+        self.assertEqual(rows[0]["observed_at"], 456)
+
+    def test_can_append_event_block_keeps_batches_under_cap(self):
+        existing = [{}] * 3
+        self.assertTrue(_can_append_event_block(existing, [{}] * 2, max_rows=5))
+        self.assertFalse(_can_append_event_block(existing, [{}] * 3, max_rows=5))
 
 
 _lag_alert_needed = _fe._lag_alert_needed


### PR DESCRIPTION
### Motivation
- Indexing `Balances.Transfer` made the producer append large numbers of native transfer rows to a single staged JSON, which can exceed the Worker's 4 MiB parse-safety cap and cause the Worker to skip entire staged batches and advance the cursor, producing permanent staleness/loss in the account-events index. 

### Description
- Introduce a producer-side row cap via `MAX_EVENT_ROWS` (env `EVENTS_MAX_EVENT_ROWS`, default `9000`) to keep staged batches below the Worker's staged-file limits. 
- Extract account-event assembly into `event_rows_for_events` and add `_can_append_event_block` so the producer evaluates whole-block units before appending and never stages a partial block. 
- Stop the live poller early when the next block would overflow the batch and apply the same whole-block cap to the archive backfill path so backfills cannot produce oversized staged objects. 
- Add unit tests for `Transfer` extraction and the batch-cap predicate in `scripts/test_fetch_events.py` to guard the new behavior. 

### Testing
- Ran `python3 -m py_compile scripts/fetch-events.py scripts/backfill-events.py scripts/test_fetch_events.py` which succeeded. 
- Ran the Python unit suite with `python3 -m unittest scripts/test_fetch_events.py` and all tests passed (31 tests, OK). 
- Attempted `npm test`; a local `vitest` run exposed an existing, environment-dependent failure in `tests/mcp-server.test.mjs` unrelated to the producer changes, so full Node test completion was not achieved in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d05329564832cbc5a7678859c7e9d)