### PR TITLE
fix(scripts): preserve committed promotions.json generated_at on local verify:candidates runs

### DIFF
--- a/scripts/verify-candidates.mjs
+++ b/scripts/verify-candidates.mjs
@@ -8,6 +8,7 @@ import {
   isUnsafeResolvedUrl,
   redactCredentialedUrl,
   loadCandidates,
+  readCommittedManifestGeneratedAt,
   readJson,
   repoRoot,
   stableStringify,
@@ -56,7 +57,7 @@ if (!dryRun) {
   );
   await writeJson(
     path.join(repoRoot, "registry/verification/promotions.json"),
-    compactVerificationArtifact(artifact),
+    await compactVerificationArtifact(artifact),
   );
 }
 
@@ -114,14 +115,22 @@ async function loadPreviousVerificationIndex() {
   }
 }
 
-function compactVerificationArtifact(artifactValue) {
+async function compactVerificationArtifact(artifactValue) {
   const observedAt =
     process.env.METAGRAPH_VERIFICATION_OBSERVED_AT ||
     artifactValue.verification_finished_at ||
     null;
+  // Preserve the committed promotions.json `generated_at` on a local build so
+  // `npm run verify:candidates` never clobbers it with the 1970 epoch
+  // placeholder; publish runs (METAGRAPH_BUILD_TIMESTAMP/RUN_ID set) get the
+  // real build timestamp via buildTimestamp(). Mirrors the r2-manifest path.
+  const generatedAt =
+    (await readCommittedManifestGeneratedAt(
+      path.join(repoRoot, "registry/verification/promotions.json"),
+    )) ?? buildTimestamp();
   return {
     schema_version: artifactValue.schema_version,
-    generated_at: buildTimestamp(),
+    generated_at: generatedAt,
     observed_at: observedAt,
     verification_started_at: null,
     verification_finished_at: null,


### PR DESCRIPTION
## Summary

`compactVerificationArtifact` in `scripts/verify-candidates.mjs` wrote the committed `registry/verification/promotions.json` with `generated_at: buildTimestamp()`, which returns the `1970-01-01T00:00:00.000Z` placeholder when `METAGRAPH_BUILD_TIMESTAMP` is unset. A local `npm run verify:candidates --write` therefore clobbered the committed timestamp with the epoch placeholder, dirtying a git-tracked artifact.

This is the same bug class fixed for `r2-manifest.json` in #1829 / #1837, in a sibling write path that was not touched.

## What Changed

- `scripts/verify-candidates.mjs`: preserve the committed `generated_at` on local builds via the existing `readCommittedManifestGeneratedAt` helper (the exact pattern `build-artifacts.mjs` uses for `r2-manifest.json`), falling back to `buildTimestamp()` during publish runs (`METAGRAPH_BUILD_TIMESTAMP` / `METAGRAPH_RUN_ID` set). The neighbouring `observed_at` was already env-guarded; this brings `generated_at` to parity.

No committed artifact changes (the fix prevents the spurious epoch rewrite). A secondary instance of the same class remains at `scripts/discover-candidates.mjs` (tracked separately).

Fixes #1893

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes.

## Validation

- [x] `node --check scripts/verify-candidates.mjs` passes.
- [x] `readCommittedManifestGeneratedAt` is already unit-tested (tests/script-utils.test.mjs): preserves the committed timestamp on local builds and returns null during publish runs.
- [x] verify-candidates.mjs is outside the vitest coverage scope, so no codecov/patch impact.
