### PR TITLE
feat(registry): add SN35 0xMarkets subnet-api surface

### DIFF
--- a/registry/subnets/sn-35.json
+++ b/registry/subnets/sn-35.json
@@ -9,7 +9,27 @@
     "level": "candidate-discovered",
     "review_state": "unreviewed"
   },
-  "surfaces": [],
+  "surfaces": [
+    {
+      "id": "sn-35-oxmarkets-subnet-api",
+      "name": "0xMarkets Cartha Verifier API",
+      "kind": "subnet-api",
+      "url": "https://cartha-verifier-826542474079.us-central1.run.app/pools",
+      "provider": "oxmarkets",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://docs.0xmarkets.io/cartha/testnet",
+        "https://github.com/General-Tao-Ventures/cartha-validator"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dev-miro26"
+      },
+      "notes": "Public no-auth endpoint of the SN35 Cartha Verifier (returns live market pool data); the verifier base URL is documented in the official 0xMarkets docs. Testnet verifier instance."
+    }
+  ],
   "contact": "contact@0xmarkets.io",
   "source_repo": "https://github.com/General-Tao-Ventures/cartha-validator",
   "website_url": "https://www.0xmarkets.io/",


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends a surface to exactly one subnet's file — `registry/subnets/sn-35.json` (SN35, 0xMarkets). No other files are touched.

## Summary

SN35's `surfaces[]` was empty. This adds the public **Cartha Verifier** API endpoint:

- **`subnet-api`** — `https://cartha-verifier-826542474079.us-central1.run.app/pools` → `200 application/json`, returns live market-pool data (BTC/USD, ETH/USD vaults), **no auth**.

Ownership is proven by the official 0xMarkets docs (`docs.0xmarkets.io/cartha/testnet`), which document this verifier URL, plus the `cartha-validator` source repo.

**Note:** This is the **testnet** Cartha Verifier (hosted on Google Cloud Run); no production verifier hostname resolves yet. It is verifiably 0xMarkets', public, no-auth, and live. The surface `notes` flag it as a testnet instance.

The subnet also serves a machine-readable OpenAPI spec at `/openapi.json`, but adding it as an `openapi` surface currently trips a build-side schema-index issue (a `not-captured` placeholder status that fails `validate:schemas`); that is left out of this PR so the API surface can land cleanly. #667 therefore remains partially open for the OpenAPI surface.

## Surface

- Netuid: 35
- Kind: `subnet-api`
- Public URL: `https://cartha-verifier-826542474079.us-central1.run.app/pools`
- Source URL (proves the claim): `https://docs.0xmarkets.io/cartha/testnet`, `https://github.com/General-Tao-Ventures/cartha-validator`
- Provider slug: `oxmarkets`

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file.
- [x] Surface carries `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface (SN35 had no surfaces).

## Validation

- [x] `npm run validate:surface -- registry/subnets/sn-35.json` → passed (1 surface, 1 file)
- [x] `npm run validate:schemas` (after `npm run build`) → passed
- [x] `npm run scan:public-safety` → passed
- [x] `prettier --check` → clean

Refs #667
