### PR TITLE
ci(python): run the Python SDK test suite in CI and before PyPI publish

### DIFF
--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -70,13 +70,18 @@ Subnet-level fields you must **not** touch in a community PR: `curation` (`level
 
 **Every contributor PR runs the FULL validation — there is no reduced "ugc" fast-lane.** (It was
 retired: it skipped the safety scans and kept tripping a stale-base preflight false-positive.) A
-one-file surface PR runs the same gates as a code PR. Two parallel jobs both build:
+one-file surface PR runs the same gates as a code PR. Three parallel jobs (the two Node jobs both
+build):
 
 - **`test`** — builds, then runs the suite in two non-overlapping passes: `test:ci` (everything
   except the two filesystem-mutating artifact writers, run in parallel, WITH coverage → the single
   Codecov upload) then `test:ci:artifacts` (those two writers, serial). Locally just use
   `npm test` / `npm run test:coverage` (full suite, serial — the config default is race-safe).
 - **`checks`** — builds, then lint + format + the ~20 contract/schema/safety validators (below).
+- **`python`** — runs the Python SDK's unittest suite via `uv run --extra test python -m unittest
+discover -s tests` (the `[test]` extra pulls in httpx so the async cases run). Node-independent, so
+  it adds no wall-clock to the long poles. The same step runs in `publish-python.yml`'s unprivileged
+  `build` job before the artifact is built, so a red suite blocks a PyPI publish.
 
 **Gates (all must pass):** `lint` · `format:check` · `validate:contract-drift` ·
 `validate:schema-enums` · `validate:openapi-examples` · `validate:generated-client` ·

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -45,6 +45,17 @@ jobs:
           RELEASE_PLEASE_TRIGGERED: ${{ inputs.released_by_release_please }}
         run: bash scripts/validate-python-release.sh
 
+      # Run the SDK's test suite (37 cases) BEFORE building/uploading, in THIS
+      # unprivileged job — a red suite fails the run before the privileged publish
+      # job (which `needs: build`) can ship to PyPI. `validate-python-release.sh`
+      # only checks version/tag/PyPI-existence, not behavior, so without this the
+      # path from source to PyPI had no test gate. `--extra test` installs the
+      # httpx-backed test deps so the async cases run. Tests deliberately never run
+      # on the privileged publish job (keep third-party code off the OIDC runner).
+      - name: Test Python SDK
+        working-directory: python
+        run: uv run --extra test python -m unittest discover -s tests
+
       # Build happens in THIS unprivileged job (no id-token). The privileged
       # publish job below never builds, so a compromised build dependency can't
       # reach the OIDC token (mirrors the npm publish split, codex #251).

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -301,3 +301,26 @@ jobs:
 
       - name: Validate private boundary
         run: npm run validate:private-boundary
+
+  # The Python SDK (python/) ships its own hermetic unittest suite (37 cases) but
+  # was never run in CI — a regression in retry/backoff, Retry-After capping,
+  # pagination, JSON-RPC unwrap, or the SSRF-safe redirect handler could land on a
+  # PR (and reach PyPI) despite covering tests existing. This job runs it on every
+  # PR. It is independent of the Node jobs, so it adds no wall-clock to the
+  # test/checks long poles.
+  python:
+    name: python
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      # `--extra test` installs the httpx-backed test deps (declared in pyproject's
+      # [test] extra) so the async cases run instead of skipping. uv provisions a
+      # Python within `requires-python = ">=3.9"`. No new runtime dependency.
+      - name: Test Python SDK
+        working-directory: python
+        run: uv run --extra test python -m unittest discover -s tests


### PR DESCRIPTION
## Summary

The Python SDK (`python/`) ships a hermetic **37-case** unittest suite (`test_client.py` + `test_aio.py`) — but nothing ran it:

1. `validate.yml` is Node-only (no `setup-python`/test invocation), so a PR changing `python/src/metagraphed/*.py` passed CI without its tests.
2. `publish-python.yml`'s `build` job runs only `validate-python-release.sh` (a version/tag/PyPI-existence check, **not** a test runner) before `uv build` + upload — **no test ran between source and PyPI.**

A regression in retry/backoff, `Retry-After` capping, pagination, JSON-RPC unwrap, or the SSRF-safe redirect handler (`_CrossOriginSafeRedirectHandler`) could reach PyPI users with passing tests sitting unused.

Closes #2098.

## Fix

- **`validate.yml`** — new independent `python` job: `setup-uv` + `uv run --extra test python -m unittest discover -s tests`. Runs on every PR; Node-independent, so it adds no wall-clock to the `test`/`checks` long poles.
- **`publish-python.yml`** — the same step in the unprivileged `build` job **before** `uv build`/upload, so a red suite fails before the privileged `publish` job (`needs: build`) can ship. Tests deliberately do **not** run on the OIDC-privileged job (third-party code stays off the token-bearing runner — preserves the existing security split).
- The `[test]` extra pulls in httpx so the **async cases run instead of skipping** (locally: `Ran 37 tests ... OK (skipped=1)` with the extra vs `skipped=10` without). No new runtime dependency.

**Why `uv` rather than the issue's suggested `setup-python`:** `astral-sh/setup-uv` is already SHA-pinned + allowlisted (publish-python.yml uses it), and `validate-workflows.mjs` requires SHA-pinned actions — reusing it avoids introducing/guessing a new pin and keeps both workflows on one toolchain.

## Validation

- `uv run --extra test python -m unittest discover -s tests` → `Ran 37 tests ... OK` locally.
- `npm run validate:workflows` green (SHA-pin + structure rules); `prettier --check` clean on all three files.
- Skill reference (`.claude/skills/metagraphed/reference.md`) updated to document the third Validate job, kept atomic with the change.