### PR TITLE
fix(scripts): tighten coldkey-only safety allowlist

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -68,7 +68,7 @@ const patterns = [
     // the isMirroredExternalSpec exemption, scoped to the safe forms so the guard
     // stays active everywhere else.
     allow:
-      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bhotkey(?:\s+or\s+|\s*\/\s*)coldkey\b|\bcoldkey-only\b|\bcoldkey\s*=/gi,
+      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bhotkey(?:\s+or\s+|\s*\/\s*)coldkey\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*=/gi,
     soft: true,
   },
   {

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -311,7 +311,7 @@ describe("captured-fixture body scan", () => {
     // strip: a hyphenated secret attempt must still trip the terminology guard.
     await fs.writeFile(
       TEST_PUBLIC_PATH,
-      "Set coldkey-seedphrase to 5xyzABCDEFGHabcdefgh in your config.\n",
+      "Set coldkey-only-seedphrase to 5xyzABCDEFGHabcdefgh in your config.\n",
       "utf8",
     );
     const output = runScanOutput();


### PR DESCRIPTION
### Motivation
- A newly added allowlist entry for the `coldkey-only` phrase could be stripped when followed by another hyphenated segment (e.g. `coldkey-only-seedphrase`), which removed the `coldkey` token before the `Bittensor key terminology` detector ran and allowed a narrow public-safety bypass.

### Description
- Tighten the public-safety scanner allowlist by changing the `coldkey-only` entry to require that it is not followed by an extra hyphen/word segment, using `\bcoldkey-only(?![-A-Za-z0-9_])` in `scripts/scan-public-safety.mjs` instead of the previous `\bcoldkey-only\b` form. 
- Update the regression in `tests/public-safety.test.mjs` to assert that the `coldkey-only-seedphrase` bypass form is flagged while preserving the legitimate `coldkey-only` API-prose exemption.

### Testing
- Ran the focused unit tests with `npm test -- tests/public-safety.test.mjs` and all tests passed. 
- Ran the scanner with `npm run scan:public-safety` and it reported no public-safety regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e20d5eb28832cac91d90d03dd0242)