### PR TITLE
fix(health): normalize unrecognized statuses in the global summary counts

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -494,7 +494,7 @@ export async function runHealthProber(env, ctx, overrides = {}) {
   await persistToKv(kv, probed, runAt);
 
   const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
-  for (const row of probed) counts[row.status] = (counts[row.status] || 0) + 1;
+  for (const row of probed) counts[normalizeProbeStatus(row.status)] += 1;
   const durationMs = now() - runAt;
   // Wall-time guard: the prober runs on a 15-minute Cron Trigger, a hard CF
   // ceiling. As the autonomous flywheel grows surfaces, a sweep that creeps past
@@ -592,7 +592,7 @@ async function persistToD1(db, probed, runAt) {
 async function persistToKv(kv, probed, runAt) {
   if (!kv?.put) return;
   const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
-  for (const row of probed) counts[row.status] = (counts[row.status] || 0) + 1;
+  for (const row of probed) counts[normalizeProbeStatus(row.status)] += 1;
 
   const surfaceRows = probed.map((row) => ({
     surface_id: row.surface_id,

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -383,6 +383,54 @@ describe("runHealthProber", () => {
     assert.equal(meta.last_run_at, new Date(50000).toISOString());
   });
 
+  test("folds an unrecognized probe status into `unknown` in the summary counts (#1739)", async () => {
+    // Per the normalizeProbeStatus contract, every caller that aggregates probe
+    // rows must normalize first so a forward-compat/unknown status can't bypass
+    // the four buckets. The per-subnet rollup (summarizeGroup) already did; the
+    // global summary status_counts must too — otherwise a status like "throttled"
+    // would add a phantom key and leave `unknown` undercounted.
+    const kv = makeKv();
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 50000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => SURFACES,
+        probeSurface: async () => ({
+          status: "throttled", // not one of ok|degraded|failed|unknown
+          classification: "rate-limited",
+          latency_ms: null,
+          status_code: 429,
+        }),
+        probeOptions: {},
+      },
+    );
+    // Returned cron counts: both surfaces fold into `unknown`, no phantom key.
+    assert.deepEqual(result.counts, {
+      ok: 0,
+      degraded: 0,
+      failed: 0,
+      unknown: 2,
+    });
+    // Served KV summary + meta: same canonical four buckets, nothing extra.
+    const current = kv.json(KV_HEALTH_CURRENT);
+    assert.deepEqual(current.summary.status_counts, {
+      ok: 0,
+      degraded: 0,
+      failed: 0,
+      unknown: 2,
+    });
+    const meta = kv.json(KV_HEALTH_META);
+    assert.deepEqual(Object.keys(meta.status_counts).sort(), [
+      "degraded",
+      "failed",
+      "ok",
+      "unknown",
+    ]);
+  });
+
   test("rejects unsafe or implausibly high live RPC block heights", async () => {
     const kv = makeKv();
     const rpcSurfaces = [


### PR DESCRIPTION
## Summary

- The per-subnet rollup `summarizeGroup` normalizes each probe status through `normalizeProbeStatus` before bucketing (#1739), honoring the documented contract in `src/health-probe-core.mjs` that aggregating callers must fold unrecognized / forward-compat statuses into the four canonical buckets. The two GLOBAL summary counters were the missed siblings.

## What Changed

- `src/health-prober.mjs`: both global `counts` loops (the `runHealthProber` return `counts` and the `persistToKv` served `status_counts`) now route the status through `normalizeProbeStatus`, mirroring `summarizeGroup` (line 353).
- Added a unit test injecting a probe with an unrecognized status (`"throttled"`) and asserting it folds into `unknown` in both the returned cron counts and the served KV `summary.status_counts` / `meta.status_counts` (no phantom key).

## Why it was observably wrong

The served `summary.status_counts` (KV `health:current`) and `meta.status_counts` come straight from the un-normalized loop. A status outside `ok|degraded|failed|unknown` did `counts[row.status] = (counts[row.status] || 0) + 1`, **creating a new key** (e.g. `status_counts.throttled = 1`) and leaving `unknown` undercounted - exactly the bypass `normalizeProbeStatus` exists to prevent, and which #1739 already fixed for the per-subnet path.

## Template Used

- backend-code.md

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No schema/contract change (the four canonical buckets are unchanged; only an out-of-set status is now folded into `unknown` instead of leaking a key).

## Validation

- [x] `npm run worker:test` (tests/health-prober.test.mjs: 75 passed)
- [x] `npx prettier --check` on the changed files
- [x] `git diff --check`

Fixes #1942