### PR TITLE
feat(api): add RFC 8288 Link headers for cursor pagination

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -745,6 +745,112 @@ describe("invalid query handling", () => {
   });
 });
 
+// --- RFC 8288 pagination Link header (#1686) ----------------------------------
+// /api/v1/subnets is the only end-to-end list fixture; the header is built once
+// for every cursor-paginated collection in workers/list-query.mjs, so proving it
+// here proves the wiring for all of them. The fixture sorts to a stable netuid
+// run, so limit=50 yields exactly three pages at cursors 0 / 50 / 100.
+describe("pagination Link header", () => {
+  const parseLink = (value) => {
+    const links = {};
+    for (const part of String(value || "").split(",")) {
+      const match = part.match(/<([^>]+)>;\s*rel="([^"]+)"/);
+      if (match) {
+        links[match[2]] = new URL(match[1]);
+      }
+    }
+    return links;
+  };
+  const page = async (querySuffix, init) => {
+    const res = await handleRequest(
+      req(`/api/v1/subnets?sort=netuid&${querySuffix}`, init),
+      createLocalArtifactEnv(),
+      {},
+    );
+    return { res, links: parseLink(res.headers.get("link")) };
+  };
+
+  test("first page advertises next + last, never prev/first", async () => {
+    const { res, links } = await page("limit=50&cursor=0");
+    assert.equal(res.status, 200);
+    assert.deepEqual(Object.keys(links).sort(), ["last", "next"]);
+    assert.equal(links.next.origin, "https://api.metagraph.sh");
+    assert.equal(links.next.searchParams.get("cursor"), "50");
+    assert.equal(links.next.searchParams.get("limit"), "50");
+    assert.equal(links.next.searchParams.get("sort"), "netuid");
+    assert.equal(links.last.searchParams.get("cursor"), "100");
+    // The Link header must be readable cross-origin (exposed via CORS), or a
+    // browser link-follower could not walk the pages.
+    assert.match(res.headers.get("access-control-expose-headers"), /\blink\b/);
+  });
+
+  test("middle page advertises all four relations", async () => {
+    const { links } = await page("limit=50&cursor=50");
+    assert.deepEqual(Object.keys(links).sort(), [
+      "first",
+      "last",
+      "next",
+      "prev",
+    ]);
+    assert.equal(links.first.searchParams.get("cursor"), "0");
+    assert.equal(links.prev.searchParams.get("cursor"), "0");
+    assert.equal(links.next.searchParams.get("cursor"), "100");
+    assert.equal(links.last.searchParams.get("cursor"), "100");
+  });
+
+  test("last page advertises first + prev, never next/last", async () => {
+    const { links } = await page("limit=50&cursor=100");
+    assert.deepEqual(Object.keys(links).sort(), ["first", "prev"]);
+    assert.equal(links.first.searchParams.get("cursor"), "0");
+    assert.equal(links.prev.searchParams.get("cursor"), "50");
+  });
+
+  test("last targets the final page, not past it, when total divides evenly", async () => {
+    // 129 subnets / limit 43 = exactly 3 pages, so `last` must be 86 (page 3
+    // start), not 129 — guarding the `(total - 1)` correction in the offset.
+    const { links } = await page("limit=43&cursor=0");
+    assert.equal(links.last.searchParams.get("cursor"), "86");
+  });
+
+  test("empty result set carries no Link header", async () => {
+    const { res } = await page("netuid=999999&limit=50");
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).meta.pagination.total, 0);
+    assert.equal(res.headers.get("link"), null);
+  });
+
+  test("an unpaged request (no limit/cursor) carries no Link header", async () => {
+    const { res } = await page("order=asc");
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("link"), null);
+  });
+
+  test("a HEAD request still carries the walkable Link header", async () => {
+    const { res, links } = await page("limit=50&cursor=0", { method: "HEAD" });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), "");
+    assert.equal(links.next.searchParams.get("cursor"), "50");
+  });
+
+  test("a 304 conditional response preserves the Link header", async () => {
+    const env = createLocalArtifactEnv();
+    const first = await handleRequest(
+      req("/api/v1/subnets?sort=netuid&limit=50&cursor=0"),
+      env,
+      {},
+    );
+    const res = await handleRequest(
+      req("/api/v1/subnets?sort=netuid&limit=50&cursor=0", {
+        headers: { "if-none-match": first.headers.get("etag") },
+      }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 304);
+    assert.match(res.headers.get("link"), /rel="next"/);
+  });
+});
+
 // --- 304 on api envelope ------------------------------------------------------
 describe("api envelope 304", () => {
   test("304 when if-none-match matches the api etag", async () => {

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -1,9 +1,37 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { applyQueryFilters } from "../workers/list-query.mjs";
+import {
+  applyQueryFilters,
+  paginationLinkHeader,
+} from "../workers/list-query.mjs";
 
 function query(path) {
   return new URL(`https://api.metagraph.sh${path}`);
+}
+
+// Parse an RFC 8288 Link header value into { rel: URL }, so a test can assert on
+// the relation set and the cursor each page link points at.
+function parseLink(value) {
+  const links = {};
+  for (const part of String(value || "").split(",")) {
+    const match = part.match(/<([^>]+)>;\s*rel="([^"]+)"/);
+    if (match) {
+      links[match[2]] = new URL(match[1]);
+    }
+  }
+  return links;
+}
+
+// Build a paginated page's Link header end-to-end: real pagination meta from
+// applyQueryFilters fed straight into paginationLinkHeader, the same wiring the
+// Worker uses.
+function pageLink(path) {
+  const url = query(path);
+  const data = {
+    subnets: Array.from({ length: 5 }, (_, i) => ({ netuid: i })),
+  };
+  const { meta } = applyQueryFilters(data, url, "subnets");
+  return paginationLinkHeader(url, meta.pagination);
 }
 
 describe("list-query field projection", () => {
@@ -210,5 +238,97 @@ describe("list-query numeric range filters", () => {
 
     assert.equal(bad.error.parameter, "max_surface_count");
     assert.match(bad.error.message, /must be a number/);
+  });
+});
+
+describe("list-query pagination Link header", () => {
+  test("first page: next + last only (no earlier page exists)", () => {
+    const links = parseLink(pageLink("/api/v1/subnets?sort=netuid&limit=2"));
+    assert.deepEqual(Object.keys(links).sort(), ["last", "next"]);
+    assert.equal(links.next.searchParams.get("cursor"), "2");
+    assert.equal(links.last.searchParams.get("cursor"), "4"); // floor((5-1)/2)*2
+  });
+
+  test("middle page: every relation, with stride-aligned offsets", () => {
+    const links = parseLink(
+      pageLink("/api/v1/subnets?sort=netuid&limit=2&cursor=2"),
+    );
+    assert.deepEqual(Object.keys(links).sort(), [
+      "first",
+      "last",
+      "next",
+      "prev",
+    ]);
+    assert.equal(links.first.searchParams.get("cursor"), "0");
+    assert.equal(links.prev.searchParams.get("cursor"), "0");
+    assert.equal(links.next.searchParams.get("cursor"), "4");
+    assert.equal(links.last.searchParams.get("cursor"), "4");
+  });
+
+  test("last page: first + prev only (no later page exists)", () => {
+    const links = parseLink(
+      pageLink("/api/v1/subnets?sort=netuid&limit=2&cursor=4"),
+    );
+    assert.deepEqual(Object.keys(links).sort(), ["first", "prev"]);
+    assert.equal(links.first.searchParams.get("cursor"), "0");
+    assert.equal(links.prev.searchParams.get("cursor"), "2");
+  });
+
+  test("last points at the final page when total is a multiple of limit", () => {
+    // limit=1 makes total (5) an exact multiple of limit — the only case where
+    // the `(total - 1)` correction matters. last must be 4 (the final row), not
+    // a naive floor(total/limit)*limit = 5, which is an empty page past the end.
+    const links = parseLink(pageLink("/api/v1/subnets?sort=netuid&limit=1"));
+    assert.equal(links.next.searchParams.get("cursor"), "1");
+    assert.equal(links.last.searchParams.get("cursor"), "4");
+  });
+
+  test("prev clamps to 0 when the cursor is less than one full page in", () => {
+    // cursor=1, limit=3 → prev = max(0, 1 - 3); without the clamp the link
+    // would carry a negative cursor. first and prev both land on page 0.
+    const links = parseLink(
+      pageLink("/api/v1/subnets?sort=netuid&limit=3&cursor=1"),
+    );
+    assert.equal(links.prev.searchParams.get("cursor"), "0");
+    assert.equal(links.first.searchParams.get("cursor"), "0");
+  });
+
+  test("links pin the resolved limit even when the client omits it", () => {
+    // ?cursor=2 with no limit → the default window (100) is resolved and pinned
+    // onto every page link, so a client can keep walking with a stable window.
+    const links = parseLink(pageLink("/api/v1/subnets?sort=netuid&cursor=2"));
+    assert.equal(links.prev.searchParams.get("limit"), "100");
+    assert.equal(links.first.searchParams.get("limit"), "100");
+  });
+
+  test("empty result emits no Link header", () => {
+    // netuid=999 matches no row → total 0 → no walkable page.
+    assert.equal(pageLink("/api/v1/subnets?netuid=999&limit=2"), null);
+  });
+
+  test("an unpaged request (no limit/cursor) emits no Link header", () => {
+    assert.equal(pageLink("/api/v1/subnets?sort=netuid"), null);
+  });
+
+  test("each page link is absolute and carries the active query through", () => {
+    const links = parseLink(
+      pageLink("/api/v1/subnets?sort=netuid&order=desc&limit=2&cursor=2"),
+    );
+    for (const rel of ["first", "prev", "next", "last"]) {
+      const target = links[rel];
+      assert.equal(target.origin, "https://api.metagraph.sh");
+      assert.equal(target.pathname, "/api/v1/subnets");
+      assert.equal(target.searchParams.get("sort"), "netuid");
+      assert.equal(target.searchParams.get("order"), "desc");
+      assert.equal(target.searchParams.get("limit"), "2"); // resolved window pinned
+    }
+  });
+
+  test("a non-list (no pagination meta) collection yields no header", () => {
+    assert.equal(
+      paginationLinkHeader(query("/api/v1/subnets"), undefined),
+      null,
+    );
+    assert.equal(paginationLinkHeader(query("/api/v1/subnets"), {}), null);
   });
 });

--- a/tests/network-routing.test.mjs
+++ b/tests/network-routing.test.mjs
@@ -159,6 +159,23 @@ describe("multi-network routing prefix (Phase 1)", () => {
     assert.equal(detail.body.data.subnet.netuid, 11);
   });
 
+  test("pagination Link header keeps the /testnet/ prefix (#1686)", async () => {
+    const env = createLocalArtifactEnv();
+    // The /{network}/ segment is stripped before dispatch, so the Link header
+    // must re-insert it — otherwise a client walking testnet via the next link
+    // would silently cross over to the mainnet collection.
+    const { res } = await get(
+      env,
+      "/api/v1/testnet/subnets?sort=netuid&limit=1&cursor=0",
+    );
+    assert.equal(res.status, 200);
+    const link = res.headers.get("link");
+    assert.ok(link, "a paginated testnet response must carry a Link header");
+    const next = link.match(/<([^>]+)>;\s*rel="next"/);
+    assert.ok(next, "the Link header must advertise rel=next");
+    assert.equal(new URL(next[1]).pathname, "/api/v1/testnet/subnets");
+  });
+
   test("testnet subnet details do not receive mainnet live economics", async () => {
     const economicsBlob = {
       schema_version: 1,

--- a/tests/responses-envelope.test.mjs
+++ b/tests/responses-envelope.test.mjs
@@ -1,12 +1,52 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { dataResponse, envelopeResponse } from "../workers/responses.mjs";
-import { errorResponse, ifNoneMatchSatisfied } from "../workers/http.mjs";
+import {
+  errorResponse,
+  ifNoneMatchSatisfied,
+  linkHeader,
+} from "../workers/http.mjs";
 
 const reqWith = (ifNoneMatch) =>
   new Request("https://metagraph.sh/api/v1/anything", {
     headers: ifNoneMatch == null ? {} : { "if-none-match": ifNoneMatch },
   });
+
+test("linkHeader joins entries into an RFC 8288 header value", () => {
+  assert.equal(
+    linkHeader([
+      { uri: "https://x/a", rel: "next" },
+      { uri: "https://x/b", rel: "prev" },
+    ]),
+    '<https://x/a>; rel="next", <https://x/b>; rel="prev"',
+  );
+  assert.equal(linkHeader([]), "");
+});
+
+test("envelopeResponse applies extra headers and skips null values", async () => {
+  const payload = { data: { ok: 1 }, meta: { contract_version: "test" } };
+  const res = await envelopeResponse(reqWith(null), payload, "standard", {
+    link: '<https://x/next>; rel="next"',
+    "x-skip-me": null,
+  });
+  assert.equal(res.headers.get("link"), '<https://x/next>; rel="next"');
+  assert.equal(res.headers.has("x-skip-me"), false);
+});
+
+test("envelopeResponse keeps extra headers on a 304 short-circuit", async () => {
+  const payload = { data: { ok: 1 }, meta: { contract_version: "test" } };
+  const first = await envelopeResponse(reqWith(null), payload, "standard", {
+    link: '<https://x/next>; rel="next"',
+  });
+  const res = await envelopeResponse(
+    reqWith(first.headers.get("etag")),
+    payload,
+    "standard",
+    { link: '<https://x/next>; rel="next"' },
+  );
+  assert.equal(res.status, 304);
+  assert.equal(res.headers.get("link"), '<https://x/next>; rel="next"');
+});
 
 // Regression guard: the two success builders (dataResponse + envelopeResponse)
 // must emit the identical SuccessEnvelope shape. dataResponse previously added an

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -5,7 +5,7 @@ import {
   artifactPathFromTemplate,
   compileRoutePattern,
 } from "../src/contracts.mjs";
-import { applyQueryFilters } from "./list-query.mjs";
+import { applyQueryFilters, paginationLinkHeader } from "./list-query.mjs";
 import {
   apiHeaders,
   errorResponse,
@@ -1667,6 +1667,21 @@ function artifactPathForNetwork(artifactPath, network = DEFAULT_NETWORK) {
   );
 }
 
+// Re-inserts the /{network}/ segment that resolveNetworkPrefix strips before
+// dispatch, so a self-referential link (e.g. the pagination Link header) stays
+// on the network the client asked for. Mainnet (prefix "") is a no-op.
+function networkPublicUrl(url, network) {
+  if (!network.prefix) {
+    return url;
+  }
+  const publicUrl = new URL(url);
+  publicUrl.pathname = publicUrl.pathname.replace(
+    /^\/(api\/v1|metagraph)(\/|$)/,
+    `/$1/${network.prefix}$2`,
+  );
+  return publicUrl;
+}
+
 // Friendly per-subnet routes: /api/v1/subnets/<slug>/... resolves to the netuid
 // (e.g. /api/v1/subnets/allways → /api/v1/subnets/7). Worker-only — the slug→
 // netuid map is read from the served subnets.json and cached per isolate; no new
@@ -2078,6 +2093,13 @@ async function handleApiRequest(
       responseData = { ...responseData, ...patch };
     }
   }
+  // Advertise the page chain via an RFC 8288 Link header on paginated list
+  // responses. networkPublicUrl restores the prefix stripped before dispatch;
+  // paginationLinkHeader returns null (no header) for non-list/single-page data.
+  const linkValue = paginationLinkHeader(
+    networkPublicUrl(url, network),
+    transformed.meta.pagination,
+  );
   const response = await envelopeResponse(
     request,
     {
@@ -2097,6 +2119,7 @@ async function handleApiRequest(
       },
     },
     matched.cache,
+    linkValue ? { link: linkValue } : {},
   );
   // Cache only route-declared pure static-artifact 200s. Live-overlay routes
   // are skipped even when their live store is cold and the response falls back

--- a/workers/http.mjs
+++ b/workers/http.mjs
@@ -12,6 +12,7 @@ import { JSON_CONTENT_TYPE } from "./config.mjs";
 // CORS-open response. Keep in sync as new client-facing headers are added.
 const EXPOSED_RESPONSE_HEADERS = [
   "etag", // conditional-request validator (If-None-Match → 304)
+  "link", // RFC 8288 pagination links (next/prev/first/last) on list routes
   // rate-limit family: detect throttling, honour the back-off
   "retry-after",
   "x-ratelimit-limit",
@@ -54,6 +55,11 @@ export function apiHeaders(cacheProfile) {
   headers.set("x-metagraph-cache-profile", cacheProfile);
   headers.set("vary", "Accept-Encoding");
   return headers;
+}
+
+// Join link entries into an RFC 8288 header value: `<uri>; rel="…", …`.
+export function linkHeader(links) {
+  return links.map(({ uri, rel }) => `<${uri}>; rel="${rel}"`).join(", ");
 }
 
 export function errorResponse(

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -4,6 +4,7 @@
 // the query-collection contract and nothing from api.mjs, so there is no cycle.
 // `applyQueryFilters` is the single public entry; the rest are internal helpers.
 import { API_QUERY_COLLECTIONS } from "../src/contracts.mjs";
+import { linkHeader } from "./http.mjs";
 
 const FIELD_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
@@ -30,6 +31,40 @@ export function applyQueryFilters(
       ).map((name) => [name, config.filters[name]]),
     ),
   });
+}
+
+// RFC 8288 Link header for a cursor-paginated response (window from
+// `paginateRows`): `first`/`prev` when an earlier page exists, `next`/`last`
+// when a later one does. Each link is an absolute URL that keeps the active
+// query and pins the resolved cursor + limit, so a client can walk pages without
+// rebuilding the request. Null when no relation applies (unpaged, single page,
+// or empty) so the caller omits the header.
+export function paginationLinkHeader(url, pagination) {
+  if (!pagination || typeof pagination.limit !== "number") {
+    return null;
+  }
+  const { cursor, limit, next_cursor: nextCursor, total } = pagination;
+  const pageUri = (offset) => {
+    const target = new URL(url.href);
+    target.searchParams.set("cursor", String(offset));
+    target.searchParams.set("limit", String(limit));
+    return target.href;
+  };
+  const links = [];
+  if (cursor > 0) {
+    links.push({ uri: pageUri(0), rel: "first" });
+    links.push({ uri: pageUri(Math.max(0, cursor - limit)), rel: "prev" });
+  }
+  if (typeof nextCursor === "number") {
+    links.push({ uri: pageUri(nextCursor), rel: "next" });
+    // Final-page start: last whole-limit stride below `total`. The "- 1" keeps
+    // an exact multiple on the prior stride, not an empty page past the end.
+    links.push({
+      uri: pageUri(Math.floor((total - 1) / limit) * limit),
+      rel: "last",
+    });
+  }
+  return links.length > 0 ? linkHeader(links) : null;
 }
 
 function filterRows(rows, params, keys, csvFilters = {}, arrayFilters = {}) {

--- a/workers/responses.mjs
+++ b/workers/responses.mjs
@@ -64,7 +64,12 @@ export function dataResponse(env, data, status = 200, extraMeta = {}) {
 
 // Cacheable success envelope with a weak ETag + 304 short-circuit; HEAD returns
 // headers only. cacheProfile selects the cache-control max-age via apiHeaders.
-export async function envelopeResponse(request, payload, cacheProfile) {
+export async function envelopeResponse(
+  request,
+  payload,
+  cacheProfile,
+  extraHeaders = {},
+) {
   const body = JSON.stringify({
     ok: true,
     schema_version: 1,
@@ -85,6 +90,13 @@ export async function envelopeResponse(request, payload, cacheProfile) {
       "x-metagraph-stale-contract",
       payload.meta.stale_contract.built_under,
     );
+  }
+  // Caller-supplied headers (e.g. the pagination Link header), set before the
+  // 304/HEAD short-circuit so every response carries them; null values skip.
+  for (const [key, value] of Object.entries(extraHeaders)) {
+    if (value != null) {
+      headers.set(key, value);
+    }
   }
   if (ifNoneMatchSatisfied(request, etag)) {
     return new Response(null, {


### PR DESCRIPTION
## Summary

Paginated list endpoints advertised the next page only inside the JSON body, as `meta.pagination.next_cursor`. This adds RFC 8288 `Link` headers to every cursor paginated list response, so generic clients, SDK generators, and link following tools can walk a collection straight from the headers without coupling to the envelope shape. The existing `meta.pagination` fields stay in place for backward compatibility, and the header style matches the feeds and API catalog Link headers already used elsewhere in the worker.

## What Changed

- Added `paginationLinkHeader`, which builds absolute `rel="first"`, `prev`, `next`, and `last` page URLs from the request URL and the resolved pagination window. Each link carries over the active query (filters, search, sort, order, projection) and pins the resolved cursor and limit, so any page stays walkable without rebuilding the request. It emits no header on unpaged, single page, and empty responses.
- Added a small `linkHeader` serializer and extended `envelopeResponse` with an optional header argument, so the value is set once and rides 200, 304, and HEAD responses alike.
- Added `networkPublicUrl` to restore the `/{network}/` segment that routing strips before dispatch, so a testnet walk keeps pointing at testnet rather than silently crossing over to mainnet.
- Declared the `Link` response header in the OpenAPI contract on the cursor paginated routes only, then regenerated `public/metagraph/openapi.json` and the generated type definitions from the contract source.
- Added coverage for first, middle, last, empty, and unpaged pages plus the HEAD, 304, and network prefixed cases across the list query, envelope, and routing test suites. Changed lines reach full line and branch coverage.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
