### PR TITLE
fix(health): normalize prober global status_counts

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -494,7 +494,7 @@ export async function runHealthProber(env, ctx, overrides = {}) {
   await persistToKv(kv, probed, runAt);
 
   const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
-  for (const row of probed) counts[row.status] = (counts[row.status] || 0) + 1;
+  for (const row of probed) counts[normalizeProbeStatus(row.status)] += 1;
   const durationMs = now() - runAt;
   // Wall-time guard: the prober runs on a 15-minute Cron Trigger, a hard CF
   // ceiling. As the autonomous flywheel grows surfaces, a sweep that creeps past
@@ -592,7 +592,7 @@ async function persistToD1(db, probed, runAt) {
 async function persistToKv(kv, probed, runAt) {
   if (!kv?.put) return;
   const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
-  for (const row of probed) counts[row.status] = (counts[row.status] || 0) + 1;
+  for (const row of probed) counts[normalizeProbeStatus(row.status)] += 1;
 
   const surfaceRows = probed.map((row) => ({
     surface_id: row.surface_id,

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -383,6 +383,48 @@ describe("runHealthProber", () => {
     assert.equal(meta.last_run_at, new Date(50000).toISOString());
   });
 
+  test("folds unrecognized probe status into unknown in global status_counts", async () => {
+    const kv = makeKv();
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 60000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => [SURFACES[0]],
+        probeSurface: async () => ({
+          status: "throttled",
+          classification: "rate-limited",
+          latency_ms: 120,
+          status_code: 429,
+        }),
+        probeOptions: {},
+      },
+    );
+    assert.deepEqual(result.counts, {
+      ok: 0,
+      degraded: 0,
+      failed: 0,
+      unknown: 1,
+    });
+    const current = kv.json(KV_HEALTH_CURRENT);
+    assert.deepEqual(current.summary.status_counts, {
+      ok: 0,
+      degraded: 0,
+      failed: 0,
+      unknown: 1,
+    });
+    const meta = kv.json(KV_HEALTH_META);
+    assert.deepEqual(meta.status_counts, {
+      ok: 0,
+      degraded: 0,
+      failed: 0,
+      unknown: 1,
+    });
+    assert.equal(current.summary.status_counts.throttled, undefined);
+  });
+
   test("rejects unsafe or implausibly high live RPC block heights", async () => {
     const kv = makeKv();
     const rpcSurfaces = [


### PR DESCRIPTION
## Summary

- The two GLOBAL summary counters in `runHealthProber` / `persistToKv` were the missed siblings of #1739: `summarizeGroup` already routes through `normalizeProbeStatus`, but the cron return `counts` and served KV `summary.status_counts` / `meta.status_counts` still bucketed raw `row.status`.

## What Changed

- `src/health-prober.mjs`: both global `counts` loops now increment `normalizeProbeStatus(row.status)`.
- `tests/health-prober.test.mjs`: regression test with `status: \"throttled\"` asserting it folds into `unknown` in the returned counts and both KV payloads.

Fixes #1942

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None.)

## Validation

- [x] `npx vitest run tests/health-prober.test.mjs -t \"folds unrecognized probe status\"`
- [x] `git diff --check`