### PR TITLE
fix(wss-lb): self-contained RPC policy (real cause of the deploy failures)

### DIFF
--- a/deploy/wss-lb/src/proxy.mjs
+++ b/deploy/wss-lb/src/proxy.mjs
@@ -5,7 +5,7 @@ import {
   MAX_RPC_BODY_BYTES,
   SAFE_RPC_METHODS,
   DENIED_RPC_PREFIXES,
-} from "../../../workers/config.mjs";
+} from "./rpc-policy.mjs";
 
 function isSafeRpcMethod(method) {
   return (

--- a/deploy/wss-lb/src/rpc-policy.mjs
+++ b/deploy/wss-lb/src/rpc-policy.mjs
@@ -1,0 +1,32 @@
+// Read-only RPC safety policy for the WSS load balancer — a SELF-CONTAINED copy
+// of the policy in workers/config.mjs (the CF HTTP proxy uses the same allowlist).
+//
+// Why a copy and not an import: the wss-lb deploys as a standalone Railway service
+// whose container only contains `deploy/wss-lb` (the Dockerfile COPYs `src` only).
+// Importing `../../../workers/config.mjs` resolves in the repo but NOT in the
+// image — it crashed every deploy with ERR_MODULE_NOT_FOUND before the server
+// could listen, so the healthcheck failed.
+//
+// KEEP IN SYNC with workers/config.mjs — tests/wss-lb-rpc-policy-sync.test.mjs
+// fails CI if these drift.
+export const SAFE_RPC_METHODS = new Set([
+  "chain_getBlock",
+  "chain_getBlockHash",
+  "chain_getFinalizedHead",
+  "chain_getHeader",
+  "rpc_methods",
+  "state_getRuntimeVersion",
+  "system_chain",
+  "system_health",
+  "system_name",
+  "system_properties",
+  "system_version",
+]);
+export const DENIED_RPC_PREFIXES = [
+  "author_",
+  "state_call",
+  "sudo_",
+  "payment_",
+  "contracts_",
+];
+export const MAX_RPC_BODY_BYTES = 65536;

--- a/tests/wss-lb-rpc-policy-sync.test.mjs
+++ b/tests/wss-lb-rpc-policy-sync.test.mjs
@@ -1,0 +1,19 @@
+// Drift guard: the wss-lb ships a SELF-CONTAINED copy of the RPC safety policy
+// (deploy/wss-lb/src/rpc-policy.mjs) because its standalone container can't import
+// workers/config.mjs. This test fails CI if that copy drifts from the source of
+// truth, so the public WSS proxy never enforces a stale allowlist.
+import assert from "node:assert/strict";
+
+import { test } from "vitest";
+
+import * as worker from "../workers/config.mjs";
+import * as wsslb from "../deploy/wss-lb/src/rpc-policy.mjs";
+
+test("wss-lb RPC policy matches workers/config.mjs (no drift)", () => {
+  assert.equal(wsslb.MAX_RPC_BODY_BYTES, worker.MAX_RPC_BODY_BYTES);
+  assert.deepEqual(wsslb.DENIED_RPC_PREFIXES, worker.DENIED_RPC_PREFIXES);
+  assert.deepEqual(
+    [...wsslb.SAFE_RPC_METHODS].sort(),
+    [...worker.SAFE_RPC_METHODS].sort(),
+  );
+});


### PR DESCRIPTION
**Root cause (from the runtime logs, not a guess):** `deploy/wss-lb/src/proxy.mjs` imported the RPC allowlist from `../../../workers/config.mjs`. That resolves in the repo (local boot + CI green) but the standalone container only COPYs `deploy/wss-lb/src` → at runtime `ERR_MODULE_NOT_FOUND '/workers/config.mjs'`, **crash before listen, healthcheck fails every deploy** (4 in a row). #2149's healthz change fixed a symptom; this fixes the cause.

Inlined the policy into `deploy/wss-lb/src/rpc-policy.mjs` (self-contained, as a standalone service must be) + `tests/wss-lb-rpc-policy-sync.test.mjs` to fail CI if it drifts from `workers/config.mjs`. **Verified by booting a copy of ONLY `deploy/wss-lb` (no `workers/`)** → listens + `healthz 200`, no module error. 10 wss-lb tests + the drift guard pass.