### PR TITLE
fix(infra): allow backfill cursor progress

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -190,13 +190,19 @@ CREATE INDEX IF NOT EXISTS idx_account_events_daily_netuid_day
 -- Indexer coordination
 -- ---------------------------------------------------------------------------
 
--- Durable cursor (also mirrored in Redis for hot access). Single row id=1.
+-- Durable cursors (also mirrored in Redis for hot access).
+-- id=1 is the live indexer; id=2 is the independent historical backfill job.
 CREATE TABLE IF NOT EXISTS indexer_cursor (
   id               SMALLINT PRIMARY KEY DEFAULT 1,
   last_block       BIGINT NOT NULL,
   updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
-  CONSTRAINT indexer_cursor_singleton CHECK (id = 1)
+  CONSTRAINT indexer_cursor_singleton CHECK (id IN (1, 2))
 );
+
+-- Upgrade deployments created before the backfill cursor existed.
+ALTER TABLE indexer_cursor
+  DROP CONSTRAINT IF EXISTS indexer_cursor_singleton,
+  ADD CONSTRAINT indexer_cursor_singleton CHECK (id IN (1, 2));
 
 -- ===========================================================================
 -- TimescaleDB (OPTIONAL) — compressed hypertables for the time-series tiers.

--- a/scripts/backfill-chain.py
+++ b/scripts/backfill-chain.py
@@ -5,7 +5,8 @@ WITHOUT stalling live ingestion.
 
 It reuses the indexer's verified decode + idempotent upserts (rows_from_decoded,
 _upsert) so there is zero decode/schema drift. Progress is a SEPARATE cursor row
-(indexer_cursor id=2) — it never touches the live cursor (id=1), and the
+(indexer_cursor id=2, allowed by deploy/postgres/schema.sql) — it never touches
+the live cursor (id=1), and the
 `INSERT ... ON CONFLICT DO NOTHING` keys make concurrent backfill + live-follow
 safe (overlapping ranges re-insert harmlessly).
 
@@ -188,7 +189,7 @@ def run():
                     pass
 
     if _stop:
-        log.info("stopped at #%d (resumable from the id=2 cursor)", committed)
+        log.info("stopped at #%d (resumable from the backfill cursor)", committed)
     else:
         log.info("backfill complete: #%d..#%d", frm, to)
 

--- a/scripts/test_index_chain.py
+++ b/scripts/test_index_chain.py
@@ -213,6 +213,11 @@ class PostgresSchemaContract(unittest.TestCase):
         ):
             self.assertIn(column, self.schema)
 
+    def test_indexer_cursor_schema_allows_live_and_backfill_cursors(self):
+        self.assertIn("CHECK (id IN (1, 2))", self.schema)
+        self.assertIn("DROP CONSTRAINT IF EXISTS indexer_cursor_singleton", self.schema)
+        self.assertNotIn("CHECK (id = 1)", self.schema)
+
 
 class BackfillStart(unittest.TestCase):
     def test_cold_cursor_with_start_block_anchors_there(self):


### PR DESCRIPTION
### Motivation
- The historical backfill job writes progress to an `indexer_cursor` row with `id=2` while the deployed schema enforced a singleton `CHECK (id = 1)`, causing the progress insert to fail, the transaction to roll back, and the backfill to retry forever.

### Description
- Relax the `indexer_cursor` constraint to allow both live and backfill cursors by changing `CHECK (id = 1)` to `CHECK (id IN (1, 2))` in `deploy/postgres/schema.sql`.
- Add an idempotent in-place schema upgrade step (`ALTER TABLE ... DROP CONSTRAINT IF EXISTS ... ADD CONSTRAINT ...`) so existing deployments can accept the backfill cursor without destructive ops.
- Tweak `scripts/backfill-chain.py` wording/logging to clarify the backfill cursor is supported by the schema.
- Add a regression assertion to `scripts/test_index_chain.py` that the schema contains the new `CHECK (id IN (1, 2))` and the upgrade statement.

### Testing
- Ran the backfill range unit tests with `python3 scripts/test_backfill_chain.py`, which passed (`OK`).
- Ran the schema/contract unit tests with `python3 scripts/test_index_chain.py`, which passed (`OK`) and includes the new regression assertion.
- Ran `git diff --check` to validate whitespace/format issues, which returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fa89eba60832cae92f1925748183a)