### PR TITLE
fix(deploy): preserve Postgres serving schema contract

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -66,8 +66,8 @@ CREATE TABLE IF NOT EXISTS account_events (
   coldkey          TEXT,
   netuid           INTEGER,
   uid              INTEGER,                 -- neuron uid when the event carries one
-  amount           NUMERIC,
-  alpha            NUMERIC,
+  amount_tao       NUMERIC,                 -- tao field / 1e9 where applicable
+  alpha_amount     NUMERIC,                 -- subnet alpha leg for stake swaps
   observed_at      BIGINT NOT NULL,
   PRIMARY KEY (block_number, event_index)
 );
@@ -105,17 +105,21 @@ CREATE TABLE IF NOT EXISTS neurons (
   uid              INTEGER NOT NULL,
   hotkey           TEXT,
   coldkey          TEXT,
-  stake_tao        NUMERIC,
+  active           BOOLEAN,
+  validator_permit BOOLEAN,
   rank             NUMERIC,
   trust            NUMERIC,
+  validator_trust  NUMERIC,
   consensus        NUMERIC,
   incentive        NUMERIC,
   dividends        NUMERIC,
-  emission         NUMERIC,
-  validator_permit BOOLEAN,
-  active           BOOLEAN,
+  emission_tao     NUMERIC,
+  stake_tao        NUMERIC,
+  registered_at_block BIGINT,
+  is_immunity_period  BOOLEAN,
   axon             TEXT,
-  captured_at      BIGINT,
+  block_number     BIGINT,
+  captured_at      BIGINT NOT NULL,
   PRIMARY KEY (netuid, uid)
 );
 CREATE INDEX IF NOT EXISTS idx_neurons_netuid_permit ON neurons (netuid, validator_permit, stake_tao DESC);
@@ -127,16 +131,28 @@ CREATE TABLE IF NOT EXISTS neuron_daily (
   uid              INTEGER NOT NULL,
   snapshot_date    DATE NOT NULL,
   hotkey           TEXT,
-  stake_tao        NUMERIC,
+  coldkey          TEXT,
+  active           BOOLEAN,
+  validator_permit BOOLEAN,
+  rank             NUMERIC,
+  trust            NUMERIC,
+  validator_trust  NUMERIC,
+  consensus        NUMERIC,
   incentive        NUMERIC,
   dividends        NUMERIC,
-  emission         NUMERIC,
-  validator_permit BOOLEAN,
+  emission_tao     NUMERIC,
+  stake_tao        NUMERIC,
+  registered_at_block BIGINT,
+  is_immunity_period  BOOLEAN,
+  axon             TEXT,
+  block_number     BIGINT,
+  captured_at      BIGINT NOT NULL,
+  updated_at       BIGINT NOT NULL,
   PRIMARY KEY (netuid, uid, snapshot_date)
 );
 -- #2083: covering index for per-subnet history aggregation (avoid per-row heap fetch).
 CREATE INDEX IF NOT EXISTS idx_nd_netuid_date ON neuron_daily (netuid, snapshot_date, uid)
-  INCLUDE (stake_tao, incentive, dividends, emission);
+  INCLUDE (stake_tao, incentive, dividends, emission_tao);
 CREATE INDEX IF NOT EXISTS idx_nd_uid_date    ON neuron_daily (netuid, uid, snapshot_date);
 CREATE INDEX IF NOT EXISTS idx_nd_hotkey_date ON neuron_daily (hotkey, snapshot_date);
 
