### PR TITLE
fix(api): clamp sub-perfect chain activity success_rate below 1

### DIFF
--- a/src/chain-analytics.mjs
+++ b/src/chain-analytics.mjs
@@ -12,8 +12,11 @@ function toCount(value) {
 }
 
 // Round a ratio to 4 dp without trailing float noise (0.99186… → 0.9919).
+// Sub-perfect ratios that would round up to 1.0 are clamped to 0.9999 so a
+// near-perfect day is never reported as a perfect success rate.
 function round4(value) {
-  return Math.round(value * 1e4) / 1e4;
+  const rounded = Math.round(value * 1e4) / 1e4;
+  return rounded >= 1 && value < 1 ? 0.9999 : rounded;
 }
 
 // Coerce a D1 fee/tip cell (TAO float, numeric string, or null) to a finite

--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -102,6 +102,20 @@ test("success_rate is successful/total, rounded to 4dp", () => {
   assert.equal(d.success_rate, 0.9917); // 12243/12345 = 0.991737…
 });
 
+test("success_rate clamps a sub-perfect ratio that rounds to 1.0", () => {
+  const [d] = buildChainActivity({
+    window: "7d",
+    extrinsicRows: [
+      {
+        day: "2026-06-25",
+        extrinsic_count: 100_000,
+        successful_extrinsics: 99_999,
+      },
+    ],
+  }).days;
+  assert.equal(d.success_rate, 0.9999); // 99_999/100_000 = 0.99999 → not 1
+});
+
 test("a day with zero extrinsics reports success_rate null, never NaN", () => {
   const out = buildChainActivity({
     window: "7d",


### PR DESCRIPTION
## Summary

- `buildChainActivity` now clamps a sub-perfect `success_rate` that would round to `1.0` down to `0.9999`.

## What Changed

- `src/chain-analytics.mjs`: extend `round4` with the same sub-1 clamp used by `displayUptimeRatio`.
- `tests/chain-analytics.test.mjs`: regression test for 99_999/100_000.

## Why it was observably wrong

A day with one failed extrinsic among 100k was reported as a perfect `success_rate = 1.0` on the chain activity endpoint.

## Template Used

- backend-code.md

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No schema/contract change.

## Validation

- [x] `npx vitest run tests/chain-analytics.test.mjs` (24 passed)
- [x] `git diff --check`

Fixes #2019
