### PR TITLE
fix(api): match all whitespace-separated q terms on list endpoints

### DIFF
--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -212,3 +212,67 @@ describe("list-query numeric range filters", () => {
     assert.match(bad.error.message, /must be a number/);
   });
 });
+
+describe("list-query free-text search", () => {
+  const data = {
+    subnets: [
+      {
+        netuid: 1,
+        name: "Gradients Training",
+        slug: "gradients",
+      },
+      {
+        netuid: 2,
+        name: "Chutes",
+        slug: "chutes",
+      },
+      {
+        netuid: 3,
+        name: "Training Hub",
+        slug: "gradients-hub",
+      },
+    ],
+  };
+  const netuids = (result) => result.data.subnets.map((r) => r.netuid);
+
+  test("matches every whitespace-separated term independently across searchable fields", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?q=gradients%20training"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [1, 3]);
+  });
+
+  test("term order does not matter", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?q=training%20gradients"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [1, 3]);
+  });
+
+  test("a single term keeps substring semantics", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?q=chutes"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [2]);
+  });
+
+  test("whitespace-only q is treated as no search", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?q=%20%20"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [1, 2, 3]);
+  });
+
+  test("an absent q is a no-op", () => {
+    const result = applyQueryFilters(data, query("/api/v1/subnets"), "subnets");
+    assert.deepEqual(netuids(result), [1, 2, 3]);
+  });
+});

--- a/tests/subnets-query.test.mjs
+++ b/tests/subnets-query.test.mjs
@@ -36,6 +36,22 @@ test("subnets collection returns no rows when q matches neither name nor slug", 
   assert.equal(data.subnets.length, 0);
 });
 
+test("subnets collection matches each whitespace-separated q term across name and slug", () => {
+  const wide = {
+    subnets: [
+      { netuid: 1, name: "Gradients Training", slug: "gradients" },
+      { netuid: 4, name: "Targon", slug: "targon" },
+      { netuid: 64, name: "Training Hub", slug: "gradients-hub" },
+    ],
+  };
+  const url = new URL("https://x/api/v1/subnets?q=gradients%20training");
+  const { data } = applyQueryFilters(wide, url, "subnets", []);
+  assert.deepEqual(
+    data.subnets.map((s) => s.netuid),
+    [1, 64],
+  );
+});
+
 test("subnets collection passes the blob through unchanged with no query", () => {
   const url = new URL("https://x/api/v1/subnets");
   const { data } = applyQueryFilters(blob, url, "subnets", []);

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -148,18 +148,25 @@ function searchRows(rows, params, keys) {
   if (!q || keys.length === 0) {
     return rows;
   }
-  const needle = q.toLowerCase();
-  return rows.filter((row) =>
-    keys
+  const terms = q
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((term) => term.toLowerCase());
+  if (terms.length === 0) {
+    return rows;
+  }
+  return rows.filter((row) => {
+    const haystack = keys
       .flatMap((key) => {
         const value = row[key];
         return Array.isArray(value) ? value : [value];
       })
       .filter(Boolean)
       .join(" ")
-      .toLowerCase()
-      .includes(needle),
-  );
+      .toLowerCase();
+    return terms.every((term) => haystack.includes(term));
+  });
 }
 
 function sortRows(rows, params) {


### PR DESCRIPTION
## Summary
- Fix `searchRows` in `workers/list-query.mjs` so `?q=` splits on whitespace and requires **every** term to match somewhere in the collection's searchable fields (order-independent AND).
- Treat blank / whitespace-only `?q=` as no search instead of matching nearly every row.
- Add regression tests in `tests/list-query.test.mjs` and `tests/subnets-query.test.mjs`.

## Problem
`?q=gradients%20training` missed a subnet named "Gradients Training" because the old code searched for the literal phrase `gradients training` as one contiguous substring.

## Test plan
- [x] `npm test -- tests/list-query.test.mjs tests/subnets-query.test.mjs`
- [x] Runtime-only change — no schema/OpenAPI regeneration

Closes #1699
