### PR TITLE
fix(scripts): preserve committed review-queue.json generated_at on local review:queue runs

### DIFF
--- a/registry/reviews/review-queue.json
+++ b/registry/reviews/review-queue.json
@@ -1,7 +1,26 @@
 {
-  "generated_at": "1970-01-01T00:00:00.000Z",
+  "generated_at": "2026-06-14T09:03:05.163Z",
   "generated_by": "metagraphed-review-queue",
   "notes": "Suggested maintainer-review elevations: provenance-strong, live callable APIs on each subnet's own on-chain-asserted domain that are not yet at the top trust tier. Machine-proposed; promote by moving an entry into maintainer-reviewed.json. Regenerate with `npm run review:queue`.",
-  "queue": [],
+  "queue": [
+    {
+      "current_level": "machine-verified",
+      "domain": "babelbit.ai",
+      "kinds": ["subnet-api"],
+      "netuid": 59,
+      "rationale": "Live subnet-api on the subnet's on-chain-asserted domain (babelbit.ai). Strong provenance — elevate by adding a decision to maintainer-reviewed.json after a quick confirm.",
+      "slug": "sn-59",
+      "source_urls": ["https://api.babelbit.ai/"]
+    },
+    {
+      "current_level": "machine-verified",
+      "domain": "theminos.ai",
+      "kinds": ["subnet-api"],
+      "netuid": 107,
+      "rationale": "Live subnet-api on the subnet's on-chain-asserted domain (theminos.ai). Strong provenance — elevate by adding a decision to maintainer-reviewed.json after a quick confirm.",
+      "slug": "sn-107",
+      "source_urls": ["https://api.theminos.ai/"]
+    }
+  ],
   "schema_version": 1
 }

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1940,6 +1940,7 @@ export function buildProvenanceReviewQueue({
   nativeSubnets = [],
   verificationResults = [],
   subnets = [],
+  generatedAt = buildTimestamp(),
 }) {
   const levelByNetuid = new Map(
     subnets.map((subnet) => [subnet.netuid, subnet.curation?.level ?? null]),
@@ -1970,7 +1971,7 @@ export function buildProvenanceReviewQueue({
   return {
     schema_version: 1,
     generated_by: "metagraphed-review-queue",
-    generated_at: buildTimestamp(),
+    generated_at: generatedAt,
     notes:
       "Suggested maintainer-review elevations: provenance-strong, live callable " +
       "APIs on each subnet's own on-chain-asserted domain that are not yet at the " +

--- a/scripts/review-queue.mjs
+++ b/scripts/review-queue.mjs
@@ -1,10 +1,12 @@
 import path from "node:path";
 import {
   buildProvenanceReviewQueue,
+  buildTimestamp,
   loadCandidates,
   loadNativeSnapshot,
   loadSubnets,
   loadVerification,
+  readCommittedManifestGeneratedAt,
   repoRoot,
   stableStringify,
   writeRepositoryJson,
@@ -32,11 +34,20 @@ const [candidates, nativeSnapshot, verification, subnets] = await Promise.all([
   loadSubnets(),
 ]);
 
+// Preserve the committed review-queue.json `generated_at` on a local build so
+// `npm run review:queue` never clobbers it with the 1970 epoch placeholder;
+// publish runs (METAGRAPH_BUILD_TIMESTAMP/RUN_ID set) get the real build
+// timestamp via buildTimestamp(). Mirrors the r2-manifest path. The queue
+// content is a pure transform of committed data, so a local run is a no-op.
+const generatedAt =
+  (await readCommittedManifestGeneratedAt(outputPath)) ?? buildTimestamp();
+
 const document = buildProvenanceReviewQueue({
   candidates,
   nativeSubnets: nativeSnapshot.subnets,
   verificationResults: verification.results || [],
   subnets,
+  generatedAt,
 });
 
 if (dryRun) {


### PR DESCRIPTION
## Summary

`registry/reviews/review-queue.json` is written by `review-queue.mjs` (via `buildProvenanceReviewQueue`) with `generated_at: buildTimestamp()`. `buildTimestamp()` returns the `1970-01-01T00:00:00.000Z` placeholder when `METAGRAPH_BUILD_TIMESTAMP` is unset, so a local `npm run review:queue --write` clobbers the committed timestamp with the epoch placeholder. The committed file was **already sitting at the 1970 placeholder on main** — this bug had already fired and stuck.

Same bug class as the r2-manifest (#1837), `promotions.json` / verify:candidates (#1894), and `public-sources.json` / discover:candidates (#1897) fixes — a committed `registry/` artifact's `generated_at` clobbered with the 1970 placeholder on local writes.

## Fix

- Thread a `generatedAt` into `buildProvenanceReviewQueue` (defaulting to `buildTimestamp()`, matching the `openapi-components.mjs` pattern).
- In `review-queue.mjs`, compute it via the existing `readCommittedManifestGeneratedAt(outputPath)` helper, falling back to `buildTimestamp()` on publish runs (`METAGRAPH_BUILD_TIMESTAMP` / `METAGRAPH_RUN_ID` set).
- Reseed the committed `generated_at` to the sibling artifacts' value (`2026-06-14T09:03:05.163Z`) and refresh the committed queue, which had **silently gone stale** (`[]` while current committed data yields the SN59 / SN107 provenance-strong elevations). The queue is a deterministic pure transform of committed data, so local runs are now idempotent no-ops.

## Validation

- Local run (`METAGRAPH_BUILD_TIMESTAMP` unset): preserves the committed `2026-06-14T09:03:05.163Z` and reproduces identical content — verified idempotent (second `--write` is a zero-diff no-op).
- Publish run (`METAGRAPH_BUILD_TIMESTAMP` set): falls through to the real build timestamp.
- `tests/script-utils.test.mjs` (guard helper) + `tests/provenance-elevation.test.mjs` (queue logic) pass; full combined reader-test run green with `--no-file-parallelism`.
- `prettier --check` + `eslint` clean on changed files.
