### PR TITLE
fix(events): capture coldkey swaps under the real ColdkeySwapped event name

### DIFF
--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -265,7 +265,7 @@ def _hotkey_swapped(a):  # HotkeySwapped: {coldkey, old_hotkey, new_hotkey} or [
     return {"coldkey": _ss58(ck), "hotkey": _ss58(hk)}
 
 
-def _coldkey_swap(a):  # ColdkeySwapScheduled: {old_coldkey, new_coldkey, ...} or [old_coldkey, new_coldkey, ...]
+def _coldkey_swap(a):  # ColdkeySwapped: {old_coldkey, new_coldkey} or [old_coldkey, new_coldkey]
     if isinstance(a, dict):
         old_ck, new_ck = a.get("old_coldkey"), a.get("new_coldkey")
     else:
@@ -292,7 +292,7 @@ EXTRACTORS = {
     "TakeIncreased": _take_changed,
     # Key rotation (#1816)
     "HotkeySwapped": _hotkey_swapped,
-    "ColdkeySwapScheduled": _coldkey_swap,
+    "ColdkeySwapped": _coldkey_swap,
     # Balances pallet — native TAO transfers between accounts (#1814)
     "Transfer": _transfer,
 }

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -392,5 +392,38 @@ class TakeDelegateExtractorTest(unittest.TestCase):
         self.assertEqual(take["hotkey"], delegate["hotkey"])
 
 
+class ColdkeySwapExtractorTest(unittest.TestCase):
+    # Subtensor emits `ColdkeySwapped { old_coldkey, new_coldkey }` — there is no
+    # `ColdkeySwapScheduled` variant, so the extractor must be keyed on the real
+    # event name or every coldkey swap is dropped (extract() returns None).
+    def test_coldkey_swapped_is_a_registered_event(self):
+        # The dispatcher must recognize the real chain event name.
+        self.assertIn("ColdkeySwapped", _fe.EXTRACTORS)
+        self.assertNotIn("ColdkeySwapScheduled", _fe.EXTRACTORS)
+
+    def test_coldkey_swapped_positional(self):
+        # [old_coldkey, new_coldkey] → old as coldkey, new as hotkey (target).
+        result = _extract("ColdkeySwapped", [_SS58_A, _SS58_B])
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertEqual(result["hotkey"], _SS58_B)
+
+    def test_coldkey_swapped_named_dict_form(self):
+        result = _extract(
+            "ColdkeySwapped", {"old_coldkey": _SS58_A, "new_coldkey": _SS58_B}
+        )
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertEqual(result["hotkey"], _SS58_B)
+
+    def test_phantom_scheduled_name_is_not_captured(self):
+        # The old (wrong) key name must no longer extract anything.
+        self.assertIsNone(_extract("ColdkeySwapScheduled", [_SS58_A, _SS58_B]))
+
+    def test_shape_drift_never_raises(self):
+        # A short payload must yield null keys, never raise.
+        result = _extract("ColdkeySwapped", [])
+        self.assertIsNone(result["coldkey"])
+        self.assertIsNone(result["hotkey"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- The chain-event poller registered its coldkey-swap extractor under the event id `ColdkeySwapScheduled`, but Subtensor never emits an event by that name, so **every coldkey swap was silently dropped** (zero rows ingested).

## What Changed

- `scripts/fetch-events.py`: register `_coldkey_swap` under the real event name `ColdkeySwapped` (was `ColdkeySwapScheduled`). `extract()` dispatches on the literal chain `event_id` (`EXTRACTORS.get(event_id)`), so the key must match the emitted name exactly.
- The `_coldkey_swap` body already reads the `{old_coldkey, new_coldkey}` shape — exactly `ColdkeySwapped`'s fields — so only the registered key name was wrong; the decode logic is unchanged.
- `scripts/test_fetch_events.py`: add `ColdkeySwapExtractorTest` covering positional + named-dict forms, the phantom-name regression (old key extracts nothing), and shape-drift safety.

Verified against opentensor/subtensor `pallets/subtensor/src/macros/events.rs`: the coldkey events are `ColdkeySwapAnnounced { who, new_coldkey_hash }`, `ColdkeySwapped { old_coldkey, new_coldkey }`, `ColdkeySwapReset`, `ColdkeySwapDisputed`, `ColdkeySwapCleared` — there is no `ColdkeySwapScheduled`.

Closes #1920

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none)

## Validation

- [x] `python3 scripts/test_fetch_events.py` (new ColdkeySwapExtractorTest passes; existing extractor tests unaffected)
- [x] `git diff --check`
