### PR TITLE
fix(api): drop malformed rows from the neuron-history builders

### DIFF
--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -285,18 +285,30 @@ export const NEURON_DAILY_READ_COLUMNS = `snapshot_date, ${NEURON_COLUMNS}`;
 // Per-UID time series: one point per snapshot_date (the handler queries newest
 // first, bounded by MAX_HISTORY_POINTS), each a live-shaped neuron plus its date.
 export function buildNeuronHistory(rows, netuid, uid, { window } = {}) {
+  // Drop any malformed row (formatNeuron → null on a non-object element) so a
+  // point is never a bare date with no neuron data, and point_count tracks the
+  // emitted array — mirroring buildSubnetMetagraph and the blocks/extrinsics
+  // feed builders (#1793). Computing formatNeuron first also stops a null/
+  // undefined element from throwing on r.snapshot_date.
+  const points = (rows ?? [])
+    .map((r) => {
+      const neuron = formatNeuron(r);
+      if (!neuron) return null;
+      return {
+        snapshot_date: r.snapshot_date,
+        captured_at: toIso(r.captured_at),
+        block_number: r.block_number ?? null,
+        ...neuron,
+      };
+    })
+    .filter(Boolean);
   return {
     schema_version: 1,
     netuid,
     uid,
     window: window ?? null,
-    point_count: rows.length,
-    points: rows.map((r) => ({
-      snapshot_date: r.snapshot_date,
-      captured_at: toIso(r.captured_at),
-      block_number: r.block_number ?? null,
-      ...formatNeuron(r),
-    })),
+    point_count: points.length,
+    points,
   };
 }
 
@@ -304,17 +316,23 @@ export function buildNeuronHistory(rows, netuid, uid, { window } = {}) {
 // snapshot_date (newest first), for a subnet-level history sparkline without
 // shipping every UID. Rows come from a GROUP BY snapshot_date query.
 export function buildSubnetHistory(rows, netuid, { window } = {}) {
-  return {
-    schema_version: 1,
-    netuid,
-    window: window ?? null,
-    point_count: rows.length,
-    points: rows.map((r) => ({
+  // Skip any non-object element so a null/undefined row never throws on
+  // r.snapshot_date, and point_count tracks the emitted array (same invariant
+  // as the neuron/feed builders, #1793).
+  const points = (rows ?? [])
+    .filter((r) => r && typeof r === "object")
+    .map((r) => ({
       snapshot_date: r.snapshot_date,
       neuron_count: r.neuron_count ?? null,
       validator_count: r.validator_count ?? null,
       total_stake_tao: r.total_stake_tao ?? null,
       total_emission_tao: r.total_emission_tao ?? null,
-    })),
+    }));
+  return {
+    schema_version: 1,
+    netuid,
+    window: window ?? null,
+    point_count: points.length,
+    points,
   };
 }

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -212,6 +212,33 @@ describe("history builders", () => {
     assert.equal(out.points[0].total_stake_tao, null);
     assert.equal(out.points[0].total_emission_tao, null);
   });
+
+  test("buildNeuronHistory drops malformed rows; point_count tracks the array (#1793)", () => {
+    // A null/undefined element (formatNeuron → null) is dropped, not leaked as a
+    // bare-date point, and never throws on r.snapshot_date. Valid sparse object
+    // rows are still kept.
+    const out = buildNeuronHistory([dailyRow(), null, undefined], 7, 3);
+    assert.equal(out.points.length, 1);
+    assert.equal(out.point_count, out.points.length);
+    assert.equal(out.points[0].uid, 3);
+    // A null rows argument yields an empty series rather than throwing.
+    const empty = buildNeuronHistory(null, 7, 3);
+    assert.equal(empty.point_count, 0);
+    assert.deepEqual(empty.points, []);
+  });
+
+  test("buildSubnetHistory drops non-object rows; point_count tracks the array", () => {
+    const out = buildSubnetHistory(
+      [{ snapshot_date: "2026-06-20", neuron_count: 5 }, null, undefined],
+      7,
+    );
+    assert.equal(out.points.length, 1);
+    assert.equal(out.point_count, out.points.length);
+    assert.equal(out.points[0].neuron_count, 5);
+    const empty = buildSubnetHistory(undefined, 7);
+    assert.equal(empty.point_count, 0);
+    assert.deepEqual(empty.points, []);
+  });
 });
 
 describe("rollupNeuronDaily idempotency invariant (#1345)", () => {


### PR DESCRIPTION
## Summary

- `buildNeuronHistory` and `buildSubnetHistory` (`src/neuron-history.mjs`) were the only response builders left that set `point_count: rows.length` and mapped every row WITHOUT the `.filter(Boolean)` guard the sibling feed builders use. They are the missed siblings of #1793 ("drop malformed rows from subnet metagraph and validator arrays").

## What Changed

- `buildNeuronHistory`: compute `formatNeuron(r)` first; a non-object row (where `formatNeuron` returns `null`) is dropped instead of leaking a partial bare-date point, and no longer throws on `r.snapshot_date` for a `null`/`undefined` element. `point_count` now equals `points.length`.
- `buildSubnetHistory`: filter to object rows before mapping, so a `null`/`undefined` element never throws on `r.snapshot_date` and the count tracks the array.
- Both tolerate a `null`/`undefined` `rows` argument (empty series).
- Added unit tests asserting malformed rows are dropped and `point_count === points.length` for both builders (valid sparse object rows are still kept, unchanged).

This restores the same `*_count === array.length` invariant #1793 established, mirroring `buildSubnetMetagraph` (`src/metagraph-neurons.mjs`) and the blocks/extrinsics/account-events builders' `.filter(Boolean)`. No contract change: a malformed row never produced a valid point; only the count and a throw edge are corrected.

Fixes #1930

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None: a malformed row never produced a valid point.)

## Validation

- [x] `npm run worker:test` (tests/neuron-history.test.mjs)
- [x] `npx prettier@3.8.4 --check` on the changed files
- [x] `git diff --check`
