### PR TITLE
fix(infra): filter unsafe WSS JSON-RPC frames in wss-lb proxy

### DIFF
--- a/deploy/wss-lb/src/proxy.mjs
+++ b/deploy/wss-lb/src/proxy.mjs
@@ -1,6 +1,87 @@
 // Client→upstream wss piping with connect-time failover (extracted for testing).
 import { WebSocket } from "ws";
 
+import {
+  MAX_RPC_BODY_BYTES,
+  SAFE_RPC_METHODS,
+  DENIED_RPC_PREFIXES,
+} from "../../../workers/config.mjs";
+
+function isSafeRpcMethod(method) {
+  return (
+    SAFE_RPC_METHODS.has(method) &&
+    !DENIED_RPC_PREFIXES.some((prefix) => method.startsWith(prefix))
+  );
+}
+
+function rpcError(id, code, message) {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id: id ?? null,
+    error: { code, message },
+  });
+}
+
+function validateClientFrame(data, isBinary) {
+  if (isBinary)
+    return {
+      ok: false,
+      reply: rpcError(
+        null,
+        -32600,
+        "Binary JSON-RPC frames are not supported.",
+      ),
+    };
+  const size = Buffer.isBuffer(data)
+    ? data.length
+    : Buffer.byteLength(String(data));
+  if (size > MAX_RPC_BODY_BYTES) {
+    return {
+      ok: false,
+      reply: rpcError(
+        null,
+        -32600,
+        "RPC request body is too large for the read-only proxy.",
+      ),
+    };
+  }
+  let rpc;
+  try {
+    rpc = JSON.parse(data.toString());
+  } catch {
+    return {
+      ok: false,
+      reply: rpcError(null, -32700, "RPC frame must be valid JSON."),
+    };
+  }
+  if (
+    !rpc ||
+    Array.isArray(rpc) ||
+    typeof rpc !== "object" ||
+    typeof rpc.method !== "string"
+  ) {
+    return {
+      ok: false,
+      reply: rpcError(
+        rpc?.id,
+        -32600,
+        "Only single JSON-RPC request objects are supported.",
+      ),
+    };
+  }
+  if (!isSafeRpcMethod(rpc.method)) {
+    return {
+      ok: false,
+      reply: rpcError(
+        rpc.id,
+        -32601,
+        `RPC method is not allowed through this proxy: ${rpc.method}`,
+      ),
+    };
+  }
+  return { ok: true };
+}
+
 // Pipe a client wss connection to the first healthy upstream, failing over to the
 // next on a failed handshake. The client listeners attach ONCE; `up` is the
 // current upstream socket, reassigned per attempt.
