### PR TITLE
infra(deploy): run a FULL ARCHIVE node (--pruning=archive --sync=full)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -10,3 +10,7 @@ POSTGRES_PASSWORD=
 # EVENTS_MAX_LOOKBACK=512                  # raise vs an archive node for long gaps
 # START_BLOCK=                             # cold-cursor historical anchor
 # LOG_LEVEL=INFO
+
+# Node mode — defaults to a FULL ARCHIVE (complete state from genesis; ~8 TB+ NVMe).
+# SUBTENSOR_SYNC=full                      # full | warp  (archive REQUIRES full)
+# SUBTENSOR_PRUNING=archive                # archive | <N blocks>  (dev: 2000 = pruned)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -120,7 +120,7 @@ cross-service variable references, e.g.:
 railway add -s indexer --repo JSONbored/metagraphed --branch main \
   -v DATABASE_URL='${{Postgres.DATABASE_URL}}' \
   -v REDIS_URL='${{Redis.REDIS_URL}}' \
-  -v EVENTS_RPC_URL='wss://entrypoint-finney.opentensor.ai:443'
+  -v EVENTS_RPC_URL='wss://archive.chain.opentensor.ai:443'   # archive, NOT pruned entrypoint
 ```
 
 The public `wss-lb` is independent of Postgres/Redis (it reads only the public

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -5,7 +5,7 @@ This is the **operator runbook**: what runs where, the exact provisioning
 commands, and the gated cutover steps.
 
 ```
-Chain → pruned subtensor-node → indexer → Postgres/Timescale
+Chain → full archive subtensor-node → indexer → Postgres/Timescale
                                               │
                           (Cloudflare Hyperdrive, pooled + cached)
                                               ▼
@@ -19,7 +19,7 @@ R2 = artifacts · Parquet/CSV exports · Postgres backups (zero-egress)
 | Tier          | Where                                  | Pieces                                                                                                                                               |
 | ------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Edge (rented) | **Cloudflare**                         | Worker serving, **Hyperdrive** → Postgres, **Durable Object** firehose, R2, KV, Vectorize, Workers AI, rate-limiters, RPC proxy                      |
-| Core (owned)  | **Railway project `metagraphed-core`** | `postgres`, `redis`, `subtensor-node` (pruned), `indexer`, `health-prober`, `rollups`, `alerter`, `exporter`, `reconciler`, `wss-lb` (public WSS LB) |
+| Core (owned)  | **Dedicated box** (data plane) + **Railway** (light glue) | box: `subtensor-node` (**full archive**, ~3.5 TB+ NVMe) + `postgres` + `redis` + `indexer`; Railway: `wss-lb` + crons (`health-prober`, `rollups`, `alerter`, `exporter`, `reconciler`). _Interim: Postgres/Redis/indexer run on Railway until the box is live._ |
 | Escape hatch  | **Hetzner** (later)                    | `postgres` (+ optional node) when compressed history > ~300–500 GB or the 1 TB Railway cap looms — see ADR 0013                                      |
 
 One Railway **project**, two **environments** (`production`, `staging`), one
@@ -75,10 +75,12 @@ That starts:
   boot; never binds a public port (Cloudflare reaches it via Hyperdrive over a
   tunnel).
 - **`redis`** — the indexer cursor + heartbeat mirror.
-- **`subtensor`** — a pruned finney node (the head source + first-party RPC
-  origin). For the one-time historical backfill, point the indexer at a transient
-  archive source via `EVENTS_RPC_URL` / `START_BLOCK` / a raised
-  `EVENTS_MAX_LOOKBACK`.
+- **`subtensor`** — a **full archive** finney node (`--pruning=archive --sync=full`:
+  complete state from genesis), the head source + first-party RPC origin + the
+  indexer's self-sufficient backfill source. Needs **~8 TB+ NVMe**; the from-genesis
+  full sync takes days, so seed the volume from an opentensor archive snapshot when
+  available. (Dev: `SUBTENSOR_PRUNING=2000 SUBTENSOR_SYNC=warp` for a small pruned
+  node; deep backfill then comes from the public archive via `EVENTS_RPC_URL`.)
 - **`indexer`** (`scripts/index-chain.py`) — follows the finalized head from the
   durable cursor and idempotently writes `blocks` / `extrinsics` /
   `account_events` into Postgres. Its pure transforms are unit-tested
@@ -156,8 +158,9 @@ tees each decoded batch to it for SSE/WS/GraphQL-subscription fan-out.
 
 Each needs a human who can verify/roll back (ADR 0013 _Sequencing_):
 
-1. **`subtensor-node`** — pruned (128 GB volume), follows head. (A permanent
-   archive node is ~3.5 TB — avoided; backfill uses a transient archive source.)
+1. **`subtensor-node`** — **full archive** (~3.5 TB+, ~8 TB+ NVMe volume): complete
+   state from genesis, so it serves first-party archive RPC + self-sufficient
+   backfill. Seed from a snapshot to skip the multi-day from-genesis sync.
 2. **`indexer` + one-time backfill** — then **verify ~100 % capture vs D1**
    before trusting it.
 3. **Serving cutover** — point the Worker at Hyperdrive→Postgres **tier by tier**

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -16,11 +16,11 @@ R2 = artifacts · Parquet/CSV exports · Postgres backups (zero-egress)
 
 ## Topology
 
