### PR TITLE
fix(api): restore most-reliable leaderboard rows

### DIFF
--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -230,6 +230,30 @@ describe("handleLeaderboards", () => {
     assert.equal(body.data.board, "most-complete");
     assert.ok(Array.isArray(body.data.boards["most-complete"]));
   });
+
+  test("uses surface uptime rollups for most-reliable board", async () => {
+    const env = d1Env({
+      "FROM surface_uptime_daily": [
+        {
+          netuid: 7,
+          samples: 10,
+          ok_count: 9,
+          avg_latency_ms: 100,
+          latency_samples: 10,
+        },
+      ],
+    });
+    const body = await json(
+      await handleLeaderboards(
+        req("/"),
+        env,
+        url("/?board=most-reliable&limit=5"),
+      ),
+    );
+    assert.equal(body.data.board, "most-reliable");
+    assert.equal(body.data.boards["most-reliable"].length, 1);
+    assert.equal(body.data.boards["most-reliable"][0].netuid, 7);
+  });
 });
 
 describe("handleCompare", () => {

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -227,8 +227,13 @@ export async function handleLeaderboards(request, env, url) {
   const sevenDaysAgo = new Date(Date.now() - 7 * DAY_MS)
     .toISOString()
     .slice(0, 10);
-  const [healthRows, rpcRows, growthSamples, economicsRows] = await Promise.all(
-    [
+  // `fastest-growing` uses a short completeness window; `most-reliable` is
+  // intentionally more durable and ranks the last 30d of uptime history.
+  const thirtyDaysAgo = new Date(Date.now() - 30 * DAY_MS)
+    .toISOString()
+    .slice(0, 10);
+  const [healthRows, rpcRows, growthSamples, economicsRows, reliabilityRows] =
+    await Promise.all([
       d1All(
         env,
         `SELECT netuid,
@@ -257,8 +262,18 @@ export async function handleLeaderboards(request, env, url) {
         [sevenDaysAgo],
       ),
       resolveEconomicsRows(env),
-    ],
-  );
+      d1All(
+        env,
+        `SELECT netuid,
+              SUM(samples) AS samples,
+              SUM(ok_count) AS ok_count,
+              ${dailyLatencyColumns({ roundedAvg: true })}
+       FROM surface_uptime_daily
+       WHERE day >= ?
+       GROUP BY netuid`,
+        [thirtyDaysAgo],
+      ),
+    ]);
 
   const growthByNetuid = new Map();
   for (const row of growthSamples) {
@@ -287,6 +302,7 @@ export async function handleLeaderboards(request, env, url) {
     rpcRows,
     mostComplete,
     growthRows,
+    reliabilityRows,
     economicsRows,
     subnetMeta,
   });
@@ -303,7 +319,7 @@ export async function handleLeaderboards(request, env, url) {
       },
     },
     "standard",
-    [healthRows, rpcRows, growthSamples],
+    [healthRows, rpcRows, growthSamples, reliabilityRows],
   );
 }
 


### PR DESCRIPTION
### Motivation
- A refactor extracted leaderboard logic into `workers/request-handlers/analytics-routes.mjs` but dropped the 30-day `surface_uptime_daily` query, causing the `most-reliable` board to be empty. This restores the original data source so public analytics remain correct.

### Description
- Re-added the 30-day `surface_uptime_daily` rollup query in `handleLeaderboards` to produce `reliabilityRows` (windowed uptime + latency). 
- Passed `reliabilityRows` into `formatLeaderboards` so the `most-reliable` board is computed from uptime rollups again. 
- Included `reliabilityRows` in the D1-fallback detection set so fallback tagging remains consistent when uptime rollups are missing. 
- Added a regression unit test in `tests/request-handlers-analytics-routes.test.mjs` that verifies `board=most-reliable` is populated from `surface_uptime_daily` rows.

### Testing
- Ran unit tests with `npm test -- tests/request-handlers-analytics-routes.test.mjs` and the test file passed (20/20 tests). 
- Ran lint (`npm run lint`) and formatting check (`npm run format:check`) and both completed successfully. 
- Performed `git diff --check` as a pre-commit validation with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f0e313750832ca558ab6fb8040c96)