### PR TITLE
ci(test): parallelize the suite by isolating the artifact-writer tests + de-flake DNS

### DIFF
--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -72,7 +72,10 @@ Subnet-level fields you must **not** touch in a community PR: `curation` (`level
 retired: it skipped the safety scans and kept tripping a stale-base preflight false-positive.) A
 one-file surface PR runs the same gates as a code PR. Two parallel jobs both build:
 
-- **`test`** — builds, then `npm run test:coverage` (Codecov is the coverage gate).
+- **`test`** — builds, then runs the suite in two non-overlapping passes: `test:ci` (everything
+  except the two filesystem-mutating artifact writers, run in parallel, WITH coverage → the single
+  Codecov upload) then `test:ci:artifacts` (those two writers, serial). Locally just use
+  `npm test` / `npm run test:coverage` (full suite, serial — the config default is race-safe).
 - **`checks`** — builds, then lint + format + the ~20 contract/schema/safety validators (below).
 
 **Gates (all must pass):** `lint` · `format:check` · `validate:contract-drift` ·
@@ -91,8 +94,9 @@ input list, which a one-file surface PR does not commit; it is served fresh on d
 (gzip-measures the `wrangler deploy --dry-run` Worker bundle against a budget so an over-1MiB bundle
 fails at PR time, not at the Cloudflare deploy) · `scan:public-safety` · `validate:private-boundary`.
 
-Codecov is configured in `codecov.yml`; run `npm run test:coverage` unsharded locally (CI shards +
-merges, so a single shard under-reports).
+Codecov is configured in `codecov.yml`; run `npm run test:coverage` locally for the full-suite number.
+CI uploads coverage once, from the `test:ci` pass — the two artifact writers run via child processes
+and contribute no in-process coverage, so splitting them out is coverage-neutral.
 
 ---
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -58,10 +58,18 @@ jobs:
       - name: Prepare test reports dir
         run: mkdir -p reports/junit
 
-      - name: Test (with coverage gate)
+      # The suite runs in two non-overlapping passes (see vitest.config.mjs's
+      # fileParallelism note). `test:ci` runs the parallelizable bulk — every
+      # file EXCEPT the two filesystem-mutating artifact writers — concurrently
+      # WITH coverage; `test:ci:artifacts` (the last step below) then runs those
+      # two writers serially, after coverage is already captured + uploaded. The
+      # writers drive their work via execFileSync child processes and add zero
+      # in-process coverage, so coverage comes only from `test:ci` and CI still
+      # makes a single Codecov upload.
+      - name: Test (parallel, with coverage gate)
         env:
           VITEST_JUNIT_PATH: reports/junit/vitest.xml
-        run: npm run test:coverage
+        run: npm run test:ci
 
       # Upload coverage to Codecov — the primary PR coverage gate (delta-based
       # project + patch, see codecov.yml). vitest's thresholds are now just a
@@ -82,6 +90,14 @@ jobs:
           files: ./reports/junit/vitest.xml
           report_type: test_results
           fail_ci_if_error: false
+
+      # The two filesystem-mutating artifact writers, run serially LAST so they
+      # never overlap the parallel readers above and coverage is already
+      # uploaded. They mutate the same on-disk artifact tree, so they cannot run
+      # concurrently with each other either — the serial default applies. This is
+      # a pure correctness gate (no coverage); a failure here still fails the job.
+      - name: Test (artifact writers, serial)
+        run: npm run test:ci:artifacts
 
   checks:
     name: checks

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ lib-cov
 coverage
 *.lcov
 
+# Test reporter output (JUnit XML written via VITEST_JUNIT_PATH in CI)
+reports/
+
 # nyc test coverage
 .nyc_output
 

--- a/package.json
+++ b/package.json
@@ -103,6 +103,8 @@
     "check": "npm run lint && npm run format:check && npm run pipeline:check && npm run validate:docs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:ci": "vitest run --coverage --fileParallelism --testTimeout=30000 --exclude '**/artifacts.test.mjs' --exclude '**/discovery-artifacts.test.mjs'",
+    "test:ci:artifacts": "vitest run tests/artifacts.test.mjs tests/discovery-artifacts.test.mjs",
     "curation:brief": "node scripts/curation-brief.mjs",
     "endpoint:brief": "node scripts/endpoint-ops-brief.mjs"
   },

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -80,7 +80,15 @@ describe("public URL safety checks", () => {
   });
 
   test("blocks hostnames that resolve to private addresses", async () => {
-    assert.equal(await isUnsafeResolvedUrl("http://localhost/"), true);
+    // Inject the resolver (the script-utils pattern) so the SSRF-resolution
+    // classification is tested deterministically, with no dependency on the CI
+    // runner's outbound DNS. A public-looking host that resolves to a private
+    // address must still be blocked.
+    const privateResolver = async () => [{ address: "10.0.0.5", family: 4 }];
+    assert.equal(
+      await isUnsafeResolvedUrl("https://internal.example/", privateResolver),
+      true,
+    );
   });
 
   test("blocks credentialed public URLs before DNS resolution", () => {
@@ -106,9 +114,21 @@ describe("public URL safety checks", () => {
   });
 
   test("resolves public hosts and blocks failed DNS lookups", async () => {
-    assert.equal(await isUnsafeResolvedUrl("https://example.com/"), false);
+    // Injected resolvers keep this deterministic and network-free: a host that
+    // resolves to a public address is allowed; a host whose lookup fails (the
+    // resolver throws, as Node's dns does on NXDOMAIN) is blocked.
+    const publicResolver = async () => [
+      { address: "93.184.216.34", family: 4 },
+    ];
+    const failingResolver = async () => {
+      throw new Error("ENOTFOUND");
+    };
     assert.equal(
-      await isUnsafeResolvedUrl("https://metagraphed.invalid/"),
+      await isUnsafeResolvedUrl("https://metagraph.example/", publicResolver),
+      false,
+    );
+    assert.equal(
+      await isUnsafeResolvedUrl("https://metagraph.invalid/", failingResolver),
       true,
     );
   });

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -23,6 +23,21 @@ export default defineConfig({
     // to a temp dir without a full input+output tree copy — serializing files
     // is the clean, low-risk fix. Per-file fork isolation is preserved; only
     // filesystem-race concurrency is removed.
+    //
+    // This serial default keeps a plain `npm test` / `npm run test:coverage`
+    // (which runs the FULL suite, including the two filesystem-mutating writers)
+    // race-free. CI instead runs the suite in two non-overlapping passes that
+    // recover the parallelism: `test:ci` runs everything EXCEPT the two writers
+    // with `--fileParallelism` (the 27 createLocalArtifactEnv readers only READ,
+    // so they parallelize safely once no writer runs alongside them) and a raised
+    // `--testTimeout` (the subprocess-spawning tests — public-safety's full-repo
+    // scan, script-utils, r2-upload — are CPU-starved under parallel load and
+    // would otherwise hit the 5s default); `test:ci:artifacts` then runs the two
+    // writers serially. The passes are sequential, so writers never overlap
+    // readers. Coverage is collected only in `test:ci` (the writers drive their
+    // work via execFileSync child processes, contributing zero in-process
+    // coverage — verified Δ=0.00 across all metrics), keeping CI to a single
+    // Codecov upload.
     fileParallelism: false,
     reporters: junitPath ? ["default", "junit"] : ["default"],
     ...(junitPath ? { outputFile: { junit: junitPath } } : {}),


### PR DESCRIPTION
## Summary

The Validate **`test`** job ran the entire suite **serially** and was the CI wall-clock long pole (~2.5 min, vs ~1 min for `checks`). `vitest.config` sets `fileParallelism: false` because two tests — `artifacts.test.mjs` and `discovery-artifacts.test.mjs` — `execFileSync` the real build and mutate the shared on-disk artifact tree in place, which would race the 27 `createLocalArtifactEnv` reader tests. That serialized **111 otherwise-parallelizable files for two files' sake**.

## Change

Run the suite in **two non-overlapping passes** (new npm scripts):
- **`test:ci`** — everything *except* the two writers, `--fileParallelism`, **with coverage**, `--testTimeout=30000` (the subprocess-spawning tests — public-safety's full-repo scan, `script-utils`, `r2-upload` — are CPU-starved under parallel load and would otherwise hit the 5 s default).
- **`test:ci:artifacts`** — the two writers, serial (config default), as the **last** job step, after coverage is captured + uploaded.

The passes are sequential, so writers never overlap readers. The config default **stays serial**, so a plain local `npm test` / `npm run test:coverage` (full suite, includes the writers) remains race-free.

## Coverage / Codecov (the part I was careful with)

Coverage stays **exactly one Codecov upload**, from `test:ci`. The two writers drive their work via `execFileSync` child processes and contribute **zero in-process coverage** — verified **Δ = 0.00 on all four metrics** (lines 98.66 / statements 98.38 / functions 97.59 / branches 92.78, identical with and without them, all above the backstop floors). No second upload and no merge → avoids the transient `codecov/patch` flakiness that multi-upload setups cause. My diff also touches no files in the coverage `include` set (src/workers/4 scripts), so patch coverage is unaffected.

## De-flake (bonus)

`public-safety.test.mjs` was the suite's only real-network test — `isUnsafeResolvedUrl` hitting live DNS (`example.com` / `*.invalid`). It now injects mock resolvers (the existing `script-utils` pattern), keeping the SSRF-resolution logic fully tested with **zero CI network dependency**.

## Verification

- `test:ci` green and **deterministic across 3 consecutive runs** (111 files / 2246 tests, **~22 s** wall vs ~2.5 min serial; ~3 cores).
- `test:ci:artifacts` green (2 files / 27 tests); artifact tree left clean afterward.
- Coverage backstop floors pass; `lcov.info` + JUnit both written.
- `lint` (eslint clean) · `prettier --check` (all changed files) · `validate:workflows` (17 files) green.
- `reports/` added to `.gitignore` (JUnit output dir); reference.md CI docs updated.

Net: the `test` job's parallel content drops from ~2 min to ~22 s; the two writers (~49 s) run serially after, so the job's wall-clock falls without adding a runner or a second coverage upload.
