### PR TITLE
fix(api): let planner choose extrinsics time index

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1532,7 +1532,7 @@ describe("handleExtrinsics", () => {
     assert.ok(captures.params.flat().includes(0));
   });
 
-  test("uses observed-at index hint for standalone time filters", async () => {
+  test("does not force observed-at index hint for standalone time filters", async () => {
     const { env, captures } = dbWith({ extrinsics: [] });
     await handleExtrinsics(
       req("/api/v1/extrinsics"),
@@ -1540,7 +1540,9 @@ describe("handleExtrinsics", () => {
       url("/api/v1/extrinsics?from=1750000000000"),
     );
     const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(/INDEXED BY idx_extrinsics_observed_order/.test(sql));
+    assert.ok(sql);
+    assert.ok(!/INDEXED BY/.test(sql), "planner must choose the best index");
+    assert.ok(/observed_at >= \?/.test(sql));
   });
 
   test("short-circuits impossible future time filters before D1", async () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -938,19 +938,13 @@ export async function handleExtrinsics(request, env, url) {
     conds.push("(block_number, extrinsic_index) < (?, ?)");
     params.push(cur[0], cur[1]);
   }
-  const hasObservedRange = fromMs != null || toMs != null;
-  const hasOrderAlignedEquality =
-    sp.get("block") != null ||
-    Boolean(sp.get("signer")) ||
-    Boolean(sp.get("call_module")) ||
-    Boolean(sp.get("call_function")) ||
-    successRaw === "true" ||
-    successRaw === "false";
-  const observedIndexHint =
-    hasObservedRange && !hasOrderAlignedEquality
-      ? " INDEXED BY idx_extrinsics_observed_order"
-      : "";
-  let sql = `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics${observedIndexHint}`;
+  // Do not force the observed_at-leading index here. Broad valid windows such
+  // as from=0 or to=now can cover the retained hot set; the feed order is still
+  // block_number/extrinsic_index, so SQLite/D1 must be free to choose the
+  // primary-key order and stop after LIMIT instead of scanning and sorting the
+  // observed_at index. The migration keeps idx_extrinsics_observed_order
+  // available for genuinely selective timestamp ranges when the planner wants it.
+  let sql = `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics`;
   if (conds.length) sql += ` WHERE ${conds.join(" AND ")}`;
   sql += " ORDER BY block_number DESC, extrinsic_index DESC LIMIT ?";
   params.push(limit);


### PR DESCRIPTION
### Motivation
- The extrinsics feed forced `INDEXED BY idx_extrinsics_observed_order` whenever a standalone `from`/`to` observed_at range was present, which can force large D1 scans and a temporary sort for broad valid windows and open a public DoS/query-amplification path.
- The migration index is useful for selective timestamp queries, but the handler must not unconditionally force the observed_at-leading index for non-selective windows so the SQLite/D1 planner can choose the primary-key order and stop after `LIMIT`.

### Description
- Removed the unconditional `INDEXED BY idx_extrinsics_observed_order` hint from `workers/request-handlers/entities.mjs` so the planner can pick the best index for `SELECT ... FROM extrinsics`.
- Preserved the `observed_at` predicates and the `ORDER BY block_number DESC, extrinsic_index DESC` feed ordering so behavior and filtering remain unchanged.
- Added an inline comment explaining why the observed-at index must not be forced for broad valid windows while keeping the index available for the planner.
- Updated `tests/request-handlers-entities.test.mjs` to assert that standalone time filters include the `observed_at` predicate but do not force an `INDEXED BY` hint.

### Testing
- Ran `git diff --check` with no issues reported (ok).
- Ran `npm run lint` and `npm run format:check`, both succeeded (no failures).
- Ran `npm test -- --run tests/request-handlers-entities.test.mjs`, all tests passed (`122` tests passed).
- Ran `npm test -- --run tests/extrinsics.test.mjs`, all tests passed (`26` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e59f58ba8832c9d27dff3d54cd52a)