### PR TITLE
fix(api): reject empty event_kind in validEventRows

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -157,6 +157,7 @@ export function validEventRows(rows) {
           Number.isInteger(r?.event_index) &&
           r.event_index >= 0 &&
           typeof r?.event_kind === "string" &&
+          r.event_kind.length > 0 &&
           Number.isInteger(r?.observed_at),
       )
     : [];

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -41,6 +41,10 @@ test("validEventRows enforces the strict row shape (#1371)", () => {
   // negative PK components — aligned with validBlockRows / validExtrinsicRows
   assert.equal(validEventRows([{ ...good, block_number: -1 }]).length, 0);
   assert.equal(validEventRows([{ ...good, event_index: -1 }]).length, 0);
+  assert.equal(
+    validEventRows([{ ...good, event_kind: "" }]).length,
+    0, // event_kind must be non-empty (mirrors block_hash guard)
+  );
 });
 
 test("eventInsertStatements builds chunked parameterized INSERT OR IGNORE", () => {


### PR DESCRIPTION
Rebase of #2050 on current main (rebased to resolve conflict with #2143). Closes #2050.