### PR TITLE
fix(indexer): default to substrate-interface-compatible WebSocket archive

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -120,7 +120,7 @@ cross-service variable references, e.g.:
 railway add -s indexer --repo JSONbored/metagraphed --branch main \
   -v DATABASE_URL='${{Postgres.DATABASE_URL}}' \
   -v REDIS_URL='${{Redis.REDIS_URL}}' \
-  -v EVENTS_RPC_URL='wss://archive.chain.opentensor.ai:443'   # archive, NOT pruned entrypoint
+  -v EVENTS_RPC_URL='wss://bittensor-finney.api.onfinality.io/public-ws'   # WS archive, NOT pruned entrypoint
 ```
 
 The public `wss-lb` is independent of Postgres/Redis (it reads only the public

--- a/deploy/railway-bootstrap.sh
+++ b/deploy/railway-bootstrap.sh
@@ -18,10 +18,11 @@ set -euo pipefail
 REPO="JSONbored/metagraphed"
 BRANCH="main"
 WORKSPACE="aethereal"
-# ARCHIVE endpoint — the indexer backfills old-block state, which pruned nodes
-# (entrypoint-finney) discard ("State already discarded"). On the box this points
-# at the local archive node instead.
-RPC_URL="${EVENTS_RPC_URL:-wss://archive.chain.opentensor.ai:443}"
+# WS ARCHIVE endpoint — the indexer backfills old-block state, which pruned nodes
+# (entrypoint-finney) discard ("State already discarded"). archive.chain is an
+# HTTP JSON-RPC proxy, not a substrate-interface WS endpoint. On the box this
+# points at the local archive node instead.
+RPC_URL="${EVENTS_RPC_URL:-wss://bittensor-finney.api.onfinality.io/public-ws}"
 
 echo "==> 1. Create the project + default (production) environment"
 railway init --name metagraphed-core --workspace "$WORKSPACE" --json

--- a/scripts/index-chain.py
+++ b/scripts/index-chain.py
@@ -25,8 +25,8 @@ gate is "~100% capture vs D1" before any serving cutover.
 Heavy deps (psycopg2, substrate-interface) are imported lazily so the pure
 transforms test without them. Run (the compose stack wires these):
   DATABASE_URL          postgresql://… (the Timescale sink)
-  EVENTS_RPC_URL        ws://subtensor:9944 (the local node)  [default: public ARCHIVE
-                        archive.chain.opentensor.ai — NOT pruned entrypoint-finney]
+  EVENTS_RPC_URL        ws://subtensor:9944 (the local node)  [default: public WS ARCHIVE
+                        bittensor-finney.api.onfinality.io — NOT pruned entrypoint-finney]
   REDIS_URL             redis://redis:6379  (optional — cursor/heartbeat mirror)
   START_BLOCK           cold-cursor anchor (else the overlap floor)
   EVENTS_WINDOW         overlap re-scan floor (default 256)
@@ -41,12 +41,16 @@ import signal
 import sys
 import time
 
-# Default to the ARCHIVE endpoint, not entrypoint-finney: the indexer's backfill
-# reads state at older blocks (System.Events/Timestamp at a past block_hash), and
-# entrypoint-finney is PRUNED — it discards old state and fails the backfill with
-# "UnknownBlock: State already discarded" (verified live). archive.chain retains
-# full state. On the bare-metal box, EVENTS_RPC_URL points at the local node.
-RPC = os.environ.get("EVENTS_RPC_URL", "wss://archive.chain.opentensor.ai:443")
+# Default to a real WS ARCHIVE endpoint, not entrypoint-finney: the indexer's
+# backfill reads state at older blocks (System.Events/Timestamp at a past
+# block_hash), and entrypoint-finney is PRUNED — it discards old state and fails
+# the backfill with "UnknownBlock: State already discarded" (verified live).
+# archive.chain.opentensor.ai is a Subway HTTP JSON-RPC proxy and does not speak
+# substrate-interface's WS protocol; OnFinality's public endpoint is the known-good
+# WS archive used by the historical backfills. On the bare-metal box,
+# EVENTS_RPC_URL points at the local node.
+DEFAULT_RPC = "wss://bittensor-finney.api.onfinality.io/public-ws"
+RPC = os.environ.get("EVENTS_RPC_URL", DEFAULT_RPC)
 WINDOW = int(os.environ.get("EVENTS_WINDOW", "256"))
 MAX_LOOKBACK = int(os.environ.get("EVENTS_MAX_LOOKBACK", "512"))
 START_BLOCK = os.environ.get("START_BLOCK")

--- a/scripts/test_index_chain.py
+++ b/scripts/test_index_chain.py
@@ -214,6 +214,17 @@ class PostgresSchemaContract(unittest.TestCase):
             self.assertIn(column, self.schema)
 
 
+class RpcDefault(unittest.TestCase):
+    def test_default_rpc_is_substrate_interface_ws_archive(self):
+        # Regression: archive.chain.opentensor.ai is a Subway HTTP JSON-RPC proxy,
+        # not a substrate-interface WebSocket endpoint, so the default must stay
+        # on the known-good WS archive unless EVENTS_RPC_URL explicitly overrides it.
+        self.assertEqual(
+            ic.DEFAULT_RPC, "wss://bittensor-finney.api.onfinality.io/public-ws"
+        )
+        self.assertEqual(ic.RPC, ic.DEFAULT_RPC)
+
+
 class BackfillStart(unittest.TestCase):
     def test_cold_cursor_with_start_block_anchors_there(self):
         # cursor=None + START_BLOCK set short-circuits before any chain/module load.


### PR DESCRIPTION
### Motivation
- The indexer defaulted to `wss://archive.chain.opentensor.ai:443`, but `archive.chain.opentensor.ai` is an HTTP JSON-RPC/Subway proxy and does not speak `substrate-interface`'s WebSocket protocol, which can cause the indexer to repeatedly fail and stall backfills. 
- The goal is to make the default endpoint a known-good WebSocket archive while preserving `EVENTS_RPC_URL` override behavior so deployments that set a custom RPC continue to work.

### Description
- Replace the hard-coded incompatible default with a `DEFAULT_RPC = "wss://bittensor-finney.api.onfinality.io/public-ws"` and use `RPC = os.environ.get("EVENTS_RPC_URL", DEFAULT_RPC)` in `scripts/index-chain.py` while adding explanatory comments. 
- Update the Railway bootstrap default in `deploy/railway-bootstrap.sh` and the example in `deploy/README.md` to reference the OnFinality WebSocket archive by default. 
- Add a unit regression test to `scripts/test_index_chain.py` that asserts the module `DEFAULT_RPC` and `RPC` are the substrate-interface-compatible WebSocket archive when `EVENTS_RPC_URL` is unset. 
- Preserve the existing behavior that an explicit `EVENTS_RPC_URL` environment variable overrides the default.

### Testing
- Ran `python3 -m unittest scripts/test_index_chain.py` which executed the test suite (including the new regression) and passed. 
- Ran the public-safety scan with `npm run scan:public-safety` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f91800498832cb027ded12a01382c)