### PR TITLE
perf(api): complete keyset-cursor pagination across the entity feeds

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1552,6 +1552,7 @@ export interface components {
             day_count: number;
             days: components["schemas"]["AccountDay"][];
             limit?: number;
+            next_cursor?: string | null;
             offset?: number;
             schema_version: number;
             ss58: string;
@@ -1597,6 +1598,7 @@ export interface components {
         /** @description The native-TAO Balances.Transfer feed for one account (#1850), newest first, from the account_events D1 tier (event_kind='Transfer'). Each row is a directional {from, to, amount_tao, direction} transfer; direction is 'sent' or 'received' relative to the queried ss58. This is the native-TAO transfer feed only, NOT a full balance ledger. Served live at /api/v1/accounts/{ss58}/transfers (no static file). */
         AccountTransfersArtifact: {
             limit?: number;
+            next_cursor?: string | null;
             offset?: number;
             schema_version: number;
             ss58: string;
@@ -4111,6 +4113,7 @@ export interface components {
             events: components["schemas"]["AccountEvent"][];
             limit?: number;
             netuid: number;
+            next_cursor?: string | null;
             offset?: number;
             schema_version: number;
         } & {
@@ -5417,6 +5420,7 @@ export interface operations {
                      *           }
                      *         ],
                      *         "limit": 1,
+                     *         "next_cursor": "example",
                      *         "offset": 1,
                      *         "schema_version": 1,
                      *         "ss58": "example"
@@ -5633,6 +5637,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "limit": 1,
+                     *         "next_cursor": "example",
                      *         "offset": 1,
                      *         "schema_version": 1,
                      *         "ss58": "example",
@@ -14107,6 +14112,7 @@ export interface operations {
                      *         ],
                      *         "limit": 1,
                      *         "netuid": 7,
+                     *         "next_cursor": "example",
                      *         "offset": 1,
                      *         "schema_version": 1
                      *       },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -341,6 +341,12 @@
           "limit": {
             "type": "integer"
           },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "offset": {
             "type": "integer"
           },
@@ -500,6 +506,12 @@
         "properties": {
           "limit": {
             "type": "integer"
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "offset": {
             "type": "integer"
@@ -10698,6 +10710,12 @@
           "netuid": {
             "type": "integer"
           },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "offset": {
             "type": "integer"
           },
@@ -14035,6 +14053,7 @@
                       }
                     ],
                     "limit": 1,
+                    "next_cursor": "example",
                     "offset": 1,
                     "schema_version": 1,
                     "ss58": "example"
@@ -14331,6 +14350,7 @@
                 "example": {
                   "data": {
                     "limit": 1,
+                    "next_cursor": "example",
                     "offset": 1,
                     "schema_version": 1,
                     "ss58": "example",
@@ -27574,6 +27594,7 @@
                     ],
                     "limit": 1,
                     "netuid": 7,
+                    "next_cursor": "example",
                     "offset": 1,
                     "schema_version": 1
                   },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1552,6 +1552,7 @@ export interface components {
             day_count: number;
             days: components["schemas"]["AccountDay"][];
             limit?: number;
+            next_cursor?: string | null;
             offset?: number;
             schema_version: number;
             ss58: string;
@@ -1597,6 +1598,7 @@ export interface components {
         /** @description The native-TAO Balances.Transfer feed for one account (#1850), newest first, from the account_events D1 tier (event_kind='Transfer'). Each row is a directional {from, to, amount_tao, direction} transfer; direction is 'sent' or 'received' relative to the queried ss58. This is the native-TAO transfer feed only, NOT a full balance ledger. Served live at /api/v1/accounts/{ss58}/transfers (no static file). */
         AccountTransfersArtifact: {
             limit?: number;
+            next_cursor?: string | null;
             offset?: number;
             schema_version: number;
             ss58: string;
@@ -4111,6 +4113,7 @@ export interface components {
             events: components["schemas"]["AccountEvent"][];
             limit?: number;
             netuid: number;
+            next_cursor?: string | null;
             offset?: number;
             schema_version: number;
         } & {
@@ -5417,6 +5420,7 @@ export interface operations {
                      *           }
                      *         ],
                      *         "limit": 1,
+                     *         "next_cursor": "example",
                      *         "offset": 1,
                      *         "schema_version": 1,
                      *         "ss58": "example"
@@ -5633,6 +5637,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "limit": 1,
+                     *         "next_cursor": "example",
                      *         "offset": 1,
                      *         "schema_version": 1,
                      *         "ss58": "example",
@@ -14107,6 +14112,7 @@ export interface operations {
                      *         ],
                      *         "limit": 1,
                      *         "netuid": 7,
+                     *         "next_cursor": "example",
                      *         "offset": 1,
                      *         "schema_version": 1
                      *       },

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -327,6 +327,12 @@
           "limit": {
             "type": "integer"
           },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "offset": {
             "type": "integer"
           },
@@ -486,6 +492,12 @@
         "properties": {
           "limit": {
             "type": "integer"
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "offset": {
             "type": "integer"
@@ -10675,6 +10687,12 @@
           },
           "netuid": {
             "type": "integer"
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "offset": {
             "type": "integer"

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1627,6 +1627,7 @@
           "day_count": { "type": "integer", "minimum": 0 },
           "limit": { "type": "integer" },
           "offset": { "type": "integer" },
+          "next_cursor": { "type": ["string", "null"] },
           "days": {
             "type": "array",
             "items": { "$ref": "#/components/schemas/AccountDay" }
@@ -1644,6 +1645,7 @@
           "event_count": { "type": "integer", "minimum": 0 },
           "limit": { "type": "integer" },
           "offset": { "type": "integer" },
+          "next_cursor": { "type": ["string", "null"] },
           "events": {
             "type": "array",
             "items": { "$ref": "#/components/schemas/AccountEvent" }
@@ -1678,6 +1680,7 @@
           "transfer_count": { "type": "integer", "minimum": 0 },
           "limit": { "type": "integer" },
           "offset": { "type": "integer" },
+          "next_cursor": { "type": ["string", "null"] },
           "transfers": {
             "type": "array",
             "items": {

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -274,7 +274,11 @@ export function buildAccountEvents(
 // The first-party chain-event stream for one subnet (#1345 block explorer):
 // the same account_events rows, filtered by netuid instead of account. Mirrors
 // buildAccountEvents — newest-first, schema-stable zero for a cold/unknown subnet.
-export function buildSubnetEvents(rows, netuid, { limit, offset } = {}) {
+export function buildSubnetEvents(
+  rows,
+  netuid,
+  { limit, offset, nextCursor } = {},
+) {
   const events = (rows || []).map(formatAccountEvent).filter(Boolean);
   return {
     schema_version: 1,
@@ -282,6 +286,7 @@ export function buildSubnetEvents(rows, netuid, { limit, offset } = {}) {
     event_count: events.length,
     limit: limit ?? null,
     offset: offset ?? null,
+    next_cursor: nextCursor ?? null,
     events,
   };
 }
@@ -329,7 +334,11 @@ export function formatAccountDay(row) {
 // account_events_daily rollup (hotkey-keyed). NOTE the rollup writes only
 // hotkey-attributed rows, so a coldkey-only ss58 returns zero days even when
 // /events shows activity — surfaced in the route comment + contract description.
-export function buildAccountHistory(rows, ss58, { limit, offset } = {}) {
+export function buildAccountHistory(
+  rows,
+  ss58,
+  { limit, offset, nextCursor } = {},
+) {
   const days = (rows || []).map(formatAccountDay).filter(Boolean);
   return {
     schema_version: 1,
@@ -337,6 +346,7 @@ export function buildAccountHistory(rows, ss58, { limit, offset } = {}) {
     day_count: days.length,
     limit: limit ?? null,
     offset: offset ?? null,
+    next_cursor: nextCursor ?? null,
     days,
   };
 }
@@ -360,7 +370,11 @@ export function buildAccountSubnets(rows, ss58) {
 // ss58: it sent (== from) or received (== to). This is the native-TAO
 // Balances.Transfer feed only, NOT a full balance ledger (stake flows are separate
 // event kinds). Null-safe on a cold store.
-export function buildAccountTransfers(rows, ss58, { limit, offset } = {}) {
+export function buildAccountTransfers(
+  rows,
+  ss58,
+  { limit, offset, nextCursor } = {},
+) {
   const transfers = (rows || [])
     .filter((r) => r && typeof r === "object")
     .map((r) => ({
@@ -379,6 +393,7 @@ export function buildAccountTransfers(rows, ss58, { limit, offset } = {}) {
     transfer_count: transfers.length,
     limit: limit ?? null,
     offset: offset ?? null,
+    next_cursor: nextCursor ?? null,
     transfers,
   };
 }

--- a/tests/account-history.test.mjs
+++ b/tests/account-history.test.mjs
@@ -1,6 +1,34 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.mjs";
+import { encodeCursor } from "../src/cursor.mjs";
+
+// SQL-capturing D1 mock variant: records each bound (sql, params) so a test can
+// assert the query shape (keyset seek vs offset).
+function dbCapture(days = []) {
+  const captured = [];
+  return {
+    captured,
+    env: {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              captured.push({ sql, params });
+              return {
+                async all() {
+                  return {
+                    results: /FROM account_events_daily/.test(sql) ? days : [],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    },
+  };
+}
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
@@ -108,4 +136,34 @@ test("GET /accounts/{ss58}/history is schema-stable when cold (never 404)", asyn
   const body = await res.json();
   assert.equal(body.data.day_count, 0);
   assert.equal(Array.isArray(body.data.days), true);
+});
+
+test("GET /accounts/{ss58}/history cursor uses a (day, netuid) keyset seek, not offset", async () => {
+  const { env, captured } = dbCapture([DAY]);
+  const res = await handleRequest(
+    req(
+      `/api/v1/accounts/${SS58}/history?limit=1&cursor=${encodeCursor([20260625, 9])}`,
+    ),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  const sql = captured.find((q) => /FROM account_events_daily/.test(q.sql)).sql;
+  assert.ok(/\(day, netuid\) < \(\?, \?\)/.test(sql));
+  assert.ok(!/OFFSET/.test(sql));
+  // DAY is 2026-06-24 / netuid 7 → next_cursor encodes day as 20260624.
+  assert.equal(body.data.next_cursor, encodeCursor([20260624, 7]));
+});
+
+test("GET /accounts/{ss58}/history ignores a malformed cursor (first page)", async () => {
+  const { env, captured } = dbCapture([DAY]);
+  await handleRequest(
+    req(`/api/v1/accounts/${SS58}/history?cursor=not-a-cursor`),
+    env,
+    {},
+  );
+  const sql = captured.find((q) => /FROM account_events_daily/.test(q.sql)).sql;
+  assert.ok(/OFFSET/.test(sql));
+  assert.ok(!/\(day, netuid\) </.test(sql));
 });

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1025,6 +1025,39 @@ describe("handleAccountTransfers", () => {
     const sql = captures.sql.find((s) => /Transfer/.test(s));
     assert.ok(/coldkey = \?/.test(sql));
   });
+
+  test("cursor uses keyset seek instead of offset", async () => {
+    const { env, captures } = dbWith({
+      transfers: [transferEventRow({ block_number: 150, event_index: 2 })],
+    });
+    const body = await json(
+      await handleAccountTransfers(
+        req(`/api/v1/accounts/${SS58}/transfers`),
+        env,
+        SS58,
+        url(
+          `/api/v1/accounts/${SS58}/transfers?limit=1&cursor=${encodeCursor([200, 1])}`,
+        ),
+      ),
+    );
+    const sql = captures.sql.find((s) => /Transfer/.test(s));
+    assert.ok(/\(block_number, event_index\) < \(\?, \?\)/.test(sql));
+    assert.ok(!/OFFSET/.test(sql));
+    assert.equal(body.data.next_cursor, encodeCursor([150, 2]));
+  });
+
+  test("a malformed cursor is ignored and falls back to the first page", async () => {
+    const { env, captures } = dbWith({ transfers: [transferEventRow()] });
+    await handleAccountTransfers(
+      req(`/api/v1/accounts/${SS58}/transfers`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/transfers?cursor=not-a-cursor`),
+    );
+    const sql = captures.sql.find((s) => /Transfer/.test(s));
+    assert.ok(/OFFSET/.test(sql));
+    assert.ok(!/block_number, event_index\) </.test(sql));
+  });
 });
 
 describe("handleAccountSubnets", () => {
@@ -1116,6 +1149,41 @@ describe("handleSubnetEvents", () => {
       url(`/api/v1/subnets/${NETUID}/events?kind=WeightsSet`),
     );
     assert.ok(captures.sql.some((s) => /event_kind = \?/.test(s)));
+  });
+
+  test("cursor uses keyset seek instead of offset", async () => {
+    const { env, captures } = dbWith({
+      subnetEvents: [accountEventRow({ block_number: 150, event_index: 2 })],
+    });
+    const body = await json(
+      await handleSubnetEvents(
+        req(`/api/v1/subnets/${NETUID}/events`),
+        env,
+        NETUID,
+        url(
+          `/api/v1/subnets/${NETUID}/events?limit=1&cursor=${encodeCursor([200, 1])}`,
+        ),
+      ),
+    );
+    const sql = captures.sql.find((s) => /FROM account_events/.test(s));
+    assert.ok(/\(block_number, event_index\) < \(\?, \?\)/.test(sql));
+    assert.ok(!/OFFSET/.test(sql));
+    assert.equal(body.data.next_cursor, encodeCursor([150, 2]));
+  });
+
+  test("a malformed cursor is ignored and falls back to the first page", async () => {
+    const { env, captures } = dbWith({
+      subnetEvents: [accountEventRow()],
+    });
+    await handleSubnetEvents(
+      req(`/api/v1/subnets/${NETUID}/events`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/events?cursor=not-a-cursor`),
+    );
+    const sql = captures.sql.find((s) => /FROM account_events/.test(s));
+    assert.ok(/OFFSET/.test(sql));
+    assert.ok(!/block_number, event_index\) </.test(sql));
   });
 });
 

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -309,6 +309,7 @@ export async function handleAccountHistory(request, env, ss58, url) {
     "to",
     "limit",
     "offset",
+    "cursor",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const from = url.searchParams.get("from");
@@ -330,6 +331,17 @@ export async function handleAccountHistory(request, env, ss58, url) {
       400,
     );
   }
+  // Keyset (cursor) pagination over (day, netuid). day is ordered as TEXT
+  // (YYYY-MM-DD sorts chronologically); the cursor encodes it as its natural
+  // sortable integer (2026-06-25 -> 20260625) so it fits the integer-only cursor
+  // codec, with netuid as the within-day tiebreaker. offset stays as a deprecated
+  // fallback; cursor wins. A cursor that does not decode to a valid YYYYMMDD day
+  // is ignored (falls back to the first page), preserving the never-throw contract.
+  const cur = decodeCursor(url.searchParams.get("cursor"), 2);
+  const cursorDay = cur
+    ? String(cur[0]).replace(/^(\d{4})(\d{2})(\d{2})$/, "$1-$2-$3")
+    : null;
+  const useCursor = Boolean(cursorDay && DAY_RE.test(cursorDay));
   const params = [ss58];
   let sql = `SELECT ${ACCOUNT_DAY_COLUMNS} FROM account_events_daily WHERE hotkey = ?`;
   if (netuid != null) {
@@ -344,10 +356,23 @@ export async function handleAccountHistory(request, env, ss58, url) {
     sql += " AND day <= ?";
     params.push(to);
   }
-  sql += " ORDER BY day DESC LIMIT ? OFFSET ?";
-  params.push(limit, offset);
+  if (useCursor) {
+    sql += " AND (day, netuid) < (?, ?)";
+    params.push(cursorDay, cur[1]);
+  }
+  sql += " ORDER BY day DESC, netuid DESC LIMIT ?";
+  params.push(limit);
+  if (!useCursor) {
+    sql += " OFFSET ?";
+    params.push(offset);
+  }
   const rows = await d1All(env, sql, params);
-  const data = buildAccountHistory(rows, ss58, { limit, offset });
+  const last = rows.length === limit ? rows[rows.length - 1] : null;
+  const nextCursor =
+    last && typeof last.day === "string" && DAY_RE.test(last.day)
+      ? encodeCursor([Number(last.day.replaceAll("-", "")), last.netuid])
+      : null;
+  const data = buildAccountHistory(rows, ss58, { limit, offset, nextCursor });
   return envelopeResponse(
     request,
     {
@@ -403,6 +428,7 @@ export async function handleAccountTransfers(request, env, ss58, url) {
     "direction",
     "limit",
     "offset",
+    "cursor",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const direction = url.searchParams.get("direction");
@@ -430,12 +456,29 @@ export async function handleAccountTransfers(request, env, ss58, url) {
     sideClause = "coldkey = ?";
     sideParams = [ss58];
   }
-  const rows = await d1All(
-    env,
-    `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE event_kind = 'Transfer' AND ${sideClause} ORDER BY block_number DESC, event_index DESC LIMIT ? OFFSET ?`,
-    [...sideParams, limit, offset],
-  );
-  const data = buildAccountTransfers(rows, ss58, { limit, offset });
+  // Keyset (cursor) pagination mirrors loadAccountEvents/handleExtrinsicsFeed: a
+  // (block_number, event_index) row-value seek, stable + O(limit) at depth on the
+  // large account_events tier. offset stays as a deprecated fallback; cursor wins.
+  const cur = decodeCursor(url.searchParams.get("cursor"), 2);
+  const useCursor = Boolean(cur);
+  const params = [...sideParams];
+  let sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE event_kind = 'Transfer' AND ${sideClause}`;
+  if (useCursor) {
+    sql += " AND (block_number, event_index) < (?, ?)";
+    params.push(cur[0], cur[1]);
+  }
+  sql += " ORDER BY block_number DESC, event_index DESC LIMIT ?";
+  params.push(limit);
+  if (!useCursor) {
+    sql += " OFFSET ?";
+    params.push(offset);
+  }
+  const rows = await d1All(env, sql, params);
+  const last = rows.length === limit ? rows[rows.length - 1] : null;
+  const nextCursor = last
+    ? encodeCursor([last.block_number, last.event_index])
+    : null;
+  const data = buildAccountTransfers(rows, ss58, { limit, offset, nextCursor });
   return envelopeResponse(
     request,
     {
@@ -474,21 +517,42 @@ export async function handleAccountSubnets(request, env, ss58) {
 // ?kind= filter; ?limit (<=1000)/?offset. Cold/absent store → schema-stable zero
 // (never 404), mirroring handleAccountEvents.
 export async function handleSubnetEvents(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, ["kind", "limit", "offset"]);
+  const validationError = validateQueryParams(url, [
+    "kind",
+    "limit",
+    "offset",
+    "cursor",
+  ]);
   if (validationError) return analyticsQueryError(validationError);
   const limit = clampInt(url.searchParams.get("limit"), 100, 1, 1000);
   const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
   const kind = url.searchParams.get("kind");
+  // Keyset (cursor) pagination on (block_number, event_index), mirroring
+  // loadAccountEvents; offset stays as a deprecated fallback, cursor wins.
+  const cur = decodeCursor(url.searchParams.get("cursor"), 2);
+  const useCursor = Boolean(cur);
   const params = [netuid];
   let sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE netuid = ?`;
   if (kind) {
     sql += " AND event_kind = ?";
     params.push(kind);
   }
-  sql += " ORDER BY block_number DESC, event_index DESC LIMIT ? OFFSET ?";
-  params.push(limit, offset);
+  if (useCursor) {
+    sql += " AND (block_number, event_index) < (?, ?)";
+    params.push(cur[0], cur[1]);
+  }
+  sql += " ORDER BY block_number DESC, event_index DESC LIMIT ?";
+  params.push(limit);
+  if (!useCursor) {
+    sql += " OFFSET ?";
+    params.push(offset);
+  }
   const rows = await d1All(env, sql, params);
-  const data = buildSubnetEvents(rows, netuid, { limit, offset });
+  const last = rows.length === limit ? rows[rows.length - 1] : null;
+  const nextCursor = last
+    ? encodeCursor([last.block_number, last.event_index])
+    : null;
+  const data = buildSubnetEvents(rows, netuid, { limit, offset, nextCursor });
   return envelopeResponse(
     request,
     {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -331,12 +331,17 @@ export async function handleAccountHistory(request, env, ss58, url) {
       400,
     );
   }
-  // Keyset (cursor) pagination over (day, netuid). day is ordered as TEXT
-  // (YYYY-MM-DD sorts chronologically); the cursor encodes it as its natural
-  // sortable integer (2026-06-25 -> 20260625) so it fits the integer-only cursor
-  // codec, with netuid as the within-day tiebreaker. offset stays as a deprecated
-  // fallback; cursor wins. A cursor that does not decode to a valid YYYYMMDD day
-  // is ignored (falls back to the first page), preserving the never-throw contract.
+  // Keyset (cursor) pagination over (day, netuid). day sorts as TEXT (YYYY-MM-DD
+  // is chronological); the cursor encodes it as its natural sortable integer
+  // (2026-06-25 -> 20260625) to fit the integer-only cursor codec, with netuid as
+  // the within-day tiebreaker. netuid is NOT NULL (a primary-key column of
+  // account_events_daily), so the cursor's netuid leg is always a real integer and
+  // the seek never degrades to a NULL comparison. ORDER BY adds `netuid DESC` to
+  // make same-day ordering deterministic — it was `day DESC` only before, where
+  // same-day order was unspecified, so existing offset callers get a stable (not a
+  // changed) page order. offset stays as a deprecated fallback; cursor wins. A
+  // cursor that does not decode to a valid YYYYMMDD day is ignored (falls back to
+  // the first page), preserving the never-throw contract.
   const cur = decodeCursor(url.searchParams.get("cursor"), 2);
   const cursorDay = cur
     ? String(cur[0]).replace(/^(\d{4})(\d{2})(\d{2})$/, "$1-$2-$3")


### PR DESCRIPTION
## Summary

Completes keyset (cursor) pagination across the remaining offset-only entity feeds, so deep-page reads are O(limit) row-value seeks instead of scanning-and-skipping up to a million offset rows. Extends the existing handleExtrinsicsFeed/loadAccountEvents pattern.

## What Changed

- GET /api/v1/accounts/{ss58}/transfers and GET /api/v1/subnets/{netuid}/events gain an optional ?cursor= and emit next_cursor via a (block_number, event_index) row-value seek over the large account_events tier.
- GET /api/v1/accounts/{ss58}/history gains ?cursor= + next_cursor via a (day, netuid) seek; day is encoded as its natural sortable integer (2026-06-25 -> 20260625) so it fits the integer cursor codec, with netuid as the within-day tiebreaker, and its ordering is now deterministic (day DESC, netuid DESC).
- offset stays accepted as a deprecated fallback on every feed and cursor takes precedence; a malformed cursor is ignored and falls back to the first page.
- The response schemas now document next_cursor for all three feeds, matching the existing events/blocks/extrinsics feeds.
- Tests cover the keyset seek, next_cursor emission, and malformed-cursor fallback for each feed.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] npm run validate
- [x] npm run validate:api
- [x] npm run validate:openapi
- [x] npm run validate:schemas
- [x] npm run validate:types

Closes #2058