### PR TITLE
fix(wss-lb): sanitize JSON-RPC ids in error replies

### DIFF
--- a/deploy/wss-lb/src/proxy.mjs
+++ b/deploy/wss-lb/src/proxy.mjs
@@ -14,10 +14,16 @@ function isSafeRpcMethod(method) {
   );
 }
 
+function normalizeRpcId(id) {
+  return typeof id === "string" || typeof id === "number" || id === null
+    ? id
+    : null;
+}
+
 function rpcError(id, code, message) {
   return JSON.stringify({
     jsonrpc: "2.0",
-    id: id ?? null,
+    id: normalizeRpcId(id),
     error: { code, message },
   });
 }

--- a/deploy/wss-lb/test/proxy.test.mjs
+++ b/deploy/wss-lb/test/proxy.test.mjs
@@ -180,3 +180,30 @@ test("security: unsafe and oversized client RPC frames do not reach upstream", a
   await lb.close();
   await new Promise((resolve) => http.close(resolve));
 });
+
+test("security: nested non-scalar RPC ids are not reflected in errors", async () => {
+  const good = await echoServer();
+  const lb = await lbServer([good.url]);
+  const nestedId = "[".repeat(5000) + "null" + "]".repeat(5000);
+  const payload = `{"jsonrpc":"2.0","id":${nestedId},"method":"author_submitExtrinsic"}`;
+
+  const reply = await new Promise((resolve, reject) => {
+    const c = new WebSocket(lb.url);
+    c.on("open", () => {
+      c.send(payload);
+    });
+    c.on("message", (d) => {
+      c.close();
+      resolve(JSON.parse(d.toString()));
+    });
+    c.on("error", reject);
+    setTimeout(() => reject(new Error("timeout")), 8000);
+  });
+
+  assert.equal(reply.id, null);
+  assert.equal(reply.error?.code, -32601);
+  assert.equal(good.connections, 1);
+
+  await lb.close();
+  await good.close();
+});


### PR DESCRIPTION
### Motivation
- The WSS proxy built JSON-RPC error replies by directly serializing caller-supplied `id` values which can be deeply nested attacker-controlled structures that make `JSON.stringify` throw and crash the Node process. 
- Normalize reflected `id`s to a safe scalar to prevent a remotely-triggerable denial-of-service while preserving existing error semantics.

### Description
- Add a `normalizeRpcId` helper and use it from `rpcError` so only a `string`, `number`, or `null` is emitted as the error `id`. 
- Update `rpcError` in `deploy/wss-lb/src/proxy.mjs` to call `normalizeRpcId(id)` instead of reflecting arbitrary parsed values. 
- Add a regression test `security: nested non-scalar RPC ids are not reflected in errors` to `deploy/wss-lb/test/proxy.test.mjs` that sends a blocked method with a 5000-level nested array `id` and asserts the proxy responds with `id: null` and does not crash.

### Testing
- Ran `node --test deploy/wss-lb/test/*.mjs` and the full proxy test suite passed with the new regression test included. 
- Ran `git diff --check` and ESLint via `npm run lint -- deploy/wss-lb/src/proxy.mjs deploy/wss-lb/test/proxy.test.mjs` with no errors. 
- Verified formatting with `npm exec prettier -- ... --check` for the modified files and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f8de2b738832cad4429e4359fa58f)