### PR TITLE
feat(chain): account transfers tab — /api/v1/accounts/{ss58}/transfers + streamer Balances coverage

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -89,6 +89,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/accounts/{ss58}.json`: schema for a cross-subnet account summary (chain-event aggregates joined to current registrations), served live from the `account_events` + `neurons` D1 tiers at `GET /api/v1/accounts/{ss58}` (no static file).
 - `/metagraph/accounts/{ss58}/events.json`: schema for an account's paginated chain-event history, served live from the `account_events` D1 tier at `GET /api/v1/accounts/{ss58}/events` (no static file).
 - `/metagraph/accounts/{ss58}/extrinsics.json`: schema for the extrinsics an account signed (by signer), served live from the `extrinsics` D1 tier at `GET /api/v1/accounts/{ss58}/extrinsics` (no static file).
+- `/metagraph/accounts/{ss58}/transfers.json`: schema for the native-TAO Balances.Transfer feed for an account (directional), served live from the `account_events` D1 tier at `GET /api/v1/accounts/{ss58}/transfers` (no static file).
 - `/metagraph/accounts/{ss58}/subnets.json`: schema for the subnets where an account's hotkey is currently registered, served live from the `neurons` D1 tier at `GET /api/v1/accounts/{ss58}/subnets` (no static file).
 - `/metagraph/accounts/{ss58}/balance.json`: schema for an account's live TAO balance (free + reserved), queried from the finney RPC at request time with a 60s KV cache, served at `GET /api/v1/accounts/{ss58}/balance` (no static file).
 - `/metagraph/blocks.json`: schema for the recent-block feed (newest first) of the block explorer, served live from the first-party `blocks` D1 tier at `GET /api/v1/blocks` (no static file).
@@ -144,6 +145,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/api/v1/accounts/{ss58}`: fetch a cross-subnet account summary (chain-event aggregates joined to current registrations + stake) for a hotkey or coldkey (live from the `account_events` + `neurons` D1 tiers).
 - `/api/v1/accounts/{ss58}/events`: fetch an account's paginated chain-event history, newest first; `?kind=` filter, `?limit` (<=1000) / `?offset` (live from the `account_events` D1 tier).
 - `/api/v1/accounts/{ss58}/extrinsics`: fetch the extrinsics an account signed (matched by signer), newest first; `?limit` (<=1000) / `?offset` (live from the `extrinsics` D1 tier).
