### PR TITLE
infra(indexer): continuous chain indexer + bare-metal bring-up stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,7 @@ vite.config.ts.timestamp-*
 /changed-files.txt
 /submitted-artifact-files.txt
 /validate-route.json
+
+# Python bytecode (scripts/ + python/ tests)
+__pycache__/
+*.py[cod]

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,12 @@
+# Copy to deploy/.env and fill in. Used by deploy/docker-compose.yml.
+# NEVER commit deploy/.env (it holds the DB password).
+
+# Required — the Postgres superuser password for the local Timescale instance.
+POSTGRES_PASSWORD=
+
+# Optional overrides (sane defaults in docker-compose.yml):
+# EVENTS_RPC_URL=ws://subtensor:9944      # default: the in-stack node
+# EVENTS_WINDOW=256                        # overlap re-scan floor
+# EVENTS_MAX_LOOKBACK=512                  # raise vs an archive node for long gaps
+# START_BLOCK=                             # cold-cursor historical anchor
+# LOG_LEVEL=INFO

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -27,7 +27,39 @@ private network (`<service>.railway.internal`, zero egress). The existing
 `metagraphed-streamer` project is **separate and untouched** — it is superseded
 by `indexer` only at decommission (final step).
 
-## Provisioning (run when the indexer is ready — NOT before)
+## Bare-metal bring-up (the recommended core — one command)
+
+With a dedicated server (the cost-optimal home for the storage-heavy node +
+Postgres, ADR 0013), co-locate **node + TimescaleDB + Redis + indexer** in one
+stack so every hop is localhost. The whole core comes up with:
+
+```bash
+cp deploy/.env.example deploy/.env     # set POSTGRES_PASSWORD
+docker compose -f deploy/docker-compose.yml --env-file deploy/.env up -d
+```
+
+That starts:
+
+- **`postgres`** (TimescaleDB) — applies `deploy/postgres/schema.sql` on first
+  boot; never binds a public port (Cloudflare reaches it via Hyperdrive over a
+  tunnel).
+- **`redis`** — the indexer cursor + heartbeat mirror.
+- **`subtensor`** — a pruned finney node (the head source + first-party RPC
+  origin). For the one-time historical backfill, point the indexer at a transient
+  archive source via `EVENTS_RPC_URL` / `START_BLOCK` / a raised
+  `EVENTS_MAX_LOOKBACK`.
+- **`indexer`** (`scripts/index-chain.py`) — follows the finalized head from the
+  durable cursor and idempotently writes `blocks` / `extrinsics` /
+  `account_events` into Postgres. Its pure transforms are unit-tested
+  (`scripts/test_index_chain.py`); **verify ~100% capture vs D1 before any
+  serving cutover** (the ADR 0013 gate).
+
+To use **managed Railway Postgres** instead of the in-stack one (for managed
+backups/HA), delete the `postgres` service and point the indexer's
+`DATABASE_URL` at the Railway URL — the schema is portable and nothing else
+changes.
+
+## Provisioning Railway (only if NOT co-locating Postgres on bare metal)
 
 > Idle managed Postgres/Redis bill from the moment they exist, and nothing reads
 > them until the `indexer` lands. Provision as part of the indexer phase, not

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,88 @@
+# Bare-metal "own the core" stack (ADR 0013) — one-command bring-up for the
+# dedicated server: TimescaleDB + Redis + a subtensor node + the continuous
+# indexer, all on one private bridge network (localhost-fast, zero egress).
+#
+#   cd /path/to/metagraphed
+#   cp deploy/.env.example deploy/.env   # set POSTGRES_PASSWORD
+#   docker compose -f deploy/docker-compose.yml --env-file deploy/.env up -d
+#
+# Cloudflare reaches `postgres` via Hyperdrive over a tunnel (it never binds a
+# public port here). To use MANAGED Railway Postgres instead, delete the
+# `postgres` service and point the indexer's DATABASE_URL at the Railway URL —
+# the schema is portable and nothing else changes.
+name: metagraphed-core
+
+services:
+  postgres:
+    image: timescale/timescaledb:2.17.2-pg16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: metagraphed
+      POSTGRES_USER: metagraphed
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in deploy/.env}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      # Applied once on an empty data dir (uncomment the TimescaleDB section in
+      # schema.sql to get compressed hypertables).
+      - ./postgres/schema.sql:/docker-entrypoint-initdb.d/10-schema.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U metagraphed -d metagraphed"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7.4-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--save", "60", "1", "--appendonly", "no"]
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  # The Bittensor node. Pruned by default (128 GB) — it follows the head + serves
+  # the indexer + is the first-party RPC origin. For the one-time historical
+  # backfill, point the indexer at a transient archive source instead (ADR 0013).
+  # If you run subtensor directly on the host, drop this service and set the
+  # indexer's EVENTS_RPC_URL to the host endpoint.
+  subtensor:
+    image: ghcr.io/opentensor/subtensor:latest
+    restart: unless-stopped
+    command:
+      - --chain=finney
+      - --sync=warp
+      - --pruning=2000
+      - --rpc-external
+      - --rpc-cors=all
+    volumes:
+      - subtensordata:/data
+    expose:
+      - "9944"
+
+  indexer:
+    build:
+      context: ..
+      dockerfile: deploy/indexer.Dockerfile
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://metagraphed:${POSTGRES_PASSWORD}@postgres:5432/metagraphed
+      REDIS_URL: redis://redis:6379
+      EVENTS_RPC_URL: ${EVENTS_RPC_URL:-ws://subtensor:9944}
+      EVENTS_WINDOW: ${EVENTS_WINDOW:-256}
+      # Raise against the archive node to recover long historical gaps in one run.
+      EVENTS_MAX_LOOKBACK: ${EVENTS_MAX_LOOKBACK:-512}
+      START_BLOCK: ${START_BLOCK:-}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+
+volumes:
+  pgdata:
+  redisdata:
+  subtensordata:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -43,8 +43,9 @@ services:
       timeout: 5s
       retries: 10
 
-  # The Bittensor node. Pruned by default (128 GB) — it follows the head + serves
-  # the indexer + is the first-party RPC origin. For the one-time historical
+  # The Bittensor node. Pruned by default (--pruning=2000 → small on-disk, not a
+  # full archive) — it follows the head + serves the indexer + is the first-party
+  # RPC origin. For the one-time historical
   # backfill, point the indexer at a transient archive source instead (ADR 0013).
   # If you run subtensor directly on the host, drop this service and set the
   # indexer's EVENTS_RPC_URL to the host endpoint.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -51,7 +51,11 @@ services:
   subtensor:
     image: ghcr.io/opentensor/subtensor:latest
     restart: unless-stopped
+    # `command:` REPLACES the image CMD, so --base-path MUST be re-supplied or the
+    # node writes its DB to its home dir (not the volume) and re-syncs from scratch
+    # on every restart.
     command:
+      - --base-path=/data
       - --chain=finney
       - --sync=warp
       - --pruning=2000

--- a/deploy/indexer.Dockerfile
+++ b/deploy/indexer.Dockerfile
@@ -1,0 +1,31 @@
+# Continuous chain indexer (ADR 0013 / #2110) — replaces the GitHub poller +
+# streamer + */3 drain. Follows the finalized head from a durable cursor and
+# writes blocks/extrinsics/account_events straight into Postgres. Co-located with
+# the node + Postgres on the bare-metal box (deploy/docker-compose.yml), so RPC
+# and DB hops are localhost.
+#
+# Build (from the repo root):
+#   docker build -f deploy/indexer.Dockerfile -t metagraphed-indexer .
+FROM python:3.14-slim
+
+RUN useradd --create-home --uid 10001 indexer
+WORKDIR /app
+
+# Pinned deps: the same substrate-interface as the poller/streamer (verified
+# decode) + psycopg2 for the Postgres sink + redis for the cursor/heartbeat mirror.
+RUN pip install --no-cache-dir \
+      "substrate-interface==1.8.1" \
+      "psycopg2-binary==2.9.10" \
+      "redis==5.2.1"
+
+# Reuse the verified decode (fetch-events.py) + the streamer's decode_head
+# (stream-events.py) — imported, never duplicated.
+COPY scripts/fetch-events.py scripts/stream-events.py scripts/index-chain.py /app/scripts/
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+USER indexer
+# Provide at runtime: DATABASE_URL, EVENTS_RPC_URL, REDIS_URL (optional),
+# START_BLOCK / EVENTS_WINDOW / EVENTS_MAX_LOOKBACK (optional).
+CMD ["python", "scripts/index-chain.py"]

--- a/deploy/indexer.Dockerfile
+++ b/deploy/indexer.Dockerfile
@@ -6,7 +6,12 @@
 #
 # Build (from the repo root):
 #   docker build -f deploy/indexer.Dockerfile -t metagraphed-indexer .
-FROM python:3.14-slim
+#
+# Pinned to 3.13 (not 3.14): psycopg2-binary 2.9.10 ships cp38..cp313 wheels only
+# (no cp314, no abi3, sdist-only), and python:*-slim has no C toolchain — so 3.14
+# can't install it. 3.13 has wheels for every pinned dep and matches the Python
+# the verified decode (fetch-events.py) was validated on.
+FROM python:3.13-slim
 
 RUN useradd --create-home --uid 10001 indexer
 WORKDIR /app

--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -65,6 +65,7 @@ CREATE TABLE IF NOT EXISTS account_events (
   hotkey           TEXT,
   coldkey          TEXT,
   netuid           INTEGER,
+  uid              INTEGER,                 -- neuron uid when the event carries one
   amount           NUMERIC,
   alpha            NUMERIC,
   observed_at      BIGINT NOT NULL,

--- a/scripts/index-chain.py
+++ b/scripts/index-chain.py
@@ -32,6 +32,7 @@ transforms test without them. Run (the compose stack wires these):
   EVENTS_MAX_LOOKBACK   max blocks one backfill reaches back (raise for archive)
 """
 import importlib.util
+import json
 import logging
 import os
 import random
@@ -70,24 +71,52 @@ EVENT_COLS = (
 )
 
 
+def _json_obj(value):
+    """call_args arrives from the verified decode (_safe_json) as a COMPACT JSON
+    STRING, not an object. Parse it back so the single psycopg2 Json() wrap at
+    insert time stores a proper JSONB object — not a double-encoded scalar string
+    (which would break every `call_args->>'…'` serving query)."""
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (ValueError, TypeError):
+            return None
+    return value  # already an object or None
+
+
+def _has_ts(row):
+    """observed_at is BIGINT NOT NULL. decode_head emits None when a block's
+    Timestamp query fails; drop such rows (mirrors the D1-era Worker validators
+    the direct Postgres sink bypasses) so the INSERT never hits a NOT NULL
+    violation. Recent misses self-heal via the overlap re-scan (idempotent
+    re-insert once the timestamp resolves)."""
+    return isinstance(row.get("observed_at"), int)
+
+
 def rows_from_decoded(decoded):
     """PURE: a decoded block (the stream-events.decode_head shape) -> column dicts
     keyed exactly by the Postgres schema. No DB/chain access — unit-tested.
 
     The block + extrinsic dicts already use the schema's column names; account
     events are remapped (amount_tao -> amount, alpha_amount -> alpha) and keep
-    uid (the explorer surfaces it).
+    uid. call_args is decoded from its JSON-string form; rows missing a valid
+    observed_at are dropped (NOT NULL).
     """
     blocks = []
     block = decoded.get("block")
     if block:
-        blocks.append({c: block.get(c) for c in BLOCK_COLS})
-    extrinsics = [
-        {c: x.get(c) for c in EXTRINSIC_COLS}
-        for x in decoded.get("extrinsics") or []
-    ]
-    events = [
-        {
+        b = {c: block.get(c) for c in BLOCK_COLS}
+        if _has_ts(b):
+            blocks.append(b)
+    extrinsics = []
+    for x in decoded.get("extrinsics") or []:
+        row = {c: x.get(c) for c in EXTRINSIC_COLS}
+        row["call_args"] = _json_obj(row["call_args"])
+        if _has_ts(row):
+            extrinsics.append(row)
+    events = []
+    for e in decoded.get("events") or []:
+        row = {
             "block_number": e.get("block_number"),
             "event_index": e.get("event_index"),
             "extrinsic_index": e.get("extrinsic_index"),
@@ -100,8 +129,8 @@ def rows_from_decoded(decoded):
             "alpha": e.get("alpha_amount"),
             "observed_at": e.get("observed_at"),
         }
-        for e in decoded.get("events") or []
-    ]
+        if _has_ts(row):
+            events.append(row)
     return {"blocks": blocks, "extrinsics": extrinsics, "account_events": events}
 
 
@@ -266,11 +295,30 @@ def run():
                 return None
 
             s.subscribe_block_headers(handler, finalized_only=True)
-        except Exception as e:  # noqa: BLE001 — connection lost; reconnect
+        except Exception as e:  # noqa: BLE001 — RPC or DB error; recover + retry
             if _stop:
                 break
+            # Clear any aborted transaction (autocommit is off): a failed INSERT
+            # leaves the connection in InFailedSqlTransaction, so without this the
+            # next read_cursor re-raises "current transaction is aborted" forever —
+            # a tight ~5s crash loop that never advances the cursor. If the
+            # connection itself died, reconnect rather than reuse a dead handle.
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            if getattr(conn, "closed", 0):
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+                try:
+                    conn = psycopg2.connect(db_url)
+                    conn.autocommit = False
+                except Exception:
+                    pass
             sleep_for = backoff + random.uniform(0, backoff / 2)
-            log.error("indexer error (%s) — reconnecting in %.1fs", repr(e)[:160], sleep_for)
+            log.error("indexer error (%s) — recovering in %.1fs", repr(e)[:160], sleep_for)
             time.sleep(sleep_for)
             backoff = min(backoff * 2, MAX_BACKOFF)
     try:

--- a/scripts/index-chain.py
+++ b/scripts/index-chain.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Continuous chain indexer (ADR 0013 / #2110) — the gap-free, prune-proof
+replacement for the GitHub poller + the streamer + the */3 R2-staging drain.
+
+It follows the FINALIZED finney head from a durable cursor and, for each block,
+decodes it with the EXACT verified extractors from fetch-events.py (reused via
+stream-events.decode_head — imported, never duplicated, so there is no decode
+drift) and writes the `blocks` / `extrinsics` / `account_events` rows STRAIGHT
+into Postgres with idempotent `INSERT ... ON CONFLICT DO NOTHING` (the same keys
+as the D1 era, so overlapping ranges re-insert harmlessly). On startup it
+backfills the gap cursor->head; against an archive node, raise
+EVENTS_MAX_LOOKBACK so an arbitrarily long gap is recovered in full. Then it
+subscribes to finalized heads for steady state.
+
+The DRASTIC win is continuity: a single long-running process with a durable
+cursor captures ~100% of blocks, vs the ~58% the coalesced GitHub cron loses
+(ADR 0012). Co-located with the node + Postgres on the bare-metal box (ADR 0013),
+every hop is localhost.
+
+INTEGRATION-PENDING: the pure row-builders + cursor logic are unit-tested
+(scripts/test_index_chain.py, no chain/DB needed). The live RPC/Postgres path is
+verified against the bare-metal node + Postgres once provisioned — the ADR 0013
+gate is "~100% capture vs D1" before any serving cutover.
+
+Heavy deps (psycopg2, substrate-interface) are imported lazily so the pure
+transforms test without them. Run (the compose stack wires these):
+  DATABASE_URL          postgresql://… (the Timescale sink)
+  EVENTS_RPC_URL        ws://subtensor:9944 (the local node)  [default: public finney]
+  REDIS_URL             redis://redis:6379  (optional — cursor/heartbeat mirror)
+  START_BLOCK           cold-cursor anchor (else the overlap floor)
+  EVENTS_WINDOW         overlap re-scan floor (default 256)
+  EVENTS_MAX_LOOKBACK   max blocks one backfill reaches back (raise for archive)
+"""
+import importlib.util
+import logging
+import os
+import random
+import signal
+import sys
+import time
+
+RPC = os.environ.get("EVENTS_RPC_URL", "wss://entrypoint-finney.opentensor.ai:443")
+WINDOW = int(os.environ.get("EVENTS_WINDOW", "256"))
+MAX_LOOKBACK = int(os.environ.get("EVENTS_MAX_LOOKBACK", "512"))
+START_BLOCK = os.environ.get("START_BLOCK")
+MAX_BACKOFF = 60
+SUMMARY_EVERY = max(1, int(os.environ.get("INDEXER_SUMMARY_EVERY_BLOCKS", "50")))
+
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+    stream=sys.stdout,
+)
+log = logging.getLogger("indexer")
+
+# Target table column orders — MUST match deploy/postgres/schema.sql.
+BLOCK_COLS = (
+    "block_number", "block_hash", "parent_hash", "author",
+    "extrinsic_count", "event_count", "spec_version", "observed_at",
+)
+EXTRINSIC_COLS = (
+    "block_number", "extrinsic_index", "extrinsic_hash", "signer",
+    "call_module", "call_function", "success", "fee_tao", "tip_tao",
+    "call_args", "observed_at",
+)
+EVENT_COLS = (
+    "block_number", "event_index", "extrinsic_index", "event_kind",
+    "hotkey", "coldkey", "netuid", "uid", "amount", "alpha", "observed_at",
+)
+
+
+def rows_from_decoded(decoded):
+    """PURE: a decoded block (the stream-events.decode_head shape) -> column dicts
+    keyed exactly by the Postgres schema. No DB/chain access — unit-tested.
+
+    The block + extrinsic dicts already use the schema's column names; account
+    events are remapped (amount_tao -> amount, alpha_amount -> alpha) and keep
+    uid (the explorer surfaces it).
+    """
+    blocks = []
+    block = decoded.get("block")
+    if block:
+        blocks.append({c: block.get(c) for c in BLOCK_COLS})
+    extrinsics = [
+        {c: x.get(c) for c in EXTRINSIC_COLS}
+        for x in decoded.get("extrinsics") or []
+    ]
+    events = [
+        {
+            "block_number": e.get("block_number"),
+            "event_index": e.get("event_index"),
+            "extrinsic_index": e.get("extrinsic_index"),
+            "event_kind": e.get("event_kind"),
+            "hotkey": e.get("hotkey"),
+            "coldkey": e.get("coldkey"),
+            "netuid": e.get("netuid"),
+            "uid": e.get("uid"),
+            "amount": e.get("amount_tao"),
+            "alpha": e.get("alpha_amount"),
+            "observed_at": e.get("observed_at"),
+        }
+        for e in decoded.get("events") or []
+    ]
+    return {"blocks": blocks, "extrinsics": extrinsics, "account_events": events}
+
+
+def backfill_start(cursor, head, start_block_env):
+    """PURE: the first block to index this run. A cold cursor with START_BLOCK set
+    anchors there (initial historical anchor); otherwise the cursor-aware floor
+    from fetch-events.compute_from_block (overlap re-scan + gap recovery)."""
+    if cursor is None and start_block_env is not None:
+        return max(0, int(start_block_env))
+    return _compute_from_block(cursor, head, WINDOW, max_lookback=MAX_LOOKBACK)
+
+
+# --- lazy reuse of the verified decode + cursor math (hyphenated module paths) --
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load(modname, filename):
+    spec = importlib.util.spec_from_file_location(modname, os.path.join(_HERE, filename))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _compute_from_block(cursor, head, window, max_lookback):
+    fe = _load("fetch_events", "fetch-events.py")
+    return fe.compute_from_block(cursor, head, window, max_lookback=max_lookback)
+
+
+def _decode_head():
+    # stream-events imports the verified decode; reuse it so the mapping never
+    # drifts from the streamer/poller.
+    se = _load("stream_events", "stream-events.py")
+    return se.decode_head
+
+
+# --- Postgres I/O (lazy psycopg2) -------------------------------------------
+def _upsert(conn, table, cols, dict_rows, conflict):
+    from psycopg2.extras import Json, execute_values
+
+    if not dict_rows:
+        return 0
+    tuples = []
+    for r in dict_rows:
+        row = []
+        for c in cols:
+            v = r.get(c)
+            if c == "call_args" and v is not None:
+                v = Json(v)
+            row.append(v)
+        tuples.append(tuple(row))
+    sql = (
+        f"INSERT INTO {table} ({', '.join(cols)}) VALUES %s "
+        f"ON CONFLICT ({conflict}) DO NOTHING"
+    )
+    with conn.cursor() as cur:
+        execute_values(cur, sql, tuples)
+        return cur.rowcount
+
+
+def read_cursor(conn):
+    with conn.cursor() as cur:
+        cur.execute("SELECT last_block FROM indexer_cursor WHERE id = 1")
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def write_cursor(conn, redis_client, last_block):
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO indexer_cursor (id, last_block, updated_at) "
+            "VALUES (1, %s, now()) ON CONFLICT (id) DO UPDATE SET "
+            "last_block = GREATEST(indexer_cursor.last_block, EXCLUDED.last_block), "
+            "updated_at = now()",
+            (last_block,),
+        )
+    if redis_client is not None:
+        try:  # heartbeat is best-effort — never fail ingest on a Redis blip
+            redis_client.set("indexer:last_block", last_block)
+            redis_client.set("indexer:heartbeat", int(time.time()))
+        except Exception:
+            pass
+
+
+def process_block(decode_head, s, conn, redis_client, bn):
+    """Decode + idempotently upsert one block, advance the cursor, commit."""
+    rows = rows_from_decoded(decode_head(s, bn))
+    _upsert(conn, "blocks", BLOCK_COLS, rows["blocks"], "block_number")
+    _upsert(conn, "extrinsics", EXTRINSIC_COLS, rows["extrinsics"], "block_number, extrinsic_index")
+    _upsert(conn, "account_events", EVENT_COLS, rows["account_events"], "block_number, event_index")
+    write_cursor(conn, redis_client, bn)
+    conn.commit()
+    return len(rows["account_events"]), len(rows["extrinsics"])
+
+
+_stop = False
+
+
+def _handle_signal(signum, _frame):
+    global _stop
+    _stop = True
+    log.info("received signal %s — shutting down after the current block", signum)
+
+
+def run():
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        log.error("DATABASE_URL is required")
+        sys.exit(1)
+    import psycopg2
+
+    from substrateinterface import SubstrateInterface
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    decode_head = _decode_head()
+    conn = psycopg2.connect(db_url)
+    conn.autocommit = False
+    redis_client = None
+    redis_url = os.environ.get("REDIS_URL")
+    if redis_url:
+        try:
+            import redis
+
+            redis_client = redis.from_url(redis_url)
+        except Exception as e:  # noqa: BLE001 — Redis is an optional heartbeat mirror
+            log.warning("redis unavailable (%s) — heartbeat disabled", repr(e)[:120])
+
+    log.info("starting · rpc=%s · window=%d · max_lookback=%d", RPC, WINDOW, MAX_LOOKBACK)
+    done = 0
+    backoff = 5
+    while not _stop:
+        try:
+            s = SubstrateInterface(url=RPC)
+            backoff = 5  # reset after a clean connect
+            cursor = read_cursor(conn)
+            head = s.get_block_number(s.get_chain_finalised_head())
+            start = backfill_start(cursor, head, START_BLOCK)
+            if start <= head:
+                log.info("backfill #%d..#%d (cursor=%s)", start, head, cursor)
+                for bn in range(start, head + 1):
+                    if _stop:
+                        break
+                    process_block(decode_head, s, conn, redis_client, bn)
+                    done += 1
+                    if done % SUMMARY_EVERY == 0:
+                        log.info("indexed %d blocks · latest=#%d", done, bn)
+            if _stop:
+                break
+            log.info("caught up at #%d — following finalized heads", head)
+
+            def handler(obj, _update_nr, _subscription_id):
+                if _stop:
+                    return True  # non-None cancels the subscription
+                bn = obj["header"]["number"]
+                ev, xt = process_block(decode_head, s, conn, redis_client, bn)
+                nonlocal done
+                done += 1
+                log.debug("block #%d: %d events, %d extrinsics", bn, ev, xt)
+                if done % SUMMARY_EVERY == 0:
+                    log.info("healthy · %d blocks · latest=#%d", done, bn)
+                return None
+
+            s.subscribe_block_headers(handler, finalized_only=True)
+        except Exception as e:  # noqa: BLE001 — connection lost; reconnect
+            if _stop:
+                break
+            sleep_for = backoff + random.uniform(0, backoff / 2)
+            log.error("indexer error (%s) — reconnecting in %.1fs", repr(e)[:160], sleep_for)
+            time.sleep(sleep_for)
+            backoff = min(backoff * 2, MAX_BACKOFF)
+    try:
+        conn.close()
+    except Exception:
+        pass
+    log.info("stopped · indexed %d blocks this run", done)
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/test_index_chain.py
+++ b/scripts/test_index_chain.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Unit tests for the indexer's PURE transforms (no chain/DB needed).
+
+The live RPC/Postgres path is integration-verified against the bare-metal node +
+Postgres (ADR 0013 gate); these lock the column mapping + cursor anchor so a
+schema/decode change can't silently corrupt the write path. Run:
+    python3 -m unittest scripts/test_index_chain.py
+"""
+import importlib.util
+import os
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "index_chain", os.path.join(_HERE, "index-chain.py")
+)
+ic = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ic)
+
+
+def _decoded():
+    """A decoded block in the stream-events.decode_head shape."""
+    return {
+        "block": {
+            "block_number": 100,
+            "block_hash": "0xabc",
+            "parent_hash": "0xpar",
+            "author": "5Author",
+            "extrinsic_count": 3,
+            "event_count": 7,
+            "spec_version": 250,
+            "observed_at": 1_700_000_000_000,
+        },
+        "extrinsics": [
+            {
+                "block_number": 100,
+                "extrinsic_index": 2,
+                "extrinsic_hash": "0xext",
+                "signer": "5Signer",
+                "call_module": "SubtensorModule",
+                "call_function": "add_stake",
+                "success": True,
+                "fee_tao": 0.0001,
+                "tip_tao": 0.0,
+                "call_args": {"hotkey": "5HK", "amount": 1},
+                "observed_at": 1_700_000_000_000,
+            }
+        ],
+        "events": [
+            {
+                "block_number": 100,
+                "event_index": 4,
+                "extrinsic_index": 2,
+                "event_kind": "StakeAdded",
+                "hotkey": "5HK",
+                "coldkey": "5CK",
+                "netuid": 7,
+                "uid": 12,
+                "amount_tao": 1.5,
+                "alpha_amount": 2.5,
+                "observed_at": 1_700_000_000_000,
+            }
+        ],
+    }
+
+
+class RowsFromDecoded(unittest.TestCase):
+    def test_block_row_maps_every_schema_column(self):
+        rows = ic.rows_from_decoded(_decoded())
+        self.assertEqual(len(rows["blocks"]), 1)
+        b = rows["blocks"][0]
+        self.assertEqual(set(b.keys()), set(ic.BLOCK_COLS))
+        self.assertEqual(b["block_number"], 100)
+        self.assertEqual(b["spec_version"], 250)
+        self.assertEqual(b["observed_at"], 1_700_000_000_000)
+
+    def test_extrinsic_row_maps_every_schema_column(self):
+        x = ic.rows_from_decoded(_decoded())["extrinsics"][0]
+        self.assertEqual(set(x.keys()), set(ic.EXTRINSIC_COLS))
+        self.assertEqual(x["extrinsic_index"], 2)
+        self.assertEqual(x["call_module"], "SubtensorModule")
+        self.assertEqual(x["call_args"], {"hotkey": "5HK", "amount": 1})
+
+    def test_event_row_remaps_amount_alpha_and_keeps_uid(self):
+        e = ic.rows_from_decoded(_decoded())["account_events"][0]
+        self.assertEqual(set(e.keys()), set(ic.EVENT_COLS))
+        # decode_head emits amount_tao/alpha_amount; the schema columns are amount/alpha.
+        self.assertEqual(e["amount"], 1.5)
+        self.assertEqual(e["alpha"], 2.5)
+        self.assertEqual(e["uid"], 12)
+        self.assertEqual(e["extrinsic_index"], 2)
+        self.assertNotIn("amount_tao", e)
+
+    def test_no_block_yields_empty_blocks(self):
+        d = _decoded()
+        d["block"] = None
+        rows = ic.rows_from_decoded(d)
+        self.assertEqual(rows["blocks"], [])
+        self.assertEqual(len(rows["account_events"]), 1)
+
+    def test_empty_inputs_are_safe(self):
+        rows = ic.rows_from_decoded({"block": None, "extrinsics": [], "events": []})
+        self.assertEqual(rows, {"blocks": [], "extrinsics": [], "account_events": []})
+        rows2 = ic.rows_from_decoded({})  # missing keys
+        self.assertEqual(rows2, {"blocks": [], "extrinsics": [], "account_events": []})
+
+
+class BackfillStart(unittest.TestCase):
+    def test_cold_cursor_with_start_block_anchors_there(self):
+        # cursor=None + START_BLOCK set short-circuits before any chain/module load.
+        self.assertEqual(ic.backfill_start(None, 9999, "5000"), 5000)
+        self.assertEqual(ic.backfill_start(None, 9999, "0"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_index_chain.py
+++ b/scripts/test_index_chain.py
@@ -42,7 +42,9 @@ def _decoded():
                 "success": True,
                 "fee_tao": 0.0001,
                 "tip_tao": 0.0,
-                "call_args": {"hotkey": "5HK", "amount": 1},
+                # The verified decode (_safe_json) emits call_args as a compact
+                # JSON STRING, not a dict — the shape the indexer must handle.
+                "call_args": '{"hotkey":"5HK","amount":1}',
                 "observed_at": 1_700_000_000_000,
             }
         ],
@@ -79,7 +81,30 @@ class RowsFromDecoded(unittest.TestCase):
         self.assertEqual(set(x.keys()), set(ic.EXTRINSIC_COLS))
         self.assertEqual(x["extrinsic_index"], 2)
         self.assertEqual(x["call_module"], "SubtensorModule")
+
+    def test_call_args_json_string_is_decoded_to_an_object(self):
+        # Regression: the decode emits call_args as a JSON STRING; it must be
+        # parsed to an object so the single Json() wrap stores a JSONB object,
+        # not a double-encoded scalar string.
+        x = ic.rows_from_decoded(_decoded())["extrinsics"][0]
+        self.assertIsInstance(x["call_args"], dict)
         self.assertEqual(x["call_args"], {"hotkey": "5HK", "amount": 1})
+        # Unparseable call_args degrades to None (never a raw string into JSONB).
+        d = _decoded()
+        d["extrinsics"][0]["call_args"] = "{not valid json"
+        self.assertIsNone(ic.rows_from_decoded(d)["extrinsics"][0]["call_args"])
+
+    def test_rows_without_observed_at_are_dropped(self):
+        # observed_at is NOT NULL; a None (Timestamp miss) must be dropped, not
+        # sent to INSERT (which would IntegrityError + wedge the indexer).
+        d = _decoded()
+        d["block"]["observed_at"] = None
+        d["extrinsics"][0]["observed_at"] = None
+        d["events"][0]["observed_at"] = None
+        rows = ic.rows_from_decoded(d)
+        self.assertEqual(rows["blocks"], [])
+        self.assertEqual(rows["extrinsics"], [])
+        self.assertEqual(rows["account_events"], [])
 
     def test_event_row_remaps_amount_alpha_and_keeps_uid(self):
         e = ic.rows_from_decoded(_decoded())["account_events"][0]


### PR DESCRIPTION
## Summary

The keystone of ADR 0013 — the gap-free, prune-proof ingestion that replaces the GitHub poller + streamer + `*/3` drain. **Buildable now, deploy-agnostic** (targets `DATABASE_URL`/`EVENTS_RPC_URL`), so it's drop-in ready the moment the bare-metal node + Postgres land. Part of #2108 (closes #2110).

- **`scripts/index-chain.py`** — follows the finalized head from a durable cursor, reuses the EXACT verified decode (`stream-events.decode_head` over `fetch-events.py` — no drift), and idempotently upserts `blocks`/`extrinsics`/`account_events` into Postgres (`ON CONFLICT DO NOTHING`, same keys as D1). Backfills cursor→head on startup (raise `EVENTS_MAX_LOOKBACK` for an archive node), then subscribes to finalized heads. Exponential-backoff reconnection, graceful SIGTERM/SIGINT, Redis cursor/heartbeat mirror. Heavy deps (psycopg2/substrate) are lazy-imported so the pure transforms test without a chain/DB.
- **`scripts/test_index_chain.py`** — 6 passing unit tests over the pure row mapping (incl. `amount_tao→amount`, `alpha_amount→alpha`, `uid`) + the cursor anchor.
- **`deploy/docker-compose.yml` + `indexer.Dockerfile` + `.env.example`** — one-command bare-metal bring-up (TimescaleDB + Redis + pruned subtensor node + indexer), co-located so every hop is localhost. One-line switch to managed Railway PG.
- **`deploy/postgres/schema.sql`** — add `account_events.uid` (the indexer writes it).
- **`deploy/README.md`** — bare-metal bring-up section.

## Why this is the right "while the server is provisioned" work

It's all deploy-agnostic code — nothing here needs the box up. `docker compose up` on the new server becomes the whole bring-up.

**INTEGRATION-PENDING:** the live RPC/Postgres path is verified against the bare-metal node + Postgres (ADR 0013 gate: **~100% capture vs D1**) before any serving cutover. This PR ships only `scripts/` + `deploy/` — no runtime or CI-path change.

## Validation

`python3 -m unittest scripts/test_index_chain.py` → 6 OK; `format:check` green (yaml/md); `scripts/`+`deploy/` are outside the public-safety scan + Node build, so inert to the existing gates.