### PR TITLE
infra(deploy): align wss-lb + indexer to the streamer's Railway monorepo pattern

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -16,16 +16,47 @@ R2 = artifacts · Parquet/CSV exports · Postgres backups (zero-egress)
 
 ## Topology
 
-| Tier          | Where                                  | Pieces                                                                                                                          |
-| ------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Edge (rented) | **Cloudflare**                         | Worker serving, **Hyperdrive** → Postgres, **Durable Object** firehose, R2, KV, Vectorize, Workers AI, rate-limiters, RPC proxy |
-| Core (owned)  | **Railway project `metagraphed-core`** | `postgres`, `redis`, `subtensor-node` (pruned), `indexer`, `health-prober`, `rollups`, `alerter`, `exporter`, `reconciler`      |
-| Escape hatch  | **Hetzner** (later)                    | `postgres` (+ optional node) when compressed history > ~300–500 GB or the 1 TB Railway cap looms — see ADR 0013                 |
+| Tier          | Where                                  | Pieces                                                                                                                                               |
+| ------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Edge (rented) | **Cloudflare**                         | Worker serving, **Hyperdrive** → Postgres, **Durable Object** firehose, R2, KV, Vectorize, Workers AI, rate-limiters, RPC proxy                      |
+| Core (owned)  | **Railway project `metagraphed-core`** | `postgres`, `redis`, `subtensor-node` (pruned), `indexer`, `health-prober`, `rollups`, `alerter`, `exporter`, `reconciler`, `wss-lb` (public WSS LB) |
+| Escape hatch  | **Hetzner** (later)                    | `postgres` (+ optional node) when compressed history > ~300–500 GB or the 1 TB Railway cap looms — see ADR 0013                                      |
 
 One Railway **project**, two **environments** (`production`, `staging`), one
 private network (`<service>.railway.internal`, zero egress). The existing
 `metagraphed-streamer` project is **separate and untouched** — it is superseded
 by `indexer` only at decommission (final step).
+
+## Railway: one project, many services
+
+A Railway **project** is the unit that groups cooperating services — the docs call
+it "an application stack, a service group" — so **all** of metagraphed-core's
+services (`postgres`, `redis`, `subtensor-node`, `indexer`, the crons, and the
+public `wss-lb`) live in **one project**, **not** one project each. Only
+same-project + same-environment services get the automatic **private network**
+(`<service>.railway.internal`, Wireguard-encrypted) and **reference variables**
+`${{Postgres.DATABASE_URL}}` / `${{Redis.REDIS_URL}}`; split them across projects
+and you lose internal DNS + cross-service vars and must wire public URLs by hand.
+
+**Two config layers — this is the "is it all one `railway.json`?" answer: no.**
+
+- **Per-service build config** (`railway.json` / `railway.toml`): each service reads
+  its OWN file. Railway does **not** auto-discover it from a subdirectory — set the
+  service's **Settings → Config-as-code → "Railway Config File"** to an **absolute**
+  repo-root path (it does **not** follow Root Directory):
+  - `metagraphed-streamer` → `/railway.json`
+  - `wss-lb` → `/deploy/wss-lb/railway.json`
+  - `indexer` → `/deploy/indexer.railway.json`
+
+  Each builds its Dockerfile from the **repo-root** build context (leave Root
+  Directory unset) and scopes redeploys with `watchPatterns`, so a streamer change
+  never rebuilds the indexer.
+
+- **Whole-project config** (`.railway/railway.ts`, project-as-code): defines ALL
+  services + DBs + variables + references in **one file**, applied with
+  `railway config plan` / `railway config apply`. Scaffold with `railway config init`
+  (or `railway config pull` to import the live project). This is the cleanest way to
+  define + version the entire topology as code once the service set stabilizes.
 
 ## Bare-metal bring-up (the recommended core — one command)
 
@@ -83,6 +114,15 @@ railway add -s indexer --repo JSONbored/metagraphed --branch main \
   -v DATABASE_URL='${{Postgres.DATABASE_URL}}' \
   -v REDIS_URL='${{Redis.REDIS_URL}}' \
   -v EVENTS_RPC_URL='wss://entrypoint-finney.opentensor.ai:443'
