### PR TITLE
fix(badge): floor uptime percent so sub-100% ratios never read 100%

### DIFF
--- a/src/badge.mjs
+++ b/src/badge.mjs
@@ -174,9 +174,11 @@ function averageReadiness(netuids, subnetsIndex) {
   return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
 }
 
-// uptime_ratio (0–1) → trimmed percent: 0.9983 → "99.83%", 1 → "100%".
-function formatUptimePercent(ratio) {
-  const pct = Math.round((Number(ratio) || 0) * 10000) / 100;
+// uptime_ratio (0–1) → trimmed percent: 0.9983 → "99.83%", 1 → "100%". Floor
+// rather than round so a genuinely sub-100% ratio is never overstated as a
+// perfect "100%" (0.99996 → "99.99%"); only an exact 1 renders "100%".
+export function formatUptimePercent(ratio) {
+  const pct = Math.floor((Number(ratio) || 0) * 10000) / 100;
   return `${pct}%`;
 }
 

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -7,6 +7,7 @@ import {
   gradeColor,
   parseBadgePath,
   parseBadgeOptions,
+  formatUptimePercent,
 } from "../src/badge.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
@@ -46,6 +47,7 @@ function makeLoadReliability(byNetuids) {
 
 const RELIABILITY = {
   7: { score: 99, grade: "A", uptime_ratio: 0.9983 }, // subnet 7
+  3: { score: 100, grade: "A", uptime_ratio: 0.99996 }, // subnet 3: just under 1
   "7,12": { score: 88, grade: "D", uptime_ratio: 0.88 }, // provider datura
 };
 
@@ -243,12 +245,29 @@ describe("badge — handleBadgeRequest", () => {
   });
 });
 
+describe("formatUptimePercent", () => {
+  test("floors the ratio so a sub-100% value never reads 100% (#1721)", () => {
+    assert.equal(formatUptimePercent(0.99996), "99.99%");
+    assert.equal(formatUptimePercent(0.999999), "99.99%");
+    assert.equal(formatUptimePercent(1), "100%");
+    assert.equal(formatUptimePercent(0.9983), "99.83%");
+    assert.equal(formatUptimePercent(0.88), "88%");
+    assert.equal(formatUptimePercent(0), "0%");
+    assert.equal(formatUptimePercent(null), "0%");
+  });
+});
+
 describe("badge — uptime / reliability metric", () => {
   test("subnet uptime renders the window % colored by the A grade", async () => {
     const { text } = await badge("/api/v1/subnets/7/badge.svg?metric=uptime");
     assert.match(text, /99\.83%/); // 0.9983 → trimmed percent
     assert.match(text, /#2ea44f/); // grade A → green
     assert.ok(!text.includes("/100")); // not the readiness rendering
+  });
+
+  test("a sub-100% ratio is floored, never rounded up to 100% (#1721)", async () => {
+    const { text } = await badge("/api/v1/subnets/3/badge.svg?metric=uptime");
+    assert.match(text, /aria-label="metagraphed: 99\.99%"/);
   });
 
   test("metric=reliability is an alias for uptime", async () => {


### PR DESCRIPTION
## Summary
- Fix `formatUptimePercent` in `src/badge.mjs` to use `Math.floor` instead of `Math.round`, so a sub-100% uptime ratio never renders as a perfect `100%` badge.
- Export the helper for direct unit coverage and add integration coverage via the subnet uptime badge path.

## Problem
`Math.round(ratio * 10000) / 100` maps `0.99996` → `"100%"`, misrepresenting reliability. Only an exact `1` should read as `100%`.

## Test plan
- [x] `npm test -- tests/badge.test.mjs`
- [x] `npm run lint`
- [x] `npm run format:check`

Closes #1721

Made with [Cursor](https://cursor.com)