### PR TITLE
fix(badge): clamp sub-1 uptime ratio so it never renders 100%

### DIFF
--- a/src/badge.mjs
+++ b/src/badge.mjs
@@ -175,8 +175,16 @@ function averageReadiness(netuids, subnetsIndex) {
 }
 
 // uptime_ratio (0–1) → trimmed percent: 0.9983 → "99.83%", 1 → "100%".
-function formatUptimePercent(ratio) {
-  const pct = Math.round((Number(ratio) || 0) * 10000) / 100;
+export function formatUptimePercent(ratio) {
+  const value = Number(ratio) || 0;
+  let pct = Math.round(value * 10000) / 100;
+  // Only an exact full ratio reads as "100%". A sub-1 ratio in [0.99995, 1)
+  // rounds up to 100, which would render a perfect-uptime badge for a service
+  // that is not actually at 100%; clamp it down to the largest 2-decimal value
+  // below 100 so the badge never overstates reliability.
+  if (pct >= 100 && value < 1) {
+    pct = 99.99;
+  }
   return `${pct}%`;
 }
 

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -7,6 +7,7 @@ import {
   gradeColor,
   parseBadgePath,
   parseBadgeOptions,
+  formatUptimePercent,
 } from "../src/badge.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
@@ -328,5 +329,28 @@ describe("badge — Worker dispatch integration", () => {
     assert.equal(res.status, 200);
     assert.match(res.headers.get("content-type"), /image\/svg\+xml/);
     assert.match(await res.text(), /<svg /);
+  });
+});
+
+describe("badge — formatUptimePercent", () => {
+  test("documented contract: trims to two decimals", () => {
+    assert.equal(formatUptimePercent(0.9983), "99.83%");
+    assert.equal(formatUptimePercent(0.5), "50%");
+    assert.equal(formatUptimePercent(0), "0%");
+  });
+
+  test("only an exact full ratio renders 100%", () => {
+    assert.equal(formatUptimePercent(1), "100%");
+  });
+
+  test("a sub-1 ratio never rounds up to a perfect 100% (#1721)", () => {
+    assert.equal(formatUptimePercent(0.99996), "99.99%");
+    assert.equal(formatUptimePercent(0.99995), "99.99%");
+    assert.equal(formatUptimePercent(0.999999), "99.99%");
+  });
+
+  test("a non-numeric ratio degrades to 0%", () => {
+    assert.equal(formatUptimePercent(undefined), "0%");
+    assert.equal(formatUptimePercent(NaN), "0%");
   });
 });


### PR DESCRIPTION
## Summary

`formatUptimePercent(ratio)` in `src/badge.mjs` computed `Math.round(ratio * 10000) / 100`, so any ratio in `[0.99995, 1)` rounded **up** to `100` — the uptime badge rendered `100%` for a service that is not actually at perfect uptime (e.g. `formatUptimePercent(0.99996) → "100%"`).

The documented contract is `0.9983 → "99.83%"`, `1 → "100%"` — only an *exact* full ratio should read as 100%. This keeps the `Math.round` two-decimal trimming intact (so every other value is unchanged) and adds a single targeted clamp: a sub-1 ratio that rounds to 100 is shown as the largest two-decimal value below it, `99.99%`. An exact `1` still renders `100%`.

This is the minimal fix — it does **not** switch to `Math.floor`, which would alter the second decimal for many unrelated ratios.

## Changes

- `src/badge.mjs` — clamp a sub-1 ratio down to `99.99%` when it would otherwise round to `100`; export `formatUptimePercent` for direct unit testing.
- `tests/badge.test.mjs` — regression coverage: documented contract values, exact `1 → 100%`, the `[0.99995, 1)` boundary never reading `100%`, and the non-numeric `→ 0%` fallback.

## Validation

- `npx vitest run tests/badge.test.mjs` — 31 passed
- `npx prettier --check src/badge.mjs tests/badge.test.mjs` — clean
- `npx eslint src/badge.mjs tests/badge.test.mjs` — clean
- `git diff --check` — clean; runtime-only, no schema/OpenAPI/artifact change

Closes #1721
