### PR TITLE
fix(api): drop empty call_module buckets in buildChainCalls

### DIFF
--- a/src/chain-analytics.mjs
+++ b/src/chain-analytics.mjs
@@ -110,7 +110,14 @@ export function buildChainCalls({
 }) {
   const totalExtrinsics = toCount(total);
   const calls = (Array.isArray(rows) ? rows : [])
-    .filter((r) => r && typeof r.call_module === "string")
+    .filter(
+      (r) =>
+        r &&
+        typeof r.call_module === "string" &&
+        r.call_module.length > 0 &&
+        (groupBy !== "module_function" ||
+          (typeof r.call_function === "string" && r.call_function.length > 0)),
+    )
     .map((r) => {
       const count = toCount(r.count);
       return {

--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -291,6 +291,31 @@ test("buildChainCalls is cold-stable (share null on empty window, junk dropped)"
   assert.equal(out.calls[0].share, null); // zero-total denominator
 });
 
+test("buildChainCalls drops empty call_module and call_function buckets", () => {
+  const moduleOnly = buildChainCalls({
+    window: "7d",
+    total: 10,
+    rows: [
+      { call_module: "", count: 5 },
+      { call_module: "Balances", count: 3 },
+    ],
+  });
+  assert.equal(moduleOnly.call_count, 1);
+  assert.equal(moduleOnly.calls[0].call_module, "Balances");
+
+  const moduleFunction = buildChainCalls({
+    window: "7d",
+    groupBy: "module_function",
+    total: 10,
+    rows: [
+      { call_module: "Balances", call_function: "", count: 5 },
+      { call_module: "Balances", call_function: "transfer", count: 2 },
+    ],
+  });
+  assert.equal(moduleFunction.call_count, 1);
+  assert.equal(moduleFunction.calls[0].call_function, "transfer");
+});
+
 test("GET /api/v1/chain/calls groups by call_module with honest share + 400 on junk param", async () => {
   const captured = [];
   const env = {


### PR DESCRIPTION
## Summary

Fixes #2053

`buildChainCalls` surfaced empty `call_module` buckets in the chain call-mix API even though sibling builders like `buildChainSigners` already require non-empty string keys.

## What Changed

- Drop rows with empty `call_module` (and empty `call_function` when grouping by `module_function`) in `src/chain-analytics.mjs`
- Add unit tests for both grouping modes

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`