### PR TITLE
fix(api): return mainnet-only errors for D1 live routes under network prefixes

### DIFF
--- a/tests/network-routing.test.mjs
+++ b/tests/network-routing.test.mjs
@@ -325,11 +325,7 @@ describe("multi-network routing prefix (Phase 1)", () => {
       const { res, body } = await get(env, path);
       assert.equal(res.status, 404, path);
       assert.equal(body.meta.network, "testnet", path);
-      assert.match(
-        body.error.message,
-        /only available on mainnet/i,
-        path,
-      );
+      assert.match(body.error.message, /only available on mainnet/i, path);
     }
     // Partitioned registry routes stay available under testnet.
     const subnets = await get(env, "/api/v1/testnet/subnets");

--- a/tests/network-routing.test.mjs
+++ b/tests/network-routing.test.mjs
@@ -6,6 +6,7 @@ import { createLocalArtifactEnv, repoRoot } from "../scripts/lib.mjs";
 import { buildNetworkRegistry } from "../scripts/build-network-registry.mjs";
 
 const ORIGIN = "https://api.metagraph.sh";
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
 // Build the testnet registry from the committed snapshot so the data-present
 // assertions don't depend on a prior `npm run build`. `local` is intentionally
@@ -304,6 +305,35 @@ describe("multi-network routing prefix (Phase 1)", () => {
     const compare = await get(env, "/api/v1/testnet/compare?netuids=1");
     assert.equal(compare.res.status, 404);
     assert.equal(compare.body.meta.network, "testnet");
+  });
+
+  test("D1-backed live routes 404 under testnet with a mainnet-only message", async () => {
+    const env = createLocalArtifactEnv();
+    for (const path of [
+      "/api/v1/testnet/blocks",
+      "/api/v1/testnet/blocks/12345",
+      "/api/v1/testnet/extrinsics",
+      `/api/v1/testnet/accounts/${SS58}`,
+      "/api/v1/testnet/subnets/7/metagraph",
+      "/api/v1/testnet/subnets/7/validators",
+      "/api/v1/testnet/subnets/7/events",
+      "/api/v1/testnet/subnets/7/health",
+      "/api/v1/testnet/incidents",
+      "/api/v1/testnet/rpc/usage",
+      "/api/v1/testnet/chain/activity",
+    ]) {
+      const { res, body } = await get(env, path);
+      assert.equal(res.status, 404, path);
+      assert.equal(body.meta.network, "testnet", path);
+      assert.match(
+        body.error.message,
+        /only available on mainnet/i,
+        path,
+      );
+    }
+    // Partitioned registry routes stay available under testnet.
+    const subnets = await get(env, "/api/v1/testnet/subnets");
+    assert.equal(subnets.res.status, 200);
   });
 
   test("raw artifact: mainnet alias and testnet both serve their partitioned data", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1324,13 +1324,40 @@ function isMainnetOnlyApiPath(pathname) {
     pathname === "/api/v1/search/semantic" ||
     pathname === "/api/v1/registry/leaderboards" ||
     pathname === "/api/v1/compare" ||
+    pathname === "/api/v1/health" ||
+    pathname === "/api/v1/incidents" ||
+    pathname === "/api/v1/rpc/usage" ||
+    pathname === "/api/v1/chain/activity" ||
+    pathname === "/api/v1/chain/calls" ||
+    pathname === "/api/v1/chain/signers" ||
+    pathname === "/api/v1/chain/fees" ||
     pathname.startsWith("/api/v1/webhooks/") ||
     BULK_TRENDS_PATH_PATTERN.test(pathname) ||
     TRENDS_PATH_PATTERN.test(pathname) ||
     PERCENTILES_PATH_PATTERN.test(pathname) ||
     INCIDENTS_PATH_PATTERN.test(pathname) ||
     TRAJECTORY_PATH_PATTERN.test(pathname) ||
-    UPTIME_PATH_PATTERN.test(pathname)
+    UPTIME_PATH_PATTERN.test(pathname) ||
+    /^\/api\/v1\/subnets\/(\d+)\/health$/.test(pathname) ||
+    SUBNET_METAGRAPH_PATH_PATTERN.test(pathname) ||
+    SUBNET_NEURON_PATH_PATTERN.test(pathname) ||
+    SUBNET_NEURON_HISTORY_PATH_PATTERN.test(pathname) ||
+    SUBNET_VALIDATORS_PATH_PATTERN.test(pathname) ||
+    SUBNET_EVENTS_PATH_PATTERN.test(pathname) ||
+    SUBNET_HISTORY_PATH_PATTERN.test(pathname) ||
+    ACCOUNT_PATH_PATTERN.test(pathname) ||
+    ACCOUNT_EVENTS_PATH_PATTERN.test(pathname) ||
+    ACCOUNT_HISTORY_PATH_PATTERN.test(pathname) ||
+    ACCOUNT_SUBNETS_PATH_PATTERN.test(pathname) ||
+    ACCOUNT_EXTRINSICS_PATH_PATTERN.test(pathname) ||
+    ACCOUNT_TRANSFERS_PATH_PATTERN.test(pathname) ||
+    ACCOUNT_BALANCE_PATH_PATTERN.test(pathname) ||
+    BLOCKS_FEED_PATH_PATTERN.test(pathname) ||
+    BLOCK_DETAIL_PATH_PATTERN.test(pathname) ||
+    BLOCK_EXTRINSICS_PATH_PATTERN.test(pathname) ||
+    BLOCK_EVENTS_PATH_PATTERN.test(pathname) ||
+    EXTRINSICS_FEED_PATH_PATTERN.test(pathname) ||
+    EXTRINSIC_DETAIL_PATH_PATTERN.test(pathname)
   );
 }
 


### PR DESCRIPTION
## Summary

- Extend `isMainnetOnlyApiPath` to include D1-backed live route patterns already used in `handleRequest` (blocks, extrinsics, accounts, subnet metagraph/validators/events/history/neurons, live subnet health, global health/incidents, rpc usage, chain analytics).
- Reuse the existing mainnet-only error envelope (`meta.network`, descriptive message).
- Add `tests/network-routing.test.mjs` coverage for representative testnet-prefixed live routes; assert partitioned `/api/v1/testnet/subnets` still returns 200.

Closes #2131

## Why

Agents integrating against `/api/v1/testnet/…` should get an explicit contract signal, not an ambiguous artifact miss. Registry artifacts are partitioned; live chain/analytics data is mainnet-only until explicitly extended.

## Test notes

The new routing test uses a constant `SS58` — a sample **Substrate/Bittensor account address** in base58 encoding (the same 47–48 character shape the API expects in `/api/v1/accounts/{ss58}`). The value is reused from `tests/account-balance.test.mjs`; it does not need to exist on-chain. It only has to match `ACCOUNT_PATH_PATTERN` so the request reaches the mainnet-only gate instead of failing on a malformed path.

## Test plan

- [x] `npm test -- tests/network-routing.test.mjs`
- [ ] `npm run validate:api`
- [x] `/api/v1/testnet/blocks`, `/subnets/7/metagraph`, `/incidents`, etc. → 404 + `meta.network === "testnet"` + mainnet-only message
- [x] `/api/v1/testnet/accounts/{ss58}` (sample SS58 fixture) → same mainnet-only 404
- [x] `/api/v1/testnet/subnets` → still 200