### PR TITLE
fix(ai): only record + upsert valid embeddings in runEmbeddingSync

### DIFF
--- a/src/ai-search.mjs
+++ b/src/ai-search.mjs
@@ -188,6 +188,18 @@ async function readManifest(env) {
   }
 }
 
+// A valid embedding is an array of exactly EMBED_DIMENSIONS finite numbers.
+// Workers AI batch embedding can return fewer rows than requested, an
+// error-shaped body (so `data` is `[]`), or a malformed row — none of which may
+// be upserted into Vectorize or recorded as "embedded" in the manifest.
+function isValidEmbeddingVector(values) {
+  return (
+    Array.isArray(values) &&
+    values.length === EMBED_DIMENSIONS &&
+    values.every((n) => typeof n === "number" && Number.isFinite(n))
+  );
+}
+
 // Embedding-sync cron: diff the search index against a deployment-scoped
 // content-hash manifest in KV, (re)embed only the deltas, upsert to Vectorize,
 // drop removed ids. Runs in
@@ -204,28 +216,55 @@ export async function runEmbeddingSync(env, deps = {}) {
   const previous = await readManifest(env);
   const next = {};
   const pending = [];
+  const currentIds = new Set();
   for (const doc of docs) {
     if (!doc?.id) continue;
     const id = vectorId(doc.id);
     const hash = contentHash(embeddingText(doc));
-    next[id] = hash;
-    if (previous[id] !== hash) pending.push({ id, doc });
+    currentIds.add(id);
+    if (previous[id] === hash) {
+      // Already embedded under this exact content — carry the hash forward so it
+      // is neither re-embedded nor treated as removed.
+      next[id] = hash;
+    } else {
+      // New or changed: (re)embed. Recorded into `next` ONLY after a valid
+      // vector is actually upserted (below), so a failed embed is retried next
+      // run instead of being permanently marked done.
+      pending.push({ id, doc, hash });
+    }
   }
-  const removed = Object.keys(previous).filter((id) => !(id in next));
+  // Removed = ids that left the index entirely, derived from the CURRENT doc set
+  // (not `next`). A doc whose embedding fails this run is absent from `next` but
+  // still present in `currentIds`, so it keeps its existing vector (stale beats
+  // missing) and is retried — never wrongly deleted.
+  const removed = Object.keys(previous).filter((id) => !currentIds.has(id));
 
   let embedded = 0;
   for (const batch of chunk(pending, EMBED_BATCH_SIZE)) {
     const response = await env.AI.run(EMBED_MODEL, {
       text: batch.map((entry) => embeddingText(entry.doc)),
     });
-    const data = response?.data || [];
-    const vectors = batch.map((entry, i) => ({
-      id: entry.id,
-      values: data[i],
-      metadata: embeddingMetadata(entry.doc),
-    }));
-    await env.VECTORIZE.upsert(vectors);
-    embedded += vectors.length;
+    const data = Array.isArray(response?.data) ? response.data : [];
+    // Upsert (and record in the manifest) ONLY entries that produced a valid
+    // vector. If Workers AI returns fewer/empty/malformed rows, the affected
+    // docs are left out of both the upsert and `next`, so the next cron retries
+    // them rather than leaving a permanent hole in the index.
+    const valid = [];
+    for (let i = 0; i < batch.length; i += 1) {
+      if (isValidEmbeddingVector(data[i])) {
+        valid.push({ entry: batch[i], values: data[i] });
+      }
+    }
+    if (valid.length === 0) continue;
+    await env.VECTORIZE.upsert(
+      valid.map(({ entry, values }) => ({
+        id: entry.id,
+        values,
+        metadata: embeddingMetadata(entry.doc),
+      })),
+    );
+    for (const { entry } of valid) next[entry.id] = entry.hash;
+    embedded += valid.length;
   }
   if (removed.length && typeof env.VECTORIZE.deleteByIds === "function") {
     await env.VECTORIZE.deleteByIds(removed);

--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -58,6 +58,23 @@ function stubAi() {
   };
 }
 
+// Embedding AI stub whose batch `data` is computed from the input texts, so a
+// test can simulate Workers AI returning fewer/empty/malformed rows than asked.
+function embedAiWith(dataFor) {
+  const calls = [];
+  return {
+    calls,
+    run(model, input) {
+      calls.push({ model, input });
+      if (model === EMBED_MODEL) {
+        return Promise.resolve({ data: dataFor(input.text) });
+      }
+      return Promise.resolve({ response: "x" });
+    },
+  };
+}
+const validVec = () => new Array(1024).fill(0.02);
+
 function stubVectorize() {
   const ops = { upserts: [], deletes: [] };
   return {
@@ -367,6 +384,108 @@ describe("runEmbeddingSync", () => {
     const r3 = await runEmbeddingSync(env3, { readArtifact: reader(dropped) });
     assert.equal(r3.removed, 1, "dropped doc is deleted");
     assert.deepEqual(env3.VECTORIZE.ops.deletes[0], ["subnet:2"]);
+  });
+
+  test("records nothing and upserts nothing when the embedder returns an empty batch", async () => {
+    const kv = memKv();
+    const env = {
+      AI: embedAiWith(() => []), // error-shaped / empty body
+      VECTORIZE: stubVectorize(),
+      METAGRAPH_CONTROL: kv,
+    };
+    const r = await runEmbeddingSync(env, { readArtifact: reader(searchDocs) });
+    assert.equal(r.embedded, 0);
+    assert.equal(env.VECTORIZE.ops.upserts.length, 0, "nothing upserted");
+    // The failed docs must NOT be recorded as embedded.
+    const manifest = JSON.parse(kv.store.get(EMBED_MANIFEST_KEY) || "{}");
+    assert.deepEqual(Object.keys(manifest), [], "no doc marked embedded");
+    // A subsequent run with a working embedder re-attempts both docs.
+    const env2 = {
+      AI: stubAi(),
+      VECTORIZE: stubVectorize(),
+      METAGRAPH_CONTROL: kv,
+    };
+    const r2 = await runEmbeddingSync(env2, {
+      readArtifact: reader(searchDocs),
+    });
+    assert.equal(r2.embedded, 2, "both docs retried after a failed run");
+    assert.equal(env2.VECTORIZE.ops.upserts[0].length, 2);
+  });
+
+  test("only upserts and records docs that produced a valid vector (partial batch)", async () => {
+    const kv = memKv();
+    // pending order is [subnet:1, subnet:2]; the embedder returns a valid vector
+    // for the first and a missing one for the second.
+    const env = {
+      AI: embedAiWith(() => [validVec(), undefined]),
+      VECTORIZE: stubVectorize(),
+      METAGRAPH_CONTROL: kv,
+    };
+    const r = await runEmbeddingSync(env, { readArtifact: reader(searchDocs) });
+    assert.equal(r.embedded, 1, "only the valid vector counts");
+    assert.equal(env.VECTORIZE.ops.upserts[0].length, 1, "only one upsert");
+    // No vector with undefined values is ever upserted.
+    assert.ok(
+      env.VECTORIZE.ops.upserts[0].every((v) => Array.isArray(v.values)),
+      "no upsert carries an undefined vector",
+    );
+    const manifest = JSON.parse(kv.store.get(EMBED_MANIFEST_KEY) || "{}");
+    assert.equal(
+      Object.keys(manifest).length,
+      1,
+      "only the embedded doc is recorded",
+    );
+    // Next run (working embedder) re-attempts only the previously-failed doc.
+    const env2 = {
+      AI: stubAi(),
+      VECTORIZE: stubVectorize(),
+      METAGRAPH_CONTROL: kv,
+    };
+    const r2 = await runEmbeddingSync(env2, {
+      readArtifact: reader(searchDocs),
+    });
+    assert.equal(r2.embedded, 1, "only the previously-failed doc retried");
+  });
+
+  test("a present doc whose re-embed fails is retried, never deleted", async () => {
+    const kv = memKv();
+    // First run embeds both docs successfully.
+    await runEmbeddingSync(
+      { AI: stubAi(), VECTORIZE: stubVectorize(), METAGRAPH_CONTROL: kv },
+      { readArtifact: reader(searchDocs) },
+    );
+    // Second run: doc 2's content changes but the embedder fails for it. It is
+    // still a current doc, so it must NOT be treated as removed (stale beats
+    // missing) — regression guard for basing `removed` on the current doc set.
+    const changed = {
+      ok: true,
+      data: {
+        documents: [
+          {
+            id: "subnet:1",
+            type: "subnet",
+            netuid: 1,
+            title: "One",
+            tokens: ["a"],
+          },
+          {
+            id: "subnet:2",
+            type: "subnet",
+            netuid: 2,
+            title: "Two CHANGED",
+            tokens: ["b"],
+          },
+        ],
+      },
+    };
+    const env2 = {
+      AI: embedAiWith(() => []), // re-embed of the changed doc fails
+      VECTORIZE: stubVectorize(),
+      METAGRAPH_CONTROL: kv,
+    };
+    const r2 = await runEmbeddingSync(env2, { readArtifact: reader(changed) });
+    assert.equal(r2.removed, 0, "a present-but-failed doc is never deleted");
+    assert.equal(env2.VECTORIZE.ops.deletes.length, 0);
   });
 
   test("skips docs without an id", async () => {


### PR DESCRIPTION
## Summary

`runEmbeddingSync` (`src/ai-search.mjs`) recorded every doc's content hash in the KV manifest **up-front** (`next[id] = hash` before any `env.AI.run`) and upserted `batch.map(... values: data[i])` with **no check** that the Workers AI batch returned a vector per input. When the embedder returns fewer rows (or an error-shaped body → `data = []`):

- a vector with `values: undefined` was upserted into Vectorize, and
- the hash was already persisted, so the next cron saw `previous[id] === hash` and **never retried** — a permanent hole in the index for that doc until its text changes; `embedded` also over-reported.

Closes #2071.

## Fix

- `isValidEmbeddingVector`: an array of exactly `EMBED_DIMENSIONS` (1024) finite numbers.
- Build the upsert list **and** `next[id] = hash` from only the entries that produced a valid vector, so a failed doc is absent from the manifest and re-attempted next run. `embedded` counts only valid upserts.
- Base `removed` on the **current doc-id set** (not `next`): a present doc whose re-embed fails keeps its existing vector (stale beats missing) instead of being wrongly flagged removed and deleted — a bug the naive fix would have introduced.

Cold-manifest / delta / removal / legacy-manifest paths are unchanged.

## Tests (`tests/ai-search.test.mjs`, +3, with a configurable `embedAiWith` stub)

- empty batch (`data = []`) → nothing upserted, no doc recorded, both retried next run.
- partial batch (`[validVec(), undefined]`) → only the valid doc upserted/recorded (no `undefined` values reach Vectorize); the failed doc retried next run.
- a present doc whose re-embed fails → `removed === 0`, never deleted (regression guard for the `removed` fix).

All 77 pass; `prettier` + `eslint` clean.