### PR TITLE
feat(chain): capture the extrinsic priority tip

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -2423,7 +2423,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
-        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
+        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); tip_tao is the priority tip in TAO (#1855, separate from fee_tao; nullable, commonly 0); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
         Extrinsic: {
             block_number: number | null;
             call_args?: Record<string, never> | unknown[] | null;
@@ -2436,6 +2436,7 @@ export interface components {
             observed_at?: string | null;
             signer?: string | null;
             success?: boolean | null;
+            tip_tao?: number | null;
         };
         /** @description Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. events (#1849) are the indexed account_events this extrinsic emitted (bounded to 50; empty for pre-migration rows, non-ApplyExtrinsic events, or a cold store). Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file). */
         ExtrinsicDetailArtifact: {
@@ -8481,7 +8482,8 @@ export interface operations {
                      *           "fee_tao": 0.5,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
                      *           "signer": "example",
-                     *           "success": false
+                     *           "success": false,
+                     *           "tip_tao": 0.5
                      *         },
                      *         "ref": "example",
                      *         "schema_version": 1

--- a/migrations/0019_extrinsic_tip_tao.sql
+++ b/migrations/0019_extrinsic_tip_tao.sql
@@ -1,0 +1,11 @@
+-- Block explorer extrinsic depth (#1855): store the priority tip per extrinsic so
+-- detail pages can show it alongside the inclusion fee, and tip-based analytics
+-- become possible.
+--
+-- tip_tao is the `tip` (3rd field) from TransactionPayment.TransactionFeePaid,
+-- converted from rao to TAO. Separate from fee_tao (the inclusion fee). Nullable:
+-- inherents, unsigned extrinsics, and the common no-tip case store null/0. Applied
+-- as an idempotent ALTER (nullable column never breaks existing rows or the
+-- INSERT OR IGNORE load path) — populates going forward only.
+
+ALTER TABLE extrinsics ADD COLUMN tip_tao REAL;

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -4118,7 +4118,7 @@
       },
       "Extrinsic": {
         "additionalProperties": false,
-        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
+        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); tip_tao is the priority tip in TAO (#1855, separate from fee_tao; nullable, commonly 0); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
         "properties": {
           "block_number": {
             "type": [
@@ -4179,6 +4179,12 @@
           "success": {
             "type": [
               "boolean",
+              "null"
+            ]
+          },
+          "tip_tao": {
+            "type": [
+              "number",
               "null"
             ]
           }
@@ -18329,7 +18335,8 @@
                       "fee_tao": 0.5,
                       "observed_at": "2026-06-01T00:00:00.000Z",
                       "signer": "example",
-                      "success": false
+                      "success": false,
+                      "tip_tao": 0.5
                     },
                     "ref": "example",
                     "schema_version": 1

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2423,7 +2423,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
-        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
+        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); tip_tao is the priority tip in TAO (#1855, separate from fee_tao; nullable, commonly 0); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
         Extrinsic: {
             block_number: number | null;
             call_args?: Record<string, never> | unknown[] | null;
@@ -2436,6 +2436,7 @@ export interface components {
             observed_at?: string | null;
             signer?: string | null;
             success?: boolean | null;
+            tip_tao?: number | null;
         };
         /** @description Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), from the first-party extrinsics D1 tier. The composite id is the guaranteed-present identifier since the hash is best-effort/nullable. events (#1849) are the indexed account_events this extrinsic emitted (bounded to 50; empty for pre-migration rows, non-ApplyExtrinsic events, or a cold store). Served live at /api/v1/extrinsics/{hash}; extrinsic is null when the ref is unknown/malformed or the store is cold (no static file). */
         ExtrinsicDetailArtifact: {
@@ -8481,7 +8482,8 @@ export interface operations {
                      *           "fee_tao": 0.5,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
                      *           "signer": "example",
-                     *           "success": false
+                     *           "success": false,
+                     *           "tip_tao": 0.5
                      *         },
                      *         "ref": "example",
                      *         "schema_version": 1

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -4104,7 +4104,7 @@
       },
       "Extrinsic": {
         "additionalProperties": false,
-        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
+        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); tip_tao is the priority tip in TAO (#1855, separate from fee_tao; nullable, commonly 0); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
         "properties": {
           "block_number": {
             "type": [
@@ -4165,6 +4165,12 @@
           "success": {
             "type": [
               "boolean",
+              "null"
+            ]
+          },
+          "tip_tao": {
+            "type": [
+              "number",
               "null"
             ]
           }

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1819,7 +1819,7 @@
       "Extrinsic": {
         "type": "object",
         "additionalProperties": false,
-        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
+        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); tip_tao is the priority tip in TAO (#1855, separate from fee_tao; nullable, commonly 0); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
         "required": ["block_number", "extrinsic_index"],
         "properties": {
           "block_number": { "type": ["integer", "null"] },
@@ -1830,6 +1830,7 @@
           "call_function": { "type": ["string", "null"] },
           "call_args": { "type": ["object", "array", "null"] },
           "fee_tao": { "type": ["number", "null"] },
+          "tip_tao": { "type": ["number", "null"] },
           "success": { "type": ["boolean", "null"] },
           "observed_at": { "type": ["string", "null"], "format": "date-time" }
         }

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -452,6 +452,41 @@ def _fee_map(events):
     return out
 
 
+def _tip_map(events):
+    """Map extrinsic_index -> tip_tao from TransactionPayment.TransactionFeePaid events (#1855).
+
+    tip is the priority tip the signer added on top of the inclusion fee (the 3rd
+    field of TransactionFeePaid: [who, actual_fee, tip]). Separate from fee_tao —
+    most extrinsics tip 0. Correlated by extrinsic_idx, same as _fee_map. NEVER raises.
+    """
+    out = {}
+    try:
+        for ev in events:
+            v = ev.value if isinstance(ev.value, dict) else {}
+            if v.get("phase") != "ApplyExtrinsic":
+                continue
+            e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
+            if e.get("module_id") != "TransactionPayment":
+                continue
+            if e.get("event_id") != "TransactionFeePaid":
+                continue
+            idx = v.get("extrinsic_idx")
+            if not isinstance(idx, int) or idx < 0:
+                continue
+            attrs = e.get("attributes")
+            if isinstance(attrs, dict):
+                tip_rao = attrs.get("tip")
+            elif isinstance(attrs, list) and len(attrs) > 2:
+                tip_rao = attrs[2]  # [who, actual_fee, tip]
+            else:
+                tip_rao = None
+            if tip_rao is not None:
+                out[idx] = _tao(tip_rao)
+    except Exception:
+        return out
+    return out
+
+
 def _extrinsic_success_map(events):
     """Map extrinsic_index -> success(1/0) from the block's already-decoded events.
 
@@ -504,6 +539,7 @@ def extrinsics_for_block(s, bn, bh, events):
         return rows
     success_map = _extrinsic_success_map(events)
     fee_map = _fee_map(events)
+    tip_map = _tip_map(events)
     for extrinsic_index, ext in enumerate(extrinsics):
         try:
             value = ext.value if ext is not None else None
@@ -522,6 +558,7 @@ def extrinsics_for_block(s, bn, bh, events):
                     "call_args": call_args,
                     "success": success_map.get(extrinsic_index),
                     "fee_tao": fee_map.get(extrinsic_index),
+                    "tip_tao": tip_map.get(extrinsic_index),
                 }
             )
         except Exception:

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -269,5 +269,70 @@ class TransferExtractorTest(unittest.TestCase):
         self.assertIsNone(result["amount_tao"])
 
 
+class _Ev:
+    """Minimal stand-in for a decoded event (`.value` is the SCALE-decoded dict)."""
+
+    def __init__(self, value):
+        self.value = value
+
+
+def _fee_paid(idx, fee_rao, tip_rao):
+    return _Ev(
+        {
+            "phase": "ApplyExtrinsic",
+            "extrinsic_idx": idx,
+            "event": {
+                "module_id": "TransactionPayment",
+                "event_id": "TransactionFeePaid",
+                "attributes": ["5Who", fee_rao, tip_rao],
+            },
+        }
+    )
+
+
+class TipMapTest(unittest.TestCase):
+    def test_tip_map_reads_the_third_attribute(self):
+        # tip is the 3rd field [who, actual_fee, tip]; converted rao -> TAO (#1855).
+        tip_map = _fe._tip_map([_fee_paid(0, 12_500_000, 500_000_000)])
+        self.assertAlmostEqual(tip_map[0], 0.5)
+
+    def test_tip_map_dict_attributes(self):
+        ev = _Ev(
+            {
+                "phase": "ApplyExtrinsic",
+                "extrinsic_idx": 3,
+                "event": {
+                    "module_id": "TransactionPayment",
+                    "event_id": "TransactionFeePaid",
+                    "attributes": {"who": "5Who", "actual_fee": 1, "tip": 2_000_000_000},
+                },
+            }
+        )
+        self.assertAlmostEqual(_fe._tip_map([ev])[3], 2.0)
+
+    def test_tip_map_ignores_non_feepaid_and_non_apply_phase(self):
+        other_module = _Ev(
+            {
+                "phase": "ApplyExtrinsic",
+                "extrinsic_idx": 0,
+                "event": {"module_id": "Balances", "event_id": "Transfer", "attributes": []},
+            }
+        )
+        init_phase = _Ev(
+            {
+                "phase": "Initialization",
+                "event": {
+                    "module_id": "TransactionPayment",
+                    "event_id": "TransactionFeePaid",
+                    "attributes": ["5Who", 1, 2],
+                },
+            }
+        )
+        self.assertEqual(_fe._tip_map([other_module, init_phase]), {})
+
+    def test_tip_map_never_raises_on_shape_drift(self):
+        self.assertEqual(_fe._tip_map([_Ev("not-a-dict"), _Ev({})]), {})
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -22,6 +22,10 @@ export const EXTRINSIC_INSERT_COLUMNS = [
   "call_args",
   "success",
   "fee_tao",
+  // The priority tip (TransactionFeePaid 3rd field), in TAO (#1855). Separate
+  // from fee_tao; most extrinsics tip 0. Nullable. 11 cols now → ROWS_PER_STMT
+  // drops to 9 (11 x 9 = 99 bound params, under D1's 100 ceiling).
+  "tip_tao",
   "observed_at",
 ];
 
@@ -46,14 +50,14 @@ export function validExtrinsicRows(rows) {
 }
 
 // Build parameterized INSERT OR IGNORE statements for extrinsics rows, chunked
-// under D1's 100-bound-param limit (10 cols x 10 = 100). Idempotent on
+// under D1's 100-bound-param limit (11 cols x 9 = 99). Idempotent on
 // (block_number, extrinsic_index) (the primary key). Values are ALWAYS bound,
 // never interpolated — a tampered payload can only fail, never inject. Mirrors
 // blockInsertStatements (#1345).
 export function extrinsicInsertStatements(db, rows) {
   const cols = EXTRINSIC_INSERT_COLUMNS;
   const colList = cols.join(",");
-  const ROWS_PER_STMT = 10;
+  const ROWS_PER_STMT = 9;
   const statements = [];
   for (let i = 0; i < rows.length; i += ROWS_PER_STMT) {
     const chunk = rows.slice(i, i + ROWS_PER_STMT);
@@ -95,7 +99,7 @@ export async function pruneExtrinsics(env, overrides = {}) {
 // ---- Extrinsic API builders ------------------------------------------------
 // The columns the extrinsic handlers SELECT for an extrinsic row.
 export const EXTRINSIC_READ_COLUMNS =
-  "block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args, success, fee_tao, observed_at";
+  "block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args, success, fee_tao, tip_tao, observed_at";
 
 // One D1 extrinsics row → a clean API extrinsic object. Null-safe on junk/sparse
 // rows. success is normalized to a boolean (null when undeterminable).
@@ -119,6 +123,7 @@ export function formatExtrinsic(row) {
     call_args,
     success: row.success == null ? null : row.success === 1,
     fee_tao: row.fee_tao ?? null,
+    tip_tao: row.tip_tao ?? null,
     observed_at: toIso(row.observed_at),
   };
 }

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -16,7 +16,7 @@ import { encodeCursor } from "../src/cursor.mjs";
 
 // ---- Pure module (#1345) ---------------------------------------------------
 
-test("EXTRINSIC_INSERT_COLUMNS is the stable load contract (#1345)", () => {
+test("EXTRINSIC_INSERT_COLUMNS is the stable load contract (#1345/#1855)", () => {
   assert.deepEqual(EXTRINSIC_INSERT_COLUMNS, [
     "block_number",
     "extrinsic_index",
@@ -27,8 +27,11 @@ test("EXTRINSIC_INSERT_COLUMNS is the stable load contract (#1345)", () => {
     "call_args",
     "success",
     "fee_tao",
+    "tip_tao",
     "observed_at",
   ]);
+  // 11 cols x ROWS_PER_STMT(9) = 99 bound params — under D1's 100 ceiling.
+  assert.equal(EXTRINSIC_INSERT_COLUMNS.length, 11);
 });
 
 test("validExtrinsicRows enforces the strict row shape (#1345)", () => {
@@ -73,13 +76,13 @@ test("extrinsicInsertStatements builds chunked parameterized INSERT OR IGNORE", 
     observed_at: 1,
   }));
   const stmts = extrinsicInsertStatements(db, rows);
-  // 30 rows / 10 per statement = 3 statements (10, 10, 10)
-  assert.equal(stmts.length, 3);
+  // 30 rows / 9 per statement = 4 statements (9, 9, 9, 3)
+  assert.equal(stmts.length, 4);
   assert.ok(prepared[0].startsWith("INSERT OR IGNORE INTO extrinsics ("));
   assert.ok(prepared[0].includes("VALUES (?"));
-  // Every value is BOUND (10 cols x 10 rows = 100 params on a full chunk, <=100).
-  assert.equal(stmts[0].v.length, 10 * 10);
-  // All ten columns appear in the column list.
+  // Every value is BOUND (11 cols x 9 rows = 99 params on a full chunk, <=100).
+  assert.equal(stmts[0].v.length, 11 * 9);
+  // All eleven columns appear in the column list.
   for (const col of EXTRINSIC_INSERT_COLUMNS) {
     assert.ok(prepared[0].includes(col), `missing ${col}`);
   }
@@ -94,8 +97,20 @@ test("extrinsicInsertStatements binds missing fields as null (never interpolates
   const [stmt] = extrinsicInsertStatements(db, [
     { block_number: 7, extrinsic_index: 2, observed_at: 9 },
   ]);
-  // extrinsic_hash, signer, call_module, call_function, call_args, success, fee_tao default to null.
-  assert.deepEqual(stmt.v, [7, 2, null, null, null, null, null, null, null, 9]);
+  // hash, signer, call_module, call_function, call_args, success, fee_tao, tip_tao default to null.
+  assert.deepEqual(stmt.v, [
+    7,
+    2,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    9,
+  ]);
 });
 
 test("formatExtrinsic maps a D1 row to an API extrinsic (ISO time, bool success)", () => {
@@ -108,6 +123,7 @@ test("formatExtrinsic maps a D1 row to an API extrinsic (ISO time, bool success)
     call_function: "add_stake",
     call_args: '[{"name":"hotkey","value":"5H..."}]',
     fee_tao: 0.0125,
+    tip_tao: 0.5,
     success: 1,
     observed_at: 1750000000000,
   });
@@ -119,6 +135,7 @@ test("formatExtrinsic maps a D1 row to an API extrinsic (ISO time, bool success)
   assert.equal(out.call_function, "add_stake");
   assert.deepEqual(out.call_args, [{ name: "hotkey", value: "5H..." }]);
   assert.equal(out.fee_tao, 0.0125);
+  assert.equal(out.tip_tao, 0.5);
   assert.equal(out.success, true);
   assert.equal(out.observed_at, new Date(1750000000000).toISOString());
 });


### PR DESCRIPTION
Closes #1855

## What

`_fee_map` already read `TransactionFeePaid`'s `actual_fee` but discarded the 3rd field — the **priority tip** the signer adds on top of the inclusion fee. Captures it as a first-class column so extrinsic detail can show it and tip analytics become possible.

## Changes

- **`_tip_map`** (mirrors `_fee_map`): reads `attrs[2]` / dict `"tip"`, rao→TAO, correlated by `extrinsic_idx`. `extrinsics_for_block` attaches `tip_tao`.
- **Migration 0019** — `extrinsics.tip_tao REAL` (nullable). **Already applied to prod** (verified column live) before this lands, since the new `INSERT`/`SELECT` reference it.
- Load contract: `EXTRINSIC_INSERT_COLUMNS` 10→11; `ROWS_PER_STMT` 10→9 (11×9 = 99 bound params, under D1's 100 ceiling); `EXTRINSIC_READ_COLUMNS` + `formatExtrinsic` surface `tip_tao`.
- `Extrinsic` schema gains `tip_tao` (`number|null`); contract regen.

## Scope

`tip` is **separate** from `fee_tao` (priority tip vs inclusion fee; most extrinsics tip 0). Populates going forward only (`INSERT OR IGNORE`).

**nonce was considered and deferred:** it lives under the signed extrinsic's signature/era (not a flat key) and is absent for unsigned extrinsics — fragile to decode for marginal value (P3). This ships tip only, as the issue recommends.

## Verification

- contract-drift / client-sdk-sync (0.6.14→0.6.15) / api (81) / openapi / migrations (19) / public-safety / lint / format → pass
- vitest extrinsics / blocks / load-staged / contracts / invariants → 100 passed (11-col contract, 99-param/4-chunk math, `tip_tao` surfaced + null-default)
- `python -m unittest` → 33 passed (incl. new `_tip_map`: list + dict attrs, phase/module guards, shape-drift never-raises)
- prod `PRAGMA` confirms `tip_tao`

Part of #1345 (explorer robustness wave).