### PR TITLE
fix(infra): bump wss-lb ws to ^8.21.0 (HIGH advisory)

### DIFF
--- a/deploy/wss-lb/package-lock.json
+++ b/deploy/wss-lb/package-lock.json
@@ -8,16 +8,16 @@
       "name": "metagraphed-wss-lb",
       "version": "0.0.0",
       "dependencies": {
-        "ws": "8.18.3"
+        "ws": "^8.21.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/deploy/wss-lb/package.json
+++ b/deploy/wss-lb/package.json
@@ -9,7 +9,7 @@
     "test": "node --test --test-force-exit test/*.test.mjs"
   },
   "dependencies": {
-    "ws": "8.18.3"
+    "ws": "^8.21.0"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Post-merge, Dependabot's security scan flagged the new `deploy/wss-lb` dependency: `ws@8.18.3` carries a **HIGH** advisory ([GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) uninitialized memory disclosure + [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) memory-exhaustion DoS; affected `< 8.21.0`).

- Bump `ws` `8.18.3` → `^8.21.0`; `package-lock.json` regenerated to `8.21.0`.
- `npm audit`: **0 vulnerabilities**.
- 9 unit/integration tests still pass (ws API unchanged).

Follow-up to #2119.