### PR TITLE
feat(infra): one-time historical backfill job (separate, non-stalling)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -14,3 +14,10 @@ POSTGRES_PASSWORD=
 # Node mode — defaults to a FULL ARCHIVE (complete state from genesis; ~8 TB+ NVMe).
 # SUBTENSOR_SYNC=full                      # full | warp  (archive REQUIRES full)
 # SUBTENSOR_PRUNING=archive                # archive | <N blocks>  (dev: 2000 = pruned)
+
+# One-time historical backfill job (scripts/backfill-chain.py, deploy/backfill.railway.json).
+# Point EVENTS_RPC_URL at an ARCHIVE endpoint (pruned can't serve old state).
+# BACKFILL_DEPTH_DAYS=365                  # how far back from head to fill (~12 months)
+# BACKFILL_FROM=  / BACKFILL_TO=           # explicit block range override
+# BACKFILL_BATCH=100                       # blocks per commit
+# BACKFILL_SLEEP_MS=0                      # pause between blocks (raise to ease a public archive)

--- a/deploy/backfill.railway.json
+++ b/deploy/backfill.railway.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "deploy/indexer.Dockerfile",
+    "watchPatterns": [
+      "scripts/backfill-chain.py",
+      "scripts/index-chain.py",
+      "scripts/fetch-events.py",
+      "scripts/stream-events.py",
+      "deploy/indexer.Dockerfile",
+      "deploy/backfill.railway.json"
+    ]
+  },
+  "deploy": {
+    "startCommand": "python scripts/backfill-chain.py",
+    "numReplicas": 1,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/deploy/indexer.Dockerfile
+++ b/deploy/indexer.Dockerfile
@@ -24,8 +24,9 @@ RUN pip install --no-cache-dir \
       "redis==5.2.1"
 
 # Reuse the verified decode (fetch-events.py) + the streamer's decode_head
-# (stream-events.py) — imported, never duplicated.
-COPY scripts/fetch-events.py scripts/stream-events.py scripts/index-chain.py /app/scripts/
+# (stream-events.py) — imported, never duplicated. backfill-chain.py shares this
+# image; the backfill service overrides the start command (deploy/backfill.railway.json).
+COPY scripts/fetch-events.py scripts/stream-events.py scripts/index-chain.py scripts/backfill-chain.py /app/scripts/
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1

--- a/scripts/backfill-chain.py
+++ b/scripts/backfill-chain.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""One-time historical backfill (ADR 0013) — walks a bounded block range from an
+ARCHIVE RPC into Postgres INDEPENDENTLY of the live indexer, so deep history fills
+WITHOUT stalling live ingestion.
+
+It reuses the indexer's verified decode + idempotent upserts (rows_from_decoded,
+_upsert) so there is zero decode/schema drift. Progress is a SEPARATE cursor row
+(indexer_cursor id=2) — it never touches the live cursor (id=1), and the
+`INSERT ... ON CONFLICT DO NOTHING` keys make concurrent backfill + live-follow
+safe (overlapping ranges re-insert harmlessly).
+
+Run as a one-time Railway service (deploy/backfill.railway.json) or manually:
+  DATABASE_URL          postgresql://…        (the SAME Postgres as the indexer)
+  EVENTS_RPC_URL        wss://archive.chain…  (an ARCHIVE endpoint — a pruned node
+                        can't serve old state and the backfill will fail)
+  BACKFILL_DEPTH_DAYS   how far back from head to fill (default 365 ≈ 12 months)
+  BACKFILL_FROM / BACKFILL_TO   explicit block-range override
+  BACKFILL_BATCH        blocks per commit (default 100)
+  BACKFILL_SLEEP_MS     pause between blocks, rate-limit-friendly (default 0)
+It resumes from the id=2 cursor on restart and exits 0 when the range is complete.
+"""
+import importlib.util
+import logging
+import os
+import signal
+import sys
+import time
+
+BLOCKS_PER_DAY = 7200  # ~1 block / 12s
+BACKFILL_ID = 2  # progress row; the live indexer is id=1
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load(modname, filename):
+    spec = importlib.util.spec_from_file_location(
+        modname, os.path.join(_HERE, filename)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Reuse the indexer's verified decode + idempotent upserts (no duplication).
+ic = _load("index_chain", "index-chain.py")
+
+RPC = os.environ.get("EVENTS_RPC_URL", "wss://archive.chain.opentensor.ai:443")
+DEPTH_DAYS = int(os.environ.get("BACKFILL_DEPTH_DAYS", "365"))
+BATCH = max(1, int(os.environ.get("BACKFILL_BATCH", "100")))
+SLEEP_MS = max(0, int(os.environ.get("BACKFILL_SLEEP_MS", "0")))
+
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+    stream=sys.stdout,
+)
+log = logging.getLogger("backfill")
+
+_stop = False
+
+
+def _handle_signal(_signum, _frame):
+    global _stop
+    _stop = True
+
+
+def backfill_range(head, depth_days, env_from, env_to):
+    """PURE: the [from, to] block range to fill. Explicit env overrides win;
+    otherwise [head - depth_days*BLOCKS_PER_DAY, head]. Clamped to >= 0."""
+    to = int(env_to) if env_to else int(head)
+    frm = int(env_from) if env_from else to - depth_days * BLOCKS_PER_DAY
+    return max(0, frm), to
+
+
+def _read_progress(conn):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT last_block FROM indexer_cursor WHERE id = %s", (BACKFILL_ID,)
+        )
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def _write_progress(conn, last_block):
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO indexer_cursor (id, last_block, updated_at) "
+            "VALUES (%s, %s, now()) ON CONFLICT (id) DO UPDATE SET "
+            "last_block = GREATEST(indexer_cursor.last_block, EXCLUDED.last_block), "
+            "updated_at = now()",
+            (BACKFILL_ID, last_block),
+        )
+
+
+def _flush(conn, decoded_batch):
+    for rows in decoded_batch:
+        ic._upsert(conn, "blocks", ic.BLOCK_COLS, rows["blocks"], "block_number")
+        ic._upsert(
+            conn,
+            "extrinsics",
+            ic.EXTRINSIC_COLS,
+            rows["extrinsics"],
+            "block_number, extrinsic_index",
+        )
+        ic._upsert(
+            conn,
+            "account_events",
+            ic.EVENT_COLS,
+            rows["account_events"],
+            "block_number, event_index",
+        )
+
+
+def run():
+    import psycopg2
+    from substrateinterface import SubstrateInterface
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        log.error("DATABASE_URL is required")
+        sys.exit(1)
+
+    decode_head = ic._decode_head()  # loads stream-events (installs its handlers)
+    signal.signal(signal.SIGTERM, _handle_signal)  # ours wins after that load
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    conn = psycopg2.connect(db_url)
+    conn.autocommit = False
+    s = SubstrateInterface(url=RPC)
+    s.init_runtime()  # warm metadata before the cold-range decode
+
+    head = s.get_block_number(s.get_chain_finalised_head())
+    frm, to = backfill_range(
+        head, DEPTH_DAYS, os.environ.get("BACKFILL_FROM"), os.environ.get("BACKFILL_TO")
+    )
+    progress = _read_progress(conn)
+    bn = max(frm, (progress + 1) if progress is not None else frm)
+    log.info(
+        "backfill #%d..#%d (resume @ #%d, depth=%dd, rpc=%s)",
+        frm, to, bn, DEPTH_DAYS, RPC,
+    )
+
+    committed = bn - 1
+    batch = []
+    batch_last = committed
+    while bn <= to and not _stop:
+        try:
+            batch.append(ic.rows_from_decoded(decode_head(s, bn)))
+            batch_last = bn
+            if len(batch) >= BATCH or bn == to:
+                _flush(conn, batch)
+                _write_progress(conn, batch_last)
+                conn.commit()
+                committed = batch_last
+                batch = []
+                pct = 100 * (committed - frm + 1) / max(1, to - frm + 1)
+                log.info("backfilled through #%d (%.1f%%)", committed, pct)
+            bn += 1
+            if SLEEP_MS:
+                time.sleep(SLEEP_MS / 1000)
+        except Exception as e:  # noqa: BLE001 — RPC/DB blip: rollback, reconnect, retry
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            batch = []
+            bn = committed + 1  # retry from after the last COMMITTED block (idempotent)
+            if getattr(conn, "closed", 0):
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+                try:
+                    conn = psycopg2.connect(db_url)
+                    conn.autocommit = False
+                except Exception:
+                    pass
+            log.error("backfill error near #%d (%s) — retry in 5s", bn, repr(e)[:160])
+            time.sleep(5)
+            try:
+                s.get_chain_finalised_head()  # liveness probe
+            except Exception:
+                try:
+                    s = SubstrateInterface(url=RPC)
+                    s.init_runtime()
+                except Exception:
+                    pass
+
+    if _stop:
+        log.info("stopped at #%d (resumable from the id=2 cursor)", committed)
+    else:
+        log.info("backfill complete: #%d..#%d", frm, to)
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/test_backfill_chain.py
+++ b/scripts/test_backfill_chain.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Unit tests for the backfill job's PURE range logic (no chain/DB needed)."""
+import importlib.util
+import os
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "backfill_chain", os.path.join(_HERE, "backfill-chain.py")
+)
+bf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bf)
+
+
+class BackfillRange(unittest.TestCase):
+    def test_depth_days_default_window(self):
+        frm, to = bf.backfill_range(8_500_000, 365, None, None)
+        self.assertEqual(to, 8_500_000)
+        self.assertEqual(frm, 8_500_000 - 365 * bf.BLOCKS_PER_DAY)
+
+    def test_explicit_from_to_override_wins(self):
+        self.assertEqual(bf.backfill_range(8_500_000, 365, "100", "200"), (100, 200))
+
+    def test_window_clamped_to_zero(self):
+        # depth window deeper than the head must not go negative.
+        frm, to = bf.backfill_range(1000, 365, None, None)
+        self.assertEqual((frm, to), (0, 1000))
+
+    def test_partial_from_override_keeps_head_as_to(self):
+        frm, to = bf.backfill_range(8_500_000, 365, "7000000", None)
+        self.assertEqual((frm, to), (7_000_000, 8_500_000))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`scripts/backfill-chain.py` — a one-time job that walks a bounded block range from an **archive** RPC into Postgres **independently of the live indexer**, so deep history fills without freezing live ingestion.

- Reuses the indexer's verified decode + idempotent upserts (zero drift).
- **Separate progress cursor (`indexer_cursor` id=2)** — never touches the live cursor (id=1); `ON CONFLICT DO NOTHING` makes concurrent backfill + live-follow safe.
- Resumable from the cursor on restart/crash; `BACKFILL_SLEEP_MS` to ease the public archive; default depth **365d (~12 months)**.
- Shares the indexer image (start command overridden in `deploy/backfill.railway.json`).
- Pure range logic unit-tested (4 tests); live path verified on deploy.

Part of the all-Railway full-history plan. Create the backfill service when ready to start the (weeks-long, background) fill.