### PR TITLE
feat(registry): enrich SN85 Vidaio — subnet-api + data-artifact surfaces

### DIFF
--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -100,6 +100,44 @@
       "schema_url": "https://api.vidaio.io/openapi.json",
       "source_urls": ["https://vidaio.io/"],
       "url": "https://api.vidaio.io/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-85-vidaio-subnet-api",
+      "kind": "subnet-api",
+      "name": "Vidaio API health",
+      "notes": "Public, unauthenticated JSON health endpoint for the Vidaio hosted API (api.vidaio.io). Documented in the live OpenAPI spec at GET /health; returns {\"status\":\"ok\"}.",
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rascalchow"
+      },
+      "source_urls": [
+        "https://api.vidaio.io/openapi.json",
+        "https://vidaio.io/"
+      ],
+      "url": "https://api.vidaio.io/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-85-vidaio-data-artifact",
+      "kind": "data-artifact",
+      "name": "Vidaio API readiness status",
+      "notes": "Public JSON readiness probe for the Vidaio hosted API. Documented in the live OpenAPI spec at GET /ready; returns {\"status\":\"ok\"} without authentication.",
+      "provider": "vidaio",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rascalchow"
+      },
+      "source_urls": [
+        "https://api.vidaio.io/openapi.json",
+        "https://vidaio.io/"
+      ],
+      "url": "https://api.vidaio.io/ready"
     }
   ],
   "website_url": "https://vidaio.io/"


### PR DESCRIPTION
## Summary

Closes #1281

Adds two verified public surfaces for SN85 Vidaio in `registry/subnets/vidaio.json`:

- **subnet-api** — `GET https://api.vidaio.io/health` — unauthenticated JSON health probe returning `{"status":"ok"}`
- **data-artifact** — `GET https://api.vidaio.io/ready` — unauthenticated JSON readiness status returning `{"status":"ok"}`

Both endpoints are documented in the live OpenAPI spec at `https://api.vidaio.io/openapi.json` (already registered as a community `openapi` surface). Verified reachable without authentication via `npm run surface:add` and `npm run validate:surface`.

## Test plan

- [x] `npm run validate:surface` — passed (433 surfaces)
- [x] `npm run validate:schemas` — passed
- [x] Manual curl: `GET /health` and `GET /ready` return `{"status":"ok"}` without API key
- [x] PR touches only `registry/subnets/vidaio.json`


Made with [Cursor](https://cursor.com)