### PR TITLE
docs(infra): ADR 0013 hybrid deployment topology + Postgres schema + runbook

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,92 @@
+# Deployment — the `metagraphed-core` hybrid (ADR 0013)
+
+The architecture and rationale live in [`docs/adr/0013-hybrid-deployment-topology.md`](../docs/adr/0013-hybrid-deployment-topology.md).
+This is the **operator runbook**: what runs where, the exact provisioning
+commands, and the gated cutover steps.
+
+```
+Chain → pruned subtensor-node → indexer → Postgres/Timescale
+                                              │
+                          (Cloudflare Hyperdrive, pooled + cached)
+                                              ▼
+            CF Worker (REST/GraphQL/MCP) + Durable Object firehose (SSE/WS)
+Railway crons/workers (prober · rollups · alerter · exporter · reconciler) ─ all read/write Postgres over private net
+R2 = artifacts · Parquet/CSV exports · Postgres backups (zero-egress)
+```
+
+## Topology
+
+| Tier          | Where                                  | Pieces                                                                                                                          |
+| ------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Edge (rented) | **Cloudflare**                         | Worker serving, **Hyperdrive** → Postgres, **Durable Object** firehose, R2, KV, Vectorize, Workers AI, rate-limiters, RPC proxy |
+| Core (owned)  | **Railway project `metagraphed-core`** | `postgres`, `redis`, `subtensor-node` (pruned), `indexer`, `health-prober`, `rollups`, `alerter`, `exporter`, `reconciler`      |
+| Escape hatch  | **Hetzner** (later)                    | `postgres` (+ optional node) when compressed history > ~300–500 GB or the 1 TB Railway cap looms — see ADR 0013                 |
+
+One Railway **project**, two **environments** (`production`, `staging`), one
+private network (`<service>.railway.internal`, zero egress). The existing
+`metagraphed-streamer` project is **separate and untouched** — it is superseded
+by `indexer` only at decommission (final step).
+
+## Provisioning (run when the indexer is ready — NOT before)
+
+> Idle managed Postgres/Redis bill from the moment they exist, and nothing reads
+> them until the `indexer` lands. Provision as part of the indexer phase, not
+> ahead of it. Run from a **dedicated directory** (NOT this repo) so this repo's
+> Railway link state stays clean — `railway init` links the current dir.
+
+```bash
+mkdir -p ~/metagraphed-core && cd ~/metagraphed-core
+railway init --name metagraphed-core --workspace aethereal --json
+railway add -d postgres          # managed Postgres (enable TimescaleDB, or use the Timescale template)
+railway add -d redis             # indexer cursor + dedup + queue
+# apply the portable schema:
+railway connect postgres < /path/to/metagraphed/deploy/postgres/schema.sql
+```
+
+Each compute service is added from the monorepo with its own root/Dockerfile and
+cross-service variable references, e.g.:
+
+```bash
+railway add -s indexer --repo JSONbored/metagraphed --branch main \
+  -v DATABASE_URL='${{Postgres.DATABASE_URL}}' \
+  -v REDIS_URL='${{Redis.REDIS_URL}}' \
+  -v EVENTS_RPC_URL='wss://entrypoint-finney.opentensor.ai:443'
+```
+
+Cron services (`rollups`, `exporter`, `reconciler`) get a crontab via the service
+settings (run-and-terminate). Long-running services (`indexer`, `subtensor-node`,
+`health-prober`, `alerter`) restart-on-failure with effectively-infinite retries
+(a head-follower must retry forever) + a `last_ingested_block` heartbeat into
+Redis so the Worker can surface "realtime stale".
+
+## Cloudflare side
+
+```bash
+# Hyperdrive over a Cloudflared tunnel / Workers VPC to the Railway Postgres.
+npx wrangler hyperdrive create metagraphed-core --connection-string "$POSTGRES_PRIVATE_URL"
+# then add the [[hyperdrive]] binding to wrangler.jsonc and read via the binding.
+```
+
+The Durable Object firehose hub is a new binding in the Worker; the `indexer`
+tees each decoded batch to it for SSE/WS/GraphQL-subscription fan-out.
+
+## Gated steps — DO NOT run unsupervised
+
+Each needs a human who can verify/roll back (ADR 0013 _Sequencing_):
+
+1. **`subtensor-node`** — pruned (128 GB volume), follows head. (A permanent
+   archive node is ~3.5 TB — avoided; backfill uses a transient archive source.)
+2. **`indexer` + one-time backfill** — then **verify ~100 % capture vs D1**
+   before trusting it.
+3. **Serving cutover** — point the Worker at Hyperdrive→Postgres **tier by tier**
+   (blocks → extrinsics → accounts → metagraph), D1 as fallback; only then delete
+   the prune-and-discard logic.
+4. **Decommission** the GitHub `*/5` poller (`refresh-events.yml`), the
+   `metagraphed-streamer` project, and the `*/3` R2-staging drain; demote D1 to a
+   hot cache.
+
+## Backups (mandatory)
+
+Postgres holds irreplaceable derived state (the node is restorable from chain).
+Ship WAL/dumps to **R2** (zero-egress): a `pg_dump`/WAL job to an R2 bucket, or
+Railway's managed backups + a periodic R2 export via the `exporter` service.

