### PR TITLE
feat(registry): add SN50 Synth public miner leaderboard API surface

### DIFF
--- a/registry/subnets/synth.json
+++ b/registry/subnets/synth.json
@@ -1,0 +1,29 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "candidate-discovered",
+    "review_state": "unreviewed"
+  },
+  "name": "Synth",
+  "netuid": 50,
+  "schema_version": 1,
+  "slug": "sn-50",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-50-synth-subnet-api",
+      "kind": "subnet-api",
+      "name": "Synth public miner leaderboard API",
+      "provider": "synth",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "minion1227"
+      },
+      "source_urls": ["https://synthdata.co/", "https://synthdata.co/docs"],
+      "url": "https://synthdata.co/api/leaderboard"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds one community subnet-api surface to registry/subnets/synth.json (SN50 Synth),
live-verified public + no-auth:
- subnet-api: https://synthdata.co/api/leaderboard
  Returns the live miner leaderboard (rank, miner_uid, coldkey, scores) as JSON. 200, no credentials.

## Surface
- Netuid: 50
- Kind: subnet-api
- Public URL: https://synthdata.co/api/leaderboard
- Source URL: https://synthdata.co/ + https://synthdata.co/docs
- Provider slug: synth

## Validation
- npm run validate:surface -- registry/subnets/synth.json  ✓
- npm run scan:public-safety  ✓

Closes #669
