### PR TITLE
feat(chain): prev/next block chain-walk links in block detail

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1808,9 +1808,11 @@ export interface components {
             parent_hash?: string | null;
             spec_version?: number | null;
         };
-        /** @description Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file). */
+        /** @description Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file). prev_block_number/next_block_number (#1853) are the nearest STORED neighbors for chain-walk navigation (skip pruned gaps; null at the window edges or when block is null). */
         BlockDetailArtifact: {
             block: components["schemas"]["Block"] | null;
+            next_block_number?: number | null;
+            prev_block_number?: number | null;
             ref?: string | null;
             schema_version: number;
         } & {
@@ -6190,6 +6192,8 @@ export interface operations {
                      *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "spec_version": 1
                      *         },
+                     *         "next_block_number": 5000000,
+                     *         "prev_block_number": 5000000,
                      *         "ref": "example",
                      *         "schema_version": 1
                      *       },

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.6.13",
+      "version": "0.6.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1606,7 +1606,7 @@
       },
       "BlockDetailArtifact": {
         "additionalProperties": true,
-        "description": "Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file).",
+        "description": "Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file). prev_block_number/next_block_number (#1853) are the nearest STORED neighbors for chain-walk navigation (skip pruned gaps; null at the window edges or when block is null).",
         "properties": {
           "block": {
             "oneOf": [
@@ -1616,6 +1616,18 @@
               {
                 "type": "null"
               }
+            ]
+          },
+          "next_block_number": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "prev_block_number": {
+            "type": [
+              "integer",
+              "null"
             ]
           },
           "ref": {
@@ -14791,6 +14803,8 @@
                       "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                       "spec_version": 1
                     },
+                    "next_block_number": 5000000,
+                    "prev_block_number": 5000000,
                     "ref": "example",
                     "schema_version": 1
                   },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1808,9 +1808,11 @@ export interface components {
             parent_hash?: string | null;
             spec_version?: number | null;
         };
-        /** @description Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file). */
+        /** @description Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file). prev_block_number/next_block_number (#1853) are the nearest STORED neighbors for chain-walk navigation (skip pruned gaps; null at the window edges or when block is null). */
         BlockDetailArtifact: {
             block: components["schemas"]["Block"] | null;
+            next_block_number?: number | null;
+            prev_block_number?: number | null;
             ref?: string | null;
             schema_version: number;
         } & {
@@ -6190,6 +6192,8 @@ export interface operations {
                      *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "spec_version": 1
                      *         },
+                     *         "next_block_number": 5000000,
+                     *         "prev_block_number": 5000000,
                      *         "ref": "example",
                      *         "schema_version": 1
                      *       },

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -1592,7 +1592,7 @@
       },
       "BlockDetailArtifact": {
         "additionalProperties": true,
-        "description": "Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file).",
+        "description": "Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file). prev_block_number/next_block_number (#1853) are the nearest STORED neighbors for chain-walk navigation (skip pruned gaps; null at the window edges or when block is null).",
         "properties": {
           "block": {
             "oneOf": [
@@ -1602,6 +1602,18 @@
               {
                 "type": "null"
               }
+            ]
+          },
+          "next_block_number": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "prev_block_number": {
+            "type": [
+              "integer",
+              "null"
             ]
           },
           "ref": {

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1765,7 +1765,7 @@
       "BlockDetailArtifact": {
         "type": "object",
         "additionalProperties": true,
-        "description": "Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file).",
+        "description": "Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file). prev_block_number/next_block_number (#1853) are the nearest STORED neighbors for chain-walk navigation (skip pruned gaps; null at the window edges or when block is null).",
         "required": ["schema_version", "block"],
         "properties": {
           "schema_version": { "type": "integer" },
@@ -1775,7 +1775,9 @@
               { "$ref": "#/components/schemas/Block" },
               { "type": "null" }
             ]
-          }
+          },
+          "prev_block_number": { "type": ["integer", "null"] },
+          "next_block_number": { "type": ["integer", "null"] }
         }
       },
       "BlockExtrinsicsArtifact": {

--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -108,12 +108,18 @@ export function formatBlock(row) {
 
 // Per-block detail artifact. `block` is null when the ref didn't resolve (cold
 // store or unknown block) — schema-stable, never throws (mirrors the neuron
-// detail route's `neuron:null`).
-export function buildBlock(row, ref) {
+// detail route's `neuron:null`). prev/next_block_number (#1853) are the nearest
+// STORED neighbors for chain-walk nav (the handler computes them, skipping pruned
+// gaps); both null when the block is null or at a window edge. parent_hash (on the
+// block object) already provides the backward hash edge.
+export function buildBlock(row, ref, { prev, next } = {}) {
+  const block = formatBlock(row);
   return {
     schema_version: 1,
     ref: ref ?? null,
-    block: formatBlock(row),
+    block,
+    prev_block_number: block ? (prev ?? null) : null,
+    next_block_number: block ? (next ?? null) : null,
   };
 }
 

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -242,7 +242,7 @@ function req(path) {
 }
 
 // A D1 mock that routes by SQL shape so the block handlers get realistic rows.
-function dbWith({ feed, detail } = {}) {
+function dbWith({ feed, detail, neighbors } = {}) {
   return {
     METAGRAPH_HEALTH_DB: {
       prepare(sql) {
@@ -250,6 +250,9 @@ function dbWith({ feed, detail } = {}) {
           bind() {
             return {
               async all() {
+                // prev/next neighbor query (#1853): the MAX/MIN CASE aggregate.
+                if (/MAX\(CASE WHEN block_number </.test(sql))
+                  return { results: [neighbors || { prev: null, next: null }] };
                 if (/LIMIT \? OFFSET \?/.test(sql))
                   return { results: feed || [] };
                 if (/WHERE block_hash = \?|WHERE block_number = \?/.test(sql))
@@ -366,6 +369,28 @@ test("GET /blocks/{number} returns detail by block_number (#1345)", async () => 
   assert.equal(body.data.block.block_hash, "0xabc");
 });
 
+test("GET /blocks/{ref} emits nearest stored prev/next neighbors (#1853)", async () => {
+  const env = dbWith({
+    detail: { block_number: 1234, block_hash: "0xabc", observed_at: 1 },
+    neighbors: { prev: 1230, next: 1240 }, // gaps skipped (pruned/missing)
+  });
+  const res = await handleRequest(req("/api/v1/blocks/1234"), env, {});
+  const body = await res.json();
+  assert.equal(body.data.prev_block_number, 1230);
+  assert.equal(body.data.next_block_number, 1240);
+});
+
+test("GET /blocks/{ref} nulls neighbors at a window edge (#1853)", async () => {
+  const env = dbWith({
+    detail: { block_number: 1, block_hash: "0x1", observed_at: 1 },
+    neighbors: { prev: null, next: 2 }, // oldest stored block: no prev
+  });
+  const res = await handleRequest(req("/api/v1/blocks/1"), env, {});
+  const body = await res.json();
+  assert.equal(body.data.prev_block_number, null);
+  assert.equal(body.data.next_block_number, 2);
+});
+
 test("GET /blocks/{hash} resolves a 0x block_hash ref (#1345)", async () => {
   const hash = `0x${"a".repeat(64)}`;
   const env = dbWith({
@@ -388,6 +413,9 @@ test("GET /blocks/{ref} is schema-stable when cold (block:null, never 404)", asy
   const body = await res.json();
   assert.equal(body.data.ref, "777");
   assert.equal(body.data.block, null);
+  // No anchor when the block didn't resolve → neighbors null (#1853).
+  assert.equal(body.data.prev_block_number, null);
+  assert.equal(body.data.next_block_number, null);
 });
 
 test("GET /blocks is schema-stable when D1 is cold (never 404)", async () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -720,7 +720,23 @@ export async function handleBlock(request, env, ref) {
     : `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_number = ? LIMIT 1`;
   const param = isHash ? ref : Number(ref);
   const rows = await d1All(env, sql, [param]);
-  const data = buildBlock(rows[0], ref);
+  // prev/next chain-walk neighbors (#1853): one bounded query for the nearest
+  // STORED block numbers around the resolved height (skips pruned gaps; null at
+  // the window edges). Derived from the resolved row's number (works for the hash
+  // path too). Only when the block resolved — a cold/unknown ref has no anchor.
+  let prev = null;
+  let next = null;
+  const resolvedNumber = rows[0]?.block_number;
+  if (Number.isInteger(resolvedNumber)) {
+    const nbr = await d1All(
+      env,
+      `SELECT MAX(CASE WHEN block_number < ? THEN block_number END) AS prev, MIN(CASE WHEN block_number > ? THEN block_number END) AS next FROM blocks`,
+      [resolvedNumber, resolvedNumber],
+    );
+    prev = nbr[0]?.prev ?? null;
+    next = nbr[0]?.next ?? null;
+  }
+  const data = buildBlock(rows[0], ref, { prev, next });
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
Closes #1853

## What

Block detail (`/api/v1/blocks/{ref}`) materialized no navigation — a user on block N had no link to N±1. Adds `prev_block_number` / `next_block_number`.

## Design

- One bounded query for the nearest **stored** neighbors: `SELECT MAX(CASE WHEN block_number < ? THEN block_number END) AS prev, MIN(CASE WHEN block_number > ? THEN block_number END) AS next FROM blocks` (2 binds, `block_number` PK index). Returns the nearest stored numbers — **skips pruned gaps** and yields `null` at the window edges, so no dead links.
- Derived from the **resolved row's** `block_number`, so the `0x`-hash path works too.
- Both `null` when `block` is `null` (cold/unknown ref) — no anchor.
- `buildBlock` takes an optional `{prev, next}`; the handler owns the D1 read (builders stay pure). `parent_hash` already provides the backward hash edge.
- `BlockDetailArtifact` gains the two fields; one extra point-lookup per detail hit ("short" cache).

No migration.

## Verification

- contract-drift / client-sdk-sync (0.6.13→0.6.14) / api (81) / openapi / public-safety / lint / format → pass
- vitest blocks / contracts / invariants → 52 passed (mid-window neighbors with gaps skipped, edge→null, cold ref→both null)

Part of #1345 (explorer robustness wave).