### PR TITLE
fix(indexer): default RPC to the archive endpoint (entrypoint-finney is pruned)

### DIFF
--- a/deploy/railway-bootstrap.sh
+++ b/deploy/railway-bootstrap.sh
@@ -18,7 +18,10 @@ set -euo pipefail
 REPO="JSONbored/metagraphed"
 BRANCH="main"
 WORKSPACE="aethereal"
-RPC_URL="${EVENTS_RPC_URL:-wss://entrypoint-finney.opentensor.ai:443}"
+# ARCHIVE endpoint — the indexer backfills old-block state, which pruned nodes
+# (entrypoint-finney) discard ("State already discarded"). On the box this points
+# at the local archive node instead.
+RPC_URL="${EVENTS_RPC_URL:-wss://archive.chain.opentensor.ai:443}"
 
 echo "==> 1. Create the project + default (production) environment"
 railway init --name metagraphed-core --workspace "$WORKSPACE" --json

--- a/scripts/index-chain.py
+++ b/scripts/index-chain.py
@@ -25,7 +25,8 @@ gate is "~100% capture vs D1" before any serving cutover.
 Heavy deps (psycopg2, substrate-interface) are imported lazily so the pure
 transforms test without them. Run (the compose stack wires these):
   DATABASE_URL          postgresql://… (the Timescale sink)
-  EVENTS_RPC_URL        ws://subtensor:9944 (the local node)  [default: public finney]
+  EVENTS_RPC_URL        ws://subtensor:9944 (the local node)  [default: public ARCHIVE
+                        archive.chain.opentensor.ai — NOT pruned entrypoint-finney]
   REDIS_URL             redis://redis:6379  (optional — cursor/heartbeat mirror)
   START_BLOCK           cold-cursor anchor (else the overlap floor)
   EVENTS_WINDOW         overlap re-scan floor (default 256)
@@ -40,7 +41,12 @@ import signal
 import sys
 import time
 
-RPC = os.environ.get("EVENTS_RPC_URL", "wss://entrypoint-finney.opentensor.ai:443")
+# Default to the ARCHIVE endpoint, not entrypoint-finney: the indexer's backfill
+# reads state at older blocks (System.Events/Timestamp at a past block_hash), and
+# entrypoint-finney is PRUNED — it discards old state and fails the backfill with
+# "UnknownBlock: State already discarded" (verified live). archive.chain retains
+# full state. On the bare-metal box, EVENTS_RPC_URL points at the local node.
+RPC = os.environ.get("EVENTS_RPC_URL", "wss://archive.chain.opentensor.ai:443")
 WINDOW = int(os.environ.get("EVENTS_WINDOW", "256"))
 MAX_LOOKBACK = int(os.environ.get("EVENTS_MAX_LOOKBACK", "512"))
 START_BLOCK = os.environ.get("START_BLOCK")


### PR DESCRIPTION
Verified live: the indexer backfill reads state at older blocks, but the default `entrypoint-finney` is **pruned** and fails with `UnknownBlock: State already discarded`. `archive.chain.opentensor.ai` retains full state (confirmed by direct probe + the indexer now writing blocks). New default; on the bare-metal box `EVENTS_RPC_URL` points at the local node. Also updated `deploy/railway-bootstrap.sh`. The running Railway indexer already has this set explicitly — this prevents a bare default from silently breaking backfill.