### PR TITLE
fix(api): force extrinsics observed-at index for standalone time filters

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1532,7 +1532,7 @@ describe("handleExtrinsics", () => {
     assert.ok(captures.params.flat().includes(0));
   });
 
-  test("does not force observed-at index hint for standalone time filters", async () => {
+  test("forces observed-at index hint for standalone time filters", async () => {
     const { env, captures } = dbWith({ extrinsics: [] });
     await handleExtrinsics(
       req("/api/v1/extrinsics"),
@@ -1541,7 +1541,10 @@ describe("handleExtrinsics", () => {
     );
     const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
     assert.ok(sql);
-    assert.ok(!/INDEXED BY/.test(sql), "planner must choose the best index");
+    assert.ok(
+      /FROM extrinsics INDEXED BY idx_extrinsics_observed_order/.test(sql),
+      "standalone observed_at filters must use the covering timestamp index",
+    );
     assert.ok(/observed_at >= \?/.test(sql));
   });
 
@@ -1606,6 +1609,7 @@ describe("handleExtrinsics", () => {
     );
     const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
     assert.ok(sql, "a valid window must reach D1");
+    assert.ok(/INDEXED BY idx_extrinsics_observed_order/.test(sql));
     assert.ok(/observed_at >= \?/.test(sql));
     assert.ok(/observed_at <= \?/.test(sql));
   });

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -912,16 +912,21 @@ export async function handleExtrinsics(request, env, url) {
     conds.push(`${col} = ?`);
     params.push(val);
   };
-  if (sp.get("block") != null)
-    eq("block_number", clampInt(sp.get("block"), 0, 0, MAX));
+  const hasBlockFilter = sp.get("block") != null;
+  const hasEqualityFilter =
+    sp.get("signer") || sp.get("call_module") || sp.get("call_function");
+  if (hasBlockFilter) eq("block_number", clampInt(sp.get("block"), 0, 0, MAX));
   if (sp.get("signer")) eq("signer", sp.get("signer"));
   if (sp.get("call_module")) eq("call_module", sp.get("call_module"));
   if (sp.get("call_function")) eq("call_function", sp.get("call_function"));
   // success is stored 1/0/NULL; bind the literal so success=false never leaks
   // NULL (undeterminable) rows. Any non-true/false value is ignored.
   const successRaw = sp.get("success");
+  const hasSuccessFilter = successRaw === "true" || successRaw === "false";
   if (successRaw === "true") eq("success", 1);
   else if (successRaw === "false") eq("success", 0);
+  const hasBlockRangeFilter =
+    sp.get("block_start") != null || sp.get("block_end") != null;
   if (sp.get("block_start") != null) {
     conds.push("block_number >= ?");
     params.push(clampInt(sp.get("block_start"), 0, 0, MAX));
@@ -947,13 +952,20 @@ export async function handleExtrinsics(request, env, url) {
     conds.push("(block_number, extrinsic_index) < (?, ?)");
     params.push(cur[0], cur[1]);
   }
-  // Do not force the observed_at-leading index here. Broad valid windows such
-  // as from=0 or to=now can cover the retained hot set; the feed order is still
-  // block_number/extrinsic_index, so SQLite/D1 must be free to choose the
-  // primary-key order and stop after LIMIT instead of scanning and sorting the
-  // observed_at index. The migration keeps idx_extrinsics_observed_order
-  // available for genuinely selective timestamp ranges when the planner wants it.
+  // Standalone observed_at ranges can be highly selective or empty while the
+  // feed order is block_number/extrinsic_index. Force the covering timestamp
+  // index for that public unauthenticated case so D1 cannot satisfy ORDER BY by
+  // walking most of the retained primary-key order before finding no rows.
+  const forceObservedOrderIndex =
+    (fromMs != null || toMs != null) &&
+    !hasBlockFilter &&
+    !hasEqualityFilter &&
+    !hasSuccessFilter &&
+    !hasBlockRangeFilter &&
+    !useCursor;
   let sql = `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics`;
+  if (forceObservedOrderIndex)
+    sql += " INDEXED BY idx_extrinsics_observed_order";
   if (conds.length) sql += ` WHERE ${conds.join(" AND ")}`;
   sql += " ORDER BY block_number DESC, extrinsic_index DESC LIMIT ?";
   params.push(limit);


### PR DESCRIPTION
### Motivation
- A recent change removed the guarded use of the observed_at-leading index, allowing attacker-controlled `from`/`to` time windows to trigger expensive primary-key scans against the retained `extrinsics` D1 table and amplify cost/availability attacks. 
- The migration `0021_extrinsics_filter_indexes.sql` intentionally provides `idx_extrinsics_observed_order` to seek timestamp ranges and avoid full PK walks for public time filters. 
- This PR restores a narrow, safe guard so unauthenticated standalone observed_at ranges use the covering timestamp index while leaving planner choice intact when other filters are present.

### Description
- Reintroduced a guarded index hint in `workers/request-handlers/entities.mjs` that appends `INDEXED BY idx_extrinsics_observed_order` to the `SELECT` when a standalone `from`/`to` observed_at predicate is present and there are no block, equality, success, block-range, or cursor filters (implements `forceObservedOrderIndex`).
- Added boolean flags `hasBlockFilter`, `hasEqualityFilter`, `hasSuccessFilter`, and `hasBlockRangeFilter` to determine when to force the observed_at-leading index and avoid forcing it in cases where a more appropriate index should be chosen by the planner.
- Updated regression tests in `tests/request-handlers-entities.test.mjs` to assert that standalone time filters (and valid recent `from`/`to` windows) use the `idx_extrinsics_observed_order` hint and that equality/cursor cases still drop the hint.

### Testing
- Ran the focused unit suite with `npm test -- tests/request-handlers-entities.test.mjs` and all tests passed (`122 passed`).
- Ran project checks `npm run build` and `npm run validate` and both completed successfully.
- Ran style and tooling checks `npm run lint` and `npm run format:check` and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e6851ccd8832c8138a99c1a943ae3)