### PR TITLE
infra(deploy): reproducible railway-bootstrap.sh + backups/PITR guidance

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -92,6 +92,11 @@ changes.
 
 ## Provisioning Railway (only if NOT co-locating Postgres on bare metal)
 
+The whole project bring-up is scripted in [`railway-bootstrap.sh`](railway-bootstrap.sh)
+— the canonical, version-controlled record of the topology (run it once against a
+fresh project to recreate prod or stand up `staging`, so it is never assembled by
+hand). The commands below are that script, annotated.
+
 > Idle managed Postgres/Redis bill from the moment they exist, and nothing reads
 > them until the `indexer` lands. Provision as part of the indexer phase, not
 > ahead of it. Run from a **dedicated directory** (NOT this repo) so this repo's
@@ -157,8 +162,23 @@ Each needs a human who can verify/roll back (ADR 0013 _Sequencing_):
    `metagraphed-streamer` project, and the `*/3` R2-staging drain; demote D1 to a
    hot cache.
 
-## Backups (mandatory)
+## Backups + PITR (mandatory)
 
-Postgres holds irreplaceable derived state (the node is restorable from chain).
-Ship WAL/dumps to **R2** (zero-egress): a `pg_dump`/WAL job to an R2 bucket, or
-Railway's managed backups + a periodic R2 export via the `exporter` service.
+Postgres holds derived state. It is **re-derivable** (re-index from the chain via
+the archive node), but a full re-index is slow — so back it up; you just don't
+need a near-zero RPO.
+
+- **Enable Railway scheduled backups — daily.** Cheap insurance. Railway bills a
+  backup at the **incremental size, per GB-minute**, so daily snapshots of a
+  compressing DB add only a modest fraction on top of the volume cost.
+- **Full continuous PITR is optional / overkill here.** PITR buys a seconds-level
+  RPO via continuous WAL — worth it for un-recreatable OLTP data, but our worst
+  case is "re-index the last day from chain," which a daily snapshot already
+  bounds. It also adds WAL-storage cost. Skip it unless the re-index window
+  becomes painful; daily snapshots + the R2 export below are enough.
+- **Cheapest durable copy: `pg_dump` → R2** (zero-egress) via the `exporter`
+  service on a schedule — the long-term archive, independent of Railway.
+
+Whichever you pick, the DB volume + backups are the storage-cost driver; when they
+outgrow Railway economics, that is the trigger for the Hetzner escape hatch
+(TimescaleDB compression ~10–20×) in ADR 0013.

--- a/deploy/railway-bootstrap.sh
+++ b/deploy/railway-bootstrap.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Reproducible bring-up of the Railway **metagraphed-core** project (ADR 0013).
+#
+# This is the canonical, version-controlled record of how the project is built —
+# run it against a FRESH project (e.g. to recreate prod, or stand up `staging`)
+# so the topology is never assembled by hand again. It is NOT idempotent: each
+# `railway add` creates a new service, so run it once per fresh project.
+#
+# Ongoing per-service build/deploy config is already code (the committed
+# railway.json files); this script captures the one-time PROJECT topology
+# (services, managed DBs, cross-service variable references, the public domain).
+#
+# Prereqs: authenticated Railway CLI (`railway whoami`), run from a DEDICATED dir
+# (NOT this repo — `railway init` links the CWD):
+#   mkdir -p ~/metagraphed-core && cd ~/metagraphed-core && bash /path/to/repo/deploy/railway-bootstrap.sh
+set -euo pipefail
+
+REPO="JSONbored/metagraphed"
+BRANCH="main"
+WORKSPACE="aethereal"
+RPC_URL="${EVENTS_RPC_URL:-wss://entrypoint-finney.opentensor.ai:443}"
+
+echo "==> 1. Create the project + default (production) environment"
+railway init --name metagraphed-core --workspace "$WORKSPACE" --json
+
+echo "==> 2. Managed databases (private only — never expose a public domain on these)"
+railway add -d postgres     # → ${{Postgres.DATABASE_URL}}, host postgres.railway.internal
+railway add -d redis        # → ${{Redis.REDIS_URL}},     host redis.railway.internal
+
+echo "==> 3. Public WSS load balancer (the ONLY service that gets a public domain)"
+railway add -s wss-lb --repo "$REPO" --branch "$BRANCH"
+#   then in the dashboard: Settings → Config-as-code → Railway Config File =
+#   /deploy/wss-lb/railway.json   (absolute; it does not follow Root Directory)
+railway domain                # mint *.up.railway.app; add a CNAME for wss.metagraph.sh
+
+echo "==> 4. Indexer (private; references the DBs over the private network)"
+railway add -s indexer --repo "$REPO" --branch "$BRANCH" \
+  -v "DATABASE_URL=\${{Postgres.DATABASE_URL}}" \
+  -v "REDIS_URL=\${{Redis.REDIS_URL}}" \
+  -v "EVENTS_RPC_URL=${RPC_URL}"
+#   then in the dashboard: Config-as-code → Railway Config File =
+#   /deploy/indexer.railway.json
+
+echo "==> 5. Apply the portable schema to Postgres (one-time, before the indexer runs)"
+#   psql against the PUBLIC proxy URL (the private host isn't reachable from your laptop):
+#   PGURL=$(railway variables -s Postgres --kv | sed -n 's/^DATABASE_PUBLIC_URL=//p')
+#   psql "$PGURL" -f /path/to/repo/deploy/postgres/schema.sql
+echo "    (see the commented psql line above — needs the repo's deploy/postgres/schema.sql)"
+
+cat <<'NOTE'
+
+==> Manual one-time toggles the CLI can't set (dashboard, per service):
+  - Config-as-code "Railway Config File" path (wss-lb, indexer) — see steps 3/4.
+  - Feature-flags → Skipped Builds: ON for wss-lb + indexer (build cache; no downside).
+  - Deploy → Serverless: OFF for wss-lb + indexer (always-on; serverless drops WS).
+  - Postgres → scheduled backups (daily) — derived state insurance (see deploy/README.md).
+Everything else (builder, watch paths, healthcheck, restart policy, replicas) comes
+from the committed railway.json on first deploy.
+NOTE


### PR DESCRIPTION
Captures the **metagraphed-core** project bring-up as a version-controlled script (`deploy/railway-bootstrap.sh`) so the topology is never assembled by hand again — run once against a fresh project to recreate prod or stand up `staging`. Per-service build/deploy is already code (committed `railway.json`); this captures the one-time project topology (services, managed Postgres/Redis, cross-service `${{…}}` references, public domain) + the dashboard-only toggles.

Also documents the **backups/PITR** decision in `deploy/README.md`: enable daily scheduled backups (Railway bills incremental size per GB-min), skip full continuous PITR (the data is re-derivable from chain, so a daily RPO is fine), keep `pg_dump`→R2 as the cheap durable copy.

Docs + script only.