### PR TITLE
feat(mcp): add live analytics tools backed by shared loaders

### DIFF
--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -1,0 +1,333 @@
+// Shared live analytics loaders for MCP tools (#1958).
+//
+// Pure orchestration over D1 rows + registry projections. REST handlers stay in
+// workers/request-handlers/analytics-routes.mjs (#1919); MCP tools call these
+// loaders so agents get REST parity without duplicating SQL paths.
+
+import { dailyLatencyColumns } from "./health-sql.mjs";
+import {
+  formatGlobalIncidents,
+  formatLeaderboards,
+  formatUptime,
+  INCIDENT_GAP_MS,
+  MIN_INCIDENT_SAMPLES,
+} from "./health-serving.mjs";
+import {
+  ANALYTICS_WINDOWS,
+  DAY_MS,
+  MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
+  MAX_INCIDENT_ROWS,
+  MAX_UPTIME_ROWS,
+  UPTIME_WINDOWS,
+} from "../workers/config.mjs";
+import { composeCompareData } from "../workers/request-handlers/analytics-routes.mjs";
+
+export { composeCompareData };
+export const COMPARE_DIMENSIONS = ["structure", "economics", "health"];
+const COMPARE_NETUIDS_PATTERN = /^\d{1,5}(,\d{1,5}){0,127}$/;
+
+export function profilesProjectionFromRows(profiles) {
+  const subnetMeta = new Map();
+  const mostComplete = [];
+  for (const profile of profiles || []) {
+    if (!Number.isInteger(profile.netuid)) continue;
+    subnetMeta.set(profile.netuid, {
+      slug: profile.slug ?? null,
+      name: profile.name ?? null,
+    });
+    mostComplete.push({
+      netuid: profile.netuid,
+      slug: profile.slug ?? null,
+      name: profile.name ?? null,
+      completeness_score: profile.completeness_score ?? null,
+      surface_count: profile.surface_count ?? 0,
+      operational_interface_count: profile.operational_interface_count ?? 0,
+    });
+  }
+  return { subnetMeta, mostComplete };
+}
+
+export function growthRowsFromSamples(growthSamples) {
+  const growthByNetuid = new Map();
+  for (const row of growthSamples || []) {
+    const entry = growthByNetuid.get(row.netuid) || {
+      first: undefined,
+      last: undefined,
+    };
+    if (entry.first === undefined) entry.first = row.completeness_score ?? null;
+    entry.last = row.completeness_score ?? null;
+    growthByNetuid.set(row.netuid, entry);
+  }
+  return [...growthByNetuid.entries()].map(([netuid, entry]) => ({
+    netuid,
+    delta:
+      entry.first != null && entry.last != null
+        ? Number(entry.last) - Number(entry.first)
+        : null,
+  }));
+}
+
+export function parseCompareNetuids(netuidsRaw) {
+  if (!netuidsRaw || !COMPARE_NETUIDS_PATTERN.test(netuidsRaw)) return null;
+  const requestedNetuids = [];
+  const seenNetuids = new Set();
+  for (const part of netuidsRaw.split(",")) {
+    const netuid = Number(part);
+    if (seenNetuids.has(netuid)) continue;
+    seenNetuids.add(netuid);
+    requestedNetuids.push(netuid);
+  }
+  return requestedNetuids;
+}
+
+export function parseCompareNetuidList(netuids) {
+  if (!Array.isArray(netuids) || netuids.length === 0) return null;
+  const requestedNetuids = [];
+  const seenNetuids = new Set();
+  for (const value of netuids) {
+    if (!Number.isInteger(value) || value < 0) return null;
+    if (seenNetuids.has(value)) continue;
+    seenNetuids.add(value);
+    requestedNetuids.push(value);
+  }
+  if (requestedNetuids.length > 128) return null;
+  return requestedNetuids;
+}
+
+export function parseCompareDimensions(dimensionsRaw) {
+  if (dimensionsRaw === null || dimensionsRaw === undefined) {
+    return COMPARE_DIMENSIONS;
+  }
+  const requested = String(dimensionsRaw).split(",");
+  const unknown = requested.find((d) => !COMPARE_DIMENSIONS.includes(d));
+  if (unknown !== undefined) return null;
+  return COMPARE_DIMENSIONS.filter((d) => requested.includes(d));
+}
+
+export function parseCompareDimensionList(dimensions) {
+  if (dimensions === undefined || dimensions === null) {
+    return COMPARE_DIMENSIONS;
+  }
+  if (!Array.isArray(dimensions) || dimensions.length === 0) return null;
+  const unknown = dimensions.find((d) => !COMPARE_DIMENSIONS.includes(d));
+  if (unknown !== undefined) return null;
+  return COMPARE_DIMENSIONS.filter((d) => dimensions.includes(d));
+}
+
+export async function loadSubnetUptime(
+  d1,
+  netuid,
+  { window = "90d", observedAt = null, now = null } = {},
+) {
+  const windowParam = Object.hasOwn(UPTIME_WINDOWS, window) ? window : "90d";
+  const days = UPTIME_WINDOWS[windowParam];
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  const rows = await d1(
+    `SELECT MAX(surface_id) AS surface_id,
+            COALESCE(surface_key, surface_id) AS surface_key,
+            day,
+            SUM(samples) AS samples,
+            SUM(ok_count) AS ok_count,
+            CASE
+              WHEN SUM(samples) > 0 THEN ROUND(CAST(SUM(ok_count) AS REAL) / SUM(samples), 4)
+              ELSE NULL
+            END AS uptime_ratio,
+            ${dailyLatencyColumns({ roundedAvg: true })},
+            MAX(p50_latency_ms) AS p50,
+            MAX(p95_latency_ms) AS p95,
+            MAX(p99_latency_ms) AS p99,
+            CASE
+              WHEN SUM(samples) = 0 THEN 'unknown'
+              WHEN SUM(ok_count) = SUM(samples) THEN 'ok'
+              WHEN SUM(ok_count) = 0 THEN 'failed'
+              ELSE 'degraded'
+            END AS status
+     FROM surface_uptime_daily
+     WHERE netuid = ? AND day >= ?
+     GROUP BY COALESCE(surface_key, surface_id), day
+     ORDER BY day DESC
+     LIMIT ?`,
+    [netuid, cutoff, MAX_UPTIME_ROWS],
+  );
+  return formatUptime({
+    netuid,
+    window: windowParam,
+    observedAt,
+    rows,
+    now: now || new Date().toISOString(),
+  });
+}
+
+export async function loadGlobalIncidents(
+  d1,
+  { windowLabel = "7d", windowDays = 7, observedAt = null } = {},
+) {
+  const since = Date.now() - windowDays * DAY_MS;
+  const incidentRows = await d1(
+    `WITH recent_checks AS (
+       SELECT netuid, COALESCE(surface_key, surface_id) AS surface_key, surface_id, checked_at, ok
+       FROM surface_checks
+       WHERE checked_at >= ?
+       ORDER BY checked_at DESC
+       LIMIT ?
+     ),
+     checks AS (
+       SELECT netuid, surface_key, surface_id, checked_at, ok,
+              checked_at - LAG(checked_at)
+                OVER (
+                  PARTITION BY netuid, surface_key
+                  ORDER BY checked_at
+                ) AS gap
+       FROM recent_checks
+     ),
+     grouped AS (
+       SELECT netuid, surface_key, surface_id, checked_at, ok,
+              SUM(CASE WHEN ok = 1 OR gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
+                OVER (PARTITION BY netuid, surface_key ORDER BY checked_at) AS grp
+       FROM checks
+     )
+     SELECT netuid,
+            MAX(surface_id) AS surface_id,
+            surface_key,
+            MIN(checked_at) AS started_at,
+            MAX(checked_at) AS ended_at,
+            COUNT(*) AS failed_samples
+     FROM grouped
+     WHERE ok = 0
+     GROUP BY netuid, surface_key, grp
+     HAVING COUNT(*) >= ?
+     ORDER BY started_at DESC
+     LIMIT ?`,
+    [
+      since,
+      MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
+      INCIDENT_GAP_MS,
+      MIN_INCIDENT_SAMPLES,
+      MAX_INCIDENT_ROWS,
+    ],
+  );
+  return formatGlobalIncidents({
+    window: windowLabel,
+    observedAt,
+    incidentRows,
+    maxIncidents: MAX_INCIDENT_ROWS,
+  });
+}
+
+export async function loadRegistryLeaderboards(
+  d1,
+  {
+    profiles = [],
+    economicsRows = [],
+    board = null,
+    limit = null,
+    observedAt = null,
+  } = {},
+) {
+  const { subnetMeta, mostComplete } = profilesProjectionFromRows(profiles);
+  const sevenDaysAgo = new Date(Date.now() - 7 * DAY_MS)
+    .toISOString()
+    .slice(0, 10);
+  const [healthRows, rpcRows, growthSamples] = await Promise.all([
+    d1(
+      `SELECT netuid,
+              COUNT(*) AS total,
+              SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
+              AVG(latency_ms) AS avg_latency_ms
+       FROM surface_status
+       GROUP BY netuid`,
+      [],
+    ),
+    d1(
+      `SELECT netuid, MIN(latency_ms) AS min_latency_ms
+       FROM surface_status
+       WHERE kind IN ('subtensor-rpc', 'subtensor-wss')
+         AND status = 'ok' AND latency_ms IS NOT NULL
+       GROUP BY netuid`,
+      [],
+    ),
+    d1(
+      `SELECT netuid, snapshot_date, completeness_score
+       FROM subnet_snapshots
+       WHERE snapshot_date >= ?
+       ORDER BY netuid, snapshot_date`,
+      [sevenDaysAgo],
+    ),
+  ]);
+  return formatLeaderboards({
+    board,
+    limit,
+    observedAt,
+    healthRows,
+    rpcRows,
+    mostComplete,
+    growthRows: growthRowsFromSamples(growthSamples),
+    economicsRows,
+    subnetMeta,
+  });
+}
+
+export async function loadCompareSubnets(
+  d1,
+  {
+    profiles = [],
+    economicsRows = [],
+    netuids,
+    dimensions = COMPARE_DIMENSIONS,
+    observedAt = null,
+  } = {},
+) {
+  if (!Array.isArray(netuids) || netuids.length === 0) {
+    return composeCompareData({
+      requestedNetuids: [],
+      dimensions,
+      subnetMeta: new Map(),
+      structureRows: [],
+      economicsRows: dimensions.includes("economics") ? economicsRows : null,
+      healthRows: [],
+      observedAt,
+    });
+  }
+  const { subnetMeta, mostComplete } = profilesProjectionFromRows(profiles);
+  const [healthRows, economics] = await Promise.all([
+    dimensions.includes("health")
+      ? d1(
+          `SELECT netuid,
+                COUNT(*) AS surface_count,
+                SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
+                ROUND(AVG(latency_ms)) AS avg_latency_ms
+         FROM surface_status
+         WHERE netuid IN (${netuids.map(() => "?").join(", ")})
+         GROUP BY netuid`,
+          netuids,
+        )
+      : null,
+    dimensions.includes("economics") ? economicsRows : null,
+  ]);
+  return composeCompareData({
+    requestedNetuids: netuids,
+    dimensions,
+    subnetMeta,
+    structureRows: mostComplete,
+    economicsRows: economics,
+    healthRows,
+    observedAt,
+  });
+}
+
+export function parseAnalyticsWindow(window) {
+  if (window === null || window === undefined) {
+    return { label: "7d", days: ANALYTICS_WINDOWS["7d"] };
+  }
+  if (!Object.hasOwn(ANALYTICS_WINDOWS, window)) return null;
+  return { label: window, days: ANALYTICS_WINDOWS[window] };
+}
+
+export function parseUptimeWindow(window) {
+  if (window === null || window === undefined) {
+    return "90d";
+  }
+  return Object.hasOwn(UPTIME_WINDOWS, window) ? window : null;
+}

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -13,6 +13,16 @@
 import { resolveClientIp, SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
+import {
+  loadCompareSubnets,
+  loadGlobalIncidents,
+  loadRegistryLeaderboards,
+  loadSubnetUptime,
+  parseAnalyticsWindow,
+  parseCompareDimensionList,
+  parseCompareNetuidList,
+  parseUptimeWindow,
+} from "./analytics-live.mjs";
 import { generateServiceSnippets } from "./integration-snippets.mjs";
 import {
   KV_HEALTH_RPC_POOL,
@@ -29,6 +39,7 @@ import { SURFACE_ALIASES_PATH } from "./surface-aliases.mjs";
 import {
   ECONOMIC_LEADERBOARD_BOARDS,
   formatLeaderboards,
+  LEADERBOARD_BOARDS,
   loadSubnetReliability,
   loadSubnetTrajectory,
   overlayCatalogDetail,
@@ -62,6 +73,7 @@ import {
   withinRateLimit,
 } from "./ai-search.mjs";
 import { keywordScore, queryTerms } from "./keyword-search.mjs";
+import { KV_HEALTH_META } from "./kv-keys.mjs";
 
 // Protocol versions we understand, newest first. We echo the client's requested
 // version when it is one of these, otherwise we answer with our latest. We meet
@@ -139,7 +151,11 @@ export const MCP_INSTRUCTIONS =
   "(base URL, auth, schema, health) for one subnet. For on-chain economics and " +
   "participation, get_subnet_economics returns a subnet's registration cost, " +
   "open slots, stake, emission split and validator/miner counts, " +
-  "get_subnet_trajectory its week-over-week trend, get_subnet_metagraph the " +
+  "get_subnet_trajectory its week-over-week trend, get_subnet_uptime its " +
+  "long-term surface uptime history, get_registry_leaderboards the live " +
+  "cross-subnet health/economics boards, compare_subnets a side-by-side view " +
+  "across structure/economics/health, get_global_incidents recent cross-subnet " +
+  "probe failures, get_subnet_metagraph the " +
   "per-UID neuron snapshot (validator_permit filters to validators), " +
   "list_subnet_validators its validators ranked by stake, and get_neuron one " +
   "UID — use these to decide where to mine or validate. For wallet lookup, " +
@@ -260,6 +276,23 @@ async function loadSubnetEconomics(ctx, netuid) {
     summary: blob?.summary ?? null,
     economics: blob?.subnets?.find((row) => row?.netuid === netuid) ?? null,
   };
+}
+
+async function mcpObservedAt(ctx) {
+  if (!ctx.readHealthKv) return null;
+  const meta = await ctx.readHealthKv(ctx.env, KV_HEALTH_META);
+  return meta?.last_run_at || null;
+}
+
+async function loadEconomicsSubnetRows(ctx) {
+  const live = await resolveLiveEconomics({
+    readHealthKv: ctx.readHealthKv,
+    env: ctx.env,
+    contractVersion: mcpContractVersion(ctx),
+  });
+  if (Array.isArray(live?.data?.subnets)) return live.data.subnets;
+  const blob = await loadArtifactData(ctx, "/metagraph/economics.json");
+  return Array.isArray(blob?.subnets) ? blob.subnets : [];
 }
 
 // AI-dependent tools (semantic_search, ask) need the VECTORIZE + AI bindings and
@@ -1034,6 +1067,168 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
       return loadSubnetTrajectory(mcpD1Runner(ctx), netuid);
+    },
+  },
+  {
+    name: "get_subnet_uptime",
+    title: "Get subnet uptime history",
+    description:
+      "Fetch one subnet's long-term daily uptime history for its operational " +
+      "surfaces from the live surface_uptime_daily rollup. Returns per-surface " +
+      "day series, window-wide uptime ratios, and reliability scores for the " +
+      "requested window (90d or 1y). Mirrors GET /api/v1/subnets/{netuid}/uptime.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: ["90d", "1y"],
+          description: "History window (default 90d).",
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const window = parseUptimeWindow(args?.window);
+      if (args?.window !== undefined && window === null) {
+        throw toolError("invalid_params", "window must be one of: 90d, 1y.");
+      }
+      return loadSubnetUptime(mcpD1Runner(ctx), netuid, {
+        window: window || "90d",
+        observedAt: await mcpObservedAt(ctx),
+      });
+    },
+  },
+  {
+    name: "get_registry_leaderboards",
+    title: "Get registry leaderboards",
+    description:
+      "Fetch the live registry leaderboards that combine D1 probe health with " +
+      "registry completeness and the economics tier: healthiest, fastest-rpc, " +
+      "most-complete, most-enriched, fastest-growing, plus the economic " +
+      "opportunity boards (open-slots, cheapest-registration, highest-emission, " +
+      "validator-headroom). Omit board for all boards. Mirrors " +
+      "GET /api/v1/registry/leaderboards.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        board: {
+          type: "string",
+          enum: [...LEADERBOARD_BOARDS],
+          description: "Optional single board. Omit to return all boards.",
+        },
+        limit: {
+          type: "integer",
+          description: "Max subnets per board (1-100, default 20).",
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const board = optionalEnum(args, "board", LEADERBOARD_BOARDS);
+      const limit = clampLimit(args?.limit, 20, 100);
+      const profiles =
+        (await loadArtifactData(ctx, "/metagraph/profiles.json")).profiles ||
+        [];
+      return loadRegistryLeaderboards(mcpD1Runner(ctx), {
+        profiles,
+        economicsRows: await loadEconomicsSubnetRows(ctx),
+        board,
+        limit,
+        observedAt: await mcpObservedAt(ctx),
+      });
+    },
+  },
+  {
+    name: "compare_subnets",
+    title: "Compare subnets side by side",
+    description:
+      "Place several subnets side by side across registry structure, economics, " +
+      "and live probe health in one call. Choose dimensions to limit the payload " +
+      "(structure, economics, health — default all). Mirrors GET /api/v1/compare.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuids: {
+          type: "array",
+          items: { type: "integer", minimum: 0 },
+          minItems: 1,
+          maxItems: 128,
+          description: "Subnet netuids to compare, in display order.",
+        },
+        dimensions: {
+          type: "array",
+          items: {
+            type: "string",
+            enum: ["structure", "economics", "health"],
+          },
+          description: "Optional subset of compare dimensions (default all).",
+        },
+      },
+      required: ["netuids"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuids = parseCompareNetuidList(args?.netuids);
+      if (!netuids) {
+        throw toolError(
+          "invalid_params",
+          "netuids must be a non-empty array of 1-128 distinct subnet ids.",
+        );
+      }
+      const dimensions = parseCompareDimensionList(args?.dimensions);
+      if (args?.dimensions !== undefined && dimensions === null) {
+        throw toolError(
+          "invalid_params",
+          "dimensions must be a non-empty subset of structure, economics, health.",
+        );
+      }
+      const profiles =
+        (await loadArtifactData(ctx, "/metagraph/profiles.json")).profiles ||
+        [];
+      return loadCompareSubnets(mcpD1Runner(ctx), {
+        profiles,
+        economicsRows: await loadEconomicsSubnetRows(ctx),
+        netuids,
+        dimensions,
+        observedAt: await mcpObservedAt(ctx),
+      });
+    },
+  },
+  {
+    name: "get_global_incidents",
+    title: "Get global probe incidents",
+    description:
+      "Fetch the cross-subnet incident ledger: surfaces that had consecutive " +
+      "probe failures grouped into downtime incidents over the requested window " +
+      "(7d or 30d). Mirrors GET /api/v1/incidents.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: ["7d", "30d"],
+          description: "Incident lookback window (default 7d).",
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const parsed = parseAnalyticsWindow(args?.window ?? "7d");
+      if (args?.window !== undefined && parsed === null) {
+        throw toolError("invalid_params", "window must be one of: 7d, 30d.");
+      }
+      const { label, days } = parseAnalyticsWindow(args?.window ?? "7d");
+      return loadGlobalIncidents(mcpD1Runner(ctx), {
+        windowLabel: label,
+        windowDays: days,
+        observedAt: await mcpObservedAt(ctx),
+      });
     },
   },
   {
@@ -2482,6 +2677,54 @@ const TOOL_OUTPUT_SCHEMAS = {
       point_count: { type: "integer" },
       points: { type: "array", items: { type: "object" } },
       deltas: { type: "object" },
+    },
+  },
+  get_subnet_uptime: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "window", "surfaces"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      surfaces: { type: "array", items: { type: "object" } },
+      reliability: { type: ["object", "null"] },
+    },
+  },
+  get_registry_leaderboards: {
+    type: "object",
+    additionalProperties: true,
+    required: ["boards"],
+    properties: {
+      schema_version: { type: "integer" },
+      board: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      boards: { type: "object" },
+    },
+  },
+  compare_subnets: {
+    type: "object",
+    additionalProperties: true,
+    required: ["requested_netuids", "subnets", "dimensions"],
+    properties: {
+      schema_version: { type: "integer" },
+      requested_netuids: { type: "array", items: { type: "integer" } },
+      dimensions: { type: "array", items: { type: "string" } },
+      subnets: { type: "array", items: { type: "object" } },
+      observed_at: NULLABLE_STRING,
+    },
+  },
+  get_global_incidents: {
+    type: "object",
+    additionalProperties: true,
+    required: ["summary", "surfaces"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      summary: { type: "object" },
+      surfaces: { type: "array", items: { type: "object" } },
     },
   },
   get_subnet_metagraph: {

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -1,0 +1,350 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import {
+  composeCompareData,
+  growthRowsFromSamples,
+  loadCompareSubnets,
+  loadGlobalIncidents,
+  loadRegistryLeaderboards,
+  loadSubnetUptime,
+  parseAnalyticsWindow,
+  parseCompareDimensionList,
+  parseCompareDimensions,
+  parseCompareNetuidList,
+  parseCompareNetuids,
+  parseUptimeWindow,
+  profilesProjectionFromRows,
+} from "../src/analytics-live.mjs";
+import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
+
+const NETUID = 7;
+const OBSERVED_AT = "2026-06-24T12:00:00.000Z";
+
+function d1(rowsBySql = {}) {
+  return async (sql, _params) => {
+    for (const [pattern, rows] of Object.entries(rowsBySql)) {
+      if (new RegExp(pattern).test(sql)) return rows;
+    }
+    return [];
+  };
+}
+
+describe("analytics-live compare helpers", () => {
+  test("parseCompareNetuids deduplicates while preserving order", () => {
+    assert.deepEqual(parseCompareNetuids("1,7,1,64"), [1, 7, 64]);
+    assert.equal(parseCompareNetuids("not-valid"), null);
+  });
+
+  test("parseCompareNetuidList validates MCP array input", () => {
+    assert.deepEqual(parseCompareNetuidList([1, 7, 1]), [1, 7]);
+    assert.equal(parseCompareNetuidList([]), null);
+    assert.equal(parseCompareNetuidList([1, -1]), null);
+  });
+
+  test("composeCompareData keeps unknown subnets found:false", () => {
+    const data = composeCompareData({
+      requestedNetuids: [1, 99999],
+      dimensions: ["structure"],
+      subnetMeta: new Map([[1, { name: "Apex", slug: "apex" }]]),
+      structureRows: [
+        {
+          netuid: 1,
+          completeness_score: 80,
+          surface_count: 5,
+          operational_interface_count: 2,
+        },
+      ],
+      economicsRows: [],
+      healthRows: [],
+      observedAt: OBSERVED_AT,
+    });
+    assert.equal(data.subnets[1].found, false);
+    assert.equal(data.subnets[0].structure.completeness_score, 80);
+  });
+
+  test("composeCompareData validates against CompareArtifact", async () => {
+    const generatedAt = "2026-06-24T12:00:00.000Z";
+    const openapi = buildOpenApiArtifact(
+      generatedAt,
+      await loadOpenApiComponentSchemas(generatedAt),
+    );
+    const ajv = new Ajv2020({ strict: false, allErrors: true });
+    addFormats(ajv);
+    const validate = ajv.compile({
+      $id: "https://metagraph.sh/test/compare-artifact-live.json",
+      components: openapi.components,
+      $ref: "#/components/schemas/CompareArtifact",
+    });
+    const data = composeCompareData({
+      requestedNetuids: [1, 2],
+      dimensions: ["structure", "economics", "health"],
+      subnetMeta: new Map([
+        [1, { name: "Apex", slug: "apex" }],
+        [2, { name: "Beta", slug: "beta" }],
+      ]),
+      structureRows: [
+        {
+          netuid: 1,
+          completeness_score: 80,
+          surface_count: 5,
+          operational_interface_count: 2,
+        },
+      ],
+      economicsRows: [{ netuid: 2, open_slots: 3 }],
+      healthRows: [
+        { netuid: 1, surface_count: 5, ok_count: 4, avg_latency_ms: 120 },
+      ],
+      observedAt: generatedAt,
+    });
+    assert.equal(validate(data), true, ajv.errorsText(validate.errors));
+  });
+});
+
+describe("analytics-live projections", () => {
+  test("profilesProjectionFromRows builds subnetMeta + mostComplete", () => {
+    const { subnetMeta, mostComplete } = profilesProjectionFromRows([
+      {
+        netuid: 1,
+        slug: "apex",
+        name: "Apex",
+        completeness_score: 80,
+        surface_count: 5,
+        operational_interface_count: 2,
+      },
+    ]);
+    assert.equal(subnetMeta.get(1).slug, "apex");
+    assert.equal(mostComplete[0].operational_interface_count, 2);
+  });
+
+  test("growthRowsFromSamples computes completeness deltas", () => {
+    assert.deepEqual(
+      growthRowsFromSamples([
+        { netuid: 1, completeness_score: 40 },
+        { netuid: 1, completeness_score: 55 },
+        { netuid: 2, completeness_score: null },
+      ]),
+      [
+        { netuid: 1, delta: 15 },
+        { netuid: 2, delta: null },
+      ],
+    );
+  });
+});
+
+describe("analytics-live loaders", () => {
+  test("loadSubnetUptime returns schema-stable empty surfaces on cold D1", async () => {
+    const data = await loadSubnetUptime(d1(), NETUID, {
+      window: "90d",
+      observedAt: OBSERVED_AT,
+    });
+    assert.equal(data.netuid, NETUID);
+    assert.equal(data.window, "90d");
+    assert.deepEqual(data.surfaces, []);
+  });
+
+  test("loadSubnetUptime aggregates daily rows into per-surface history", async () => {
+    const data = await loadSubnetUptime(
+      d1({
+        "FROM surface_uptime_daily": [
+          {
+            surface_id: "api-root",
+            surface_key: "api-root",
+            day: "2026-06-01",
+            samples: 50,
+            ok_count: 45,
+            uptime_ratio: 0.9,
+            avg_latency_ms: 90,
+            p50: 80,
+            p95: 110,
+            p99: 130,
+            status: "ok",
+          },
+        ],
+      }),
+      NETUID,
+      { window: "1y", observedAt: OBSERVED_AT },
+    );
+    assert.equal(data.window, "1y");
+    assert.equal(data.surfaces.length, 1);
+    assert.equal(data.surfaces[0].samples, 50);
+    assert.equal(data.surfaces[0].days[0].uptime_ratio, 0.9);
+  });
+
+  test("loadRegistryLeaderboards returns all boards object", async () => {
+    const data = await loadRegistryLeaderboards(d1(), {
+      profiles: [
+        {
+          netuid: 1,
+          slug: "apex",
+          name: "Apex",
+          completeness_score: 80,
+          surface_count: 5,
+          operational_interface_count: 2,
+        },
+      ],
+      economicsRows: [{ netuid: 1, open_slots: 2, emission_share: 0.1 }],
+      observedAt: OBSERVED_AT,
+    });
+    assert.ok(typeof data.boards === "object");
+    assert.ok(Object.keys(data.boards).length > 0);
+  });
+
+  test("loadRegistryLeaderboards can return a single requested board", async () => {
+    const data = await loadRegistryLeaderboards(
+      d1({
+        "FROM surface_status": [
+          {
+            netuid: 1,
+            total: 5,
+            ok_count: 4,
+            avg_latency_ms: 100,
+          },
+        ],
+      }),
+      {
+        profiles: [
+          {
+            netuid: 1,
+            slug: "apex",
+            name: "Apex",
+            completeness_score: 80,
+            surface_count: 5,
+            operational_interface_count: 2,
+          },
+        ],
+        economicsRows: [{ netuid: 1, open_slots: 2, emission_share: 0.1 }],
+        board: "healthiest",
+        limit: 1,
+        observedAt: OBSERVED_AT,
+      },
+    );
+    assert.ok(data.boards.healthiest);
+    assert.equal("fastest-rpc" in data.boards, false);
+  });
+
+  test("loadCompareSubnets composes requested dimensions", async () => {
+    const data = await loadCompareSubnets(
+      d1({
+        "FROM surface_status": [
+          { netuid: 1, surface_count: 5, ok_count: 4, avg_latency_ms: 100 },
+        ],
+      }),
+      {
+        profiles: [{ netuid: 1, slug: "apex", name: "Apex" }],
+        economicsRows: [],
+        netuids: [1],
+        dimensions: parseCompareDimensionList(["health"]),
+        observedAt: OBSERVED_AT,
+      },
+    );
+    assert.deepEqual(data.requested_netuids, [1]);
+    assert.deepEqual(data.dimensions, ["health"]);
+    assert.equal(data.subnets[0].health.ok_count, 4);
+    assert.equal("structure" in data.subnets[0], false);
+  });
+
+  test("loadCompareSubnets includes structure and economics when requested", async () => {
+    const data = await loadCompareSubnets(d1(), {
+      profiles: [
+        {
+          netuid: 1,
+          slug: "apex",
+          name: "Apex",
+          completeness_score: 80,
+          surface_count: 5,
+          operational_interface_count: 2,
+        },
+      ],
+      economicsRows: [{ netuid: 1, open_slots: 2, emission_share: 0.1 }],
+      netuids: [1],
+      dimensions: ["structure", "economics"],
+      observedAt: OBSERVED_AT,
+    });
+    assert.deepEqual(data.dimensions, ["structure", "economics"]);
+    assert.equal(data.subnets[0].structure.completeness_score, 80);
+    assert.equal(data.subnets[0].economics.open_slots, 2);
+    assert.equal("health" in data.subnets[0], false);
+  });
+
+  test("loadCompareSubnets returns empty payload for missing netuids", async () => {
+    const data = await loadCompareSubnets(d1(), {
+      profiles: [],
+      economicsRows: [],
+      netuids: [],
+      observedAt: OBSERVED_AT,
+    });
+    assert.deepEqual(data.requested_netuids, []);
+    assert.deepEqual(data.subnets, []);
+  });
+
+  test("loadGlobalIncidents returns empty summary on cold D1", async () => {
+    const data = await loadGlobalIncidents(d1(), {
+      windowLabel: "7d",
+      windowDays: 7,
+      observedAt: OBSERVED_AT,
+    });
+    assert.equal(data.window, "7d");
+    assert.equal(data.summary.incident_count, 0);
+    assert.deepEqual(data.surfaces, []);
+  });
+
+  test("loadGlobalIncidents formats grouped incident rows", async () => {
+    const now = Date.now();
+    const data = await loadGlobalIncidents(
+      d1({
+        "FROM surface_checks": [
+          {
+            netuid: NETUID,
+            surface_id: "api-root",
+            surface_key: "api-root",
+            started_at: now - 3_600_000,
+            ended_at: now - 1_800_000,
+            failed_samples: 4,
+          },
+        ],
+      }),
+      {
+        windowLabel: "30d",
+        windowDays: 30,
+        observedAt: OBSERVED_AT,
+      },
+    );
+    assert.equal(data.window, "30d");
+    assert.equal(data.summary.incident_count, 1);
+    assert.equal(data.surfaces[0].incidents[0].failed_samples, 4);
+  });
+});
+
+describe("analytics-live window parsers", () => {
+  test("parseUptimeWindow accepts 90d and 1y only", () => {
+    assert.equal(parseUptimeWindow(undefined), "90d");
+    assert.equal(parseUptimeWindow("1y"), "1y");
+    assert.equal(parseUptimeWindow("30d"), null);
+  });
+
+  test("parseAnalyticsWindow maps REST incident windows", () => {
+    assert.deepEqual(parseAnalyticsWindow("30d"), { label: "30d", days: 30 });
+    assert.equal(parseAnalyticsWindow("90d"), null);
+  });
+
+  test("parseCompareDimensionList rejects unknown dimensions", () => {
+    assert.deepEqual(parseCompareDimensionList(["structure"]), ["structure"]);
+    assert.equal(parseCompareDimensionList(["bogus"]), null);
+  });
+
+  test("parseCompareDimensions mirrors REST comma-list input", () => {
+    assert.deepEqual(parseCompareDimensions("structure,health"), [
+      "structure",
+      "health",
+    ]);
+    assert.deepEqual(parseCompareDimensions(null), [
+      "structure",
+      "economics",
+      "health",
+    ]);
+    assert.equal(parseCompareDimensions("bogus"), null);
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3046,7 +3046,15 @@ describe("MCP economics + metagraph data tools", () => {
   ];
 
   // D1 binding honoring the loaders' WHERE clauses (neurons + subnet_snapshots).
-  function metagraphD1({ neurons = [], snapshots = [] } = {}) {
+  function metagraphD1({
+    neurons = [],
+    snapshots = [],
+    surfaceStatus = [],
+    uptimeRows = [],
+    incidentRows = [],
+    growthSamples = [],
+    rpcRows = [],
+  } = {}) {
     return {
       prepare(sql) {
         return {
@@ -3064,7 +3072,30 @@ describe("MCP economics + metagraph data tools", () => {
                   return Promise.resolve({ results: r });
                 }
                 if (sql.includes("FROM subnet_snapshots")) {
+                  if (sql.includes("snapshot_date >=")) {
+                    return Promise.resolve({ results: growthSamples });
+                  }
                   return Promise.resolve({ results: snapshots });
+                }
+                if (sql.includes("FROM surface_uptime_daily")) {
+                  return Promise.resolve({ results: uptimeRows });
+                }
+                if (sql.includes("FROM surface_checks")) {
+                  return Promise.resolve({ results: incidentRows });
+                }
+                if (sql.includes("min_latency_ms")) {
+                  return Promise.resolve({ results: rpcRows });
+                }
+                if (sql.includes("FROM surface_status")) {
+                  if (sql.includes("WHERE netuid IN")) {
+                    const netuids = params.map(Number);
+                    return Promise.resolve({
+                      results: surfaceStatus.filter((row) =>
+                        netuids.includes(row.netuid),
+                      ),
+                    });
+                  }
+                  return Promise.resolve({ results: surfaceStatus });
                 }
                 return Promise.resolve({ results: [] });
               },
@@ -3078,8 +3109,41 @@ describe("MCP economics + metagraph data tools", () => {
     METAGRAPH_HEALTH_DB: metagraphD1({
       neurons: [ROW, MINER],
       snapshots: SNAPSHOTS,
+      surfaceStatus: [
+        { netuid: 1, surface_count: 5, ok_count: 4, avg_latency_ms: 100 },
+        { netuid: 7, surface_count: 3, ok_count: 2, avg_latency_ms: 120 },
+      ],
     }),
   };
+  const liveAnalyticsDeps = makeDeps({
+    "/metagraph/profiles.json": {
+      profiles: [
+        {
+          netuid: 1,
+          slug: "alpha",
+          name: "Alpha",
+          completeness_score: 80,
+          surface_count: 5,
+          operational_interface_count: 2,
+        },
+        {
+          netuid: 7,
+          slug: "gamma",
+          name: "Gamma",
+          completeness_score: 70,
+          surface_count: 4,
+          operational_interface_count: 1,
+        },
+      ],
+    },
+    "/metagraph/economics.json": {
+      generated_at: "2026-06-20T00:00:00Z",
+      subnets: [
+        { netuid: 1, open_slots: 2, emission_share: 0.1 },
+        { netuid: 7, open_slots: 1, emission_share: 0.05 },
+      ],
+    },
+  });
 
   test("get_subnet_metagraph returns every neuron with booleans coerced", async () => {
     const res = await callTool(
@@ -3177,6 +3241,178 @@ describe("MCP economics + metagraph data tools", () => {
 
     const traj = await callTool("get_subnet_trajectory", { netuid: 7 });
     assert.equal(traj.body.result.structuredContent.point_count, 0);
+  });
+
+  test("get_subnet_uptime returns schema-stable empty surfaces on cold D1", async () => {
+    const res = await callTool("get_subnet_uptime", { netuid: 7 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.window, "90d");
+    assert.deepEqual(out.surfaces, []);
+  });
+
+  test("get_registry_leaderboards returns boards from committed profiles", async () => {
+    const res = await callTool(
+      "get_registry_leaderboards",
+      { limit: 5 },
+      { deps: liveAnalyticsDeps, env: d1Env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.ok(typeof out.boards === "object");
+    assert.ok(Object.keys(out.boards).length > 0);
+  });
+
+  test("compare_subnets composes health-only dimensions", async () => {
+    const res = await callTool(
+      "compare_subnets",
+      { netuids: [1, 7], dimensions: ["health"] },
+      { deps: liveAnalyticsDeps, env: d1Env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(out.requested_netuids, [1, 7]);
+    assert.deepEqual(out.dimensions, ["health"]);
+    assert.equal(out.subnets.length, 2);
+    for (const subnet of out.subnets) {
+      assert.equal("health" in subnet, true);
+      assert.equal("structure" in subnet, false);
+    }
+  });
+
+  test("get_global_incidents returns empty summary on cold D1", async () => {
+    const res = await callTool("get_global_incidents", { window: "7d" });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.summary.incident_count, 0);
+    assert.deepEqual(out.surfaces, []);
+  });
+
+  test("live analytics tools reject invalid window/board params", async () => {
+    const uptime = await callTool("get_subnet_uptime", {
+      netuid: 7,
+      window: "30d",
+    });
+    assert.equal(uptime.body.result.isError, true);
+
+    const incidents = await callTool("get_global_incidents", { window: "90d" });
+    assert.equal(incidents.body.result.isError, true);
+
+    const compare = await callTool("compare_subnets", {
+      netuids: [],
+    });
+    assert.equal(compare.body.result.isError, true);
+
+    const dimensions = await callTool("compare_subnets", {
+      netuids: [1],
+      dimensions: ["bogus"],
+    });
+    assert.equal(dimensions.body.result.isError, true);
+
+    const board = await callTool("get_registry_leaderboards", {
+      board: "not-a-board",
+    });
+    assert.equal(board.body.result.isError, true);
+  });
+
+  test("get_subnet_uptime returns per-surface history for the 1y window", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: metagraphD1({
+        uptimeRows: [
+          {
+            surface_id: "api-root",
+            surface_key: "api-root",
+            day: "2026-06-01",
+            samples: 100,
+            ok_count: 95,
+            uptime_ratio: 0.95,
+            avg_latency_ms: 80,
+            p50: 70,
+            p95: 120,
+            p99: 150,
+            status: "ok",
+          },
+        ],
+      }),
+    };
+    const deps = makeDeps({}, { "health:meta": { last_run_at: FRESH_RUN } });
+    const res = await callTool(
+      "get_subnet_uptime",
+      { netuid: 7, window: "1y" },
+      { deps, env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "1y");
+    assert.equal(out.observed_at, FRESH_RUN);
+    assert.equal(out.surfaces.length, 1);
+    assert.equal(out.surfaces[0].samples, 100);
+  });
+
+  test("get_registry_leaderboards can filter to one board", async () => {
+    const res = await callTool(
+      "get_registry_leaderboards",
+      { board: "healthiest", limit: 2 },
+      { deps: liveAnalyticsDeps, env: d1Env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.ok(out.boards.healthiest);
+    assert.equal("fastest-rpc" in out.boards, false);
+  });
+
+  test("compare_subnets defaults to all dimensions and uses live economics KV", async () => {
+    const deps = {
+      ...liveAnalyticsDeps,
+      readHealthKv: makeDeps(
+        {},
+        {
+          "health:meta": { last_run_at: FRESH_RUN },
+          "economics:current": ECON_BLOB,
+        },
+      ).readHealthKv,
+    };
+    const res = await callTool(
+      "compare_subnets",
+      { netuids: [1, 7] },
+      {
+        deps,
+        env: { ...d1Env, METAGRAPH_CONTRACT_VERSION: "test-contract" },
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(out.dimensions, ["structure", "economics", "health"]);
+    assert.equal(out.subnets[1].structure.completeness_score, 70);
+    assert.equal(out.subnets[1].economics.open_slots, 3);
+    assert.equal(out.subnets[1].health.ok_count, 2);
+    assert.equal(out.observed_at, FRESH_RUN);
+  });
+
+  test("get_global_incidents returns incident rows for the 30d window", async () => {
+    const now = Date.now();
+    const env = {
+      METAGRAPH_HEALTH_DB: metagraphD1({
+        incidentRows: [
+          {
+            netuid: 7,
+            surface_id: "api-root",
+            surface_key: "api-root",
+            started_at: now - 3_600_000,
+            ended_at: now - 1_800_000,
+            failed_samples: 3,
+          },
+        ],
+      }),
+    };
+    const res = await callTool(
+      "get_global_incidents",
+      { window: "30d" },
+      {
+        deps: makeDeps({}, { "health:meta": { last_run_at: FRESH_RUN } }),
+        env,
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.observed_at, FRESH_RUN);
+    assert.equal(out.summary.incident_count, 1);
+    assert.equal(out.surfaces[0].incidents[0].failed_samples, 3);
   });
 
   test("the D1 runner swallows a query error and a missing result set", async () => {


### PR DESCRIPTION
## Summary

- Adds `src/analytics-live.mjs` with shared live analytics loaders (`loadSubnetUptime`, `loadRegistryLeaderboards`, `loadCompareSubnets`, `loadGlobalIncidents`) for MCP tools.
- Adds four MCP tools mirroring REST analytics endpoints:
  - `get_subnet_uptime` → `/api/v1/subnets/{netuid}/uptime`
  - `get_registry_leaderboards` → `/api/v1/registry/leaderboards`
  - `compare_subnets` → `/api/v1/compare`
  - `get_global_incidents` → `/api/v1/incidents`
- Reuses `composeCompareData` from `workers/request-handlers/analytics-routes.mjs` (#1919) — no `api.mjs` handler reversion, no logic duplication.
- **No committed build artifacts** — per #2055 the server card is worker-computed; this diff touches only source + tests (no `server-card.json`, `operational-surfaces.json`, or `r2-manifest.json`).

Closes #1958

Fresh resubmission of #2046 per maintainer review (substantively approved; dropped generated artifacts). Issue #1958 documents the REST/MCP parity gap from `api-index.json` — filed to track the scoped work for review, same pattern as other MCP-parity issues (#1903 account tools).

### Scope (4 files, ~1.1k LOC)

| File | Role |
|------|------|
| `src/analytics-live.mjs` | Shared D1 + registry loaders (no SQL duplication) |
| `src/mcp-server.mjs` | Four MCP tool handlers + output schemas |
| `tests/analytics-live.test.mjs` | Parser + loader unit tests |
| `tests/mcp-server.test.mjs` | MCP `callTool` integration tests |

## Test plan

- [x] `npm test -- tests/analytics-live.test.mjs tests/mcp-server.test.mjs`
- [x] `npm run lint`
- [x] `npm run format:check`