### PR TITLE
fix(api): validate chain analytics query values

### DIFF
--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -323,6 +323,24 @@ test("GET /api/v1/chain/calls groups by call_module with honest share + 400 on j
   assert.equal(bad.status, 400);
 });
 
+test("GET /api/v1/chain/calls rejects inert group_by and non-canonical limits", async () => {
+  const env = createLocalArtifactEnv();
+  for (const [path, parameter] of [
+    ["/api/v1/chain/calls?group_by=x1", "group_by"],
+    ["/api/v1/chain/calls?limit=abc1", "limit"],
+    ["/api/v1/chain/calls?limit=001", "limit"],
+    ["/api/v1/chain/calls?limit=999999", "limit"],
+  ]) {
+    const res = await handleRequest(
+      new Request(`https://api.metagraph.sh${path}`),
+      env,
+      {},
+    );
+    assert.equal(res.status, 400, path);
+    assert.equal((await res.json()).meta.parameter, parameter);
+  }
+});
+
 // ---- signers (#1990) builder + handler ------------------------------------
 
 test("buildChainSigners maps rows + is cold-stable", () => {
@@ -400,6 +418,23 @@ test("GET /api/v1/chain/signers ranks by tx_count via the signer GROUP BY", asyn
   assert.match(sql, /GROUP BY signer/);
   assert.match(sql, /ORDER BY tx_count DESC/);
   assert.equal(captured[0].params.at(-1), 10);
+});
+
+test("GET /api/v1/chain/signers rejects non-canonical limits", async () => {
+  const env = createLocalArtifactEnv();
+  for (const path of [
+    "/api/v1/chain/signers?limit=abc1",
+    "/api/v1/chain/signers?limit=001",
+    "/api/v1/chain/signers?limit=999999",
+  ]) {
+    const res = await handleRequest(
+      new Request(`https://api.metagraph.sh${path}`),
+      env,
+      {},
+    );
+    assert.equal(res.status, 400, path);
+    assert.equal((await res.json()).meta.parameter, "limit");
+  }
 });
 
 // ---- fees (#1988) builder + handler ---------------------------------------
@@ -488,6 +523,23 @@ test("GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL f
   assert.equal(body.data.top_fee_payers[0].signer, "5Pay");
   const daily = captured.find((q) => /GROUP BY day/.test(q.sql));
   assert.match(daily.sql, /COALESCE\(fee_tao, 0\)/);
+});
+
+test("GET /api/v1/chain/fees rejects non-canonical limits", async () => {
+  const env = createLocalArtifactEnv();
+  for (const path of [
+    "/api/v1/chain/fees?limit=abc1",
+    "/api/v1/chain/fees?limit=001",
+    "/api/v1/chain/fees?limit=999999",
+  ]) {
+    const res = await handleRequest(
+      new Request(`https://api.metagraph.sh${path}`),
+      env,
+      {},
+    );
+    assert.equal(res.status, 400, path);
+    assert.equal((await res.json()).meta.parameter, "limit");
+  }
 });
 
 test("the new chain routes are schema-stable empty when D1 is cold", async () => {

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -124,6 +124,29 @@ function analyticsQueryError(error) {
   });
 }
 
+function validateEnumParam(url, parameter, allowedValues) {
+  const raw = url.searchParams.get(parameter);
+  if (raw === null) return null;
+  if (allowedValues.includes(raw)) return null;
+  return {
+    parameter,
+    message: `${parameter} must be one of: ${allowedValues.join(", ")}.`,
+  };
+}
+
+function validateIntegerParam(url, parameter, min, max) {
+  const raw = url.searchParams.get(parameter);
+  if (raw === null) return null;
+  const value = Number(raw);
+  if (!/^[1-9]\d*$/.test(raw) || value < min || value > max) {
+    return {
+      parameter,
+      message: `${parameter} must be an integer between ${min} and ${max}.`,
+    };
+  }
+  return null;
+}
+
 let d1FallbackGeneration = 0;
 const D1_FALLBACK_ROWS = new WeakSet();
 const D1_FALLBACK_RESPONSES = new WeakSet();
@@ -696,10 +719,14 @@ export async function handleChainActivity(request, env, url, ctx = {}) {
 export async function handleChainCalls(request, env, url, ctx = {}) {
   const { label, days, error } = analyticsWindow(url, ["group_by", "limit"]);
   if (error) return analyticsQueryError(error);
-  const groupBy =
-    url.searchParams.get("group_by") === "module_function"
-      ? "module_function"
-      : "module";
+  const groupByError = validateEnumParam(url, "group_by", [
+    "module",
+    "module_function",
+  ]);
+  if (groupByError) return analyticsQueryError(groupByError);
+  const limitError = validateIntegerParam(url, "limit", 1, 100);
+  if (limitError) return analyticsQueryError(limitError);
+  const groupBy = url.searchParams.get("group_by") || "module";
   const limit = clampInt(url.searchParams.get("limit"), 50, 1, 100);
   return withEdgeCache(request, ctx, env, "chain-calls", async () => {
     const cutoff = Date.now() - days * DAY_MS;
@@ -760,6 +787,8 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
 export async function handleChainSigners(request, env, url, ctx = {}) {
   const { label, days, error } = analyticsWindow(url, ["limit"]);
   if (error) return analyticsQueryError(error);
+  const limitError = validateIntegerParam(url, "limit", 1, 100);
+  if (limitError) return analyticsQueryError(limitError);
   const limit = clampInt(url.searchParams.get("limit"), 50, 1, 100);
   return withEdgeCache(request, ctx, env, "chain-signers", async () => {
     const cutoff = Date.now() - days * DAY_MS;
@@ -807,6 +836,8 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
 export async function handleChainFees(request, env, url, ctx = {}) {
   const { label, days, error } = analyticsWindow(url, ["limit"]);
   if (error) return analyticsQueryError(error);
+  const limitError = validateIntegerParam(url, "limit", 1, 100);
+  if (limitError) return analyticsQueryError(limitError);
   const limit = clampInt(url.searchParams.get("limit"), 25, 1, 100);
   return withEdgeCache(request, ctx, env, "chain-fees", async () => {
     const cutoff = Date.now() - days * DAY_MS;


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated clients from bypassing the analytics edge cache by varying inert query strings and forcing repeated expensive D1 aggregations.  
- Enforce the documented contract for `group_by` and `limit` on the new chain analytics endpoints so cache keys reflect canonical semantics rather than raw user input.

### Description
- Added `validateEnumParam` and `validateIntegerParam` helpers in `workers/request-handlers/analytics.mjs` to validate allowed enum values and canonical integer ranges.  
- Applied enum validation for `group_by` and integer validation for `limit` in `handleChainCalls`, and integer validation for `limit` in `handleChainSigners` and `handleChainFees`, returning `400` on invalid inputs before any cache or D1 work.  
- Preserved the default `group_by = "module"` only when the parameter is omitted, avoiding treating arbitrary strings as different cacheable routes.  
- Added regression tests in `tests/chain-analytics.test.mjs` that assert handlers reject inert `group_by` values and non-canonical/ out-of-range `limit` values for `calls`, `signers`, and `fees`.

### Testing
- Ran the analytics unit tests with `npm test -- tests/chain-analytics.test.mjs`, and all tests in that file passed.  
- Ran code quality checks `npm run lint` and `npm run format:check`, and both checks passed.  
- Built generated artifacts with `npm run build` and validated the Worker API with `npm run validate:api`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e6d13c4a0832c8ce1702b170ea50a)