### PR TITLE
fix(api): reject contradictory numeric range bounds on list endpoints

### DIFF
--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -267,7 +267,10 @@ describe("list-query numeric range filters", () => {
       "subnets",
     );
     assert.equal(bad.error.parameter, "min_surface_count");
-    assert.match(bad.error.message, /must not be greater than max_surface_count/);
+    assert.match(
+      bad.error.message,
+      /must not be greater than max_surface_count/,
+    );
   });
 
   test("equal min_ and max_ bounds form a single-value inclusive range", () => {

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -259,4 +259,23 @@ describe("list-query numeric range filters", () => {
     assert.equal(bad.error.parameter, "max_surface_count");
     assert.match(bad.error.message, /must be a number/);
   });
+
+  test("contradictory min_ > max_ on the same field is a query error", () => {
+    const bad = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?min_surface_count=9&max_surface_count=2"),
+      "subnets",
+    );
+    assert.equal(bad.error.parameter, "min_surface_count");
+    assert.match(bad.error.message, /must not be greater than max_surface_count/);
+  });
+
+  test("equal min_ and max_ bounds form a single-value inclusive range", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?min_surface_count=5&max_surface_count=5"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [3]);
+  });
 });

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -297,6 +297,19 @@ function validateListQuery(params, config) {
         };
       }
     }
+    const minKey = `min_${field}`;
+    const maxKey = `max_${field}`;
+    if (!params.has(minKey) || !params.has(maxKey)) {
+      continue;
+    }
+    const minValue = numberParam(params.get(minKey));
+    const maxValue = numberParam(params.get(maxKey));
+    if (minValue !== null && maxValue !== null && minValue > maxValue) {
+      return {
+        parameter: minKey,
+        message: `${minKey} must not be greater than ${maxKey}.`,
+      };
+    }
   }
 
   return null;


### PR DESCRIPTION
## Summary
- Reject list queries where `min_<field>` is greater than `max_<field>` on the same numeric range field.
- Return `400 invalid_query` naming `min_<field>` instead of a silent empty `200`.
- Equal bounds (`min=5&max=5`) remain valid as a single-value inclusive range.

## Problem
`/api/v1/subnets?min_surface_count=9&max_surface_count=2` passed validation and always returned zero rows with no signal that the query itself was contradictory (#1697).

## Test plan
- [x] `npm test -- tests/list-query.test.mjs`
- [x] Runtime-only — no schema/OpenAPI regeneration

Closes #1697

Made with [Cursor](https://cursor.com)