### PR TITLE
fix(chain): lowercase 0x block/extrinsic hashes before D1 lookup

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1285,6 +1285,18 @@ describe("handleBlock", () => {
     assert.equal(body.data.ref, HASH);
     assert.equal(body.data.block.block_hash, HASH);
   });
+
+  test("normalizes an uppercase 0x block_hash to lowercase before D1 lookup", async () => {
+    const upperHash = `0x${"A".repeat(64)}`;
+    const lowerHash = upperHash.toLowerCase();
+    const { env, captures } = dbWith({ blockDetail: blockRow() });
+    await handleBlock(req(`/api/v1/blocks/${upperHash}`), env, upperHash);
+    const idx = captures.sql.findIndex((s) =>
+      /FROM blocks WHERE block_hash = \?/.test(s),
+    );
+    assert.ok(idx !== -1, "expected a block_hash lookup");
+    assert.equal(captures.params[idx][0], lowerHash);
+  });
 });
 
 describe("handleBlockExtrinsics", () => {
@@ -1357,6 +1369,23 @@ describe("handleBlockExtrinsics", () => {
     assert.equal(body.data.block_number, null);
     assert.equal(body.data.extrinsic_count, 0);
   });
+
+  test("normalizes an uppercase 0x block_hash to lowercase before D1 lookup", async () => {
+    const upperHash = `0x${"A".repeat(64)}`;
+    const lowerHash = upperHash.toLowerCase();
+    const { env, captures } = dbWith({ blockNumberByHash: 9, extrinsics: [] });
+    await handleBlockExtrinsics(
+      req(`/api/v1/blocks/${upperHash}/extrinsics`),
+      env,
+      upperHash,
+      url(`/api/v1/blocks/${upperHash}/extrinsics`),
+    );
+    const idx = captures.sql.findIndex((s) =>
+      /SELECT block_number FROM blocks WHERE block_hash = \?/.test(s),
+    );
+    assert.ok(idx !== -1, "expected a block_hash resolution lookup");
+    assert.equal(captures.params[idx][0], lowerHash);
+  });
 });
 
 describe("handleBlockEvents", () => {
@@ -1411,6 +1440,23 @@ describe("handleBlockEvents", () => {
     );
     assert.equal(body.data.block_number, 9);
     assert.equal(body.data.event_count, 1);
+  });
+
+  test("normalizes an uppercase 0x block_hash to lowercase before D1 lookup", async () => {
+    const upperHash = `0x${"A".repeat(64)}`;
+    const lowerHash = upperHash.toLowerCase();
+    const { env, captures } = dbWith({ blockNumberByHash: 9, blockEvents: [] });
+    await handleBlockEvents(
+      req(`/api/v1/blocks/${upperHash}/events`),
+      env,
+      upperHash,
+      url(`/api/v1/blocks/${upperHash}/events`),
+    );
+    const idx = captures.sql.findIndex((s) =>
+      /SELECT block_number FROM blocks WHERE block_hash = \?/.test(s),
+    );
+    assert.ok(idx !== -1, "expected a block_hash resolution lookup");
+    assert.equal(captures.params[idx][0], lowerHash);
   });
 });
 
@@ -1515,6 +1561,22 @@ describe("handleExtrinsic", () => {
     );
     assert.equal(body.data.extrinsic.extrinsic_hash, HASH);
     assert.equal(body.data.extrinsic.call_function, "add_stake");
+  });
+
+  test("normalizes an uppercase 0x extrinsic_hash to lowercase before D1 lookup", async () => {
+    const upperHash = `0x${"A".repeat(64)}`;
+    const lowerHash = upperHash.toLowerCase();
+    const { env, captures } = dbWith({ extrinsicDetail: extrinsicRow() });
+    await handleExtrinsic(
+      req(`/api/v1/extrinsics/${upperHash}`),
+      env,
+      upperHash,
+    );
+    const idx = captures.sql.findIndex((s) =>
+      /WHERE extrinsic_hash = \?/.test(s),
+    );
+    assert.ok(idx !== -1, "expected an extrinsic_hash lookup");
+    assert.equal(captures.params[idx][0], lowerHash);
   });
 
   test("happy path resolves by composite id block-index", async () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -638,7 +638,7 @@ export async function handleBlock(request, env, ref) {
   const sql = isHash
     ? `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_hash = ? LIMIT 1`
     : `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_number = ? LIMIT 1`;
-  const param = isHash ? ref : Number(ref);
+  const param = isHash ? ref.toLowerCase() : Number(ref);
   const rows = await d1All(env, sql, [param]);
   // prev/next chain-walk neighbors (#1853): one bounded query for the nearest
   // STORED block numbers around the resolved height (skips pruned gaps; null at
@@ -688,7 +688,7 @@ export async function handleBlockExtrinsics(request, env, ref, url) {
     const blockRows = await d1All(
       env,
       `SELECT block_number FROM blocks WHERE block_hash = ? LIMIT 1`,
-      [ref],
+      [ref.toLowerCase()],
     );
     blockNumber = blockRows[0]?.block_number ?? null;
   }
@@ -732,7 +732,7 @@ export async function handleBlockEvents(request, env, ref, url) {
     const blockRows = await d1All(
       env,
       `SELECT block_number FROM blocks WHERE block_hash = ? LIMIT 1`,
-      [ref],
+      [ref.toLowerCase()],
     );
     blockNumber = blockRows[0]?.block_number ?? null;
   }
@@ -874,7 +874,7 @@ export async function handleExtrinsic(request, env, ref) {
     rows = await d1All(
       env,
       `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE extrinsic_hash = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT 1`,
-      [ref],
+      [ref.toLowerCase()],
     );
   } else {
     // Composite "<block>-<index>": coerce both halves; a non-finite half is a


### PR DESCRIPTION
## Summary

- D1 uses BINARY collation for `TEXT` columns; the chain poller writes all hashes in lowercase.
- Mixed-case hex refs (e.g. `0xABCDEF…`) matched the route pattern regex correctly but were passed **unchanged** as D1 bind parameters → `WHERE block_hash = ?` never matched a stored row → silent `block:null` / `extrinsic:null` even when the block/extrinsic exists.
- Fix: call `.toLowerCase()` on the hash bind-parameter at each of the four affected lookup sites in `workers/request-handlers/entities.mjs`: `handleBlock`, `handleBlockExtrinsics`, `handleBlockEvents`, `handleExtrinsic`.

## Validation

```sh
npm run lint       # clean
npm run validate   # 129 subnets, 1199 surfaces, 124 providers validated
npm test           # 2266/2266 passed
```

## Test plan

- [ ] Four new `captures`-based tests in `tests/request-handlers-entities.test.mjs` (one per affected handler) verify the D1 bind-parameter is the lowercased form when an uppercase hash ref is supplied.
- [ ] All 2266 tests pass, lint clean.

Closes #1955