### PR TITLE
fix(wss-lb): fail healthcheck on stale pools

### DIFF
--- a/deploy/wss-lb/src/server.mjs
+++ b/deploy/wss-lb/src/server.mjs
@@ -77,13 +77,10 @@ const server = http.createServer((req, res) => {
       NETWORKS.map((n) => [n, poolFor(n).length]),
     );
     const stale = !lastRefresh || Date.now() - lastRefresh > REFRESH_MS * 3;
-    // Always 200 once the process is listening — the platform healthcheck verifies
-    // the server is UP, not that the upstream pool is warm. A cold start (the first
-    // pool refresh not yet complete) or a transient API blip would otherwise 503
-    // and fail the deploy even though the proxy is fine (this failed Railway
-    // deploys). `stale`/`ok` report pool freshness as a non-fatal field; a wss
-    // upgrade still 503s on its own when its network has zero eligible upstreams.
-    res.writeHead(200, { "content-type": "application/json" });
+    // Railway keys health on the HTTP status, so keep the readiness signal in the
+    // status code: a stale or uninitialized pool would also reject configured WSS
+    // upgrades with 503 because there are no eligible upstreams.
+    res.writeHead(stale ? 503 : 200, { "content-type": "application/json" });
     res.end(
       JSON.stringify({
         ok: !stale,

--- a/deploy/wss-lb/test/health.test.mjs
+++ b/deploy/wss-lb/test/health.test.mjs
@@ -1,0 +1,81 @@
+// Run with: cd deploy/wss-lb && npm test
+import { spawn } from "node:child_process";
+import http from "node:http";
+import { once } from "node:events";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+async function listen(server) {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return server.address().port;
+}
+
+async function freePort() {
+  const server = http.createServer();
+  const port = await listen(server);
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function waitForListening(child) {
+  let output = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    output += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    output += chunk;
+  });
+
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    if (output.includes("wss-lb listening")) return;
+    if (child.exitCode !== null) {
+      throw new Error(`server exited early with ${child.exitCode}: ${output}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`timed out waiting for server: ${output}`);
+}
+
+test("/healthz reports stale upstream pools with HTTP 503", async (t) => {
+  const api = http.createServer((req, res) => {
+    if (req.url === "/api/v1/rpc/pools") {
+      res.writeHead(500, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "upstream unavailable" }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  const apiPort = await listen(api);
+  t.after(() => api.close());
+
+  const port = await freePort();
+  const server = spawn(process.execPath, ["src/server.mjs"], {
+    cwd: new URL("..", import.meta.url),
+    env: {
+      ...process.env,
+      METAGRAPHED_API: `http://127.0.0.1:${apiPort}`,
+      PORT: String(port),
+      REFRESH_MS: "1000",
+      NETWORKS: "finney",
+    },
+  });
+  t.after(() => server.kill());
+
+  await waitForListening(server);
+
+  const res = await fetch(`http://127.0.0.1:${port}/healthz`);
+  const body = await res.json();
+
+  assert.equal(res.status, 503);
+  assert.deepEqual(body, {
+    ok: false,
+    stale: true,
+    pools: { finney: 0 },
+    last_refresh_ms: 0,
+  });
+});


### PR DESCRIPTION
### Motivation
- The WSS load balancer health endpoint previously returned unconditional HTTP `200` once the process was listening, which could mark an instance healthy while its upstream pool was stale or empty and thus unable to serve configured WebSocket upgrades.
- Railway is configured to use `/healthz` as the status-code healthcheck, so readiness semantics must include pool freshness to avoid keeping unusable instances marked healthy.

### Description
- Restore readiness semantics by making `GET /healthz` (and `/`) return `503` when the upstream pool is stale or uninitialized via `res.writeHead(stale ? 503 : 200, ...)` in `deploy/wss-lb/src/server.mjs`.
- Keep the same JSON body (`{ ok, stale, pools, last_refresh_ms }`) so callers can inspect pool state while the HTTP status communicates readiness.
- Add an integration regression test `deploy/wss-lb/test/health.test.mjs` that launches the real server against a failing mock `METAGRAPHED_API` and asserts `/healthz` returns `503` with the expected stale-pool JSON.

### Testing
- Ran `npx prettier --check` and `eslint` on the modified files and they passed. 
- Ran `npm test` in `deploy/wss-lb` and all WSS-LB unit/integration tests passed (11/11). 
- Ran `npm run build` which completed successfully and regenerated artifacts. 
- Ran the repository `npm run validate` which completed successfully (local validation run passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fa990a49c832c96ff0d7f204d6b4d)