### PR TITLE
fix(mcp): share 60s verify cache with REST verify_integration

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -32,7 +32,7 @@ import {
 import {
   findSurface,
   primarySurfaceForNetuid,
-  verifySurface,
+  verifySurfaceWithCache,
   SURFACE_ID_PATTERN,
 } from "./surface-verify.mjs";
 import { SURFACE_ALIASES_PATH } from "./surface-aliases.mjs";
@@ -2452,7 +2452,7 @@ export const MCP_TOOLS = [
           "Provide either surface_id or netuid.",
         );
       }
-      return await verifySurface(surface, {
+      return await verifySurfaceWithCache(surface, {
         isUnsafeUrl: workerResolvedUrlSafetyGuard({
           fetchImpl: globalThis.fetch,
         }),
@@ -3142,6 +3142,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       status_code: NULLABLE_INT,
       error: NULLABLE_STRING,
       probed_at: NULLABLE_STRING,
+      from_cache: { type: "boolean" },
     },
   },
 };

--- a/src/surface-verify.mjs
+++ b/src/surface-verify.mjs
@@ -77,3 +77,45 @@ export async function verifySurface(
     probed_at: probe.last_checked || probe.verified_at || null,
   };
 }
+
+export const VERIFY_CACHE_TTL_SECONDS = 60;
+
+export function verifyCacheRequest(surface) {
+  const canonicalSurfaceId = surface.surface_key || surface.surface_id;
+  return new Request(
+    `https://verify.metagraph.sh/${encodeURIComponent(canonicalSurfaceId)}`,
+  );
+}
+
+// Shared 60s Cache-API layer for REST verify and MCP verify_integration (#358).
+export async function verifySurfaceWithCache(
+  surface,
+  probeOptions = {},
+  { cache = globalThis.caches?.default ?? null, waitUntil = null, prober } = {},
+) {
+  const cacheKey = cache ? verifyCacheRequest(surface) : null;
+  if (cache && cacheKey) {
+    const hit = await cache.match(cacheKey);
+    if (hit) {
+      const cached = await hit.json();
+      return { ...cached, from_cache: true };
+    }
+  }
+
+  const result = await verifySurface(surface, probeOptions, prober);
+  if (cache && cacheKey) {
+    const stored = new Response(JSON.stringify(result), {
+      headers: {
+        "content-type": "application/json",
+        "cache-control": `public, s-maxage=${VERIFY_CACHE_TTL_SECONDS}`,
+      },
+    });
+    const put = cache.put(cacheKey, stored);
+    if (typeof waitUntil === "function") {
+      waitUntil(put);
+    } else {
+      await put;
+    }
+  }
+  return { ...result, from_cache: false };
+}

--- a/tests/surface-verify.test.mjs
+++ b/tests/surface-verify.test.mjs
@@ -4,6 +4,7 @@ import {
   findSurface,
   primarySurfaceForNetuid,
   verifySurface,
+  verifySurfaceWithCache,
   SURFACE_ID_PATTERN,
 } from "../src/surface-verify.mjs";
 import { handleRequest } from "../workers/api.mjs";
@@ -136,6 +137,43 @@ describe("surface-verify core (#358)", () => {
     assert.equal(bare.auth_required, false);
     assert.equal(bare.netuid, null);
     assert.equal(bare.probed_at, "2026-06-16T01:00:00Z"); // verified_at fallback
+  });
+
+  test("verifySurfaceWithCache serves a 60s cache keyed by surface_key", async () => {
+    let probes = 0;
+    const store = new Map();
+    const cache = {
+      async match(key) {
+        return store.get(key.url);
+      },
+      async put(key, res) {
+        store.set(key.url, res);
+      },
+    };
+    const prober = async () => {
+      probes += 1;
+      return {
+        status: "ok",
+        classification: "live",
+        latency_ms: 12,
+        status_code: 200,
+        last_checked: "2026-06-16T00:00:00.000Z",
+      };
+    };
+    const first = await verifySurfaceWithCache(
+      surfaces[0],
+      {},
+      { cache, waitUntil: (p) => p, prober },
+    );
+    assert.equal(first.from_cache, false);
+    assert.equal(probes, 1);
+    const second = await verifySurfaceWithCache(
+      surfaces[0],
+      {},
+      { cache, prober },
+    );
+    assert.equal(second.from_cache, true);
+    assert.equal(probes, 1);
   });
 });
 