--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -1,0 +1,201 @@
+-- metagraphed-core chain sink — target Postgres schema (ADR 0013)
+--
+-- The durable replacement for the D1 chain tiers (blocks / extrinsics /
+-- account_events / neurons / neuron_daily / economics) once they outgrow D1's
+-- ~10GB cap and 90-day prune. Portable VANILLA Postgres — runs as-is on Railway
+-- Postgres OR a self-hosted Hetzner box (the ADR 0013 escape hatch). The
+-- TimescaleDB section at the bottom is OPTIONAL: it upgrades the time-series
+-- tables to compressed hypertables; skip it on plain Postgres and everything
+-- still works.
+--
+-- Key invariants preserved from the D1 era so the Worker serving code
+-- (src/blocks.mjs / extrinsics.mjs / account-events.mjs) changes only its
+-- binding, not its queries:
+--   * idempotent keys: block_number / (block_number, extrinsic_index) /
+--     (block_number, event_index) — overlapping ingest windows re-insert
+--     harmlessly via ON CONFLICT DO NOTHING.
+--   * observed_at = block timestamp in epoch milliseconds (BIGINT), matching D1.
+--   * tao/alpha amounts as NUMERIC (exact; no float drift on balances/yield).
+
+-- ---------------------------------------------------------------------------
+-- Block-explorer hot/deep tiers
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS blocks (
+  block_number     BIGINT PRIMARY KEY,
+  block_hash       TEXT UNIQUE,
+  parent_hash      TEXT,
+  author           TEXT,
+  extrinsic_count  INTEGER,
+  event_count      INTEGER,
+  spec_version     INTEGER,
+  observed_at      BIGINT NOT NULL          -- epoch ms
+);
+CREATE INDEX IF NOT EXISTS idx_blocks_hash     ON blocks (block_hash);
+CREATE INDEX IF NOT EXISTS idx_blocks_observed ON blocks (observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS extrinsics (
+  block_number     BIGINT NOT NULL,
+  extrinsic_index  INTEGER NOT NULL,
+  extrinsic_hash   TEXT,
+  signer           TEXT,
+  call_module      TEXT,
+  call_function    TEXT,
+  success          BOOLEAN,
+  fee_tao          NUMERIC,
+  tip_tao          NUMERIC,
+  call_args        JSONB,
+  observed_at      BIGINT NOT NULL,
+  PRIMARY KEY (block_number, extrinsic_index)
+);
+CREATE INDEX IF NOT EXISTS idx_extrinsics_hash     ON extrinsics (extrinsic_hash);
+CREATE INDEX IF NOT EXISTS idx_extrinsics_observed ON extrinsics (observed_at DESC);
+-- #2082: composite covers the /accounts/{ss58}/extrinsics filesort + summary aggregates.
+CREATE INDEX IF NOT EXISTS idx_extrinsics_signer_block
+  ON extrinsics (signer, block_number DESC, extrinsic_index DESC);
+-- #2082 sibling: extrinsics-feed call_module/call_function/success filters.
+CREATE INDEX IF NOT EXISTS idx_extrinsics_call
+  ON extrinsics (call_module, call_function, success, block_number DESC);
+
+CREATE TABLE IF NOT EXISTS account_events (
+  block_number     BIGINT NOT NULL,
+  event_index      INTEGER NOT NULL,
+  extrinsic_index  INTEGER,
+  event_kind       TEXT,
+  hotkey           TEXT,
+  coldkey          TEXT,
+  netuid           INTEGER,
+  amount           NUMERIC,
+  alpha            NUMERIC,
+  observed_at      BIGINT NOT NULL,
+  PRIMARY KEY (block_number, event_index)
+);
+CREATE INDEX IF NOT EXISTS idx_ae_hotkey   ON account_events (hotkey, block_number DESC);
+CREATE INDEX IF NOT EXISTS idx_ae_coldkey  ON account_events (coldkey, block_number DESC);
+CREATE INDEX IF NOT EXISTS idx_ae_netuid   ON account_events (netuid, block_number DESC);
+CREATE INDEX IF NOT EXISTS idx_ae_observed ON account_events (observed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ae_extrinsic ON account_events (block_number, extrinsic_index);
+-- #2079: covers the /subnets/{netuid}/events ?kind filter (unindexed post-filter today).
+CREATE INDEX IF NOT EXISTS idx_ae_netuid_kind ON account_events (netuid, event_kind, block_number DESC);
+
+-- Generic all-events tier (audit gap: only ~8 kinds of 2 pallets decoded today).
+-- Stores EVERY decoded event; the curated account_events stays the fast path.
+CREATE TABLE IF NOT EXISTS chain_events (
+  block_number     BIGINT NOT NULL,
+  event_index      INTEGER NOT NULL,
+  pallet           TEXT,
+  method           TEXT,
+  args             JSONB,
+  phase            TEXT,
+  extrinsic_index  INTEGER,
+  observed_at      BIGINT NOT NULL,
+  PRIMARY KEY (block_number, event_index)
+);
+CREATE INDEX IF NOT EXISTS idx_ce_pallet_method ON chain_events (pallet, method, block_number DESC);
+CREATE INDEX IF NOT EXISTS idx_ce_observed      ON chain_events (observed_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- Metagraph tiers
+-- ---------------------------------------------------------------------------
+
+-- Current per-UID snapshot (mirror of D1 `neurons`).
+CREATE TABLE IF NOT EXISTS neurons (
+  netuid           INTEGER NOT NULL,
+  uid              INTEGER NOT NULL,
+  hotkey           TEXT,
+  coldkey          TEXT,
+  stake_tao        NUMERIC,
+  rank             NUMERIC,
+  trust            NUMERIC,
+  consensus        NUMERIC,
+  incentive        NUMERIC,
+  dividends        NUMERIC,
+  emission         NUMERIC,
+  validator_permit BOOLEAN,
+  active           BOOLEAN,
+  axon             TEXT,
+  captured_at      BIGINT,
+  PRIMARY KEY (netuid, uid)
+);
+CREATE INDEX IF NOT EXISTS idx_neurons_netuid_permit ON neurons (netuid, validator_permit, stake_tao DESC);
+CREATE INDEX IF NOT EXISTS idx_neurons_hotkey        ON neurons (hotkey);
+
+-- Daily per-UID history (mirror of D1 `neuron_daily`, ~10.8M rows / 370d).
+CREATE TABLE IF NOT EXISTS neuron_daily (
+  netuid           INTEGER NOT NULL,
+  uid              INTEGER NOT NULL,
+  snapshot_date    DATE NOT NULL,
+  hotkey           TEXT,
+  stake_tao        NUMERIC,
+  incentive        NUMERIC,
+  dividends        NUMERIC,
+  emission         NUMERIC,
+  validator_permit BOOLEAN,
+  PRIMARY KEY (netuid, uid, snapshot_date)
+);
+-- #2083: covering index for per-subnet history aggregation (avoid per-row heap fetch).
+CREATE INDEX IF NOT EXISTS idx_nd_netuid_date ON neuron_daily (netuid, snapshot_date, uid)
+  INCLUDE (stake_tao, incentive, dividends, emission);
+CREATE INDEX IF NOT EXISTS idx_nd_uid_date    ON neuron_daily (netuid, uid, snapshot_date);
+CREATE INDEX IF NOT EXISTS idx_nd_hotkey_date ON neuron_daily (hotkey, snapshot_date);
+
+-- ---------------------------------------------------------------------------
+-- Economics tiers
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS economics_history (
+  netuid             INTEGER NOT NULL,
+  snapshot_date      DATE NOT NULL,
+  alpha_price_tao    NUMERIC,
+  emission_share     NUMERIC,
+  total_stake_tao    NUMERIC,
+  registration_cost  NUMERIC,
+  PRIMARY KEY (netuid, snapshot_date)
+);
+CREATE INDEX IF NOT EXISTS idx_econ_netuid_date ON economics_history (netuid, snapshot_date);
+
+-- Account daily rollup (#2079 / audit: removes the temp-sort on default account history).
+CREATE TABLE IF NOT EXISTS account_events_daily (
+  hotkey           TEXT NOT NULL,
+  day              DATE NOT NULL,
+  event_count      INTEGER,
+  netuid_count     INTEGER,
+  PRIMARY KEY (hotkey, day)
+);
+
+-- ---------------------------------------------------------------------------
+-- Indexer coordination
+-- ---------------------------------------------------------------------------
+
+-- Durable cursor (also mirrored in Redis for hot access). Single row id=1.
+CREATE TABLE IF NOT EXISTS indexer_cursor (
+  id               SMALLINT PRIMARY KEY DEFAULT 1,
+  last_block       BIGINT NOT NULL,
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT indexer_cursor_singleton CHECK (id = 1)
+);
+
+-- ===========================================================================
+-- TimescaleDB (OPTIONAL) — compressed hypertables for the time-series tiers.
+-- Safe to skip on vanilla Postgres. Integer-time hypertables on observed_at
+-- (epoch ms): chunk interval = 1 day = 86_400_000 ms. Daily tables partition on
+-- their DATE column. Compression on chunks older than 7 days (~10-20x on chain
+-- data); cold partitions are exported to R2 Parquet (see deploy/README.md).
+-- ===========================================================================
+-- CREATE EXTENSION IF NOT EXISTS timescaledb;
+--
+-- SELECT create_hypertable('blocks',         'observed_at', chunk_time_interval => 86400000, migrate_data => true, if_not_exists => true);
+-- SELECT create_hypertable('extrinsics',     'observed_at', chunk_time_interval => 86400000, migrate_data => true, if_not_exists => true);
+-- SELECT create_hypertable('account_events', 'observed_at', chunk_time_interval => 86400000, migrate_data => true, if_not_exists => true);
+-- SELECT create_hypertable('chain_events',   'observed_at', chunk_time_interval => 86400000, migrate_data => true, if_not_exists => true);
+-- SELECT create_hypertable('neuron_daily',   'snapshot_date', chunk_time_interval => INTERVAL '30 days', migrate_data => true, if_not_exists => true);
+--
+-- ALTER TABLE blocks         SET (timescaledb.compress, timescaledb.compress_orderby = 'observed_at DESC');
+-- ALTER TABLE extrinsics     SET (timescaledb.compress, timescaledb.compress_segmentby = 'signer', timescaledb.compress_orderby = 'observed_at DESC');
+-- ALTER TABLE account_events SET (timescaledb.compress, timescaledb.compress_segmentby = 'hotkey', timescaledb.compress_orderby = 'observed_at DESC');
+-- ALTER TABLE chain_events   SET (timescaledb.compress, timescaledb.compress_segmentby = 'pallet', timescaledb.compress_orderby = 'observed_at DESC');
+--
+-- SELECT add_compression_policy('blocks',         BIGINT '604800000');  -- 7d in ms
+-- SELECT add_compression_policy('extrinsics',     BIGINT '604800000');
+-- SELECT add_compression_policy('account_events', BIGINT '604800000');
+-- SELECT add_compression_policy('chain_events',   BIGINT '604800000');

--- a/docs/adr/0013-hybrid-deployment-topology.md
+++ b/docs/adr/0013-hybrid-deployment-topology.md
@@ -1,0 +1,129 @@
+# ADR 0013 — Hybrid deployment topology: Cloudflare edge · Railway core · Postgres migration
+
+- **Status:** Accepted — ratified 2026-06-27. Implements the deployment + storage
+  topology for the continuous indexer that ADR 0012 left as "the end state."
+  Foundation (this ADR + the portable schema + runbook) shipped; provisioning and
+  the serving cutover are gated, phased steps (see _Sequencing_).
+- **Date:** 2026-06-27
+- **Relates to:** ADR 0010 (chain-direct block explorer), ADR 0012 (chain-data
+  ingestion — the continuous indexer this deploys), ADR 0001/0006 (storage tiers),
+  and the own-the-core infrastructure program (#1345, #1349, #1519, #1749).
+
+## Context
+
+The explorer's chain data is structurally a **rolling cache, not an archive**, and
+the system is engineered around Cloudflare's ceilings rather than the data:
+
+- **Storage ceiling.** The chain sink is **D1 (~10 GB cap)**, so `blocks` /
+  `extrinsics` / `account_events` are **pruned and discarded** past ~90 days
+  (`migrations/0013_blocks.sql`). Every history feature (weights/stake/pool/
+  economics/balance over time) is blocked by this.
+- **Ingestion gaps.** Two public-RPC tiers feed it: a GitHub `*/5` poller (GitHub
+  **coalesces it to ~1.5–4.5 h → ~58 % of blocks missed**, ADR 0012) and the
+  Railway streamer. Neither is gap-free.
+- **Compute ceiling.** Daily rollups (the ~33k-row neuron rollup), uptime/event
+  aggregates, and on-request `GROUP BY`s run **in the Worker isolate** with
+  row-cap gymnastics and subrequest limits.
+- **Third-party dependency.** The per-UID metagraph tier is **Taostats-sourced**
+  (the only non-first-party tier) and **daily** granularity.
+
+ADR 0012 ratified the _continuous indexer_ as the ingestion end-state but did not
+decide **where each piece runs** or **what replaces D1**. The owner's stated
+direction is **"own the core, rent the edge."**
+
+A cost note that shaped this decision: a permanent **archive node is ~3.5 TB and
+growing ~1.4 TB/yr** (subtensor docs, Mar 2026), which is prohibitive on metered
+volume storage. A **lite/pruned node is only 128 GB.**
+
+## Decision
+
+Adopt a three-tier hybrid. **Cloudflare = rented edge, Railway = owned compute
+core, Postgres = the durable chain sink** (Railway now, Hetzner escape hatch),
+with one Railway project for everything off the edge.
+
+1. **One Railway project `metagraphed-core`** (environments `production` +
+   `staging`) holds every off-edge service, on one private WireGuard network
+   (`<service>.railway.internal`, zero egress) with cross-service variable
+   references and monorepo deploys. Easiest to operate: one dashboard, one
+   network, one bill. Services: `postgres`, `redis`, `subtensor-node` (pruned),
+   `indexer`, `health-prober`, `rollups`, `alerter`, `exporter`, `reconciler`.
+2. **D1 chain sink → Postgres (TimescaleDB).** The portable schema lives at
+   `deploy/postgres/schema.sql` and keeps the existing idempotent keys
+   (`block_number` / `(block_number, extrinsic_index)` / `(block_number,
+event_index)`) so the serving code (`src/blocks.mjs`, `extrinsics.mjs`,
+   `account-events.mjs`) changes only its binding. **D1 demotes to the hot/recent
+   cache**; the prune-and-discard logic is deleted on cutover.
+3. **Cloudflare adds two edge primitives and keeps the rest.** A **Hyperdrive**
+   binding is the _only_ way the Worker reaches Postgres (pooled + edge query
+   cache); one **Durable Object** is the realtime firehose hub (SSE/WS +
+   GraphQL subscriptions + MCP). R2 (artifacts + cold Parquet + PG backups, all
+   zero-egress), KV, Vectorize, Workers AI, the rate-limiters, the RPC proxy, and
+   all REST/GraphQL/MCP serving **stay on Cloudflare**. The embedding-sync cron
+   stays on CF (binding-bound).
+4. **Continuous indexer replaces poller + streamer + `*/3` drain.** One
+   long-running Railway service follows the finalized head from a durable cursor
+   (Redis), reusing the verified decode in `scripts/fetch-events.py`, writing
+   straight to Postgres over private net. Continuity — not self-hosting — is what
+   fixes the 58 % loss.
+5. **Pruned node, not a permanent archive.** Run a **128 GB pruned**
+   `subtensor-node` for ongoing head-following + a first-party RPC origin (first
+   entry in `TRUSTED_RPC_UPSTREAM_ORIGINS`, public nodes demoted to failover).
+   The one-time historical backfill uses a **transient** archive source, then is
+   torn down — the explorer serves history from Postgres, not node state.
+6. **Light services move off CF isolates** to Railway cron/workers against
+   Postgres: `health-prober` (stable IP, real retry/backoff, higher concurrency),
+   `rollups` (Timescale continuous aggregates), plus net-new `alerter`,
+   `exporter` (DuckDB → Parquet/CSV → R2), and `reconciler` (folded-state vs
+   runtime drift).
+
+### Why Postgres on Railway _first_ (not Hetzner immediately)
+
+The prohibitive cost was the **permanent 3.5 TB archive node**, which this design
+avoids (pruned node + transient backfill). The remaining big store is the
+**compressed Timescale history**, which compresses ~10–20× and tiers cold
+partitions to R2 — plausibly **low-hundreds of GB for years**, comfortably under
+Railway's **1 TB volume cap** at **$0.15/GB-mo**. So:
+
+- **Start with `postgres` on Railway** — in-project, all private-net, simplest.
+- **Escape hatch to a Hetzner box** when compressed history crosses ~300–500 GB
+  (where a ~€60/mo box beats metered storage) or the 1 TB cap looms. This is
+  **low-friction by construction**: the only coupling is `DATABASE_URL` + the
+  Hyperdrive config, and the schema is portable vanilla Postgres. Designed for
+  portability from day one — no Railway-specific SQL.
+
+## Consequences
+
+**Gains:** deep history retained (prune-and-discard deleted); ingestion ~58 % →
+~100 % (no trigger coalescing); heavy aggregations leave the isolate; the
+metagraph tier becomes first-party (no Taostats); the explorer becomes
+real-time-pushable; one operable core project.
+
+**Costs / risks (tracked, not hand-waved):**
+
+- **New ops surface** — a Railway project to run; mitigated by the single-project
+  shape + staging environment.
+- **Reconciliation** — folded balances/stake/yield must be diffed against runtime
+  truth before users trust portfolio/APY numbers (`reconciler` service).
+- **Auth / monetization is a prerequisite** for the write-side services
+  (alerts, agent actions) — out of scope here, gating those phases.
+- **Backups** — Postgres holds irreplaceable derived state (the node is restorable
+  from chain); WAL/dumps → R2 (zero-egress) are mandatory.
+- **Test/CI** — reader tests serve R2-only artifacts; a Hyperdrive/Postgres path
+  needs integration coverage before cutover.
+
+**This is NOT a blind cutover.** Each phase is independently shippable and gated.
+
+## Sequencing
+
+1. **Foundation** — this ADR + `deploy/postgres/schema.sql` + `deploy/README.md`
+   runbook. _(shipped)_
+2. **Provision** `metagraphed-core` (postgres + redis), apply the schema, add the
+   Hyperdrive binding. Dual-write the chain tiers to Postgres alongside D1 — **no
+   serving change.** _(run when the indexer is ready — avoids paying for idle DBs)_
+3. **Continuous indexer** replaces poller/streamer/drain; backfill once; **verify
+   ~100 % capture vs D1** (gate).
+4. **Cut serving over** to Hyperdrive→Postgres tier-by-tier (blocks → extrinsics →
+   accounts → metagraph), D1 as fallback; delete prune-and-discard.
+5. **Move scheduled jobs** to Railway; add `exporter` + `reconciler`; add the
+   Durable Object firehose + `alerter`.
+6. **Decommission** the GitHub poller + streamer + `*/3` drain; D1 → hot cache.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,7 @@ change.
 | [0010](0010-chain-direct-block-explorer.md) | Chain-direct block explorer + first-party event indexer                                                                 | Accepted (partial) · ingestion/serving shipped, deep history pending infra                                       |
 | [0011](0011-retire-submission-preflight.md) | Retire the metagraphed-side submission preflight (the gate is external; `validate-surface`/`validate-intake` own shape) | Accepted · implemented                                                                                           |
 | [0012](0012-chain-data-ingestion.md)        | Chain-data ingestion — bootstrap poller → self-hosted archive indexer (gap-free, prune-proof)                           | Accepted · poller made archive-ready (cursor recovery); continuous indexer is the end state                      |
+| [0013](0013-hybrid-deployment-topology.md)  | Hybrid deployment topology — Cloudflare edge · Railway core · D1→Postgres (Hyperdrive); single project, pruned node     | Accepted · foundation shipped (ADR + schema + runbook); provisioning + serving cutover gated/phased              |
 
 ## Keeping these current
 


### PR DESCRIPTION
## Summary

Scaffolds (docs + schema + runbook, **no runtime change**) the deployment topology that lands ADR 0012's continuous indexer: **Cloudflare edge · Railway core · D1 → Postgres**.

- **`docs/adr/0013-hybrid-deployment-topology.md`** — the topology decision: one Railway project `metagraphed-core` (private-networked microservices), D1 chain sink → Timescale Postgres reached via **Cloudflare Hyperdrive**, a **pruned 128 GB node (not a permanent ~3.5 TB archive)** with one-time backfill, and a documented **Hetzner escape hatch** for when compressed history outgrows Railway's 1 TB cap. Consequences + a 6-step **gated** sequencing.
- **`deploy/postgres/schema.sql`** — portable target schema (vanilla Postgres + optional TimescaleDB hypertables/compression) mirroring the D1 chain tiers (blocks/extrinsics/account_events/neurons/neuron_daily/economics + a generic events tier + indexer cursor), with the audit's recommended indexes. Same idempotent keys → serving changes only its binding.
- **`deploy/README.md`** — operator runbook: verified Railway CLI provisioning, the CF Hyperdrive/Durable-Object additions, and the **gated** steps (node, indexer + backfill, serving cutover, decommission).

## Why this is the whole PR (autonomous-session scope)

The chain migration is **gated by design** (ADR 0012 + this ADR sequence it with verification: "verify ~100% capture vs D1", tier-by-tier cutover). Those gates need a human who can roll back, so I did **not** provision idle infra, stand up the node, or touch live serving unsupervised:
- **No idle provisioning** — managed Postgres/Redis bill from creation but have no consumer until the indexer lands; the runbook provisions them in that phase instead.
- **No prod cutover / decommission** — those are the gated steps.

This PR is the durable, reversible foundation; the remaining phases are tracked as issues (linked).

## Validation

`format:check` · `scan:public-safety` · `validate:docs` all green locally; docs/schema/runbook only — inert to build/test.