### PR TITLE
fix(health): clamp analytics uptime_ratio below 1

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -7,7 +7,7 @@
 // serving zero-downtime and regression-proof. No I/O here: callers pass parsed
 // objects + D1 rows in.
 
-import { computeReliability, scoreFromStats } from "./reliability.mjs";
+import { computeReliability, scoreFromStats, displayUptimeRatio } from "./reliability.mjs";
 import {
   rollupSubnetStatus,
   normalizeProbeStatus,
@@ -321,7 +321,7 @@ export function formatTrends({ netuid, observedAt, windows }) {
       perSurface.push({
         surface_id: row.surface_id,
         samples: rowTotal,
-        uptime_ratio: rowTotal ? Number((rowOk / rowTotal).toFixed(4)) : null,
+        uptime_ratio: rowTotal ? displayUptimeRatio(rowOk / rowTotal) : null,
         avg_latency_ms: roundInt(row.avg_latency_ms),
         latency_sample_count: latencySamples,
         latency_ms: {
@@ -334,7 +334,7 @@ export function formatTrends({ netuid, observedAt, windows }) {
     perSurface.sort((a, b) => a.surface_id.localeCompare(b.surface_id));
     return {
       samples: total,
-      uptime_ratio: total ? Number((okCount / total).toFixed(4)) : null,
+      uptime_ratio: total ? displayUptimeRatio(okCount / total) : null,
       latency_sample_count: latencySampleTotal,
       surfaces: perSurface,
     };
@@ -405,7 +405,7 @@ export function formatBulkTrends({ observedAt, windows, windowDays = {} }) {
       entry.points.push({
         date,
         samples,
-        uptime_ratio: samples ? round4(okCount / samples) : null,
+        uptime_ratio: samples ? displayUptimeRatio(okCount / samples) : null,
         avg_latency_ms: avgLatency,
         latency_sample_count: latencyCount,
       });
@@ -416,7 +416,7 @@ export function formatBulkTrends({ observedAt, windows, windowDays = {} }) {
         netuid: entry.netuid,
         samples: entry.samples,
         uptime_ratio: entry.samples
-          ? round4(entry.okCount / entry.samples)
+          ? displayUptimeRatio(entry.okCount / entry.samples)
           : null,
         avg_latency_ms: entry.latencySamples
           ? Math.round(entry.latencyTotal / entry.latencySamples)
@@ -628,7 +628,7 @@ export function formatIncidents({
       return {
         surface_id: row.surface_id,
         samples: total,
-        uptime_ratio: total ? round4(okCount / total) : null,
+        uptime_ratio: total ? displayUptimeRatio(okCount / total) : null,
         incident_count: incidents.length,
         downtime_ms: downtimeMs,
         incidents,
@@ -866,7 +866,7 @@ export function formatLeaderboards({
       return {
         netuid: row.netuid,
         ...metaFor(row.netuid),
-        uptime_ratio: total ? round4(ok / total) : null,
+        uptime_ratio: total ? displayUptimeRatio(ok / total) : null,
         surfaces_ok: ok,
         surfaces_total: total,
         avg_latency_ms: roundInt(row.avg_latency_ms),
@@ -1096,7 +1096,7 @@ export function formatUptime({
         surface_id: entry.surface_id || surfaceKey,
         day_count: days.length,
         samples,
-        uptime_ratio: samples ? Number((okCount / samples).toFixed(4)) : null,
+        uptime_ratio: samples ? displayUptimeRatio(okCount / samples) : null,
         reliability: reliability.surfaces[surfaceKey] || null,
         // Per-day series without the internal ok_count (uptime_ratio covers it).
         days: days.map((d) => ({

--- a/src/reliability.mjs
+++ b/src/reliability.mjs
@@ -31,7 +31,7 @@ function gradeFor(score) {
 // is already collapsed to 1 upstream). Only a genuine okCount === samples ratio
 // (exactly 1) keeps the perfect value; any sub-1 ratio clamps to the largest
 // 4-decimal value below 1.
-function displayUptimeRatio(ratio) {
+export function displayUptimeRatio(ratio) {
   const rounded = Number(ratio.toFixed(4));
   return rounded >= 1 && ratio < 1 ? 0.9999 : rounded;
 }

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -285,6 +285,25 @@ describe("formatTrends", () => {
     assert.equal(out.windows["30d"].uptime_ratio, 0.95);
     assert.equal(out.netuid, 7);
   });
+  test("clamps a sub-perfect uptime_ratio that would round up to 1", () => {
+    const out = formatTrends({
+      netuid: 7,
+      observedAt: "r",
+      windows: {
+        "7d": [{ surface_id: "a", total: 25000, ok_count: 24999 }],
+      },
+    });
+    assert.equal(out.windows["7d"].uptime_ratio, 0.9999);
+    assert.equal(out.windows["7d"].surfaces[0].uptime_ratio, 0.9999);
+    const perfect = formatTrends({
+      netuid: 7,
+      observedAt: "r",
+      windows: {
+        "7d": [{ surface_id: "a", total: 25000, ok_count: 25000 }],
+      },
+    });
+    assert.equal(perfect.windows["7d"].uptime_ratio, 1);
+  });
   test("empty windows yield null ratios (D1 cold)", () => {
     const out = formatTrends({
       netuid: 7,


### PR DESCRIPTION
## Summary

- `displayUptimeRatio` in `reliability.mjs` already prevents sub-perfect ratios from rounding up to an exact `1` for `scoreFromStats` / badges (#1796), but several analytics formatters in `health-serving.mjs` still used naive `toFixed(4)` / `round4` for `uptime_ratio`.

## What Changed

- Export `displayUptimeRatio` from `reliability.mjs`.
- Route all `uptime_ratio` emission in `formatTrends`, subnet uptime trends, incidents SLA, leaderboards, and uptime history through `displayUptimeRatio`.
- Regression test: `24999/25000` ? `0.9999`, not `1`.

Fixes #2025

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None.)

## Validation

- [x] `npx vitest run tests/health-serving.test.mjs -t \"clamps a sub-perfect uptime_ratio\"`
- [x] `git diff --check`