@@ -472,6 +510,65 @@ describe("verify_integration MCP tool (#358)", () => {
       globalThis.fetch = of;
     }
     assert.equal(surfaceFetches, 0);
+  });
+
+  test("caches probe results for ~60s like REST verify", async () => {
+    let probeCount = 0;
+    const store = new Map();
+    const cache = {
+      async match(key) {
+        return store.get(key.url);
+      },
+      async put(key, res) {
+        store.set(key.url, res);
+      },
+    };
+    const of = globalThis.fetch;
+    const oc = globalThis.caches;
+    globalThis.fetch = async () => {
+      probeCount += 1;
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    globalThis.caches = { default: cache };
+    const invoke = async (args) => {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: { name: "verify_integration", arguments: args },
+          }),
+        }),
+        {},
+        deps,
+      );
+      return (await response.json()).result;
+    };
+    try {
+      const first = await invoke({ surface_id: "x:api:1" });
+      assert.equal(first.isError, false);
+      assert.equal(first.structuredContent.from_cache, false);
+      const probesAfterFirst = probeCount;
+      assert.ok(probesAfterFirst > 0);
+
+      const second = await invoke({ surface_id: "x:api:1" });
+      assert.equal(second.isError, false);
+      assert.equal(second.structuredContent.from_cache, true);
+      assert.equal(
+        probeCount,
+        probesAfterFirst,
+        "second call must not re-probe",
+      );
+    } finally {
+      globalThis.fetch = of;
+      globalThis.caches = oc;
+    }
   });
 
   test("error paths require no probe", async () => {

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -39,7 +39,10 @@ import {
   analyticsWindow,
   d1All,
 } from "./analytics.mjs";
-import { findSurface, verifySurface } from "../../src/surface-verify.mjs";
+import {
+  findSurface,
+  verifySurfaceWithCache,
+} from "../../src/surface-verify.mjs";
 import { SURFACE_ALIASES_PATH } from "../../src/surface-aliases.mjs";
 import {
   KV_HEALTH_RPC_POOL,
@@ -311,41 +314,21 @@ export async function handleSurfaceVerify(request, env, surfaceId, ctx = {}) {
     );
   }
 
-  const canonicalSurfaceId = surface.surface_key || surface.surface_id;
-  const cache = globalThis.caches?.default || null;
-  const cacheKey = cache
-    ? new Request(
-        `https://verify.metagraph.sh/${encodeURIComponent(canonicalSurfaceId)}`,
-      )
-    : null;
-  if (cache) {
-    const hit = await cache.match(cacheKey);
-    if (hit) {
-      const cached = await hit.json();
-      return envelopeResponse(
-        request,
-        { data: { ...cached, from_cache: true }, meta: await verifyMeta(env) },
-        "short",
-      );
-    }
-  }
-
-  const result = await verifySurface(surface, {
-    isUnsafeUrl: workerResolvedUrlSafetyGuard({ fetchImpl: globalThis.fetch }),
-    connect: workerWebSocketConnector(globalThis.fetch),
-  });
-  if (cache) {
-    const stored = new Response(JSON.stringify(result), {
-      headers: {
-        "content-type": "application/json",
-        "cache-control": "public, s-maxage=60",
-      },
-    });
-    ctx?.waitUntil?.(cache.put(cacheKey, stored));
-  }
+  const result = await verifySurfaceWithCache(
+    surface,
+    {
+      isUnsafeUrl: workerResolvedUrlSafetyGuard({
+        fetchImpl: globalThis.fetch,
+      }),
+      connect: workerWebSocketConnector(globalThis.fetch),
+    },
+    {
+      waitUntil: (promise) => ctx?.waitUntil?.(promise),
+    },
+  );
   return envelopeResponse(
     request,
-    { data: { ...result, from_cache: false }, meta: await verifyMeta(env) },
+    { data: result, meta: await verifyMeta(env) },
     "short",
   );
 }


### PR DESCRIPTION
## Summary

- Extract a shared `verifySurfaceWithCache` helper (or reuse REST handler internals) used by both `handleSurfaceVerify` and MCP `verify_integration`.
- Align cache key on canonical `surface_key || surface_id`, 60s TTL, `from_cache` on hits.
- Update MCP tests to assert second call hits cache without re-probing.

Closes #2173

## Why

MCP agents poll verify more aggressively than browser clients. Uncached MCP probes add load on subnet APIs and contradict the documented ~60s cache contract.

## Test plan

- [x] `npm test -- tests/surface-verify.test.mjs tests/mcp-server.test.mjs tests/request-handlers-rpc-proxy.test.mjs`
- [x] MCP verify: two calls within 60s → one probe, second returns cached result
- [x] REST verify behavior unchanged
