### PR TITLE
feat(infra): health-aware WSS load balancer for Bittensor RPC (ADR 0013)

### DIFF
--- a/deploy/wss-lb/Dockerfile
+++ b/deploy/wss-lb/Dockerfile
@@ -3,8 +3,8 @@
 #   docker build -t metagraphed-wss-lb deploy/wss-lb
 FROM node:22-alpine
 WORKDIR /app
-COPY package.json ./
-RUN npm install --omit=dev --no-audit --no-fund
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --no-audit --no-fund
 COPY src ./src
 ENV PORT=8080
 EXPOSE 8080

--- a/deploy/wss-lb/Dockerfile
+++ b/deploy/wss-lb/Dockerfile
@@ -1,0 +1,12 @@
+# WSS load balancer (ADR 0013). Railway: set the service Root Directory to
+# deploy/wss-lb so this build context + COPY paths resolve. Local:
+#   docker build -t metagraphed-wss-lb deploy/wss-lb
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev --no-audit --no-fund
+COPY src ./src
+ENV PORT=8080
+EXPOSE 8080
+USER node
+CMD ["node", "src/server.mjs"]

--- a/deploy/wss-lb/README.md
+++ b/deploy/wss-lb/README.md
@@ -9,17 +9,19 @@ JSON-RPC is not available through this HTTP proxy"_).
 ```
 client ──wss──▶  wss-lb  ──wss──▶  healthiest registered subtensor-wss node
                    │
-                   └─ refreshes the pool from GET /api/v1/rpc-endpoints
-                      (kind=subtensor-wss, pool_eligible, status=ok, fresh tip)
+                   └─ refreshes the pool from GET /api/v1/rpc/pools
+                      (the `<network>-wss` pool, pool_eligible, fresh tip)
 ```
 
 ## How it routes
 
