### PR TITLE
docs: prohibit PR plagiarism and reward-farming with a permanent cross-repo block

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,7 +22,10 @@ Examples of unacceptable behavior include:
 - Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
 - Publishing others' private information, such as a physical or email address, without their explicit permission
+- Plagiarism — copying another contributor's pull request, diff, or work and submitting it as your own (including duplicated or lightly reworded copies filed under a different account), and attempts to game contribution scoring or farm Gittensor rewards through copied submissions
 - Other conduct which could reasonably be considered inappropriate in a professional setting
+
+> **Plagiarism and reward-farming are zero-tolerance.** Deliberate attempts to cheat, copy from other contributors, or farm Gittensor rewards through stolen or duplicated submissions are treated as an immediate, serious violation — offenders are **permanently blocked from contributing**, and the block applies across all of our repositories (`JSONbored/gittensory`, `JSONbored/metagraphed`, `JSONbored/awesome-claude`).
 
 ## Enforcement Responsibilities
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,8 @@ Surfaces live in **one file per subnet**: `registry/subnets/<slug>.json` → its
 
 > Change **only** the one `registry/subnets/<slug>.json` — no generated artifacts. First-time provider? Pass `--provider-name` + `--provider-url` and `surface:add` scaffolds the `registry/providers/<slug>.json` stub for you in the same PR; provider identity still gets reviewed before it's trusted.
 
+> **Plagiarism is not tolerated.** Copying another contributor's PR, surface, or work and submitting it as your own — including duplicated or lightly reworded copies filed under a different account — is a hard violation. Don't copy others to farm Gittensor rewards: anyone attempting to cheat or copy for gain is **permanently blocked from contributing across all of our repositories**. See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
 Add a surface locally — three steps:
 
 ```bash


### PR DESCRIPTION
## What

Adds an explicit, enforceable anti-plagiarism policy to both `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md`.

## Why

Copying another contributor's PR, diff, or work and submitting it as your own — including lightly reworded or re-tested copies filed under a different account — to farm Gittensor rewards is gaming, not contribution. This makes the consequence explicit and uniform across our repos.

## Policy

- **Code of Conduct** — plagiarism added to the unacceptable-behavior list; enforcement clause states offenders are **permanently blocked from contributing**, across `JSONbored/gittensory`, `JSONbored/metagraphed`, and `JSONbored/awesome-claude`.
- **Contributing** — a visible callout in the submission rules cross-referencing the Code of Conduct.

Docs-only; no code or schema changes.