### PR TITLE
fix(test): remove URL-substring CodeQL finding in rpc-failover redirect tests

### DIFF
--- a/tests/rpc-failover.test.mjs
+++ b/tests/rpc-failover.test.mjs
@@ -218,9 +218,10 @@ describe("proxyWithFailover", () => {
     assert.equal(res.headers.get("x-metagraph-rpc-endpoint-id"), "b");
     assert.equal(res.headers.get("x-metagraph-rpc-attempts"), "2");
     // Only the two allowlisted endpoints were contacted — never the redirect
-    // target (the proxy did not auto-follow the 302).
+    // target (the deepEqual is exact, so it proves UNSAFE was not fetched; an
+    // `.includes(UNSAFE)` substring check would trip CodeQL's
+    // incomplete-url-substring-sanitization rule and is redundant here).
     assert.deepEqual(fetchFn.calls, [SAFE_A, SAFE_B]);
-    assert.equal(fetchFn.calls.includes(UNSAFE), false);
     // The security property itself: the upstream fetch pins redirect:"manual" so
     // the platform never auto-follows a 3xx (without this, the body would be
     // re-POSTed to the off-allowlist Location). Guards against the option being
@@ -252,9 +253,10 @@ describe("proxyWithFailover", () => {
       fetchFn,
     });
     assert.equal(res.status, 502);
-    // Both allowlisted endpoints tried; neither redirect was followed.
+    // Both allowlisted endpoints tried; neither redirect was followed (the
+    // exact deepEqual proves UNSAFE was not fetched without a URL-substring
+    // check).
     assert.deepEqual(fetchFn.calls, [SAFE_A, SAFE_B]);
-    assert.equal(fetchFn.calls.includes(UNSAFE), false);
   });
 
   test("fails over on HTTP 5xx without reading its response body", async () => {


### PR DESCRIPTION
## Summary

Resolves the two **High** CodeQL alerts (`js/incomplete-url-substring-sanitization`) introduced by #2100 at `tests/rpc-failover.test.mjs:223` and `:257`:

```js
assert.equal(fetchFn.calls.includes(UNSAFE), false); // UNSAFE = 'https://evil.example.com/rpc'
```

An `.includes(<url-literal>)` containment check is exactly what that rule targets. Both assertions were **redundant**: each is immediately preceded by `assert.deepEqual(fetchFn.calls, [SAFE_A, SAFE_B])`, an exact array comparison that already proves the off-allowlist redirect target was never fetched. Removed the substring checks; the `deepEqual` (plus the `redirect:"manual"` init assertion) fully covers the security property.

Test-only; the RPC-proxy behavior from #2100 is unchanged. 35 tests pass; prettier + eslint clean.

## Context

This is a follow-up to #2100 — that PR was merged while the CodeQL finding was unresolved (I misread the failing default-setup CodeQL check as an infra flake). This corrects it.

## Acceptance

- CodeQL clean (the two alerts at `:223`/`:257` resolved); all checks green before merge.