### PR TITLE
feat(registry): enrich SN13 Data Universe — add subnet-api surface (#680)

### DIFF
--- a/registry/subnets/data-universe.json
+++ b/registry/subnets/data-universe.json
@@ -237,6 +237,26 @@
       },
       "source_urls": ["https://github.com/macrocosm-os/data-universe"],
       "url": "https://github.com/macrocosm-os/macrocosmos-py"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-13-macrocosmos-subnet-api",
+      "kind": "subnet-api",
+      "name": "Data Universe on-demand data API (Constellation)",
+      "notes": "SN13 Data Universe real-time on-demand data query (X/Reddit/YouTube) via the Macrocosmos Constellation API (Sn13Service.OnDemandData); requires a Bearer API key (macrocosmos SDK Sn13Client/GravityClient).",
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dexterity104"
+      },
+      "source_urls": [
+        "https://github.com/macrocosm-os/macrocosmos-py/blob/main/protos/sn13/v1/sn13_validator.proto",
+        "https://github.com/macrocosm-os/macrocosmos-py/blob/main/src/macrocosmos/resources/_client.py",
+        "https://github.com/macrocosm-os/macrocosmos-py"
+      ],
+      "url": "https://constellation.api.cloud.macrocosmos.ai/sn13.v1.Sn13Service/OnDemandData"
     }
   ],
   "website_url": "https://datauniverse.macrocosmos.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet file —
`registry/subnets/data-universe.json` (SN13, Data Universe by Macrocosmos). No
other file is touched.

## Summary

SN13's file had no callable API surface (only website/docs/source-repo/dashboard/
sdk/example), and its maintainer-curated `curation.gap_notes` records *"No verified
safe public subnet API endpoint yet."* This adds a `subnet-api` surface for SN13's
**officially documented** developer API — the Macrocosmos **Constellation API**:

- **url**: `https://constellation.api.cloud.macrocosmos.ai/sn13.v1.Sn13Service/OnDemandData`
- **auth_required**: `true` — Bearer API key (`Authorization: Bearer <key>`); no
  credentials embedded (`auth` is null). Matches the accepted authed-`subnet-api`
  precedent already in the registry (`desearch`, `nepher-robotics`, `green-compute`).
- **provider**: `macrocosmos` (already registered), `authority: community`,
  `review.state: community-submitted`.

The exact endpoint is proven directly from the official `macrocosm-os/macrocosmos-py`
SDK source:

- `src/macrocosmos/resources/_client.py` → `DEFAULT_BASE_URL = "constellation.api.cloud.macrocosmos.ai"` (the host)
- `protos/sn13/v1/sn13_validator.proto` → `package sn13.v1; service Sn13Service { … rpc OnDemandData(…) }` (the path)
- the SDK README → *"SN13 OnDemandAPI"* / *"Gravity … powered by Subnet 13 (Data Universe)"*, used with an `api_key`

A live `POST` to the endpoint returns `401 {"code":"unauthenticated"}` (real, auth-gated).

## Surface

- Netuid: 13
- Kind: `subnet-api`
- Public URL: `https://constellation.api.cloud.macrocosmos.ai/sn13.v1.Sn13Service/OnDemandData`
- Source URLs (independently prove the exact endpoint):
  - `https://github.com/macrocosm-os/macrocosmos-py/blob/main/protos/sn13/v1/sn13_validator.proto` — proves the RPC path (`sn13.v1` · `Sn13Service` · `OnDemandData`)
  - `https://github.com/macrocosm-os/macrocosmos-py/blob/main/src/macrocosmos/resources/_client.py` — proves the base host (`constellation.api.cloud.macrocosmos.ai`)
  - `https://github.com/macrocosm-os/macrocosmos-py` — ties it to Subnet 13 (Data Universe) and the `api_key` requirement
- Provider slug: `macrocosmos`

## Why this host (and not a per-validator deployment)

The official, documented SN13 developer API is the Macrocosmos **Constellation**
platform (Bearer-authed, served via the `macrocosmos` Gravity/Sn13 SDK), owner-matched
to SN13's registered identity (`macrocosmos`). No standalone `openapi` surface is
added: the Constellation API is Connect-RPC with no public machine-readable OpenAPI
document, and a new `openapi`-kind surface would also drift the committed
`schemas/index.json` (which needs a captured snapshot, out of scope for a one-file PR).

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file.
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is the documented SN13 API endpoint (live, auth-gated 401 on POST); the three `source_url`s are official, server-rendered, owner-matched (`macrocosm-os`) and together prove the exact host + RPC path.
- [x] No secrets/wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts. The surface declares `auth_required: true` with `auth: null` — Bearer-key-gated but embeds no credentials.
- [x] Does not duplicate an existing Metagraphed surface (no `subnet-api` on SN13; host unused by any registry surface; not in the native-chain promotion set).
- [x] Links a tracked issue.

Closes #680

## Validation

- [x] `npm run validate:surface -- registry/subnets/data-universe.json` → `Surface validation passed: 11 surface(s)`
- [x] `npm run scan:public-safety` → `Public-safety scan passed.`
- [x] `npm run build` then `npm run validate` → `Validated … 1177 surface(s) …` (passes in CI's build→validate order)
- [x] `npm run validate:schemas` + `npx vitest run tests/committed-seed-gate.test.mjs` → passed (no `schemas/index.json` drift — surface carries no `schema_url`)
- [x] `npx prettier --check registry/subnets/data-universe.json` → clean
- [x] Verified against the SDK source (base URL + proto service/method) and a live `POST …/sn13.v1.Sn13Service/OnDemandData` → `HTTP 401`
