### PR TITLE
feat(registry): add SN18 Zeus public subnet-api surface

### DIFF
--- a/registry/subnets/sn-18.json
+++ b/registry/subnets/sn-18.json
@@ -1,18 +1,34 @@
 {
-  "schema_version": 1,
-  "netuid": 18,
-  "name": "Zeus",
-  "slug": "sn-18",
-  "status": "active",
   "categories": [],
   "curation": {
     "level": "candidate-discovered",
     "review_state": "unreviewed"
   },
-  "surfaces": [],
+  "name": "Zeus",
+  "netuid": 18,
+  "schema_version": 1,
+  "slug": "sn-18",
   "social": {
     "x": "https://x.com/zeussubnet"
   },
   "source_repo": "https://github.com/Orpheus-AI/Zeus",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-18-zeus-subnet-api",
+      "kind": "subnet-api",
+      "name": "Zeus subnet-api",
+      "provider": "zeus",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "gildardodev"
+      },
+      "source_urls": ["https://api.zeussubnet.com/openapi.json"],
+      "url": "https://api.zeussubnet.com/v1/meta"
+    }
+  ],
   "website_url": "https://www.zeussubnet.com/"
 }


### PR DESCRIPTION
Zeus (SN18) had no callable surface in the registry. This adds its public meta endpoint at api.zeussubnet.com/v1/meta, which returns the service identity as JSON with no auth. The endpoint is part of Zeus public BOREAS Edge API documented at api.zeussubnet.com/openapi.json.

Checked with npm run validate:surface and npm run scan:public-safety.