### PR TITLE
fix(api): drop malformed rows from the neuron-history builders

### DIFF
--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -287,18 +287,30 @@ export const NEURON_DAILY_READ_COLUMNS = `snapshot_date, ${NEURON_COLUMNS}`;
 // Per-UID time series: one point per snapshot_date (the handler queries newest
 // first, bounded by MAX_HISTORY_POINTS), each a live-shaped neuron plus its date.
 export function buildNeuronHistory(rows, netuid, uid, { window } = {}) {
+  // Drop any malformed (non-object) row so the array only holds real points and
+  // the count tracks it (point_count === points.length) -- mirroring the
+  // blocks/extrinsics/metagraph builders' .filter(Boolean) guard (#1793). Reading
+  // formatNeuron(r) first also means a null/undefined element degrades gracefully
+  // instead of throwing on `r.snapshot_date`.
+  const points = (rows || [])
+    .map((r) => {
+      const neuron = formatNeuron(r);
+      if (!neuron) return null;
+      return {
+        snapshot_date: r.snapshot_date,
+        captured_at: toIso(r.captured_at),
+        block_number: r.block_number ?? null,
+        ...neuron,
+      };
+    })
+    .filter(Boolean);
   return {
     schema_version: 1,
     netuid,
     uid,
     window: window ?? null,
-    point_count: rows.length,
-    points: rows.map((r) => ({
-      snapshot_date: r.snapshot_date,
-      captured_at: toIso(r.captured_at),
-      block_number: r.block_number ?? null,
-      ...formatNeuron(r),
-    })),
+    point_count: points.length,
+    points,
   };
 }
 
@@ -416,17 +428,23 @@ function median(values) {
 // snapshot_date (newest first), for a subnet-level history sparkline without
 // shipping every UID. Rows come from a GROUP BY snapshot_date query.
 export function buildSubnetHistory(rows, netuid, { window } = {}) {
-  return {
-    schema_version: 1,
-    netuid,
-    window: window ?? null,
-    point_count: rows.length,
-    points: rows.map((r) => ({
+  // Drop any malformed (non-object) row so the count tracks the emitted array
+  // (point_count === points.length) and a null/undefined element never throws on
+  // `r.snapshot_date` -- mirroring the sibling feed builders' guard (#1793).
+  const points = (rows || [])
+    .filter((r) => r && typeof r === "object")
+    .map((r) => ({
       snapshot_date: r.snapshot_date,
       neuron_count: r.neuron_count ?? null,
       validator_count: r.validator_count ?? null,
       total_stake_tao: r.total_stake_tao ?? null,
       total_emission_tao: r.total_emission_tao ?? null,
-    })),
+    }));
+  return {
+    schema_version: 1,
+    netuid,
+    window: window ?? null,
+    point_count: points.length,
+    points,
   };
 }

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -293,6 +293,38 @@ describe("history builders", () => {
     assert.deepEqual(out.days, []);
     assert.equal(out.window, null);
   });
+
+  test("buildNeuronHistory drops malformed rows and the count tracks the array (#1793)", () => {
+    // A null/non-object row can't become a Neuron point, so it must not leak into
+    // the array — and the count tracks the array (point_count === points.length),
+    // mirroring the blocks/extrinsics/metagraph builders' .filter(Boolean). A
+    // non-object element must also degrade gracefully, never throw.
+    const out = buildNeuronHistory(
+      [dailyRow(), null, dailyRow({ uid: 9 }), undefined, 0],
+      7,
+      3,
+    );
+    assert.equal(out.points.length, 2);
+    assert.equal(out.point_count, 2);
+    assert.ok(out.points.every(Boolean));
+    assert.deepEqual(
+      out.points.map((p) => p.uid),
+      [3, 9],
+    );
+    // A null/undefined rows argument is tolerated (empty series, never throws).
+    assert.deepEqual(buildNeuronHistory(null, 7, 3).points, []);
+  });
+
+  test("buildSubnetHistory drops malformed rows and the count tracks the array (#1793)", () => {
+    const out = buildSubnetHistory(
+      [{ snapshot_date: "2026-06-20", neuron_count: 256 }, null, undefined],
+      7,
+    );
+    assert.equal(out.points.length, 1);
+    assert.equal(out.point_count, 1);
+    assert.equal(out.points[0].neuron_count, 256);
+    assert.deepEqual(buildSubnetHistory(undefined, 7).points, []);
+  });
 });
 
 describe("rollupNeuronDaily idempotency invariant (#1345)", () => {


### PR DESCRIPTION
## Summary

- `buildNeuronHistory` and `buildSubnetHistory` (`src/neuron-history.mjs`) were the only response builders left that set `point_count: rows.length` and mapped every row WITHOUT the `.filter(Boolean)` guard the sibling feed builders use. This makes them drop malformed rows and track the count off the emitted array, mirroring the metagraph/validator builders fixed in #1793.

## What Changed

- `buildNeuronHistory`: compute `formatNeuron(r)` first; a non-object row (where `formatNeuron` returns `null`) is dropped instead of leaking a partial point - and no longer throws on `r.snapshot_date` for a `null`/`undefined` element. `point_count` now equals `points.length`.
- `buildSubnetHistory`: filter to object rows before mapping, so a `null`/`undefined` element never throws on `r.snapshot_date` and the count tracks the array.
- Both tolerate a `null`/`undefined` `rows` argument (empty series).
- Added unit tests asserting malformed rows are dropped and `point_count === points.length` for both builders (valid sparse object rows are still kept, unchanged).

This is the same invariant #1793 ("drop malformed rows from subnet metagraph and validator arrays") established - `*_count === array.length`, mirroring the blocks/extrinsics/account-events builders' `.filter(Boolean)`. These two history builders were the missed siblings.

Fixes #1928

## Template Used

- backend-code.md

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change: a malformed row never produced a valid point; only the count and a throw edge are corrected.)

## Validation

- [x] `npm run worker:test` (tests/neuron-history.test.mjs: 38 passed)
- [x] `npx prettier --check` on the changed files
- [x] `git diff --check`