### PR TITLE
fix(scripts): make local adapter snapshots deterministic so they never dirty committed files

### DIFF
--- a/scripts/snapshot-adapters.mjs
+++ b/scripts/snapshot-adapters.mjs
@@ -39,6 +39,44 @@ async function loadPreviousAdapterSnapshot(slug) {
     return null;
   }
 }
+
+// Observation timestamps re-stamped on every snapshot run: the top-level
+// generated_at plus the per-dimension/per-schema captured_at (and the
+// carried-forward metadata_as_of). They are wall-clock, so a re-snapshot of
+// otherwise-unchanged GitHub data differs only here.
+const OBSERVATION_TIMESTAMP_KEYS = new Set([
+  "generated_at",
+  "captured_at",
+  "metadata_as_of",
+]);
+
+// Deep clone with every observation timestamp nulled, so two snapshots can be
+// compared on substance alone.
+export function stripObservationTimestamps(value) {
+  if (Array.isArray(value)) {
+    return value.map(stripObservationTimestamps);
+  }
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const [key, inner] of Object.entries(value)) {
+      out[key] = OBSERVATION_TIMESTAMP_KEYS.has(key)
+        ? null
+        : stripObservationTimestamps(inner);
+    }
+    return out;
+  }
+  return value;
+}
+
+// True when the committed snapshot already reflects this run's data and differs
+// only in observation timestamps — i.e. re-writing would churn timestamps with
+// no substantive change.
+export function committedSnapshotIsCurrent(previous, fresh) {
+  return (
+    stableStringify(stripObservationTimestamps(previous)) ===
+    stableStringify(stripObservationTimestamps(fresh))
+  );
+}
 const OPENAPI_METHODS = new Set([
   "delete",
   "get",
@@ -70,8 +108,27 @@ async function main() {
   );
 
   if (!dryRun) {
+    // A publish run (METAGRAPH_BUILD_TIMESTAMP/RUN_ID set) always records fresh
+    // observation timestamps. A local run must not dirty the git-tracked
+    // snapshots: keep the committed file byte-identical when only timestamps
+    // differ, and never stamp the 1970 epoch placeholder (buildTimestamp() with
+    // the env unset) into a genuinely-changed one. Mirrors the committed-artifact
+    // timestamp guards in discover-candidates / verify-candidates / review-queue.
+    const publishRun = Boolean(
+      process.env.METAGRAPH_BUILD_TIMESTAMP || process.env.METAGRAPH_RUN_ID,
+    );
     for (const snapshot of snapshots) {
-      await writeJson(path.join(outputRoot, `${snapshot.slug}.json`), snapshot);
+      const outputPath = path.join(outputRoot, `${snapshot.slug}.json`);
+      if (!publishRun) {
+        const previous = await loadPreviousAdapterSnapshot(snapshot.slug);
+        if (previous && committedSnapshotIsCurrent(previous, snapshot)) {
+          continue;
+        }
+        if (previous?.generated_at) {
+          snapshot.generated_at = previous.generated_at;
+        }
+      }
+      await writeJson(outputPath, snapshot);
     }
   }
 

--- a/tests/adapter-snapshot-determinism.test.mjs
+++ b/tests/adapter-snapshot-determinism.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  stripObservationTimestamps,
+  committedSnapshotIsCurrent,
+} from "../scripts/snapshot-adapters.mjs";
+
+// A snapshot shaped like the committed registry/adapters/latest/*.json files:
+// a top-level generated_at plus per-dimension and per-schema captured_at, with
+// a carried-forward metadata_as_of.
+function sampleSnapshot(stamp, { repoCount = 2 } = {}) {
+  return {
+    slug: "sn-22",
+    netuid: 22,
+    generated_at: stamp,
+    status: "ok",
+    dimensions: {
+      openapi_schemas: {
+        captured_at: stamp,
+        schemas: Array.from({ length: repoCount }, (_, i) => ({
+          path: `/openapi-${i}.json`,
+          captured_at: stamp,
+        })),
+      },
+      repository_metadata: {
+        captured_at: stamp,
+        repositories: [{ full_name: "org/repo", metadata_as_of: stamp }],
+      },
+    },
+  };
+}
+
+describe("snapshot-adapters — observation-timestamp determinism", () => {
+  test("stripObservationTimestamps nulls every timestamp at any depth", () => {
+    const stripped = stripObservationTimestamps(
+      sampleSnapshot("2026-06-14T00:00:00.000Z"),
+    );
+    assert.equal(stripped.generated_at, null);
+    assert.equal(stripped.dimensions.openapi_schemas.captured_at, null);
+    assert.equal(
+      stripped.dimensions.openapi_schemas.schemas[0].captured_at,
+      null,
+    );
+    assert.equal(
+      stripped.dimensions.openapi_schemas.schemas[1].captured_at,
+      null,
+    );
+    assert.equal(stripped.dimensions.repository_metadata.captured_at, null);
+    assert.equal(
+      stripped.dimensions.repository_metadata.repositories[0].metadata_as_of,
+      null,
+    );
+    // Non-timestamp substance is preserved.
+    assert.equal(stripped.slug, "sn-22");
+    assert.equal(
+      stripped.dimensions.openapi_schemas.schemas[0].path,
+      "/openapi-0.json",
+    );
+  });
+
+  test("does not mutate its input", () => {
+    const input = sampleSnapshot("2026-06-14T00:00:00.000Z");
+    stripObservationTimestamps(input);
+    assert.equal(input.generated_at, "2026-06-14T00:00:00.000Z");
+    assert.equal(
+      input.dimensions.openapi_schemas.captured_at,
+      "2026-06-14T00:00:00.000Z",
+    );
+  });
+
+  test("committedSnapshotIsCurrent: true when only timestamps differ", () => {
+    const committed = sampleSnapshot("2026-06-14T09:03:05.163Z");
+    // A fresh re-snapshot of unchanged data: every timestamp re-stamped, even
+    // the 1970 epoch placeholder a local run would produce.
+    const fresh = sampleSnapshot("1970-01-01T00:00:00.000Z");
+    assert.equal(committedSnapshotIsCurrent(committed, fresh), true);
+  });
+
+  test("committedSnapshotIsCurrent: false when substance changes", () => {
+    const committed = sampleSnapshot("2026-06-14T09:03:05.163Z", {
+      repoCount: 2,
+    });
+    const fresh = sampleSnapshot("2026-06-14T09:03:05.163Z", { repoCount: 3 });
+    assert.equal(committedSnapshotIsCurrent(committed, fresh), false);
+  });
+
+  test("committedSnapshotIsCurrent: false when a non-timestamp field changes", () => {
+    const committed = sampleSnapshot("2026-06-14T09:03:05.163Z");
+    const fresh = sampleSnapshot("2026-06-14T09:03:05.163Z");
+    fresh.status = "degraded";
+    assert.equal(committedSnapshotIsCurrent(committed, fresh), false);
+  });
+});


### PR DESCRIPTION
## Summary

`snapshot-adapters.mjs` re-stamps wall-clock observation timestamps on every run — the top-level `generated_at` (`buildTimestamp()`, which is the `1970-01-01T00:00:00.000Z` placeholder when `METAGRAPH_BUILD_TIMESTAMP` is unset) plus per-dimension and per-schema `captured_at`. A local `npm run adapters:snapshot` therefore rewrote all 13 git-tracked `registry/adapters/latest/*.json` with churned timestamps and a 1970 `generated_at` — a spurious diff on tracked files.

Same committed-artifact footgun fixed for `r2-manifest.json` (#1837), `promotions.json` (#1894), and `public-sources.json` (#1897). Here it's compounded: the per-observation `captured_at` values (≈20 sites) mean a `generated_at` guard alone would be only half a fix.

**Why not gitignore (like `public/datasets/` in #1597)?** Unlike datasets, the committed adapter snapshots are read during the *committed-data* CI build (`build-artifacts.mjs` `loadAdapterSnapshots()` + `validate-adapters`), and CI does not re-snapshot (that's publish-only, network-gated). Untracking them would break CI. The right fix is a deterministic writer.

## Fix

On a **non-publish** run (`METAGRAPH_BUILD_TIMESTAMP` / `METAGRAPH_RUN_ID` unset):
- Keep the committed snapshot **byte-identical** when it differs from the fresh one only in observation timestamps — `committedSnapshotIsCurrent()` compares the two with all timestamps stripped (`stripObservationTimestamps`), and the write loop `continue`s when they match. So a re-snapshot of unchanged GitHub data produces zero diff.
- For a genuinely-changed snapshot, carry the committed `generated_at` forward so a local run never stamps the 1970 placeholder.

**Publish** runs are unchanged — they always record fresh observation timestamps.

## Validation

- New `tests/adapter-snapshot-determinism.test.mjs`: `stripObservationTimestamps` nulls every timestamp at any depth (and doesn't mutate input); `committedSnapshotIsCurrent` is true for timestamp-only deltas (incl. a 1970 re-stamp) and false for substantive or non-timestamp changes.
- Verified against the **real** committed files (gittensor, sn-22, allways): a timestamp-only re-stamp is detected as current (→ skip, no diff); a `status` flip is detected as a change (→ write).
- Existing `adapter-snapshot-security` + `validate-adapters` tests still pass; `prettier` + `eslint` clean. No committed adapter files changed in this PR.
