### PR TITLE
fix(ai-search): cap semanticSearch query length at SEMANTIC_MAX_QUERY_LENGTH

### DIFF
--- a/src/ai-search.mjs
+++ b/src/ai-search.mjs
@@ -36,6 +36,7 @@ export const SEMANTIC_TYPES = ["subnet", "surface", "provider"];
 const FILTERED_RETRIEVE_TOPK = SEMANTIC_MAX_LIMIT;
 export const ASK_CONTEXT_COUNT = 6;
 export const ASK_MAX_QUESTION_LENGTH = 1000;
+export const SEMANTIC_MAX_QUERY_LENGTH = 1000;
 export const ASK_MAX_TOKENS = 512;
 const EMBED_BATCH_SIZE = 100;
 const VECTOR_ID_MAX_BYTES = 64;
@@ -367,6 +368,10 @@ async function retrieveMatches(env, vector, limit, types) {
 export async function semanticSearch(env, query, options = {}) {
   const q = typeof query === "string" ? query.trim() : "";
   if (!q) throw aiInputError("Query parameter `q` is required.");
+  if (q.length > SEMANTIC_MAX_QUERY_LENGTH)
+    throw aiInputError(
+      `Field \`q\` must be at most ${SEMANTIC_MAX_QUERY_LENGTH} characters.`,
+    );
   const limit = clampLimit(
     options.limit,
     SEMANTIC_DEFAULT_LIMIT,

--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -535,7 +535,11 @@ describe("semanticSearch", () => {
       () => semanticSearch(env, overlong),
       (err) => err.aiInput === true,
     );
-    assert.equal(aiCalled, false, "env.AI.run must not be called for an oversized query");
+    assert.equal(
+      aiCalled,
+      false,
+      "env.AI.run must not be called for an oversized query",
+    );
   });
   test("accepts a query exactly at the length cap", async () => {
     const env = { AI: stubAi(), VECTORIZE: stubVectorize() };

--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -15,6 +15,7 @@ import {
   runEmbeddingSync,
   semanticSearch,
   askQuestion,
+  SEMANTIC_MAX_QUERY_LENGTH,
 } from "../src/ai-search.mjs";
 import { handleRequest, handleScheduled } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
@@ -517,6 +518,30 @@ describe("semanticSearch", () => {
   test("rejects a blank query", async () => {
     const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
     await assert.rejects(() => semanticSearch(env, "   "), /required/);
+  });
+  test("rejects a query over SEMANTIC_MAX_QUERY_LENGTH and does not call env.AI.run", async () => {
+    let aiCalled = false;
+    const env = {
+      AI: {
+        run(...args) {
+          aiCalled = true;
+          return stubAi().run(...args);
+        },
+      },
+      VECTORIZE: stubVectorize(),
+    };
+    const overlong = "x".repeat(SEMANTIC_MAX_QUERY_LENGTH + 1);
+    await assert.rejects(
+      () => semanticSearch(env, overlong),
+      (err) => err.aiInput === true,
+    );
+    assert.equal(aiCalled, false, "env.AI.run must not be called for an oversized query");
+  });
+  test("accepts a query exactly at the length cap", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    const atCap = "x".repeat(SEMANTIC_MAX_QUERY_LENGTH);
+    const out = await semanticSearch(env, atCap, { limit: 1 });
+    assert.ok(out.results.length >= 0);
   });
   test("clamps the limit to the maximum", async () => {
     const env = { AI: stubAi(), VECTORIZE: stubVectorize() };


### PR DESCRIPTION
## Summary
- Export `SEMANTIC_MAX_QUERY_LENGTH = 1000` constant in `src/ai-search.mjs`
- Add query-length guard in `semanticSearch()` after the blank-check; throws `aiInputError` before any `embedQuery` / `env.AI.run` call
- Add tests: oversized query is rejected without calling `env.AI.run`; at-cap query succeeds

## Related Issues
Closes #2088.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing
- [x] Tests added/updated
- [x] Manually tested

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)