### PR TITLE
enrich(registry): add Targon inventory API surface (SN4)

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 73,
+  "surface_count": 74,
   "surfaces": [
     {
       "auth_required": false,
@@ -155,6 +155,24 @@
       "surface_id": "opentensor-lite-wss",
       "surface_key": "srf-dcf48d017826dc4b",
       "url": "wss://lite.chain.opentensor.ai:443"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 4,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "targon",
+      "public_safe": true,
+      "subnet_name": "Targon",
+      "subnet_slug": "sn-4",
+      "surface_id": "sn-4-targon-subnet-api",
+      "surface_key": "srf-40be5162d95eb737",
+      "url": "https://api.targon.com/tha/v2/inventory"
     },
     {
       "auth_required": false,

--- a/registry/subnets/targon.json
+++ b/registry/subnets/targon.json
@@ -105,6 +105,24 @@
         "timeout_ms": 10000
       },
       "notes": "Official Targon source repository."
+    },
+    {
+      "id": "sn-4-targon-subnet-api",
+      "name": "Targon inventory API",
+      "kind": "subnet-api",
+      "url": "https://api.targon.com/tha/v2/inventory",
+      "provider": "targon",
+      "authority": "community",
+      "auth_required": false,
+      "public_safe": true,
+      "source_urls": ["https://docs.targon.com/api/inventory"],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": { "state": "community-submitted", "submitted_by": "nickmopen" }
     }
   ],
   "social": { "x": "https://x.com/targoncompute" },


### PR DESCRIPTION
## Summary

- Appends a community-submitted `subnet-api` surface to `registry/subnets/targon.json`
- URL: `https://api.targon.com/tha/v2/inventory` — public, no-auth, returns JSON inventory of compute resource types and pricing
- Source: `https://docs.targon.com/api/inventory` (official Targon API docs)
- Updates `public/metagraph/operational-surfaces.json` (`surface_count` 73 → 74, new entry for netuid 4)
- Updates hardcoded snapshot counts in `tests/artifacts.test.mjs` (+1 callable, +1 without schema, +1 subnet-api without schema)

Curation overlay (`notes`, `gap_notes`) left exactly as found — surface append only.

Closes #682