### PR TITLE
fix(api): normalize concentration snapshot timestamps

### DIFF
--- a/src/concentration.mjs
+++ b/src/concentration.mjs
@@ -22,6 +22,17 @@ function round(value, dp = 6) {
   return Math.round(value * factor) / factor;
 }
 
+function captureStamp(value) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return { ms: value, value: new Date(value).toISOString() };
+  }
+  if (typeof value === "string") {
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms)) return { ms, value };
+  }
+  return null;
+}
+
 // Coerce a raw column array to the finite, strictly-positive values that actually
 // make up a distribution. Zero / negative / NaN / null entries carry no share and
 // are dropped, so `holders` counts real participants and the shares sum to 1.
@@ -177,8 +188,8 @@ export function buildConcentration(rows, netuid) {
   // The rows share one cron capture, but don't assume an order — take the newest.
   let capturedAt = null;
   for (const row of list) {
-    const captured = row?.captured_at ?? null;
-    if (captured != null && (capturedAt == null || captured > capturedAt)) {
+    const captured = captureStamp(row?.captured_at);
+    if (captured && (capturedAt == null || captured.ms > capturedAt.ms)) {
       capturedAt = captured;
     }
   }
@@ -195,7 +206,7 @@ export function buildConcentration(rows, netuid) {
     // a distinct owner; higher = fewer operators each running many hotkeys).
     uids_per_entity:
       entities.count > 0 ? round(list.length / entities.count, 4) : null,
-    captured_at: capturedAt,
+    captured_at: capturedAt?.value ?? null,
     stake: computeConcentration(list.map((row) => row?.stake_tao)),
     emission: computeConcentration(list.map((row) => row?.emission_tao)),
     entity_stake: computeConcentration(entities.stake),

--- a/tests/concentration.test.mjs
+++ b/tests/concentration.test.mjs
@@ -155,6 +155,17 @@ describe("buildConcentration", () => {
     assert.equal(data.entity_stake.holders, 3);
   });
 
+  test("converts D1 epoch-millisecond captured_at values to ISO strings", () => {
+    const data = buildConcentration(
+      [
+        { stake_tao: 1, emission_tao: 1, captured_at: 1_750_000_000_000 },
+        { stake_tao: 2, emission_tao: 2, captured_at: 1_750_000_060_000 },
+      ],
+      9,
+    );
+    assert.equal(data.captured_at, "2025-06-15T15:07:40.000Z");
+  });
+
   test("tolerates rows missing captured_at / value columns", () => {
     const data = buildConcentration(
       [


### PR DESCRIPTION
### Motivation
- The concentration endpoint was returning D1 `captured_at` values as raw epoch-millisecond numbers, which conflicts with the SubnetConcentrationArtifact schema that declares `captured_at` as `string|null` and can break clients or validation.

### Description
- Add `captureStamp()` and normalize the chosen snapshot stamp to an ISO string in `buildConcentration` (`src/concentration.mjs`) so numeric D1 `captured_at` values are converted to ISO timestamps while preserving valid ISO input strings.
- Compare snapshot times using parsed milliseconds (`.ms`) to pick the newest stamp and return `captured_at` as an ISO string or `null` when absent.
- Update unit tests: add a regression test that numeric D1 `captured_at` values convert to ISO in `tests/concentration.test.mjs`, and assert the handler-level response and `meta.generated_at` use the normalized ISO stamp in `tests/request-handlers-entities.test.mjs`.

### Testing
- Ran unit tests with `npm test -- --run tests/concentration.test.mjs tests/request-handlers-entities.test.mjs` and all tests passed (152/152).
- Ran lint with `npm run lint` (passed) and schema validation with `npm run validate:schemas` (passed after generating local artifacts via `npm run build`).
- Ran `npm run build` to regenerate derived artifacts (completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3faf40b740832cbf81310387cfa5e0)