### PR TITLE
fix(ci): exclude operational-surfaces.json from the derived-artifact freshness gate

### DIFF
--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -78,9 +78,12 @@ one-file surface PR runs the same gates as a code PR. Two parallel jobs both bui
 **Gates (all must pass):** `lint` · `format:check` · `validate:contract-drift` ·
 `validate:schema-enums` · `validate:openapi-examples` · `validate:generated-client` ·
 `validate:committed-seed` · `npm run build` · committed-derived-artifact freshness (working tree clean
-under `public/` after a fresh build — only CONTRACT artifacts are gated; DATA artifacts like
-`public/datasets/` + the llms.txt catalogs are gitignored, and the README catalog is refreshed
-out-of-band by `readme-catalog-refresh.yml`) · `validate` · `validate:schemas` · `validate:api` ·
+under `public/` after a fresh build — only CONTRACT artifacts are gated; DATA/CONTENT-derived artifacts
+are NOT: `public/datasets/` + the llms.txt catalogs are gitignored, the README catalog is refreshed
+out-of-band by `readme-catalog-refresh.yml`, and `operational-surfaces.json` is committed-but-excluded —
+adding a probe-enabled operational-kind surface (subnet-api/sse/data-artifact) regenerates the prober's
+input list, which a one-file surface PR does not commit; it is served fresh on deploy) · `validate` ·
+`validate:schemas` · `validate:api` ·
 `validate:mcp` · `validate:ai` · `validate:openapi` · `validate:types` · `validate:artifact-budgets` ·
 `validate:docs` · `validate:intake` · `validate:surface` · `validate:workflows` ·
 `validate:migrations` (unique, gap-free D1 migration prefixes) ·

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -175,18 +175,26 @@ jobs:
       - name: Verify committed derived artifacts are fresh
         run: |
           # Only CONTRACT artifacts are gated here — openapi.json / types.d.ts /
-          # contracts.json / api-index.json / operational-surfaces.json — because they
-          # change only with reviewed schema/source PRs and MUST be regenerated +
-          # committed. DATA-derived artifacts are NOT gated: they re-drift on every
-          # registry/data edit and would red-line build-less community surface PRs (the
-          # single-file model makes adding a surface a one-file data PR). Those are
-          # handled out-of-band: public/datasets/ + the llms.txt catalogs are gitignored
-          # (rebuilt + served via ASSETS on deploy); r2-manifest.json is the publish
-          # lockfile; schemas/index.json is a network-capture cache the build reconciles
-          # in place (a new openapi surface legitimately adds a not-captured placeholder).
+          # contracts.json / api-index.json — because they change only with reviewed
+          # schema/source PRs and MUST be regenerated + committed. DATA/CONTENT-derived
+          # artifacts are NOT gated: they re-drift on every registry/data edit and would
+          # red-line build-less community surface PRs (the single-file model makes adding
+          # a surface a one-file data PR). Those are handled out-of-band: public/datasets/
+          # + the llms.txt catalogs are gitignored (rebuilt + served via ASSETS on
+          # deploy); r2-manifest.json is the publish lockfile; schemas/index.json is a
+          # network-capture cache the build reconciles in place (a new openapi surface
+          # legitimately adds a not-captured placeholder); and operational-surfaces.json
+          # is CONTENT-derived — the prober's input list regenerates whenever a
+          # probe-enabled, public-safe operational-kind surface (subnet-api / sse /
+          # data-artifact / wss / rpc) is added or changed, which a one-file community
+          # surface PR does NOT regenerate (there is no authority/review gate on that
+          # list). It stays committed so the prober's ASSETS read succeeds on a cold
+          # start, but the served copy is rebuilt fresh on every deploy — so a
+          # momentarily-stale git copy is a tolerated cache, not a runtime fault.
           excludes=(
             ':(exclude)public/metagraph/r2-manifest.json'
             ':(exclude)public/metagraph/schemas/index.json'
+            ':(exclude)public/metagraph/operational-surfaces.json'
             ':(exclude)public/datasets'
           )
           status=$(git status --porcelain --untracked-files=all -- public/ "${excludes[@]}")


### PR DESCRIPTION
## Problem

`operational-surfaces.json` is the **only committed artifact that is content-derived**, yet it's freshness-gated as if it were a contract artifact. The build regenerates the prober's input list from `surfaces.filter(probe.enabled && public_safe && operational-kind)` — **with no authority/review gate** — so adding a probe-enabled `subnet-api` / `sse` / `data-artifact` / `wss` / `rpc` surface regenerates it.

A one-file community surface PR (the #1800 single-file model) does **not** regenerate it, so merging such a PR left the committed copy stale → the freshness gate then **red-lined for every subsequent PR** on a file it never touched. This is the recurring "merging content broke CI."

## Fix

Exclude `operational-surfaces.json` from the freshness gate, exactly like the other content/data-derived artifacts (`public/datasets`, the llms.txt catalogs). It **stays committed** so the prober's ASSETS read succeeds on a cold start, but the **served copy is rebuilt fresh on every deploy** — so a momentarily-stale git copy is a tolerated cache, not a runtime fault. The freshness gate keeps protecting the genuine contract artifacts (openapi/types/contracts/api-index).

## Verification

A drifted `operational-surfaces.json` is **flagged by the old gate** and **ignored by the new one** (confirmed with the exact `git status --porcelain` the gate runs). `validate:workflows` + prettier clean.

Skill `reference.md` updated to document the reclassification.

Follow-up (not this PR): moving it to R2-only — needs investigating why `#1017` reverted that.