### PR TITLE
feat(registry): add SN74 Gittensor PR records data-artifact surface

### DIFF
--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -382,6 +382,21 @@
       },
       "source_urls": ["https://api.gittensor.io/swagger-json"],
       "url": "https://api.gittensor.io/miners"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-data-artifact-api-gittensor-io-5",
+      "kind": "data-artifact",
+      "name": "Gittensor data-artifact",
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "gildardodev"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/prs"
     }
   ],
   "website_url": "https://gittensor.io/"


### PR DESCRIPTION
Gittensor (SN74) exposes a public PR-records endpoint that complements the already-listed issues artifact. This adds api.gittensor.io/prs as a data-artifact surface. It returns the subnet pull-request records as JSON with no auth, and is documented in the API OpenAPI at api.gittensor.io/swagger-json. Closes #1632.

Checked with npm run validate:surface and npm run scan:public-safety.