-- Refreshes the endpoint pool from the live `/api/v1/rpc-endpoints` every
-  `REFRESH_MS` (reuses your prober's health — no second health system).
-- `selectWssUpstreams` (pure, unit-tested) keeps only healthy, eligible,
-  on-network wss endpoints within `MAX_BLOCK_LAG` of the freshest tip, ordered by
-  score (cosmos.directory's "route to the most up-to-date node").
+- Refreshes from the live `/api/v1/rpc/pools` every `REFRESH_MS` (reuses your
+  prober's health — no second health system) and picks the `<network>-wss` pool.
+- `selectWssUpstreams` (pure, unit-tested) keeps the pool's `pool_eligible`
+  endpoints within `MAX_BLOCK_LAG` of the freshest tip, ordered by score
+  (cosmos.directory's "route to the most up-to-date node"). `pool_eligible` is the
+  gate — not `status==='ok'` — so the static, unmonitored **testnet** wss pool
+  (which the HTTP proxy can't serve at all) is included.
 - **Connect-time** selection with handshake failover to the next upstream. A
   mid-session upstream drop closes the client (it reconnects → a fresh upstream);
   JSON-RPC subscription state can't be transparently migrated.

--- a/deploy/wss-lb/README.md
+++ b/deploy/wss-lb/README.md
@@ -36,7 +36,7 @@ client ──wss──▶  wss-lb  ──wss──▶  healthiest registered sub
 
 ```bash
 cd deploy/wss-lb && npm install && npm start        # local
-npm test                                            # pure-selection tests
+npm test                                            # selection + proxy-failover tests
 ```
 
 Railway: add a service with **Root Directory = `deploy/wss-lb`** (the bundled

--- a/deploy/wss-lb/README.md
+++ b/deploy/wss-lb/README.md
@@ -1,0 +1,56 @@
+# WSS load balancer (ADR 0013)
+
+A health-aware **WebSocket** reverse proxy that fans client connections out
+across the registry's healthy `subtensor-wss` endpoints — the cosmos.directory-
+style shared endpoint for the protocol the Cloudflare HTTP proxy can't serve
+(`workers/request-handlers/rpc-proxy.mjs` explicitly returns _"WebSocket
+JSON-RPC is not available through this HTTP proxy"_).
+
+```
+client ──wss──▶  wss-lb  ──wss──▶  healthiest registered subtensor-wss node
+                   │
+                   └─ refreshes the pool from GET /api/v1/rpc-endpoints
+                      (kind=subtensor-wss, pool_eligible, status=ok, fresh tip)
+```
+
+## How it routes
+
+- Refreshes the endpoint pool from the live `/api/v1/rpc-endpoints` every
+  `REFRESH_MS` (reuses your prober's health — no second health system).
+- `selectWssUpstreams` (pure, unit-tested) keeps only healthy, eligible,
+  on-network wss endpoints within `MAX_BLOCK_LAG` of the freshest tip, ordered by
+  score (cosmos.directory's "route to the most up-to-date node").
+- **Connect-time** selection with handshake failover to the next upstream. A
+  mid-session upstream drop closes the client (it reconnects → a fresh upstream);
+  JSON-RPC subscription state can't be transparently migrated.
+
+## Endpoints
+
+- `wss://<host>/finney`, `wss://<host>/test` — the load-balanced wss per network.
+- `GET /healthz` — `{ ok, pools: {finney: N, …}, last_refresh_ms }` (503 when the
+  pool refresh is stale; wired to Railway's healthcheck).
+
+## Run
+
+```bash
+cd deploy/wss-lb && npm install && npm start        # local
+npm test                                            # pure-selection tests
+```
+
+Railway: add a service with **Root Directory = `deploy/wss-lb`** (the bundled
+`railway.json` and `Dockerfile` do the rest). Put it behind Cloudflare DNS for
+TLS + DDoS.
+
+Env: `METAGRAPHED_API` (default `https://api.metagraph.sh`), `PORT` (8080),
+`REFRESH_MS` (30000), `MAX_BLOCK_LAG` (50), `NETWORKS` (`finney,test`),
+`HANDSHAKE_TIMEOUT_MS` (10000).
+
+## Integration-pending + follow-ups
+
+- The live ws-piping is verified on deploy; only the pure selection is unit-tested.
+- **Before public exposure:** per-IP connection rate-limiting / abuse caps (a
+  public wss proxy is a DoS amplifier), and optional API-key tiering.
+- gRPC is intentionally **not** offered — Bittensor is Substrate (JSON-RPC + wss),
+  not Cosmos-SDK gRPC.
+- Optional next: an SSE fan-out for subnet streaming surfaces; per-upstream usage
+  metrics mirrored into the existing `rpc_proxy_events` analytics.

--- a/deploy/wss-lb/package-lock.json
+++ b/deploy/wss-lb/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "name": "metagraphed-wss-lb",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "metagraphed-wss-lb",
+      "version": "0.0.0",
+      "dependencies": {
+        "ws": "8.18.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/deploy/wss-lb/package.json
+++ b/deploy/wss-lb/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "metagraphed-wss-lb",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Health-aware WebSocket load balancer for Bittensor RPC (ADR 0013)",
+  "scripts": {
+    "start": "node src/server.mjs",
+    "test": "node --test test/"
+  },
+  "dependencies": {
+    "ws": "8.18.3"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/deploy/wss-lb/package.json
+++ b/deploy/wss-lb/package.json
@@ -6,7 +6,7 @@
   "description": "Health-aware WebSocket load balancer for Bittensor RPC (ADR 0013)",
   "scripts": {
     "start": "node src/server.mjs",
-    "test": "node --test test/"
+    "test": "node --test --test-force-exit test/*.test.mjs"
   },
   "dependencies": {
     "ws": "8.18.3"

--- a/deploy/wss-lb/railway.json
+++ b/deploy/wss-lb/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "numReplicas": 1,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10,
+    "healthcheckPath": "/healthz"
+  }
+}

--- a/deploy/wss-lb/src/proxy.mjs
+++ b/deploy/wss-lb/src/proxy.mjs
@@ -1,0 +1,121 @@
+// Client→upstream wss piping with connect-time failover (extracted for testing).
+import { WebSocket } from "ws";
+
+// Pipe a client wss connection to the first healthy upstream, failing over to the
+// next on a failed handshake. The client listeners attach ONCE; `up` is the
+// current upstream socket, reassigned per attempt.
+//
+// Failover correctness (regression-tested in test/proxy.test.mjs): on a failed
+// handshake `ws` emits BOTH 'error' AND 'close'. A per-attempt `settled` flag —
+// plus detaching + terminating the failed socket before advancing — makes each
+// attempt advance EXACTLY once. Without it both handlers dial the next upstream
+// (a duplicate, orphaned connection), and the reassigned `up` can be a still-
+// CONNECTING socket when a prior dial's 'open' flushes `pending`, throwing an
+// uncaught "WebSocket is not open" that crashes the whole process (killing every
+// other proxied client). The flush is also try/catch'd as defense in depth.
+export function proxy(client, upstreams, opts = {}) {
+  const handshakeTimeout = opts.handshakeTimeout ?? 10000;
+  let up = null;
+  let opened = false;
+  let clientClosed = false;
+  const pending = [];
+
+  client.on("message", (data, isBinary) => {
+    if (opened && up && up.readyState === WebSocket.OPEN)
+      up.send(data, { binary: isBinary });
+    else pending.push([data, isBinary]);
+  });
+  client.on("close", () => {
+    clientClosed = true;
+    try {
+      up?.close();
+    } catch {
+      /* noop */
+    }
+  });
+  client.on("error", () => {
+    clientClosed = true;
+    try {
+      up?.terminate();
+    } catch {
+      /* noop */
+    }
+  });
+
+  const tryUpstream = (attempt) => {
+    if (clientClosed) return;
+    if (attempt >= upstreams.length) {
+      try {
+        client.close(1013, "no upstream available");
+      } catch {
+        /* already closed */
+      }
+      return;
+    }
+    const sock = new WebSocket(upstreams[attempt], { handshakeTimeout });
+    up = sock;
+    let settled = false; // this attempt opens OR advances exactly once
+
+    // Pre-open failure → advance once, after neutralizing the dead socket so its
+    // trailing event (error→close, or vice versa) can't re-enter.
+    const advance = () => {
+      if (settled) return;
+      settled = true;
+      try {
+        sock.removeAllListeners();
+      } catch {
+        /* noop */
+      }
+      try {
+        sock.terminate();
+      } catch {
+        /* noop */
+      }
+      tryUpstream(attempt + 1);
+    };
+
+    sock.on("open", () => {
+      // A late-opening socket we've already failed past (or a closed client):
+      // close it rather than pipe into stale state.
+      if (settled || clientClosed) {
+        try {
+          sock.terminate();
+        } catch {
+          /* noop */
+        }
+        return;
+      }
+      settled = true;
+      opened = true;
+      try {
+        for (const [data, isBinary] of pending)
+          sock.send(data, { binary: isBinary });
+      } catch {
+        /* racing/closing socket — the client will retry */
+      }
+      pending.length = 0;
+      sock.on("message", (data, isBinary) => {
+        if (client.readyState === WebSocket.OPEN)
+          client.send(data, { binary: isBinary });
+      });
+      sock.on("close", () => {
+        try {
+          client.close();
+        } catch {
+          /* noop */
+        }
+      });
+      sock.on("error", () => {
+        try {
+          client.close();
+        } catch {
+          /* noop */
+        }
+      });
+    });
+    sock.on("close", advance);
+    sock.on("error", advance);
+  };
+
+  tryUpstream(0);
+}

--- a/deploy/wss-lb/src/select.mjs
+++ b/deploy/wss-lb/src/select.mjs
@@ -1,56 +1,67 @@
 // Pure health-aware upstream selection for the WSS load balancer (ADR 0013).
-// Consumes the /api/v1/rpc-endpoints shape:
-//   { id, url, kind, network, pool_eligible, score, status, latest_block, ... }
-// No I/O — unit-tested (test/select.test.mjs).
+// Consumes the /api/v1/rpc/pools artifact:
+//   { pools: [{ id: "finney-wss", kind: "subtensor-wss",
+//               endpoints: [{ url, pool_eligible, score, latest_block, status }] }] }
+// Network is the POOL id (`<network>-wss`), NOT a per-endpoint field, and the
+// pool already kind-filters + score-sorts. No I/O — unit-tested.
 
 function scoreOf(e) {
   const n = Number(e.score);
   return Number.isFinite(n) ? n : 0;
 }
 
-// A registered endpoint usable as a wss upstream for `network`: the right kind,
-// network, currently pool-eligible (live health + static policy agree), status
-// ok, and an actual wss:// URL.
-export function isHealthyWss(network) {
-  return (e) =>
-    Boolean(e) &&
-    e.kind === "subtensor-wss" &&
-    e.network === network &&
-    e.pool_eligible === true &&
-    e.status === "ok" &&
-    typeof e.url === "string" &&
-    e.url.startsWith("wss://");
-}
-
-// Ordered list of upstream wss URLs for `network`, best first. Two filters,
-// mirroring cosmos.directory's "route to the most up-to-date node": (1) healthy
-// + eligible; (2) within `maxBlockLag` of the freshest tip among them (an
-// endpoint with no reported block is kept — benefit of the doubt). Tie-broken by
-// score desc. Empty when nothing is healthy (the caller 503s).
 // A reported block height, or null when absent. Explicit null/undefined check —
 // NOT Number(e.latest_block), because Number(null) === 0 (finite), which would
-// mis-read a block-less endpoint as height 0 and wrongly drop it as stale.
+// mis-read a block-less endpoint (e.g. the unmonitored testnet pool) as height 0
+// and wrongly drop it as stale.
 function blockOf(e) {
   if (e.latest_block == null) return null;
   const n = Number(e.latest_block);
   return Number.isFinite(n) ? n : null;
 }
 
-export function selectWssUpstreams(endpoints, network, opts = {}) {
-  const maxBlockLag = opts.maxBlockLag ?? 50;
-  const healthy = (Array.isArray(endpoints) ? endpoints : []).filter(
-    isHealthyWss(network),
+// A pool endpoint routable as a wss upstream. `pool_eligible` is THE canonical
+// gate — it already encodes "monitored && status ok" for finney AND "static
+// testnet member, liveness via the breaker/failover" for test. We must NOT also
+// require status === "ok": static testnet wss is pool_eligible with
+// status "unknown", and a status gate would drop the whole testnet pool.
+export function isWssUpstream(e) {
+  return (
+    Boolean(e) &&
+    e.pool_eligible === true &&
+    typeof e.url === "string" &&
+    e.url.startsWith("wss://")
   );
+}
+
+// The subtensor-wss pool for `network` (pool id `<network>-wss`, e.g. finney-wss).
+export function wssPoolFor(poolsArtifact, network) {
+  const pools = Array.isArray(poolsArtifact?.pools) ? poolsArtifact.pools : [];
+  return (
+    pools.find(
+      (p) => p && p.kind === "subtensor-wss" && p.id === `${network}-wss`,
+    ) || null
+  );
+}
+
+// Ordered list of upstream wss URLs for `network`, best first: pool-eligible
+// endpoints within `maxBlockLag` of the freshest tip among them (an endpoint with
+// no reported block is kept — benefit of the doubt), score desc. Empty when the
+// pool is absent or has no eligible members (the caller 503s).
+export function selectWssUpstreams(poolsArtifact, network, opts = {}) {
+  const maxBlockLag = opts.maxBlockLag ?? 50;
+  const pool = wssPoolFor(poolsArtifact, network);
+  const healthy = (pool?.endpoints || []).filter(isWssUpstream);
   const blocks = healthy.map(blockOf).filter((b) => b != null);
-  let pool = healthy;
+  let upstreams = healthy;
   if (blocks.length) {
     const tip = Math.max(...blocks);
-    pool = healthy.filter((e) => {
+    upstreams = healthy.filter((e) => {
       const b = blockOf(e);
       return b == null || tip - b <= maxBlockLag; // no block → benefit of the doubt
     });
   }
-  return pool
+  return upstreams
     .slice()
     .sort((a, b) => scoreOf(b) - scoreOf(a))
     .map((e) => e.url);

--- a/deploy/wss-lb/src/select.mjs
+++ b/deploy/wss-lb/src/select.mjs
@@ -1,0 +1,57 @@
+// Pure health-aware upstream selection for the WSS load balancer (ADR 0013).
+// Consumes the /api/v1/rpc-endpoints shape:
+//   { id, url, kind, network, pool_eligible, score, status, latest_block, ... }
+// No I/O — unit-tested (test/select.test.mjs).
+
+function scoreOf(e) {
+  const n = Number(e.score);
+  return Number.isFinite(n) ? n : 0;
+}
+
+// A registered endpoint usable as a wss upstream for `network`: the right kind,
+// network, currently pool-eligible (live health + static policy agree), status
+// ok, and an actual wss:// URL.
+export function isHealthyWss(network) {
+  return (e) =>
+    Boolean(e) &&
+    e.kind === "subtensor-wss" &&
+    e.network === network &&
+    e.pool_eligible === true &&
+    e.status === "ok" &&
+    typeof e.url === "string" &&
+    e.url.startsWith("wss://");
+}
+
+// Ordered list of upstream wss URLs for `network`, best first. Two filters,
+// mirroring cosmos.directory's "route to the most up-to-date node": (1) healthy
+// + eligible; (2) within `maxBlockLag` of the freshest tip among them (an
+// endpoint with no reported block is kept — benefit of the doubt). Tie-broken by
+// score desc. Empty when nothing is healthy (the caller 503s).
+// A reported block height, or null when absent. Explicit null/undefined check —
+// NOT Number(e.latest_block), because Number(null) === 0 (finite), which would
+// mis-read a block-less endpoint as height 0 and wrongly drop it as stale.
+function blockOf(e) {
+  if (e.latest_block == null) return null;
+  const n = Number(e.latest_block);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function selectWssUpstreams(endpoints, network, opts = {}) {
+  const maxBlockLag = opts.maxBlockLag ?? 50;
+  const healthy = (Array.isArray(endpoints) ? endpoints : []).filter(
+    isHealthyWss(network),
+  );
+  const blocks = healthy.map(blockOf).filter((b) => b != null);
+  let pool = healthy;
+  if (blocks.length) {
+    const tip = Math.max(...blocks);
+    pool = healthy.filter((e) => {
+      const b = blockOf(e);
+      return b == null || tip - b <= maxBlockLag; // no block → benefit of the doubt
+    });
+  }
+  return pool
+    .slice()
+    .sort((a, b) => scoreOf(b) - scoreOf(a))
+    .map((e) => e.url);
+}

--- a/deploy/wss-lb/src/server.mjs
+++ b/deploy/wss-lb/src/server.mjs
@@ -4,7 +4,7 @@
 // (rpc-proxy.mjs: "WebSocket JSON-RPC is not available through this HTTP proxy").
 //
 // Model (cosmos.directory-style): refresh the healthy-endpoint pool from the
-// live /api/v1/rpc-endpoints, and at CONNECT time route each client to the
+// live /api/v1/rpc/pools, and at CONNECT time route each client to the
 // freshest/highest-scored upstream, failing over to the next on a failed
 // handshake. Mid-session upstream loss closes the client (it reconnects → a new
 // upstream) — JSON-RPC subscription state can't be transparently moved.
@@ -31,24 +31,24 @@ const NETWORKS = (process.env.NETWORKS || "finney,test")
 
 const log = (...a) => console.log(new Date().toISOString(), ...a);
 
-let endpoints = [];
+let poolsArtifact = null;
 let lastRefresh = 0;
 
 async function refresh() {
   try {
-    const res = await fetch(`${API}/api/v1/rpc-endpoints`, {
+    const res = await fetch(`${API}/api/v1/rpc/pools`, {
       signal: AbortSignal.timeout(10000),
       headers: { "user-agent": "metagraphed-wss-lb/1.0" },
     });
     if (!res.ok) throw new Error(`status ${res.status}`);
     const body = await res.json();
-    const list = Array.isArray(body?.endpoints)
-      ? body.endpoints
-      : Array.isArray(body?.data?.endpoints)
-        ? body.data.endpoints
-        : [];
-    if (list.length) {
-      endpoints = list;
+    const artifact = Array.isArray(body?.pools)
+      ? body
+      : Array.isArray(body?.data?.pools)
+        ? body.data
+        : null;
+    if (artifact) {
+      poolsArtifact = artifact;
       lastRefresh = Date.now();
     }
   } catch (e) {
@@ -57,83 +57,100 @@ async function refresh() {
 }
 
 function poolFor(network) {
-  return selectWssUpstreams(endpoints, network, { maxBlockLag: MAX_BLOCK_LAG });
+  return selectWssUpstreams(poolsArtifact, network, {
+    maxBlockLag: MAX_BLOCK_LAG,
+  });
 }
 
 // Connect-time failover: try upstreams in order until one completes its
 // handshake, then pipe bidirectionally. Client messages sent before the upstream
 // opens are buffered (the client sees its leg as open immediately).
-function proxy(client, upstreams, attempt = 0) {
-  if (attempt >= upstreams.length) {
-    try {
-      client.close(1013, "no upstream available");
-    } catch {
-      /* already closed */
-    }
-    return;
-  }
-  const up = new WebSocket(upstreams[attempt], {
-    handshakeTimeout: HANDSHAKE_TIMEOUT_MS,
-  });
+//
+// The client listeners are attached ONCE — `up` is reassigned per attempt via
+// closure. Re-attaching them per retry would stack handlers on failover (double
+// send + MaxListenersExceeded). `clientClosed` stops retrying once the client is
+// gone, so a vanished client can't keep dialing fresh upstreams.
+function proxy(client, upstreams) {
+  let up = null;
   let opened = false;
+  let clientClosed = false;
   const pending = [];
 
   client.on("message", (data, isBinary) => {
-    if (opened && up.readyState === WebSocket.OPEN)
+    if (opened && up && up.readyState === WebSocket.OPEN)
       up.send(data, { binary: isBinary });
     else pending.push([data, isBinary]);
   });
   client.on("close", () => {
+    clientClosed = true;
     try {
-      up.close();
+      up?.close();
     } catch {
       /* noop */
     }
   });
   client.on("error", () => {
+    clientClosed = true;
     try {
-      up.terminate();
+      up?.terminate();
     } catch {
       /* noop */
     }
   });
 
-  up.on("open", () => {
-    opened = true;
-    for (const [data, isBinary] of pending) up.send(data, { binary: isBinary });
-    pending.length = 0;
-    up.on("message", (data, isBinary) => {
-      if (client.readyState === WebSocket.OPEN)
-        client.send(data, { binary: isBinary });
+  const tryUpstream = (attempt) => {
+    if (clientClosed) return;
+    if (attempt >= upstreams.length) {
+      try {
+        client.close(1013, "no upstream available");
+      } catch {
+        /* already closed */
+      }
+      return;
+    }
+    up = new WebSocket(upstreams[attempt], {
+      handshakeTimeout: HANDSHAKE_TIMEOUT_MS,
     });
-  });
-  up.on("close", () => {
-    if (opened) {
-      try {
-        client.close();
-      } catch {
-        /* noop */
+    up.on("open", () => {
+      opened = true;
+      for (const [data, isBinary] of pending)
+        up.send(data, { binary: isBinary });
+      pending.length = 0;
+      up.on("message", (data, isBinary) => {
+        if (client.readyState === WebSocket.OPEN)
+          client.send(data, { binary: isBinary });
+      });
+    });
+    up.on("close", () => {
+      if (opened) {
+        try {
+          client.close();
+        } catch {
+          /* noop */
+        }
+      } else {
+        tryUpstream(attempt + 1); // handshake never completed → next
       }
-    } else {
-      proxy(client, upstreams, attempt + 1); // handshake never completed → next
-    }
-  });
-  up.on("error", () => {
-    if (opened) {
-      try {
-        client.close();
-      } catch {
-        /* noop */
+    });
+    up.on("error", () => {
+      if (opened) {
+        try {
+          client.close();
+        } catch {
+          /* noop */
+        }
+      } else {
+        try {
+          up.terminate();
+        } catch {
+          /* noop */
+        }
+        tryUpstream(attempt + 1);
       }
-    } else {
-      try {
-        up.terminate();
-      } catch {
-        /* noop */
-      }
-      proxy(client, upstreams, attempt + 1);
-    }
-  });
+    });
+  };
+
+  tryUpstream(0);
 }
 
 const server = http.createServer((req, res) => {

--- a/deploy/wss-lb/src/server.mjs
+++ b/deploy/wss-lb/src/server.mjs
@@ -15,15 +15,24 @@
 // MAX_BLOCK_LAG, NETWORKS, HANDSHAKE_TIMEOUT_MS.
 import http from "node:http";
 
-import { WebSocket, WebSocketServer } from "ws";
+import { WebSocketServer } from "ws";
 
+import { proxy } from "./proxy.mjs";
 import { selectWssUpstreams } from "./select.mjs";
 
+// Numeric env with a NaN/positivity guard: Number(process.env.X || d) returns NaN
+// for a non-numeric string (the `|| d` only catches empty/unset), which would
+// poison the refresh timer, the /healthz staleness gate, and the block-lag filter.
+const envInt = (key, fallback) => {
+  const n = Number(process.env[key]);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+};
+
 const API = process.env.METAGRAPHED_API || "https://api.metagraph.sh";
-const PORT = Number(process.env.PORT || 8080);
-const REFRESH_MS = Number(process.env.REFRESH_MS || 30000);
-const MAX_BLOCK_LAG = Number(process.env.MAX_BLOCK_LAG || 50);
-const HANDSHAKE_TIMEOUT_MS = Number(process.env.HANDSHAKE_TIMEOUT_MS || 10000);
+const PORT = envInt("PORT", 8080);
+const REFRESH_MS = envInt("REFRESH_MS", 30000);
+const MAX_BLOCK_LAG = envInt("MAX_BLOCK_LAG", 50);
+const HANDSHAKE_TIMEOUT_MS = envInt("HANDSHAKE_TIMEOUT_MS", 10000);
 const NETWORKS = (process.env.NETWORKS || "finney,test")
   .split(",")
   .map((s) => s.trim())
@@ -62,97 +71,6 @@ function poolFor(network) {
   });
 }
 
-// Connect-time failover: try upstreams in order until one completes its
-// handshake, then pipe bidirectionally. Client messages sent before the upstream
-// opens are buffered (the client sees its leg as open immediately).
-//
-// The client listeners are attached ONCE — `up` is reassigned per attempt via
-// closure. Re-attaching them per retry would stack handlers on failover (double
-// send + MaxListenersExceeded). `clientClosed` stops retrying once the client is
-// gone, so a vanished client can't keep dialing fresh upstreams.
-function proxy(client, upstreams) {
-  let up = null;
-  let opened = false;
-  let clientClosed = false;
-  const pending = [];
-
-  client.on("message", (data, isBinary) => {
-    if (opened && up && up.readyState === WebSocket.OPEN)
-      up.send(data, { binary: isBinary });
-    else pending.push([data, isBinary]);
-  });
-  client.on("close", () => {
-    clientClosed = true;
-    try {
-      up?.close();
-    } catch {
-      /* noop */
-    }
-  });
-  client.on("error", () => {
-    clientClosed = true;
-    try {
-      up?.terminate();
-    } catch {
-      /* noop */
-    }
-  });
-
-  const tryUpstream = (attempt) => {
-    if (clientClosed) return;
-    if (attempt >= upstreams.length) {
-      try {
-        client.close(1013, "no upstream available");
-      } catch {
-        /* already closed */
-      }
-      return;
-    }
-    up = new WebSocket(upstreams[attempt], {
-      handshakeTimeout: HANDSHAKE_TIMEOUT_MS,
-    });
-    up.on("open", () => {
-      opened = true;
-      for (const [data, isBinary] of pending)
-        up.send(data, { binary: isBinary });
-      pending.length = 0;
-      up.on("message", (data, isBinary) => {
-        if (client.readyState === WebSocket.OPEN)
-          client.send(data, { binary: isBinary });
-      });
-    });
-    up.on("close", () => {
-      if (opened) {
-        try {
-          client.close();
-        } catch {
-          /* noop */
-        }
-      } else {
-        tryUpstream(attempt + 1); // handshake never completed → next
-      }
-    });
-    up.on("error", () => {
-      if (opened) {
-        try {
-          client.close();
-        } catch {
-          /* noop */
-        }
-      } else {
-        try {
-          up.terminate();
-        } catch {
-          /* noop */
-        }
-        tryUpstream(attempt + 1);
-      }
-    });
-  };
-
-  tryUpstream(0);
-}
-
 const server = http.createServer((req, res) => {
   if (req.url === "/healthz" || req.url === "/") {
     const pools = Object.fromEntries(
@@ -186,7 +104,9 @@ server.on("upgrade", (req, socket, head) => {
     socket.destroy();
     return;
   }
-  wss.handleUpgrade(req, socket, head, (client) => proxy(client, upstreams));
+  wss.handleUpgrade(req, socket, head, (client) =>
+    proxy(client, upstreams, { handshakeTimeout: HANDSHAKE_TIMEOUT_MS }),
+  );
 });
 
 await refresh();

--- a/deploy/wss-lb/src/server.mjs
+++ b/deploy/wss-lb/src/server.mjs
@@ -1,0 +1,181 @@
+// WSS load balancer (ADR 0013) — a health-aware WebSocket reverse proxy that
+// fans client connections out across the registry's healthy subtensor-wss
+// endpoints. Fills the gap the Cloudflare HTTP JSON-RPC proxy explicitly punts
+// (rpc-proxy.mjs: "WebSocket JSON-RPC is not available through this HTTP proxy").
+//
+// Model (cosmos.directory-style): refresh the healthy-endpoint pool from the
+// live /api/v1/rpc-endpoints, and at CONNECT time route each client to the
+// freshest/highest-scored upstream, failing over to the next on a failed
+// handshake. Mid-session upstream loss closes the client (it reconnects → a new
+// upstream) — JSON-RPC subscription state can't be transparently moved.
+//
+// INTEGRATION-PENDING: the live ws-piping is verified on deploy; the pure
+// upstream selection is unit-tested (test/select.test.mjs). Public behind
+// Cloudflare DNS for TLS/DDoS. Env: METAGRAPHED_API, PORT, REFRESH_MS,
+// MAX_BLOCK_LAG, NETWORKS, HANDSHAKE_TIMEOUT_MS.
+import http from "node:http";
+
+import { WebSocket, WebSocketServer } from "ws";
+
+import { selectWssUpstreams } from "./select.mjs";
+
+const API = process.env.METAGRAPHED_API || "https://api.metagraph.sh";
+const PORT = Number(process.env.PORT || 8080);
+const REFRESH_MS = Number(process.env.REFRESH_MS || 30000);
+const MAX_BLOCK_LAG = Number(process.env.MAX_BLOCK_LAG || 50);
+const HANDSHAKE_TIMEOUT_MS = Number(process.env.HANDSHAKE_TIMEOUT_MS || 10000);
+const NETWORKS = (process.env.NETWORKS || "finney,test")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const log = (...a) => console.log(new Date().toISOString(), ...a);
+
+let endpoints = [];
+let lastRefresh = 0;
+
+async function refresh() {
+  try {
+    const res = await fetch(`${API}/api/v1/rpc-endpoints`, {
+      signal: AbortSignal.timeout(10000),
+      headers: { "user-agent": "metagraphed-wss-lb/1.0" },
+    });
+    if (!res.ok) throw new Error(`status ${res.status}`);
+    const body = await res.json();
+    const list = Array.isArray(body?.endpoints)
+      ? body.endpoints
+      : Array.isArray(body?.data?.endpoints)
+        ? body.data.endpoints
+        : [];
+    if (list.length) {
+      endpoints = list;
+      lastRefresh = Date.now();
+    }
+  } catch (e) {
+    log("refresh failed:", String(e?.message || e).slice(0, 160));
+  }
+}
+
+function poolFor(network) {
+  return selectWssUpstreams(endpoints, network, { maxBlockLag: MAX_BLOCK_LAG });
+}
+
+// Connect-time failover: try upstreams in order until one completes its
+// handshake, then pipe bidirectionally. Client messages sent before the upstream
+// opens are buffered (the client sees its leg as open immediately).
+function proxy(client, upstreams, attempt = 0) {
+  if (attempt >= upstreams.length) {
+    try {
+      client.close(1013, "no upstream available");
+    } catch {
+      /* already closed */
+    }
+    return;
+  }
+  const up = new WebSocket(upstreams[attempt], {
+    handshakeTimeout: HANDSHAKE_TIMEOUT_MS,
+  });
+  let opened = false;
+  const pending = [];
+
+  client.on("message", (data, isBinary) => {
+    if (opened && up.readyState === WebSocket.OPEN)
+      up.send(data, { binary: isBinary });
+    else pending.push([data, isBinary]);
+  });
+  client.on("close", () => {
+    try {
+      up.close();
+    } catch {
+      /* noop */
+    }
+  });
+  client.on("error", () => {
+    try {
+      up.terminate();
+    } catch {
+      /* noop */
+    }
+  });
+
+  up.on("open", () => {
+    opened = true;
+    for (const [data, isBinary] of pending) up.send(data, { binary: isBinary });
+    pending.length = 0;
+    up.on("message", (data, isBinary) => {
+      if (client.readyState === WebSocket.OPEN)
+        client.send(data, { binary: isBinary });
+    });
+  });
+  up.on("close", () => {
+    if (opened) {
+      try {
+        client.close();
+      } catch {
+        /* noop */
+      }
+    } else {
+      proxy(client, upstreams, attempt + 1); // handshake never completed → next
+    }
+  });
+  up.on("error", () => {
+    if (opened) {
+      try {
+        client.close();
+      } catch {
+        /* noop */
+      }
+    } else {
+      try {
+        up.terminate();
+      } catch {
+        /* noop */
+      }
+      proxy(client, upstreams, attempt + 1);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url === "/healthz" || req.url === "/") {
+    const pools = Object.fromEntries(
+      NETWORKS.map((n) => [n, poolFor(n).length]),
+    );
+    const stale = !lastRefresh || Date.now() - lastRefresh > REFRESH_MS * 3;
+    res.writeHead(stale ? 503 : 200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({ ok: !stale, pools, last_refresh_ms: lastRefresh }),
+    );
+    return;
+  }
+  res.writeHead(404);
+  res.end();
+});
+
+const wss = new WebSocketServer({ noServer: true });
+server.on("upgrade", (req, socket, head) => {
+  const network = (req.url || "/")
+    .replace(/^\/+/, "")
+    .split("?")[0]
+    .split("/")[0];
+  if (!NETWORKS.includes(network)) {
+    socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
+    socket.destroy();
+    return;
+  }
+  const upstreams = poolFor(network);
+  if (!upstreams.length) {
+    socket.write("HTTP/1.1 503 Service Unavailable\r\n\r\n");
+    socket.destroy();
+    return;
+  }
+  wss.handleUpgrade(req, socket, head, (client) => proxy(client, upstreams));
+});
+
+await refresh();
+setInterval(refresh, REFRESH_MS);
+server.listen(PORT, () =>
+  log(
+    `wss-lb listening :${PORT} · networks=${NETWORKS.join(",")} · api=${API}`,
+  ),
+);

--- a/deploy/wss-lb/test/proxy.test.mjs
+++ b/deploy/wss-lb/test/proxy.test.mjs
@@ -1,0 +1,92 @@
+// Integration tests for the failover proxy against REAL ws sockets — needs the
+// `ws` dep installed (npm install in deploy/wss-lb). Run:
+//   node --test deploy/wss-lb/test/
+//
+// These reproduce the failover defects the adversarial review found: on a failed
+// handshake ws emits BOTH 'error' and 'close', so a naive proxy advances twice
+// (duplicate dial) and can flush `pending` into a still-CONNECTING socket, an
+// uncaught exception that crashes the whole process.
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { test } from "node:test";
+
+import { WebSocket, WebSocketServer } from "ws";
+
+import { proxy } from "../src/proxy.mjs";
+
+function echoServer() {
+  return new Promise((resolve) => {
+    const http = createServer();
+    const wss = new WebSocketServer({ server: http });
+    let connections = 0;
+    wss.on("connection", (ws) => {
+      connections += 1;
+      ws.on("message", (d, isBinary) => ws.send(d, { binary: isBinary }));
+    });
+    http.listen(0, "127.0.0.1", () => {
+      const { port } = http.address();
+      resolve({
+        url: `ws://127.0.0.1:${port}`,
+        get connections() {
+          return connections;
+        },
+        close: () => new Promise((r) => http.close(r)),
+      });
+    });
+  });
+}
+
+function lbServer(upstreams) {
+  return new Promise((resolve) => {
+    const http = createServer();
+    const wss = new WebSocketServer({ server: http });
+    wss.on("connection", (client) =>
+      proxy(client, upstreams, { handshakeTimeout: 2000 }),
+    );
+    http.listen(0, "127.0.0.1", () => {
+      const { port } = http.address();
+      resolve({
+        url: `ws://127.0.0.1:${port}`,
+        close: () => new Promise((r) => http.close(r)),
+      });
+    });
+  });
+}
+
+// A guaranteed-dead upstream: bind an ephemeral port, then free it.
+async function deadUrl() {
+  const s = await echoServer();
+  const u = s.url;
+  await s.close();
+  return u;
+}
+
+test("failover: dead upstream then good → one dial, echo works, no crash", async () => {
+  const good = await echoServer();
+  const lb = await lbServer([await deadUrl(), good.url]);
+  const echoed = await new Promise((resolve, reject) => {
+    const c = new WebSocket(lb.url);
+    c.on("open", () => c.send("ping")); // pre-open send → the buffered/crash path
+    c.on("message", (d) => {
+      c.close();
+      resolve(d.toString());
+    });
+    c.on("error", reject);
+    setTimeout(() => reject(new Error("timeout")), 8000);
+  });
+  assert.equal(echoed, "ping");
+  assert.equal(good.connections, 1); // not 2 — no duplicate dial
+  await lb.close();
+  await good.close();
+});
+
+test("all upstreams dead → client closed with 1013", async () => {
+  const lb = await lbServer([await deadUrl(), await deadUrl()]);
+  const code = await new Promise((resolve) => {
+    const c = new WebSocket(lb.url);
+    c.on("close", (closeCode) => resolve(closeCode));
+    setTimeout(() => resolve(-1), 8000);
+  });
+  assert.equal(code, 1013);
+  await lb.close();
+});

--- a/deploy/wss-lb/test/select.test.mjs
+++ b/deploy/wss-lb/test/select.test.mjs
@@ -3,13 +3,17 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { isHealthyWss, selectWssUpstreams } from "../src/select.mjs";
+import {
+  isWssUpstream,
+  selectWssUpstreams,
+  wssPoolFor,
+} from "../src/select.mjs";
 
+// A pool endpoint (the /api/v1/rpc/pools endpoints[] shape).
 const ep = (over = {}) => ({
-  id: "x",
+  id: "endpoint-x",
   url: "wss://node.example:443",
   kind: "subtensor-wss",
-  network: "finney",
   pool_eligible: true,
   score: 100,
   status: "ok",
@@ -17,24 +21,35 @@ const ep = (over = {}) => ({
   ...over,
 });
 
-test("isHealthyWss rejects wrong kind/network/status/url/eligibility", () => {
-  const ok = isHealthyWss("finney");
-  assert.equal(ok(ep()), true);
-  assert.equal(ok(ep({ kind: "subtensor-rpc" })), false);
-  assert.equal(ok(ep({ network: "test" })), false);
-  assert.equal(ok(ep({ status: "down" })), false);
-  assert.equal(ok(ep({ pool_eligible: false })), false);
-  assert.equal(ok(ep({ url: "https://node.example" })), false);
-  assert.equal(ok(null), false);
+// The pools artifact: a finney-wss pool plus noise pools the selector must skip.
+const artifact = (wssEndpoints, extra = []) => ({
+  pools: [
+    { id: "finney-rpc", kind: "subtensor-rpc", endpoints: [ep()] },
+    { id: "finney-wss", kind: "subtensor-wss", endpoints: wssEndpoints },
+    ...extra,
+  ],
+});
+
+test("isWssUpstream gates on pool_eligible + a wss:// url", () => {
+  assert.equal(isWssUpstream(ep()), true);
+  assert.equal(isWssUpstream(ep({ pool_eligible: false })), false);
+  assert.equal(isWssUpstream(ep({ url: "https://node.example" })), false);
+  assert.equal(isWssUpstream(null), false);
+});
+
+test("wssPoolFor selects the <network>-wss pool, not rpc/other", () => {
+  const a = artifact([ep()]);
+  assert.equal(wssPoolFor(a, "finney")?.id, "finney-wss");
+  assert.equal(wssPoolFor(a, "test"), null);
 });
 
 test("orders by score desc and returns urls", () => {
   const urls = selectWssUpstreams(
-    [
+    artifact([
       ep({ id: "a", url: "wss://a:443", score: 10 }),
       ep({ id: "b", url: "wss://b:443", score: 90 }),
       ep({ id: "c", url: "wss://c:443", score: 50 }),
-    ],
+    ]),
     "finney",
   );
   assert.deepEqual(urls, ["wss://b:443", "wss://c:443", "wss://a:443"]);
@@ -42,10 +57,10 @@ test("orders by score desc and returns urls", () => {
 
 test("drops stale nodes lagging the tip beyond maxBlockLag", () => {
   const urls = selectWssUpstreams(
-    [
+    artifact([
       ep({ id: "fresh", url: "wss://fresh:443", latest_block: 1000 }),
       ep({ id: "stale", url: "wss://stale:443", latest_block: 800 }),
-    ],
+    ]),
     "finney",
     { maxBlockLag: 50 },
   );
@@ -54,27 +69,45 @@ test("drops stale nodes lagging the tip beyond maxBlockLag", () => {
 
 test("keeps an endpoint with no reported block (benefit of the doubt)", () => {
   const urls = selectWssUpstreams(
-    [
+    artifact([
       ep({ id: "fresh", url: "wss://fresh:443", latest_block: 1000 }),
       ep({ id: "noblock", url: "wss://noblock:443", latest_block: null }),
-    ],
+    ]),
     "finney",
   );
   assert.deepEqual(urls.sort(), ["wss://fresh:443", "wss://noblock:443"]);
 });
 
-test("only the requested network is selected", () => {
+test("static testnet wss (pool_eligible, status unknown, no block) is kept", () => {
+  // Regression: gating on status==='ok' would wrongly drop the unmonitored
+  // testnet pool, whose members are pool_eligible with status 'unknown'.
   const urls = selectWssUpstreams(
-    [
-      ep({ id: "f", url: "wss://f:443", network: "finney" }),
-      ep({ id: "t", url: "wss://t:443", network: "test" }),
-    ],
+    {
+      pools: [
+        {
+          id: "test-wss",
+          kind: "subtensor-wss",
+          endpoints: [
+            ep({
+              id: "t",
+              url: "wss://test:443",
+              status: "unknown",
+              latest_block: null,
+            }),
+          ],
+        },
+      ],
+    },
     "test",
   );
-  assert.deepEqual(urls, ["wss://t:443"]);
+  assert.deepEqual(urls, ["wss://test:443"]);
 });
 
-test("empty when nothing is healthy", () => {
-  assert.deepEqual(selectWssUpstreams([], "finney"), []);
-  assert.deepEqual(selectWssUpstreams([ep({ status: "down" })], "finney"), []);
+test("empty when the pool is absent or has no eligible members", () => {
+  assert.deepEqual(selectWssUpstreams({ pools: [] }, "finney"), []);
+  assert.deepEqual(selectWssUpstreams({}, "finney"), []);
+  assert.deepEqual(
+    selectWssUpstreams(artifact([ep({ pool_eligible: false })]), "finney"),
+    [],
+  );
 });

--- a/deploy/wss-lb/test/select.test.mjs
+++ b/deploy/wss-lb/test/select.test.mjs
@@ -1,0 +1,80 @@
+// Pure-logic tests for the WSS LB upstream selection. Zero deps — run with:
+//   node --test deploy/wss-lb/test/
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHealthyWss, selectWssUpstreams } from "../src/select.mjs";
+
+const ep = (over = {}) => ({
+  id: "x",
+  url: "wss://node.example:443",
+  kind: "subtensor-wss",
+  network: "finney",
+  pool_eligible: true,
+  score: 100,
+  status: "ok",
+  latest_block: 1000,
+  ...over,
+});
+
+test("isHealthyWss rejects wrong kind/network/status/url/eligibility", () => {
+  const ok = isHealthyWss("finney");
+  assert.equal(ok(ep()), true);
+  assert.equal(ok(ep({ kind: "subtensor-rpc" })), false);
+  assert.equal(ok(ep({ network: "test" })), false);
+  assert.equal(ok(ep({ status: "down" })), false);
+  assert.equal(ok(ep({ pool_eligible: false })), false);
+  assert.equal(ok(ep({ url: "https://node.example" })), false);
+  assert.equal(ok(null), false);
+});
+
+test("orders by score desc and returns urls", () => {
+  const urls = selectWssUpstreams(
+    [
+      ep({ id: "a", url: "wss://a:443", score: 10 }),
+      ep({ id: "b", url: "wss://b:443", score: 90 }),
+      ep({ id: "c", url: "wss://c:443", score: 50 }),
+    ],
+    "finney",
+  );
+  assert.deepEqual(urls, ["wss://b:443", "wss://c:443", "wss://a:443"]);
+});
+
+test("drops stale nodes lagging the tip beyond maxBlockLag", () => {
+  const urls = selectWssUpstreams(
+    [
+      ep({ id: "fresh", url: "wss://fresh:443", latest_block: 1000 }),
+      ep({ id: "stale", url: "wss://stale:443", latest_block: 800 }),
+    ],
+    "finney",
+    { maxBlockLag: 50 },
+  );
+  assert.deepEqual(urls, ["wss://fresh:443"]);
+});
+
+test("keeps an endpoint with no reported block (benefit of the doubt)", () => {
+  const urls = selectWssUpstreams(
+    [
+      ep({ id: "fresh", url: "wss://fresh:443", latest_block: 1000 }),
+      ep({ id: "noblock", url: "wss://noblock:443", latest_block: null }),
+    ],
+    "finney",
+  );
+  assert.deepEqual(urls.sort(), ["wss://fresh:443", "wss://noblock:443"]);
+});
+
+test("only the requested network is selected", () => {
+  const urls = selectWssUpstreams(
+    [
+      ep({ id: "f", url: "wss://f:443", network: "finney" }),
+      ep({ id: "t", url: "wss://t:443", network: "test" }),
+    ],
+    "test",
+  );
+  assert.deepEqual(urls, ["wss://t:443"]);
+});
+
+test("empty when nothing is healthy", () => {
+  assert.deepEqual(selectWssUpstreams([], "finney"), []);
+  assert.deepEqual(selectWssUpstreams([ep({ status: "down" })], "finney"), []);
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,6 +41,8 @@ export default [
         process: "readonly",
         setTimeout: "readonly",
         clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
         TextDecoder: "readonly",
         TextEncoder: "readonly",
         WebSocket: "readonly",

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -7,7 +7,9 @@ export default defineConfig({
     environment: "node",
     // `.claude/**` keeps gitignored agent worktrees (.claude/worktrees/*, each a
     // full repo copy with its own tests) from doubling the run + skewing coverage.
-    exclude: ["node_modules/**", "private/**", ".claude/**"],
+    // `deploy/**` is standalone infra (the wss-lb service is tested via
+    // `node --test`, not vitest) — keep it out of the Worker test run.
+    exclude: ["node_modules/**", "private/**", ".claude/**", "deploy/**"],
     // Run test FILES sequentially (each still in its own isolated fork). The
     // artifact-build tests (tests/artifacts.test.mjs) execFileSync the real
     // scripts/build-artifacts.mjs, which mutates the shared on-disk artifact


### PR DESCRIPTION
## What

A cosmos.directory-style **health-aware WebSocket load balancer** (`deploy/wss-lb`) — the missing wss endpoint the Cloudflare HTTP proxy explicitly can't serve (`workers/request-handlers/rpc-proxy.mjs` returns _"WebSocket JSON-RPC is not available through this HTTP proxy"_).

```
client ──wss──▶  wss-lb  ──wss──▶  healthiest registered subtensor-wss node
                   └─ refreshes the pool from GET /api/v1/rpc-endpoints
```

## How

- Refreshes the upstream pool from the live **`/api/v1/rpc-endpoints`** every `REFRESH_MS` — reuses the cron prober's health, no second health system.
- `selectWssUpstreams` (pure, unit-tested) keeps only healthy + `pool_eligible` + on-network wss endpoints within `MAX_BLOCK_LAG` of the freshest tip, ordered by score (route-to-the-most-up-to-date-node).
- **Connect-time** selection with handshake failover; mid-session upstream loss closes the client (reconnect → fresh upstream, since JSON-RPC subscription state can't migrate).
- `/healthz` → Railway healthcheck. `Dockerfile` + `railway.json` for a service with **Root Directory = `deploy/wss-lb`**, behind Cloudflare DNS for TLS/DDoS.

## Tests / CI

- 6 `node --test` unit tests for the pure selection — one caught a real `Number(null)===0` bug that would've dropped block-less endpoints as stale.
- Full Worker suite green (2624 tests). `deploy/**` excluded from vitest (tested via `node --test`); `setInterval`/`clearInterval` added to the shared eslint globals.
- Live ws-piping is integration-verified on deploy (no live wss+client path in CI).

## Follow-ups before public exposure

- Per-IP connection rate-limiting / abuse caps (a public wss proxy is a DoS amplifier); optional API-key tiering.

Part of #2108 · ADR 0013.