### PR TITLE
fix(indexer): preserve signal handlers during decode import

### DIFF
--- a/scripts/index-chain.py
+++ b/scripts/index-chain.py
@@ -161,8 +161,15 @@ def _compute_from_block(cursor, head, window, max_lookback):
 
 def _decode_head():
     # stream-events imports the verified decode; reuse it so the mapping never
-    # drifts from the streamer/poller.
-    se = _load("stream_events", "stream-events.py")
+    # drifts from the streamer/poller. That module also installs CLI signal
+    # handlers at import time, so preserve the indexer handlers around the load.
+    previous_term = signal.getsignal(signal.SIGTERM)
+    previous_int = signal.getsignal(signal.SIGINT)
+    try:
+        se = _load("stream_events", "stream-events.py")
+    finally:
+        signal.signal(signal.SIGTERM, previous_term)
+        signal.signal(signal.SIGINT, previous_int)
     return se.decode_head
 
 

--- a/scripts/test_index_chain.py
+++ b/scripts/test_index_chain.py
@@ -8,7 +8,10 @@ schema/decode change can't silently corrupt the write path. Run:
 """
 import importlib.util
 import os
+import signal
+import types
 import unittest
+from unittest import mock
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _spec = importlib.util.spec_from_file_location(
@@ -128,6 +131,36 @@ class RowsFromDecoded(unittest.TestCase):
         self.assertEqual(rows, {"blocks": [], "extrinsics": [], "account_events": []})
         rows2 = ic.rows_from_decoded({})  # missing keys
         self.assertEqual(rows2, {"blocks": [], "extrinsics": [], "account_events": []})
+
+
+class DecodeHeadImport(unittest.TestCase):
+    def test_decode_head_preserves_indexer_signal_handlers(self):
+        previous_term = signal.getsignal(signal.SIGTERM)
+        previous_int = signal.getsignal(signal.SIGINT)
+
+        def stream_events_signal_handler(_signum, _frame):
+            return None
+
+        def decode_head(_s, _block_number):
+            return {}
+
+        def import_stream_events(_modname, _filename):
+            signal.signal(signal.SIGTERM, stream_events_signal_handler)
+            signal.signal(signal.SIGINT, stream_events_signal_handler)
+            return types.SimpleNamespace(decode_head=decode_head)
+
+        try:
+            signal.signal(signal.SIGTERM, ic._handle_signal)
+            signal.signal(signal.SIGINT, ic._handle_signal)
+
+            with mock.patch.object(ic, "_load", side_effect=import_stream_events):
+                self.assertIs(ic._decode_head(), decode_head)
+
+            self.assertIs(signal.getsignal(signal.SIGTERM), ic._handle_signal)
+            self.assertIs(signal.getsignal(signal.SIGINT), ic._handle_signal)
+        finally:
+            signal.signal(signal.SIGTERM, previous_term)
+            signal.signal(signal.SIGINT, previous_int)
 
 
 class BackfillStart(unittest.TestCase):


### PR DESCRIPTION
### Motivation

- The indexer dynamically imports `scripts/stream-events.py` to reuse the verified `decode_head`, but that module registers its own SIGTERM/SIGINT handlers at import time and overwrote the indexer's handlers, leaving the indexer's `_stop` flag unset on shutdown and causing graceful-stop to hang.

### Description

- Preserve the indexer-installed SIGTERM/SIGINT handlers around the dynamic import in `scripts/index-chain.py` by saving `signal.getsignal(...)` before loading and restoring them after the import, so import-time side effects cannot replace the indexer shutdown handler.
- Add a regression test in `scripts/test_index_chain.py` that mocks the `_load` import to simulate `stream-events` installing handlers and verifies `_decode_head()` returns the expected `decode_head` while the indexer handlers remain installed.
- Changes touch `scripts/index-chain.py` (handler-preserve around `_load`) and `scripts/test_index_chain.py` (new `DecodeHeadImport` test). 

### Testing

- Ran `python3 -m unittest scripts/test_index_chain.py` and the full test suite passed (all tests OK).
- Ran formatting check with `npm run format:check` and lint with `npm run lint`, both succeeded.
- Ran `git diff --check` to ensure no whitespace/issues (no problems reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f7c6e6074832cbe61f763dcf68fba)