### PR TITLE
fix(badge): floor uptime percent so a sub-100% ratio never reads 100% (#1721)

### DIFF
--- a/src/badge.mjs
+++ b/src/badge.mjs
@@ -174,9 +174,11 @@ function averageReadiness(netuids, subnetsIndex) {
   return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
 }
 
-// uptime_ratio (0–1) → trimmed percent: 0.9983 → "99.83%", 1 → "100%".
-function formatUptimePercent(ratio) {
-  const pct = Math.round((Number(ratio) || 0) * 10000) / 100;
+// uptime_ratio (0–1) → trimmed percent: 0.9983 → "99.83%", 1 → "100%". Floor
+// rather than round so a genuinely sub-100% ratio is never overstated as a
+// perfect "100%" (0.99996 → "99.99%"); only an exact 1 renders "100%".
+export function formatUptimePercent(ratio) {
+  const pct = Math.floor((Number(ratio) || 0) * 10000) / 100;
   return `${pct}%`;
 }
 

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -7,6 +7,7 @@ import {
   gradeColor,
   parseBadgePath,
   parseBadgeOptions,
+  formatUptimePercent,
 } from "../src/badge.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
@@ -46,6 +47,7 @@ function makeLoadReliability(byNetuids) {
 
 const RELIABILITY = {
   7: { score: 99, grade: "A", uptime_ratio: 0.9983 }, // subnet 7
+  3: { score: 100, grade: "A", uptime_ratio: 0.99996 }, // subnet 3: just under 1
   "7,12": { score: 88, grade: "D", uptime_ratio: 0.88 }, // provider datura
 };
 
@@ -243,12 +245,30 @@ describe("badge — handleBadgeRequest", () => {
   });
 });
 
+describe("formatUptimePercent", () => {
+  test("floors the ratio so a sub-100% value never reads 100% (#1721)", () => {
+    assert.equal(formatUptimePercent(0.99996), "99.99%"); // not "100%"
+    assert.equal(formatUptimePercent(0.999999), "99.99%");
+    assert.equal(formatUptimePercent(1), "100%"); // only an exact 1
+    assert.equal(formatUptimePercent(0.9983), "99.83%");
+    assert.equal(formatUptimePercent(0.88), "88%");
+    assert.equal(formatUptimePercent(0), "0%");
+    assert.equal(formatUptimePercent(null), "0%"); // non-numeric → 0
+  });
+});
+
 describe("badge — uptime / reliability metric", () => {
   test("subnet uptime renders the window % colored by the A grade", async () => {
     const { text } = await badge("/api/v1/subnets/7/badge.svg?metric=uptime");
     assert.match(text, /99\.83%/); // 0.9983 → trimmed percent
     assert.match(text, /#2ea44f/); // grade A → green
     assert.ok(!text.includes("/100")); // not the readiness rendering
+  });
+
+  test("a sub-100% ratio is floored, never rounded up to 100% (#1721)", async () => {
+    const { text } = await badge("/api/v1/subnets/3/badge.svg?metric=uptime");
+    // 0.99996 floors to 99.99% — the value must not overstate as a perfect 100%.
+    assert.match(text, /aria-label="metagraphed: 99\.99%"/);
   });
 
   test("metric=reliability is an alias for uptime", async () => {


### PR DESCRIPTION
## Summary
`formatUptimePercent` computed the badge percent with `Math.round(ratio * 10000) / 100`, so a
genuinely sub-100% uptime ratio rounded **up** to a perfect `"100%"` — e.g. `0.99996` rendered
`100%`, overstating reliability. This switches to `Math.floor`, so the badge never claims more
uptime than measured: `0.99996 → "99.99%"`, and only an exact `1` renders `"100%"`.

Floor introduces no regression on existing values (`0.9983 → "99.83%"`, `0.88 → "88%"` — verified;
those terms land on integer boundaries so floor and round agree).

## Changes
- `src/badge.mjs` — `formatUptimePercent` floors instead of rounds.
- `tests/badge.test.mjs` — regression: subnet with `uptime_ratio: 0.99996` renders aria-label
  `99.99%`, not `100%`.

## Validation
- `npx vitest run tests/badge.test.mjs` — 27/27 pass
- `npm run validate` — green (src+test only; no contract/registry drift)
- `npx eslint` + `npx prettier --check` clean; `git diff --check` clean

Closes #1721
