### PR TITLE
fix(adapters): guard null repo entries in gittensor master summary

### DIFF
--- a/scripts/snapshot-adapters.mjs
+++ b/scripts/snapshot-adapters.mjs
@@ -784,7 +784,7 @@ function isPublicSafeFieldName(key) {
   );
 }
 
-function summarizeGittensorMaster(url, fetched) {
+export function summarizeGittensorMaster(url, fetched) {
   if (!fetched.ok || !fetched.body || typeof fetched.body !== "object") {
     return {
       status: fetched.status || "failed",
@@ -798,14 +798,17 @@ function summarizeGittensorMaster(url, fetched) {
   const entries = Object.entries(fetched.body).sort(([a], [b]) =>
     a.localeCompare(b),
   );
-  const emissionShares = entries.map(
-    ([, config]) => Number(config.emission_share) || 0,
-  );
-  const maintainerCuts = entries.map(
-    ([, config]) => Number(config.maintainer_cut) || 0,
-  );
-  const issueDiscoveryShares = entries.map(
-    ([, config]) => Number(config.issue_discovery_share) || 0,
+  // A repo value may be JSON null, so read shares through optional chaining.
+  const repoShares = entries.map(([repository, config]) => ({
+    repository,
+    emission_share: Number(config?.emission_share) || 0,
+    maintainer_cut: Number(config?.maintainer_cut) || 0,
+    issue_discovery_share: Number(config?.issue_discovery_share) || 0,
+  }));
+  const emissionShares = repoShares.map((repo) => repo.emission_share);
+  const maintainerCuts = repoShares.map((repo) => repo.maintainer_cut);
+  const issueDiscoveryShares = repoShares.map(
+    (repo) => repo.issue_discovery_share,
   );
 
   return {
@@ -827,13 +830,7 @@ function summarizeGittensorMaster(url, fetched) {
     issue_discovery_enabled_count: issueDiscoveryShares.filter(
       (value) => value > 0,
     ).length,
-    top_emission_repositories: entries
-      .map(([repository, config]) => ({
-        repository,
-        emission_share: Number(config.emission_share) || 0,
-        maintainer_cut: Number(config.maintainer_cut) || 0,
-        issue_discovery_share: Number(config.issue_discovery_share) || 0,
-      }))
+    top_emission_repositories: [...repoShares]
       .sort(
         (a, b) =>
           b.emission_share - a.emission_share ||

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -85,7 +85,10 @@ import {
   optionalHttpStatus,
   preservePreviousGithubMetadata,
 } from "../scripts/verification-quality.mjs";
-import { summarizeGithubMetadata } from "../scripts/snapshot-adapters.mjs";
+import {
+  summarizeGithubMetadata,
+  summarizeGittensorMaster,
+} from "../scripts/snapshot-adapters.mjs";
 
 describe("script utility contracts", () => {
   test("uses public-safe fixture capture parse failure reasons", () => {
@@ -2285,6 +2288,91 @@ describe("adapter github metadata carry-forward", () => {
     assert.equal(summary.captured_count, 0);
     assert.equal(summary.carried_forward_count, 0);
     assert.equal(summary.repositories.length, 0);
+  });
+});
+
+describe("adapter gittensor master summary", () => {
+  const url =
+    "https://raw.githubusercontent.com/entrius/gittensor/main/master_repositories.json";
+
+  test("returns the failed shape when the body is missing or not an object", () => {
+    const summary = summarizeGittensorMaster(url, {
+      ok: false,
+      status: "rate-limited",
+      error: "HTTP 429",
+      status_code: 429,
+      captured_at: "2026-06-10T00:00:00.000Z",
+    });
+    assert.equal(summary.status, "rate-limited");
+    assert.equal(summary.error, "HTTP 429");
+    assert.equal(summary.status_code, 429);
+    assert.equal(summary.repository_count, undefined);
+  });
+
+  test("aggregates shares and ranks the top emission repositories", () => {
+    const summary = summarizeGittensorMaster(url, {
+      ok: true,
+      status_code: 200,
+      content_type: "application/json",
+      latency_ms: 12,
+      captured_at: "2026-06-10T00:00:00.000Z",
+      body: {
+        "org/low": {
+          emission_share: 0.2,
+          maintainer_cut: 0,
+          issue_discovery_share: 0,
+        },
+        "org/high": {
+          emission_share: 0.5,
+          maintainer_cut: 0.1,
+          issue_discovery_share: 0.05,
+        },
+        "org/zero": {
+          emission_share: 0,
+          maintainer_cut: 0.25,
+          issue_discovery_share: 0,
+        },
+      },
+    });
+    assert.equal(summary.status, "captured");
+    assert.equal(summary.repository_count, 3);
+    assert.equal(summary.total_emission_share, 0.7);
+    assert.equal(summary.zero_emission_count, 1);
+    assert.equal(summary.maintainer_cut_repo_count, 2);
+    assert.equal(summary.max_maintainer_cut, 0.25);
+    assert.equal(summary.issue_discovery_enabled_count, 1);
+    assert.deepEqual(
+      summary.top_emission_repositories.map((repo) => repo.repository),
+      ["org/high", "org/low", "org/zero"],
+    );
+  });
+
+  test("treats a JSON null repo value as zero shares without throwing", () => {
+    const summary = summarizeGittensorMaster(url, {
+      ok: true,
+      status_code: 200,
+      captured_at: "2026-06-10T00:00:00.000Z",
+      body: {
+        "org/real": {
+          emission_share: 0.4,
+          maintainer_cut: 0.1,
+          issue_discovery_share: 0.02,
+        },
+        "org/null": null,
+      },
+    });
+    assert.equal(summary.repository_count, 2);
+    assert.equal(summary.total_emission_share, 0.4);
+    assert.equal(summary.zero_emission_count, 1);
+    const nulled = summary.top_emission_repositories.find(
+      (repo) => repo.repository === "org/null",
+    );
+    assert.deepEqual(nulled, {
+      repository: "org/null",
+      emission_share: 0,
+      maintainer_cut: 0,
+      issue_discovery_share: 0,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- A JSON null value for any repository key in the upstream `master_repositories.json` aborted the entire adapter snapshot run. The guard in `summarizeGittensorMaster` confirmed the response body was an object but never validated the values inside it, so a null entry raised a `TypeError` that bubbled through the `Promise.all` in `main()` and took down the whole `snapshot-adapters` process.
- The live upstream (entrius/gittensor) is currently clean, so this was latent, but a single null placeholder added upstream was enough to break every snapshot until then.

## What Changed

- `summarizeGittensorMaster` now reads each numeric share through optional chaining, so a null repository value resolves to zero shares instead of throwing. This matches the defensive `?.` style already used throughout the file.
- The emission, maintainer, and issue discovery reads were folded into one pass (`repoShares`) that feeds both the aggregate counts and the top emission ranking, removing the duplicated extraction that previously existed in two places.
- Output stays byte for byte identical on clean payloads, so committed snapshots do not drift.
- Added unit tests for the function covering the failed body guard, normal aggregation and ranking, and the null repository value regression. Line and branch coverage of the changed code is complete.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
