### PR TITLE
fix(health): normalize D1 fallback global status_counts

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1250,7 +1250,7 @@ function liveFromD1Rows(rows) {
   const lastRun = latestIso(surfaces.map((s) => s.last_checked));
   const statusCounts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
   for (const row of surfaces) {
-    statusCounts[row.status] = (statusCounts[row.status] || 0) + 1;
+    statusCounts[normalizeProbeStatus(row.status)] += 1;
   }
   return {
     schema_version: 1,

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -1164,6 +1164,43 @@ describe("resolveLiveHealth (KV → D1 → null)", () => {
     assert.match(live.surfaces[0].last_checked, /^20\d\d-/);
   });
 
+  test("D1 fallback folds unrecognized surface status into unknown in global status_counts", async () => {
+    const now = 1_700_000_600_000;
+    const db = {
+      prepare: () => ({
+        bind: () => ({
+          all: async () => ({
+            results: [
+              {
+                surface_id: "7:subnet-api:x",
+                surface_key: "srf-d1fallback0000",
+                netuid: 7,
+                kind: "subnet-api",
+                provider: "x",
+                url: "https://x",
+                status: "throttled",
+                classification: "rate-limited",
+                latency_ms: null,
+                status_code: 429,
+                last_checked: 1_700_000_000_000,
+                last_ok: null,
+              },
+            ],
+          }),
+        }),
+      }),
+    };
+    const live = await resolveLiveHealth({
+      readHealthKv: async () => null,
+      env: {},
+      db,
+      now: () => now,
+    });
+    assert.equal(live.summary.status_counts.unknown, 1);
+    assert.equal(live.summary.status_counts.throttled, undefined);
+    assert.equal(live.summary.surface_count, 1);
+  });
+
   test("does not return stale D1-only surface_status rows", async () => {
     const db = {
       prepare: () => ({


### PR DESCRIPTION
## Summary

- `liveFromD1Rows` (the D1 fallback path in `resolveLiveHealth`) was the missed sibling of #1739 / #1942: per-subnet rollups already route through `normalizeProbeStatus` via `summarizeRows`, but the global `summary.status_counts` loop still bucketed raw `row.status`, creating phantom keys for unrecognized forward-compat statuses.

## What Changed

- `src/health-serving.mjs`: global D1-fallback counter now uses `normalizeProbeStatus` before incrementing.
- `tests/health-serving.test.mjs`: regression test with `status: \"throttled\"` asserting it folds into `unknown`.

Fixes #2021

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None.)

## Validation

- [x] `npx vitest run tests/health-serving.test.mjs -t \"D1 fallback folds\"`
- [x] `git diff --check`