@@ -158,11 +174,17 @@ CREATE INDEX IF NOT EXISTS idx_econ_netuid_date ON economics_history (netuid, sn
 -- Account daily rollup (#2079 / audit: removes the temp-sort on default account history).
 CREATE TABLE IF NOT EXISTS account_events_daily (
   hotkey           TEXT NOT NULL,
+  netuid           INTEGER NOT NULL,
   day              DATE NOT NULL,
-  event_count      INTEGER,
-  netuid_count     INTEGER,
-  PRIMARY KEY (hotkey, day)
+  event_count      INTEGER NOT NULL,
+  event_kinds      TEXT,
+  first_block      BIGINT,
+  last_block       BIGINT,
+  updated_at       BIGINT NOT NULL,
+  PRIMARY KEY (hotkey, netuid, day)
 );
+CREATE INDEX IF NOT EXISTS idx_account_events_daily_netuid_day
+  ON account_events_daily (netuid, day);
 
 -- ---------------------------------------------------------------------------
 -- Indexer coordination

--- a/scripts/index-chain.py
+++ b/scripts/index-chain.py
@@ -67,7 +67,8 @@ EXTRINSIC_COLS = (
 )
 EVENT_COLS = (
     "block_number", "event_index", "extrinsic_index", "event_kind",
-    "hotkey", "coldkey", "netuid", "uid", "amount", "alpha", "observed_at",
+    "hotkey", "coldkey", "netuid", "uid",
+    "amount_tao", "alpha_amount", "observed_at",
 )
 
 
@@ -104,9 +105,8 @@ def rows_from_decoded(decoded):
     """PURE: a decoded block (the stream-events.decode_head shape) -> column dicts
     keyed exactly by the Postgres schema. No DB/chain access — unit-tested.
 
-    The block + extrinsic dicts already use the schema's column names; account
-    events are remapped (amount_tao -> amount, alpha_amount -> alpha) and keep
-    uid. call_args is decoded from its JSON-string form; rows missing a valid
+    The block, extrinsic, and account-event dicts use the serving schema's column
+    names. call_args is decoded from its JSON-string form; rows missing a valid
     observed_at are dropped (NOT NULL).
     """
     blocks = []
@@ -133,8 +133,8 @@ def rows_from_decoded(decoded):
             "coldkey": e.get("coldkey"),
             "netuid": e.get("netuid"),
             "uid": e.get("uid"),
-            "amount": e.get("amount_tao"),
-            "alpha": e.get("alpha_amount"),
+            "amount_tao": e.get("amount_tao"),
+            "alpha_amount": e.get("alpha_amount"),
             "observed_at": e.get("observed_at"),
         }
         if _has_ts(row):

--- a/scripts/test_index_chain.py
+++ b/scripts/test_index_chain.py
@@ -122,15 +122,15 @@ class RowsFromDecoded(unittest.TestCase):
         self.assertEqual(rows["extrinsics"], [])
         self.assertEqual(rows["account_events"], [])
 
-    def test_event_row_remaps_amount_alpha_and_keeps_uid(self):
+    def test_event_row_preserves_serving_amount_columns_and_keeps_uid(self):
         e = ic.rows_from_decoded(_decoded())["account_events"][0]
         self.assertEqual(set(e.keys()), set(ic.EVENT_COLS))
-        # decode_head emits amount_tao/alpha_amount; the schema columns are amount/alpha.
-        self.assertEqual(e["amount"], 1.5)
-        self.assertEqual(e["alpha"], 2.5)
+        # Keep the D1-era serving names so Worker readers need only a binding swap.
+        self.assertEqual(e["amount_tao"], 1.5)
+        self.assertEqual(e["alpha_amount"], 2.5)
         self.assertEqual(e["uid"], 12)
         self.assertEqual(e["extrinsic_index"], 2)
-        self.assertNotIn("amount_tao", e)
+        self.assertNotIn("amount", e)
 
     def test_no_block_yields_empty_blocks(self):
         d = _decoded()
@@ -174,6 +174,44 @@ class DecodeHeadImport(unittest.TestCase):
         finally:
             signal.signal(signal.SIGTERM, previous_term)
             signal.signal(signal.SIGINT, previous_int)
+
+
+class PostgresSchemaContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        root = os.path.dirname(_HERE)
+        with open(
+            os.path.join(root, "deploy", "postgres", "schema.sql"), encoding="utf-8"
+        ) as schema_file:
+            cls.schema = schema_file.read()
+
+    def test_account_events_schema_uses_serving_columns(self):
+        for column in ("uid", "amount_tao", "alpha_amount", "extrinsic_index"):
+            self.assertIn(column, self.schema)
+        self.assertNotIn("  amount           NUMERIC", self.schema)
+        self.assertNotIn("  alpha            NUMERIC", self.schema)
+
+    def test_metagraph_schema_uses_serving_columns(self):
+        for column in (
+            "validator_trust",
+            "emission_tao",
+            "registered_at_block",
+            "is_immunity_period",
+            "block_number",
+            "captured_at",
+        ):
+            self.assertIn(column, self.schema)
+        self.assertNotIn("  emission         NUMERIC", self.schema)
+
+    def test_account_events_daily_schema_uses_history_columns(self):
+        for column in (
+            "netuid",
+            "event_kinds",
+            "first_block",
+            "last_block",
+            "updated_at",
+        ):
+            self.assertIn(column, self.schema)
 
 
 class BackfillStart(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- The new Postgres scaffold diverged from the D1-era serving column names and history rollup contract, which would break existing Worker readers and ingesters on a binding-only cutover. 
- Restore the schema and indexer mapping so the runtime can switch bindings without changing queries or causing read/write failures. 

### Description
- Restored D1-serving column names in `deploy/postgres/schema.sql` for `account_events` (`uid`, `amount_tao`, `alpha_amount`, `extrinsic_index`) and for metagraph/neuron tables (`validator_trust`, `emission_tao`, `registered_at_block`, `is_immunity_period`, `block_number`, `captured_at`, `updated_at` where applicable). 
- Reinstated the `account_events_daily` hotkey/netuid/day rollup columns (`netuid`, `event_kinds`, `first_block`, `last_block`, `updated_at`) and added the covering index `idx_account_events_daily_netuid_day`. 
- Aligned the continuous indexer mapping in `scripts/index-chain.py` to emit the serving-compatible `amount_tao` and `alpha_amount` column names and adjusted `EVENT_COLS` accordingly. 
- Added regression coverage in `scripts/test_index_chain.py` to assert the indexer event mapping and to validate the deploy Postgres schema contains the expected serving/history columns. 

### Testing
- Ran the Python unit suite with `python3 -m unittest scripts/test_index_chain.py`, which passed (all tests OK). 
- Built generated artifacts with `npm run build`, which completed successfully and produced the API/type artifacts. 
- Ran validators and checks: `npm run lint` and `npm run format:check` passed, and `node scripts/validate.mjs` passed after running the build. 
- Executed the public-safety scan with `npm run scan:public-safety`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f7c700694832c82ff514d0e37c77a)