### PR TITLE
fix(mcp): refactor/trajectory loader expose rows

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1017,7 +1017,9 @@ export async function loadSubnetTrajectory(d1, netuid) {
      LIMIT 400`,
     [netuid],
   );
-  return formatTrajectory({ netuid, rows });
+  // Return rows alongside the formatted data so callers can check fallback
+  // status (e.g. hasD1FallbackRows(rows)) without re-running the query.
+  return { data: formatTrajectory({ netuid, rows }), rows };
 }
 
 function diff(now, then) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -976,7 +976,8 @@ export const MCP_TOOLS = [
     },
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
-      return loadSubnetTrajectory(mcpD1Runner(ctx), netuid);
+      const { data } = await loadSubnetTrajectory(mcpD1Runner(ctx), netuid);
+      return data;
     },
   },
   {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -124,9 +124,9 @@ import { dailyLatencyColumns } from "../src/health-sql.mjs";
 import {
   buildGlobalHealth,
   formatLeaderboards,
-  formatTrajectory,
   formatUptime,
   LEADERBOARD_BOARDS,
+  loadSubnetTrajectory,
   mergeFreshness,
   mergeRpcEndpoints,
   overlayArtifactEndpoints,
@@ -2120,18 +2120,10 @@ async function handleApiRequest(
 async function handleTrajectory(request, env, netuid, url) {
   const validationError = validateQueryParams(url, []);
   if (validationError) return analyticsQueryError(validationError);
-  const rows = await d1All(
-    env,
-    `SELECT snapshot_date, completeness_score, surface_count, endpoint_count,
-            validator_count, miner_count, total_stake_tao, alpha_price_tao,
-            emission_share
-     FROM subnet_snapshots
-     WHERE netuid = ?
-     ORDER BY snapshot_date DESC
-     LIMIT 400`,
-    [netuid],
+  const { data, rows } = await loadSubnetTrajectory(
+    (sql, params) => d1All(env, sql, params),
+    netuid,
   );
-  const data = formatTrajectory({ netuid, rows });
   const response = envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

- `loadSubnetTrajectory` now returns `{ data, rows }` instead of bare `data`, exposing the raw
  `rows` reference so callers can check D1 fallback status without re-running the query.
- `handleTrajectory` (REST route) is rewritten to call the shared loader; the duplicate 9-line
  `SELECT … FROM subnet_snapshots` block is removed.
- The MCP `get_subnet_trajectory` handler is updated to destructure `.data`.
- `formatTrajectory` is dropped from the `workers/api.mjs` import list (no longer called directly).

Fixes https://github.com/JSONbored/metagraphed/issues/1906

## What Changed

- `src/health-serving.mjs` — `loadSubnetTrajectory` returns `{ data, rows }`
- `workers/api.mjs` — `handleTrajectory` calls `loadSubnetTrajectory((sql, p) => d1All(env, sql, p), netuid)`;
  inline SQL removed; `formatTrajectory` import replaced with `loadSubnetTrajectory`
- `src/mcp-server.mjs` — `return (await loadSubnetTrajectory(...)).data`

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`


