### PR TITLE
feat(registry): add SN88 Investing public asset-ratio JSON data-artifact (#2003)

### DIFF
--- a/registry/subnets/investing.json
+++ b/registry/subnets/investing.json
@@ -89,6 +89,30 @@
       "notes": "Public Investing asset-list surface. It currently returns HTML/table content rather than a JSON API contract."
     },
     {
+      "id": "sn-88-investing-ratio",
+      "name": "Investing asset-ratio value",
+      "kind": "data-artifact",
+      "url": "https://api.investing88.ai/ratio",
+      "provider": "mobiusfund",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/mobiusfund/investing/blob/main/README.md"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorysr1209-png"
+      },
+      "notes": "Public asset-ratio value served by the Investing API host. The official README documents api.investing88.ai/ratio as the asset-class split that partitions UID space and subnet emissions; an unauthenticated GET returns a JSON array (e.g. [0.5, 0.5]). Unlike the HTML asset-list surface, this is a machine-readable (JSON) public endpoint."
+    },
+    {
       "id": "sn-88-investing-source",
       "name": "Investing source repository",
       "kind": "source-repo",


### PR DESCRIPTION
## Summary

Adds one new public, unauthenticated **data-artifact** surface to SN88 Investing: the asset-ratio endpoint `https://api.investing88.ai/ratio`.

This is a single-file registry enrichment ? `registry/subnets/investing.json` only.

Closes #2003

## Surface

| field | value |
|---|---|
| subnet | SN88 Investing (`sn-88`) |
| id | `sn-88-investing-ratio` |
| kind | `data-artifact` |
| url | https://api.investing88.ai/ratio |
| provider | `mobiusfund` (existing) |
| auth_required | `false` |
| authority | `community` (community-submitted, pending maintainer verification) |
| public_safe | `true` |

## Ownership proof

Documented in the subnet's official `source_repo` README (`mobiusfund/investing`):

> "the UID space and subnet emissions are partitioned based on [asset ratio](https://api.investing88.ai/ratio)"

`source_urls` points at `https://github.com/mobiusfund/investing/blob/main/README.md`, and the host `api.investing88.ai` is the same API host already registered for the `/assets` surface.

## Liveness / response

```text
GET https://api.investing88.ai/ratio
HTTP 200  content-type: application/json
"[0.5, 0.5]"
```

Live, unauthenticated, no secrets. Distinct data from the existing `/assets` surface (HTML ticker list) ? `/ratio` is the subnet's first **machine-readable JSON** public surface, directly addressing the file's `gap_notes` ("asset surface returns HTML/table content, not JSON or OpenAPI").

## Checklist

- [x] Exactly one `registry/subnets/*.json` changed (no code/schema/build changes)
- [x] New surface has a unique `id`, owner-matched `url` + `source_urls`
- [x] `url` is public + unauthenticated; not a duplicate of an existing surface
- [x] `provider` already exists (`mobiusfund`)
- [x] `npm run` validators pass locally: `validate:surface` (432 surfaces / 99 files), `validate:schemas`, `scan:public-safety`
