### PR TITLE
chore(enrich): taostats identity gap-fills

### DIFF
--- a/registry/subnets/gm.json
+++ b/registry/subnets/gm.json
@@ -11,7 +11,7 @@
     "marketplace",
     "tee"
   ],
-  "source_repo": null,
+  "source_repo": "https://github.com/taostat/gm-miner",
   "website_url": "https://saygm.com/",
   "docs_url": null,
   "dashboard_url": null,

--- a/registry/subnets/nodexo.json
+++ b/registry/subnets/nodexo.json
@@ -15,7 +15,7 @@
   "website_url": "https://nodexo.ai/",
   "docs_url": "https://docs.nodexo.ai/",
   "dashboard_url": "https://console.nodexo.ai/",
-  "source_repo": null,
+  "source_repo": "https://github.com/nodexo-ai/nodexo",
   "baseline_excluded_surface_ids": [
     "sn-106-taomarketcap-source-repo",
     "sn-106-taomarketcap-website",


### PR DESCRIPTION
## Summary

Gap-fills for two subnets where `source_repo` is null in the registry but taostats has a value. These are **third-party TAOSTATS fills** — human review of provenance is required before treating them as authoritative.

| Subnet | netuid | Field | Value | Source |
|--------|--------|-------|-------|--------|
| gm (SN28) | 28 | `source_repo` | `https://github.com/taostat/gm-miner` | taostats identity v1 |
| Nodexo (SN106) | 106 | `source_repo` | `https://github.com/nodexo-ai/nodexo` | taostats identity v1 |

Both URLs return HTTP 200. Both pass `backfilledIdentityUrl` sanitization. Lint is clean. Schema validates (Ajv 2020-12).

**Provenance notes for review:**
- **SN28 gm**: taostats lists `taostat/gm-miner` — the `taostat` org is a third-party Bittensor indexer; this may be a community miner repo rather than the canonical protocol source. The existing social.x (`@say_gm_`) matches taostats, increasing confidence this is the correct subnet match.
- **SN106 nodexo**: taostats lists `nodexo-ai/nodexo` — the org name matches the website domain `nodexo.ai`. Previously discovered candidates returned 404; this candidate currently resolves.

**Skipped:** SN29 (coldint) — taostats reports `twitter: @cacheon_ai` for netuid 29, which is a different subnet's handle; entire record flagged as suspicious and excluded.

No merge. No approval. Awaiting human provenance review.