### PR TITLE
fix(ai): preserve failed re-embed manifest entries

### DIFF
--- a/src/ai-search.mjs
+++ b/src/ai-search.mjs
@@ -245,14 +245,18 @@ export async function runEmbeddingSync(env, deps = {}) {
       text: batch.map((entry) => embeddingText(entry.doc)),
     });
     const data = Array.isArray(response?.data) ? response.data : [];
-    // Upsert (and record in the manifest) ONLY entries that produced a valid
-    // vector. If Workers AI returns fewer/empty/malformed rows, the affected
-    // docs are left out of both the upsert and `next`, so the next cron retries
-    // them rather than leaving a permanent hole in the index.
+    // Upsert (and record the new hash for) ONLY entries that produced a valid
+    // vector. If Workers AI returns fewer/empty/malformed rows, keep any
+    // existing manifest hash so a later removal still deletes the stale vector,
+    // while the changed content remains a delta and is retried next run. New
+    // docs with no previous vector stay absent from the manifest until they
+    // embed successfully.
     const valid = [];
     for (let i = 0; i < batch.length; i += 1) {
       if (isValidEmbeddingVector(data[i])) {
         valid.push({ entry: batch[i], values: data[i] });
+      } else if (Object.prototype.hasOwnProperty.call(previous, batch[i].id)) {
+        next[batch[i].id] = previous[batch[i].id];
       }
     }
     if (valid.length === 0) continue;

--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -488,6 +488,69 @@ describe("runEmbeddingSync", () => {
     assert.equal(env2.VECTORIZE.ops.deletes.length, 0);
   });
 
+  test("a changed doc whose re-embed fails is deleted if it is later removed", async () => {
+    const kv = memKv();
+    await runEmbeddingSync(
+      { AI: stubAi(), VECTORIZE: stubVectorize(), METAGRAPH_CONTROL: kv },
+      { readArtifact: reader(searchDocs) },
+    );
+
+    const changed = {
+      ok: true,
+      data: {
+        documents: [
+          {
+            id: "subnet:1",
+            type: "subnet",
+            netuid: 1,
+            title: "One",
+            tokens: ["a"],
+          },
+          {
+            id: "subnet:2",
+            type: "subnet",
+            netuid: 2,
+            title: "Two CHANGED",
+            tokens: ["b"],
+          },
+        ],
+      },
+    };
+    await runEmbeddingSync(
+      {
+        AI: embedAiWith(() => []),
+        VECTORIZE: stubVectorize(),
+        METAGRAPH_CONTROL: kv,
+      },
+      { readArtifact: reader(changed) },
+    );
+
+    const dropped = {
+      ok: true,
+      data: {
+        documents: [
+          {
+            id: "subnet:1",
+            type: "subnet",
+            netuid: 1,
+            title: "One",
+            tokens: ["a"],
+          },
+        ],
+      },
+    };
+    const env3 = {
+      AI: stubAi(),
+      VECTORIZE: stubVectorize(),
+      METAGRAPH_CONTROL: kv,
+    };
+
+    const r3 = await runEmbeddingSync(env3, { readArtifact: reader(dropped) });
+
+    assert.equal(r3.removed, 1, "stale vector is still tracked for removal");
+    assert.deepEqual(env3.VECTORIZE.ops.deletes[0], ["subnet:2"]);
+  });
+
   test("skips docs without an id", async () => {
     const env = {
       AI: stubAi(),


### PR DESCRIPTION
### Motivation
- A failed re-embed for an already-indexed document could cause the manifest to drop that id while the old Vectorize row remained, leaving stale vectors permanently queryable after a later removal. 
- The intent is to avoid upserting malformed embeddings while still ensuring stale vectors are tracked for deletion if the document is removed. 

### Description
- In `runEmbeddingSync` preserve the prior manifest hash into `next[id]` when a pending entry's embedding row is missing/invalid but `previous` contains the id, so changed-but-failed docs remain tracked for later removal. 
- Continue to withhold new documents (no previous vector) from the manifest until they produce a valid vector, so failed cold embeds are retried. 
- Add a regression test in `tests/ai-search.test.mjs` that exercises initial successful embed, a changed doc with a failed re-embed, and a later removal that deletes the stale Vectorize id. 

### Testing
- Ran the focused embedding-sync tests with `npm test -- tests/ai-search.test.mjs -t runEmbeddingSync`, which passed (targeted coverage for `runEmbeddingSync` succeeded). 
- Ran `npm run lint` and `npm run format:check`, both of which passed. 
- Ran `npm run validate:ai`, which passed; a full `npm test -- tests/ai-search.test.mjs` run still shows an unrelated cron-environment test failure, but the targeted regression and embedding-sync assertions succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f7b8498f0832c83da8662a489424b)