### PR TITLE
feat(chain): populate the all-events tier (chain_events) from the indexer

### DIFF
--- a/scripts/index-chain.py
+++ b/scripts/index-chain.py
@@ -76,6 +76,12 @@ EVENT_COLS = (
     "hotkey", "coldkey", "netuid", "uid",
     "amount_tao", "alpha_amount", "observed_at",
 )
+# Generic all-events tier: EVERY decoded event (all pallets/methods), not just the
+# curated account_events. `args` is JSONB (parsed from its compact JSON string).
+CHAIN_EVENT_COLS = (
+    "block_number", "event_index", "pallet", "method",
+    "args", "phase", "extrinsic_index", "observed_at",
+)
 
 
 def _json_obj(value):
@@ -145,7 +151,18 @@ def rows_from_decoded(decoded):
         }
         if _has_ts(row):
             events.append(row)
-    return {"blocks": blocks, "extrinsics": extrinsics, "account_events": events}
+    chain_events = []
+    for ce in decoded.get("chain_events") or []:
+        row = {c: ce.get(c) for c in CHAIN_EVENT_COLS}
+        row["args"] = _json_obj(row["args"])  # JSON string -> JSONB object
+        if _has_ts(row):
+            chain_events.append(row)
+    return {
+        "blocks": blocks,
+        "extrinsics": extrinsics,
+        "account_events": events,
+        "chain_events": chain_events,
+    }
 
 
 def backfill_start(cursor, head, start_block_env):
@@ -198,7 +215,7 @@ def _upsert(conn, table, cols, dict_rows, conflict):
         row = []
         for c in cols:
             v = r.get(c)
-            if c == "call_args" and v is not None:
+            if c in ("call_args", "args") and v is not None:
                 v = Json(v)
             row.append(v)
         tuples.append(tuple(row))
@@ -241,6 +258,7 @@ def process_block(decode_head, s, conn, redis_client, bn):
     _upsert(conn, "blocks", BLOCK_COLS, rows["blocks"], "block_number")
     _upsert(conn, "extrinsics", EXTRINSIC_COLS, rows["extrinsics"], "block_number, extrinsic_index")
     _upsert(conn, "account_events", EVENT_COLS, rows["account_events"], "block_number, event_index")
+    _upsert(conn, "chain_events", CHAIN_EVENT_COLS, rows["chain_events"], "block_number, event_index")
     write_cursor(conn, redis_client, bn)
     conn.commit()
     return len(rows["account_events"]), len(rows["extrinsics"])

--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -107,23 +107,39 @@ def decode_head(s, block_number):
         head_ts = None
     events = s.query("System", "Events", block_hash=block_hash)
     event_rows = []
+    chain_event_rows = []
     for event_index, ev in enumerate(events):
         v = ev.value if isinstance(ev.value, dict) else {}
         e = v.get("event", {}) if isinstance(v.get("event"), dict) else {}
-        # Match the CI poller's coverage (#1850): SubtensorModule + Balances, so
-        # realtime ingest captures native-TAO Transfer events too (extract()
-        # returns None for any non-indexed kind, so this only widens, never noise).
+        # Link the event to its emitting extrinsic (#1849): the ApplyExtrinsic-phase
+        # extrinsic_idx, null for Initialization/Finalization events.
+        phase = v.get("phase")
+        xidx = v.get("extrinsic_idx") if phase == "ApplyExtrinsic" else None
+        if not isinstance(xidx, int) or xidx < 0:
+            xidx = None
+        # All-events tier (chain_events): EVERY decoded event, every pallet/method —
+        # the complete block-explorer record, not just the curated account_events.
+        # args is a compact JSON string of the decoded attributes (parsed to JSONB at
+        # insert, like extrinsics.call_args). NEVER raises (best-effort _safe_json).
+        chain_event_rows.append(
+            {
+                "block_number": block_number,
+                "event_index": event_index,
+                "pallet": e.get("module_id"),
+                "method": e.get("event_id"),
+                "args": _fe._safe_json(e.get("attributes")),
+                "phase": phase if isinstance(phase, str) else None,
+                "extrinsic_index": xidx,
+                "observed_at": head_ts if head_ts else None,
+            }
+        )
+        # Curated account_events: SubtensorModule + Balances known kinds only (#1850);
+        # extract() returns None for any non-indexed kind, so this only narrows.
         if e.get("module_id") not in ("SubtensorModule", "Balances"):
             continue
         ent = extract(e.get("event_id"), e.get("attributes"))
         if ent is None:
             continue
