### PR TITLE
fix(api): reject negative block_number/event_index in validEventRows

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -149,7 +149,9 @@ export function validEventRows(rows) {
     ? rows.filter(
         (r) =>
           Number.isInteger(r?.block_number) &&
+          r.block_number >= 0 &&
           Number.isInteger(r?.event_index) &&
+          r.event_index >= 0 &&
           typeof r?.event_kind === "string" &&
           Number.isInteger(r?.observed_at),
       )

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -38,6 +38,14 @@ test("validEventRows enforces the strict row shape (#1371)", () => {
     validEventRows([{ ...good, observed_at: "x" }]).length,
     0, // observed_at must be an integer
   );
+  assert.equal(
+    validEventRows([{ ...good, block_number: -1 }]).length,
+    0, // block_number must be non-negative (mirrors validBlockRows)
+  );
+  assert.equal(
+    validEventRows([{ ...good, event_index: -1 }]).length,
+    0, // event_index must be non-negative
+  );
 });
 
 test("eventInsertStatements builds chunked parameterized INSERT OR IGNORE", () => {


### PR DESCRIPTION
## Summary

- `validEventRows` now rejects negative `block_number` / `event_index`, matching `validBlockRows` and `validExtrinsicRows`.

## What Changed

- `src/account-events.mjs`: require `block_number >= 0` and `event_index >= 0`.
- `tests/account-events.test.mjs`: regression tests for negative PK components.

## Why it was observably wrong

Negative primary-key components could be ingested via staging/realtime paths that share `validEventRows`, unlike the blocks/extrinsics loaders that already guard `>= 0`.

## Template Used

- backend-code.md

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No schema/contract change.

## Validation

- [x] `npx vitest run tests/account-events.test.mjs` (24 passed)
- [x] `git diff --check`

Fixes #2017
