### PR TITLE
feat(registry): add SN99 Leoma openapi, subnet-api, and data-artifact surfaces

### DIFF
--- a/registry/subnets/leoma.json
+++ b/registry/subnets/leoma.json
@@ -1,0 +1,44 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "candidate-discovered",
+    "review_state": "unreviewed"
+  },
+  "name": "Leoma",
+  "netuid": 99,
+  "schema_version": 1,
+  "slug": "sn-99",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-subnet-api",
+      "kind": "subnet-api",
+      "name": "Leoma public scores API",
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "minion1227"
+      },
+      "source_urls": ["https://leoma.ai/", "https://api.leoma.ai/openapi.json"],
+      "url": "https://api.leoma.ai/scores"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-data-artifact",
+      "kind": "data-artifact",
+      "name": "Leoma miners snapshot",
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "minion1227"
+      },
+      "source_urls": ["https://leoma.ai/", "https://api.leoma.ai/openapi.json"],
+      "url": "https://api.leoma.ai/miners/list"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Appends three community surfaces to registry/subnets/leoma.json (SN99), all live-verified public no-auth:
- openapi: https://api.leoma.ai/openapi.json (Leoma API, 28 paths)
- subnet-api: https://api.leoma.ai/scores
- data-artifact: https://api.leoma.ai/miners/list

## Surface
- Netuid: 99
- Kind: openapi, subnet-api, data-artifact
- Public URL: https://api.leoma.ai/openapi.json
- Source URL: https://leoma.ai/ + https://api.leoma.ai/openapi.json
- Provider slug: leoma

## Validation
- npm run validate:surface -- registry/subnets/leoma.json  ✓
- npm run scan:public-safety  ✓

Closes #587
