### PR TITLE
fix(api): bound SS58 balance address validation

### DIFF
--- a/tests/account-balance.test.mjs
+++ b/tests/account-balance.test.mjs
@@ -72,6 +72,38 @@ test("GET /accounts/{ss58}/balance returns 400 for a too-short address", async (
   assert.equal(res.status, 400);
 });
 
+test("GET /accounts/{ss58}/balance rejects overlong base58 before rate limiting or RPC", async () => {
+  let limiterCalls = 0;
+  let fetchCalls = 0;
+  const env = {
+    RPC_RATE_LIMITER: {
+      limit: async () => {
+        limiterCalls += 1;
+        return { success: true };
+      },
+    },
+  };
+  await withFetchStub(
+    async () => {
+      fetchCalls += 1;
+      throw new Error("should not fetch");
+    },
+    async () => {
+      const overlong = "5" + "a".repeat(4096);
+      const res = await handleRequest(
+        req(`/api/v1/accounts/${overlong}/balance`),
+        env,
+        {},
+      );
+      assert.equal(res.status, 400);
+      assert.equal(limiterCalls, 0);
+      assert.equal(fetchCalls, 0);
+      const body = await res.json();
+      assert.equal(body.error.code, "invalid_ss58");
+    },
+  );
+});
+
 test("GET /accounts/{ss58}/balance returns 200 with balance_tao:null on RPC failure", async () => {
   // No fetch mock — the Worker's global fetch will fail or env has no fetch.
   // Simulate by providing an env whose fetch throws.

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -511,6 +511,8 @@ const SS58_BASE58_INDEX = new Map(
   [...SS58_BASE58_ALPHABET].map((char, index) => [char, index]),
 );
 const FINNEY_SS58_PREFIX = 42;
+const FINNEY_SS58_MIN_LENGTH = 47;
+const FINNEY_SS58_MAX_LENGTH = 48;
 const FINNEY_SS58_DECODED_LENGTH = 35;
 const BALANCE_KV_TTL = 60; // seconds
 const BALANCE_NEGATIVE_KV_TTL = 10; // seconds
@@ -542,6 +544,13 @@ function decodeBase58(value) {
 }
 
 function isFinneySs58Address(value) {
+  if (
+    value.length < FINNEY_SS58_MIN_LENGTH ||
+    value.length > FINNEY_SS58_MAX_LENGTH
+  ) {
+    return false;
+  }
+
   const decoded = decodeBase58(value);
   return (
     decoded?.length === FINNEY_SS58_DECODED_LENGTH &&


### PR DESCRIPTION
### Motivation
- Prevent CPU exhaustion from attacker-controlled, overlong base58 path captures by rejecting addresses outside the expected SS58 length before running the expensive base58 decoder. 
- Ensure malformed/overlong inputs are rejected cheaply before any per-client RPC rate limiter or upstream RPC fan-out is invoked.

### Description
- Add fixed-length bounds for Finney SS58 strings (`FINNEY_SS58_MIN_LENGTH = 47`, `FINNEY_SS58_MAX_LENGTH = 48`) in `workers/request-handlers/entities.mjs`.
- Perform a cheap length check at the start of `isFinneySs58Address(value)` and return `false` if the capture is too short or too long, avoiding `decodeBase58` on unbounded input.
- Add a regression test in `tests/account-balance.test.mjs` that submits a very long base58 capture and asserts a `400` response occurs without calling the RPC or the rate limiter.

### Testing
- Ran the focused test file with `npm test -- tests/account-balance.test.mjs` and all tests passed (16/16).
- Ran linters and format checks with `npm run lint` and `npm run format:check` against the modified files and they passed.
- Built artifacts and validated the API with `npm run build && npm run validate:api`, and validation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e5d4659c0832ca206a1d79aede337)