### PR TITLE
fix(health): return 410 for retired health artifacts on every network prefix

### DIFF
--- a/tests/network-routing.test.mjs
+++ b/tests/network-routing.test.mjs
@@ -319,6 +319,33 @@ describe("multi-network routing prefix (Phase 1)", () => {
     assert.notEqual(testnet.body.subnets.length, mainnet.body.subnets.length);
   });
 
+  test("retired current-health raw artifacts return 410 under a network prefix", async () => {
+    let reads = 0;
+    const env = createLocalArtifactEnv({
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          reads += 1;
+          return {
+            async json() {
+              return { stale: true, summary: { status: "ok" } };
+            },
+          };
+        },
+      },
+    });
+    for (const path of [
+      "/metagraph/testnet/health/latest.json",
+      "/metagraph/testnet/health/summary.json",
+      "/metagraph/testnet/health/subnets/1.json",
+    ]) {
+      const { res, body } = await get(env, path);
+      assert.equal(res.status, 410, path);
+      assert.equal(body.error.code, "retired_artifact", path);
+      assert.match(body.meta.artifact_path, /^\/metagraph\/testnet\/health\//);
+    }
+    assert.equal(reads, 0, "retired paths must not read R2");
+  });
+
   test("a real route segment that merely looks adjacent is never shadowed by the alias set", async () => {
     const env = createLocalArtifactEnv();
     // "subnets"/"providers"/"surfaces" are real routes, not network aliases.

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1452,10 +1452,11 @@ async function handleRawArtifactRequest(
   }
 
   const networkPath = artifactPathForNetwork(url.pathname, network);
-  if (
-    network.isDefault &&
-    RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN.test(networkPath)
-  ) {
+  // Current-state health artifacts are retired on every network prefix — the
+  // live-only policy (#490/#498) is not mainnet-specific. Match the canonical
+  // path (prefix already stripped by resolveNetworkPrefix); networkPath is only
+  // the partitioned R2 key used in the error payload.
+  if (RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN.test(url.pathname)) {
     return errorResponse(
       "retired_artifact",
       "Current-state health artifacts are retired; use the live API health endpoints instead.",


### PR DESCRIPTION
## Summary

- Apply `RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN` on the canonical stripped path (`url.pathname`) for every network, not only mainnet.
- Drop the `network.isDefault` guard so prefixed raw fetchers (`/metagraph/testnet/health/…`) receive the same 410 as bare mainnet paths.
- Keep `meta.artifact_path` as the partitioned R2 key (`networkPath`) in the error payload.
- Add regression tests proving testnet-prefixed retired paths return 410 without touching R2.

Closes #2124 
## Why

Current-state health is live-only across the API contract. A legacy static object under `metagraph/testnet/health/` must not leak probe-derived status to agents polling raw `/metagraph/{network}/…` paths.

## Test plan

- [x] `npm test -- tests/network-routing.test.mjs -t "retired current-health"`
- [x] `npm test -- tests/api-coverage.test.mjs -t retired` (mainnet 410 unchanged)
- [x] `npm run validate:api`
