### PR TITLE
fix(schema): allow block and extrinsic response fields

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1634,6 +1634,7 @@ export interface components {
             /** Format: date-time */
             observed_at?: string | null;
             parent_hash?: string | null;
+            spec_version?: number | null;
         };
         /** @description Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file). */
         BlockDetailArtifact: {
@@ -2226,10 +2227,12 @@ export interface components {
         /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
         Extrinsic: {
             block_number: number | null;
+            call_args?: Record<string, never> | unknown[] | string | number | boolean | null;
             call_function?: string | null;
             call_module?: string | null;
             extrinsic_hash?: string | null;
             extrinsic_index: number | null;
+            fee_tao?: number | null;
             /** Format: date-time */
             observed_at?: string | null;
             signer?: string | null;
@@ -5612,7 +5615,8 @@ export interface operations {
                      *           "event_count": 1,
                      *           "extrinsic_count": 1,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
-                     *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1"
+                     *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                     *           "spec_version": 1
                      *         },
                      *         "ref": "example",
                      *         "schema_version": 1
@@ -7647,10 +7651,12 @@ export interface operations {
                      *       "data": {
                      *         "extrinsic": {
                      *           "block_number": 5000000,
+                     *           "call_args": {},
                      *           "call_function": "example",
                      *           "call_module": "example",
                      *           "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "extrinsic_index": 1,
+                     *           "fee_tao": 0.5,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
                      *           "signer": "example",
                      *           "success": false

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1311,6 +1311,12 @@
               "string",
               "null"
             ]
+          },
+          "spec_version": {
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "required": [
@@ -3734,6 +3740,16 @@
               "null"
             ]
           },
+          "call_args": {
+            "type": [
+              "object",
+              "array",
+              "string",
+              "number",
+              "boolean",
+              "null"
+            ]
+          },
           "call_function": {
             "type": [
               "string",
@@ -3755,6 +3771,12 @@
           "extrinsic_index": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "fee_tao": {
+            "type": [
+              "number",
               "null"
             ]
           },
@@ -13810,7 +13832,8 @@
                       "event_count": 1,
                       "extrinsic_count": 1,
                       "observed_at": "2026-06-01T00:00:00.000Z",
-                      "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1"
+                      "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                      "spec_version": 1
                     },
                     "ref": "example",
                     "schema_version": 1
@@ -16927,10 +16950,12 @@
                   "data": {
                     "extrinsic": {
                       "block_number": 5000000,
+                      "call_args": {},
                       "call_function": "example",
                       "call_module": "example",
                       "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                       "extrinsic_index": 1,
+                      "fee_tao": 0.5,
                       "observed_at": "2026-06-01T00:00:00.000Z",
                       "signer": "example",
                       "success": false

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,14 +1,14 @@
 {
-  "artifact_count": 5,
-  "artifact_size_bytes": 1461620,
+  "artifact_count": 6,
+  "artifact_size_bytes": 1738104,
   "artifacts": [
     {
       "content_type": "application/json",
       "key": "runs/2026-06-18T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "3a730ab97210f043c4abc401f19295c29d322ffc78e6eed9f2a684766dddbff1",
-      "size_bytes": 114064,
+      "sha256": "d047809c3fa223f66d93cf241dc37132bc560a431346929d76e4641ce37dba0e",
+      "size_bytes": 131054,
       "storage_tier": "dual"
     },
     {
@@ -16,8 +16,8 @@
       "key": "runs/2026-06-18T00-00-00-000Z/contracts.json",
       "latest_key": "latest/contracts.json",
       "path": "/metagraph/contracts.json",
-      "sha256": "f07e9a28c4f5423f758972faa90ff995f117b2fb77b42ced9b5f94ffb248e254",
-      "size_bytes": 28908,
+      "sha256": "80019c3fe17cc0a460eb89bc61356b48369afd8a37fb4f8b7827813312d4bd4d",
+      "size_bytes": 35915,
       "storage_tier": "dual"
     },
     {
@@ -25,8 +25,17 @@
       "key": "runs/2026-06-18T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "719e737d1a0c51751651d657ee3a3f44def223b78b3c623426d39a63ceafa12a",
-      "size_bytes": 744473,
+      "sha256": "77ee337f45cc4a7a3a5d6ec5d76c2dd535b5dad060053bff39ee41dc48b63e71",
+      "size_bytes": 854591,
+      "storage_tier": "dual"
+    },
+    {
+      "content_type": "application/json",
+      "key": "runs/2026-06-18T00-00-00-000Z/operational-surfaces.json",
+      "latest_key": "latest/operational-surfaces.json",
+      "path": "/metagraph/operational-surfaces.json",
+      "sha256": "d7682bd8f58ff7383d55ef3ff79412fed61794004b822e5ae392b336b2416dfc",
+      "size_bytes": 37581,
       "storage_tier": "dual"
     },
     {
@@ -34,8 +43,8 @@
       "key": "runs/2026-06-18T00-00-00-000Z/schemas/index.json",
       "latest_key": "latest/schemas/index.json",
       "path": "/metagraph/schemas/index.json",
-      "sha256": "8c492328cbcc45813a0563b8f587b125dd06d88e931e3286ba8df88386658607",
-      "size_bytes": 23965,
+      "sha256": "cf46bb7bae1b832a07b9937f4bf4b839a870275b835fe0fd5eaf49b4e1b0da26",
+      "size_bytes": 37277,
       "storage_tier": "dual"
     },
     {
@@ -43,16 +52,16 @@
       "key": "runs/2026-06-18T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "a4d4c221e7fc842e8e74fee8dfe7ed98dfe15616e8f38bdda587f5a9c3418804",
-      "size_bytes": 550210,
+      "sha256": "b9890a9cbed807bc86995c37ca9d0a87cf222505b0dff20cdc6652c759208469",
+      "size_bytes": 641686,
       "storage_tier": "dual"
     }
   ],
   "bucket_binding": "METAGRAPH_ARCHIVE",
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
-  "full_artifact_count": 2185,
-  "full_artifact_size_bytes": 38151278,
+  "full_artifact_count": 2256,
+  "full_artifact_size_bytes": 38855954,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/2026-06-18T00-00-00-000Z/r2-manifest.json",
   "generated_at": "2026-06-18T00:00:00.000Z",
@@ -70,11 +79,11 @@
   "run_prefix": "runs/2026-06-18T00-00-00-000Z/",
   "schema_version": 1,
   "storage_tier_counts": {
-    "dual": 5,
-    "r2": 2180
+    "dual": 6,
+    "r2": 2250
   },
   "storage_tier_size_bytes": {
-    "dual": 1461620,
-    "r2": 36689658
+    "dual": 1738104,
+    "r2": 37117850
   }
 }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1634,6 +1634,7 @@ export interface components {
             /** Format: date-time */
             observed_at?: string | null;
             parent_hash?: string | null;
+            spec_version?: number | null;
         };
         /** @description Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), from the first-party blocks D1 tier. Served live at /api/v1/blocks/{ref}; block is null when the ref is unknown or the store is cold (no static file). */
         BlockDetailArtifact: {
@@ -2226,10 +2227,12 @@ export interface components {
         /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
         Extrinsic: {
             block_number: number | null;
+            call_args?: Record<string, never> | unknown[] | string | number | boolean | null;
             call_function?: string | null;
             call_module?: string | null;
             extrinsic_hash?: string | null;
             extrinsic_index: number | null;
+            fee_tao?: number | null;
             /** Format: date-time */
             observed_at?: string | null;
             signer?: string | null;
@@ -5612,7 +5615,8 @@ export interface operations {
                      *           "event_count": 1,
                      *           "extrinsic_count": 1,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
-                     *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1"
+                     *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                     *           "spec_version": 1
                      *         },
                      *         "ref": "example",
                      *         "schema_version": 1
@@ -7647,10 +7651,12 @@ export interface operations {
                      *       "data": {
                      *         "extrinsic": {
                      *           "block_number": 5000000,
+                     *           "call_args": {},
                      *           "call_function": "example",
                      *           "call_module": "example",
                      *           "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "extrinsic_index": 1,
+                     *           "fee_tao": 0.5,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
                      *           "signer": "example",
                      *           "success": false

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -1297,6 +1297,12 @@
               "string",
               "null"
             ]
+          },
+          "spec_version": {
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "required": [
@@ -3720,6 +3726,16 @@
               "null"
             ]
           },
+          "call_args": {
+            "type": [
+              "object",
+              "array",
+              "string",
+              "number",
+              "boolean",
+              "null"
+            ]
+          },
           "call_function": {
             "type": [
               "string",
@@ -3741,6 +3757,12 @@
           "extrinsic_index": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "fee_tao": {
+            "type": [
+              "number",
               "null"
             ]
           },

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1613,6 +1613,7 @@
           "author": { "type": ["string", "null"] },
           "extrinsic_count": { "type": ["integer", "null"] },
           "event_count": { "type": ["integer", "null"] },
+          "spec_version": { "type": ["integer", "null"] },
           "observed_at": { "type": ["string", "null"], "format": "date-time" }
         }
       },
@@ -1660,7 +1661,9 @@
           "signer": { "type": ["string", "null"] },
           "call_module": { "type": ["string", "null"] },
           "call_function": { "type": ["string", "null"] },
+          "call_args": { "type": ["object", "array", "string", "number", "boolean", "null"] },
           "success": { "type": ["boolean", "null"] },
+          "fee_tao": { "type": ["number", "null"] },
           "observed_at": { "type": ["string", "null"], "format": "date-time" }
         }
       },


### PR DESCRIPTION
### Motivation
- The Block and Extrinsic formatters were extended to emit `spec_version`, `fee_tao`, and `call_args` but the strict component schemas omitted those fields, causing schema validation failures for `/api/v1/blocks` and `/api/v1/extrinsics` responses. 
- This is contract drift that can break schema-governed clients and validation tooling and must be fixed by updating the canonical schemas.

### Description
- Add `spec_version` (nullable integer) to the `Block` component schema in `schemas/components/05-subnets.schema.json`. 
- Add `call_args` (accepting `object | array | string | number | boolean | null`) and `fee_tao` (nullable number) to the `Extrinsic` component schema while preserving `additionalProperties: false`. 
- Regenerate the bundled OpenAPI and derived artifacts via the build, updating `public/metagraph/openapi.json`, `schemas/api-components.schema.json`, generated TypeScript contract artifacts, and the `r2-manifest` so clients and validators include the new fields.

### Testing
- Ran `npm run build` which bundled the component schemas and regenerated types and client helpers successfully. 
- Ran `npm run validate:contract-drift`, `npm run validate:schemas`, `npm run validate:openapi`, `npm run validate:api`, and `npm run validate:types`, and all validators passed. 
- Ran tests with `npm test -- --run tests/blocks.test.mjs tests/extrinsics.test.mjs` and both test files (40 tests total) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d073cdce4832cb91c806c63784f7c)