### PR TITLE
feat(registry): add SN39 Basilica public subnet-api surface

### DIFF
--- a/registry/providers/basilica.json
+++ b/registry/providers/basilica.json
@@ -1,0 +1,10 @@
+{
+  "authority": "community",
+  "github_url": "https://github.com/one-covenant/basilica",
+  "id": "basilica",
+  "kind": "subnet-team",
+  "name": "Basilica",
+  "public_notes": "",
+  "schema_version": 1,
+  "website_url": "https://www.basilica.ai/"
+}

--- a/registry/subnets/basilica.json
+++ b/registry/subnets/basilica.json
@@ -110,6 +110,25 @@
       },
       "source_urls": ["https://www.basilica.ai/"],
       "url": "https://docs.basilica.ai/miners"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-39-basilica-subnet-api",
+      "kind": "subnet-api",
+      "name": "Basilica API health",
+      "notes": "Public, unauthenticated JSON health endpoint for the Basilica validator API (api.basilica.ai is the documented BASILICA_API_URL base). Returns service status, version, and validator counts.",
+      "provider": "basilica",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rascalchow"
+      },
+      "source_urls": [
+        "https://docs.basilica.ai/llms-full.txt",
+        "https://www.basilica.ai/"
+      ],
+      "url": "https://api.basilica.ai/health"
     }
   ],
   "website_url": "https://www.basilica.ai/"


### PR DESCRIPTION
## Summary
Enriches **SN39 Basilica** with a verified **public, unauthenticated `subnet-api` surface** and a debut provider stub for the Basilica team.

- **Endpoint:** `https://api.basilica.ai/health` — public, no auth, `application/json`. Returns `status`, `version`, and validator counts.
- **Proof it's official:** `api.basilica.ai` is the documented `BASILICA_API_URL` base in Basilica's own docs (`docs.basilica.ai/llms-full.txt`), cited as a `source_url`.
- Resolves the subnet's existing curation gap note: *"No verified safe public subnet API endpoint yet."*
- 
## Validation
- `validate:surface` ✅ (405 surfaces / 99 files)
- `validate:schemas` ✅
- `prettier --check` ✅
- Live verify (surface:add): `OK reachable + public-safe`

Closes #702