### PR TITLE
feat(infra): Postgres → R2 backup job (durability insurance)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -21,3 +21,10 @@ POSTGRES_PASSWORD=
 # BACKFILL_FROM=  / BACKFILL_TO=           # explicit block range override
 # BACKFILL_BATCH=100                       # blocks per commit
 # BACKFILL_SLEEP_MS=0                      # pause between blocks (raise to ease a public archive)
+
+# Postgres -> R2 backup job (deploy/backup/, deploy/backup.railway.json).
+# R2_BUCKET=metagraphed-backups
+# R2_ENDPOINT=https://<accountid>.r2.cloudflarestorage.com
+# AWS_ACCESS_KEY_ID=<r2-s3-access-key>     # R2 API token (S3 credentials)
+# AWS_SECRET_ACCESS_KEY=<r2-s3-secret>
+# BACKUP_PREFIX=postgres

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -170,6 +170,24 @@ Each needs a human who can verify/roll back (ADR 0013 _Sequencing_):
    `metagraphed-streamer` project, and the `*/3` R2-staging drain; demote D1 to a
    hot cache.
 
+## Backup job (Postgres → R2)
+
+`deploy/backup/` is the scheduled durability job — `pg_dump | gzip | aws s3 cp` to
+R2 (zero egress). Restoring a dump is minutes; re-backfilling history is weeks.
+
+One-time setup:
+
+1. Create an R2 bucket (e.g. `metagraphed-backups`) + an **R2 API token** (S3
+   access key + secret) in the Cloudflare dashboard.
+2. Add a Railway service from the repo, **Config File = `/deploy/backup.railway.json`**,
+   env: `DATABASE_URL=${{Postgres.DATABASE_URL}}`, `R2_BUCKET`, `R2_ENDPOINT`
+   (`https://<accountid>.r2.cloudflarestorage.com`), `AWS_ACCESS_KEY_ID`,
+   `AWS_SECRET_ACCESS_KEY`.
+3. Set the service's **Cron Schedule** in Settings (e.g. `17 4 * * *` — daily) so it
+   runs and terminates (`restartPolicyType: NEVER` is already in the config).
+4. Set an **R2 lifecycle rule** on the bucket for retention (e.g. expire after 30
+   days) — the robust way, not a script-side prune.
+
 ## Backups + PITR (mandatory)
 
 Postgres holds derived state. It is **re-derivable** (re-index from the chain via

--- a/deploy/backup.railway.json
+++ b/deploy/backup.railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "deploy/backup/Dockerfile",
+    "watchPatterns": ["deploy/backup/**"]
+  },
+  "deploy": {
+    "restartPolicyType": "NEVER"
+  }
+}

--- a/deploy/backup/Dockerfile
+++ b/deploy/backup/Dockerfile
@@ -1,0 +1,11 @@
+# Postgres -> R2 backup job (ADR 0013). postgres:17-alpine gives pg_dump 17
+# (dumps PG 16/17 servers); aws-cli streams to R2's S3 API. Build context = repo
+# root (set the Railway service Config File to /deploy/backup.railway.json).
+#   docker build -f deploy/backup/Dockerfile -t metagraphed-pg-backup .
+FROM postgres:17-alpine
+RUN apk add --no-cache aws-cli
+COPY deploy/backup/backup-postgres.sh /usr/local/bin/backup-postgres.sh
+RUN chmod +x /usr/local/bin/backup-postgres.sh
+# Override the postgres image entrypoint (which would try to start a server) so
+# the container just runs the backup script and exits.
+ENTRYPOINT ["/usr/local/bin/backup-postgres.sh"]

--- a/deploy/backup/backup-postgres.sh
+++ b/deploy/backup/backup-postgres.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+# Postgres -> R2 backup (ADR 0013 durability). pg_dump the metagraphed DB, gzip,
+# and stream it to R2 (S3-compatible, ZERO egress) under a timestamped key.
+# Restoring a dump takes minutes; re-backfilling the same history takes weeks — so
+# this is the cheap insurance against a catastrophic Postgres loss. The data is
+# also re-derivable from chain, so a ~daily RPO is plenty (no PITR needed).
+#
+# Runs as a scheduled (cron) Railway service — see deploy/backup.railway.json.
+# Env (set on that service):
+#   DATABASE_URL           ${{Postgres.DATABASE_URL}}  (private net; no egress)
+#   R2_BUCKET              the R2 bucket name
+#   R2_ENDPOINT           https://<accountid>.r2.cloudflarestorage.com
+#   AWS_ACCESS_KEY_ID     R2 S3 access key id
+#   AWS_SECRET_ACCESS_KEY R2 S3 secret
+#   BACKUP_PREFIX         key prefix (default: postgres)
+# Retention: set an R2 lifecycle rule on the bucket (e.g. expire after 30 days) —
+# that is the robust way, not a script-side prune.
+set -eu
+
+: "${DATABASE_URL:?DATABASE_URL required}"
+: "${R2_BUCKET:?R2_BUCKET required}"
+: "${R2_ENDPOINT:?R2_ENDPOINT required}"
+PREFIX="${BACKUP_PREFIX:-postgres}"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+KEY="${PREFIX}/metagraphed-${TS}.sql.gz"
+
+echo "backup: pg_dump | gzip -> s3://${R2_BUCKET}/${KEY}"
+# Stream straight through — never lands the full dump on the container disk.
+pg_dump --no-owner --no-privileges "$DATABASE_URL" \
+  | gzip -9 \
+  | aws s3 cp - "s3://${R2_BUCKET}/${KEY}" --endpoint-url "$R2_ENDPOINT"
+echo "backup complete: s3://${R2_BUCKET}/${KEY}"


### PR DESCRIPTION
`deploy/backup/` — a scheduled `pg_dump | gzip | aws s3 cp` to R2 (zero egress). The cheap catastrophe insurance: restoring a dump is **minutes** vs re-backfilling history for **weeks**. The data is also re-derivable from chain, so a daily RPO is plenty — **no PITR** (its continuous-WAL cost buys nothing for re-derivable data).

- `postgres:17-alpine` (pg_dump 17) + `aws-cli`; ENTRYPOINT overridden so it runs the script and exits (not a server); streams through (never lands the dump on disk).
- `deploy/backup.railway.json` (`restartPolicyType: NEVER`); **cron schedule** + **R2 lifecycle retention** are dashboard/bucket settings (documented).
- R2 creds via env (you provide the bucket + S3 token). Setup steps in `deploy/README.md`.

Docs + script + Dockerfile only.