### PR TITLE
fix(api): preserve u128 rao precision in account balance

### DIFF
--- a/tests/account-balance.test.mjs
+++ b/tests/account-balance.test.mjs
@@ -206,6 +206,40 @@ test("GET /accounts/{ss58}/balance decodes hex-encoded rao balances", async () =
   );
 });
 
+test("GET /accounts/{ss58}/balance keeps u128 rao precision above 2^53 (#2070)", async () => {
+  // A u128 `free` far above Number.MAX_SAFE_INTEGER rao. The pre-fix path
+  // Number(BigInt(free)) / 1e9 collapses the low-order rao digits to the nearest
+  // double *before* scaling; summing in BigInt and splitting whole/fractional TAO
+  // at the very end preserves them. This magnitude is where the two paths diverge
+  // as IEEE-754 doubles, so it doubles as a regression guard.
+  const freeRao = 123_456_789_012_345_678_901n; // 0x6b14e9f812f366c35
+  const exact =
+    Number(freeRao / 1_000_000_000n) + Number(freeRao % 1_000_000_000n) / 1e9;
+  const preFix = Number(freeRao) / 1e9; // what the old conversion produced
+  assert.notEqual(exact, preFix); // sanity: the paths really differ at this scale
+  await withFetchStub(
+    async () => ({
+      ok: true,
+      json: async () => ({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { data: { free: `0x${freeRao.toString(16)}` } },
+      }),
+    }),
+    async () => {
+      const res = await handleRequest(
+        req(`/api/v1/accounts/${SS58}/balance`),
+        {},
+        {},
+      );
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.data.balance_tao, exact);
+      assert.notEqual(body.data.balance_tao, preFix);
+    },
+  );
+});
+
 test("GET /accounts/{ss58}/balance returns null when RPC responds non-ok", async () => {
   await withFetchStub(
     async () => ({ ok: false }),

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -640,15 +640,20 @@ export async function handleAccountBalance(request, env, ss58) {
       const data = rpcBody?.result?.data;
       if (data && typeof data.free !== "undefined") {
         // free + reserved are hex-encoded u128 rao values (1 TAO = 1e9 rao).
-        const freeRao =
-          typeof data.free === "string"
-            ? Number(BigInt(data.free))
-            : Number(data.free);
-        const reservedRao =
-          typeof data.reserved === "string"
-            ? Number(BigInt(data.reserved))
-            : Number(data.reserved ?? 0);
-        balanceTao = (freeRao + reservedRao) / 1e9;
+        // Sum in BigInt space and split the whole / fractional TAO only at the
+        // end, so a balance above Number.MAX_SAFE_INTEGER rao (~9.007M TAO) keeps
+        // its low-order rao digits — a direct Number(BigInt(...)) cast would
+        // collapse them to the nearest double *before* the 1e9 scale. A malformed
+        // hex `free` still throws here (BigInt parse) and is caught below →
+        // balance_tao:null, 200 (unchanged error path).
+        const toRao = (v) =>
+          typeof v === "string"
+            ? BigInt(v)
+            : BigInt(Math.trunc(Number(v ?? 0)));
+        const totalRao = toRao(data.free) + toRao(data.reserved);
+        balanceTao =
+          Number(totalRao / 1_000_000_000n) +
+          Number(totalRao % 1_000_000_000n) / 1e9;
         rpcOk = true;
       }
     }


### PR DESCRIPTION
## Summary

`handleAccountBalance` (`GET /api/v1/accounts/{ss58}/balance`) read the chain's hex-encoded **u128** `free`/`reserved` rao values, then cast each to a JS number with `Number(BigInt(...))` **before** summing and dividing by `1e9`. That cast collapses any magnitude above `Number.MAX_SAFE_INTEGER` rao (2^53 − 1 ≈ **9.007M TAO**) to the nearest double *before* the scale, silently corrupting the low-order rao digits of large balances — exactly the treasury / exchange / foundation wallets a balance API is most asked about.

## What Changed

Sum the legs in BigInt space and split the whole / fractional TAO only at the end:

```js
const toRao = (v) => (typeof v === "string" ? BigInt(v) : BigInt(Math.trunc(Number(v ?? 0))));
const totalRao = toRao(data.free) + toRao(data.reserved);
balanceTao = Number(totalRao / 1_000_000_000n) + Number(totalRao % 1_000_000_000n) / 1e9;
```

The integer TAO part stays exact and the fraction keeps full rao resolution. Behavior is preserved for:
- numeric inputs (`2.5 TAO` path),
- hex-string inputs,
- an absent `reserved` (still defaults to 0),
- a malformed hex `free` — still throws inside the existing `try` → `balance_tao: null`, `200` (unchanged error path).

Adds a regression test feeding a u128 `free` far above 2^53 rao and asserting `balance_tao` equals the BigInt-derived value (and differs from the pre-fix double conversion — the two paths diverge as IEEE-754 doubles at that scale, so the test fails on the old code).

This is a Worker read-path change only — no schema/contract surface change (`validate:contract-drift` green).

## Validation

- [x] `npx vitest run tests/account-balance.test.mjs` — 17 passed (1 new)
- [x] Regression-verified: reverting the source fails exactly the new test
- [x] `npm run validate:contract-drift` — passed
- [x] `npm run scan:public-safety` — passed
- [x] `eslint` + `prettier --check` — clean

Closes #2070