### PR TITLE
fix(health): fold unrecognized surface status into unknown in summari…

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -107,7 +107,11 @@ export function summarizeRows(rows) {
   const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
   const latencies = [];
   for (const row of rows) {
-    counts[row.status] = (counts[row.status] || 0) + 1;
+    // Fold any unrecognized status into `unknown` so it still counts toward the
+    // rollup; left as a stray key it would be invisible to rollupSubnetStatus
+    // (failed/degraded stay 0) and a fully-unrecognized subnet would read "ok".
+    const status = Object.hasOwn(counts, row.status) ? row.status : "unknown";
+    counts[status] += 1;
     if (Number.isFinite(row.latency_ms)) latencies.push(row.latency_ms);
   }
   return {

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -390,14 +390,22 @@ describe("summarizeRows / rollupStatus", () => {
     assert.equal(out.status, "failed");
     assert.equal(out.failed_count, 2);
   });
-  test("unrecognized status key initializes its own count (|| 0 branch)", () => {
-    // A status outside the known keys exercises the `counts[row.status] || 0`
-    // default-init branch in summarizeRows. With no failed/degraded counts,
-    // rollupStatus reports "ok".
+  test("all-unrecognized statuses fold into unknown, not a false ok (#1738)", () => {
+    // Regression: a status outside the known keys must count as `unknown` so the
+    // rollup can't read a subnet with zero recognized-ok rows as healthy. Left as
+    // a stray key it was invisible to rollupSubnetStatus and reported "ok".
     const out = summarizeRows([row("weird"), row("weird")]);
-    assert.equal(out.status, "ok");
-    assert.equal(out.failed_count, 0);
+    assert.equal(out.status, "unknown");
+    assert.equal(out.unknown_count, 2);
     assert.equal(out.ok_count, 0);
+    assert.equal(out.failed_count, 0);
+  });
+  test("unrecognized status alongside a real failure still surfaces failed", () => {
+    // The unrecognized row folds into unknown; the failed row must still carry.
+    const out = summarizeRows([row("weird"), row("failed")]);
+    assert.equal(out.status, "failed");
+    assert.equal(out.unknown_count, 1);
+    assert.equal(out.failed_count, 1);
   });
   test("aggregates latency (rounded), latest last_checked/last_ok", () => {
     const out = summarizeRows([


### PR DESCRIPTION
## Summary
`summarizeRows` tallied each `row.status` with `counts[row.status] = (counts[row.status] || 0) + 1`,
so a status outside the known set (`ok`/`degraded`/`failed`/`unknown`) created a stray key that
`rollupSubnetStatus` never reads. With `failed` and `degraded` both 0 and `unknown !== total`, the
rollup returned **`ok`** — a subnet whose surfaces were *all* unrecognized reported healthy.

This folds any unrecognized status into `unknown` (guarded by `Object.hasOwn`, the idiom already used
in `workers/api.mjs`/`list-query.mjs`), so an all-unrecognized subnet correctly rolls up to `unknown`,
while a real `failed`/`degraded` row still carries.

## Changes
- `src/health-serving.mjs` — bucket unrecognized `row.status` into `unknown` in `summarizeRows`.
- `tests/health-serving.test.mjs` — replaced the test that asserted the buggy `"ok"` with a regression
  asserting all-unrecognized → `unknown` (#1738), plus a mixed unrecognized+failed → `failed` case.

## Validation
- `npx vitest run tests/health-serving.test.mjs -t summarizeRows` — 10/10 pass
- `npm run validate` — green (no contract/registry drift; src+test only)
- `npx eslint` + `npx prettier --check` on both files — clean; `git diff --check` clean
- Note: the pre-existing `…/health/trends queries compact all-subnet D1 rows` test fails locally on
  clean `main` too (needs a seeded D1) — unrelated to this change.

Closes #1738
