### PR TITLE
fix(schema): document Extrinsic decoded fields (`call_args`, `fee_tao`) and regenerate contract

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -2223,13 +2223,19 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
-        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
+        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments as JSON when available; success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); fee_tao is the TransactionPayment fee in TAO when emitted; observed_at is the block time. */
         Extrinsic: {
             block_number: number | null;
+            /** @description Decoded extrinsic call arguments parsed from the D1 call_args JSON payload, or null when unavailable or unparsable. */
+            call_args?: {
+                [key: string]: unknown;
+            } | unknown[] | string | number | boolean | null;
             call_function?: string | null;
             call_module?: string | null;
             extrinsic_hash?: string | null;
             extrinsic_index: number | null;
+            /** @description Transaction fee in TAO from TransactionPayment.TransactionFeePaid, or null when unavailable. */
+            fee_tao?: number | null;
             /** Format: date-time */
             observed_at?: string | null;
             signer?: string | null;
@@ -7647,10 +7653,12 @@ export interface operations {
                      *       "data": {
                      *         "extrinsic": {
                      *           "block_number": 5000000,
+                     *           "call_args": {},
                      *           "call_function": "example",
                      *           "call_module": "example",
                      *           "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "extrinsic_index": 1,
+                     *           "fee_tao": 0.5,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
                      *           "signer": "example",
                      *           "success": false

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3726,11 +3726,23 @@
       },
       "Extrinsic": {
         "additionalProperties": false,
-        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
+        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments as JSON when available; success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); fee_tao is the TransactionPayment fee in TAO when emitted; observed_at is the block time.",
         "properties": {
           "block_number": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "call_args": {
+            "additionalProperties": true,
+            "description": "Decoded extrinsic call arguments parsed from the D1 call_args JSON payload, or null when unavailable or unparsable.",
+            "type": [
+              "object",
+              "array",
+              "string",
+              "number",
+              "boolean",
               "null"
             ]
           },
@@ -3755,6 +3767,13 @@
           "extrinsic_index": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "fee_tao": {
+            "description": "Transaction fee in TAO from TransactionPayment.TransactionFeePaid, or null when unavailable.",
+            "type": [
+              "number",
               "null"
             ]
           },
@@ -16927,10 +16946,12 @@
                   "data": {
                     "extrinsic": {
                       "block_number": 5000000,
+                      "call_args": {},
                       "call_function": "example",
                       "call_module": "example",
                       "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                       "extrinsic_index": 1,
+                      "fee_tao": 0.5,
                       "observed_at": "2026-06-01T00:00:00.000Z",
                       "signer": "example",
                       "success": false

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2223,13 +2223,19 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
-        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
+        /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments as JSON when available; success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); fee_tao is the TransactionPayment fee in TAO when emitted; observed_at is the block time. */
         Extrinsic: {
             block_number: number | null;
+            /** @description Decoded extrinsic call arguments parsed from the D1 call_args JSON payload, or null when unavailable or unparsable. */
+            call_args?: {
+                [key: string]: unknown;
+            } | unknown[] | string | number | boolean | null;
             call_function?: string | null;
             call_module?: string | null;
             extrinsic_hash?: string | null;
             extrinsic_index: number | null;
+            /** @description Transaction fee in TAO from TransactionPayment.TransactionFeePaid, or null when unavailable. */
+            fee_tao?: number | null;
             /** Format: date-time */
             observed_at?: string | null;
             signer?: string | null;
@@ -7647,10 +7653,12 @@ export interface operations {
                      *       "data": {
                      *         "extrinsic": {
                      *           "block_number": 5000000,
+                     *           "call_args": {},
                      *           "call_function": "example",
                      *           "call_module": "example",
                      *           "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "extrinsic_index": 1,
+                     *           "fee_tao": 0.5,
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
                      *           "signer": "example",
                      *           "success": false

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3712,11 +3712,23 @@
       },
       "Extrinsic": {
         "additionalProperties": false,
-        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
+        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments as JSON when available; success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); fee_tao is the TransactionPayment fee in TAO when emitted; observed_at is the block time.",
         "properties": {
           "block_number": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "call_args": {
+            "additionalProperties": true,
+            "description": "Decoded extrinsic call arguments parsed from the D1 call_args JSON payload, or null when unavailable or unparsable.",
+            "type": [
+              "object",
+              "array",
+              "string",
+              "number",
+              "boolean",
               "null"
             ]
           },
@@ -3741,6 +3753,13 @@
           "extrinsic_index": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "fee_tao": {
+            "description": "Transaction fee in TAO from TransactionPayment.TransactionFeePaid, or null when unavailable.",
+            "type": [
+              "number",
               "null"
             ]
           },

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1651,7 +1651,7 @@
       "Extrinsic": {
         "type": "object",
         "additionalProperties": false,
-        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
+        "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments as JSON when available; success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); fee_tao is the TransactionPayment fee in TAO when emitted; observed_at is the block time.",
         "required": ["block_number", "extrinsic_index"],
         "properties": {
           "block_number": { "type": ["integer", "null"] },
@@ -1660,7 +1660,16 @@
           "signer": { "type": ["string", "null"] },
           "call_module": { "type": ["string", "null"] },
           "call_function": { "type": ["string", "null"] },
+          "call_args": {
+            "type": ["object", "array", "string", "number", "boolean", "null"],
+            "additionalProperties": true,
+            "description": "Decoded extrinsic call arguments parsed from the D1 call_args JSON payload, or null when unavailable or unparsable."
+          },
           "success": { "type": ["boolean", "null"] },
+          "fee_tao": {
+            "type": ["number", "null"],
+            "description": "Transaction fee in TAO from TransactionPayment.TransactionFeePaid, or null when unavailable."
+          },
           "observed_at": { "type": ["string", "null"], "format": "date-time" }
         }
       },


### PR DESCRIPTION
### Motivation
- The API began emitting a `call_args` property (and `fee_tao`) for extrinsic objects but the canonical Extrinsic schema/OpenAPI component still used `additionalProperties: false` and omitted those fields, causing contract drift and breaking client/validator consumers. 

### Description
- Add `call_args` to the canonical `Extrinsic` schema as a flexible JSON-typed field (`object|array|string|number|boolean|null`) with `additionalProperties: true` and a clarifying description in `schemas/components/05-subnets.schema.json`. 
- Add `fee_tao` to the `Extrinsic` schema as `number|null` with a short description. 
- Regenerate the bundled contract artifacts via `npm run build`, updating `schemas/api-components.schema.json`, `public/metagraph/openapi.json`, `public/metagraph/types.d.ts`, and the generated client/type files so published OpenAPI/types reflect the new fields. 

### Testing
- Ran `npm run build` and the build completed successfully. 
- Ran unit tests with `npm test -- --run tests/extrinsics.test.mjs` and all tests passed (`19 passed`). 
- Ran contract and schema validators `npm run validate:contract-drift`, `npm run validate:schemas`, `npm run validate:openapi`, `npm run validate:types`, and `npm run validate:generated-client`, and all checks passed. 
- Ran `npm run format:check` and code style checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d073db93c832cbe1785174409575e)