@@ -21,9 +102,14 @@ export function proxy(client, upstreams, opts = {}) {
   const pending = [];
 
   client.on("message", (data, isBinary) => {
+    const validation = validateClientFrame(data, isBinary);
+    if (!validation.ok) {
+      if (client.readyState === WebSocket.OPEN) client.send(validation.reply);
+      return;
+    }
     if (opened && up && up.readyState === WebSocket.OPEN)
-      up.send(data, { binary: isBinary });
-    else pending.push([data, isBinary]);
+      up.send(data, { binary: false });
+    else pending.push([data, false]);
   });
   client.on("close", () => {
     clientClosed = true;

--- a/deploy/wss-lb/test/proxy.test.mjs
+++ b/deploy/wss-lb/test/proxy.test.mjs
@@ -66,7 +66,11 @@ test("failover: dead upstream then good → one dial, echo works, no crash", asy
   const lb = await lbServer([await deadUrl(), good.url]);
   const echoed = await new Promise((resolve, reject) => {
     const c = new WebSocket(lb.url);
-    c.on("open", () => c.send("ping")); // pre-open send → the buffered/crash path
+    c.on("open", () =>
+      c.send(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, method: "system_health" }),
+      ),
+    ); // pre-open send → the buffered/crash path
     c.on("message", (d) => {
       c.close();
       resolve(d.toString());
@@ -74,7 +78,11 @@ test("failover: dead upstream then good → one dial, echo works, no crash", asy
     c.on("error", reject);
     setTimeout(() => reject(new Error("timeout")), 8000);
   });
-  assert.equal(echoed, "ping");
+  assert.deepEqual(JSON.parse(echoed), {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "system_health",
+  });
   assert.equal(good.connections, 1); // not 2 — no duplicate dial
   await lb.close();
   await good.close();
@@ -89,4 +97,86 @@ test("all upstreams dead → client closed with 1013", async () => {
   });
   assert.equal(code, 1013);
   await lb.close();
+});
+
+test("security: unsafe and oversized client RPC frames do not reach upstream", async () => {
+  const upstreamMessages = [];
+  const http = createServer();
+  const wss = new WebSocketServer({ server: http });
+  wss.on("connection", (ws) => {
+    ws.on("message", (d) => {
+      upstreamMessages.push(d.toString());
+      ws.send(JSON.stringify({ jsonrpc: "2.0", id: 99, result: "accepted" }));
+    });
+  });
+  const upstream = await new Promise((resolve) =>
+    http.listen(0, "127.0.0.1", () =>
+      resolve(`ws://127.0.0.1:${http.address().port}`),
+    ),
+  );
+  const lb = await lbServer([upstream]);
+
+  const replies = await new Promise((resolve, reject) => {
+    const seen = [];
+    const c = new WebSocket(lb.url);
+    c.on("open", () => {
+      c.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "author_submitExtrinsic",
+        }),
+      );
+      c.send(
+        JSON.stringify({ jsonrpc: "2.0", id: 2, method: "system_health" }),
+      );
+      c.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 3,
+          method: "state_call",
+          params: ["x".repeat(70000)],
+        }),
+      );
+    });
+    c.on("message", (d) => {
+      seen.push(JSON.parse(d.toString()));
+      if (seen.length === 3) {
+        c.close();
+        resolve(seen);
+      }
+    });
+    c.on("error", reject);
+    setTimeout(() => reject(new Error("timeout")), 8000);
+  });
+
+  assert.ok(
+    replies.some(
+      (reply) =>
+        reply.error?.message ===
+        "RPC method is not allowed through this proxy: author_submitExtrinsic",
+    ),
+  );
+  assert.ok(
+    replies.some(
+      (reply) =>
+        reply.error?.message ===
+        "RPC request body is too large for the read-only proxy.",
+    ),
+  );
+  assert.ok(
+    replies.some(
+      (reply) =>
+        reply.jsonrpc === "2.0" &&
+        reply.id === 99 &&
+        reply.result === "accepted",
+    ),
+  );
+  assert.deepEqual(
+    upstreamMessages.map((m) => JSON.parse(m).method),
+    ["system_health"],
+  );
+
+  await lb.close();
+  await new Promise((resolve) => http.close(resolve));
 });


### PR DESCRIPTION
### Motivation
- The WSS load balancer previously forwarded client WebSocket frames transparently to upstreams, bypassing the HTTP proxy's body-size caps, method allowlist, and denied-prefix filters and exposing upstreams to unauthenticated abuse. 
- The change adds in-line JSON-RPC validation to prevent binary/malformed/oversized/batched/unsafe method frames from reaching upstream nodes.

### Description
- Add JSON-RPC frame validation to `deploy/wss-lb/src/proxy.mjs`, reusing `MAX_RPC_BODY_BYTES`, `SAFE_RPC_METHODS`, and `DENIED_RPC_PREFIXES` from `workers/config.mjs` and returning JSON-RPC errors for rejected frames. 
- Validate and reject binary frames, non-JSON or batched payloads, frames exceeding `MAX_RPC_BODY_BYTES`, and methods blocked by the deny/allow policy before any upstream send. 
- Preserve existing failover and piping semantics for validated frames and keep client listeners single-attached; ensure forwarded frames are text JSON-RPC only. 
- Update `deploy/wss-lb/test/proxy.test.mjs` with a regression that proves unsafe (`author_submitExtrinsic`) and oversized (`state_call`) frames are rejected locally while an allowed `system_health` call is forwarded.

### Testing
- Ran `cd deploy/wss-lb && npm test` and observed all WSS package tests pass (10/10). 
- Ran `npm run lint -- deploy/wss-lb/src/proxy.mjs deploy/wss-lb/test/proxy.test.mjs` and `npx prettier --check` with no errors. 
- Ran `npm run build` and `npm run validate` for the repo; both completed successfully with validators passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f5a5cd2b0832c9bbac62c37650bb5)