-| Tier          | Where                                  | Pieces                                                                                                                                               |
-| ------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Edge (rented) | **Cloudflare**                         | Worker serving, **Hyperdrive** → Postgres, **Durable Object** firehose, R2, KV, Vectorize, Workers AI, rate-limiters, RPC proxy                      |
+| Tier          | Where                                                     | Pieces                                                                                                                                                                                                                                                           |
+| ------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Edge (rented) | **Cloudflare**                                            | Worker serving, **Hyperdrive** → Postgres, **Durable Object** firehose, R2, KV, Vectorize, Workers AI, rate-limiters, RPC proxy                                                                                                                                  |
 | Core (owned)  | **Dedicated box** (data plane) + **Railway** (light glue) | box: `subtensor-node` (**full archive**, ~3.5 TB+ NVMe) + `postgres` + `redis` + `indexer`; Railway: `wss-lb` + crons (`health-prober`, `rollups`, `alerter`, `exporter`, `reconciler`). _Interim: Postgres/Redis/indexer run on Railway until the box is live._ |
-| Escape hatch  | **Hetzner** (later)                    | `postgres` (+ optional node) when compressed history > ~300–500 GB or the 1 TB Railway cap looms — see ADR 0013                                      |
+| Escape hatch  | **Hetzner** (later)                                       | `postgres` (+ optional node) when compressed history > ~300–500 GB or the 1 TB Railway cap looms — see ADR 0013                                                                                                                                                  |
 
 One Railway **project**, two **environments** (`production`, `staging`), one
 private network (`<service>.railway.internal`, zero egress). The existing

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -43,10 +43,17 @@ services:
       timeout: 5s
       retries: 10
 
-  # The Bittensor node. Pruned by default (--pruning=2000 → small on-disk, not a
-  # full archive) — it follows the head + serves the indexer + is the first-party
-  # RPC origin. For the one-time historical
-  # backfill, point the indexer at a transient archive source instead (ADR 0013).
+  # The Bittensor node — a FULL ARCHIVE by default: --pruning=archive keeps the
+  # complete state trie from genesis and --sync=full replays every block to build
+  # it, so it is a real archive (state queryable at ANY block), the first-party
+  # RPC origin, and a self-sufficient backfill source for the indexer.
+  #
+  #   Requires ~8 TB+ NVMe (chain ~3.5 TB + ~1.4 TB/yr) — see deploy/README.md.
+  #   A from-genesis full sync takes DAYS; import an opentensor archive snapshot
+  #   into the volume first to skip the replay.
+  #   Dev override (pruned, small): SUBTENSOR_PRUNING=2000 SUBTENSOR_SYNC=warp.
+  #   (NOTE: warp + archive is contradictory — warp skips historical state, so a
+  #   real archive MUST use --sync=full.)
   # If you run subtensor directly on the host, drop this service and set the
   # indexer's EVENTS_RPC_URL to the host endpoint.
   subtensor:
@@ -58,8 +65,8 @@ services:
     command:
       - --base-path=/data
       - --chain=finney
-      - --sync=warp
-      - --pruning=2000
+      - --sync=${SUBTENSOR_SYNC:-full}
+      - --pruning=${SUBTENSOR_PRUNING:-archive}
       - --rpc-external
       - --rpc-cors=all
     volumes:

--- a/docs/adr/0013-hybrid-deployment-topology.md
+++ b/docs/adr/0013-hybrid-deployment-topology.md
@@ -9,6 +9,18 @@
   ingestion — the continuous indexer this deploys), ADR 0001/0006 (storage tiers),
   and the own-the-core infrastructure program (#1345, #1349, #1519, #1749).
 
+> **Amendment (2026-06-27): node tier is a FULL ARCHIVE, superseding the
+> pruned-node default below.** We are running a real archive node
+> (`--pruning=archive --sync=full`, complete state from genesis, ~3.5 TB+ on
+> ~8 TB+ NVMe) on the dedicated box, not a 128 GB pruned node. Rationale: a pruned
+> node is not a true archive — it can't serve historical state queries or be a
+> self-sufficient backfill source, and we want a **first-party archive RPC origin**
+> (addable to the RPC/WSS pools) independent of public archives' rate limits. The
+> cost the original decision avoided (the ~3.5 TB archive) is consciously accepted
+> for that capability. The pruned-node + transient-public-backfill path below
+> remains the cheaper dev/interim fallback (`SUBTENSOR_PRUNING=2000`). Everything
+> else in this ADR (CF edge · Postgres · Hyperdrive cutover · sequencing) stands.
+
 ## Context
 
 The explorer's chain data is structurally a **rolling cache, not an archive**, and


### PR DESCRIPTION
Decision: a **real archive node**, not a pruned one — complete state from genesis, so it serves first-party archive RPC + is a self-sufficient backfill source (a pruned node is not an archive).

**Correctness fix:** `--sync=warp` is contradictory with archive (warp skips historical state) → the node uses `--sync=full`.

- **docker-compose:** subtensor → `--sync=${SUBTENSOR_SYNC:-full}` `--pruning=${SUBTENSOR_PRUNING:-archive}` (env-overridable to a pruned dev node).
- **.env.example:** `SUBTENSOR_SYNC` / `SUBTENSOR_PRUNING` documented.
- **README:** topology / bring-up / gated-steps updated (pruned 128 GB → full archive ~8 TB+ NVMe; snapshot-seed to skip the multi-day from-genesis sync); archive RPC in the provisioning example.
- **ADR 0013:** amendment note superseding the pruned-node default (history preserved).

Docs + compose config only.