### PR TITLE
fix(api): reject negative alpha_price_tao in validEconomicsBackfillRows

### DIFF
--- a/src/economics-backfill.mjs
+++ b/src/economics-backfill.mjs
@@ -28,7 +28,8 @@ export function validEconomicsBackfillRows(rows) {
       typeof row.snapshot_date === "string" &&
       SNAPSHOT_DATE_RE.test(row.snapshot_date) &&
       typeof row.alpha_price_tao === "number" &&
-      Number.isFinite(row.alpha_price_tao),
+      Number.isFinite(row.alpha_price_tao) &&
+      row.alpha_price_tao >= 0,
   );
 }
 

--- a/tests/economics-backfill.test.mjs
+++ b/tests/economics-backfill.test.mjs
@@ -85,6 +85,7 @@ test("economics backfill upserts valid rows + filters invalid (200, parameterize
     row({ netuid: 11, alpha_price_tao: "0.1" }), // non-numeric price → filtered
     row({ netuid: -1 }), // negative netuid → filtered
     row({ netuid: 12, alpha_price_tao: Number.NaN }), // NaN price → filtered
+    row({ netuid: 13, alpha_price_tao: -0.5 }), // negative price → filtered
   ];
   const res = await handleEconomicsBackfill(
     post(rows, { secret: SECRET }),
@@ -93,7 +94,7 @@ test("economics backfill upserts valid rows + filters invalid (200, parameterize
   assert.equal(res.status, 200);
   const body = await res.json();
   assert.equal(body.ok, true);
-  assert.equal(body.received, 7);
+  assert.equal(body.received, 8);
   assert.equal(body.inserted, 2);
   assert.equal(captured.length, 1); // one batch
   assert.equal(captured[0].length, 2); // of the 2 valid rows
@@ -194,4 +195,10 @@ test("validEconomicsBackfillRows + upsert: captured_at falls back to the snapsho
   // netuid 0 and alpha_price_tao 0 are preserved (not treated as falsy-invalid).
   assert.equal(stmts[1].v[0], 0);
   assert.equal(stmts[1].v[2], 0);
+  assert.equal(
+    validEconomicsBackfillRows([
+      { netuid: 8, snapshot_date: "2025-12-01", alpha_price_tao: -0.5 },
+    ]).length,
+    0,
+  );
 });


### PR DESCRIPTION
## Summary

Fixes #2051

`validEconomicsBackfillRows` accepted negative `alpha_price_tao` even though the same module already rejects negative `netuid` and `toTao` elsewhere rejects negative fee cells. Negative prices can reach the economics backfill upsert and poison marquee sparklines.

## What Changed

- Require `alpha_price_tao >= 0` in `validEconomicsBackfillRows` (`src/economics-backfill.mjs`)
- Extend ingest + unit tests; `0` remains valid

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`