-        # Link the event to its emitting extrinsic (#1849), kept 1:1 with the CI
-        # poller's fetch-events.py emit: the ApplyExtrinsic-phase extrinsic_idx,
-        # null for Initialization/Finalization events.
-        xidx = v.get("extrinsic_idx") if v.get("phase") == "ApplyExtrinsic" else None
-        if not isinstance(xidx, int) or xidx < 0:
-            xidx = None
         event_rows.append(
             {
                 "block_number": block_number,
@@ -149,7 +165,12 @@ def decode_head(s, block_number):
     extrinsic_rows = _fe.extrinsics_for_block(s, block_number, block_hash, events)
     for xrow in extrinsic_rows:
         xrow["observed_at"] = head_ts
-    return {"events": event_rows, "block": block_row, "extrinsics": extrinsic_rows}
+    return {
+        "events": event_rows,
+        "block": block_row,
+        "extrinsics": extrinsic_rows,
+        "chain_events": chain_event_rows,
+    }
 
 
 def push(url, payload):

--- a/scripts/test_index_chain.py
+++ b/scripts/test_index_chain.py
@@ -140,10 +140,34 @@ class RowsFromDecoded(unittest.TestCase):
         self.assertEqual(len(rows["account_events"]), 1)
 
     def test_empty_inputs_are_safe(self):
+        empty = {"blocks": [], "extrinsics": [], "account_events": [], "chain_events": []}
         rows = ic.rows_from_decoded({"block": None, "extrinsics": [], "events": []})
-        self.assertEqual(rows, {"blocks": [], "extrinsics": [], "account_events": []})
+        self.assertEqual(rows, empty)
         rows2 = ic.rows_from_decoded({})  # missing keys
-        self.assertEqual(rows2, {"blocks": [], "extrinsics": [], "account_events": []})
+        self.assertEqual(rows2, empty)
+
+    def test_chain_events_all_events_with_args_jsonb(self):
+        d = {
+            "chain_events": [
+                {
+                    "block_number": 9, "event_index": 0, "pallet": "System",
+                    "method": "ExtrinsicSuccess", "args": '{"weight":123}',
+                    "phase": "ApplyExtrinsic", "extrinsic_index": 2, "observed_at": 7,
+                },
+                {  # no observed_at -> dropped (BIGINT NOT NULL)
+                    "block_number": 9, "event_index": 1, "pallet": "Aura",
+                    "method": "X", "args": None, "phase": "Initialization",
+                    "extrinsic_index": None, "observed_at": None,
+                },
+            ]
+        }
+        ce = ic.rows_from_decoded(d)["chain_events"]
+        self.assertEqual(len(ce), 1)  # the row missing observed_at is dropped
+        self.assertEqual(ce[0]["pallet"], "System")
+        self.assertEqual(ce[0]["method"], "ExtrinsicSuccess")
+        self.assertEqual(ce[0]["args"], {"weight": 123})  # JSON string -> JSONB object
+        self.assertEqual(ce[0]["phase"], "ApplyExtrinsic")
+        self.assertEqual(ce[0]["extrinsic_index"], 2)
 
 
 class DecodeHeadImport(unittest.TestCase):


### PR DESCRIPTION
## What
The block explorer should show **every** event in a block, not just the ~14 curated SubtensorModule/Balances kinds in `account_events`. The `chain_events` table (pallet, method, args, phase, extrinsic_index) existed in the schema but **neither the indexer nor the poller filled it**. This populates it.

## How
- **`stream-events.decode_head`** now emits a `chain_events` row for **every** decoded event (all pallets/methods) alongside the curated `account_events`:
  `pallet=module_id`, `method=event_id`, `args=`compact JSON of attributes (→ JSONB at insert, like `call_args`), `phase`, and the ApplyExtrinsic `extrinsic_idx`.
- **`index-chain`** upserts them idempotently on `(block_number, event_index)`; `_upsert` now wraps the JSONB `args` column. The curated `account_events` stays the fast path.
- The Railway historical backfill writes the **same** `chain_events` rows, verified to match this Python decode byte-for-byte on the keyed fields (pallet/method/phase/extrinsic_index/event_index) across 804 events / 23 pallet.method types / spec 127→423.

## Tests
`scripts/test_index_chain.py`: new `rows_from_decoded` chain_events case (all-events captured, `args` parsed to JSONB object, NOT-NULL `observed_at` drop) + updated the empty-input shape. All Python suites pass.

_Volume note: chain_events ~doubles event rows vs account_events; the table + indexes already exist in the schema. Idempotent ON CONFLICT DO NOTHING, so overlapping ranges re-insert harmlessly._