### PR TITLE
fix(rpc): never follow upstream redirects in the RPC proxy

### DIFF
--- a/tests/rpc-failover.test.mjs
+++ b/tests/rpc-failover.test.mjs
@@ -32,16 +32,20 @@ const jsonResponse = (status, body) => ({
 });
 
 // fetchFn that returns the i-th scripted reply (a thunk that may throw, or a
-// response object), recording the URLs it was called with.
+// response object), recording the URLs AND init options it was called with so a
+// test can assert the security-critical fetch options (e.g. redirect:"manual").
 function scriptedFetch(...replies) {
   const calls = [];
-  const fn = async (url) => {
+  const inits = [];
+  const fn = async (url, init) => {
     const reply = replies[calls.length];
     calls.push(url);
+    inits.push(init);
     if (typeof reply === "function") return reply();
     return reply;
   };
   fn.calls = calls;
+  fn.inits = inits;
   return fn;
 }
 
@@ -217,6 +221,11 @@ describe("proxyWithFailover", () => {
     // target (the proxy did not auto-follow the 302).
     assert.deepEqual(fetchFn.calls, [SAFE_A, SAFE_B]);
     assert.equal(fetchFn.calls.includes(UNSAFE), false);
+    // The security property itself: the upstream fetch pins redirect:"manual" so
+    // the platform never auto-follows a 3xx (without this, the body would be
+    // re-POSTed to the off-allowlist Location). Guards against the option being
+    // dropped in a future refactor.
+    assert.equal(fetchFn.inits[0]?.redirect, "manual");
   });
 
   test("treats an opaqueredirect (status 0) as a failed attempt", async () => {

--- a/tests/rpc-failover.test.mjs
+++ b/tests/rpc-failover.test.mjs
@@ -51,6 +51,15 @@ describe("classifyUpstreamAttempt", () => {
     ["http 500", { status: 500 }, "transient"],
     ["http 503", { status: 503 }, "transient"],
     ["http 429", { status: 429 }, "transient"],
+    // 3xx redirects + the opaqueredirect sentinel (status 0) are never valid
+    // JSON-RPC responses; they must be failed attempts (transient), never
+    // reaching the status<400 success branch — the allowlist only vetted the
+    // initial upstream, so a redirect target is unvetted.
+    ["http 301", { status: 301 }, "transient"],
+    ["http 302", { status: 302 }, "transient"],
+    ["http 307", { status: 307 }, "transient"],
+    ["http 399", { status: 399 }, "transient"],
+    ["opaqueredirect (status 0)", { status: 0 }, "transient"],
     ["http 400", { status: 400 }, "fatal"],
     ["http 404", { status: 404 }, "fatal"],
     ["200 result", { status: 200, parsedBody: { result: {} } }, "success"],
@@ -186,6 +195,57 @@ describe("proxyWithFailover", () => {
     assert.equal(res.headers.get("x-metagraph-rpc-endpoint-id"), "b");
     assert.equal(res.headers.get("x-metagraph-rpc-attempts"), "2");
     assert.deepEqual(fetchFn.calls, [SAFE_A, SAFE_B]);
+  });
+
+  test("treats an upstream 3xx as a failed attempt and never follows the redirect", async () => {
+    // A trusted upstream replies 302 with a Location to an off-allowlist host.
+    // With redirect:"manual" the fetch surfaces the 3xx itself; the proxy must
+    // NOT accept or follow it — it fails over to the next allowlisted endpoint
+    // and never re-POSTs the caller's body to the redirect target.
+    const fetchFn = scriptedFetch(
+      { status: 302, headers: new Headers({ location: UNSAFE }), body: null },
+      jsonResponse(200, { jsonrpc: "2.0", id: 1, result: { ok: true } }),
+    );
+    const res = await proxyWithFailover([ep("a", SAFE_A), ep("b", SAFE_B)], {
+      ...base,
+      fetchFn,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-rpc-endpoint-id"), "b");
+    assert.equal(res.headers.get("x-metagraph-rpc-attempts"), "2");
+    // Only the two allowlisted endpoints were contacted — never the redirect
+    // target (the proxy did not auto-follow the 302).
+    assert.deepEqual(fetchFn.calls, [SAFE_A, SAFE_B]);
+    assert.equal(fetchFn.calls.includes(UNSAFE), false);
+  });
+
+  test("treats an opaqueredirect (status 0) as a failed attempt", async () => {
+    const fetchFn = scriptedFetch(
+      { status: 0, body: null }, // opaqueredirect sentinel from redirect:"manual"
+      jsonResponse(200, { jsonrpc: "2.0", id: 1, result: { ok: true } }),
+    );
+    const res = await proxyWithFailover([ep("a", SAFE_A), ep("b", SAFE_B)], {
+      ...base,
+      fetchFn,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-rpc-endpoint-id"), "b");
+    assert.deepEqual(fetchFn.calls, [SAFE_A, SAFE_B]);
+  });
+
+  test("returns 502 when every upstream redirects (body never re-POSTed off-allowlist)", async () => {
+    const fetchFn = scriptedFetch(
+      { status: 302, headers: new Headers({ location: UNSAFE }), body: null },
+      { status: 0, body: null },
+    );
+    const res = await proxyWithFailover([ep("a", SAFE_A), ep("b", SAFE_B)], {
+      ...base,
+      fetchFn,
+    });
+    assert.equal(res.status, 502);
+    // Both allowlisted endpoints tried; neither redirect was followed.
+    assert.deepEqual(fetchFn.calls, [SAFE_A, SAFE_B]);
+    assert.equal(fetchFn.calls.includes(UNSAFE), false);
   });
 
   test("fails over on HTTP 5xx without reading its response body", async () => {

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -740,6 +740,15 @@ async function rpcCacheKey(network, method, params) {
 export function classifyUpstreamAttempt({ thrown, status, parsedBody }) {
   if (thrown) return "transient"; // network error or AbortSignal timeout
   if (status >= 500 || status === 429) return "transient";
+  // A redirect (3xx) or the opaqueredirect sentinel (status 0, produced by the
+  // `redirect: "manual"` fetch below) is never a valid JSON-RPC response. The
+  // allowlist only vetted the INITIAL upstream, so a redirect must not be
+  // followed OR accepted. Classify it as transient — NOT fatal: the success
+  // branch in proxyWithFailover gates on `status < 400` (not the classification),
+  // so a "fatal" 3xx would still slip through there and be returned to the
+  // client with recordRpcSuccess. "transient" is caught first, so the attempt is
+  // recorded as failed and we fail over to the next allowlisted endpoint.
+  if (status === 0 || (status >= 300 && status < 400)) return "transient";
   if (status >= 400) return "fatal"; // upstream rejected the request itself
   if (parsedBody && typeof parsedBody === "object" && parsedBody.error) {
     if (TRANSIENT_RPC_ERROR_CODES.has(Number(parsedBody.error.code))) {
@@ -859,6 +868,13 @@ export async function proxyWithFailover(
         method: "POST",
         headers: { "content-type": "application/json" },
         body: bodyText,
+        // Never auto-follow an upstream redirect: only the initial endpoint was
+        // checked against TRUSTED_RPC_UPSTREAM_ORIGINS, so following a 3xx would
+        // re-POST the caller's body to an unvetted host. A 3xx/opaqueredirect is
+        // classified transient (see classifyUpstreamAttempt) → failed attempt.
+        // Mirrors the redirect:"manual" invariant in webhooks.mjs /
+        // health-probe-core.mjs.
+        redirect: "manual",
         signal: AbortSignal.timeout(timeoutMs),
       });
       status = upstream.status;


### PR DESCRIPTION
## Summary

`proxyWithFailover` (`workers/request-handlers/rpc-proxy.mjs`) POSTed the caller's JSON-RPC body to each allowlisted upstream with the default `redirect: "follow"`. A `3xx` from a trusted upstream would transparently **re-POST that body to the redirect's `Location`** — a host `TRUSTED_RPC_UPSTREAM_ORIGINS` never vetted (only the *initial* target is checked). Every other outbound fetch in the safety lane already pins `redirect: "manual"` (`src/webhooks.mjs`, `src/health-probe-core.mjs`); the proxy was the lone diverging path.

Closes #2087.

## Fix

- Pin `redirect: "manual"` on the upstream fetch.
- Classify `3xx` and the opaqueredirect sentinel (`status === 0`) as **transient** in `classifyUpstreamAttempt`.

**Why transient, not "fatal" (the issue's parenthetical):** the success branch gates on `status < 400`, *not* the classification — so a `fatal` 302 (302 < 400) would still hit it and be returned to the client with `recordRpcSuccess`. `transient` is caught first (line 869, before 881), so the redirect is recorded as a **failed attempt** and we fail over to the next allowlisted endpoint. This matches the acceptance criteria ("failed attempt / records the attempt as failed / keeps the success branch from accepting them").

Normal 2xx / JSON-RPC-error / 4xx / 5xx handling is unchanged.

## Tests (`tests/rpc-failover.test.mjs`, +8)

- `classifyUpstreamAttempt`: 301/302/307/399 + opaqueredirect (status 0) → `transient`.
- `proxyWithFailover`: a 302-with-`Location` and an opaqueredirect each become a failed attempt → fails over to the next endpoint; `fetchFn.calls` is exactly the two allowlisted URLs (never the redirect target); all-redirect → `502` with the body never re-POSTed off-allowlist.

All 35 pass; `prettier` + `eslint` clean.