### PR TITLE
fix(api): reject empty event_kind in validEventRows

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -151,6 +151,7 @@ export function validEventRows(rows) {
           Number.isInteger(r?.block_number) &&
           Number.isInteger(r?.event_index) &&
           typeof r?.event_kind === "string" &&
+          r.event_kind.length > 0 &&
           Number.isInteger(r?.observed_at),
       )
     : [];

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -38,6 +38,10 @@ test("validEventRows enforces the strict row shape (#1371)", () => {
     validEventRows([{ ...good, observed_at: "x" }]).length,
     0, // observed_at must be an integer
   );
+  assert.equal(
+    validEventRows([{ ...good, event_kind: "" }]).length,
+    0, // event_kind must be non-empty (mirrors block_hash guard)
+  );
 });
 
 test("eventInsertStatements builds chunked parameterized INSERT OR IGNORE", () => {


### PR DESCRIPTION
## Summary

Fixes #2043

`validEventRows` accepted `event_kind: ""` even though sibling staged-batch validators require non-empty string keys (`block_hash` in `validBlockRows`). Empty kinds can reach D1 ingest and poison downstream activity rollups.

## What Changed

- Require `event_kind.length > 0` in `validEventRows` (`src/account-events.mjs`)
- Add a unit test mirroring the `validBlockRows` empty-string guard

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`