### PR TITLE
fix(discovery): add ETag/304 to homepage and api-catalog; serialize catalog body once

### DIFF
--- a/tests/discovery-conditional.test.mjs
+++ b/tests/discovery-conditional.test.mjs
@@ -233,9 +233,7 @@ describe("discovery conditional requests", () => {
 
   test("homepage honors If-None-Match lists and the * wildcard", async () => {
     await assertConditional((headers) =>
-      homepageResponse(
-        new Request("https://api.metagraph.sh/", { headers }),
-      ),
+      homepageResponse(new Request("https://api.metagraph.sh/", { headers })),
     );
   });
 

--- a/tests/discovery-conditional.test.mjs
+++ b/tests/discovery-conditional.test.mjs
@@ -8,6 +8,7 @@ import {
   agentToolsResponse,
   apiCatalogResponse,
   handleBadgeSvgRequest,
+  homepageResponse,
   mcpServerCardResponse,
 } from "../workers/request-handlers/discovery.mjs";
 
@@ -164,7 +165,7 @@ describe("discovery conditional requests", () => {
 
   test("api catalog HEAD returns the discovery headers with no body", async () => {
     const url = "https://api.metagraph.sh/.well-known/api-catalog";
-    const res = apiCatalogResponse(new Request(url, { method: "HEAD" }));
+    const res = await apiCatalogResponse(new Request(url, { method: "HEAD" }));
     assert.equal(res.status, 200);
     assert.equal(res.headers.get("content-type"), "application/linkset+json");
     // HEAD never carries a body, but the discovery Link header is still present.
@@ -174,7 +175,7 @@ describe("discovery conditional requests", () => {
 
   test("api catalog GET returns the RFC 9264 linkset body", async () => {
     const url = "https://api.metagraph.sh/.well-known/api-catalog";
-    const res = apiCatalogResponse(new Request(url, { method: "GET" }));
+    const res = await apiCatalogResponse(new Request(url, { method: "GET" }));
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.linkset));
@@ -218,5 +219,32 @@ describe("discovery conditional requests", () => {
         {},
       ),
     );
+  });
+
+  test("api catalog honors If-None-Match lists and the * wildcard", async () => {
+    await assertConditional((headers) =>
+      apiCatalogResponse(
+        new Request("https://api.metagraph.sh/.well-known/api-catalog", {
+          headers,
+        }),
+      ),
+    );
+  });
+
+  test("homepage honors If-None-Match lists and the * wildcard", async () => {
+    await assertConditional((headers) =>
+      homepageResponse(
+        new Request("https://api.metagraph.sh/", { headers }),
+      ),
+    );
+  });
+
+  test("homepage HEAD returns the discovery headers with no body", async () => {
+    const res = await homepageResponse(
+      new Request("https://api.metagraph.sh/", { method: "HEAD" }),
+    );
+    assert.equal(res.status, 200);
+    assert.ok(res.headers.get("etag"));
+    assert.equal(await res.text(), "");
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -936,11 +936,11 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // Both are worker-owned (see wrangler `run_worker_first`) so they carry the
   // right headers/content-type instead of 404-ing through to the static assets.
   if (url.pathname === "/" || url.pathname === "") {
-    return homepageResponse(request);
+    return await homepageResponse(request);
   }
 
   if (url.pathname === "/.well-known/api-catalog") {
-    return apiCatalogResponse(request);
+    return await apiCatalogResponse(request);
   }
 
   if (url.pathname === "/.well-known/mcp/server-card.json") {

--- a/workers/request-handlers/discovery.mjs
+++ b/workers/request-handlers/discovery.mjs
@@ -241,7 +241,10 @@ const CATALOG_BODY = (() => {
         {
           anchor: `${base}/api/v1`,
           "service-desc": [
-            { href: `${base}/metagraph/openapi.json`, type: "application/json" },
+            {
+              href: `${base}/metagraph/openapi.json`,
+              type: "application/json",
+            },
           ],
           "service-doc": [
             { href: `${base}/llms.txt`, type: "text/plain" },

--- a/workers/request-handlers/discovery.mjs
+++ b/workers/request-handlers/discovery.mjs
@@ -230,10 +230,64 @@ function discoveryHeaders(contentType) {
   return headers;
 }
 
+// Pre-serialized once per isolate — the catalog content depends only on the
+// module-level PRIMARY_DOMAIN constant, so allocating + stringifying per
+// request is redundant. ETag is lazy-memoized (weakEtag is async).
+const CATALOG_BODY = (() => {
+  const base = `https://${PRIMARY_DOMAIN}`;
+  return `${JSON.stringify(
+    {
+      linkset: [
+        {
+          anchor: `${base}/api/v1`,
+          "service-desc": [
+            { href: `${base}/metagraph/openapi.json`, type: "application/json" },
+          ],
+          "service-doc": [
+            { href: `${base}/llms.txt`, type: "text/plain" },
+            { href: `${base}/agent.md`, type: "text/markdown" },
+            { href: `${base}/agent-workflows.md`, type: "text/markdown" },
+          ],
+          status: [{ href: `${base}/health`, type: "application/json" }],
+          describedby: [
+            {
+              href: `${base}/.well-known/mcp/server-card.json`,
+              type: "application/json",
+            },
+            {
+              href: `${base}/.well-known/agent-tools/index.json`,
+              type: "application/json",
+            },
+          ],
+        },
+      ],
+    },
+    null,
+    2,
+  )}\n`;
+})();
+
+let _homepageEtagPromise = null;
+function getHomepageEtag() {
+  if (!_homepageEtagPromise) _homepageEtagPromise = weakEtag(HOMEPAGE_HTML);
+  return _homepageEtagPromise;
+}
+
+let _catalogEtagPromise = null;
+function getCatalogEtag() {
+  if (!_catalogEtagPromise) _catalogEtagPromise = weakEtag(CATALOG_BODY);
+  return _catalogEtagPromise;
+}
+
 // api.metagraph.sh homepage: a small human/agent landing whose response carries
 // the RFC 8288 Link headers (an agent can bootstrap from a single HEAD of `/`).
-export function homepageResponse(request) {
+export async function homepageResponse(request) {
+  const etag = await getHomepageEtag();
   const headers = discoveryHeaders("text/html; charset=utf-8");
+  headers.set("etag", etag);
+  if (ifNoneMatchSatisfied(request, etag)) {
+    return new Response(null, { status: 304, headers });
+  }
   if (request.method === "HEAD") {
     return new Response(null, { headers });
   }
@@ -244,39 +298,17 @@ export function homepageResponse(request) {
 // canonical API host (api.metagraph.sh) regardless of which host served this —
 // the apex (metagraph.sh) routes /.well-known/* here too, and its catalog must
 // reference the real API, not the apex.
-export function apiCatalogResponse(request) {
-  const base = `https://${PRIMARY_DOMAIN}`;
-  const linkset = {
-    linkset: [
-      {
-        anchor: `${base}/api/v1`,
-        "service-desc": [
-          { href: `${base}/metagraph/openapi.json`, type: "application/json" },
-        ],
-        "service-doc": [
-          { href: `${base}/llms.txt`, type: "text/plain" },
-          { href: `${base}/agent.md`, type: "text/markdown" },
-          { href: `${base}/agent-workflows.md`, type: "text/markdown" },
-        ],
-        status: [{ href: `${base}/health`, type: "application/json" }],
-        describedby: [
-          {
-            href: `${base}/.well-known/mcp/server-card.json`,
-            type: "application/json",
-          },
-          {
-            href: `${base}/.well-known/agent-tools/index.json`,
-            type: "application/json",
-          },
-        ],
-      },
-    ],
-  };
+export async function apiCatalogResponse(request) {
+  const etag = await getCatalogEtag();
   const headers = discoveryHeaders("application/linkset+json");
+  headers.set("etag", etag);
+  if (ifNoneMatchSatisfied(request, etag)) {
+    return new Response(null, { status: 304, headers });
+  }
   if (request.method === "HEAD") {
     return new Response(null, { headers });
   }
-  return new Response(`${JSON.stringify(linkset, null, 2)}\n`, { headers });
+  return new Response(CATALOG_BODY, { headers });
 }
 
 // Stable deterministic JSON serializer (recursive key sort) — matches


### PR DESCRIPTION
## Summary
- Pre-serialize the api-catalog linkset body once per isolate via an IIFE (`CATALOG_BODY`); eliminates redundant `JSON.stringify` on every request
- Lazy-memoize the `weakEtag` promise for both `HOMEPAGE_HTML` and `CATALOG_BODY` (async, so cached as a resolved promise on first call)
- Make `homepageResponse` and `apiCatalogResponse` async; add `etag` header + `ifNoneMatchSatisfied` → 304 path matching the three existing sibling handlers
- Extend `tests/discovery-conditional.test.mjs`: add `homepageResponse` to imports; update two existing catalog tests to `await` the now-async function; add conditional tests for api-catalog and homepage (including HEAD with etag)

## Related Issues
Closes #2091.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing
- [x] Tests added/updated
- [x] Manually tested

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)