### PR TITLE
feat(api): negation filters (not_) on list endpoints

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/client": "0.7.0",
+  "packages/client": "0.8.0",
   "python": "0.4.1",
   ".": "0.24.0"
 }

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -6630,6 +6630,10 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -7262,6 +7266,10 @@ export interface operations {
                 agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
                 blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
                 q?: string;
+                not_netuid?: number;
+                not_tier?: "agent-ready" | "machine-usable" | "candidate-review" | "needs-evidence" | "hard-blocked" | "missing-interface";
+                not_agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
+                not_blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -7454,6 +7462,8 @@ export interface operations {
             query?: {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
+                not_netuid?: number;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -7590,6 +7600,8 @@ export interface operations {
                 netuid?: number;
                 registration_allowed?: "true" | "false";
                 q?: string;
+                not_netuid?: number;
+                not_registration_allowed?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -7737,6 +7749,12 @@ export interface operations {
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 severity?: "critical" | "warning" | "info";
                 state?: "active" | "resolved";
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
+                not_severity?: "critical" | "warning" | "info";
+                not_state?: "active" | "resolved";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -7883,6 +7901,8 @@ export interface operations {
             query?: {
                 id?: string;
                 kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
+                not_id?: string;
+                not_kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -8056,6 +8076,13 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_netuid?: number;
+                not_pool_eligible?: "true" | "false";
+                not_provider?: string;
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -8829,6 +8856,9 @@ export interface operations {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_netuid?: number;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -8959,6 +8989,8 @@ export interface operations {
             query?: {
                 netuid?: number;
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_netuid?: number;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9086,6 +9118,11 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
+                not_classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9702,6 +9739,12 @@ export interface operations {
                 confidence?: "low" | "medium" | "high";
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
                 q?: string;
+                not_netuid?: number;
+                not_subnet_type?: "root" | "application";
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_review_state?: string;
+                not_confidence?: "low" | "medium" | "high";
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9953,6 +9996,9 @@ export interface operations {
                 id?: string;
                 kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
                 authority?: "community" | "official" | "provider-claimed" | "registry-observed";
+                not_id?: string;
+                not_kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
+                not_authority?: "community" | "official" | "provider-claimed" | "registry-observed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10204,6 +10250,12 @@ export interface operations {
                 pool_eligible?: "true" | "false";
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_netuid?: number;
+                not_pool_eligible?: "true" | "false";
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10599,6 +10651,12 @@ export interface operations {
                 operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 reason_codes?: string;
                 recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
+                not_netuid?: number;
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_candidate_api_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_reason_codes?: string;
+                not_recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10752,6 +10810,11 @@ export interface operations {
                 missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 netuid?: number;
                 q?: string;
+                not_direct_submission_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                not_lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                not_missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_netuid?: number;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10915,6 +10978,17 @@ export interface operations {
                 review_state?: string;
                 manual_review_required?: "true" | "false";
                 q?: string;
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_direct_submission_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                not_identity_level?: "none" | "directory" | "partial" | "complete";
+                not_lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                not_missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_netuid?: number;
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                not_reason_codes?: string;
+                not_review_state?: string;
+                not_manual_review_required?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11123,6 +11197,19 @@ export interface operations {
                 target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 target_type?: "surface-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 q?: string;
+                not_auto_review_candidate?: "true" | "false";
+                not_evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                not_identity_level?: "none" | "directory" | "partial" | "complete";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                not_manual_review_required?: "true" | "false";
+                not_missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_netuid?: number;
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                not_reason_codes?: string;
+                not_submission_route?: "direct-candidate-pr" | "adapter-request" | "maintainer-review" | "status-report";
+                not_target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
+                not_target_type?: "surface-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11331,6 +11418,9 @@ export interface operations {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                not_netuid?: number;
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_review_state?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11462,6 +11552,12 @@ export interface operations {
                 identity_level?: "none" | "directory" | "partial" | "complete";
                 identity_promotion_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 native_name_quality?: "chain" | "placeholder" | "empty";
+                not_netuid?: number;
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                not_confidence?: "low" | "medium" | "high";
+                not_identity_level?: "none" | "directory" | "partial" | "complete";
+                not_identity_promotion_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_native_name_quality?: "chain" | "placeholder" | "empty";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11658,6 +11754,13 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_netuid?: number;
+                not_pool_eligible?: "true" | "false";
+                not_provider?: string;
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12593,6 +12696,13 @@ export interface operations {
                 max_surface_count?: number;
                 min_tempo?: number;
                 max_tempo?: number;
+                not_netuid?: number;
+                not_netuids?: string;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_domain?: "agents" | "compute" | "data" | "finance" | "inference" | "media" | "prediction" | "privacy" | "robotics" | "science" | "search" | "security" | "storage" | "training";
+                not_status?: "active" | "inactive";
+                not_subnet_type?: "root" | "application";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13004,6 +13114,9 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13135,6 +13248,12 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_pool_eligible?: "true" | "false";
+                not_provider?: string;
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13528,6 +13647,8 @@ export interface operations {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_review_state?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13734,6 +13855,10 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
+                not_classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15361,6 +15486,8 @@ export interface operations {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15845,6 +15972,9 @@ export interface operations {
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -894,6 +894,87 @@
           }
         },
         {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_netuids",
+          "schema": {
+            "maxLength": 767,
+            "pattern": "^\\d{1,5}(,\\d{1,5}){0,127}$",
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_coverage_level",
+          "schema": {
+            "enum": [
+              "native-only",
+              "manifested",
+              "probed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_domain",
+          "schema": {
+            "enum": [
+              "agents",
+              "compute",
+              "data",
+              "finance",
+              "inference",
+              "media",
+              "prediction",
+              "privacy",
+              "robotics",
+              "science",
+              "search",
+              "security",
+              "storage",
+              "training"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "active",
+              "inactive"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_subnet_type",
+          "schema": {
+            "enum": [
+              "root",
+              "application"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1040,6 +1121,66 @@
         {
           "name": "q",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_subnet_type",
+          "schema": {
+            "enum": [
+              "root",
+              "application"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_review_state",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_confidence",
+          "schema": {
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_profile_level",
+          "schema": {
+            "enum": [
+              "directory-only",
+              "identity-partial",
+              "identity-complete",
+              "operational",
+              "adapter-backed"
+            ],
             "type": "string"
           }
         },
@@ -1193,6 +1334,41 @@
           }
         },
         {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1276,6 +1452,34 @@
         },
         {
           "name": "provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
           "schema": {
             "type": "string"
           }
@@ -1418,6 +1622,89 @@
         },
         {
           "name": "status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_layer",
+          "schema": {
+            "enum": [
+              "bittensor-base",
+              "data-provider",
+              "docs-provider",
+              "subnet-app"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_pool_eligible",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_publication_state",
+          "schema": {
+            "enum": [
+              "candidate",
+              "verified",
+              "monitored",
+              "pool-eligible",
+              "disabled",
+              "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
           "schema": {
             "enum": [
               "ok",
@@ -1574,6 +1861,82 @@
           }
         },
         {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_layer",
+          "schema": {
+            "enum": [
+              "bittensor-base",
+              "data-provider",
+              "docs-provider",
+              "subnet-app"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_pool_eligible",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_publication_state",
+          "schema": {
+            "enum": [
+              "candidate",
+              "verified",
+              "monitored",
+              "pool-eligible",
+              "disabled",
+              "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1677,6 +2040,55 @@
         },
         {
           "name": "state",
+          "schema": {
+            "enum": [
+              "schema-invalid",
+              "schema-valid",
+              "maintainer-review",
+              "verified",
+              "stale",
+              "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_state",
           "schema": {
             "enum": [
               "schema-invalid",
@@ -1795,6 +2207,48 @@
           }
         },
         {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_state",
+          "schema": {
+            "enum": [
+              "schema-invalid",
+              "schema-valid",
+              "maintainer-review",
+              "verified",
+              "stale",
+              "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1878,6 +2332,37 @@
         },
         {
           "name": "authority",
+          "schema": {
+            "enum": [
+              "community",
+              "official",
+              "provider-claimed",
+              "registry-observed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_id",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "data-provider",
+              "docs-provider",
+              "infrastructure-provider",
+              "registry",
+              "subnet-team"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_authority",
           "schema": {
             "enum": [
               "community",
@@ -2041,6 +2526,83 @@
           }
         },
         {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_layer",
+          "schema": {
+            "enum": [
+              "bittensor-base",
+              "data-provider",
+              "docs-provider",
+              "subnet-app"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_pool_eligible",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_publication_state",
+          "schema": {
+            "enum": [
+              "candidate",
+              "verified",
+              "monitored",
+              "pool-eligible",
+              "disabled",
+              "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2172,6 +2734,52 @@
           }
         },
         {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_tier",
+          "schema": {
+            "enum": [
+              "agent-ready",
+              "machine-usable",
+              "candidate-review",
+              "needs-evidence",
+              "hard-blocked",
+              "missing-interface"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_agent_status",
+          "schema": {
+            "enum": [
+              "callable",
+              "base-layer",
+              "candidate",
+              "needs-evidence",
+              "blocked"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_blocker_level",
+          "schema": {
+            "enum": [
+              "none",
+              "hard-blocked",
+              "needs-review",
+              "missing-data"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2253,6 +2861,23 @@
         {
           "name": "q",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_registration_allowed",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
             "type": "string"
           }
         },
@@ -2392,6 +3017,24 @@
           }
         },
         {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_coverage_level",
+          "schema": {
+            "enum": [
+              "native-only",
+              "manifested",
+              "probed"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2471,6 +3114,37 @@
         },
         {
           "name": "curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_coverage_level",
+          "schema": {
+            "enum": [
+              "native-only",
+              "manifested",
+              "probed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_curation_level",
           "schema": {
             "enum": [
               "native",
@@ -2570,6 +3244,32 @@
           }
         },
         {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_review_state",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2647,6 +3347,25 @@
         },
         {
           "name": "review_state",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_review_state",
           "schema": {
             "type": "string"
           }
@@ -2785,6 +3504,82 @@
         },
         {
           "name": "native_name_quality",
+          "schema": {
+            "enum": [
+              "chain",
+              "placeholder",
+              "empty"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_profile_level",
+          "schema": {
+            "enum": [
+              "directory-only",
+              "identity-partial",
+              "identity-complete",
+              "operational",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_confidence",
+          "schema": {
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_identity_level",
+          "schema": {
+            "enum": [
+              "none",
+              "directory",
+              "partial",
+              "complete"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_identity_promotion_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_native_name_quality",
           "schema": {
             "enum": [
               "chain",
@@ -2939,6 +3734,88 @@
         },
         {
           "name": "recommended_adapter_kind",
+          "schema": {
+            "enum": [
+              "custom-adapter",
+              "data-artifact-adapter",
+              "generic-openapi-or-custom",
+              "stream-adapter"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_candidate_api_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_operational_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_reason_codes",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_recommended_adapter_kind",
           "schema": {
             "enum": [
               "custom-adapter",
@@ -3167,6 +4044,144 @@
           }
         },
         {
+          "name": "not_curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_direct_submission_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_evidence_action",
+          "schema": {
+            "enum": [
+              "submit-new-evidence",
+              "verify-existing-evidence",
+              "replace-stale-evidence",
+              "review-existing-evidence",
+              "maintainer-review-existing-evidence",
+              "monitor"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_identity_level",
+          "schema": {
+            "enum": [
+              "none",
+              "directory",
+              "partial",
+              "complete"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_lane",
+          "schema": {
+            "enum": [
+              "direct-submission",
+              "maintainer-review",
+              "adapter-candidate",
+              "monitoring-followup",
+              "baseline-monitoring"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_missing_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_profile_level",
+          "schema": {
+            "enum": [
+              "directory-only",
+              "identity-partial",
+              "identity-complete",
+              "operational",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_reason_codes",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_review_state",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_manual_review_required",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -3324,6 +4339,84 @@
           "name": "q",
           "schema": {
             "type": "string"
+          }
+        },
+        {
+          "name": "not_direct_submission_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_evidence_action",
+          "schema": {
+            "enum": [
+              "submit-new-evidence",
+              "verify-existing-evidence",
+              "replace-stale-evidence",
+              "review-existing-evidence",
+              "maintainer-review-existing-evidence",
+              "monitor"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_lane",
+          "schema": {
+            "enum": [
+              "direct-submission",
+              "maintainer-review",
+              "adapter-candidate",
+              "monitoring-followup",
+              "baseline-monitoring"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_missing_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
           }
         },
         {
@@ -3572,6 +4665,174 @@
           }
         },
         {
+          "name": "not_auto_review_candidate",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_evidence_action",
+          "schema": {
+            "enum": [
+              "submit-new-evidence",
+              "verify-existing-evidence",
+              "replace-stale-evidence",
+              "review-existing-evidence",
+              "maintainer-review-existing-evidence",
+              "monitor"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_identity_level",
+          "schema": {
+            "enum": [
+              "none",
+              "directory",
+              "partial",
+              "complete"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_lane",
+          "schema": {
+            "enum": [
+              "direct-submission",
+              "maintainer-review",
+              "adapter-candidate",
+              "monitoring-followup",
+              "baseline-monitoring"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_manual_review_required",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_missing_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_profile_level",
+          "schema": {
+            "enum": [
+              "directory-only",
+              "identity-partial",
+              "identity-complete",
+              "operational",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_reason_codes",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_submission_route",
+          "schema": {
+            "enum": [
+              "direct-candidate-pr",
+              "adapter-request",
+              "maintainer-review",
+              "status-report"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_target_action",
+          "schema": {
+            "enum": [
+              "submit-new-candidate",
+              "replace-stale-candidate",
+              "verify-existing-candidate",
+              "review-existing-candidate",
+              "adapter-review",
+              "maintainer-review",
+              "monitoring-followup"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_target_type",
+          "schema": {
+            "enum": [
+              "surface-candidate",
+              "adapter-review",
+              "maintainer-review",
+              "monitoring-followup"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -3648,6 +4909,25 @@
         },
         {
           "name": "status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_status",
           "schema": {
             "enum": [
               "ok",
@@ -3794,6 +5074,72 @@
           }
         },
         {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_classification",
+          "schema": {
+            "enum": [
+              "auth-required",
+              "content-mismatch",
+              "dead",
+              "live",
+              "rate-limited",
+              "redirected",
+              "timeout",
+              "transient",
+              "unsupported",
+              "unsafe",
+              "wrong-chain"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -3903,6 +5249,65 @@
         },
         {
           "name": "classification",
+          "schema": {
+            "enum": [
+              "auth-required",
+              "content-mismatch",
+              "dead",
+              "live",
+              "rate-limited",
+              "redirected",
+              "timeout",
+              "transient",
+              "unsupported",
+              "unsafe",
+              "wrong-chain"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_classification",
           "schema": {
             "enum": [
               "auth-required",
@@ -5025,6 +6430,89 @@
           }
         },
         {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_layer",
+          "schema": {
+            "enum": [
+              "bittensor-base",
+              "data-provider",
+              "docs-provider",
+              "subnet-app"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_pool_eligible",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_publication_state",
+          "schema": {
+            "enum": [
+              "candidate",
+              "verified",
+              "monitored",
+              "pool-eligible",
+              "disabled",
+              "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -5109,6 +6597,23 @@
         },
         {
           "name": "kind",
+          "schema": {
+            "enum": [
+              "subtensor-rpc",
+              "subtensor-wss",
+              "archive"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_id",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_kind",
           "schema": {
             "enum": [
               "subtensor-rpc",
@@ -5241,6 +6746,74 @@
         },
         {
           "name": "state",
+          "schema": {
+            "enum": [
+              "active",
+              "resolved"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_severity",
+          "schema": {
+            "enum": [
+              "critical",
+              "warning",
+              "info"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_state",
           "schema": {
             "enum": [
               "active",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -15439,6 +15439,63 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "schema-invalid",
+                "schema-valid",
+                "maintainer-review",
+                "verified",
+                "stale",
+                "rejected"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -16287,6 +16344,60 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_tier",
+            "required": false,
+            "schema": {
+              "enum": [
+                "agent-ready",
+                "machine-usable",
+                "candidate-review",
+                "needs-evidence",
+                "hard-blocked",
+                "missing-interface"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_agent_status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "callable",
+                "base-layer",
+                "candidate",
+                "needs-evidence",
+                "blocked"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_blocker_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "none",
+                "hard-blocked",
+                "needs-review",
+                "missing-data"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -16570,6 +16681,28 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_coverage_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native-only",
+                "manifested",
+                "probed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -16793,6 +16926,27 @@
             "name": "q",
             "required": false,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_registration_allowed",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
               "type": "string"
             }
           },
@@ -17095,6 +17249,86 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_severity",
+            "required": false,
+            "schema": {
+              "enum": [
+                "critical",
+                "warning",
+                "info"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "active",
+                "resolved"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -17320,6 +17554,27 @@
           {
             "in": "query",
             "name": "kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "subtensor-rpc",
+                "subtensor-wss",
+                "archive"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
             "required": false,
             "schema": {
               "enum": [
@@ -17648,6 +17903,103 @@
           {
             "in": "query",
             "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_layer",
+            "required": false,
+            "schema": {
+              "enum": [
+                "bittensor-base",
+                "data-provider",
+                "docs-provider",
+                "subnet-app"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_pool_eligible",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_publication_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "candidate",
+                "verified",
+                "monitored",
+                "pool-eligible",
+                "disabled",
+                "rejected"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
             "required": false,
             "schema": {
               "enum": [
@@ -18791,6 +19143,43 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_coverage_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native-only",
+                "manifested",
+                "probed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -18996,6 +19385,29 @@
           {
             "in": "query",
             "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
             "required": false,
             "schema": {
               "enum": [
@@ -19269,6 +19681,82 @@
           {
             "in": "query",
             "name": "classification",
+            "required": false,
+            "schema": {
+              "enum": [
+                "auth-required",
+                "content-mismatch",
+                "dead",
+                "live",
+                "rate-limited",
+                "redirected",
+                "timeout",
+                "transient",
+                "unsupported",
+                "unsafe",
+                "wrong-chain"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_classification",
             "required": false,
             "schema": {
               "enum": [
@@ -20135,6 +20623,78 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_subnet_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "root",
+                "application"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_review_state",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_confidence",
+            "required": false,
+            "schema": {
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_profile_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "directory-only",
+                "identity-partial",
+                "identity-complete",
+                "operational",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -20480,6 +21040,43 @@
           {
             "in": "query",
             "name": "authority",
+            "required": false,
+            "schema": {
+              "enum": [
+                "community",
+                "official",
+                "provider-claimed",
+                "registry-observed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "data-provider",
+                "docs-provider",
+                "infrastructure-provider",
+                "registry",
+                "subnet-team"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_authority",
             "required": false,
             "schema": {
               "enum": [
@@ -20915,6 +21512,95 @@
           {
             "in": "query",
             "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_layer",
+            "required": false,
+            "schema": {
+              "enum": [
+                "bittensor-base",
+                "data-provider",
+                "docs-provider",
+                "subnet-app"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_pool_eligible",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_publication_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "candidate",
+                "verified",
+                "monitored",
+                "pool-eligible",
+                "disabled",
+                "rejected"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
             "required": false,
             "schema": {
               "enum": [
@@ -21547,6 +22233,100 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_candidate_api_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_operational_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_reason_codes",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_recommended_adapter_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "custom-adapter",
+                "data-artifact-adapter",
+                "generic-openapi-or-custom",
+                "stream-adapter"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -21858,6 +22638,94 @@
             "required": false,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_direct_submission_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_evidence_action",
+            "required": false,
+            "schema": {
+              "enum": [
+                "submit-new-evidence",
+                "verify-existing-evidence",
+                "replace-stale-evidence",
+                "review-existing-evidence",
+                "maintainer-review-existing-evidence",
+                "monitor"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_lane",
+            "required": false,
+            "schema": {
+              "enum": [
+                "direct-submission",
+                "maintainer-review",
+                "adapter-candidate",
+                "monitoring-followup",
+                "baseline-monitoring"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_missing_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
             }
           },
           {
@@ -22245,6 +23113,166 @@
             "name": "q",
             "required": false,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_direct_submission_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_evidence_action",
+            "required": false,
+            "schema": {
+              "enum": [
+                "submit-new-evidence",
+                "verify-existing-evidence",
+                "replace-stale-evidence",
+                "review-existing-evidence",
+                "maintainer-review-existing-evidence",
+                "monitor"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_identity_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "none",
+                "directory",
+                "partial",
+                "complete"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_lane",
+            "required": false,
+            "schema": {
+              "enum": [
+                "direct-submission",
+                "maintainer-review",
+                "adapter-candidate",
+                "monitoring-followup",
+                "baseline-monitoring"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_missing_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_profile_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "directory-only",
+                "identity-partial",
+                "identity-complete",
+                "operational",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_reason_codes",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_review_state",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_manual_review_required",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
               "type": "string"
             }
           },
@@ -22728,6 +23756,200 @@
           },
           {
             "in": "query",
+            "name": "not_auto_review_candidate",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_evidence_action",
+            "required": false,
+            "schema": {
+              "enum": [
+                "submit-new-evidence",
+                "verify-existing-evidence",
+                "replace-stale-evidence",
+                "review-existing-evidence",
+                "maintainer-review-existing-evidence",
+                "monitor"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_identity_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "none",
+                "directory",
+                "partial",
+                "complete"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_lane",
+            "required": false,
+            "schema": {
+              "enum": [
+                "direct-submission",
+                "maintainer-review",
+                "adapter-candidate",
+                "monitoring-followup",
+                "baseline-monitoring"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_manual_review_required",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_missing_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_profile_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "directory-only",
+                "identity-partial",
+                "identity-complete",
+                "operational",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_reason_codes",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_submission_route",
+            "required": false,
+            "schema": {
+              "enum": [
+                "direct-candidate-pr",
+                "adapter-request",
+                "maintainer-review",
+                "status-report"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_target_action",
+            "required": false,
+            "schema": {
+              "enum": [
+                "submit-new-candidate",
+                "replace-stale-candidate",
+                "verify-existing-candidate",
+                "review-existing-candidate",
+                "adapter-review",
+                "maintainer-review",
+                "monitoring-followup"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_target_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "surface-candidate",
+                "adapter-review",
+                "maintainer-review",
+                "monitoring-followup"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -23042,6 +24264,38 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_review_state",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -23314,6 +24568,94 @@
           {
             "in": "query",
             "name": "native_name_quality",
+            "required": false,
+            "schema": {
+              "enum": [
+                "chain",
+                "placeholder",
+                "empty"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_profile_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "directory-only",
+                "identity-partial",
+                "identity-complete",
+                "operational",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_confidence",
+            "required": false,
+            "schema": {
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_identity_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "none",
+                "directory",
+                "partial",
+                "complete"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_identity_promotion_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_native_name_quality",
             "required": false,
             "schema": {
               "enum": [
@@ -23677,6 +25019,103 @@
           {
             "in": "query",
             "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_layer",
+            "required": false,
+            "schema": {
+              "enum": [
+                "bittensor-base",
+                "data-provider",
+                "docs-provider",
+                "subnet-app"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_pool_eligible",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_publication_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "candidate",
+                "verified",
+                "monitored",
+                "pool-eligible",
+                "disabled",
+                "rejected"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
             "required": false,
             "schema": {
               "enum": [
@@ -25121,6 +26560,101 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuids",
+            "required": false,
+            "schema": {
+              "maxLength": 767,
+              "pattern": "^\\d{1,5}(,\\d{1,5}){0,127}$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_coverage_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native-only",
+                "manifested",
+                "probed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_domain",
+            "required": false,
+            "schema": {
+              "enum": [
+                "agents",
+                "compute",
+                "data",
+                "finance",
+                "inference",
+                "media",
+                "prediction",
+                "privacy",
+                "robotics",
+                "science",
+                "search",
+                "security",
+                "storage",
+                "training"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "active",
+                "inactive"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_subnet_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "root",
+                "application"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -25687,6 +27221,54 @@
           },
           {
             "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "schema-invalid",
+                "schema-valid",
+                "maintainer-review",
+                "verified",
+                "stale",
+                "rejected"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -25964,6 +27546,94 @@
           {
             "in": "query",
             "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_layer",
+            "required": false,
+            "schema": {
+              "enum": [
+                "bittensor-base",
+                "data-provider",
+                "docs-provider",
+                "subnet-app"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_pool_eligible",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_publication_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "candidate",
+                "verified",
+                "monitored",
+                "pool-eligible",
+                "disabled",
+                "rejected"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
             "required": false,
             "schema": {
               "enum": [
@@ -26602,6 +28272,29 @@
           },
           {
             "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_review_state",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -26930,6 +28623,73 @@
           {
             "in": "query",
             "name": "classification",
+            "required": false,
+            "schema": {
+              "enum": [
+                "auth-required",
+                "content-mismatch",
+                "dead",
+                "live",
+                "rate-limited",
+                "redirected",
+                "timeout",
+                "transient",
+                "unsupported",
+                "unsafe",
+                "wrong-chain"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_classification",
             "required": false,
             "schema": {
               "enum": [
@@ -29005,6 +30765,38 @@
           },
           {
             "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -29678,6 +31470,47 @@
           {
             "in": "query",
             "name": "provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
             "required": false,
             "schema": {
               "type": "string"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6630,6 +6630,10 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -7262,6 +7266,10 @@ export interface operations {
                 agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
                 blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
                 q?: string;
+                not_netuid?: number;
+                not_tier?: "agent-ready" | "machine-usable" | "candidate-review" | "needs-evidence" | "hard-blocked" | "missing-interface";
+                not_agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
+                not_blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -7454,6 +7462,8 @@ export interface operations {
             query?: {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
+                not_netuid?: number;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -7590,6 +7600,8 @@ export interface operations {
                 netuid?: number;
                 registration_allowed?: "true" | "false";
                 q?: string;
+                not_netuid?: number;
+                not_registration_allowed?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -7737,6 +7749,12 @@ export interface operations {
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 severity?: "critical" | "warning" | "info";
                 state?: "active" | "resolved";
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
+                not_severity?: "critical" | "warning" | "info";
+                not_state?: "active" | "resolved";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -7883,6 +7901,8 @@ export interface operations {
             query?: {
                 id?: string;
                 kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
+                not_id?: string;
+                not_kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -8056,6 +8076,13 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_netuid?: number;
+                not_pool_eligible?: "true" | "false";
+                not_provider?: string;
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -8829,6 +8856,9 @@ export interface operations {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_netuid?: number;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -8959,6 +8989,8 @@ export interface operations {
             query?: {
                 netuid?: number;
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_netuid?: number;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9086,6 +9118,11 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
+                not_classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9702,6 +9739,12 @@ export interface operations {
                 confidence?: "low" | "medium" | "high";
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
                 q?: string;
+                not_netuid?: number;
+                not_subnet_type?: "root" | "application";
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_review_state?: string;
+                not_confidence?: "low" | "medium" | "high";
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9953,6 +9996,9 @@ export interface operations {
                 id?: string;
                 kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
                 authority?: "community" | "official" | "provider-claimed" | "registry-observed";
+                not_id?: string;
+                not_kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
+                not_authority?: "community" | "official" | "provider-claimed" | "registry-observed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10204,6 +10250,12 @@ export interface operations {
                 pool_eligible?: "true" | "false";
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_netuid?: number;
+                not_pool_eligible?: "true" | "false";
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10599,6 +10651,12 @@ export interface operations {
                 operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 reason_codes?: string;
                 recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
+                not_netuid?: number;
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_candidate_api_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_reason_codes?: string;
+                not_recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10752,6 +10810,11 @@ export interface operations {
                 missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 netuid?: number;
                 q?: string;
+                not_direct_submission_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                not_lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                not_missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_netuid?: number;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10915,6 +10978,17 @@ export interface operations {
                 review_state?: string;
                 manual_review_required?: "true" | "false";
                 q?: string;
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_direct_submission_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                not_identity_level?: "none" | "directory" | "partial" | "complete";
+                not_lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                not_missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_netuid?: number;
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                not_reason_codes?: string;
+                not_review_state?: string;
+                not_manual_review_required?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11123,6 +11197,19 @@ export interface operations {
                 target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 target_type?: "surface-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 q?: string;
+                not_auto_review_candidate?: "true" | "false";
+                not_evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                not_identity_level?: "none" | "directory" | "partial" | "complete";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                not_manual_review_required?: "true" | "false";
+                not_missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_netuid?: number;
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                not_reason_codes?: string;
+                not_submission_route?: "direct-candidate-pr" | "adapter-request" | "maintainer-review" | "status-report";
+                not_target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
+                not_target_type?: "surface-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11331,6 +11418,9 @@ export interface operations {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                not_netuid?: number;
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_review_state?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11462,6 +11552,12 @@ export interface operations {
                 identity_level?: "none" | "directory" | "partial" | "complete";
                 identity_promotion_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 native_name_quality?: "chain" | "placeholder" | "empty";
+                not_netuid?: number;
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                not_confidence?: "low" | "medium" | "high";
+                not_identity_level?: "none" | "directory" | "partial" | "complete";
+                not_identity_promotion_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_native_name_quality?: "chain" | "placeholder" | "empty";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11658,6 +11754,13 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_netuid?: number;
+                not_pool_eligible?: "true" | "false";
+                not_provider?: string;
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12593,6 +12696,13 @@ export interface operations {
                 max_surface_count?: number;
                 min_tempo?: number;
                 max_tempo?: number;
+                not_netuid?: number;
+                not_netuids?: string;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_domain?: "agents" | "compute" | "data" | "finance" | "inference" | "media" | "prediction" | "privacy" | "robotics" | "science" | "search" | "security" | "storage" | "training";
+                not_status?: "active" | "inactive";
+                not_subnet_type?: "root" | "application";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13004,6 +13114,9 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13135,6 +13248,12 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_pool_eligible?: "true" | "false";
+                not_provider?: string;
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13528,6 +13647,8 @@ export interface operations {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                not_curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_review_state?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13734,6 +13855,10 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
+                not_classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15361,6 +15486,8 @@ export interface operations {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15845,6 +15972,9 @@ export interface operations {
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2465,6 +2465,12 @@ function listQuery(collection, options = {}) {
     { name: `min_${field}`, schema: { type: "number" } },
     { name: `max_${field}`, schema: { type: "number" } },
   ]);
+  // Each equality filter F → a `not_F` exclusion parameter accepting the same
+  // values: `?not_F=v` returns the complement of `?F=v`.
+  const negationParameters = filterParameters.map((parameter) => ({
+    name: `not_${parameter.name}`,
+    schema: parameter.schema,
+  }));
   return {
     collection,
     filterNames: filterParameters.map((parameter) => parameter.name),
@@ -2472,6 +2478,7 @@ function listQuery(collection, options = {}) {
       ...filterParameters,
       ...searchParameters,
       ...rangeParameters,
+      ...negationParameters,
       {
         name: "fields",
         schema: fieldListSchema,

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -311,6 +311,178 @@ describe("list-query numeric range filters", () => {
   });
 });
 
+describe("list-query negation (exclusion) filters", () => {
+  const data = {
+    subnets: [
+      {
+        netuid: 1,
+        status: "active",
+        subnet_type: "application",
+        categories: ["agents"],
+      },
+      {
+        netuid: 2,
+        status: "inactive",
+        subnet_type: "application",
+        derived_categories: ["compute"],
+      },
+      {
+        netuid: 3,
+        status: "active",
+        subnet_type: "root",
+        categories: ["data", "agents"],
+      },
+      { netuid: 4 }, // none of the filter fields present
+    ],
+  };
+  const netuids = (result) => result.data.subnets.map((r) => r.netuid);
+
+  test("not_<scalar> drops rows matching the value (complement of equality)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_status=active"),
+      "subnets",
+    );
+    // active {1,3} dropped; inactive {2} and status-absent {4} kept.
+    assert.deepEqual(netuids(result), [2, 4]);
+  });
+
+  test("a row missing the field is never excluded", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_subnet_type=application"),
+      "subnets",
+    );
+    // application {1,2} dropped; root {3} and absent {4} kept.
+    assert.deepEqual(netuids(result), [3, 4]);
+  });
+
+  test("multiple not_ params AND together", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_status=active&not_subnet_type=application"),
+      "subnets",
+    );
+    // drop active (1,3) ∪ application (1,2) → only {4} survives both.
+    assert.deepEqual(netuids(result), [4]);
+  });
+
+  test("not_<csv-membership> drops rows whose mapped field is in the set", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_netuids=1,3"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [2, 4]);
+  });
+
+  test("not_<array-membership> drops rows whose array union contains the value", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_domain=agents"),
+      "subnets",
+    );
+    // agents ∈ categories of {1,3}; dropped. {2} (compute) and {4} kept.
+    assert.deepEqual(netuids(result), [2, 4]);
+  });
+
+  test("not_F is the exact complement of F (the two partition the rows)", () => {
+    const included = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?status=active"),
+      "subnets",
+    );
+    const excluded = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_status=active"),
+      "subnets",
+    );
+    assert.deepEqual(
+      [...netuids(included), ...netuids(excluded)].sort(),
+      [1, 2, 3, 4],
+    );
+  });
+
+  test("not_ composes with range, search, sort, and order", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_subnet_type=root&sort=netuid&order=desc"),
+      "subnets",
+    );
+    // drop root {3}; remaining {1,2,4} returned descending by netuid.
+    assert.deepEqual(netuids(result), [4, 2, 1]);
+  });
+
+  test("an array-valued field excludes when the value is a member of the array", () => {
+    const arrayData = {
+      subnets: [
+        { netuid: 1, subnet_type: ["application", "root"] },
+        { netuid: 2, subnet_type: "application" },
+      ],
+    };
+    const result = applyQueryFilters(
+      arrayData,
+      query("/api/v1/subnets?not_subnet_type=root"),
+      "subnets",
+    );
+    // row 1's array contains "root" → dropped; row 2 scalar → kept.
+    assert.deepEqual(
+      result.data.subnets.map((r) => r.netuid),
+      [2],
+    );
+  });
+
+  test("no not_ param is a no-op (every row passes)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?sort=netuid"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [1, 2, 3, 4]);
+  });
+
+  test("an invalid not_<enum> value is a query error naming the not_ param", () => {
+    const bad = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_status=bogus"),
+      "subnets",
+    );
+    assert.equal(bad.error.parameter, "not_status");
+    assert.match(bad.error.message, /not supported for this route/);
+  });
+
+  test("an invalid not_<integer> value is a query error", () => {
+    const bad = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_netuid=-1"),
+      "subnets",
+    );
+    assert.equal(bad.error.parameter, "not_netuid");
+    assert.match(bad.error.message, /must be a non-negative integer/);
+  });
+
+  test("a malformed not_<pattern> value is a query error", () => {
+    const bad = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_netuids=abc"),
+      "subnets",
+    );
+    assert.equal(bad.error.parameter, "not_netuids");
+    assert.match(bad.error.message, /not in the expected format/);
+  });
+
+  test("an over-length not_<maxLength> value is a query error", () => {
+    const tooLong = `1${",1".repeat(400)}`; // 801 chars, over the 767 cap
+    const bad = applyQueryFilters(
+      data,
+      query(`/api/v1/subnets?not_netuids=${tooLong}`),
+      "subnets",
+    );
+    assert.equal(bad.error.parameter, "not_netuids");
+    assert.match(bad.error.message, /too long/);
+  });
+});
+
 describe("list-query pagination Link header", () => {
   test("first page: next + last only (no earlier page exists)", () => {
     const links = parseLink(pageLink("/api/v1/subnets?sort=netuid&limit=2"));

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -131,6 +131,58 @@ function rangeFilterRows(rows, params, rangeFields) {
   );
 }
 
+// Exclusion (negation) filter: for each configured filter field F, `?not_F=v`
+// drops exactly the rows that the inclusion filter `?F=v` would keep — the
+// logical complement of filterRows, field for field. The engine could match a
+// value but never exclude one; this closes that gap for every filter kind
+// (CSV-membership, array-membership, and scalar/array equality) so a `not_F`
+// behaves consistently with its `F`. A row that does not match v is kept.
+// Validation (validateListQuery) has already confirmed each present not_F value
+// satisfies F's schema.
+function excludeFilterRows(
+  rows,
+  params,
+  keys,
+  csvFilters = {},
+  arrayFilters = {},
+) {
+  const csvUnwantedByKey = new Map(
+    keys
+      .filter((key) => csvFilters[key] && params.has(`not_${key}`))
+      .map((key) => [key, new Set(params.get(`not_${key}`).split(","))]),
+  );
+  const exclusions = keys.filter((key) => params.has(`not_${key}`));
+  if (exclusions.length === 0) {
+    return rows;
+  }
+  return rows.filter((row) =>
+    exclusions.every((key) => {
+      const expected = params.get(`not_${key}`);
+      // CSV-membership negation: drop a row whose mapped field is in the set.
+      // csvUnwantedByKey is built from the same (csvFilters[key] && present)
+      // condition that selects this branch, so its entry is always defined here.
+      const csvField = csvFilters[key];
+      if (csvField) {
+        return !csvUnwantedByKey.get(key).has(String(row[csvField]));
+      }
+      // Array-membership negation over the UNION of one or more array fields.
+      const arrayFields = arrayFilters[key];
+      if (arrayFields) {
+        return !arrayFields.some(
+          (field) =>
+            Array.isArray(row[field]) &&
+            row[field].map(String).includes(expected),
+        );
+      }
+      const value = row[key];
+      if (Array.isArray(value)) {
+        return !value.map(String).includes(expected);
+      }
+      return String(value) !== expected;
+    }),
+  );
+}
+
 function applyListTransform(data, params, config) {
   const queryError = validateListQuery(params, config);
   if (queryError) {
@@ -142,16 +194,22 @@ function applyListTransform(data, params, config) {
     return { error: projection.error };
   }
   const filterKeys = Object.keys(config.filters);
-  const filtered = rangeFilterRows(
-    filterRows(
-      searchRows(data[key], params, config.search_keys),
+  const filtered = excludeFilterRows(
+    rangeFilterRows(
+      filterRows(
+        searchRows(data[key], params, config.search_keys),
+        params,
+        filterKeys,
+        config.csv_filters,
+        config.array_filters,
+      ),
       params,
-      filterKeys,
-      config.csv_filters,
-      config.array_filters,
+      config.range_filters,
     ),
     params,
-    config.range_filters,
+    filterKeys,
+    config.csv_filters,
+    config.array_filters,
   );
   const sorted = sortRows(filtered, params);
   const paginated = paginateRows(sorted, params);
@@ -259,6 +317,37 @@ function paginateRows(rows, params) {
   };
 }
 
+// Validate one equality-filter value against its field schema. `parameter` is
+// the actual query-param name (the field `F` or its negation `not_F`) so the
+// error message names the param the client sent. Returns an error object or null.
+function validateFilterValue(parameter, value, schema) {
+  if (schema.type === "integer" && integerParam(value) === null) {
+    return {
+      parameter,
+      message: `${parameter} must be a non-negative integer.`,
+    };
+  }
+  if (schema.enum && !schema.enum.includes(value)) {
+    return {
+      parameter,
+      message: `${parameter} is not supported for this route.`,
+    };
+  }
+  if (schema.maxLength && value.length > schema.maxLength) {
+    return {
+      parameter,
+      message: `${parameter} is too long.`,
+    };
+  }
+  if (schema.pattern && !new RegExp(schema.pattern).test(value)) {
+    return {
+      parameter,
+      message: `${parameter} is not in the expected format.`,
+    };
+  }
+  return null;
+}
+
 function validateListQuery(params, config) {
   const limit = params.get("limit");
   if (limit !== null && (integerParam(limit) === null || Number(limit) < 1)) {
@@ -298,34 +387,22 @@ function validateListQuery(params, config) {
     };
   }
 
+  // Each equality filter field validates its inclusion param (`F`) and its
+  // exclusion param (`not_F`) against the same schema — the negation accepts
+  // exactly the values the inclusion does.
   for (const [key, schema] of Object.entries(config.filters)) {
-    if (!params.has(key)) {
-      continue;
-    }
-    const value = params.get(key);
-    if (schema.type === "integer" && integerParam(value) === null) {
-      return {
-        parameter: key,
-        message: `${key} must be a non-negative integer.`,
-      };
-    }
-    if (schema.enum && !schema.enum.includes(value)) {
-      return {
-        parameter: key,
-        message: `${key} is not supported for this route.`,
-      };
-    }
-    if (schema.maxLength && value.length > schema.maxLength) {
-      return {
-        parameter: key,
-        message: `${key} is too long.`,
-      };
-    }
-    if (schema.pattern && !new RegExp(schema.pattern).test(value)) {
-      return {
-        parameter: key,
-        message: `${key} is not in the expected format.`,
-      };
+    for (const parameter of [key, `not_${key}`]) {
+      if (!params.has(parameter)) {
+        continue;
+      }
+      const error = validateFilterValue(
+        parameter,
+        params.get(parameter),
+        schema,
+      );
+      if (error) {
+        return error;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

The shared list-query engine (`workers/list-query.mjs`) supported several *inclusion* primitives — exact-equality, CSV-membership, array-membership, inclusive numeric range (`min_`/`max_`, #1611), free-text `q`, sort, and cursor pagination — but no way to **exclude** rows matching a value. Every filter could narrow *to* a value, never *away from* one.

This adds a generic negation parameter `not_<field>` for each configured filter field `F`: `?not_F=v` returns the exact complement of `?F=v`. It is the field-for-field logical negation of the existing match (CSV-membership, array-membership, and scalar/array equality all mirrored), validated against the same per-field schema, so a `not_F` accepts exactly the values `F` does. It derives from the existing `filters` allow-list and applies uniformly across every list collection — no new routes, no per-collection special-casing — parallel to the `min_`/`max_` range filters.

Examples now expressible server-side:
- `?not_status=active` — every subnet except active ones
- `?not_netuids=1,3` — exclude a set of netuids
- `?not_domain=agents` — exclude an array-membership domain

## Changes

- `workers/list-query.mjs`: `excludeFilterRows` (the negation pass, wired after the range filter) and a `validateFilterValue` helper so each field validates both its inclusion (`F`) and exclusion (`not_F`) param against the same schema.
- `src/contracts.mjs`: emit a `not_F` query parameter for every filter field.
- Regenerated `openapi.json`, `api-index.json`, and the generated type/client declarations.
- `tests/list-query.test.mjs`: 13 cases covering scalar/CSV/array negation, the absent-field rule, multi-`not_` AND, the exact-complement partition, composition with range/search/sort, and the four validation branches.

## Validation

- `npm run lint`, `npm run format:check`, `npm run validate`, `npm run validate:contract-drift`, `npm run validate:openapi` — all green
- `npx vitest run tests/list-query.test.mjs` — 47 passed; new lines fully covered

Closes #1946