### PR TITLE
fix(api): index selective extrinsics time filters

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1770,6 +1770,38 @@ describe("handleExtrinsics", () => {
     assert.ok(/observed_at <= \?/.test(sql));
   });
 
+  test("uses the observed-at index for selective one-sided time filters", async () => {
+    const now = Date.now();
+
+    {
+      const { env, captures } = dbWith({ extrinsics: [] });
+      await handleExtrinsics(
+        req("/api/v1/extrinsics"),
+        env,
+        url(`/api/v1/extrinsics?from=${now + 60_000}`),
+      );
+      const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
+      assert.ok(sql, "a near-future one-sided from filter must reach D1");
+      assert.ok(/INDEXED BY idx_extrinsics_observed_order/.test(sql));
+      assert.ok(/observed_at >= \?/.test(sql));
+    }
+
+    {
+      const { env, captures } = dbWith({ extrinsics: [] });
+      await handleExtrinsics(
+        req("/api/v1/extrinsics"),
+        env,
+        url(
+          `/api/v1/extrinsics?to=${now - 365 * 24 * 60 * 60 * 1000 + 60_000}`,
+        ),
+      );
+      const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
+      assert.ok(sql, "a near-floor one-sided to filter must reach D1");
+      assert.ok(/INDEXED BY idx_extrinsics_observed_order/.test(sql));
+      assert.ok(/observed_at <= \?/.test(sql));
+    }
+  });
+
   test("drops the observed-at index hint when an equality filter is present", async () => {
     // With a (signer) equality the planner should use the order-aligned
     // signer index, not be forced onto the observed-at one.

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1042,11 +1042,15 @@ export async function handleExtrinsics(request, env, url) {
     params.push(cur[0], cur[1]);
   }
   // Standalone observed_at windows can be highly selective while the feed order
-  // is block_number/extrinsic_index. Only force the timestamp index for bounded
-  // narrow windows; broad or malformed public filters must stay planner-selected
-  // so SQLite/D1 can use the order-aligned primary-key path and stop at LIMIT.
+  // is block_number/extrinsic_index. Force the timestamp index for bounded
+  // narrow windows and one-sided ranges whose effective retained window is
+  // narrow; broad public filters stay planner-selected so SQLite/D1 can use the
+  // order-aligned primary-key path and stop at LIMIT.
+  const effectiveFromMs = fromMs ?? observedFloorMs;
+  const effectiveToMs = toMs ?? nowMs + DAY_MS;
   const hasNarrowObservedWindow =
-    fromMs != null && toMs != null && toMs - fromMs <= DAY_MS;
+    (fromMs != null || toMs != null) &&
+    effectiveToMs - effectiveFromMs <= DAY_MS;
   const forceObservedOrderIndex =
     hasNarrowObservedWindow &&
     !hasBlockFilter &&


### PR DESCRIPTION
### Motivation
- One-sided `from`/`to` observed_at filters could avoid the protective `idx_extrinsics_observed_order` hint and allow SQLite/D1 to choose an order-aligned primary-key scan, enabling resource-exhausting queries against the public `/api/v1/extrinsics` feed. 
- The previous change only applied the timestamp index when both `from` and `to` were present and narrow, which left selective one-sided ranges unprotected. 
- The intent is to preserve the prior protection while still allowing broad planner-selected queries to use the order-aligned PK path when appropriate.

### Description
- Compute an effective retained window inside `handleExtrinsics` by deriving `effectiveFromMs = fromMs ?? observedFloorMs` and `effectiveToMs = toMs ?? nowMs + DAY_MS`, and treat one-sided filters as narrow when `effectiveToMs - effectiveFromMs <= DAY_MS`. 
- Update the `hasNarrowObservedWindow` condition in `workers/request-handlers/entities.mjs` so one-sided `from` or `to` filters whose effective window is narrow will set `forceObservedOrderIndex` and thus emit `INDEXED BY idx_extrinsics_observed_order`. 
- Add regression coverage in `tests/request-handlers-entities.test.mjs` to assert that near-future `from` and near-retention-floor `to` one-sided queries reach D1 and include the `INDEXED BY idx_extrinsics_observed_order` hint. 

### Testing
- Ran the focused unit tests with `npm test -- tests/request-handlers-entities.test.mjs` and all tests passed (`134` tests). 
- Ran the lint step with `npm run lint` and it completed without errors. 
- Verified formatting with `npx prettier --check` and the checked files passed the style check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f17262ac4832c950239d092f0ac59)