### PR TITLE
fix(indexer): coerce extrinsic success 1/0 → bool for Postgres BOOLEAN

### DIFF
--- a/scripts/index-chain.py
+++ b/scripts/index-chain.py
@@ -84,6 +84,13 @@ def _json_obj(value):
     return value  # already an object or None
 
 
+def _as_bool(value):
+    """`success` arrives as 1/0 (int) from _extrinsic_success_map, but the Postgres
+    `extrinsics.success` column is BOOLEAN (strict — unlike the loose D1/SQLite era).
+    Coerce; None stays NULL (index missing its ExtrinsicSuccess/Failed event)."""
+    return None if value is None else bool(value)
+
+
 def _has_ts(row):
     """observed_at is BIGINT NOT NULL. decode_head emits None when a block's
     Timestamp query fails; drop such rows (mirrors the D1-era Worker validators
@@ -112,6 +119,7 @@ def rows_from_decoded(decoded):
     for x in decoded.get("extrinsics") or []:
         row = {c: x.get(c) for c in EXTRINSIC_COLS}
         row["call_args"] = _json_obj(row["call_args"])
+        row["success"] = _as_bool(row.get("success"))
         if _has_ts(row):
             extrinsics.append(row)
     events = []

--- a/scripts/test_index_chain.py
+++ b/scripts/test_index_chain.py
@@ -39,7 +39,9 @@ def _decoded():
                 "signer": "5Signer",
                 "call_module": "SubtensorModule",
                 "call_function": "add_stake",
-                "success": True,
+                # _extrinsic_success_map emits 1/0 (int), NOT a bool — the shape
+                # the indexer must coerce for the Postgres BOOLEAN column.
+                "success": 1,
                 "fee_tao": 0.0001,
                 "tip_tao": 0.0,
                 # The verified decode (_safe_json) emits call_args as a compact
@@ -81,6 +83,17 @@ class RowsFromDecoded(unittest.TestCase):
         self.assertEqual(set(x.keys()), set(ic.EXTRINSIC_COLS))
         self.assertEqual(x["extrinsic_index"], 2)
         self.assertEqual(x["call_module"], "SubtensorModule")
+
+    def test_success_int_is_coerced_to_bool_for_postgres(self):
+        # Regression: _extrinsic_success_map emits 1/0 (int); the Postgres column
+        # is BOOLEAN (strict), so 1 -> True, 0 -> False, missing -> None.
+        x = ic.rows_from_decoded(_decoded())["extrinsics"][0]
+        self.assertIs(x["success"], True)
+        d = _decoded()
+        d["extrinsics"][0]["success"] = 0
+        self.assertIs(ic.rows_from_decoded(d)["extrinsics"][0]["success"], False)
+        d["extrinsics"][0]["success"] = None
+        self.assertIsNone(ic.rows_from_decoded(d)["extrinsics"][0]["success"])
 
     def test_call_args_json_string_is_decoded_to_an_object(self):
         # Regression: the decode emits call_args as a JSON STRING; it must be


### PR DESCRIPTION
Second live type-strictness bug (after the `init_runtime` fix). Postgres rejected inserts with `column "success" is of type boolean but expression is of type integer`. `_extrinsic_success_map` emits `1`/`0` (int) — fine for the loose D1/SQLite era, not for the strict Postgres `extrinsics.success` BOOLEAN. Coerce in `rows_from_decoded` (1→True, 0→False, missing→None). +regression test (the old fixture used a bool, which hid it). `success` is the only boolean column the indexer writes; the numeric fee/amount/alpha are floats→NUMERIC.