### PR TITLE
feat(registry): enrich SN22 Desearch — public data-artifact surfaces

### DIFF
--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -241,6 +241,44 @@
       "schema_url": "https://api.desearch.ai/openapi.json",
       "source_urls": ["https://www.desearch.ai/docs"],
       "url": "https://api.desearch.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-22-desearch-data-artifact",
+      "kind": "data-artifact",
+      "name": "Desearch miner manifest template",
+      "notes": "Official static JSON manifest template for SN22 miner capacity declarations (web_search, x_search, ai_search concurrency). Referenced in the subnet-22 README and copied to manifest.json during miner setup.",
+      "provider": "desearch",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rascalchow"
+      },
+      "source_urls": [
+        "https://github.com/Desearch-ai/subnet-22",
+        "https://www.desearch.ai/docs"
+      ],
+      "url": "https://raw.githubusercontent.com/Desearch-ai/subnet-22/main/neurons/miners/manifest.template.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-22-desearch-data-artifact-api-desearch-ai",
+      "kind": "data-artifact",
+      "name": "Desearch API health status",
+      "notes": "Public, unauthenticated JSON health probe for the Desearch hosted API (api.desearch.ai). Returns {\"status\":\"health\"} without authentication; used for miner/validator runtime health checks.",
+      "provider": "desearch",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "rascalchow"
+      },
+      "source_urls": [
+        "https://github.com/Desearch-ai/subnet-22",
+        "https://api.desearch.ai/openapi.json"
+      ],
+      "url": "https://api.desearch.ai/health"
     }
   ],
   "website_url": "https://www.desearch.ai/"


### PR DESCRIPTION
## Summary

Refs #912

Adds two verified public **data-artifact** surfaces for SN22 Desearch in `registry/subnets/desearch.json`:

- **Miner manifest template** — `https://raw.githubusercontent.com/Desearch-ai/subnet-22/main/neurons/miners/manifest.template.json` — official static JSON declaring miner search capacity (`web_search`, `x_search`, `ai_search` concurrency), referenced in the subnet-22 README
- **API health status** — `GET https://api.desearch.ai/health` — unauthenticated JSON health probe returning `{"status":"health"}`

Both are owner-documented in the official `Desearch-ai/subnet-22` repository and verified reachable without authentication via `npm run surface:add`.

**SSE note:** I searched the live OpenAPI spec (`api.desearch.ai/openapi.json`), official docs, and source repo for a public `text/event-stream` endpoint and did not find one. Happy to add an SSE surface in a follow-up if a public stream URL is identified.

## Test plan

- [x] `npm run validate:surface` — passed
- [x] `npm run validate:schemas` — passed
- [x] Manual curl: manifest template returns JSON; `GET /health` returns `{"status":"health"}` without auth
- [x] PR touches only `registry/subnets/desearch.json`


Made with [Cursor](https://cursor.com)