### PR TITLE
fix(api): reject negative netuid/uid in validNeuronDailyRows

### DIFF
--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -260,17 +260,19 @@ export function neuronDailyUpsertStatements(
 
 const SNAPSHOT_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
-// Keep only well-formed backfill rows: integer netuid+uid, a YYYY-MM-DD
-// snapshot_date, and a non-empty hotkey (mirrors the forward path, which drops
-// null-hotkey UIDs). Anything else is silently dropped so a partial/garbage batch
-// can never poison the table.
+// Keep only well-formed backfill rows: non-negative integer netuid+uid, a
+// YYYY-MM-DD snapshot_date, and a non-empty hotkey (mirrors the forward path,
+// which drops null-hotkey UIDs). Anything else is silently dropped so a
+// partial/garbage batch can never poison the table.
 export function validNeuronDailyRows(rows) {
   if (!Array.isArray(rows)) return [];
   return rows.filter(
     (row) =>
       row &&
       Number.isInteger(row.netuid) &&
+      row.netuid >= 0 &&
       Number.isInteger(row.uid) &&
+      row.uid >= 0 &&
       typeof row.snapshot_date === "string" &&
       SNAPSHOT_DATE_RE.test(row.snapshot_date) &&
       typeof row.hotkey === "string" &&

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -860,6 +860,8 @@ describe("backfill ingest helpers (#1345 Phase 1)", () => {
       { netuid: 7, uid: "x", snapshot_date: "2025-12-01", hotkey: "5Hk" }, // uid not int
       { uid: 4, snapshot_date: "2025-12-01", hotkey: "5Hk" }, // no netuid
       { netuid: 7, uid: 5, snapshot_date: "2025-12-01", hotkey: "" }, // empty hotkey
+      { netuid: -1, uid: 1, snapshot_date: "2025-12-01", hotkey: "5Hk" }, // negative netuid
+      { netuid: 7, uid: -1, snapshot_date: "2025-12-01", hotkey: "5Hk" }, // negative uid
     ]);
     assert.deepEqual(rows, [good]);
     assert.deepEqual(validNeuronDailyRows("nope"), []);


### PR DESCRIPTION
## Summary

- `validNeuronDailyRows` now rejects negative `netuid` / `uid`, matching `validStagedNeuronRow` and `validEconomicsBackfillRows`.

## What Changed

- `src/neuron-history.mjs`: require `netuid >= 0` and `uid >= 0` in the backfill row filter.
- `tests/neuron-history.test.mjs`: regression cases for negative netuid and uid.

## Why it was observably wrong

The neuron_daily backfill ingest (`POST /api/v1/internal/backfill-neurons`) shared validation with staging/economics loaders on date/hotkey shape but not on non-negative keys. A payload with `netuid: -1` or `uid: -5` passed validation and could upsert invalid primary-key components.

## Template Used

- backend-code.md

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No schema/contract change.

## Validation

- [x] `npx vitest run tests/neuron-history.test.mjs` (36 passed)
- [x] `git diff --check`

Fixes #2038