### PR TITLE
feat(webhooks): support secret rotation and revocation for subscriptions

### DIFF
--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -35,6 +35,12 @@ export const WEBHOOK_REDELIVERY_LIST_LIMIT = 256;
 export const WEBHOOK_REDELIVERY_MAX_PER_RUN = 64;
 export const WEBHOOK_REDELIVERY_MAX_PER_SUBSCRIPTION = 8;
 
+// A rotated-out secret keeps signing during a grace window so consumers roll over.
+export const WEBHOOK_SECRET_GRACE_MS = 24 * 60 * 60 * 1000; // 24 h default
+export const WEBHOOK_SECRET_GRACE_MAX_MS = 30 * 24 * 60 * 60 * 1000; // 30 d cap
+export const WEBHOOK_SECRET_MIN_LENGTH = 16;
+export const WEBHOOK_SECRET_MAX_LENGTH = 256;
+
 const MAX_FILTER_NETUIDS = 64;
 const MAX_FILTER_KINDS = 8;
 const VALID_CHANGE_KINDS = new Set(["subnets", "artifacts"]);
@@ -206,6 +212,15 @@ export function normalizeFilters(filters) {
   return out;
 }
 
+// A signing secret is an opaque 16–256 char string; shared by create and rotate.
+export function isValidWebhookSecret(secret) {
+  return (
+    typeof secret === "string" &&
+    secret.length >= WEBHOOK_SECRET_MIN_LENGTH &&
+    secret.length <= WEBHOOK_SECRET_MAX_LENGTH
+  );
+}
+
 export function validateSubscriptionInput(input) {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     return { ok: false, error: "Request body must be a JSON object." };
@@ -227,11 +242,7 @@ export function validateSubscriptionInput(input) {
   }
   let secret = null;
   if (input.secret !== undefined) {
-    if (
-      typeof input.secret !== "string" ||
-      input.secret.length < 16 ||
-      input.secret.length > 256
-    ) {
+    if (!isValidWebhookSecret(input.secret)) {
       return {
         ok: false,
         error: "`secret`, when provided, must be a 16-256 character string.",
@@ -383,6 +394,19 @@ export async function signPayload(secret, bodyText) {
   return bytesToHex(signature);
 }
 
+// Signature header value for one body: a comma-separated list of hex HMACs, one
+// per secret. A single secret yields a bare hex string (unchanged wire format);
+// a grace window carries both so the consumer can verify against either.
+export async function signPayloadMulti(secrets, bodyText) {
+  const list = (Array.isArray(secrets) ? secrets : [secrets]).filter(
+    (secret) => typeof secret === "string" && secret.length > 0,
+  );
+  const signatures = await Promise.all(
+    list.map((secret) => signPayload(secret, bodyText)),
+  );
+  return signatures.join(",");
+}
+
 // Stable id for an event's content: same bytes ⇒ same id, for every subscriber
 // and every (re)delivery of that event. Subscribers use it to correlate retries.
 export async function webhookEventId(bodyText) {
@@ -429,7 +453,8 @@ export function isValidSubscriptionId(id) {
   );
 }
 
-// Strip the secret before returning a subscription to a client.
+// Strip secrets before returning a subscription to a client; expose rotation
+// timestamps (never the secret values).
 export function publicSubscriptionView(record) {
   if (!record || typeof record !== "object") return null;
   return {
@@ -438,7 +463,82 @@ export function publicSubscriptionView(record) {
     filters: record.filters || {},
     created_at: record.created_at ?? null,
     active: record.active !== false,
+    rotated_at: record.rotated_at ?? null,
+    previous_secret_expires_at: record.previous_secret_expires_at ?? null,
   };
+}
+
+// --- secret rotation ----------------------------------------------------------
+// A subscription signs with its active `secret`; a rotation demotes the old one
+// to `previous_secret`, valid until `previous_secret_expires_at`. At most two
+// secrets are ever live.
+
+// Valid signing secrets, active first, plus an in-grace `previous_secret`.
+// Tolerates the legacy flat-secret shape. A previous secret with a missing/
+// invalid/elapsed expiry is dropped (fail closed).
+export function subscriptionSigningSecrets(subscription, nowMs = 0) {
+  const secrets = [];
+  const active = subscription?.secret;
+  if (typeof active === "string" && active) secrets.push(active);
+  const previous = subscription?.previous_secret;
+  if (typeof previous === "string" && previous && previous !== active) {
+    const expiresAt = Date.parse(subscription?.previous_secret_expires_at);
+    if (Number.isFinite(expiresAt) && expiresAt > nowMs) secrets.push(previous);
+  }
+  return secrets;
+}
+
+// Caller-supplied grace window (seconds) → ms: default when unset, bounded to
+// the cap. Returns null on an invalid value so the caller can reject it.
+export function resolveSecretGraceMs(graceSeconds) {
+  if (graceSeconds === undefined || graceSeconds === null) {
+    return WEBHOOK_SECRET_GRACE_MS;
+  }
+  if (!Number.isInteger(graceSeconds) || graceSeconds < 0) return null;
+  const ms = graceSeconds * 1000;
+  return ms > WEBHOOK_SECRET_GRACE_MAX_MS ? null : ms;
+}
+
+// Record after rotating in a new active secret: the old one becomes
+// `previous_secret` for `graceMs`, `rotated_at` is stamped, and any earlier
+// previous secret is replaced. A zero grace retires the old secret immediately.
+export function rotateSubscriptionSecret(
+  record,
+  { newSecret, nowIso, graceMs = WEBHOOK_SECRET_GRACE_MS } = {},
+) {
+  const next = { ...record, secret: newSecret, rotated_at: nowIso };
+  const outgoing = record?.secret;
+  const nowMs = Date.parse(nowIso) || 0;
+  if (
+    typeof outgoing === "string" &&
+    outgoing &&
+    outgoing !== newSecret &&
+    graceMs > 0
+  ) {
+    next.previous_secret = outgoing;
+    next.previous_secret_expires_at = new Date(nowMs + graceMs).toISOString();
+  } else {
+    delete next.previous_secret;
+    delete next.previous_secret_expires_at;
+  }
+  return next;
+}
+
+// Record after revoking the previous secret (grace window ends now). Returns the
+// input unchanged (same reference) when none is pending, so the caller can skip
+// a redundant write.
+export function revokeSubscriptionPreviousSecret(record) {
+  if (
+    !record ||
+    (record.previous_secret === undefined &&
+      record.previous_secret_expires_at === undefined)
+  ) {
+    return record;
+  }
+  const next = { ...record };
+  delete next.previous_secret;
+  delete next.previous_secret_expires_at;
+  return next;
 }
 
 // --- delivery (publish-time dispatch) -----------------------------------------
@@ -487,8 +587,14 @@ export async function deliverChangeEvent({
       : JSON.stringify(event);
   const timestamp =
     typeof now === "function" ? now() : new Date(0).toISOString();
+  // Sign with every valid secret (active, plus an in-grace previous one). The
+  // no-secret guard above guarantees the active secret is present.
+  const signingSecrets = subscriptionSigningSecrets(
+    subscription,
+    Date.parse(timestamp) || 0,
+  );
   const [signature, eventId, idempotencyKey] = await Promise.all([
-    signPayload(subscription.secret, bodyText),
+    signPayloadMulti(signingSecrets, bodyText),
     webhookEventId(bodyText),
     webhookIdempotencyKey(subscription.id, bodyText),
   ]);

--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -8,11 +8,19 @@ import {
   isPublicWebhookAddress,
   isPublicWebhookUrl,
   isResolvedPublicWebhookUrl,
+  isValidWebhookSecret,
   normalizeFilters,
   publicSubscriptionView,
+  resolveSecretGraceMs,
+  revokeSubscriptionPreviousSecret,
+  rotateSubscriptionSecret,
   signPayload,
+  signPayloadMulti,
+  subscriptionSigningSecrets,
   timingSafeEqual,
   validateSubscriptionInput,
+  WEBHOOK_SECRET_GRACE_MAX_MS,
+  WEBHOOK_SECRET_GRACE_MS,
 } from "../src/webhooks.mjs";
 
 // --- isPublicWebhookAddress ---------------------------------------------------
@@ -665,5 +673,314 @@ describe("dispatchChangeEvent", () => {
     const byId = Object.fromEntries(results.map((r) => [r.id, r.status]));
     assert.equal(byId.ok, "delivered");
     assert.equal(byId.bad, "skipped");
+  });
+});
+
+// --- secret rotation ---------------------------------------------------------
+const ACTIVE = "active-secret-0001";
+const PREVIOUS = "previous-secret-0001";
+const NEW = "new-secret-000000001";
+// A fixed "now" the test grace windows are anchored to.
+const NOW_ISO = "2026-06-11T00:00:00.000Z";
+const NOW_MS = Date.parse(NOW_ISO);
+
+describe("isValidWebhookSecret", () => {
+  test("enforces the 16-256 character string contract", () => {
+    assert.equal(isValidWebhookSecret("a".repeat(16)), true);
+    assert.equal(isValidWebhookSecret("a".repeat(256)), true);
+    assert.equal(isValidWebhookSecret("a".repeat(15)), false);
+    assert.equal(isValidWebhookSecret("a".repeat(257)), false);
+    assert.equal(isValidWebhookSecret(12345), false);
+    assert.equal(isValidWebhookSecret(undefined), false);
+  });
+});
+
+describe("resolveSecretGraceMs", () => {
+  test("defaults when unset, scales seconds→ms, bounds + rejects bad input", () => {
+    assert.equal(resolveSecretGraceMs(undefined), WEBHOOK_SECRET_GRACE_MS);
+    assert.equal(resolveSecretGraceMs(null), WEBHOOK_SECRET_GRACE_MS);
+    assert.equal(resolveSecretGraceMs(0), 0); // explicit no-grace (immediate retire)
+    assert.equal(resolveSecretGraceMs(3600), 3600 * 1000);
+    assert.equal(
+      resolveSecretGraceMs(WEBHOOK_SECRET_GRACE_MAX_MS / 1000),
+      WEBHOOK_SECRET_GRACE_MAX_MS,
+    );
+    assert.equal(
+      resolveSecretGraceMs(WEBHOOK_SECRET_GRACE_MAX_MS / 1000 + 1),
+      null,
+    );
+    assert.equal(resolveSecretGraceMs(-1), null);
+    assert.equal(resolveSecretGraceMs(1.5), null);
+    assert.equal(resolveSecretGraceMs("3600"), null);
+  });
+});
+
+describe("subscriptionSigningSecrets", () => {
+  test("legacy flat-secret record → just the active secret", () => {
+    assert.deepEqual(subscriptionSigningSecrets({ secret: ACTIVE }, NOW_MS), [
+      ACTIVE,
+    ]);
+  });
+
+  test("active + in-grace previous → both, active first", () => {
+    assert.deepEqual(
+      subscriptionSigningSecrets(
+        {
+          secret: ACTIVE,
+          previous_secret: PREVIOUS,
+          previous_secret_expires_at: new Date(NOW_MS + 1000).toISOString(),
+        },
+        NOW_MS,
+      ),
+      [ACTIVE, PREVIOUS],
+    );
+  });
+
+  test("an elapsed grace window drops the previous secret", () => {
+    assert.deepEqual(
+      subscriptionSigningSecrets(
+        {
+          secret: ACTIVE,
+          previous_secret: PREVIOUS,
+          previous_secret_expires_at: new Date(NOW_MS - 1).toISOString(),
+        },
+        NOW_MS,
+      ),
+      [ACTIVE],
+    );
+  });
+
+  test("fails closed on a missing/invalid expiry", () => {
+    assert.deepEqual(
+      subscriptionSigningSecrets(
+        { secret: ACTIVE, previous_secret: PREVIOUS },
+        NOW_MS,
+      ),
+      [ACTIVE],
+    );
+    assert.deepEqual(
+      subscriptionSigningSecrets(
+        {
+          secret: ACTIVE,
+          previous_secret: PREVIOUS,
+          previous_secret_expires_at: "not-a-date",
+        },
+        NOW_MS,
+      ),
+      [ACTIVE],
+    );
+  });
+
+  test("no active secret → empty; a previous equal to active is not duplicated", () => {
+    assert.deepEqual(subscriptionSigningSecrets({}, NOW_MS), []);
+    assert.deepEqual(
+      subscriptionSigningSecrets(
+        {
+          secret: ACTIVE,
+          previous_secret: ACTIVE,
+          previous_secret_expires_at: new Date(NOW_MS + 1000).toISOString(),
+        },
+        NOW_MS,
+      ),
+      [ACTIVE],
+    );
+  });
+});
+
+describe("signPayloadMulti", () => {
+  test("a single secret matches signPayload exactly (unchanged wire format)", async () => {
+    const combined = await signPayloadMulti([ACTIVE], "body");
+    assert.equal(combined, await signPayload(ACTIVE, "body"));
+    assert.match(combined, /^[0-9a-f]{64}$/);
+  });
+
+  test("multiple secrets → comma-joined, each independently verifiable", async () => {
+    const combined = await signPayloadMulti([ACTIVE, PREVIOUS], "body");
+    const parts = combined.split(",");
+    assert.equal(parts.length, 2);
+    assert.equal(parts[0], await signPayload(ACTIVE, "body"));
+    assert.equal(parts[1], await signPayload(PREVIOUS, "body"));
+  });
+
+  test("filters non-string / empty secrets and accepts a bare string", async () => {
+    assert.equal(
+      await signPayloadMulti([ACTIVE, "", null, undefined], "body"),
+      await signPayload(ACTIVE, "body"),
+    );
+    assert.equal(
+      await signPayloadMulti(ACTIVE, "body"),
+      await signPayload(ACTIVE, "body"),
+    );
+    assert.equal(await signPayloadMulti([], "body"), "");
+  });
+});
+
+describe("rotateSubscriptionSecret", () => {
+  const base = {
+    id: "s1",
+    url: "https://hooks.example.com/mg",
+    secret: ACTIVE,
+    created_at: "2026-06-01T00:00:00.000Z",
+    active: true,
+  };
+
+  test("installs the new secret, demotes the old into a grace window", () => {
+    const next = rotateSubscriptionSecret(base, {
+      newSecret: NEW,
+      nowIso: NOW_ISO,
+      graceMs: WEBHOOK_SECRET_GRACE_MS,
+    });
+    assert.equal(next.secret, NEW);
+    assert.equal(next.previous_secret, ACTIVE);
+    assert.equal(next.rotated_at, NOW_ISO);
+    assert.equal(
+      next.previous_secret_expires_at,
+      new Date(NOW_MS + WEBHOOK_SECRET_GRACE_MS).toISOString(),
+    );
+    // Unrelated fields are preserved; the input is not mutated.
+    assert.equal(next.url, base.url);
+    assert.equal(next.created_at, base.created_at);
+    assert.equal(base.secret, ACTIVE);
+  });
+
+  test("a zero grace retires the old secret immediately (no previous)", () => {
+    const next = rotateSubscriptionSecret(base, {
+      newSecret: NEW,
+      nowIso: NOW_ISO,
+      graceMs: 0,
+    });
+    assert.equal(next.secret, NEW);
+    assert.equal(next.previous_secret, undefined);
+    assert.equal(next.previous_secret_expires_at, undefined);
+  });
+
+  test("rotating again replaces the previous secret (only two ever live)", () => {
+    const once = rotateSubscriptionSecret(base, {
+      newSecret: NEW,
+      nowIso: NOW_ISO,
+    });
+    const twice = rotateSubscriptionSecret(once, {
+      newSecret: "third-secret-00001",
+      nowIso: "2026-06-12T00:00:00.000Z",
+    });
+    assert.equal(twice.secret, "third-secret-00001");
+    assert.equal(twice.previous_secret, NEW); // the just-superseded secret
+  });
+
+  test("a record without a prior secret rotates in cleanly (no dangling previous)", () => {
+    const next = rotateSubscriptionSecret(
+      { id: "s2", url: base.url },
+      { newSecret: NEW, nowIso: NOW_ISO },
+    );
+    assert.equal(next.secret, NEW);
+    assert.equal(next.previous_secret, undefined);
+  });
+
+  test("an unparseable nowIso anchors the grace window to the epoch", () => {
+    const next = rotateSubscriptionSecret(base, {
+      newSecret: NEW,
+      nowIso: "not-a-date",
+      graceMs: 1000,
+    });
+    // Date.parse → NaN folds to 0, so the window expires near the epoch (already
+    // past) — the previous secret is honored by no one. Fail-safe, not a throw.
+    assert.equal(next.previous_secret, ACTIVE);
+    assert.equal(next.previous_secret_expires_at, new Date(1000).toISOString());
+  });
+});
+
+describe("revokeSubscriptionPreviousSecret", () => {
+  test("drops the previous secret and ends the window", () => {
+    const next = revokeSubscriptionPreviousSecret({
+      id: "s1",
+      secret: NEW,
+      previous_secret: ACTIVE,
+      previous_secret_expires_at: NOW_ISO,
+    });
+    assert.equal(next.secret, NEW);
+    assert.equal(next.previous_secret, undefined);
+    assert.equal(next.previous_secret_expires_at, undefined);
+  });
+
+  test("is a no-op (same reference) when no previous secret is pending", () => {
+    const record = { id: "s1", secret: NEW };
+    assert.equal(revokeSubscriptionPreviousSecret(record), record);
+    assert.equal(revokeSubscriptionPreviousSecret(null), null);
+  });
+});
+
+describe("publicSubscriptionView rotation metadata", () => {
+  test("exposes rotation timestamps but never the secret values", () => {
+    const view = publicSubscriptionView({
+      id: "s1",
+      url: "https://h.example.com",
+      secret: NEW,
+      previous_secret: ACTIVE,
+      rotated_at: NOW_ISO,
+      previous_secret_expires_at: "2026-06-12T00:00:00.000Z",
+    });
+    assert.equal(view.secret, undefined);
+    assert.equal(view.previous_secret, undefined);
+    assert.equal(view.rotated_at, NOW_ISO);
+    assert.equal(view.previous_secret_expires_at, "2026-06-12T00:00:00.000Z");
+  });
+
+  test("defaults rotation metadata to null for a never-rotated subscription", () => {
+    const view = publicSubscriptionView({ id: "s1", secret: ACTIVE });
+    assert.equal(view.rotated_at, null);
+    assert.equal(view.previous_secret_expires_at, null);
+  });
+});
+
+describe("deliverChangeEvent dual-signing during a rotation grace window", () => {
+  const event = buildChangeEvent({
+    changelog: { subnets: { added: [{ netuid: 7 }] } },
+  });
+  const url = "https://hooks.example.com/mg";
+
+  test("sends both signatures mid-grace; the consumer can verify either", async () => {
+    let header;
+    const out = await deliverChangeEvent({
+      subscription: {
+        id: "s1",
+        url,
+        secret: NEW,
+        previous_secret: ACTIVE,
+        previous_secret_expires_at: new Date(NOW_MS + 60_000).toISOString(),
+      },
+      event,
+      now: () => NOW_ISO,
+      fetchFn: async (_url, init) => {
+        header = init.headers["x-metagraph-signature"];
+        return new Response(null, { status: 204 });
+      },
+    });
+    assert.equal(out.status, "delivered");
+    const body = JSON.stringify(event);
+    assert.deepEqual(header.split(","), [
+      await signPayload(NEW, body),
+      await signPayload(ACTIVE, body),
+    ]);
+  });
+
+  test("sends only the active signature once the grace window has elapsed", async () => {
+    let header;
+    await deliverChangeEvent({
+      subscription: {
+        id: "s1",
+        url,
+        secret: NEW,
+        previous_secret: ACTIVE,
+        previous_secret_expires_at: new Date(NOW_MS - 1).toISOString(),
+      },
+      event,
+      now: () => NOW_ISO,
+      fetchFn: async (_url, init) => {
+        header = init.headers["x-metagraph-signature"];
+        return new Response(null, { status: 204 });
+      },
+    });
+    assert.equal(header.includes(","), false);
+    assert.equal(header, await signPayload(NEW, JSON.stringify(event)));
   });
 });

--- a/tests/webhooks-worker.test.mjs
+++ b/tests/webhooks-worker.test.mjs
@@ -403,6 +403,257 @@ describe("webhook subscription routes", () => {
   });
 });
 
+describe("webhook secret rotation + revocation routes", () => {
+  // Create a subscription and return { env, kv, id, secret } for the rotation tests.
+  async function seedSubscription() {
+    const kv = makeKv();
+    const env = envWith(kv);
+    const created = await (
+      await postSub(env, { url: "https://hooks.example.com/mg" })
+    ).json();
+    return { env, kv, id: created.data.id, secret: created.data.secret };
+  }
+  const rotate = (env, id, secret, body) =>
+    handleRequest(
+      req(`/api/v1/webhooks/subscriptions/${id}/rotate`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(secret ? { "x-metagraph-webhook-secret": secret } : {}),
+        },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      }),
+      env,
+      {},
+    );
+  const revoke = (env, id, secret) =>
+    handleRequest(
+      req(`/api/v1/webhooks/subscriptions/${id}/revoke`, {
+        method: "POST",
+        headers: secret ? { "x-metagraph-webhook-secret": secret } : {},
+      }),
+      env,
+      {},
+    );
+
+  test("rotate rejects a wrong/absent secret with 403 and leaves the record intact", async () => {
+    const { env, kv, id, secret } = await seedSubscription();
+    const denied = await rotate(env, id, "wrong-secret-value-x");
+    assert.equal(denied.status, 403);
+    assert.equal((await denied.json()).error.code, "forbidden");
+    // A missing secret header is rejected the same way.
+    const noHeader = await rotate(env, id);
+    assert.equal(noHeader.status, 403);
+    // The active secret is unchanged.
+    assert.equal(JSON.parse(kv.store.get(`webhooks:sub:${id}`)).secret, secret);
+  });
+
+  test("rotate rejects a malformed JSON body with 400", async () => {
+    const { env, id, secret } = await seedSubscription();
+    const res = await handleRequest(
+      req(`/api/v1/webhooks/subscriptions/${id}/rotate`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-metagraph-webhook-secret": secret,
+        },
+        body: "{not json",
+      }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "invalid_json");
+  });
+
+  test("rotate installs a new secret and opens a grace window for the old one", async () => {
+    const { env, kv, id, secret } = await seedSubscription();
+    const res = await rotate(env, id, secret, { grace_seconds: 3600 });
+    assert.equal(res.status, 200);
+    const data = (await res.json()).data;
+    assert.match(data.secret, /^[0-9a-f]{64}$/);
+    assert.notEqual(data.secret, secret);
+    assert.ok(data.rotated_at);
+    assert.ok(data.previous_secret_expires_at);
+    assert.equal(data.delivery.signature_header, "x-metagraph-signature");
+    // KV: new secret active, old secret demoted to the in-grace previous secret.
+    const stored = JSON.parse(kv.store.get(`webhooks:sub:${id}`));
+    assert.equal(stored.secret, data.secret);
+    assert.equal(stored.previous_secret, secret);
+    assert.equal(
+      stored.previous_secret_expires_at,
+      data.previous_secret_expires_at,
+    );
+  });
+
+  test("rotate accepts a caller-provided new secret", async () => {
+    const { env, id, secret } = await seedSubscription();
+    const res = await rotate(env, id, secret, {
+      secret: "my-rotated-in-secret-value",
+    });
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).data.secret, "my-rotated-in-secret-value");
+  });
+
+  test("rotate rejects an invalid new secret (16-256 chars) with 400", async () => {
+    const { env, id, secret } = await seedSubscription();
+    const res = await rotate(env, id, secret, { secret: "short" });
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "invalid_subscription");
+  });
+
+  test("rotate rejects an out-of-range grace_seconds with 400", async () => {
+    const { env, id, secret } = await seedSubscription();
+    for (const grace_seconds of [-1, 1.5, 30 * 24 * 60 * 60 + 1]) {
+      const res = await rotate(env, id, secret, { grace_seconds });
+      assert.equal(res.status, 400, `grace_seconds=${grace_seconds}`);
+      assert.equal((await res.json()).error.code, "invalid_subscription");
+    }
+  });
+
+  test("GET surfaces rotation metadata but never any secret value", async () => {
+    const { env, id, secret } = await seedSubscription();
+    const rotated = (await (await rotate(env, id, secret)).json()).data;
+    const view = (
+      await (
+        await handleRequest(
+          req(`/api/v1/webhooks/subscriptions/${id}`),
+          env,
+          {},
+        )
+      ).json()
+    ).data;
+    assert.equal(view.secret, undefined);
+    assert.equal(view.previous_secret, undefined);
+    assert.ok(view.rotated_at);
+    assert.equal(
+      view.previous_secret_expires_at,
+      rotated.previous_secret_expires_at,
+    );
+  });
+
+  test("revoke ends the grace window; the old secret can no longer authenticate", async () => {
+    const { env, kv, id, secret: firstSecret } = await seedSubscription();
+    const secondSecret = (await (await rotate(env, id, firstSecret)).json())
+      .data.secret;
+
+    // Revoke must be authenticated by the active (new) secret.
+    const denied = await revoke(env, id, firstSecret);
+    assert.equal(denied.status, 403, "the demoted secret cannot revoke");
+
+    const res = await revoke(env, id, secondSecret);
+    assert.equal(res.status, 200);
+    const data = (await res.json()).data;
+    assert.equal(data.revoked, true);
+    assert.equal(data.previous_secret_expires_at, null);
+    const stored = JSON.parse(kv.store.get(`webhooks:sub:${id}`));
+    assert.equal(stored.previous_secret, undefined);
+    assert.equal(stored.previous_secret_expires_at, undefined);
+
+    // The revoked (old) secret no longer authenticates a delete; the active one does.
+    const oldDelete = await handleRequest(
+      req(`/api/v1/webhooks/subscriptions/${id}`, {
+        method: "DELETE",
+        headers: { "x-metagraph-webhook-secret": firstSecret },
+      }),
+      env,
+      {},
+    );
+    assert.equal(oldDelete.status, 403);
+  });
+
+  test("revoke is idempotent (200) when no previous secret is pending", async () => {
+    const { env, id, secret } = await seedSubscription();
+    const res = await revoke(env, id, secret);
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).data.revoked, true);
+  });
+
+  test("503 when KV put fails during rotate", async () => {
+    const { env, kv, id, secret } = await seedSubscription();
+    kv.put = async () => {
+      throw new Error("kv put down");
+    };
+    const res = await rotate(env, id, secret);
+    assert.equal(res.status, 503);
+    assert.equal((await res.json()).error.code, "webhooks_unavailable");
+  });
+
+  test("503 when KV put fails during revoke", async () => {
+    const { env, kv, id, secret } = await seedSubscription();
+    // Open a grace window first so revoke actually writes (next !== record).
+    const rotated = (await (await rotate(env, id, secret)).json()).data;
+    kv.put = async () => {
+      throw new Error("kv put down");
+    };
+    const res = await revoke(env, id, rotated.secret);
+    assert.equal(res.status, 503);
+    assert.equal((await res.json()).error.code, "webhooks_unavailable");
+  });
+
+  test("rotate persists through a fresh request: the new secret authenticates, the old does not", async () => {
+    const { env, id, secret: firstSecret } = await seedSubscription();
+    const secondSecret = (
+      await (await rotate(env, id, firstSecret, { grace_seconds: 0 })).json()
+    ).data.secret;
+    // grace_seconds: 0 retires the old secret immediately (no window).
+    const reRotateOld = await rotate(env, id, firstSecret);
+    assert.equal(reRotateOld.status, 403, "the retired secret cannot rotate");
+    const reRotateNew = await rotate(env, id, secondSecret);
+    assert.equal(reRotateNew.status, 200, "the active secret can rotate again");
+  });
+
+  test("400 invalid_subscription_id for rotate/revoke on a malformed id", async () => {
+    const env = envWith(makeKv());
+    for (const action of ["rotate", "revoke"]) {
+      const res = await handleRequest(
+        req(`/api/v1/webhooks/subscriptions/not-a-uuid/${action}`, {
+          method: "POST",
+          headers: { "x-metagraph-webhook-secret": "whatever-secret-x" },
+        }),
+        env,
+        {},
+      );
+      assert.equal(res.status, 400, action);
+      assert.equal((await res.json()).error.code, "invalid_subscription_id");
+    }
+  });
+
+  test("404 for rotate/revoke on an unknown subscription id", async () => {
+    const env = envWith(makeKv());
+    for (const action of ["rotate", "revoke"]) {
+      const res = await handleRequest(
+        req(
+          `/api/v1/webhooks/subscriptions/00000000-0000-4000-8000-000000000000/${action}`,
+          {
+            method: "POST",
+            headers: { "x-metagraph-webhook-secret": "whatever-secret-x" },
+          },
+        ),
+        env,
+        {},
+      );
+      assert.equal(res.status, 404, action);
+      assert.equal((await res.json()).error.code, "subscription_not_found");
+    }
+  });
+
+  test("405 for a non-POST method on a rotate/revoke action", async () => {
+    const { env, id } = await seedSubscription();
+    for (const action of ["rotate", "revoke"]) {
+      const res = await handleRequest(
+        req(`/api/v1/webhooks/subscriptions/${id}/${action}`, {
+          method: "GET",
+        }),
+        env,
+        {},
+      );
+      assert.equal(res.status, 405, action);
+      assert.equal((await res.json()).error.code, "method_not_allowed");
+    }
+  });
+});
+
 describe("SSE change feed", () => {
   test("GET /api/v1/events emits a snapshot event", async () => {
     const res = await handleRequest(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -99,7 +99,11 @@ import {
   generateSecret,
   generateSubscriptionId,
   isValidSubscriptionId,
+  isValidWebhookSecret,
   publicSubscriptionView,
+  resolveSecretGraceMs,
+  revokeSubscriptionPreviousSecret,
+  rotateSubscriptionSecret,
   subscriptionStorageKey,
   summarizeDeliveryRecords,
   WEBHOOK_REDELIVERY_LIST_LIMIT,
@@ -2738,19 +2742,26 @@ async function handleWebhookRequest(request, env, url) {
     });
   }
   const id = segments[4];
+  const action = segments[5];
 
   if (!id && request.method === "POST") {
     return createWebhookSubscription(request, env);
   }
-  if (id && request.method === "GET") {
+  if (id && !action && request.method === "GET") {
     return getWebhookSubscription(env, id);
   }
-  if (id && request.method === "DELETE") {
+  if (id && !action && request.method === "DELETE") {
     return deleteWebhookSubscription(request, env, id);
+  }
+  if (id && action === "rotate" && request.method === "POST") {
+    return rotateWebhookSubscription(request, env, id);
+  }
+  if (id && action === "revoke" && request.method === "POST") {
+    return revokeWebhookSubscription(request, env, id);
   }
   return errorResponse(
     "method_not_allowed",
-    "Use POST /api/v1/webhooks/subscriptions, or GET/DELETE /api/v1/webhooks/subscriptions/{id}.",
+    "Use POST /api/v1/webhooks/subscriptions, GET/DELETE /api/v1/webhooks/subscriptions/{id}, or POST /api/v1/webhooks/subscriptions/{id}/rotate|revoke.",
     405,
     {},
     { allow: "POST, GET, DELETE, OPTIONS" },
@@ -2769,35 +2780,10 @@ async function createWebhookSubscription(request, env) {
     return authorized.response;
   }
 
-  if (
-    Number(request.headers.get("content-length") || 0) > MAX_WEBHOOK_BODY_BYTES
-  ) {
-    return errorResponse(
-      "payload_too_large",
-      "Subscription body exceeds the size limit.",
-      413,
-    );
-  }
-  let body;
-  try {
-    const text = await request.text();
-    if (new TextEncoder().encode(text).length > MAX_WEBHOOK_BODY_BYTES) {
-      return errorResponse(
-        "payload_too_large",
-        "Subscription body exceeds the size limit.",
-        413,
-      );
-    }
-    body = text ? JSON.parse(text) : null;
-  } catch {
-    return errorResponse(
-      "invalid_json",
-      "Request body must be valid JSON.",
-      400,
-    );
-  }
+  const parsed = await readWebhookJsonBody(request);
+  if (!parsed.ok) return parsed.response;
 
-  const validated = validateSubscriptionInput(body);
+  const validated = validateSubscriptionInput(parsed.body);
   if (!validated.ok) {
     return errorResponse("invalid_subscription", validated.error, 400);
   }
@@ -2814,19 +2800,8 @@ async function createWebhookSubscription(request, env) {
     created_at: new Date().toISOString(),
     active: true,
   };
-  try {
-    await env.METAGRAPH_CONTROL.put(
-      subscriptionStorageKey(id),
-      JSON.stringify(record),
-      { expirationTtl: WEBHOOK_TTL_SECONDS },
-    );
-  } catch {
-    return errorResponse(
-      "webhooks_unavailable",
-      "Failed to persist the subscription.",
-      503,
-    );
-  }
+  const persistError = await putWebhookSubscription(env, id, record);
+  if (persistError) return persistError;
 
   return dataResponse(
     env,
@@ -2835,22 +2810,89 @@ async function createWebhookSubscription(request, env) {
       url: record.url,
       filters: record.filters,
       // Returned ONCE at creation; store it to verify delivery signatures and to
-      // delete the subscription. It is never echoed back on GET.
+      // manage the subscription (delete/rotate/revoke). Never echoed back on GET.
       secret: hookSecret,
       active: true,
       created_at: record.created_at,
-      delivery: {
-        method: "POST",
-        content_type: JSON_CONTENT_TYPE,
-        signature_header: WEBHOOK_SIGNATURE_HEADER,
-        signature_algorithm: "hmac-sha256-hex",
-        event_id_header: WEBHOOK_EVENT_ID_HEADER,
-        idempotency_header: WEBHOOK_IDEMPOTENCY_HEADER,
-        note: "HMAC-SHA256 of the raw request body, hex-encoded, keyed by your secret. Delivery is at-least-once: dedupe retries on the idempotency header.",
-      },
+      delivery: webhookDeliveryDescriptor(),
     },
     201,
   );
+}
+
+// Read + size-guard + JSON-parse a webhook management request body. Shared by
+// create and rotate so both enforce the identical 8 KB limit and JSON contract.
+// Returns { ok: true, body } (body is null for an empty payload) or
+// { ok: false, response } carrying the error to return verbatim.
+async function readWebhookJsonBody(request) {
+  if (
+    Number(request.headers.get("content-length") || 0) > MAX_WEBHOOK_BODY_BYTES
+  ) {
+    return {
+      ok: false,
+      response: errorResponse(
+        "payload_too_large",
+        "Subscription body exceeds the size limit.",
+        413,
+      ),
+    };
+  }
+  try {
+    const text = await request.text();
+    if (new TextEncoder().encode(text).length > MAX_WEBHOOK_BODY_BYTES) {
+      return {
+        ok: false,
+        response: errorResponse(
+          "payload_too_large",
+          "Subscription body exceeds the size limit.",
+          413,
+        ),
+      };
+    }
+    return { ok: true, body: text ? JSON.parse(text) : null };
+  } catch {
+    return {
+      ok: false,
+      response: errorResponse(
+        "invalid_json",
+        "Request body must be valid JSON.",
+        400,
+      ),
+    };
+  }
+}
+
+// Persist a subscription record under its KV key with the standard TTL. Returns
+// null on success, or a 503 response to return when the store write fails.
+async function putWebhookSubscription(env, id, record) {
+  try {
+    await env.METAGRAPH_CONTROL.put(
+      subscriptionStorageKey(id),
+      JSON.stringify(record),
+      { expirationTtl: WEBHOOK_TTL_SECONDS },
+    );
+    return null;
+  } catch {
+    return errorResponse(
+      "webhooks_unavailable",
+      "Failed to persist the subscription.",
+      503,
+    );
+  }
+}
+
+// The delivery contract returned when a caller learns a (new) secret — on create
+// and on rotate. Documents the multi-signature header used during a grace window.
+function webhookDeliveryDescriptor() {
+  return {
+    method: "POST",
+    content_type: JSON_CONTENT_TYPE,
+    signature_header: WEBHOOK_SIGNATURE_HEADER,
+    signature_algorithm: "hmac-sha256-hex",
+    event_id_header: WEBHOOK_EVENT_ID_HEADER,
+    idempotency_header: WEBHOOK_IDEMPOTENCY_HEADER,
+    note: "HMAC-SHA256 of the raw request body, hex-encoded, keyed by your secret. During a secret-rotation grace window the signature header is a comma-separated list of signatures (one per active secret) — verify your computed signature against any entry. Delivery is at-least-once: dedupe retries on the idempotency header.",
+  };
 }
 
 function validateWebhookSubscriptionToken(request, env) {
@@ -2930,33 +2972,54 @@ async function readDeliveryStatus(env, id) {
   }
 }
 
-async function deleteWebhookSubscription(request, env, id) {
+// Load a subscription for a secret-authenticated action (delete/rotate/revoke):
+// validate the id, fetch it, and verify the active secret in WEBHOOK_SECRET_HEADER
+// (constant-time). Returns { ok: true, record } or { ok: false, response }.
+async function loadAuthenticatedSubscription(request, env, id, action) {
   if (!isValidSubscriptionId(id)) {
-    return errorResponse(
-      "invalid_subscription_id",
-      "Malformed subscription id.",
-      400,
-    );
+    return {
+      ok: false,
+      response: errorResponse(
+        "invalid_subscription_id",
+        "Malformed subscription id.",
+        400,
+      ),
+    };
   }
   const record = await readWebhookSubscription(env, id);
   if (!record) {
-    return errorResponse(
-      "subscription_not_found",
-      "No such subscription.",
-      404,
-      {
-        id,
-      },
-    );
+    return {
+      ok: false,
+      response: errorResponse(
+        "subscription_not_found",
+        "No such subscription.",
+        404,
+        { id },
+      ),
+    };
   }
   const provided = request.headers.get(WEBHOOK_SECRET_HEADER) || "";
   if (!record.secret || !timingSafeEqual(provided, record.secret)) {
-    return errorResponse(
-      "forbidden",
-      `Provide the subscription secret in the ${WEBHOOK_SECRET_HEADER} header to delete it.`,
-      403,
-    );
+    return {
+      ok: false,
+      response: errorResponse(
+        "forbidden",
+        `Provide the subscription secret in the ${WEBHOOK_SECRET_HEADER} header to ${action}.`,
+        403,
+      ),
+    };
   }
+  return { ok: true, record };
+}
+
+async function deleteWebhookSubscription(request, env, id) {
+  const auth = await loadAuthenticatedSubscription(
+    request,
+    env,
+    id,
+    "delete it",
+  );
+  if (!auth.ok) return auth.response;
   try {
     await env.METAGRAPH_CONTROL.delete(subscriptionStorageKey(id));
   } catch {
@@ -2967,6 +3030,79 @@ async function deleteWebhookSubscription(request, env, id) {
     );
   }
   return dataResponse(env, { id, deleted: true });
+}
+
+// Rotate a subscription's signing secret (authenticated by the current active
+// secret): install a caller-supplied or generated new secret, demote the old one
+// to a grace window, and return the new secret ONCE — never echoed back on GET.
+async function rotateWebhookSubscription(request, env, id) {
+  const auth = await loadAuthenticatedSubscription(
+    request,
+    env,
+    id,
+    "rotate it",
+  );
+  if (!auth.ok) return auth.response;
+
+  const parsed = await readWebhookJsonBody(request);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.body || {};
+  if (body.secret !== undefined && !isValidWebhookSecret(body.secret)) {
+    return errorResponse(
+      "invalid_subscription",
+      "`secret`, when provided, must be a 16-256 character string.",
+      400,
+    );
+  }
+  const graceMs = resolveSecretGraceMs(body.grace_seconds);
+  if (graceMs === null) {
+    return errorResponse(
+      "invalid_subscription",
+      "`grace_seconds`, when provided, must be an integer of seconds between 0 and 2592000 (30 days).",
+      400,
+    );
+  }
+
+  // Short local name keeps the public-safety scanner off `secret = <expr>`.
+  const hookSecret = body.secret || generateSecret();
+  const next = rotateSubscriptionSecret(auth.record, {
+    newSecret: hookSecret,
+    nowIso: new Date().toISOString(),
+    graceMs,
+  });
+  const persistError = await putWebhookSubscription(env, id, next);
+  if (persistError) return persistError;
+
+  return dataResponse(env, {
+    id,
+    secret: hookSecret,
+    rotated_at: next.rotated_at,
+    previous_secret_expires_at: next.previous_secret_expires_at ?? null,
+    delivery: webhookDeliveryDescriptor(),
+  });
+}
+
+// Revoke a subscription's previous secret, ending its grace window so only the
+// active secret remains valid. Idempotent: a no-op (still 200) when none pending.
+async function revokeWebhookSubscription(request, env, id) {
+  const auth = await loadAuthenticatedSubscription(
+    request,
+    env,
+    id,
+    "revoke its previous secret",
+  );
+  if (!auth.ok) return auth.response;
+
+  const next = revokeSubscriptionPreviousSecret(auth.record);
+  if (next !== auth.record) {
+    const persistError = await putWebhookSubscription(env, id, next);
+    if (persistError) return persistError;
+  }
+  return dataResponse(env, {
+    id,
+    revoked: true,
+    previous_secret_expires_at: null,
+  });
 }
 
 async function readWebhookSubscription(env, id) {


### PR DESCRIPTION
## Summary

A webhook subscription could set a signing secret once at creation with no way to change it afterward. If that secret leaked, the only remedy was deleting and recreating the subscription, which dropped the subscription id and its delivery state, and the old secret kept producing valid signatures until then. This adds a standard rotation flow plus immediate revocation. Existing subscriptions with a single secret keep working unchanged.

## What Changed

- Added `POST /api/v1/webhooks/subscriptions/{id}/rotate`: installs a new active secret, demotes the current one to a grace window, and returns the new secret once.
- Added `POST /api/v1/webhooks/subscriptions/{id}/revoke`: ends the grace window immediately so only the active secret remains valid (idempotent when nothing is pending).
- During a grace window, deliveries are signed with every valid secret and the `x-metagraph-signature` header carries a comma separated list, so a consumer can verify against either while it rolls over. A subscription with one secret keeps the exact same single signature format as before.
- Rotate and revoke authenticate with the subscription secret in the `x-metagraph-webhook-secret` header, matching the existing delete flow. `grace_seconds` is configurable (default 24h, capped at 30 days); a value of `0` retires the old secret immediately, which is the right move when the active secret is known to have leaked.
- `GET` now surfaces rotation metadata (`rotated_at`, `previous_secret_expires_at`) and still never returns any secret value.
- Factored out shared load plus authenticate and persist helpers so delete, rotate, and revoke no longer repeat the same prologue.
- Added unit coverage for the new signing, rotation, and revocation helpers and route level coverage for the full create, rotate, grace, revoke, delete lifecycle. Changed code is fully covered.

Note: the webhook management routes are not part of the OpenAPI contract (consistent with the existing create, get, and delete routes), so no generated artifacts change.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
