### PR TITLE
fix(api): canonicalize chain analytics cache keys

### DIFF
--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -20,6 +20,7 @@ import {
   hasD1FallbackRows,
   markD1FallbackResponse,
   analyticsQueryError,
+  canonicalAnalyticsCacheRoute,
 } from "../workers/request-handlers/analytics.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
@@ -324,6 +325,26 @@ describe("validateQueryParams", () => {
     const u = url("/x?netuid=7");
     const err = validateQueryParams(u, []);
     assert.equal(err.parameter, "netuid");
+  });
+});
+
+describe("canonicalAnalyticsCacheRoute", () => {
+  test("normalizes decoded query values for cache keys", () => {
+    const plain = url(
+      "/api/v1/chain/signers?call_module=Balances&limit=10&window=30d",
+    );
+    const encoded = url(
+      "/api/v1/chain/signers?limit=10&call_module=%42alances&window=30d",
+    );
+
+    assert.equal(
+      canonicalAnalyticsCacheRoute(plain, ["limit", "call_module"]),
+      "/api/v1/chain/signers?window=30d&limit=10&call_module=Balances",
+    );
+    assert.equal(
+      canonicalAnalyticsCacheRoute(encoded, ["limit", "call_module"]),
+      canonicalAnalyticsCacheRoute(plain, ["limit", "call_module"]),
+    );
   });
 });
 

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -97,6 +97,16 @@ function validateQueryParams(url, allowedParams) {
   return null;
 }
 