+- `/api/v1/accounts/{ss58}/transfers`: fetch the native-TAO Balances.Transfer feed for an account, newest first; `?direction=all|sent|received`, `?limit` (<=1000) / `?offset` (live from the `account_events` D1 tier).
 - `/api/v1/accounts/{ss58}/subnets`: fetch the subnets where an account's hotkey is currently registered (live from the `neurons` D1 tier).
 - `/api/v1/accounts/{ss58}/balance`: fetch an account's live TAO balance (free + reserved, in TAO), queried from the finney RPC at request time with a 60s KV cache; `balance_tao` is null on RPC failure.
 - `/api/v1/blocks`: fetch the recent-block feed (newest first) for the block explorer; `?limit` (<=100) / `?offset` (live from the first-party `blocks` D1 tier).

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -106,6 +106,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/accounts/{ss58}/transfers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; ?limit (<=1000) / ?offset. */
+        get: operations["accountTransfers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/adapters/{slug}": {
         parameters: {
             query?: never;
@@ -1430,6 +1447,27 @@ export interface components {
             schema_version: number;
             ss58: string;
             subnet_count?: number;
+        } & {
+            [key: string]: unknown;
+        };
+        /** @description The native-TAO Balances.Transfer feed for one account (#1850), newest first, from the account_events D1 tier (event_kind='Transfer'). Each row is a directional {from, to, amount_tao, direction} transfer; direction is 'sent' or 'received' relative to the queried ss58. This is the native-TAO transfer feed only, NOT a full balance ledger. Served live at /api/v1/accounts/{ss58}/transfers (no static file). */
+        AccountTransfersArtifact: {
+            limit?: number;
+            offset?: number;
+            schema_version: number;
+            ss58: string;
+            transfer_count: number;
+            transfers: {
+                amount_tao?: number | null;
+                block_number: number | null;
+                /** @enum {string|null} */
+                direction?: "sent" | "received" | null;
+                event_index?: number | null;
+                from: string | null;
+                /** Format: date-time */
+                observed_at?: string | null;
+                to: string | null;
+            }[];
         } & {
             [key: string]: unknown;
         };
@@ -5133,6 +5171,122 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountSubnetsArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    accountTransfers: {
+        parameters: {
+            query?: {
+                direction?: "all" | "sent" | "received";
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path: {
+                ss58: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "limit": 1,
+                     *         "offset": 1,
+                     *         "schema_version": 1,
+                     *         "ss58": "example",
+                     *         "transfer_count": 1,
+                     *         "transfers": [
+                     *           {
+                     *             "block_number": 5000000,
+                     *             "from": "example",
+                     *             "to": "example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["AccountTransfersArtifact"];
                     };
                 };
             };

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.6.10",
+      "version": "0.6.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -415,6 +415,13 @@
     },
     {
       "contract_version": "2026-06-06.1",
+      "id": "account-transfers",
+      "path": "/metagraph/accounts/{ss58}/transfers.json",
+      "schema_ref": "#/components/schemas/AccountTransfersArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "contract_version": "2026-06-06.1",
       "id": "account-subnets",
       "path": "/metagraph/accounts/{ss58}/subnets.json",
       "schema_ref": "#/components/schemas/AccountSubnetsArtifact",
@@ -4222,6 +4229,45 @@
       "query_collection": null,
       "query_filter_names": [],
       "query_parameters": [
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "offset",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    {
+      "artifact_path": "/metagraph/accounts/{ss58}/transfers.json",
+      "cache": "short",
+      "description": "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; ?limit (<=1000) / ?offset.",
+      "id": "account-transfers",
+      "method": "GET",
+      "path": "/api/v1/accounts/{ss58}/transfers",
+      "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
+      "query_parameters": [
+        {
+          "name": "direction",
+          "schema": {
+            "enum": [
+              "all",
+              "sent",
+              "received"
+            ],
+            "type": "string"
+          }
+        },
         {
           "name": "limit",
           "schema": {

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -534,6 +534,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
+      "description": "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers (no static file).",
+      "id": "account-transfers",
+      "path": "/metagraph/accounts/{ss58}/transfers.json",
+      "schema_ref": "#/components/schemas/AccountTransfersArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-06-06.1",
       "description": "The subnets where an account's hotkey is currently registered, served live from the neurons D1 tier at /api/v1/accounts/{ss58}/subnets (no static file).",
       "id": "account-subnets",
       "path": "/metagraph/accounts/{ss58}/subnets.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -400,6 +400,97 @@
         ],
         "type": "object"
       },
+      "AccountTransfersArtifact": {
+        "additionalProperties": true,
+        "description": "The native-TAO Balances.Transfer feed for one account (#1850), newest first, from the account_events D1 tier (event_kind='Transfer'). Each row is a directional {from, to, amount_tao, direction} transfer; direction is 'sent' or 'received' relative to the queried ss58. This is the native-TAO transfer feed only, NOT a full balance ledger. Served live at /api/v1/accounts/{ss58}/transfers (no static file).",
+        "properties": {
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "ss58": {
+            "type": "string"
+          },
+          "transfer_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "transfers": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "amount_tao": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "block_number": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "direction": {
+                  "enum": [
+                    "sent",
+                    "received",
+                    null
+                  ],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "event_index": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "from": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "observed_at": {
+                  "format": "date-time",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "to": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "block_number",
+                "from",
+                "to"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "ss58",
+          "transfer_count",
+          "transfers"
+        ],
+        "type": "object"
+      },
       "AdapterArtifact": {
         "allOf": [
           {
@@ -13398,6 +13489,176 @@
         "tags": [
           "accounts",
           "subnets"
+        ]
+      }
+    },
+    "/api/v1/accounts/{ss58}/transfers": {
+      "get": {
+        "operationId": "accountTransfers",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ss58",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "enum": [
+                "all",
+                "sent",
+                "received"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "limit": 1,
+                    "offset": 1,
+                    "schema_version": 1,
+                    "ss58": "example",
+                    "transfer_count": 1,
+                    "transfers": [
+                      {
+                        "block_number": 5000000,
+                        "from": "example",
+                        "to": "example"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AccountTransfersArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; ?limit (<=1000) / ?offset.",
+        "tags": [
+          "accounts",
+          "analytics"
         ]
       }
     },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -106,6 +106,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/accounts/{ss58}/transfers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; ?limit (<=1000) / ?offset. */
+        get: operations["accountTransfers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/adapters/{slug}": {
         parameters: {
             query?: never;
@@ -1430,6 +1447,27 @@ export interface components {
             schema_version: number;
             ss58: string;
             subnet_count?: number;
+        } & {
+            [key: string]: unknown;
+        };
+        /** @description The native-TAO Balances.Transfer feed for one account (#1850), newest first, from the account_events D1 tier (event_kind='Transfer'). Each row is a directional {from, to, amount_tao, direction} transfer; direction is 'sent' or 'received' relative to the queried ss58. This is the native-TAO transfer feed only, NOT a full balance ledger. Served live at /api/v1/accounts/{ss58}/transfers (no static file). */
+        AccountTransfersArtifact: {
+            limit?: number;
+            offset?: number;
+            schema_version: number;
+            ss58: string;
+            transfer_count: number;
+            transfers: {
+                amount_tao?: number | null;
+                block_number: number | null;
+                /** @enum {string|null} */
+                direction?: "sent" | "received" | null;
+                event_index?: number | null;
+                from: string | null;
+                /** Format: date-time */
+                observed_at?: string | null;
+                to: string | null;
+            }[];
         } & {
             [key: string]: unknown;
         };
@@ -5133,6 +5171,122 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountSubnetsArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    accountTransfers: {
+        parameters: {
+            query?: {
+                direction?: "all" | "sent" | "received";
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path: {
+                ss58: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "limit": 1,
+                     *         "offset": 1,
+                     *         "schema_version": 1,
+                     *         "ss58": "example",
+                     *         "transfer_count": 1,
+                     *         "transfers": [
+                     *           {
+                     *             "block_number": 5000000,
+                     *             "from": "example",
+                     *             "to": "example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["AccountTransfersArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -386,6 +386,97 @@
         ],
         "type": "object"
       },
+      "AccountTransfersArtifact": {
+        "additionalProperties": true,
+        "description": "The native-TAO Balances.Transfer feed for one account (#1850), newest first, from the account_events D1 tier (event_kind='Transfer'). Each row is a directional {from, to, amount_tao, direction} transfer; direction is 'sent' or 'received' relative to the queried ss58. This is the native-TAO transfer feed only, NOT a full balance ledger. Served live at /api/v1/accounts/{ss58}/transfers (no static file).",
+        "properties": {
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "ss58": {
+            "type": "string"
+          },
+          "transfer_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "transfers": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "amount_tao": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "block_number": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "direction": {
+                  "enum": [
+                    "sent",
+                    "received",
+                    null
+                  ],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "event_index": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "from": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "observed_at": {
+                  "format": "date-time",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "to": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "block_number",
+                "from",
+                "to"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "ss58",
+          "transfer_count",
+          "transfers"
+        ],
+        "type": "object"
+      },
       "AdapterArtifact": {
         "allOf": [
           {

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1634,6 +1634,42 @@
           }
         }
       },
+      "AccountTransfersArtifact": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "The native-TAO Balances.Transfer feed for one account (#1850), newest first, from the account_events D1 tier (event_kind='Transfer'). Each row is a directional {from, to, amount_tao, direction} transfer; direction is 'sent' or 'received' relative to the queried ss58. This is the native-TAO transfer feed only, NOT a full balance ledger. Served live at /api/v1/accounts/{ss58}/transfers (no static file).",
+        "required": ["schema_version", "ss58", "transfer_count", "transfers"],
+        "properties": {
+          "schema_version": { "type": "integer" },
+          "ss58": { "type": "string" },
+          "transfer_count": { "type": "integer", "minimum": 0 },
+          "limit": { "type": "integer" },
+          "offset": { "type": "integer" },
+          "transfers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["block_number", "from", "to"],
+              "properties": {
+                "block_number": { "type": ["integer", "null"] },
+                "event_index": { "type": ["integer", "null"] },
+                "from": { "type": ["string", "null"] },
+                "to": { "type": ["string", "null"] },
+                "amount_tao": { "type": ["number", "null"] },
+                "direction": {
+                  "type": ["string", "null"],
+                  "enum": ["sent", "received", null]
+                },
+                "observed_at": {
+                  "type": ["string", "null"],
+                  "format": "date-time"
+                }
+              }
+            }
+          }
+        }
+      },
       "AccountSubnetsArtifact": {
         "type": "object",
         "additionalProperties": true,

--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -110,7 +110,10 @@ def decode_head(s, block_number):
     for event_index, ev in enumerate(events):
         v = ev.value if isinstance(ev.value, dict) else {}
         e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
-        if e.get("module_id") != "SubtensorModule":
+        # Match the CI poller's coverage (#1850): SubtensorModule + Balances, so
+        # realtime ingest captures native-TAO Transfer events too (extract()
+        # returns None for any non-indexed kind, so this only widens, never noise).
+        if e.get("module_id") not in ("SubtensorModule", "Balances"):
             continue
         ent = extract(e.get("event_id"), e.get("attributes"))
         if ent is None:

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -153,6 +153,13 @@ const checks = [
     },
   ],
   [
+    "/api/v1/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5/transfers",
+    (body) => {
+      assert.equal(Array.isArray(body.data.transfers), true);
+      assert.equal(typeof body.data.transfer_count, "number");
+    },
+  ],
+  [
     "/api/v1/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5/subnets",
     (body) => {
       assert.equal(Array.isArray(body.data.subnets), true);

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -36,6 +36,7 @@ const COMPUTED_ARTIFACTS = new Set([
   "account-summary",
   "account-events",
   "account-extrinsics",
+  "account-transfers",
   "account-subnets",
   "account-balance",
   "blocks-feed",

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -280,3 +280,34 @@ export function buildAccountSubnets(rows, ss58) {
     subnets,
   };
 }
+
+// Per-account native-TAO Transfer feed (#1850), newest first. Reshapes the
+// account_events rows for event_kind='Transfer' — where the _transfer extractor
+// overloads hotkey=from (sender) and coldkey=to (recipient) — into a clean
+// directional {from, to, amount_tao, direction} ledger, hiding the column overload
+// behind the contract. `direction` is derived per-row by comparing the queried
+// ss58: it sent (== from) or received (== to). This is the native-TAO
+// Balances.Transfer feed only, NOT a full balance ledger (stake flows are separate
+// event kinds). Null-safe on a cold store.
+export function buildAccountTransfers(rows, ss58, { limit, offset } = {}) {
+  const transfers = (rows || [])
+    .filter((r) => r && typeof r === "object")
+    .map((r) => ({
+      block_number: r.block_number ?? null,
+      event_index: r.event_index ?? null,
+      from: r.hotkey ?? null,
+      to: r.coldkey ?? null,
+      amount_tao: r.amount_tao ?? null,
+      direction:
+        r.hotkey === ss58 ? "sent" : r.coldkey === ss58 ? "received" : null,
+      observed_at: toIso(r.observed_at),
+    }));
+  return {
+    schema_version: 1,
+    ss58,
+    transfer_count: transfers.length,
+    limit: limit ?? null,
+    offset: offset ?? null,
+    transfers,
+  };
+}

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -50,6 +50,7 @@ export const R2_ONLY_PATTERNS = [
   /^accounts\/(?:[1-9A-HJ-NP-Za-km-z]{47,48}|\{ss58\})\.json$/,
   /^accounts\/(?:[1-9A-HJ-NP-Za-km-z]{47,48}|\{ss58\})\/events\.json$/,
   /^accounts\/(?:[1-9A-HJ-NP-Za-km-z]{47,48}|\{ss58\})\/extrinsics\.json$/,
+  /^accounts\/(?:[1-9A-HJ-NP-Za-km-z]{47,48}|\{ss58\})\/transfers\.json$/,
   /^accounts\/(?:[1-9A-HJ-NP-Za-km-z]{47,48}|\{ss58\})\/subnets\.json$/,
   // Live TAO balance query (#1818): computed from RPC at request time, never a static file.
   /^accounts\/(?:[1-9A-HJ-NP-Za-km-z]{47,48}|\{ss58\})\/balance\.json$/,

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -960,6 +960,12 @@ export const PUBLIC_ARTIFACTS = [
     "AccountExtrinsicsArtifact",
   ),
   artifact(
+    "account-transfers",
+    "/metagraph/accounts/{ss58}/transfers.json",
+    "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers (no static file).",
+    "AccountTransfersArtifact",
+  ),
+  artifact(
     "account-subnets",
     "/metagraph/accounts/{ss58}/subnets.json",
     "The subnets where an account's hotkey is currently registered, served live from the neurons D1 tier at /api/v1/accounts/{ss58}/subnets (no static file).",
@@ -1710,6 +1716,24 @@ export const API_ROUTES = [
     "short",
     ["accounts", "analytics"],
     [
+      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
+      { name: "offset", schema: { type: "integer", minimum: 0 } },
+    ],
+    [{ name: "ss58", schema: { type: "string" } }],
+  ),
+  route(
+    "account-transfers",
+    "GET",
+    "/api/v1/accounts/{ss58}/transfers",
+    "/metagraph/accounts/{ss58}/transfers.json",
+    "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; ?limit (<=1000) / ?offset.",
+    "short",
+    ["accounts", "analytics"],
+    [
+      {
+        name: "direction",
+        schema: { type: "string", enum: ["all", "sent", "received"] },
+      },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
     ],

--- a/tests/account-routes.test.mjs
+++ b/tests/account-routes.test.mjs
@@ -241,3 +241,57 @@ test("GET /accounts/{ss58}/extrinsics is schema-stable when D1 is cold (never 40
   assert.equal(body.data.extrinsic_count, 0);
   assert.equal(Array.isArray(body.data.extrinsics), true);
 });
+
+test("GET /accounts/{ss58}/transfers reshapes Transfer rows directionally (#1850)", async () => {
+  const env = dbWith({
+    // The poller stores hotkey=from / coldkey=to for Transfer events.
+    events: [
+      {
+        block_number: 300,
+        event_index: 0,
+        event_kind: "Transfer",
+        hotkey: SS58, // sender == queried account → "sent"
+        coldkey: "5Recipient",
+        netuid: null,
+        uid: null,
+        amount_tao: 4.2,
+        observed_at: 1750009000000,
+      },
+    ],
+  });
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/transfers?direction=sent`),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.ss58, SS58);
+  assert.equal(body.data.transfer_count, 1);
+  assert.equal(body.data.transfers[0].from, SS58);
+  assert.equal(body.data.transfers[0].to, "5Recipient");
+  assert.equal(body.data.transfers[0].amount_tao, 4.2);
+  assert.equal(body.data.transfers[0].direction, "sent");
+});
+
+test("GET /accounts/{ss58}/transfers rejects an unsupported query param (#1850)", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/transfers?bogus=1`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 400);
+});
+
+test("GET /accounts/{ss58}/transfers is schema-stable when D1 is cold (never 404)", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/transfers`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.ss58, SS58);
+  assert.equal(body.data.transfer_count, 0);
+  assert.equal(Array.isArray(body.data.transfers), true);
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -65,6 +65,7 @@ import {
   handleAccountBalance,
   handleAccountEvents,
   handleAccountExtrinsics,
+  handleAccountTransfers,
   handleAccountSubnets,
   handleBlocks,
   handleBlock,
@@ -179,6 +180,7 @@ import {
   ACCOUNT_BALANCE_PATH_PATTERN,
   ACCOUNT_EVENTS_PATH_PATTERN,
   ACCOUNT_EXTRINSICS_PATH_PATTERN,
+  ACCOUNT_TRANSFERS_PATH_PATTERN,
   ACCOUNT_PATH_PATTERN,
   ACCOUNT_SUBNETS_PATH_PATTERN,
   BLOCK_DETAIL_PATH_PATTERN,
@@ -1213,6 +1215,17 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         request,
         env,
         accountExtrinsicsMatch[1],
+        resolved.url,
+      );
+    }
+    const accountTransfersMatch = ACCOUNT_TRANSFERS_PATH_PATTERN.exec(
+      resolved.url.pathname,
+    );
+    if (accountTransfersMatch) {
+      return handleAccountTransfers(
+        request,
+        env,
+        accountTransfersMatch[1],
         resolved.url,
       );
     }

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -67,6 +67,10 @@ export const ACCOUNT_SUBNETS_PATH_PATTERN =
 // matched by extrinsics.signer (a single column, not the hotkey or coldkey union).
 export const ACCOUNT_EXTRINSICS_PATH_PATTERN =
   /^\/api\/v1\/accounts\/([1-9A-HJ-NP-Za-km-z]{47,48})\/extrinsics$/;
+// Per-account native-TAO transfers (#1850): the Balances.Transfer feed for this
+// account, from account_events (event_kind='Transfer'); ?direction=all|sent|received.
+export const ACCOUNT_TRANSFERS_PATH_PATTERN =
+  /^\/api\/v1\/accounts\/([1-9A-HJ-NP-Za-km-z]{47,48})\/transfers$/;
 // Live TAO balance query (#1818): captures any non-slash segment; the handler
 // applies a stricter ^5[a-zA-Z0-9]{46,47}$ guard before making the RPC call.
 export const ACCOUNT_BALANCE_PATH_PATTERN =

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -47,6 +47,7 @@ import {
   buildAccountEvents,
   buildAccountSubnets,
   buildAccountSummary,
+  buildAccountTransfers,
   buildSubnetEvents,
   formatAccountEvent,
 } from "../../src/account-events.mjs";
@@ -355,6 +356,53 @@ export async function handleAccountExtrinsics(request, env, ss58, url) {
         env,
         `/metagraph/accounts/${ss58}/extrinsics.json`,
         data.extrinsics[0]?.observed_at ?? null,
+      ),
+    },
+    "short",
+  );
+}
+
+// GET /api/v1/accounts/{ss58}/transfers: the native-TAO Balances.Transfer feed for
+// this account (#1850), newest first, from the account_events tier (event_kind=
+// 'Transfer', where the poller stores hotkey=from / coldkey=to). ?direction=
+// all|sent|received narrows by side; ?limit (<=1000) / ?offset. This is the
+// native-TAO transfer feed only, NOT a full balance ledger. Cold/absent store →
+// schema-stable zero (never 404).
+export async function handleAccountTransfers(request, env, ss58, url) {
+  const validationError = validateQueryParams(url, [
+    "direction",
+    "limit",
+    "offset",
+  ]);
+  if (validationError) return analyticsQueryError(validationError);
+  const limit = clampInt(url.searchParams.get("limit"), 100, 1, 1000);
+  const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
+  const direction = url.searchParams.get("direction");
+  // sent => this account is the sender (hotkey=from); received => recipient
+  // (coldkey=to); default/all => either side.
+  let sideClause = "(hotkey = ? OR coldkey = ?)";
+  let sideParams = [ss58, ss58];
+  if (direction === "sent") {
+    sideClause = "hotkey = ?";
+    sideParams = [ss58];
+  } else if (direction === "received") {
+    sideClause = "coldkey = ?";
+    sideParams = [ss58];
+  }
+  const rows = await d1All(
+    env,
+    `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE event_kind = 'Transfer' AND ${sideClause} ORDER BY block_number DESC, event_index DESC LIMIT ? OFFSET ?`,
+    [...sideParams, limit, offset],
+  );
+  const data = buildAccountTransfers(rows, ss58, { limit, offset });
+  return envelopeResponse(
+    request,
+    {
+      data,
+      meta: await accountMeta(
+        env,
+        `/metagraph/accounts/${ss58}/transfers.json`,
+        data.transfers[0]?.observed_at ?? null,
       ),
     },
     "short",


### PR DESCRIPTION
Closes #1850

## What

`Balances.Transfer` was captured into `account_events` (`event_kind='Transfer'`, `hotkey=from` / `coldkey=to`) but had no first-class surface — only the generic `/events?kind=Transfer` with the misleadingly-named columns — and the realtime streamer **dropped `Balances` entirely** (SubtensorModule-only filter), so realtime under-covered transfers vs the CI poller.

## Changes

- **`GET /api/v1/accounts/{ss58}/transfers?direction=all|sent|received`** — the native-TAO Transfer feed, reshaped into a clean directional `{from, to, amount_tao, direction}` ledger that hides the column overload. `direction` narrows the side (`sent` ⇒ hotkey/from, `received` ⇒ coldkey/to); the builder derives per-row `direction` relative to the queried ss58. Read path needs **no migration/index** — `idx_account_events_hotkey`/`coldkey` + the `event_kind` row-filter.
- **`stream-events.py`** — widen the filter to `(SubtensorModule, Balances)` so realtime matches the poller (`extract()` already returns `None` for non-indexed kinds, so it only widens).
- `AccountTransfersArtifact` schema + route + `R2_ONLY_PATTERNS` + `COMPUTED_ARTIFACTS` + `validate-api` + docs + client bump.

## Scope

Native-TAO `Balances.Transfer` only — **not** a full balance ledger (stake flows are separate event kinds). Stated in the title/description/schema. The existing `/events?kind=Transfer` keeps emitting the raw `hotkey`/`coldkey` for the same rows; this route is the clean directional view.

## Verification

- contract-drift / client-sdk-sync / api (78) / openapi / docs / public-safety → pass
- vitest account-routes / account-events / contracts / invariants-contracts → 57 passed (directional reshape, 400-on-bad-param, cold-store zero)
- `py_compile` streamer; eslint + prettier clean

Part of #1345 (explorer robustness wave).