### PR TITLE
feat(registry): add SN59 Babelbit public API discovery root surface

### DIFF
--- a/registry/subnets/babelbit.json
+++ b/registry/subnets/babelbit.json
@@ -1,0 +1,32 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "candidate-discovered",
+    "review_state": "unreviewed"
+  },
+  "name": "Babelbit",
+  "netuid": 59,
+  "schema_version": 1,
+  "slug": "sn-59",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-59-babelbit-subnet-api",
+      "kind": "subnet-api",
+      "name": "Babelbit public API discovery root",
+      "provider": "babelbit",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "minion1227"
+      },
+      "source_urls": [
+        "https://babelbit.ai/",
+        "https://github.com/babelbit/babelbit_subnet"
+      ],
+      "url": "https://api.babelbit.ai/"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds one community subnet-api surface to registry/subnets/babelbit.json (SN59 Babelbit),
live-verified public + no-auth:
- subnet-api: https://api.babelbit.ai/
  The public API discovery root — returns service, version, authentication scheme, and the
  list of public vs validator-protected endpoints as JSON. 200, no credentials.

## Surface
- Netuid: 59
- Kind: subnet-api
- Public URL: https://api.babelbit.ai/
- Source URL: https://babelbit.ai/ + https://github.com/babelbit/babelbit_subnet
- Provider slug: babelbit

## Validation
- npm run validate:surface -- registry/subnets/babelbit.json  ✓
- npm run scan:public-safety  ✓

Refs #464
