### PR TITLE
feat(chain): surface signing activity in the account summary (tx_count, modules, last tx)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1317,6 +1317,18 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** @description Signing activity for one account (#1847) from the extrinsics tier, matched by signer. Hot-window aggregates (retention-bounded), not all-time. tx_count is the count of extrinsics this account signed; modules_called is the top call_modules by frequency. */
+        AccountActivity: {
+            /** Format: date-time */
+            last_tx_at?: string | null;
+            last_tx_block?: number | null;
+            modules_called: {
+                call_module: string | null;
+                count: number;
+            }[];
+            total_fee_tao?: number | null;
+            tx_count: number;
+        };
         /** @description Live TAO balance for an account (ss58), queried from the finney RPC at request time and cached for 60s. balance_tao is null on RPC failure. */
         AccountBalanceArtifact: {
             balance_tao?: number | null;
@@ -1386,6 +1398,7 @@ export interface components {
         };
         /** @description Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file). */
         AccountSummaryArtifact: {
+            activity?: components["schemas"]["AccountActivity"];
             event_count: number;
             event_kinds?: components["schemas"]["AccountEventKindCount"][];
             first_block?: number | null;
@@ -4583,6 +4596,18 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "activity": {
+                     *           "last_tx_at": "2026-06-01T00:00:00.000Z",
+                     *           "last_tx_block": 5000000,
+                     *           "modules_called": [
+                     *             {
+                     *               "call_module": "example",
+                     *               "count": 1
+                     *             }
+                     *           ],
+                     *           "total_fee_tao": 0.5,
+                     *           "tx_count": 1
+                     *         },
                      *         "event_count": 1,
                      *         "event_kinds": [
                      *           {

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -18,6 +18,63 @@
       }
     },
     "schemas": {
+      "AccountActivity": {
+        "additionalProperties": false,
+        "description": "Signing activity for one account (#1847) from the extrinsics tier, matched by signer. Hot-window aggregates (retention-bounded), not all-time. tx_count is the count of extrinsics this account signed; modules_called is the top call_modules by frequency.",
+        "properties": {
+          "last_tx_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last_tx_block": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "modules_called": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "call_module": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "count": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "call_module",
+                "count"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "total_fee_tao": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "tx_count": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "tx_count",
+          "modules_called"
+        ],
+        "type": "object"
+      },
       "AccountBalanceArtifact": {
         "additionalProperties": true,
         "description": "Live TAO balance for an account (ss58), queried from the finney RPC at request time and cached for 60s. balance_tao is null on RPC failure.",
@@ -267,6 +324,9 @@
         "additionalProperties": true,
         "description": "Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file).",
         "properties": {
+          "activity": {
+            "$ref": "#/components/schemas/AccountActivity"
+          },
           "event_count": {
             "minimum": 0,
             "type": "integer"
@@ -12567,6 +12627,18 @@
               "application/json": {
                 "example": {
                   "data": {
+                    "activity": {
+                      "last_tx_at": "2026-06-01T00:00:00.000Z",
+                      "last_tx_block": 5000000,
+                      "modules_called": [
+                        {
+                          "call_module": "example",
+                          "count": 1
+                        }
+                      ],
+                      "total_fee_tao": 0.5,
+                      "tx_count": 1
+                    },
                     "event_count": 1,
                     "event_kinds": [
                       {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1317,6 +1317,18 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** @description Signing activity for one account (#1847) from the extrinsics tier, matched by signer. Hot-window aggregates (retention-bounded), not all-time. tx_count is the count of extrinsics this account signed; modules_called is the top call_modules by frequency. */
+        AccountActivity: {
+            /** Format: date-time */
+            last_tx_at?: string | null;
+            last_tx_block?: number | null;
+            modules_called: {
+                call_module: string | null;
+                count: number;
+            }[];
+            total_fee_tao?: number | null;
+            tx_count: number;
+        };
         /** @description Live TAO balance for an account (ss58), queried from the finney RPC at request time and cached for 60s. balance_tao is null on RPC failure. */
         AccountBalanceArtifact: {
             balance_tao?: number | null;
@@ -1386,6 +1398,7 @@ export interface components {
         };
         /** @description Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file). */
         AccountSummaryArtifact: {
+            activity?: components["schemas"]["AccountActivity"];
             event_count: number;
             event_kinds?: components["schemas"]["AccountEventKindCount"][];
             first_block?: number | null;
@@ -4583,6 +4596,18 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "activity": {
+                     *           "last_tx_at": "2026-06-01T00:00:00.000Z",
+                     *           "last_tx_block": 5000000,
+                     *           "modules_called": [
+                     *             {
+                     *               "call_module": "example",
+                     *               "count": 1
+                     *             }
+                     *           ],
+                     *           "total_fee_tao": 0.5,
+                     *           "tx_count": 1
+                     *         },
                      *         "event_count": 1,
                      *         "event_kinds": [
                      *           {

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -4,6 +4,63 @@
   "additionalProperties": false,
   "components": {
     "schemas": {
+      "AccountActivity": {
+        "additionalProperties": false,
+        "description": "Signing activity for one account (#1847) from the extrinsics tier, matched by signer. Hot-window aggregates (retention-bounded), not all-time. tx_count is the count of extrinsics this account signed; modules_called is the top call_modules by frequency.",
+        "properties": {
+          "last_tx_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last_tx_block": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "modules_called": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "call_module": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "count": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "call_module",
+                "count"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "total_fee_tao": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "tx_count": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "tx_count",
+          "modules_called"
+        ],
+        "type": "object"
+      },
       "AccountBalanceArtifact": {
         "additionalProperties": true,
         "description": "Live TAO balance for an account (ss58), queried from the finney RPC at request time and cached for 60s. balance_tao is null on RPC failure.",
@@ -253,6 +310,9 @@
         "additionalProperties": true,
         "description": "Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file).",
         "properties": {
+          "activity": {
+            "$ref": "#/components/schemas/AccountActivity"
+          },
           "event_count": {
             "minimum": 0,
             "type": "integer"

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1554,6 +1554,31 @@
           "recent_events": {
             "type": "array",
             "items": { "$ref": "#/components/schemas/AccountEvent" }
+          },
+          "activity": { "$ref": "#/components/schemas/AccountActivity" }
+        }
+      },
+      "AccountActivity": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Signing activity for one account (#1847) from the extrinsics tier, matched by signer. Hot-window aggregates (retention-bounded), not all-time. tx_count is the count of extrinsics this account signed; modules_called is the top call_modules by frequency.",
+        "required": ["tx_count", "modules_called"],
+        "properties": {
+          "tx_count": { "type": "integer", "minimum": 0 },
+          "last_tx_block": { "type": ["integer", "null"] },
+          "last_tx_at": { "type": ["string", "null"], "format": "date-time" },
+          "total_fee_tao": { "type": ["number", "null"] },
+          "modules_called": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["call_module", "count"],
+              "properties": {
+                "call_module": { "type": ["string", "null"] },
+                "count": { "type": "integer", "minimum": 0 }
+              }
+            }
           }
         }
       },

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -194,9 +194,27 @@ export function formatRegistration(row) {
 // matched by hotkey OR coldkey) joined to current registrations (from neurons,
 // by hotkey). `agg` is the single aggregate row; kinds/registrations/recent are
 // row arrays. Null-safe on a cold/absent store (returns a schema-stable zero).
+// Signing-activity sub-object (#1847) from the extrinsics tier, by signer. These
+// are hot-window aggregates (retention-bounded), not all-time. Matched by signer
+// only — an account queried by a key that did not sign won't line up with the
+// account_events aggregates (which match hotkey OR coldkey). Null-safe on a cold
+// store: tx_count 0, others null, modules_called [].
+export function formatAccountActivity(agg, modules) {
+  const a = agg || {};
+  return {
+    tx_count: a.tx_count ?? 0,
+    last_tx_block: a.last_tx_block ?? null,
+    last_tx_at: toIso(a.last_tx_at),
+    total_fee_tao: a.total_fee_tao ?? null,
+    modules_called: (modules || [])
+      .filter((m) => m && m.call_module)
+      .map((m) => ({ call_module: m.call_module, count: m.count ?? 0 })),
+  };
+}
+
 export function buildAccountSummary(
   ss58,
-  { agg, kinds, registrations, recent } = {},
+  { agg, kinds, registrations, recent, activity, modules } = {},
 ) {
   const a = agg || {};
   return {
@@ -215,6 +233,7 @@ export function buildAccountSummary(
       .map(formatRegistration)
       .filter(Boolean),
     recent_events: (recent || []).map(formatAccountEvent).filter(Boolean),
+    activity: formatAccountActivity(activity, modules),
   };
 }
 

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -254,6 +254,34 @@ test("buildAccountSummary is schema-stable with no data", () => {
   assert.deepEqual(out.registrations, []);
   assert.deepEqual(out.event_kinds, []);
   assert.equal(out.first_seen_at, null);
+  // Activity sub-object (#1847) is always present + schema-stable.
+  assert.equal(out.activity.tx_count, 0);
+  assert.equal(out.activity.last_tx_block, null);
+  assert.equal(out.activity.last_tx_at, null);
+  assert.equal(out.activity.total_fee_tao, null);
+  assert.deepEqual(out.activity.modules_called, []);
+});
+
+test("buildAccountSummary threads the signing activity sub-object (#1847)", () => {
+  const out = buildAccountSummary("5Hk", {
+    activity: {
+      tx_count: 4,
+      last_tx_block: 200,
+      last_tx_at: 1750009000000,
+      total_fee_tao: 0.02,
+    },
+    modules: [
+      { call_module: "SubtensorModule", count: 3 },
+      { call_module: null, count: 1 },
+    ],
+  });
+  assert.equal(out.activity.tx_count, 4);
+  assert.equal(out.activity.last_tx_block, 200);
+  assert.equal(out.activity.last_tx_at, new Date(1750009000000).toISOString());
+  assert.equal(out.activity.total_fee_tao, 0.02);
+  // the {call_module:null} row is dropped
+  assert.equal(out.activity.modules_called.length, 1);
+  assert.equal(out.activity.modules_called[0].call_module, "SubtensorModule");
 });
 
 test("formatRegistration defaults every sparse field to null/false (null-safe)", () => {

--- a/tests/account-routes.test.mjs
+++ b/tests/account-routes.test.mjs
@@ -8,9 +8,17 @@ function req(path) {
   return new Request(`https://api.metagraph.sh${path}`);
 }
 
-// A D1 mock that routes by SQL shape so the account handlers (#1347) get
-// realistic rows. Order matters: GROUP BY (kinds) before COUNT (agg).
-function dbWith({ agg, kinds, registrations, events, extrinsics } = {}) {
+// A D1 mock that routes by SQL shape so the account handlers (#1347/#1847) get
+// realistic rows. Order matters: more-specific shapes first.
+function dbWith({
+  agg,
+  kinds,
+  registrations,
+  events,
+  extrinsics,
+  activity,
+  modules,
+} = {}) {
   return {
     METAGRAPH_HEALTH_DB: {
       prepare(sql) {
@@ -20,7 +28,14 @@ function dbWith({ agg, kinds, registrations, events, extrinsics } = {}) {
               async all() {
                 if (/GROUP BY event_kind/.test(sql))
                   return { results: kinds || [] };
-                if (/COUNT\(\*\) AS c/.test(sql))
+                // Activity (#1847): the GROUP BY call_module list + tx_count
+                // aggregate must be matched BEFORE the account_events `AS c`
+                // aggregate (whose loose "AS c" substring also matches "AS count").
+                if (/GROUP BY call_module/.test(sql))
+                  return { results: modules || [] };
+                if (/AS tx_count/.test(sql))
+                  return { results: activity ? [activity] : [] };
+                if (/COUNT\(\*\) AS c\b/.test(sql))
                   return { results: agg ? [agg] : [] };
                 if (/FROM neurons/.test(sql))
                   return { results: registrations || [] };
@@ -68,6 +83,16 @@ test("GET /accounts/{ss58} returns a cross-subnet summary (#1347)", async () => 
         observed_at: 1750009000000,
       },
     ],
+    activity: {
+      tx_count: 9,
+      last_tx_block: 200,
+      last_tx_at: 1750009000000,
+      total_fee_tao: 0.05,
+    },
+    modules: [
+      { call_module: "SubtensorModule", count: 7 },
+      { call_module: "Balances", count: 2 },
+    ],
   });
   const res = await handleRequest(req(`/api/v1/accounts/${SS58}`), env, {});
   assert.equal(res.status, 200);
@@ -75,6 +100,18 @@ test("GET /accounts/{ss58} returns a cross-subnet summary (#1347)", async () => 
   assert.equal(body.data.ss58, SS58);
   assert.equal(body.data.event_count, 12);
   assert.equal(body.data.subnet_count, 3);
+  // Activity sub-object (#1847) from the extrinsics tier.
+  assert.equal(body.data.activity.tx_count, 9);
+  assert.equal(body.data.activity.last_tx_block, 200);
+  assert.equal(
+    body.data.activity.last_tx_at,
+    new Date(1750009000000).toISOString(),
+  );
+  assert.equal(body.data.activity.total_fee_tao, 0.05);
+  assert.equal(
+    body.data.activity.modules_called[0].call_module,
+    "SubtensorModule",
+  );
   assert.equal(body.data.registrations[0].netuid, 7);
   assert.equal(body.data.registrations[0].validator_permit, true);
   assert.equal(body.data.event_kinds[0].kind, "StakeAdded");
@@ -144,6 +181,10 @@ test("GET /accounts/{ss58} is schema-stable when D1 is cold (never 404)", async 
   const body = await res.json();
   assert.equal(body.data.event_count, 0);
   assert.equal(Array.isArray(body.data.registrations), true);
+  // Activity (#1847) is schema-stable on a cold store.
+  assert.equal(body.data.activity.tx_count, 0);
+  assert.equal(body.data.activity.last_tx_at, null);
+  assert.deepEqual(body.data.activity.modules_called, []);
 });
 
 test("GET /accounts/{ss58}/extrinsics returns this account's signed extrinsics (#1844)", async () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -239,33 +239,49 @@ async function accountMeta(env, artifactPath, generatedAt) {
 // (neurons, by hotkey). Cold/absent store → schema-stable zero (never 404).
 export async function handleAccount(request, env, ss58) {
   const where = "hotkey = ? OR coldkey = ?";
-  const [aggRows, kindRows, regRows, recentRows] = await Promise.all([
-    d1All(
-      env,
-      `SELECT COUNT(*) AS c, COUNT(DISTINCT netuid) AS sc, MIN(block_number) AS fb, MAX(block_number) AS lb, MIN(observed_at) AS fo, MAX(observed_at) AS lo FROM account_events WHERE ${where}`,
-      [ss58, ss58],
-    ),
-    d1All(
-      env,
-      `SELECT event_kind AS kind, COUNT(*) AS count FROM account_events WHERE ${where} GROUP BY event_kind ORDER BY count DESC`,
-      [ss58, ss58],
-    ),
-    d1All(
-      env,
-      `SELECT netuid, uid, stake_tao, validator_permit, active FROM neurons WHERE hotkey = ? ORDER BY stake_tao DESC`,
-      [ss58],
-    ),
-    d1All(
-      env,
-      `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE ${where} ORDER BY block_number DESC, event_index DESC LIMIT 10`,
-      [ss58, ss58],
-    ),
-  ]);
+  const [aggRows, kindRows, regRows, recentRows, activityRows, moduleRows] =
+    await Promise.all([
+      d1All(
+        env,
+        `SELECT COUNT(*) AS c, COUNT(DISTINCT netuid) AS sc, MIN(block_number) AS fb, MAX(block_number) AS lb, MIN(observed_at) AS fo, MAX(observed_at) AS lo FROM account_events WHERE ${where}`,
+        [ss58, ss58],
+      ),
+      d1All(
+        env,
+        `SELECT event_kind AS kind, COUNT(*) AS count FROM account_events WHERE ${where} GROUP BY event_kind ORDER BY count DESC`,
+        [ss58, ss58],
+      ),
+      d1All(
+        env,
+        `SELECT netuid, uid, stake_tao, validator_permit, active FROM neurons WHERE hotkey = ? ORDER BY stake_tao DESC`,
+        [ss58],
+      ),
+      d1All(
+        env,
+        `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE ${where} ORDER BY block_number DESC, event_index DESC LIMIT 10`,
+        [ss58, ss58],
+      ),
+      // Signing activity (#1847): aggregates from the extrinsics tier by signer
+      // (idx_extrinsics_signer). Single [ss58] bind. Hot-window-bounded, not
+      // all-time. Matched by signer only — see formatAccountActivity.
+      d1All(
+        env,
+        `SELECT COUNT(*) AS tx_count, MAX(block_number) AS last_tx_block, MAX(observed_at) AS last_tx_at, SUM(fee_tao) AS total_fee_tao FROM extrinsics WHERE signer = ?`,
+        [ss58],
+      ),
+      d1All(
+        env,
+        `SELECT call_module, COUNT(*) AS count FROM extrinsics WHERE signer = ? GROUP BY call_module ORDER BY count DESC LIMIT 10`,
+        [ss58],
+      ),
+    ]);
   const data = buildAccountSummary(ss58, {
     agg: aggRows[0],
     kinds: kindRows,
     registrations: regRows,
     recent: recentRows,
+    activity: activityRows[0],
+    modules: moduleRows,
   });
   return envelopeResponse(
     request,


### PR DESCRIPTION
Closes #1847

## What

`AccountSummaryArtifact` was built purely from `account_events` + `neurons` — zero extrinsic signal. An account profile couldn't show how many transactions it signed, which modules it called, or when it last signed.

Adds an `activity` sub-object from the `extrinsics` tier (by signer, via `idx_extrinsics_signer`):

```
activity: { tx_count, last_tx_block, last_tx_at, total_fee_tao, modules_called: [{ call_module, count }] }
```

## Design

- Two extra parallel `d1All` queries in `handleAccount` (single `[ss58]` bind each — no added latency): the aggregate (`COUNT(*)`/`MAX`/`SUM(fee_tao)`) and the top-10 `GROUP BY call_module`.
- `total_fee_tao` sums the `fee_tao` column declared in the contract by #1860.
- Hot-window aggregates (retention-bounded), **not** all-time — documented.
- Matched by **signer only** — an account queried by a key that did not sign won't line up with the `hotkey OR coldkey` event aggregates (doc note in `formatAccountActivity`).
- `formatAccountActivity` is a pure, null-safe helper (`tx_count:0`, others null, `modules_called:[]` on a cold store).
- Explicit `AccountActivity` schema component (not leaning on `additionalProperties:true`).

## Verification

- contract-drift / client-sdk-sync / api (77) / openapi / docs / public-safety → pass
- vitest account-routes / account-events / contracts / invariants-contracts → 54 passed (populated activity, cold-store zero, `{call_module:null}` drop)
- eslint + prettier clean

Part of #1345 (explorer robustness wave).