### PR TITLE
fix(indexer): warm runtime metadata before cold backfill

### DIFF
--- a/scripts/index-chain.py
+++ b/scripts/index-chain.py
@@ -265,6 +265,15 @@ def run():
     while not _stop:
         try:
             s = SubstrateInterface(url=RPC)
+            # Warm the runtime metadata BEFORE the cold backfill. decode_head's
+            # per-block `s.query(...)` needs `s.metadata`, which is lazy-loaded;
+            # the streamer gets it implicitly because it only decodes from inside
+            # subscribe_block_headers (which inits the runtime first). The indexer
+            # decodes in the backfill loop first, so without this the very first
+            # query raises AttributeError: 'NoneType' has no attribute
+            # 'get_metadata_pallet'. init_runtime() loads metadata at the head;
+            # recent blocks share that runtime version, so it is reused.
+            s.init_runtime()
             backoff = 5  # reset after a clean connect
             cursor = read_cursor(conn)
             head = s.get_block_number(s.get_chain_finalised_head())


### PR DESCRIPTION
Live deploy of the indexer crash-looped on every block with `AttributeError: 'NoneType' object has no attribute 'get_metadata_pallet'` → **0 rows written**.

**Cause:** `decode_head`'s per-block `s.query(...)` needs `s.metadata`, which substrate-interface lazy-loads. The streamer never hits this because it only decodes *inside* `subscribe_block_headers` (which inits the runtime first). The indexer decodes in the **backfill loop cold**, so the first query sees `metadata=None`.

**Fix:** call `s.init_runtime()` right after connect (loads metadata at the head; recent blocks reuse that runtime version). Mirrors the streamer's working init order. The review-added rollback/reconnect loop kept it from wedging — it recovered each retry — but it never progressed; this lets it.

Live-RPC-only path (no CI coverage). The indexer auto-redeploys on merge (`scripts/index-chain.py` is in its watch paths); I'll verify `blocks` climbs after.