### PR TITLE
fix(mcp): bound get_block neighbor lookups

### DIFF
--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -184,7 +184,7 @@ export async function loadBlock(d1, ref) {
   const resolvedNumber = rows[0]?.block_number;
   if (Number.isInteger(resolvedNumber)) {
     const nbr = await d1(
-      `SELECT MAX(CASE WHEN block_number < ? THEN block_number END) AS prev, MIN(CASE WHEN block_number > ? THEN block_number END) AS next FROM blocks`,
+      `SELECT (SELECT MAX(block_number) FROM blocks WHERE block_number < ?) AS prev, (SELECT MIN(block_number) FROM blocks WHERE block_number > ?) AS next`,
       [resolvedNumber, resolvedNumber],
     );
     prev = nbr[0]?.prev ?? null;

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3786,7 +3786,11 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_extrinsics, get
                     return Promise.resolve({
                       results: fixtures.block ? [fixtures.block] : [],
                     });
-                  if (/MAX\(CASE WHEN block_number/.test(sql))
+                  if (
+                    /SELECT MAX\(block_number\) FROM blocks WHERE block_number < \?/.test(
+                      sql,
+                    )
+                  )
                     return Promise.resolve({
                       results: [
                         {
@@ -3890,13 +3894,25 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_extrinsics, get
   });
 
   test("get_block returns block detail with prev/next neighbors", async () => {
-    const env = chainD1({ block: BLOCK_ROW, prev: 4199999, next: 4200001 });
+    const capture = [];
+    const env = chainD1(
+      { block: BLOCK_ROW, prev: 4199999, next: 4200001 },
+      capture,
+    );
     const res = await callTool("get_block", { ref: "4200000" }, { env });
     const out = res.body.result.structuredContent;
     assert.equal(out.ref, "4200000");
     assert.equal(out.block.block_number, 4200000);
     assert.equal(out.prev_block_number, 4199999);
     assert.equal(out.next_block_number, 4200001);
+    const neighborQuery = capture.find(
+      (c) => /AS prev/.test(c.sql) && /AS next/.test(c.sql),
+    );
+    assert.ok(neighborQuery, "get_block must query nearest stored neighbors");
+    assert.ok(/WHERE block_number < \?/.test(neighborQuery.sql));
+    assert.ok(/WHERE block_number > \?/.test(neighborQuery.sql));
+    assert.ok(!/CASE WHEN block_number/.test(neighborQuery.sql));
+    assert.deepEqual(neighborQuery.params, [4200000, 4200000]);
   });
 
   test("get_block accepts a 0x hash ref", async () => {


### PR DESCRIPTION
### Motivation
- The MCP `get_block` loader used a `CASE` aggregate over `FROM blocks` to compute `prev`/`next`, which forces a full retained-blocks table scan in SQLite/D1 and enables unauthenticated cost-amplification via the public tool. 
- The intent is to match the REST handler's bounded-subquery pattern so neighbor lookups can seek by the `block_number` primary key instead of scanning the retained table.

### Description
- In `src/blocks.mjs` replaced the unbounded aggregate with WHERE-bounded scalar subqueries: `SELECT (SELECT MAX(block_number) FROM blocks WHERE block_number < ?) AS prev, (SELECT MIN(block_number) FROM blocks WHERE block_number > ?) AS next` so SQLite/D1 can use indexed seeks. 
- Added regression coverage in `tests/mcp-server.test.mjs` that captures the executed SQL for `get_block` and asserts the neighbor query contains `WHERE block_number < ?` / `WHERE block_number > ?` and does not use the prior `CASE WHEN` form. 
- Preserved behavioral semantics so `loadBlock` still returns schema-stable results and the same `prev`/`next` neighbor values for resolved blocks and `null` when the store is cold or the ref is unknown.

### Testing
- Ran formatting checks with `npx prettier --check src/blocks.mjs tests/mcp-server.test.mjs` which passed. 
- Ran `npm run build` and `npm run validate:mcp` and both completed successfully. 
- Ran the test suite with `npm test -- tests/mcp-server.test.mjs` and the full suite passed (all relevant tests including the new regression assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f0d000f88832cb6cc0ee0af665586)