### PR TITLE
fix(list-query): add netuid tie-break to sortRows for deterministic pagination

### DIFF
--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -233,6 +233,26 @@ describe("list-query sort tie-break", () => {
       [2, 1, 3],
     );
   });
+
+  test("ties where rows lack netuid fall back to stable source order", () => {
+    const data = {
+      subnets: [
+        { id: "c", name: "Alpha" },
+        { id: "a", name: "Alpha" },
+        { id: "b", name: "Beta" },
+      ],
+    };
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?sort=name"),
+      "subnets",
+    );
+    // Both Alpha rows lack netuid — sort falls back to stable source order (c, a)
+    assert.deepEqual(
+      result.data.subnets.map((r) => r.id),
+      ["c", "a", "b"],
+    );
+  });
 });
 
 describe("list-query numeric range filters", () => {

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -192,6 +192,49 @@ describe("list-query sort with missing values", () => {
   });
 });
 
+describe("list-query sort tie-break", () => {
+  test("ties on a non-unique field are broken by ascending netuid", () => {
+    const data = {
+      subnets: [
+        { netuid: 3, name: "Alpha" },
+        { netuid: 1, name: "Alpha" },
+        { netuid: 2, name: "Beta" },
+        { netuid: 5, name: "Alpha" },
+      ],
+    };
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?sort=name"),
+      "subnets",
+    );
+    assert.deepEqual(
+      result.data.subnets.map((r) => r.netuid),
+      [1, 3, 5, 2],
+      "ties on name=Alpha must be broken by ascending netuid",
+    );
+  });
+
+  test("ties on a non-unique field in desc order are still broken by ascending netuid", () => {
+    const data = {
+      subnets: [
+        { netuid: 3, name: "Alpha" },
+        { netuid: 1, name: "Alpha" },
+        { netuid: 2, name: "Beta" },
+      ],
+    };
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?sort=name&order=desc"),
+      "subnets",
+    );
+    // desc: Beta first, then Alpha ties broken by netuid asc
+    assert.deepEqual(
+      result.data.subnets.map((r) => r.netuid),
+      [2, 1, 3],
+    );
+  });
+});
+
 describe("list-query numeric range filters", () => {
   const data = {
     subnets: [

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -274,7 +274,12 @@ function sortRows(rows, params) {
       present.push(row);
     }
   }
-  present.sort((a, b) => compareValues(a[key], b[key]) * direction);
+  present.sort((a, b) => {
+    const cmp = compareValues(a[key], b[key]) * direction;
+    if (cmp !== 0) return cmp;
+    if (a.netuid != null && b.netuid != null) return a.netuid - b.netuid;
+    return 0;
+  });
   return [...present, ...missing];
 }
 


### PR DESCRIPTION
## Summary
- Add deterministic `netuid` tie-break to `sortRows` in `workers/list-query.mjs`, matching the existing tie-break in MCP `sortSubnets`
- When two rows compare equal on the sort field, they are ordered by ascending `netuid` (rows without a `netuid` field are unaffected)
- Add tests asserting REST `sortRows` breaks ties by ascending `netuid` for both ascending and descending primary sorts

## Related Issues
Closes #2089.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing
- [x] Tests added/updated
- [x] Manually tested

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)