### PR TITLE
fix(feeds): source incidents feed from live D1 instead of missing artifact

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -350,6 +350,17 @@ async function readData(readArtifact, env, path) {
   }
 }
 
+async function loadIncidentsData(deps, env) {
+  if (typeof deps.loadLiveIncidents === "function") {
+    try {
+      return await deps.loadLiveIncidents(env);
+    } catch {
+      return null;
+    }
+  }
+  return readData(deps.readArtifact, env, "/metagraph/incidents.json");
+}
+
 export async function handleFeedRequest(request, env, url, deps = {}) {
   const readArtifact = deps.readArtifact;
   // Feed errors go through the shared canonical envelope (workers/http.mjs
@@ -386,11 +397,7 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
       "New and updated Bittensor subnets, surfaces, and coverage from the metagraphed registry.";
     updatedSource = changelog?.generated_at;
   } else if (target.kind === "incidents") {
-    const incidents = await readData(
-      readArtifact,
-      env,
-      "/metagraph/incidents.json",
-    );
+    const incidents = await loadIncidentsData(deps, env);
     items = incidentItems(incidents);
     title = "metagraphed — surface incidents";
     description =
@@ -399,7 +406,7 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
   } else {
     const [changelog, incidents] = await Promise.all([
       readData(readArtifact, env, "/metagraph/changelog.json"),
-      readData(readArtifact, env, "/metagraph/incidents.json"),
+      loadIncidentsData(deps, env),
     ]);
     items = [
       ...registryItems(changelog, target.netuid),

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -424,6 +424,28 @@ describe("feeds — handleFeedRequest", () => {
     assert.equal(parsed.items.length, 2);
   });
 
+  test("incidents feed returns empty when loadLiveIncidents throws", async () => {
+    const { res, text } = await feed("/api/v1/feeds/incidents", {
+      deps: {
+        readArtifact: makeReadArtifact({}),
+        loadLiveIncidents: async () => {
+          throw new Error("D1 unavailable");
+        },
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(JSON.parse(text).items.length, 0);
+  });
+
+  test("incidents feed falls back to static artifact when loadLiveIncidents is absent", async () => {
+    const url = new URL("https://api.metagraph.sh/api/v1/feeds/incidents");
+    const res = await handleFeedRequest(new Request(url), {}, url, {
+      readArtifact: makeReadArtifact({ "/metagraph/incidents.json": INCIDENTS }),
+    });
+    assert.equal(res.status, 200);
+    assert.equal(JSON.parse(await res.text()).items.length, 2);
+  });
+
   test("?tag= narrows the registry feed to matching items", async () => {
     const { res, text } = await feed("/api/v1/feeds/registry?tag=coverage");
     assert.equal(res.status, 200);
@@ -574,6 +596,54 @@ describe("feeds — Worker dispatch integration", () => {
     assert.equal(res.status, 200);
     assert.match(res.headers.get("content-type"), /application\/rss\+xml/);
     assert.match(await res.text(), /<rss version="2\.0"/);
+  });
+
+  test("handleRequest wires incidents feed to loadGlobalIncidentsLedger", async () => {
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind() {
+              return {
+                all: () =>
+                  sql.includes("recent_checks")
+                    ? Promise.resolve({
+                        results: [
+                          {
+                            netuid: 7,
+                            surface_id: "allways-api",
+                            surface_key: "allways-api",
+                            started_at: 1781266255266,
+                            ended_at: 1781499480737,
+                            failed_samples: 1945,
+                          },
+                        ],
+                      })
+                    : Promise.resolve({ results: [] }),
+              };
+            },
+          };
+        },
+      },
+      METAGRAPH_CONTROL: {
+        async get(key) {
+          if (key === "health:meta") {
+            return { last_run_at: "2026-06-15T00:00:00.000Z" };
+          }
+          return null;
+        },
+      },
+    };
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/feeds/incidents.json"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    const parsed = await res.json();
+    assert.ok(parsed.items.length >= 1);
+    assert.ok(parsed.items[0].id.startsWith("incident:"));
   });
 
   test("an unknown feed path is a 404 with the canonical error envelope", async () => {

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -440,7 +440,9 @@ describe("feeds — handleFeedRequest", () => {
   test("incidents feed falls back to static artifact when loadLiveIncidents is absent", async () => {
     const url = new URL("https://api.metagraph.sh/api/v1/feeds/incidents");
     const res = await handleFeedRequest(new Request(url), {}, url, {
-      readArtifact: makeReadArtifact({ "/metagraph/incidents.json": INCIDENTS }),
+      readArtifact: makeReadArtifact({
+        "/metagraph/incidents.json": INCIDENTS,
+      }),
     });
     assert.equal(res.status, 200);
     assert.equal(JSON.parse(await res.text()).items.length, 2);

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -85,14 +85,27 @@ async function feed(
   if (accept) headers.accept = accept;
   if (ifNoneMatch) headers["if-none-match"] = ifNoneMatch;
   const request = new Request(url, { method, headers });
-  const readArtifact =
-    deps ||
-    makeReadArtifact({
-      "/metagraph/changelog.json": CHANGELOG,
-      "/metagraph/incidents.json": INCIDENTS,
-      "/metagraph/health/incidents/7.json": INCIDENTS,
-    });
-  const res = await handleFeedRequest(request, {}, url, { readArtifact });
+  const defaultReadArtifact = makeReadArtifact({
+    "/metagraph/changelog.json": CHANGELOG,
+    "/metagraph/incidents.json": INCIDENTS,
+    "/metagraph/health/incidents/7.json": INCIDENTS,
+  });
+  let handlerDeps;
+  if (typeof deps === "function") {
+    handlerDeps = {
+      readArtifact: deps,
+      loadLiveIncidents: async (env) => {
+        const result = await deps(env, "/metagraph/incidents.json");
+        return result?.ok ? result.data : null;
+      },
+    };
+  } else {
+    handlerDeps = {
+      readArtifact: deps?.readArtifact ?? defaultReadArtifact,
+      loadLiveIncidents: deps?.loadLiveIncidents ?? (async () => INCIDENTS),
+    };
+  }
+  const res = await handleFeedRequest(request, {}, url, handlerDeps);
   return { res, text: await res.text() };
 }
 
@@ -380,14 +393,35 @@ describe("feeds — handleFeedRequest", () => {
   });
 
   test("a feed with no underlying data still serializes validly (empty)", async () => {
-    const empty = makeReadArtifact({});
     const { res, text } = await feed("/api/v1/feeds/incidents", {
-      deps: empty,
+      deps: {
+        readArtifact: makeReadArtifact({}),
+        loadLiveIncidents: async () => null,
+      },
     });
     assert.equal(res.status, 200);
     const parsed = JSON.parse(text);
     assert.equal(parsed.items.length, 0);
     assert.ok(parsed.title && parsed.feed_url);
+  });
+
+  test("incidents feed reads the live D1 ledger, not a static artifact", async () => {
+    let liveCalled = false;
+    const { res, text } = await feed("/api/v1/feeds/incidents", {
+      deps: {
+        readArtifact: makeReadArtifact({
+          "/metagraph/changelog.json": CHANGELOG,
+        }),
+        loadLiveIncidents: async () => {
+          liveCalled = true;
+          return INCIDENTS;
+        },
+      },
+    });
+    assert.ok(liveCalled);
+    assert.equal(res.status, 200);
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.items.length, 2);
   });
 
   test("?tag= narrows the registry feed to matching items", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -46,6 +46,7 @@ import {
   handleChainFees,
   handleChainSigners,
   handleGlobalIncidents,
+  loadGlobalIncidentsLedger,
   handleHealthIncidents,
   handleHealthPercentiles,
   handleHealthTrends,
@@ -903,6 +904,10 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     return handleFeedRequest(request, env, url, {
       readArtifact,
       errorResponse,
+      loadLiveIncidents: async (feedEnv) => {
+        const { data } = await loadGlobalIncidentsLedger(feedEnv);
+        return data;
+      },
     });
   }
 

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -606,15 +606,7 @@ export async function handleHealthIncidents(
 // — the per-subnet /incidents route (no global cap) is the authoritative source
 // for a single subnet. Widening this to an exact bound would mean aggregating
 // from surface_uptime_daily (out of scope here).
-export async function handleGlobalIncidents(request, env, url) {
-  const { label, days, error } = analyticsWindow(url);
-  if (error) {
-    return analyticsQueryError(error);
-  }
-  const since = Date.now() - days * DAY_MS;
-  const incidentRows = await d1All(
-    env,
-    `WITH recent_checks AS (
+const GLOBAL_INCIDENTS_SQL = `WITH recent_checks AS (
        -- Source-row cap (LIMIT ?): bounds the gap-island scan, but an incident
        -- straddling this newest-N boundary is only partially counted (see the
        -- handler doc-note above — this feed is approximate near the cap).
@@ -650,21 +642,39 @@ export async function handleGlobalIncidents(request, env, url) {
      GROUP BY netuid, surface_key, grp
      HAVING COUNT(*) >= ?
      ORDER BY started_at DESC
-     LIMIT ?`,
-    [
-      since,
-      MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
-      INCIDENT_GAP_MS,
-      MIN_INCIDENT_SAMPLES,
-      MAX_INCIDENT_ROWS,
-    ],
-  );
+     LIMIT ?`;
+
+/** Shared D1 incident ledger used by GET /api/v1/incidents and content feeds. */
+export async function loadGlobalIncidentsLedger(
+  env,
+  { label = "7d", days = 7 } = {},
+) {
+  const since = Date.now() - days * DAY_MS;
+  const incidentRows = await d1All(env, GLOBAL_INCIDENTS_SQL, [
+    since,
+    MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
+    INCIDENT_GAP_MS,
+    MIN_INCIDENT_SAMPLES,
+    MAX_INCIDENT_ROWS,
+  ]);
   const meta = await readHealthMetaKv(env);
   const data = formatGlobalIncidents({
     window: label,
     observedAt: meta?.last_run_at || null,
     incidentRows,
     maxIncidents: MAX_INCIDENT_ROWS,
+  });
+  return { data, incidentRows };
+}
+
+export async function handleGlobalIncidents(request, env, url) {
+  const { label, days, error } = analyticsWindow(url);
+  if (error) {
+    return analyticsQueryError(error);
+  }
+  const { data, incidentRows } = await loadGlobalIncidentsLedger(env, {
+    label,
+    days,
   });
   const response = await envelopeResponse(
     request,


### PR DESCRIPTION
## Summary

- Wire incidents feed generation to the live D1 incident ledger (`formatGlobalIncidents` / shared helper used by `handleGlobalIncidents`) instead of `readArtifact("/metagraph/incidents.json")`.
- Update subnet combined feeds to use the same live source, filtered by netuid.
- Extend `tests/feeds.test.mjs` with a D1-backed regression so the feed is non-empty when incidents exist.

Closes #2161 

## Why

Subscribers to `/api/v1/feeds/incidents.{rss,atom,json}` receive a valid but permanently empty feed in production, while `/api/v1/incidents` returns real probe-derived downtime. The contract explicitly marks `incidents.json` as live-only.

## Test plan

- [x] `npm test -- tests/feeds.test.mjs`
- [x] `npm run validate:api`
- [x] Incidents feed includes items when D1 returns incident rows
- [x] Registry-only feed behavior unchanged
