### PR TITLE
fix(api): reject negative account_events PK in validEventRows

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -153,7 +153,9 @@ export function validEventRows(rows) {
     ? rows.filter(
         (r) =>
           Number.isInteger(r?.block_number) &&
+          r.block_number >= 0 &&
           Number.isInteger(r?.event_index) &&
+          r.event_index >= 0 &&
           typeof r?.event_kind === "string" &&
           Number.isInteger(r?.observed_at),
       )

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -38,6 +38,9 @@ test("validEventRows enforces the strict row shape (#1371)", () => {
     validEventRows([{ ...good, observed_at: "x" }]).length,
     0, // observed_at must be an integer
   );
+  // negative PK components — aligned with validBlockRows / validExtrinsicRows
+  assert.equal(validEventRows([{ ...good, block_number: -1 }]).length, 0);
+  assert.equal(validEventRows([{ ...good, event_index: -1 }]).length, 0);
 });
 
 test("eventInsertStatements builds chunked parameterized INSERT OR IGNORE", () => {

--- a/tests/load-staged-events.test.mjs
+++ b/tests/load-staged-events.test.mjs
@@ -152,6 +152,21 @@ test("loadStagedEvents drops rows lacking the (block, index) key", async () => {
   assert.deepEqual(m.deleted, ["events/account-events-pending.json"]);
 });
 
+test("loadStagedEvents drops rows with negative PK components", async () => {
+  const valid = eventRow(1000, 0);
+  const m = mockEnv({
+    rows: signedEventEnvelope([
+      { ...valid, block_number: -1 },
+      { ...valid, event_index: -2 },
+      { ...valid, event_index: 2 },
+    ]),
+  });
+  const r = await loadStagedEvents(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.rows, 1);
+  assert.deepEqual(m.batches, [1]);
+});
+
 test("loadStagedEvents drops rows missing required insert fields", async () => {
   const valid = eventRow(1000, 0);
   const m = mockEnv({


### PR DESCRIPTION
## Summary

Closes #2141

Align validEventRows with the blocks and extrinsics ingest validators by rejecting negative block_number and event_index primary-key components before account_events rows reach D1.

## What Changed

- Tighten validEventRows to require block_number >= 0 and event_index >= 0, matching validBlockRows and validExtrinsicRows.
- Add unit coverage for the negative-PK rejection path.
- Add staged-load coverage proving negative rows are dropped during ingest.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] npm run check
- [ ] npm run validate
- [ ] npm run validate:schemas
- [ ] npm run validate:api
- [ ] npm run validate:openapi
- [ ] npm run validate:types
- [ ] npm run validate:artifact-budgets
- [ ] npm run validate:docs
- [ ] npm run validate:intake
- [ ] npm run validate:workflows
- [ ] npm run worker:test
- [ ] npm run test:coverage
- [ ] npm run scan:public-safety
- [ ] git diff --check

Focused tests (not run in this environment — no Node 22 available):

- npx vitest run tests/account-events.test.mjs tests/load-staged-events.test.mjs
