### PR TITLE
feat(registry): add SN17 404-GEN Blender add-on sdk surface (#1748)

### DIFF
--- a/registry/subnets/sn-17.json
+++ b/registry/subnets/sn-17.json
@@ -1,19 +1,39 @@
 {
-  "schema_version": 1,
-  "netuid": 17,
-  "name": "404—GEN",
-  "slug": "sn-17",
-  "status": "active",
   "categories": [],
+  "contact": "404@404.xyz",
   "curation": {
     "level": "candidate-discovered",
     "review_state": "unreviewed"
   },
-  "surfaces": [],
+  "name": "404—GEN",
+  "netuid": 17,
+  "schema_version": 1,
+  "slug": "sn-17",
   "social": {
     "x": "https://x.com/404gen_"
   },
-  "contact": "404@404.xyz",
   "source_repo": "https://github.com/404-Repo/404-gen-subnet",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-17-404-gen-sdk",
+      "kind": "sdk",
+      "name": "404—GEN Blender add-on",
+      "notes": "Official 404-Repo Blender add-on to generate SN17 3D assets directly in Blender; its README links the canonical 404-gen-subnet project repo.",
+      "provider": "404-gen",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "minion1227"
+      },
+      "source_urls": [
+        "https://github.com/404-Repo/404-gen-subnet",
+        "https://www.404.xyz/plugin"
+      ],
+      "url": "https://github.com/404-Repo/404-gen-blender-add-on"
+    }
+  ],
   "website_url": "https://www.404.xyz/"
 }


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community `sdk` surface to exactly one subnet file —
`registry/subnets/sn-17.json`.

## Surface

- Netuid: 17 (404—GEN)
- Kind: sdk
- Public URL: https://github.com/404-Repo/404-gen-blender-add-on
- Source URL (proves the claim): https://github.com/404-Repo/404-gen-subnet (registered SN17 source_repo, same 404-Repo org; add-on README links it) — plus https://www.404.xyz/plugin (official site lists the Blender plugin)
- Provider slug: 404-gen

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file.
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public + probe-safe; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no secrets, private URLs, or generated artifacts touched.
- [x] Does not duplicate an existing surface (sn-17 had `surfaces: []`).
- [x] Links a tracked issue (`Closes #1748`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/sn-17.json` — passed
- [x] `npm run scan:public-safety` — passed
- [x] `npm run validate` (post-build) — passed, 0 issues

Closes #1748