+function canonicalAnalyticsCacheRoute(url, params = []) {
+  const search = new URL("https://cache-key.invalid/").searchParams;
+  for (const param of [ANALYTICS_WINDOW_PARAM, ...params]) {
+    const value = url.searchParams.get(param);
+    if (value !== null) search.set(param, value);
+  }
+  const query = search.toString();
+  return `${url.pathname}${query ? `?${query}` : ""}`;
+}
+
 function analyticsWindow(url, extraParams = []) {
   const validationError = validateQueryParams(url, [
     ANALYTICS_WINDOW_PARAM,
@@ -826,11 +836,16 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
   const moduleClause = callModule ? " AND call_module = ?" : "";
-  return withEdgeCache(request, ctx, env, "chain-signers", async () => {
-    const cutoff = Date.now() - days * DAY_MS;
-    const rows = await d1All(
-      env,
-      `SELECT signer,
+  return withEdgeCache(
+    request,
+    ctx,
+    env,
+    "chain-signers",
+    async () => {
+      const cutoff = Date.now() - days * DAY_MS;
+      const rows = await d1All(
+        env,
+        `SELECT signer,
               COUNT(*) AS tx_count,
               SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
               SUM(COALESCE(tip_tao, 0)) AS total_tip_tao,
@@ -840,30 +855,32 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
        GROUP BY signer
        ORDER BY tx_count DESC
        LIMIT ?`,
-      callModule ? [cutoff, callModule, limit] : [cutoff, limit],
-    );
-    const meta = await readHealthMetaKv(env);
-    const data = buildChainSigners({
-      window: label,
-      observedAt: meta?.last_run_at || null,
-      rows,
-    });
-    const response = await envelopeResponse(
-      request,
-      {
-        data,
-        meta: await analyticsMeta(
-          env,
-          "/metagraph/chain/signers.json",
-          data.observed_at,
-        ),
-      },
-      "short",
-    );
-    return hasD1FallbackRows(rows)
-      ? markD1FallbackResponse(response)
-      : response;
-  });
+        callModule ? [cutoff, callModule, limit] : [cutoff, limit],
+      );
+      const meta = await readHealthMetaKv(env);
+      const data = buildChainSigners({
+        window: label,
+        observedAt: meta?.last_run_at || null,
+        rows,
+      });
+      const response = await envelopeResponse(
+        request,
+        {
+          data,
+          meta: await analyticsMeta(
+            env,
+            "/metagraph/chain/signers.json",
+            data.observed_at,
+          ),
+        },
+        "short",
+      );
+      return hasD1FallbackRows(rows)
+        ? markD1FallbackResponse(response)
+        : response;
+    },
+    canonicalAnalyticsCacheRoute(url, ["limit", "call_module"]),
+  );
 }
 
 // Fee/tip market analytics (#1988): a per-UTC-day fee series (totals + averages)
@@ -881,23 +898,28 @@ export async function handleChainFees(request, env, url, ctx = {}) {
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
   const moduleClause = callModule ? " AND call_module = ?" : "";
-  return withEdgeCache(request, ctx, env, "chain-fees", async () => {
-    const cutoff = Date.now() - days * DAY_MS;
-    const [dailyRows, payerRows] = await Promise.all([
-      d1All(
-        env,
-        `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
+  return withEdgeCache(
+    request,
+    ctx,
+    env,
+    "chain-fees",
+    async () => {
+      const cutoff = Date.now() - days * DAY_MS;
+      const [dailyRows, payerRows] = await Promise.all([
+        d1All(
+          env,
+          `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
                 COUNT(*) AS extrinsic_count,
                 SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
                 SUM(COALESCE(tip_tao, 0)) AS total_tip_tao
          FROM extrinsics
          WHERE observed_at >= ?${moduleClause}
          GROUP BY day`,
-        callModule ? [cutoff, callModule] : [cutoff],
-      ),
-      d1All(
-        env,
-        `SELECT signer,
+          callModule ? [cutoff, callModule] : [cutoff],
+        ),
+        d1All(
+          env,
+          `SELECT signer,
                 SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
                 SUM(COALESCE(tip_tao, 0)) AS total_tip_tao,
                 COUNT(*) AS extrinsic_count
@@ -906,32 +928,34 @@ export async function handleChainFees(request, env, url, ctx = {}) {
          GROUP BY signer
          ORDER BY total_fee_tao DESC
          LIMIT ?`,
-        callModule ? [cutoff, callModule, limit] : [cutoff, limit],
-      ),
-    ]);
-    const meta = await readHealthMetaKv(env);
-    const data = buildChainFees({
-      window: label,
-      observedAt: meta?.last_run_at || null,
-      dailyRows,
-      payerRows,
-    });
-    const response = await envelopeResponse(
-      request,
-      {
-        data,
-        meta: await analyticsMeta(
-          env,
-          "/metagraph/chain/fees.json",
-          data.observed_at,
+          callModule ? [cutoff, callModule, limit] : [cutoff, limit],
         ),
-      },
-      "short",
-    );
-    return hasD1FallbackRows(dailyRows, payerRows)
-      ? markD1FallbackResponse(response)
-      : response;
-  });
+      ]);
+      const meta = await readHealthMetaKv(env);
+      const data = buildChainFees({
+        window: label,
+        observedAt: meta?.last_run_at || null,
+        dailyRows,
+        payerRows,
+      });
+      const response = await envelopeResponse(
+        request,
+        {
+          data,
+          meta: await analyticsMeta(
+            env,
+            "/metagraph/chain/fees.json",
+            data.observed_at,
+          ),
+        },
+        "short",
+      );
+      return hasD1FallbackRows(dailyRows, payerRows)
+        ? markD1FallbackResponse(response)
+        : response;
+    },
+    canonicalAnalyticsCacheRoute(url, ["limit", "call_module"]),
+  );
 }
 
 // Shared analytics helpers also used by the deferred handler clusters (trajectory,
@@ -941,6 +965,7 @@ export async function handleChainFees(request, env, url, ctx = {}) {
 export {
   analyticsMeta,
   analyticsQueryError,
+  canonicalAnalyticsCacheRoute,
   analyticsWindow,
   d1All,
   d1Runner,


### PR DESCRIPTION
### Motivation
- Prevent availability/cost amplification where semantically-identical percent-encoded query values (e.g. `call_module=Balances` vs `call_module=%42alances`) produced distinct edge-cache keys and forced repeated expensive D1 aggregations for the public analytics endpoints.
- Preserve existing SQL binding and validation behavior while ensuring the edge cache amortizes work correctly across equivalent query encodings.

### Description
- Add `canonicalAnalyticsCacheRoute(url, params)` which builds a normalized cache route from decoded, allow-listed query parameters (keeps `window` plus handler-specific params such as `limit` and `call_module`).
- Use the canonical route as the `cachePathAndSearch` argument to `withEdgeCache` for the `chain-signers` and `chain-fees` handlers so equivalent encoded inputs map to the same cache key.
- Export the new helper from `workers/request-handlers/analytics.mjs` and keep the D1 SQL bind behavior unchanged so query semantics and validation remain intact.
- Add a regression test in `tests/request-handlers-analytics.test.mjs` that verifies encoded and plain `call_module` values produce the same canonical cache route.

### Testing
- Ran formatting and lint checks with `npm run format:check` and `npm run lint`, both succeeded.
- Executed the targeted unit tests with `npm test -- tests/request-handlers-analytics.test.mjs tests/chain-analytics.test.mjs`, and all tests passed (`128 tests` across the two files).
- Verified the new regression test confirms that encoded and decoded `call_module` values normalize to an identical cache route.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fb7803864832c93897d7676f3a460)