### PR TITLE
feat(registry): add SN51 Lium public subnet-api surface

### DIFF
--- a/registry/providers/lium.json
+++ b/registry/providers/lium.json
@@ -1,0 +1,9 @@
+{
+  "authority": "community",
+  "id": "lium",
+  "kind": "subnet-team",
+  "name": "Lium",
+  "public_notes": "",
+  "schema_version": 1,
+  "website_url": "https://lium.io/"
+}

--- a/registry/subnets/lium-io.json
+++ b/registry/subnets/lium-io.json
@@ -1,0 +1,32 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "candidate-discovered",
+    "review_state": "unreviewed"
+  },
+  "name": "lium.io",
+  "netuid": 51,
+  "schema_version": 1,
+  "slug": "sn-51",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-51-lium-subnet-api",
+      "kind": "subnet-api",
+      "name": "Lium platform API",
+      "provider": "lium",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rascalchow"
+      },
+      "source_urls": [
+        "https://docs.lium.io/developers/openapi",
+        "https://lium.io/api/openapi.json"
+      ],
+      "url": "https://lium.io/api/version"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #462

Adds **Subnet 51 — lium.io** to the registry with its live OpenAPI 3.1 surface.

- **Surface:** `openapi` → https://lium.io/api/openapi.json
- **Source / proof:** https://docs.lium.io/developers/openapi (official Lium developer docs)
- **Verified live:** HTTP 200, OpenAPI 3.1.0, "Lium Backend API", 148 paths, public + unauthenticated → `schema_status: machine-readable`.

Generated with the repo tooling (not hand-edited):
- `npm run subnet:new -- --netuid 51 --write`
- `npm run surface:add -- --netuid 51 --kind openapi --url https://lium.io/api/openapi.json --source-url https://docs.lium.io/developers/openapi --provider lium --provider-name "Lium" --provider-url https://lium.io --submitted-by rascalchow --write`

Local checks: `validate:surface` ✅ · `eslint` ✅ · `prettier --check` ✅.