### PR TITLE
feat(chain): persist the alpha leg on stake events

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1419,8 +1419,9 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows). */
+        /** @description One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); alpha_amount (#1856) is the alpha leg of a stake swap in TAO units (StakeAdded/StakeRemoved only, else null); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows). */
         AccountEvent: {
+            alpha_amount?: number | null;
             amount_tao?: number | null;
             block_number: number | null;
             coldkey?: string | null;

--- a/migrations/0020_account_events_alpha.sql
+++ b/migrations/0020_account_events_alpha.sql
@@ -1,0 +1,13 @@
+-- Bittensor stake semantics (#1856, Phase 1): persist the alpha leg of a stake
+-- swap that the poller already decodes but currently drops.
+--
+-- alpha_amount is the subnet alpha bought (StakeAdded) or sold (StakeRemoved),
+-- in TAO units (alpha_rao / 1e9), read from the 4th field of the Stake* event.
+-- Null for every non-stake event kind and for StakeMoved (no single alpha leg).
+-- Applied as an idempotent ALTER (nullable column never breaks existing rows or
+-- the INSERT OR IGNORE load path) — populates going forward only.
+--
+-- Phase 2 (realized alpha price / slippage) is deferred: it needs the subnet AMM
+-- reserves at the event's block, a poller-side state read, not a pure transform.
+
+ALTER TABLE account_events ADD COLUMN alpha_amount REAL;

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.6.15",
+      "version": "0.6.16",
       "license": "Apache-2.0",
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -154,8 +154,14 @@
       },
       "AccountEvent": {
         "additionalProperties": false,
-        "description": "One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows).",
+        "description": "One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); alpha_amount (#1856) is the alpha leg of a stake swap in TAO units (StakeAdded/StakeRemoved only, else null); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows).",
         "properties": {
+          "alpha_amount": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "amount_tao": {
             "type": [
               "number",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1419,8 +1419,9 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows). */
+        /** @description One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); alpha_amount (#1856) is the alpha leg of a stake swap in TAO units (StakeAdded/StakeRemoved only, else null); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows). */
         AccountEvent: {
+            alpha_amount?: number | null;
             amount_tao?: number | null;
             block_number: number | null;
             coldkey?: string | null;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -140,8 +140,14 @@
       },
       "AccountEvent": {
         "additionalProperties": false,
-        "description": "One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows).",
+        "description": "One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); alpha_amount (#1856) is the alpha leg of a stake swap in TAO units (StakeAdded/StakeRemoved only, else null); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows).",
         "properties": {
+          "alpha_amount": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "amount_tao": {
             "type": [
               "number",

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1489,7 +1489,7 @@
       "AccountEvent": {
         "type": "object",
         "additionalProperties": false,
-        "description": "One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows).",
+        "description": "One decoded chain event attributed to an account (#1347), from the first-party account_events D1 tier. amount_tao is a TAO float where applicable (stake events); alpha_amount (#1856) is the alpha leg of a stake swap in TAO units (StakeAdded/StakeRemoved only, else null); observed_at is the block time; extrinsic_index (#1849) is the 0-based index of the emitting extrinsic in the block (null for Initialization/Finalization events and pre-migration rows).",
         "required": ["block_number", "event_kind"],
         "properties": {
           "block_number": { "type": ["integer", "null"] },
@@ -1500,6 +1500,7 @@
           "netuid": { "type": ["integer", "null"] },
           "uid": { "type": ["integer", "null"] },
           "amount_tao": { "type": ["number", "null"] },
+          "alpha_amount": { "type": ["number", "null"] },
           "observed_at": { "type": ["string", "null"], "format": "date-time" },
           "extrinsic_index": { "type": ["integer", "null"] }
         }

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -187,6 +187,9 @@ def _stake(a):  # [coldkey, hotkey, tao_rao, alpha_rao, netuid, ...]
         "coldkey": _ss58(a[0]),
         "hotkey": _ss58(a[1]),
         "amount_tao": _tao(a[2]),
+        # The alpha leg of the swap (#1856): how much subnet alpha the TAO bought
+        # (StakeAdded) or sold (StakeRemoved). Null on shape drift / other kinds.
+        "alpha_amount": _tao(a[3]) if len(a) > 3 else None,
         "netuid": _idx(a[4]) if len(a) > 4 else None,
     }
 
@@ -580,6 +583,7 @@ def extract(event_id, attrs):
         "netuid": f.get("netuid"),
         "uid": f.get("uid"),
         "amount_tao": f.get("amount_tao"),
+        "alpha_amount": f.get("alpha_amount"),
     }
 
 
@@ -707,6 +711,7 @@ def main():
                     "netuid": ent["netuid"],
                     "uid": ent["uid"],
                     "amount_tao": ent["amount_tao"],
+                    "alpha_amount": ent["alpha_amount"],
                     "observed_at": observed_at,
                     "extrinsic_index": xidx,
                 }

--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -134,6 +134,7 @@ def decode_head(s, block_number):
                 "netuid": ent["netuid"],
                 "uid": ent["uid"],
                 "amount_tao": ent["amount_tao"],
+                "alpha_amount": ent["alpha_amount"],
                 "observed_at": head_ts if head_ts else None,
                 "extrinsic_index": xidx,
             }

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -334,5 +334,36 @@ class TipMapTest(unittest.TestCase):
         self.assertEqual(_fe._tip_map([_Ev("not-a-dict"), _Ev({})]), {})
 
 
+class StakeAlphaExtractorTest(unittest.TestCase):
+    """The alpha leg of stake events (#1856): _stake reads a[3] = alpha_rao."""
+
+    _ALPHA = 9_250_000_000  # 9.25 alpha (in rao units)
+
+    def test_stake_added_carries_the_alpha_leg(self):
+        # [coldkey, hotkey, tao_rao, alpha_rao, netuid]
+        result = _extract(
+            "StakeAdded", [_SS58_A, _SS58_B, _RAO_100, self._ALPHA, 7]
+        )
+        self.assertAlmostEqual(result["amount_tao"], 100.0)
+        self.assertAlmostEqual(result["alpha_amount"], 9.25)
+        self.assertEqual(result["netuid"], 7)
+
+    def test_stake_removed_carries_the_alpha_leg(self):
+        result = _extract(
+            "StakeRemoved", [_SS58_A, _SS58_B, _RAO_100, self._ALPHA, 7]
+        )
+        self.assertAlmostEqual(result["alpha_amount"], 9.25)
+
+    def test_missing_alpha_leg_is_null(self):
+        # A short payload (no a[3]) → alpha_amount null, never raises.
+        result = _extract("StakeAdded", [_SS58_A, _SS58_B, _RAO_100])
+        self.assertIsNone(result["alpha_amount"])
+
+    def test_non_stake_kind_has_no_alpha(self):
+        # Transfer carries no alpha leg → null (extract() defaults the key).
+        result = _extract("Transfer", [_SS58_A, _SS58_B, _RAO_100])
+        self.assertIsNone(result["alpha_amount"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -20,10 +20,13 @@ export const EVENT_INSERT_COLUMNS = [
   "netuid",
   "uid",
   "amount_tao",
+  // The alpha leg of a stake swap (#1856): subnet alpha bought/sold, in TAO units.
+  // Only StakeAdded/StakeRemoved carry it; null for every other kind. Display-only.
+  "alpha_amount",
   "observed_at",
   // The 0-based index of the extrinsic that emitted this event (#1849), read from
   // the event's phase=ApplyExtrinsic; null for Initialization/Finalization events.
-  // 10 cols x ROWS_PER_STMT(10) = 100 bound params — exactly D1's ceiling.
+  // 11 cols x ROWS_PER_STMT(9) = 99 bound params — under D1's 100 ceiling.
   "extrinsic_index",
 ];
 
@@ -56,6 +59,7 @@ export function formatAccountEvent(row) {
     netuid: row.netuid ?? null,
     uid: row.uid ?? null,
     amount_tao: row.amount_tao ?? null,
+    alpha_amount: row.alpha_amount ?? null,
     observed_at: toIso(row.observed_at),
     extrinsic_index: row.extrinsic_index ?? null,
   };
@@ -151,14 +155,14 @@ export function validEventRows(rows) {
 }
 
 // Build parameterized INSERT OR IGNORE statements for account_events rows, chunked
-// under D1's 100-bound-param limit (9 cols x 10 = 90). Idempotent on (block_number,
+// under D1's 100-bound-param limit (11 cols x 9 = 99). Idempotent on (block_number,
 // event_index). Values are ALWAYS bound, never interpolated — a tampered payload
 // can only fail, never inject. Shared by loadStagedEvents (#1346) + the ingest
 // endpoint (#1360).
 export function eventInsertStatements(db, rows) {
   const cols = EVENT_INSERT_COLUMNS;
   const colList = cols.join(",");
-  const ROWS_PER_STMT = 10;
+  const ROWS_PER_STMT = 9;
   const statements = [];
   for (let i = 0; i < rows.length; i += ROWS_PER_STMT) {
     const chunk = rows.slice(i, i + ROWS_PER_STMT);
@@ -180,7 +184,7 @@ export function eventInsertStatements(db, rows) {
 // ---- Entity API builders (#1347) -------------------------------------------
 // The columns the account handlers SELECT for an event row.
 export const ACCOUNT_EVENT_COLUMNS =
-  "block_number, event_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, observed_at, extrinsic_index";
+  "block_number, event_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at, extrinsic_index";
 
 // One neurons-table row (subset) → an AccountRegistration: where this hotkey is
 // currently registered + staked (the live cross-subnet footprint).

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -58,7 +58,7 @@ test("eventInsertStatements builds chunked parameterized INSERT OR IGNORE", () =
   assert.ok(prepared[0].includes("VALUES (?"));
 });
 
-test("EVENT_INSERT_COLUMNS is the stable load contract (#1346/#1849)", () => {
+test("EVENT_INSERT_COLUMNS is the stable load contract (#1346/#1849/#1856)", () => {
   assert.deepEqual(EVENT_INSERT_COLUMNS, [
     "block_number",
     "event_index",
@@ -68,11 +68,12 @@ test("EVENT_INSERT_COLUMNS is the stable load contract (#1346/#1849)", () => {
     "netuid",
     "uid",
     "amount_tao",
+    "alpha_amount",
     "observed_at",
     "extrinsic_index",
   ]);
-  // 10 cols x ROWS_PER_STMT(10) = 100 bound params — exactly D1's ceiling.
-  assert.equal(EVENT_INSERT_COLUMNS.length, 10);
+  // 11 cols x ROWS_PER_STMT(9) = 99 bound params — under D1's 100 ceiling.
+  assert.equal(EVENT_INSERT_COLUMNS.length, 11);
 });
 
 test("INDEXED_EVENT_KINDS covers the core entity events", () => {
@@ -97,11 +98,13 @@ test("formatAccountEvent maps a D1 row to an API event (ISO time)", () => {
     netuid: 1,
     uid: null,
     amount_tao: 12.5,
+    alpha_amount: 9.25,
     observed_at: 1750000000000,
     extrinsic_index: 2,
   });
   assert.equal(out.event_kind, "StakeAdded");
   assert.equal(out.amount_tao, 12.5);
+  assert.equal(out.alpha_amount, 9.25);
   assert.equal(out.observed_at, new Date(1750000000000).toISOString());
   assert.equal(out.extrinsic_index, 2);
 });


### PR DESCRIPTION
Closes #1856

## What

`StakeAdded`/`StakeRemoved` are a TAO↔alpha swap, but the poller emitted only the TAO leg (`amount_tao`) — the **alpha leg** (`a[3]` = `alpha_rao`) the `_stake` extractor already sees was dropped. Captures it (Phase 1).

## Changes

- `_stake` reads `a[3]` → `alpha_amount` (rao→TAO); `extract()` carries it through; the **fetch + stream** row builders both emit it (kept 1:1). Null for `StakeMoved` and all non-stake kinds.
- **Migration 0020** — `account_events.alpha_amount REAL` (nullable). **Already applied to prod** (verified column live) before this lands, since the new `INSERT`/`SELECT` reference it.
- Load contract: `EVENT_INSERT_COLUMNS` 10→11; `ROWS_PER_STMT` 10→9 (11×9 = 99 bound params, under D1's 100 ceiling); `ACCOUNT_EVENT_COLUMNS` + `formatAccountEvent` surface `alpha_amount`.
- `AccountEvent` schema gains `alpha_amount` (`number|null`); contract regen.

## Scope

Phase 1 (the alpha quantity) only. **Phase 2** — realized alpha price + slippage — is deferred: it needs the subnet AMM reserves at the event's block (a poller-side state read, not a pure transform). Populates going forward only (`INSERT OR IGNORE`).

## Verification

- contract-drift / client-sdk-sync (0.6.15→0.6.16) / migrations (20) / public-safety / lint / format → pass
- vitest account-events / account-routes / contracts / invariants → 57 passed (11-col contract, `alpha_amount` surfaced)
- `python -m unittest` → 37 passed (incl. `_stake` alpha leg: added/removed/short-payload→null/non-stake→null)
- prod `PRAGMA` confirms `alpha_amount`

Part of #1345 (explorer robustness wave) — the final one.