### PR TITLE
feat(chain): composite-id extrinsic detail — /api/v1/extrinsics/{block}-{index}

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -470,7 +470,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch per-extrinsic detail by 0x extrinsic_hash. Computed live from the first-party extrinsics D1 tier (#1345); 200 with extrinsic:null when cold/unknown. */
+        /** Fetch per-extrinsic detail by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id (the guaranteed-present identifier, since the hash is best-effort/nullable). Computed live from the first-party extrinsics D1 tier (#1345/#1848); 200 with extrinsic:null when cold/unknown/malformed. */
         get: operations["extrinsicDetail"];
         put?: never;
         post?: never;
@@ -2308,7 +2308,7 @@ export interface components {
             signer?: string | null;
             success?: boolean | null;
         };
-        /** @description Per-extrinsic detail (by 0x extrinsic_hash) for the block explorer (#1345), from the first-party extrinsics D1 tier. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the hash is unknown or the store is cold (no static file). */
+        /** @description Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file). */
         ExtrinsicDetailArtifact: {
             extrinsic: components["schemas"]["Extrinsic"] | null;
             ref?: string | null;

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4384,7 +4384,7 @@
     {
       "artifact_path": "/metagraph/extrinsics/{hash}.json",
       "cache": "short",
-      "description": "Fetch per-extrinsic detail by 0x extrinsic_hash. Computed live from the first-party extrinsics D1 tier (#1345); 200 with extrinsic:null when cold/unknown.",
+      "description": "Fetch per-extrinsic detail by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id (the guaranteed-present identifier, since the hash is best-effort/nullable). Computed live from the first-party extrinsics D1 tier (#1345/#1848); 200 with extrinsic:null when cold/unknown/malformed.",
       "id": "extrinsic-detail",
       "method": "GET",
       "path": "/api/v1/extrinsics/{hash}",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -579,7 +579,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
-      "description": "Per-extrinsic detail (by 0x extrinsic_hash) for the block explorer (#1345), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics/{hash} (no static file).",
+      "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics/{hash} (no static file).",
       "id": "extrinsic-detail",
       "path": "/metagraph/extrinsics/{hash}.json",
       "schema_ref": "#/components/schemas/ExtrinsicDetailArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3944,7 +3944,7 @@
       },
       "ExtrinsicDetailArtifact": {
         "additionalProperties": true,
-        "description": "Per-extrinsic detail (by 0x extrinsic_hash) for the block explorer (#1345), from the first-party extrinsics D1 tier. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the hash is unknown or the store is cold (no static file).",
+        "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file).",
         "properties": {
           "extrinsic": {
             "oneOf": [
@@ -17595,7 +17595,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch per-extrinsic detail by 0x extrinsic_hash. Computed live from the first-party extrinsics D1 tier (#1345); 200 with extrinsic:null when cold/unknown.",
+        "summary": "Fetch per-extrinsic detail by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id (the guaranteed-present identifier, since the hash is best-effort/nullable). Computed live from the first-party extrinsics D1 tier (#1345/#1848); 200 with extrinsic:null when cold/unknown/malformed.",
         "tags": [
           "extrinsics",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -470,7 +470,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch per-extrinsic detail by 0x extrinsic_hash. Computed live from the first-party extrinsics D1 tier (#1345); 200 with extrinsic:null when cold/unknown. */
+        /** Fetch per-extrinsic detail by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id (the guaranteed-present identifier, since the hash is best-effort/nullable). Computed live from the first-party extrinsics D1 tier (#1345/#1848); 200 with extrinsic:null when cold/unknown/malformed. */
         get: operations["extrinsicDetail"];
         put?: never;
         post?: never;
@@ -2308,7 +2308,7 @@ export interface components {
             signer?: string | null;
             success?: boolean | null;
         };
-        /** @description Per-extrinsic detail (by 0x extrinsic_hash) for the block explorer (#1345), from the first-party extrinsics D1 tier. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the hash is unknown or the store is cold (no static file). */
+        /** @description Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file). */
         ExtrinsicDetailArtifact: {
             extrinsic: components["schemas"]["Extrinsic"] | null;
             ref?: string | null;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3930,7 +3930,7 @@
       },
       "ExtrinsicDetailArtifact": {
         "additionalProperties": true,
-        "description": "Per-extrinsic detail (by 0x extrinsic_hash) for the block explorer (#1345), from the first-party extrinsics D1 tier. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the hash is unknown or the store is cold (no static file).",
+        "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file).",
         "properties": {
           "extrinsic": {
             "oneOf": [

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1746,7 +1746,7 @@
       "ExtrinsicDetailArtifact": {
         "type": "object",
         "additionalProperties": true,
-        "description": "Per-extrinsic detail (by 0x extrinsic_hash) for the block explorer (#1345), from the first-party extrinsics D1 tier. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the hash is unknown or the store is cold (no static file).",
+        "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file).",
         "required": ["schema_version", "extrinsic"],
         "properties": {
           "schema_version": { "type": "integer" },

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -992,7 +992,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "extrinsic-detail",
     "/metagraph/extrinsics/{hash}.json",
-    "Per-extrinsic detail (by 0x extrinsic_hash) for the block explorer (#1345), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics/{hash} (no static file).",
+    "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics/{hash} (no static file).",
     "ExtrinsicDetailArtifact",
   ),
   artifact(
@@ -1783,7 +1783,7 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/extrinsics/{hash}",
     "/metagraph/extrinsics/{hash}.json",
-    "Fetch per-extrinsic detail by 0x extrinsic_hash. Computed live from the first-party extrinsics D1 tier (#1345); 200 with extrinsic:null when cold/unknown.",
+    "Fetch per-extrinsic detail by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id (the guaranteed-present identifier, since the hash is best-effort/nullable). Computed live from the first-party extrinsics D1 tier (#1345/#1848); 200 with extrinsic:null when cold/unknown/malformed.",
     "short",
     ["extrinsics", "analytics"],
     [],

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -291,6 +291,11 @@ function dbWith({ feed, detail } = {}) {
               async all() {
                 if (/WHERE extrinsic_hash = \?/.test(sql))
                   return { results: detail ? [detail] : [] };
+                // Composite-id detail (#1848): WHERE block_number=? AND extrinsic_index=?.
+                if (
+                  /WHERE block_number = \? AND extrinsic_index = \?/.test(sql)
+                )
+                  return { results: detail ? [detail] : [] };
                 if (/LIMIT \? OFFSET \?/.test(sql))
                   return { results: feed || [] };
                 return { results: [] };
@@ -468,6 +473,36 @@ test("GET /extrinsics/{hash} is schema-stable when cold (extrinsic:null, never 4
   assert.equal(res.status, 200);
   const body = await res.json();
   assert.equal(body.data.ref, hash);
+  assert.equal(body.data.extrinsic, null);
+});
+
+test("GET /extrinsics/{block}-{index} resolves by the composite id (#1848)", async () => {
+  const env = dbWith({
+    detail: {
+      block_number: 1234,
+      extrinsic_index: 3,
+      extrinsic_hash: null,
+      call_module: "Timestamp",
+      call_function: "set",
+      success: 1,
+      observed_at: 1750009000000,
+    },
+  });
+  const res = await handleRequest(req("/api/v1/extrinsics/1234-3"), env, {});
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.ref, "1234-3");
+  assert.equal(body.data.extrinsic.block_number, 1234);
+  assert.equal(body.data.extrinsic.extrinsic_index, 3);
+  // A null-hash extrinsic — previously unaddressable — is now reachable.
+  assert.equal(body.data.extrinsic.extrinsic_hash, null);
+});
+
+test("GET /extrinsics/{block}-{index} is schema-stable when cold (#1848)", async () => {
+  const res = await handleRequest(req("/api/v1/extrinsics/777-0"), {}, {});
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.ref, "777-0");
   assert.equal(body.data.extrinsic, null);
 });
 

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -83,8 +83,11 @@ export const BLOCK_EXTRINSICS_PATH_PATTERN =
 // detail, computed live from the `extrinsics` D1 tier. {hash} is a 0x extrinsic_hash
 // (32-byte blake2b = 64 hex chars).
 export const EXTRINSICS_FEED_PATH_PATTERN = /^\/api\/v1\/extrinsics$/;
+// Per-extrinsic detail (#1345/#1848): ref is a 0x extrinsic_hash OR the canonical
+// composite id "<block_number>-<extrinsic_index>" (the guaranteed-present id, since
+// the hash is best-effort/nullable). Single capture group; the handler branches.
 export const EXTRINSIC_DETAIL_PATH_PATTERN =
-  /^\/api\/v1\/extrinsics\/(0x[0-9a-fA-F]{64})$/;
+  /^\/api\/v1\/extrinsics\/(0x[0-9a-fA-F]{64}|\d+-\d+)$/;
 export const UPTIME_WINDOWS = { "90d": 90, "1y": 365 };
 export const MAX_UPTIME_ROWS = 10000;
 export const MAX_BULK_TREND_ROWS = 10000;

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -659,24 +659,45 @@ export async function handleExtrinsics(request, env, url) {
   );
 }
 
-// GET /api/v1/extrinsics/{hash}: per-extrinsic detail (#1345). hash is a 0x
-// extrinsic_hash. Served live from the `extrinsics` D1 tier; an unknown hash /
-// cold store → 200 with extrinsic:null (schema-stable, mirrors the block detail
-// route — NEVER 404/throw).
-export async function handleExtrinsic(request, env, hash) {
-  const rows = await d1All(
-    env,
-    `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE extrinsic_hash = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT 1`,
-    [hash],
-  );
-  const data = buildExtrinsic(rows[0], hash);
+// GET /api/v1/extrinsics/{ref}: per-extrinsic detail (#1345/#1848). ref is EITHER
+// a 0x extrinsic_hash OR the canonical composite id "<block_number>-<extrinsic_index>".
+// The hash is best-effort/nullable in the decoder, so the composite id is the
+// guaranteed-present identifier; the composite path does a direct (block_number,
+// extrinsic_index) PK hit. Served live from the `extrinsics` D1 tier; an unknown
+// ref / cold store / malformed composite → 200 with extrinsic:null (schema-stable,
+// mirrors handleBlock's numeric-OR-hash branch — NEVER 404/throw).
+export async function handleExtrinsic(request, env, ref) {
+  const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
+  let rows;
+  if (isHash) {
+    rows = await d1All(
+      env,
+      `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE extrinsic_hash = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT 1`,
+      [ref],
+    );
+  } else {
+    // Composite "<block>-<index>": coerce both halves; a non-finite half is a
+    // miss (extrinsic:null), never a bad bind.
+    const [b, i] = ref.split("-");
+    const blockNumber = Number(b);
+    const extrinsicIndex = Number(i);
+    rows =
+      Number.isInteger(blockNumber) && Number.isInteger(extrinsicIndex)
+        ? await d1All(
+            env,
+            `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE block_number = ? AND extrinsic_index = ? LIMIT 1`,
+            [blockNumber, extrinsicIndex],
+          )
+        : [];
+  }
+  const data = buildExtrinsic(rows[0], ref);
   return envelopeResponse(
     request,
     {
       data,
       meta: await accountMeta(
         env,
-        `/metagraph/extrinsics/${hash}.json`,
+        `/metagraph/extrinsics/${ref}.json`,
         data.extrinsic?.observed_at ?? null,
       ),
     },


### PR DESCRIPTION
Closes #1848

## What

Extrinsic detail resolved **only** by `0x extrinsic_hash`. But the hash is best-effort/nullable in the decoder, while the PRIMARY KEY is `(block_number, extrinsic_index)` — so a null-hash extrinsic appeared in the feed but had **no addressable detail URL**.

Broadens the detail route to accept **either** a `0x` hash **or** the canonical composite id `<block_number>-<extrinsic_index>` — the guaranteed-present identifier across every Substrate explorer.

## Design

- Single capture group `(0x[0-9a-fA-F]{64}|\d+-\d+)`; the handler branches like `handleBlock`'s numeric-OR-hash `{ref}`: `0x` → `WHERE extrinsic_hash=?`; `N-M` → a direct `(block_number, extrinsic_index)` PK hit (`LIMIT 1`, no ORDER BY).
- Non-finite composite halves are a miss (`extrinsic:null`), never a bad bind. Never-404 preserved.
- The OpenAPI path token stays `{hash}` so the publish smoke's `0x` substitution keeps matching; the param now accepts both forms per the updated description. No new index (direct PK lookup); no migration.

## Verification

- contract-drift / client-sdk-sync / api (77) / openapi / public-safety → pass
- vitest extrinsics / contracts / invariants-contracts → 47 passed (hash, composite resolving a null-hash extrinsic, composite cold→null)
- eslint + prettier clean

Part of #1345 (explorer robustness wave).