### PR TITLE
fix(api): guard block count filters

### DIFF
--- a/migrations/0023_block_count_filter_indexes.sql
+++ b/migrations/0023_block_count_filter_indexes.sql
@@ -1,0 +1,10 @@
+-- Back the public /api/v1/blocks count-floor filters so high/no-match
+-- ?min_extrinsics and ?min_events predicates seek instead of scanning the
+-- retained blocks window. Additive + idempotent; handler-side no-match guards
+-- remain the first line of defense for impossible values.
+
+CREATE INDEX IF NOT EXISTS idx_blocks_extrinsic_count
+  ON blocks (extrinsic_count, block_number DESC);
+
+CREATE INDEX IF NOT EXISTS idx_blocks_event_count
+  ON blocks (event_count, block_number DESC);

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1325,6 +1325,34 @@ describe("handleBlocks", () => {
     assert.ok(!/OFFSET/.test(sql));
   });
 
+  test("short-circuits impossible count floors before querying D1", async () => {
+    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
+    const body = await json(
+      await handleBlocks(
+        req("/api/v1/blocks"),
+        env,
+        url("/api/v1/blocks?min_events=9007199254740991"),
+      ),
+    );
+    assert.equal(body.data.block_count, 0);
+    assert.deepEqual(body.data.blocks, []);
+    assert.equal(captures.sql.length, 0);
+  });
+
+  test("short-circuits inverted block and time ranges before querying D1", async () => {
+    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
+    const body = await json(
+      await handleBlocks(
+        req("/api/v1/blocks"),
+        env,
+        url("/api/v1/blocks?block_start=20&block_end=10&from=200&to=100"),
+      ),
+    );
+    assert.equal(body.data.block_count, 0);
+    assert.deepEqual(body.data.blocks, []);
+    assert.equal(captures.sql.length, 0);
+  });
+
   test("the unfiltered feed keeps the plain OFFSET path (no WHERE)", async () => {
     const { env, captures } = dbWith({ blocksFeed: [] });
     await handleBlocks(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -18,6 +18,7 @@
 // handlers back and dispatches them from the router.
 
 import { DAY_MS, clampInt, resolveClientIp } from "../config.mjs";
+
 import { errorResponse } from "../http.mjs";
 import {
   contractVersion,
@@ -67,6 +68,8 @@ import {
   buildExtrinsic,
   buildExtrinsicFeed,
 } from "../../src/extrinsics.mjs";
+
+const MAX_BLOCK_COUNT_FILTER = 1_000_000;
 
 // --- Per-UID metagraph (#1304/#1305): served live from the neurons D1 tier ---
 // (migration 0007, populated by the refresh-metagraph cron). Null-safe: an
@@ -697,9 +700,40 @@ export async function handleBlocks(request, env, url) {
   const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
   const sp = url.searchParams;
   const MAX = Number.MAX_SAFE_INTEGER;
+  const intParam = (name) => clampInt(sp.get(name), 0, 0, MAX);
+  const blockStart =
+    sp.get("block_start") != null ? intParam("block_start") : null;
+  const blockEnd = sp.get("block_end") != null ? intParam("block_end") : null;
+  const from = sp.get("from") != null ? intParam("from") : null;
+  const to = sp.get("to") != null ? intParam("to") : null;
+  const minExtrinsics =
+    sp.get("min_extrinsics") != null ? intParam("min_extrinsics") : null;
+  const minEvents =
+    sp.get("min_events") != null ? intParam("min_events") : null;
+
+  // Inverted indexed ranges and astronomically high per-block count floors are
+  // deterministic no-match cases. Short-circuit them before D1 so public callers
+  // cannot amplify cost by forcing scans to prove an impossible empty result.
+  if (
+    (blockStart != null && blockEnd != null && blockStart > blockEnd) ||
+    (from != null && to != null && from > to) ||
+    (minExtrinsics != null && minExtrinsics > MAX_BLOCK_COUNT_FILTER) ||
+    (minEvents != null && minEvents > MAX_BLOCK_COUNT_FILTER)
+  ) {
+    const data = buildBlockFeed([], { limit, offset, nextCursor: null });
+    return envelopeResponse(
+      request,
+      {
+        data,
+        meta: await accountMeta(env, "/metagraph/blocks.json", null),
+      },
+      "short",
+    );
+  }
+
   // Conjunctive (AND-ed) filter set mirroring handleExtrinsics (#1846/#1991):
-  // every value is BOUND, never interpolated; an inverted range or an absent
-  // nullable column simply matches nothing — never a throw.
+  // every value is BOUND, never interpolated; no-match filters return an empty
+  // feed rather than throwing.
   const conds = [];
   const params = [];
   if (sp.get("author")) {
@@ -710,29 +744,29 @@ export async function handleBlocks(request, env, url) {
     conds.push("spec_version = ?");
     params.push(clampInt(sp.get("spec_version"), 0, 0, MAX));
   }
-  if (sp.get("block_start") != null) {
+  if (blockStart != null) {
     conds.push("block_number >= ?");
-    params.push(clampInt(sp.get("block_start"), 0, 0, MAX));
+    params.push(blockStart);
   }
-  if (sp.get("block_end") != null) {
+  if (blockEnd != null) {
     conds.push("block_number <= ?");
-    params.push(clampInt(sp.get("block_end"), 0, 0, MAX));
+    params.push(blockEnd);
   }
-  if (sp.get("from") != null) {
+  if (from != null) {
     conds.push("observed_at >= ?");
-    params.push(clampInt(sp.get("from"), 0, 0, MAX));
+    params.push(from);
   }
-  if (sp.get("to") != null) {
+  if (to != null) {
     conds.push("observed_at <= ?");
-    params.push(clampInt(sp.get("to"), 0, 0, MAX));
+    params.push(to);
   }
-  if (sp.get("min_extrinsics") != null) {
+  if (minExtrinsics != null) {
     conds.push("extrinsic_count >= ?");
-    params.push(clampInt(sp.get("min_extrinsics"), 0, 0, MAX));
+    params.push(minExtrinsics);
   }
-  if (sp.get("min_events") != null) {
+  if (minEvents != null) {
     conds.push("event_count >= ?");
-    params.push(clampInt(sp.get("min_events"), 0, 0, MAX));
+    params.push(minEvents);
   }
   // Keyset cursor (#1851) takes precedence over offset: fold its block_number < ?
   // seek into the same conds so it ANDs with the filters (PK-ordered, stable under


### PR DESCRIPTION
### Motivation
- The public `/api/v1/blocks` conjunctive filters introduced optional count-floor predicates (`min_extrinsics` / `min_events`) that can force expensive scans of the 365-day retained `blocks` D1 window for impossible or astronomically large values. This is a cost-amplification/availability risk for an unauthenticated route.

### Description
- Short-circuit deterministic no-match filter combinations in `handleBlocks` so inverted ranges (`block_start > block_end`, `from > to`) and absurdly large count floors return an empty feed without issuing a D1 query by checking parsed numeric params early in `workers/request-handlers/entities.mjs` and returning an empty `buildBlockFeed` envelope. 
- Add a small guard constant `MAX_BLOCK_COUNT_FILTER = 1_000_000` and reuse parsed/clamped integer values for SQL predicates to avoid double-parsing. 
- Add a migration `migrations/0023_block_count_filter_indexes.sql` that creates `idx_blocks_extrinsic_count` and `idx_blocks_event_count` to back the public count-floor predicates so they can seek instead of scanning when present. 
- Add regression tests in `tests/request-handlers-entities.test.mjs` verifying that impossible count floors and inverted block/time ranges short-circuit and do not emit any D1 SQL.

### Testing
- Ran `npm test -- tests/request-handlers-entities.test.mjs` and the suite passed (`127` tests passed). 
- Ran `npm run validate:migrations`, `npm run format:check`, `npm run lint`, `npm run build`, `npm run validate:api`, and the full `npm run validate`, and all validators used in development completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e6f2017cc832c8507b568cddf12a9)