### PR TITLE
fix(scripts): preserve committed public-sources.json generated_at on local discover:candidates runs

### DIFF
--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -2,6 +2,7 @@ import path from "node:path";
 import {
   apiDocsSubdomainOrigins,
   buildTimestamp,
+  readCommittedManifestGeneratedAt,
   isBrandImpersonationUrl,
   isCredentialedUrl,
   isLikelyExampleLink,
@@ -159,7 +160,14 @@ if (!dryRun) {
     {
       schema_version: 1,
       generated_by: "metagraphed-discover-candidates",
-      generated_at: buildTimestamp(),
+      // Preserve the committed generated_at on a local build so this never
+      // clobbers the tracked artifact with the 1970 epoch placeholder; publish
+      // runs (METAGRAPH_BUILD_TIMESTAMP/RUN_ID set) get the real build
+      // timestamp via buildTimestamp(). Mirrors the r2-manifest/verify:candidates path.
+      generated_at:
+        (await readCommittedManifestGeneratedAt(
+          path.join(repoRoot, "registry/candidates/generated/public-sources.json"),
+        )) ?? buildTimestamp(),
       native_snapshot_captured_at: nativeSnapshot.captured_at,
       notes:
         "Generated candidate surfaces from public sources. These are not verified registry surfaces until maintainer review promotes them into registry/subnets.",


### PR DESCRIPTION
## Summary

`scripts/discover-candidates.mjs` wrote the committed `registry/candidates/generated/public-sources.json` with `generated_at: buildTimestamp()`, which returns the `1970-01-01T00:00:00.000Z` placeholder when `METAGRAPH_BUILD_TIMESTAMP` is unset. A local write therefore clobbered the committed timestamp with the epoch placeholder, dirtying a git-tracked artifact.

This is the same bug class fixed for `r2-manifest.json` (#1829 / #1837) and `verify:candidates` promotions.json (#1893), in another sibling write path.

## What Changed

- `scripts/discover-candidates.mjs`: preserve the committed `generated_at` on local builds via the existing `readCommittedManifestGeneratedAt` helper, falling back to `buildTimestamp()` during publish runs (`METAGRAPH_BUILD_TIMESTAMP` / `METAGRAPH_RUN_ID` set).

No committed artifact changes (the fix prevents the spurious epoch rewrite).

Fixes #1897

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes.

## Validation

- [x] `node --check scripts/discover-candidates.mjs` passes.
- [x] `readCommittedManifestGeneratedAt` is already unit-tested (tests/script-utils.test.mjs).
- [x] discover-candidates.mjs is outside the vitest coverage scope, so no codecov/patch impact.