+```
+
+The public `wss-lb` is independent of Postgres/Redis (it reads only the public
+API), so it can ship **first**, before any DB exists:
+
+```bash
+railway add -s wss-lb --repo JSONbored/metagraphed --branch main
+# set its Config File = /deploy/wss-lb/railway.json (dashboard), then expose it:
+railway domain
 ```
 
 Cron services (`rollups`, `exporter`, `reconciler`) get a crontab via the service

--- a/deploy/indexer.railway.json
+++ b/deploy/indexer.railway.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "deploy/indexer.Dockerfile",
+    "watchPatterns": [
+      "scripts/index-chain.py",
+      "scripts/fetch-events.py",
+      "scripts/stream-events.py",
+      "deploy/indexer.Dockerfile",
+      "deploy/indexer.railway.json"
+    ]
+  },
+  "deploy": {
+    "numReplicas": 1,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/deploy/wss-lb/Dockerfile
+++ b/deploy/wss-lb/Dockerfile
@@ -1,11 +1,16 @@
-# WSS load balancer (ADR 0013). Railway: set the service Root Directory to
-# deploy/wss-lb so this build context + COPY paths resolve. Local:
-#   docker build -t metagraphed-wss-lb deploy/wss-lb
+# WSS load balancer (ADR 0013). Deployed as one SERVICE in the metagraphed-core
+# Railway project, with a REPO-ROOT build context (same shape as the streamer):
+#   - Source repo JSONbored/metagraphed, branch main, auto-deploy on push
+#   - Service > Settings > Config-as-code "Railway Config File" = /deploy/wss-lb/railway.json
+#     (the config path is absolute from the repo root; it does NOT follow Root Directory)
+#   - Leave Root Directory unset → build context is the repo root, so these COPYs
+#     are written relative to it.
+# Local:  docker build -f deploy/wss-lb/Dockerfile -t metagraphed-wss-lb .
 FROM node:22-alpine
 WORKDIR /app
-COPY package.json package-lock.json ./
+COPY deploy/wss-lb/package.json deploy/wss-lb/package-lock.json ./
 RUN npm ci --omit=dev --no-audit --no-fund
-COPY src ./src
+COPY deploy/wss-lb/src ./src
 ENV PORT=8080
 EXPOSE 8080
 USER node

--- a/deploy/wss-lb/README.md
+++ b/deploy/wss-lb/README.md
@@ -39,9 +39,28 @@ cd deploy/wss-lb && npm install && npm start        # local
 npm test                                            # selection + proxy-failover tests
 ```
 
-Railway: add a service with **Root Directory = `deploy/wss-lb`** (the bundled
-`railway.json` and `Dockerfile` do the rest). Put it behind Cloudflare DNS for
-TLS + DDoS.
+Railway — one **service** in the shared **metagraphed-core** project (see
+[`../README.md`](../README.md#railway-one-project-many-services) for the full
+topology):
+
+- Source repo `JSONbored/metagraphed`, branch `main`, **auto-deploy on push**
+  (same as metagraphed-streamer). Leave **Root Directory unset**.
+- Set the service's **Config-as-code → Railway Config File** to
+  `/deploy/wss-lb/railway.json` (absolute path — it does **not** follow Root
+  Directory). That config builds `deploy/wss-lb/Dockerfile` from the repo root and
+  only redeploys on `deploy/wss-lb/**` changes (`watchPatterns`).
+- `railway domain` to mint the public WSS endpoint, then point Cloudflare DNS at it
+  for TLS + DDoS.
+
+```bash
+# from a clone linked to the metagraphed-core project (railway link)
+railway add --service wss-lb --repo JSONbored/metagraphed --branch main
+# set Config File = /deploy/wss-lb/railway.json (dashboard), then:
+railway domain
+```
+
+It needs **no siblings** (it reads only the public API), but lives in the same
+project so it shares one dashboard/bill and can later use private DNS.
 
 Env: `METAGRAPHED_API` (default `https://api.metagraph.sh`), `PORT` (8080),
 `REFRESH_MS` (30000), `MAX_BLOCK_LAG` (50), `NETWORKS` (`finney,test`),

--- a/deploy/wss-lb/railway.json
+++ b/deploy/wss-lb/railway.json
@@ -2,7 +2,8 @@
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "Dockerfile"
+    "dockerfilePath": "deploy/wss-lb/Dockerfile",
+    "watchPatterns": ["deploy/wss-lb/**"]
   },
   "deploy": {
     "numReplicas": 1,


### PR DESCRIPTION
Follow-up to #2119/#2117. The new Railway services were configured for a per-service Root Directory, but the working `metagraphed-streamer` service uses **repo-root build context + a per-service config-file path**. This aligns them so they deploy identically.

- **wss-lb** `railway.json`: `dockerfilePath` → `deploy/wss-lb/Dockerfile`, add `watchPatterns: [deploy/wss-lb/**]`; Dockerfile COPYs from the repo-root context.
- **indexer**: add `deploy/indexer.railway.json` (it needs `scripts/` from the repo root → repo-root context too).
- **docs** (`deploy/README.md`): ONE project `metagraphed-core` with many services (private network + reference variables are project-scoped), the per-service **Railway Config File** absolute-path rule (does not follow Root Directory), and the `.railway/railway.ts` whole-project-as-code option.

Config + docs only — no app logic. wss-lb tests 9/9; format clean.