### PR TITLE
feat(registry): add verified SN33 api.conversations.xyz subnet-api surface (#2010)

### DIFF
--- a/registry/subnets/readyai.json
+++ b/registry/subnets/readyai.json
@@ -156,6 +156,31 @@
       "schema_url": "https://api.readyai.ai/openapi.json",
       "source_urls": ["https://readyai.ai/docs"],
       "url": "https://api.readyai.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-33-conversations-health",
+      "kind": "subnet-api",
+      "name": "ReadyAI Conversation Genome API",
+      "notes": "Public unauthenticated health endpoint of the SN33 protocol API host (api.conversations.xyz), the validator read host documented in the official README (CGP_API_READ_HOST). GET /health returns JSON {\"status\":\"healthy\"}; the machine-readable schema (schema_url) self-identifies as \"sn33api\". The /api/v1/* task endpoints require hotkey auth and are out of scope for proxying.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "readyai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorysr1209-png"
+      },
+      "schema_url": "https://api.conversations.xyz/openapi.json",
+      "source_urls": [
+        "https://github.com/afterpartyai/bittensor-conversation-genome-project/blob/main/README.md"
+      ],
+      "url": "https://api.conversations.xyz/health"
     }
   ],
   "website_url": "https://readyai.ai/"


### PR DESCRIPTION
## Summary

Adds the verified **SN33 protocol API host** `api.conversations.xyz` to ReadyAI's registry entry ? previously absent (the file only listed the unverified `api.readyai.ai`). A single public, unauthenticated `subnet-api` surface in one file (`registry/subnets/readyai.json`):

- `subnet-api` ? `https://api.conversations.xyz/health` (public health endpoint), with `schema_url` pointing at the machine-readable schema (`info.title: "sn33api"`).

Closes #2010

## Ownership proof

Documented in the subnet's official `source_repo` README (`afterpartyai/bittensor-conversation-genome-project`):

> `CGP_API_READ_HOST=https://api.conversations.xyz` ? "For Validators. Read from api.conversations.xyz"

The OpenAPI schema at `api.conversations.xyz/openapi.json` self-identifies as `sn33api`, with paths under `/api/v1/conversation/*`.

## Liveness / responses

```text
GET https://api.conversations.xyz/health         -> 200 application/json  {"status":"healthy"}
GET https://api.conversations.xyz/openapi.json    -> 200 application/json  (title: "sn33api")  [referenced via schema_url]
```

Both unauthenticated, no secrets. The `/api/v1/*` task endpoints require hotkey auth and are explicitly scoped out of proxying in the surface notes.

## Why it matters

Closes the file's `curation.gap_note` "No verified safe public subnet API endpoint yet" with an owner-proven, unauthenticated endpoint on the actual validator read host (distinct from the existing `api.readyai.ai` product entry).

## Notes on scope

Kept to a single `subnet-api` surface so the change stays a clean, reproducible single-file registry edit (an `openapi`-kind surface would require regenerating + committing the `schemas/index.json` artifact; the schema is instead referenced here via `schema_url`).

## Checklist

- [x] Exactly one `registry/subnets/*.json` changed (no code/schema/build/artifact changes)
- [x] New surface has a unique `id`, owner-matched `url` + `source_urls` (on-chain repo README)
- [x] URL is public + unauthenticated; not a duplicate (new host)
- [x] `provider` already exists (`readyai`)
- [x] Local validators pass: `validate:surface` (432 surfaces / 99 files), `validate:schemas`, `scan:public-safety`
