### PR TITLE
fix(chain): recover block author from raw UTF-8 Aura digest payload

### DIFF
--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -302,6 +302,32 @@ EXTRACTORS = {
 }
 
 
+def _aura_slot(data):
+    """The u64 LE Aura slot from a PreRuntime digest payload, across the shapes
+    substrate-interface returns it in — else None.
+
+    The 8-byte slot arrives as raw ``bytes``, a ``0x…`` hex string, OR a raw ``str``
+    that is substrate-interface's UTF-8 decode of those bytes (NOT hex). The original
+    code assumed hex and ran ``bytes.fromhex`` on the raw str, which raised and — via
+    the caller's broad ``except`` — silently produced ``author = NULL``. Verified on
+    finney #4000000 (spec 202): slot bytes ``4eca9508…`` arrive as the str ``'Nʕ\\x08…'``
+    (the ``ʕ`` is U+0295, so latin-1 can't encode it — only UTF-8 round-trips it back
+    to the original bytes). Takes the first 8 bytes; returns None on any drift.
+    """
+    try:
+        if isinstance(data, (bytes, bytearray)):
+            raw = bytes(data)
+        elif isinstance(data, str):
+            raw = bytes.fromhex(data[2:]) if data.startswith("0x") else data.encode("utf-8")
+        else:
+            return None
+    except (ValueError, UnicodeError):
+        return None
+    if len(raw) != 8:
+        return None
+    return int.from_bytes(raw, "little")
+
+
 def _block_author(s, block_hash, header):
     """Block author (ss58) decoded from the Aura PreRuntime digest, else None.
 
@@ -323,11 +349,9 @@ def _block_author(s, block_hash, header):
                 continue
             engine, data = pre[0], pre[1]
             if engine == AURA_ENGINE_ID:
-                hex_data = data[2:] if str(data).startswith("0x") else str(data)
-                slot_data = bytes.fromhex(hex_data)
-                if len(slot_data) != 8:
+                slot = _aura_slot(data)
+                if slot is None:
                     return None
-                slot = int.from_bytes(slot_data, "little")
                 break
         if slot is None:
             return None

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -27,6 +27,7 @@ compute_from_block = _fe.compute_from_block
 compute_scan_range = _fe.compute_scan_range
 _parse_cursor = _fe._parse_cursor
 _block_author = _fe._block_author
+_aura_slot = _fe._aura_slot
 AURA_ENGINE_ID = _fe.AURA_ENGINE_ID
 PRUNE_HORIZON = _fe.PRUNE_HORIZON
 event_rows_for_events = _fe.event_rows_for_events
@@ -163,6 +164,40 @@ class BlockAuthorTest(unittest.TestCase):
             _block_author(substrate, "0xblock", self.header("0x0100000000000000")),
             "5AUTHORITY01",
         )
+
+    def test_aura_digest_decodes_raw_utf8_slot(self):
+        # Regression: some runtimes return the PreRuntime slot as a raw UTF-8 str,
+        # not "0x" hex (finney #4000000). bytes.fromhex used to raise -> author NULL.
+        # slot bytes 4eca9508.. arrive as this str; slot=144034382, 144034382 % 3 == 2.
+        substrate = self.Substrate()
+        self.assertEqual(
+            _block_author(substrate, "0xblock", self.header("Nʕ\x08\x00\x00\x00\x00")),
+            "5AUTHORITY02",
+        )
+
+
+class AuraSlotTest(unittest.TestCase):
+    SLOT = 144034382  # little-endian u64 of bytes 4e ca 95 08 00 00 00 00
+
+    def test_raw_utf8_str_payload(self):
+        # The bug: substrate-interface UTF-8-decodes the 8 slot bytes into a str
+        # (the 0xca 0x95 pair becomes U+0295), which bytes.fromhex cannot parse.
+        self.assertEqual(_aura_slot("Nʕ\x08\x00\x00\x00\x00"), self.SLOT)
+
+    def test_hex_string_payload(self):
+        self.assertEqual(_aura_slot("0x4eca950800000000"), self.SLOT)
+
+    def test_raw_bytes_payload(self):
+        self.assertEqual(_aura_slot(bytes.fromhex("4eca950800000000")), self.SLOT)
+
+    def test_wrong_length_is_none(self):
+        self.assertIsNone(_aura_slot("0x01"))  # too short
+        self.assertIsNone(_aura_slot("0x010000000000000000"))  # 9 bytes, too long
+        self.assertIsNone(_aura_slot(b"\x01\x02\x03"))  # short bytes
+
+    def test_non_payload_is_none(self):
+        self.assertIsNone(_aura_slot(None))
+        self.assertIsNone(_aura_slot(12345))
 
 
 class ParseCursorTest(unittest.TestCase):


### PR DESCRIPTION
## Problem
`_block_author` (scripts/fetch-events.py) decodes the Aura `PreRuntime` digest to find the block producer, assuming the payload is a `0x`-hex string and calling `bytes.fromhex` on it. At some runtime versions, substrate-interface returns that payload as a **raw UTF-8 string** (the 8 little-endian slot bytes decoded as text, e.g. `'Nʕ\x08…'`). `bytes.fromhex` then raises, the function's broad `except Exception: return None` swallows it, and the block silently gets **`author = NULL`**.

Confirmed deterministic on **finney #4,000,000** (spec 202): the slot bytes `4eca9508…` arrive as a raw str, the poller produced `NULL`, while the true author is `5CfBaz…` (independently decoded by the Rust historical backfiller, which reads the raw bytes directly).

## Fix
New `_aura_slot(data)` helper normalizes the payload to the u64 LE slot across **all shapes**:
- raw `bytes`/`bytearray` → used directly
- `0x…` hex string → `bytes.fromhex`
- any other `str` → `encode("utf-8")` (latin-1 can't represent the multi-byte chars — verified)

`_block_author` now delegates to it. Strict 8-byte semantics preserved (matches the existing test).

## Tests
`scripts/test_fetch_events.py` (stdlib `unittest`, no deps): new `AuraSlotTest` covers the raw-UTF-8, `0x`-hex, raw-bytes, wrong-length, and non-payload cases, plus an end-to-end `_block_author` raw-UTF-8 case. All 52 tests pass.

Verified end-to-end against live finney: #4000000 → `5CfBaz…` (was NULL), #8497000 (normal hex digest) unchanged.

_Note: makes the live indexer's `author` column complete going forward; the Rust historical backfill already decodes it correctly._