### PR TITLE
feat(chain): link account_events to their extrinsic + embed events in extrinsic detail

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1339,13 +1339,14 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time. */
+        /** @description One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows). */
         AccountEvent: {
             amount_tao?: number | null;
             block_number: number | null;
             coldkey?: string | null;
             event_index?: number | null;
             event_kind: string | null;
+            extrinsic_index?: number | null;
             hotkey?: string | null;
             netuid?: number | null;
             /** Format: date-time */
@@ -2308,8 +2309,9 @@ export interface components {
             signer?: string | null;
             success?: boolean | null;
         };
-        /** @description Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file). */
+        /** @description Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. events (#1849) are the indexed account_events this extrinsic emitted (bounded to 50; empty for pre-migration rows, non-ApplyExtrinsic events, or a cold store). Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file). */
         ExtrinsicDetailArtifact: {
+            events?: components["schemas"]["AccountEvent"][];
             extrinsic: components["schemas"]["Extrinsic"] | null;
             ref?: string | null;
             schema_version: number;
@@ -7968,6 +7970,12 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "events": [
+                     *           {
+                     *             "block_number": 5000000,
+                     *             "event_kind": "example"
+                     *           }
+                     *         ],
                      *         "extrinsic": {
                      *           "block_number": 5000000,
                      *           "call_args": {},

--- a/migrations/0018_account_events_extrinsic_index.sql
+++ b/migrations/0018_account_events_extrinsic_index.sql
@@ -1,0 +1,16 @@
+-- Block explorer chain hierarchy (#1849): link each account_events row back to the
+-- extrinsic that emitted it, so extrinsic detail can embed its events and "which
+-- extrinsic caused this StakeAdded" becomes answerable.
+--
+-- extrinsic_index is the 0-based index of the emitting extrinsic within the block,
+-- read from the event's phase=ApplyExtrinsic by the chain poller (the same
+-- extrinsic_idx already used to correlate fee/success). Nullable: Initialization /
+-- Finalization phase events store null, and all pre-migration rows are null
+-- (the link only populates going forward).
+--
+-- Applied as an idempotent ALTER (nullable column never breaks existing rows or the
+-- INSERT OR IGNORE load path). The reverse-lookup index serves the extrinsic-detail
+-- embed (SELECT ... WHERE block_number = ? AND extrinsic_index = ?).
+
+ALTER TABLE account_events ADD COLUMN extrinsic_index INTEGER;
+CREATE INDEX IF NOT EXISTS idx_account_events_extrinsic ON account_events (block_number, extrinsic_index);

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -107,7 +107,7 @@
       },
       "AccountEvent": {
         "additionalProperties": false,
-        "description": "One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time.",
+        "description": "One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows).",
         "properties": {
           "amount_tao": {
             "type": [
@@ -136,6 +136,12 @@
           "event_kind": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "extrinsic_index": {
+            "type": [
+              "integer",
               "null"
             ]
           },
@@ -3944,8 +3950,14 @@
       },
       "ExtrinsicDetailArtifact": {
         "additionalProperties": true,
-        "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file).",
+        "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. events (#1849) are the indexed account_events this extrinsic emitted (bounded to 50; empty for pre-migration rows, non-ApplyExtrinsic events, or a cold store). Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file).",
         "properties": {
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/AccountEvent"
+            },
+            "type": "array"
+          },
           "extrinsic": {
             "oneOf": [
               {
@@ -17481,6 +17493,12 @@
               "application/json": {
                 "example": {
                   "data": {
+                    "events": [
+                      {
+                        "block_number": 5000000,
+                        "event_kind": "example"
+                      }
+                    ],
                     "extrinsic": {
                       "block_number": 5000000,
                       "call_args": {},

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1339,13 +1339,14 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time. */
+        /** @description One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows). */
         AccountEvent: {
             amount_tao?: number | null;
             block_number: number | null;
             coldkey?: string | null;
             event_index?: number | null;
             event_kind: string | null;
+            extrinsic_index?: number | null;
             hotkey?: string | null;
             netuid?: number | null;
             /** Format: date-time */
@@ -2308,8 +2309,9 @@ export interface components {
             signer?: string | null;
             success?: boolean | null;
         };
-        /** @description Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file). */
+        /** @description Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. events (#1849) are the indexed account_events this extrinsic emitted (bounded to 50; empty for pre-migration rows, non-ApplyExtrinsic events, or a cold store). Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file). */
         ExtrinsicDetailArtifact: {
+            events?: components["schemas"]["AccountEvent"][];
             extrinsic: components["schemas"]["Extrinsic"] | null;
             ref?: string | null;
             schema_version: number;
@@ -7968,6 +7970,12 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "events": [
+                     *           {
+                     *             "block_number": 5000000,
+                     *             "event_kind": "example"
+                     *           }
+                     *         ],
                      *         "extrinsic": {
                      *           "block_number": 5000000,
                      *           "call_args": {},

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -93,7 +93,7 @@
       },
       "AccountEvent": {
         "additionalProperties": false,
-        "description": "One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time.",
+        "description": "One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows).",
         "properties": {
           "amount_tao": {
             "type": [
@@ -122,6 +122,12 @@
           "event_kind": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "extrinsic_index": {
+            "type": [
+              "integer",
               "null"
             ]
           },
@@ -3930,8 +3936,14 @@
       },
       "ExtrinsicDetailArtifact": {
         "additionalProperties": true,
-        "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file).",
+        "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. events (#1849) are the indexed account_events this extrinsic emitted (bounded to 50; empty for pre-migration rows, non-ApplyExtrinsic events, or a cold store). Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file).",
         "properties": {
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/AccountEvent"
+            },
+            "type": "array"
+          },
           "extrinsic": {
             "oneOf": [
               {

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1489,7 +1489,7 @@
       "AccountEvent": {
         "type": "object",
         "additionalProperties": false,
-        "description": "One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time.",
+        "description": "One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows).",
         "required": ["block_number", "event_kind"],
         "properties": {
           "block_number": { "type": ["integer", "null"] },
@@ -1500,7 +1500,8 @@
           "netuid": { "type": ["integer", "null"] },
           "uid": { "type": ["integer", "null"] },
           "amount_tao": { "type": ["number", "null"] },
-          "observed_at": { "type": ["string", "null"], "format": "date-time" }
+          "observed_at": { "type": ["string", "null"], "format": "date-time" },
+          "extrinsic_index": { "type": ["integer", "null"] }
         }
       },
       "AccountRegistration": {
@@ -1746,7 +1747,7 @@
       "ExtrinsicDetailArtifact": {
         "type": "object",
         "additionalProperties": true,
-        "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file).",
+        "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. events (#1849) are the indexed account_events this extrinsic emitted (bounded to 50; empty for pre-migration rows, non-ApplyExtrinsic events, or a cold store). Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file).",
         "required": ["schema_version", "extrinsic"],
         "properties": {
           "schema_version": { "type": "integer" },
@@ -1756,6 +1757,10 @@
               { "$ref": "#/components/schemas/Extrinsic" },
               { "type": "null" }
             ]
+          },
+          "events": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AccountEvent" }
           }
         }
       },

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -653,6 +653,13 @@ def main():
             ent = extract(eid, e.get("attributes"))
             if ent is None:
                 continue
+            # Link the event to the extrinsic that emitted it (#1849): the
+            # ApplyExtrinsic-phase extrinsic_idx (the same field _fee_map /
+            # _extrinsic_success_map correlate on). Initialization / Finalization
+            # phase events have no extrinsic — store null.
+            xidx = v.get("extrinsic_idx") if v.get("phase") == "ApplyExtrinsic" else None
+            if not isinstance(xidx, int) or xidx < 0:
+                xidx = None
             rows.append(
                 {
                     "block_number": bn,
@@ -664,6 +671,7 @@ def main():
                     "uid": ent["uid"],
                     "amount_tao": ent["amount_tao"],
                     "observed_at": observed_at,
+                    "extrinsic_index": xidx,
                 }
             )
 

--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -115,6 +115,12 @@ def decode_head(s, block_number):
         ent = extract(e.get("event_id"), e.get("attributes"))
         if ent is None:
             continue
+        # Link the event to its emitting extrinsic (#1849), kept 1:1 with the CI
+        # poller's fetch-events.py emit: the ApplyExtrinsic-phase extrinsic_idx,
+        # null for Initialization/Finalization events.
+        xidx = v.get("extrinsic_idx") if v.get("phase") == "ApplyExtrinsic" else None
+        if not isinstance(xidx, int) or xidx < 0:
+            xidx = None
         event_rows.append(
             {
                 "block_number": block_number,
@@ -126,6 +132,7 @@ def decode_head(s, block_number):
                 "uid": ent["uid"],
                 "amount_tao": ent["amount_tao"],
                 "observed_at": head_ts if head_ts else None,
+                "extrinsic_index": xidx,
             }
         )
     # Block-explorer block + extrinsic rows (#1345 Option B). The _fe helpers are

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -21,6 +21,10 @@ export const EVENT_INSERT_COLUMNS = [
   "uid",
   "amount_tao",
   "observed_at",
+  // The 0-based index of the extrinsic that emitted this event (#1849), read from
+  // the event's phase=ApplyExtrinsic; null for Initialization/Finalization events.
+  // 10 cols x ROWS_PER_STMT(10) = 100 bound params — exactly D1's ceiling.
+  "extrinsic_index",
 ];
 
 // The SubtensorModule events the poller indexes — entity-relevant only, which
@@ -53,6 +57,7 @@ export function formatAccountEvent(row) {
     uid: row.uid ?? null,
     amount_tao: row.amount_tao ?? null,
     observed_at: toIso(row.observed_at),
+    extrinsic_index: row.extrinsic_index ?? null,
   };
 }
 
@@ -175,7 +180,7 @@ export function eventInsertStatements(db, rows) {
 // ---- Entity API builders (#1347) -------------------------------------------
 // The columns the account handlers SELECT for an event row.
 export const ACCOUNT_EVENT_COLUMNS =
-  "block_number, event_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, observed_at";
+  "block_number, event_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, observed_at, extrinsic_index";
 
 // One neurons-table row (subset) → an AccountRegistration: where this hotkey is
 // currently registered + staked (the live cross-subnet footprint).

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -125,12 +125,15 @@ export function formatExtrinsic(row) {
 
 // Per-extrinsic detail artifact. `extrinsic` is null when the ref didn't resolve
 // (cold store or unknown extrinsic) — schema-stable, never throws (mirrors the
-// block detail route's `block:null`).
-export function buildExtrinsic(row, ref) {
+// block detail route's `block:null`). `events` are the indexed account_events this
+// extrinsic emitted (#1849), already formatted + bounded by the handler; defaults
+// to [] (empty for pre-migration rows, non-ApplyExtrinsic events, or a cold store).
+export function buildExtrinsic(row, ref, events = []) {
   return {
     schema_version: 1,
     ref: ref ?? null,
     extrinsic: formatExtrinsic(row),
+    events: events || [],
   };
 }
 

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -58,7 +58,7 @@ test("eventInsertStatements builds chunked parameterized INSERT OR IGNORE", () =
   assert.ok(prepared[0].includes("VALUES (?"));
 });
 
-test("EVENT_INSERT_COLUMNS is the stable load contract (#1346)", () => {
+test("EVENT_INSERT_COLUMNS is the stable load contract (#1346/#1849)", () => {
   assert.deepEqual(EVENT_INSERT_COLUMNS, [
     "block_number",
     "event_index",
@@ -69,7 +69,10 @@ test("EVENT_INSERT_COLUMNS is the stable load contract (#1346)", () => {
     "uid",
     "amount_tao",
     "observed_at",
+    "extrinsic_index",
   ]);
+  // 10 cols x ROWS_PER_STMT(10) = 100 bound params — exactly D1's ceiling.
+  assert.equal(EVENT_INSERT_COLUMNS.length, 10);
 });
 
 test("INDEXED_EVENT_KINDS covers the core entity events", () => {
@@ -95,10 +98,12 @@ test("formatAccountEvent maps a D1 row to an API event (ISO time)", () => {
     uid: null,
     amount_tao: 12.5,
     observed_at: 1750000000000,
+    extrinsic_index: 2,
   });
   assert.equal(out.event_kind, "StakeAdded");
   assert.equal(out.amount_tao, 12.5);
   assert.equal(out.observed_at, new Date(1750000000000).toISOString());
+  assert.equal(out.extrinsic_index, 2);
 });
 
 test("formatAccountEvent is null-safe on junk + sparse rows", () => {

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -281,7 +281,7 @@ function req(path) {
 }
 
 // A D1 mock that routes by SQL shape so the extrinsic handlers get realistic rows.
-function dbWith({ feed, detail } = {}) {
+function dbWith({ feed, detail, events } = {}) {
   return {
     METAGRAPH_HEALTH_DB: {
       prepare(sql) {
@@ -289,6 +289,10 @@ function dbWith({ feed, detail } = {}) {
           bind() {
             return {
               async all() {
+                // Emitted-events embed (#1849): FROM account_events — check the
+                // table BEFORE the generic composite WHERE (both share that shape).
+                if (/FROM account_events/.test(sql))
+                  return { results: events || [] };
                 if (/WHERE extrinsic_hash = \?/.test(sql))
                   return { results: detail ? [detail] : [] };
                 // Composite-id detail (#1848): WHERE block_number=? AND extrinsic_index=?.
@@ -504,6 +508,44 @@ test("GET /extrinsics/{block}-{index} is schema-stable when cold (#1848)", async
   const body = await res.json();
   assert.equal(body.data.ref, "777-0");
   assert.equal(body.data.extrinsic, null);
+  // The events embed (#1849) is always present + empty when the ref is cold.
+  assert.deepEqual(body.data.events, []);
+});
+
+test("GET /extrinsics/{ref} embeds the events the extrinsic emitted (#1849)", async () => {
+  const hash = `0x${"e".repeat(64)}`;
+  const env = dbWith({
+    detail: {
+      block_number: 1234,
+      extrinsic_index: 2,
+      extrinsic_hash: hash,
+      call_module: "SubtensorModule",
+      call_function: "add_stake",
+      success: 1,
+      observed_at: 1750009000000,
+    },
+    events: [
+      {
+        block_number: 1234,
+        event_index: 5,
+        event_kind: "StakeAdded",
+        hotkey: "5Hk",
+        coldkey: "5Co",
+        netuid: 7,
+        uid: 3,
+        amount_tao: 1.5,
+        observed_at: 1750009000000,
+        extrinsic_index: 2,
+      },
+    ],
+  });
+  const res = await handleRequest(req(`/api/v1/extrinsics/${hash}`), env, {});
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.extrinsic.extrinsic_index, 2);
+  assert.equal(body.data.events.length, 1);
+  assert.equal(body.data.events[0].event_kind, "StakeAdded");
+  assert.equal(body.data.events[0].extrinsic_index, 2);
 });
 
 test("GET /extrinsics is schema-stable when D1 is cold (never 404)", async () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -47,6 +47,7 @@ import {
   buildAccountEvents,
   buildAccountSubnets,
   buildAccountSummary,
+  formatAccountEvent,
 } from "../../src/account-events.mjs";
 import {
   BLOCK_READ_COLUMNS,
@@ -666,6 +667,10 @@ export async function handleExtrinsics(request, env, url) {
 // extrinsic_index) PK hit. Served live from the `extrinsics` D1 tier; an unknown
 // ref / cold store / malformed composite → 200 with extrinsic:null (schema-stable,
 // mirrors handleBlock's numeric-OR-hash branch — NEVER 404/throw).
+//
+// When the extrinsic resolves, the indexed account_events it emitted (#1849) are
+// embedded via a second lookup on (block_number, extrinsic_index) — bounded to 50.
+// Empty for pre-migration rows, non-ApplyExtrinsic events, or a cold store.
 export async function handleExtrinsic(request, env, ref) {
   const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
   let rows;
@@ -690,7 +695,24 @@ export async function handleExtrinsic(request, env, ref) {
           )
         : [];
   }
-  const data = buildExtrinsic(rows[0], ref);
+  // Embed the emitted events once we have the resolved (block_number,
+  // extrinsic_index). A second sequential read; d1All swallows a missing-column
+  // error pre-migration → [] (the embed is additive, never breaks the detail).
+  let events = [];
+  const resolved = rows[0];
+  if (
+    resolved &&
+    resolved.block_number != null &&
+    resolved.extrinsic_index != null
+  ) {
+    const eventRows = await d1All(
+      env,
+      `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE block_number = ? AND extrinsic_index = ? ORDER BY event_index ASC LIMIT 50`,
+      [resolved.block_number, resolved.extrinsic_index],
+    );
+    events = eventRows.map(formatAccountEvent).filter(Boolean);
+  }
+  const data = buildExtrinsic(resolved, ref, events);
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
Closes #1849

## What

`account_events` rows carried `block_number` + `event_index` only — no link to the extrinsic that emitted them, even though the poller already reads each event's `ApplyExtrinsic`-phase `extrinsic_idx` to correlate fee/success. So "which events did this extrinsic emit" / "which extrinsic caused this `StakeAdded`" was decodable on-chain but **unjoinable in D1**.

Adds the `block → extrinsic → event` link and embeds the emitted events in extrinsic detail.

## Changes

- **Migration 0018** — `account_events.extrinsic_index` (nullable) + `idx_account_events_extrinsic (block_number, extrinsic_index)`. **Already applied to prod** (additive/nullable; verified column + index live) before this lands, since the new `SELECT`/`INSERT` reference the column.
- **Poller emit** — `fetch-events.py` + `stream-events.py` (kept 1:1): the `ApplyExtrinsic` `extrinsic_idx`; `null` for Initialization/Finalization.
- **Load contract** — `EVENT_INSERT_COLUMNS` 9→10 (`ROWS_PER_STMT=10` ⇒ 100 params, exactly D1's ceiling, precedented by `extrinsics`); `ACCOUNT_EVENT_COLUMNS` + `formatAccountEvent` surface `extrinsic_index`.
- **Embed** — extrinsic detail runs a second lookup on the resolved `(block_number, extrinsic_index)` and embeds `events[]` (the indexed `account_events`), bounded to 50. Empty for pre-migration rows, non-ApplyExtrinsic events, or a cold store. `d1All` swallows a missing-column error, so the embed is additive and never breaks the detail.
- **Schema** — `AccountEvent` gains `extrinsic_index`; `ExtrinsicDetailArtifact` gains `events[]`.

## Verification

- contract-drift / client-sdk-sync / api (77) / openapi / public-safety / migrations (18, sequential) → pass
- vitest account-events / account-routes / extrinsics / contracts / invariants-contracts → 79 passed (load contract 10-col, `formatAccountEvent` `extrinsic_index`, embed populated + cold-empty)
- `py_compile` on both pollers; eslint + prettier clean
- prod `PRAGMA table_info` confirms column + index

## Note on history depth

Backfill is null-only for pre-migration rows; the embed populates going forward. `account_events_daily` rollups carry no `extrinsic_index` (deep history can't gain the link). Documented in the migration + schema.

Part of #1345 (explorer robustness wave).