### PR TITLE
fix(scripts): allow hotkey/coldkey and coldkey-only API prose in public-safety scan

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -56,14 +56,19 @@ const patterns = [
     regex: /\bcoldkey\b/i,
     // Bare "coldkey" as a public API field name (JSON property / required entry /
     // TS type member) is legitimate metagraph vocabulary (#1304) — an ss58 coldkey
-    // is public on-chain data, not a secret. Also allow the "hotkey or coldkey"
-    // field-pair phrase (account routes #1347 doc text) and the `coldkey =` SQL
-    // column comparison. Strip those legitimate spans so only suspicious prose
-    // ("your coldkey seed phrase" — still caught by the wallet/key-wording rule)
-    // trips. Same rationale as the isMirroredExternalSpec exemption, scoped to the
-    // safe forms so the guard stays active everywhere else.
+    // is public on-chain data, not a secret. Also allow the "hotkey or coldkey" /
+    // "hotkey/coldkey" field-pair phrase (account routes #1347 doc text + the
+    // generated MCP server-card prose), the "coldkey-only" behaviour descriptor (a
+    // coldkey-only ss58 address has no hotkey-attributed rollup), and the
+    // `coldkey =` SQL column comparison. Strip those legitimate spans so only
+    // suspicious prose ("your coldkey seed phrase" — still caught here and by the
+    // wallet/key-wording rule) trips. The "coldkey-only" exemption is the exact
+    // hyphenated phrase, NOT a blanket `coldkey-` strip, so a hyphen can't be used
+    // to smuggle a secret ("coldkey-seedphrase: …" still trips). Same rationale as
+    // the isMirroredExternalSpec exemption, scoped to the safe forms so the guard
+    // stays active everywhere else.
     allow:
-      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bhotkey\s+or\s+coldkey\b|\bcoldkey\s*=/gi,
+      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bhotkey(?:\s+or\s+|\s*\/\s*)coldkey\b|\bcoldkey-only\b|\bcoldkey\s*=/gi,
     soft: true,
   },
   {

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -263,4 +263,41 @@ describe("captured-fixture body scan", () => {
       `hard secrets must fire even inside doc fields; got:\n${output}`,
     );
   });
+
+  test("allows the hotkey/coldkey and coldkey-only API-prose forms", async () => {
+    // Regression for the generated MCP server-card prose: the slash form
+    // "hotkey/coldkey" and the "coldkey-only" behaviour descriptor are standard
+    // Bittensor API vocabulary explaining public read-only behaviour — the same
+    // safe class as the already-allowed "hotkey or coldkey" phrase, just written
+    // differently. Neither carries any secret.
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      [
+        "The hotkey/coldkey owning the account, base58, 47-48 chars.",
+        "A coldkey-only SS58 address won't appear in the hotkey-attributed rollup.",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.equal(
+      output.includes(TEST_PUBLIC_FILE),
+      false,
+      `hotkey/coldkey and coldkey-only API prose should be exempt; got:\n${output}`,
+    );
+  });
+
+  test("still flags suspicious coldkey prose that a hyphen can't smuggle past", async () => {
+    // The coldkey-only exemption is the exact phrase, not a blanket `coldkey-`
+    // strip: a hyphenated secret attempt must still trip the terminology guard.
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      "Set coldkey-seedphrase to 5xyzABCDEFGHabcdefgh in your config.\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.ok(
+      output.includes(`${TEST_PUBLIC_FILE}:1: Bittensor key terminology`),
+      `a hyphenated coldkey secret attempt must still be flagged; got:\n${output}`,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

The `scan:public-safety` "Bittensor key terminology" rule (`/\bcoldkey\b/i`) strips legitimate field-name forms (`"coldkey":`, `coldkey:`, `coldkey =`) and the `hotkey or coldkey` phrase from a line before flagging a bare `coldkey`. Two equally-safe **prose** forms used in real API documentation aren't covered, so they false-positive:

1. **`hotkey/coldkey`** — the slash form of the already-allowed `hotkey or coldkey` phrase.
2. **`coldkey-only`** — a behaviour descriptor (a coldkey-only SS58 address won't appear in the hotkey-attributed rollup).

Both are standard Bittensor vocabulary explaining public, read-only behaviour — the same safe class as the phrase already allowed, just written differently. They appear (or will, on the next tool-description edit) in the generated `public/.well-known/mcp/server-card.json`, where they'd wedge the scan even though they carry zero security risk.

The scan currently passes only because the committed server-card uses the `hotkey or coldkey` form; this is a preventive fix for the slash/hyphen forms.

## Fix

Extend the allow-list regex:
- `\bhotkey\s+or\s+coldkey\b` → `\bhotkey(?:\s+or\s+|\s*\/\s*)coldkey\b` (covers `hotkey or coldkey`, `hotkey/coldkey`, `hotkey / coldkey`).
- add `\bcoldkey-only\b`.

The hyphen exemption is the **exact** `coldkey-only` phrase, deliberately **not** a blanket `coldkey-` strip — so a hyphen can't be used to smuggle a secret (`coldkey-seedphrase: …` still trips the terminology guard). Bare suspicious prose (`your coldkey seed phrase`) is unaffected and still caught here and by the independent wallet/key-wording rule.

I surveyed every `coldkey` occurrence across all scanned roots: the only other non-field forms are `coldkeys` (plural) and `owner_coldkey`, which already don't match `\bcoldkey\b` (no word boundary), so no further prose forms need coverage.

## Validation

- New regression tests in `tests/public-safety.test.mjs` (run the real scanner as a subprocess over a `public/` fixture):
  - `hotkey/coldkey` + `coldkey-only` prose → **not** flagged (would have failed on the old regex).
  - `coldkey-seedphrase: <token>` → **still** flagged `Bittensor key terminology` (guards against over-broadening).
- Full `tests/public-safety.test.mjs` suite (18 tests) green; the real `node scripts/scan-public-safety.mjs` still passes the whole tree; `prettier` + `eslint` clean.
