### PR TITLE
fix(health): clamp a sub-perfect day's stored uptime_ratio below 1

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -726,7 +726,16 @@ export async function rollupDailyUptime(env, overrides = {}) {
        ? AS day,
        COUNT(*) AS samples,
        SUM(ok) AS ok_count,
-       ROUND(CAST(SUM(ok) AS REAL) / COUNT(*), 4) AS uptime_ratio,
+       -- Only a genuinely perfect day (every probe ok) stores 1; a sub-perfect
+       -- day whose 4-dp round would reach 1.0 (e.g. 0.99996) is clamped down to
+       -- 0.9999, mirroring displayUptimeRatio (#1799). Without this the stored
+       -- ratio contradicts the co-computed degraded status, and the per-day
+       -- series reports 100% for a day that had a failed probe.
+       CASE
+         WHEN SUM(ok) = COUNT(*) THEN 1.0
+         WHEN ROUND(CAST(SUM(ok) AS REAL) / COUNT(*), 4) >= 1.0 THEN 0.9999
+         ELSE ROUND(CAST(SUM(ok) AS REAL) / COUNT(*), 4)
+       END AS uptime_ratio,
        ${latencyStatColumns({ roundedAvg: true, includeMinMax: false })},
        CASE
          WHEN SUM(ok) = COUNT(*) THEN 'ok'

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -1781,6 +1781,28 @@ describe("rollupDailyUptime (durable daily history)", () => {
     assert.equal(stmts[1].binds[0], Date.UTC(2026, 5, 12));
   });
 
+  test("clamps a sub-perfect day's stored uptime_ratio below 1 (#1799)", async () => {
+    // The stored uptime_ratio is served verbatim in the per-day series, so a
+    // sub-perfect day must never round up to a perfect 1.0 (SQLite
+    // ROUND(0.99996, 4) === 1.0). Only SUM(ok) = COUNT(*) may store 1; any other
+    // day that rounds to 1 is clamped to 0.9999, mirroring displayUptimeRatio —
+    // and so the stored ratio never contradicts the co-computed degraded status.
+    const db = makeDb();
+    await rollupDailyUptime(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => Date.UTC(2026, 5, 13, 10, 0, 0) },
+    );
+    const { sql } = db.calls.batches[0][0];
+    assert.match(sql, /WHEN SUM\(ok\) = COUNT\(\*\) THEN 1/);
+    assert.match(sql, /THEN 0\.9999/);
+    // The naive bare-round form (which collapses 0.99996 -> 1) must be gone as
+    // the standalone column expression.
+    assert.doesNotMatch(
+      sql,
+      /ROUND\(CAST\(SUM\(ok\) AS REAL\) \/ COUNT\(\*\), 4\) AS uptime_ratio/,
+    );
+  });
+
   test("no-ops without a D1 binding", async () => {
     assert.deepEqual(await rollupDailyUptime({}), { rolled: false });
   });


### PR DESCRIPTION
## Summary

- `rollupDailyUptime` (`src/health-prober.mjs`) stored each surface/day `uptime_ratio` as a bare `ROUND(CAST(SUM(ok) AS REAL) / COUNT(*), 4)`. SQLite `ROUND(0.99996, 4)` is `1.0`, so a sub-perfect day was persisted as a perfect `uptime_ratio = 1`. This is the SQL-writer sibling of #1799, which fixed the same sub-perfect-rounds-to-1 collapse on the live read path (`displayUptimeRatio`).

## What Changed

- The stored `uptime_ratio` column is now computed with a clamp that mirrors `displayUptimeRatio`:
  - `SUM(ok) = COUNT(*)` (a genuinely perfect day) -> `1.0`
  - otherwise, a value that rounds to `>= 1.0` -> `0.9999`
  - otherwise -> the 4-dp rounded ratio
- Added a unit test asserting the rollup SQL contains the clamp guard and no longer emits the bare-round column expression.

## Why it was observably wrong

The stored column is served verbatim in the per-day uptime series (`src/health-serving.mjs` reads `row.uptime_ratio`), and the same SELECT's co-computed `status` derives from `SUM(ok) = COUNT(*)`. So a 24999/25000 day stored `uptime_ratio = 1.0` **and** `status = 'degraded'` - a perfect ratio reported (as 100%) for a day that had a failed probe. Now only a truly perfect day reaches 1.

## Template Used

- backend-code.md

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No schema/contract change (only the stored numeric value is corrected; column set unchanged).

## Validation

- [x] `npm run worker:test` (tests/health-prober.test.mjs: 75 passed)
- [x] `npx prettier --check` on the changed files
- [x] `git diff --check`

Fixes #1935