### PR TITLE
feat(registry): add SN18 Zeus docs, benchmark paper, forecast map, and two repos

### DIFF
--- a/registry/subnets/sn-18.json
+++ b/registry/subnets/sn-18.json
@@ -9,7 +9,88 @@
     "level": "candidate-discovered",
     "review_state": "unreviewed"
   },
-  "surfaces": [],
+  "surfaces": [
+    {
+      "id": "sn-18-zeus-docs",
+      "name": "Zeus BOREAS Edge API documentation",
+      "kind": "docs",
+      "url": "https://docs.zeussubnet.com/docs/introduction",
+      "provider": "zeus",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://www.zeussubnet.com/"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Official Zeus documentation site (BOREAS Edge API reference), linked from the project homepage www.zeussubnet.com."
+    },
+    {
+      "id": "sn-18-zeus-benchmark-paper",
+      "name": "Zeus V2 benchmark paper",
+      "kind": "docs",
+      "url": "https://www.zeussubnet.com/news-and-updates/ZEUS_V2_Benchmark.pdf",
+      "provider": "zeus",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://www.zeussubnet.com/"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Official ZEUS V2 benchmark paper (application/pdf) on the project domain, linked from the homepage."
+    },
+    {
+      "id": "sn-18-zeus-forecast-map",
+      "name": "Zeus forecast map",
+      "kind": "dashboard",
+      "url": "https://www.zeussubnet.com/map",
+      "provider": "zeus",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://www.zeussubnet.com/"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Team-run Zeus forecast map (page title \"Forecast map | Zeus\"), linked from the homepage."
+    },
+    {
+      "id": "sn-18-zeus-benchmarking-repo",
+      "name": "Zeus benchmarking repository",
+      "kind": "source-repo",
+      "url": "https://github.com/Orpheus-AI/SN18-Benchmarking",
+      "provider": "zeus",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Orpheus-AI/SN18-Benchmarking"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Zeus (SN18) benchmarking repo (description: \"Repository to share benchmarks regarding Zeus\") in the team's Orpheus-AI org. Distinct from the top-level Orpheus-AI/Zeus repo."
+    },
+    {
+      "id": "sn-18-zeus-aurora-repo",
+      "name": "Zeus SN18 Aurora repository",
+      "kind": "source-repo",
+      "url": "https://github.com/Orpheus-AI/Zeus-SN18-Aurora",
+      "provider": "zeus",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Orpheus-AI/Zeus-SN18-Aurora"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Public Zeus (SN18) Aurora repository in the team's Orpheus-AI org. Distinct from the top-level Orpheus-AI/Zeus repo."
+    }
+  ],
   "social": {
     "x": "https://x.com/zeussubnet"
   },


### PR DESCRIPTION
## Summary

Populates the empty `surfaces[]` of `registry/subnets/sn-18.json` (Zeus, SN18, by Orpheus-AI) with five first-party public surfaces from the `zeussubnet.com` domain and the team's `Orpheus-AI` GitHub org.

Related to surface enrichment epic #427.

## Surfaces (all verified live + first-party + non-callable)

| kind | url | verification |
| --- | --- | --- |
| `docs` | `https://docs.zeussubnet.com/docs/introduction` | HTTP 200; BOREAS Edge API docs site |
| `docs` | `https://www.zeussubnet.com/news-and-updates/ZEUS_V2_Benchmark.pdf` | HTTP 200, `application/pdf` |
| `dashboard` | `https://www.zeussubnet.com/map` | HTTP 200; page title "Forecast map \| Zeus" |
| `source-repo` | `https://github.com/Orpheus-AI/SN18-Benchmarking` | public, not a fork, not archived |
| `source-repo` | `https://github.com/Orpheus-AI/Zeus-SN18-Aurora` | public, not a fork, not archived |

**Provider:** `zeus` (already registered — `registry/providers/zeus.json`, github `Orpheus-AI/Zeus`).

## First-party proof + netuid attribution

- The official homepage `https://www.zeussubnet.com/` (the subnet's registered `website_url`) links all three web surfaces: `docs.zeussubnet.com/docs/introduction`, `/news-and-updates/ZEUS_V2_Benchmark.pdf`, and `/map`.
- Both repos live in the team's `Orpheus-AI` org (the provider's registered github org); `SN18-Benchmarking` description is *"Repository to share benchmarks regarding Zeus"*, and both names carry **Zeus / SN18** — netuid-18 unambiguous.
- All surfaces are distinct from the top-level `source_repo` (`Orpheus-AI/Zeus`) and the empty `surfaces[]`.

## Validation run

```
npm run validate:surface -- registry/subnets/sn-18.json   # passed (5 surfaces)
npm run scan:public-safety                                # passed
npx prettier --check registry/subnets/sn-18.json          # clean
```

Single file changed; only community surfaces appended (`authority: community`, `review.state: community-submitted`); all kinds non-callable. Branch current with `main`. No health/verification set by hand.