### PR TITLE
fix(scripts): preserve committed public-sources.json generated_at on local discover:candidates runs

### DIFF
--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -14,6 +14,7 @@ import {
   nativeDisplayName,
   OPENAPI_PROBE_PATHS,
   probeOpenApiSpec,
+  readCommittedManifestGeneratedAt,
   readJson,
   isLikelyProjectDomain,
   README_KIND_LIMITS,
@@ -155,57 +156,65 @@ const summary = {
 };
 
 if (!dryRun) {
-  await writeJson(
-    path.join(repoRoot, "registry/candidates/generated/public-sources.json"),
-    {
-      schema_version: 1,
-      generated_by: "metagraphed-discover-candidates",
-      generated_at: buildTimestamp(),
-      native_snapshot_captured_at: nativeSnapshot.captured_at,
-      notes:
-        "Generated candidate surfaces from public sources. These are not verified registry surfaces until maintainer review promotes them into registry/subnets.",
-      observed_at: observedAt,
-      sources: [
-        {
-          id: "native-subnet-identities-v3",
-          url: "https://docs.learnbittensor.org/python-api/html/_modules/bittensor/core/chain_data/subnet_identity.html",
-        },
-        {
-          id: "taomarketcap",
-          url: "https://api.taomarketcap.com/public/v1/subnets/",
-        },
-        {
-          id: "backprop-finance",
-          url: "https://backprop.finance/dtao/subnets/",
-        },
-        {
-          id: "taostats",
-          url: "https://taostats.io/subnets/",
-        },
-        {
-          id: "subnetradar",
-          url: "https://subnetradar.com/subnet/",
-        },
-        {
-          id: "tensorplex-subnet-docs",
-          url: "https://github.com/tensorplex-labs/subnet-docs",
-        },
-        {
-          id: "taopedia-articles",
-          url: "https://github.com/e35ventura/taopedia-articles",
-        },
-        {
-          id: "github-readme-links",
-          url: "https://github.com",
-        },
-        {
-          id: "project-website-links",
-          url: "https://metagraph.sh",
-        },
-      ],
-      candidates,
-    },
+  const publicSourcesPath = path.join(
+    repoRoot,
+    "registry/candidates/generated/public-sources.json",
   );
+  // Preserve the committed public-sources.json `generated_at` on a local build
+  // so `npm run discover:candidates` never clobbers it with the 1970 epoch
+  // placeholder; publish runs (METAGRAPH_BUILD_TIMESTAMP/RUN_ID set) get the
+  // real build timestamp via buildTimestamp(). Mirrors the r2-manifest path.
+  const generatedAt =
+    (await readCommittedManifestGeneratedAt(publicSourcesPath)) ??
+    buildTimestamp();
+  await writeJson(publicSourcesPath, {
+    schema_version: 1,
+    generated_by: "metagraphed-discover-candidates",
+    generated_at: generatedAt,
+    native_snapshot_captured_at: nativeSnapshot.captured_at,
+    notes:
+      "Generated candidate surfaces from public sources. These are not verified registry surfaces until maintainer review promotes them into registry/subnets.",
+    observed_at: observedAt,
+    sources: [
+      {
+        id: "native-subnet-identities-v3",
+        url: "https://docs.learnbittensor.org/python-api/html/_modules/bittensor/core/chain_data/subnet_identity.html",
+      },
+      {
+        id: "taomarketcap",
+        url: "https://api.taomarketcap.com/public/v1/subnets/",
+      },
+      {
+        id: "backprop-finance",
+        url: "https://backprop.finance/dtao/subnets/",
+      },
+      {
+        id: "taostats",
+        url: "https://taostats.io/subnets/",
+      },
+      {
+        id: "subnetradar",
+        url: "https://subnetradar.com/subnet/",
+      },
+      {
+        id: "tensorplex-subnet-docs",
+        url: "https://github.com/tensorplex-labs/subnet-docs",
+      },
+      {
+        id: "taopedia-articles",
+        url: "https://github.com/e35ventura/taopedia-articles",
+      },
+      {
+        id: "github-readme-links",
+        url: "https://github.com",
+      },
+      {
+        id: "project-website-links",
+        url: "https://metagraph.sh",
+      },
+    ],
+    candidates,
+  });
 }
 
 console.log(stableStringify(summary));


### PR DESCRIPTION
## Summary

`scripts/discover-candidates.mjs` wrote the committed `registry/candidates/generated/public-sources.json` with `generated_at: buildTimestamp()`. `buildTimestamp()` returns the `1970-01-01T00:00:00.000Z` placeholder when `METAGRAPH_BUILD_TIMESTAMP` is unset, so a local `npm run discover:candidates` (write mode) rewrote the committed timestamp to the epoch placeholder and dirtied a git-tracked artifact.

This is the same bug class fixed for `r2-manifest.json` in #1829 / #1837 and for `promotions.json` (verify:candidates) in #1894 — a committed registry artifact's `generated_at` clobbered with the 1970 placeholder on local writes. #1893 explicitly named this as the remaining sibling instance.

## Fix

Preserve the committed `generated_at` on local runs via the existing `readCommittedManifestGeneratedAt(manifestPath)` helper (the exact r2-manifest / verify:candidates pattern), falling back to `buildTimestamp()` during publish runs (`METAGRAPH_BUILD_TIMESTAMP` / `METAGRAPH_RUN_ID` set). One file changed, mirroring #1894's shape.

## Validation

- Behavior check against the actual committed file: with the env unset, the guard returns the committed `2026-06-14T09:03:05.163Z` (no clobber); with `METAGRAPH_BUILD_TIMESTAMP` set, it falls through to the real publish timestamp.
- `readCommittedManifestGeneratedAt` is already unit-tested in `tests/script-utils.test.mjs` (preserve-on-local / null-when-env-set / missing-file). The sibling fix #1894 added no script-level test for the same reason; this PR matches that precedent.
- `npx prettier --check` + `npx eslint` on the changed file — clean.

Closes #1897
