### PR TITLE
feat(feeds): add ?since= filter for incremental feed polling

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -16,6 +16,10 @@
 // "subnet"/"artifact"/"coverage" + the change verb (added/removed/renamed/
 // modified); incident items carry "incident", "sn<netuid>", and
 // "ongoing"/"resolved". An unknown tag yields an empty (but valid) feed.
+//
+// Optional `?since=<ISO-8601>` returns only items at or after that instant
+// (e.g. ?since=2026-06-01 or ?since=2026-06-01T00:00:00Z), for incremental
+// polling; it composes with `?tag=`. A malformed `since` is a 400.
 
 import { ifNoneMatchSatisfied, weakEtag } from "../workers/http.mjs";
 
@@ -218,6 +222,17 @@ function filterByTag(items, tag) {
   return items.filter((item) => (item.tags || []).includes(tag));
 }
 
+// Optional `?since=` filter: keep only items at or after `sinceMs` (epoch ms).
+// A null bound (absent param) is a no-op; items whose timestamp can't be parsed
+// are dropped, so a malformed feed entry never leaks past an explicit `since`.
+function filterSince(items, sinceMs) {
+  if (sinceMs == null) return items;
+  return items.filter((item) => {
+    const t = Date.parse(item.timestamp);
+    return !Number.isNaN(t) && t >= sinceMs;
+  });
+}
+
 function jsonFeed(meta, items) {
   return `${JSON.stringify(
     {
@@ -368,6 +383,21 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
   }
   const format = resolveFeedFormat(url.pathname, request.headers.get("accept"));
 
+  // Optional `?since=` lower bound (parsed once, here, so a malformed value is
+  // rejected before any artifact work). null when the param is absent.
+  let sinceMs = null;
+  const sinceParam = url.searchParams.get("since");
+  if (sinceParam != null) {
+    sinceMs = Date.parse(sinceParam);
+    if (Number.isNaN(sinceMs)) {
+      return fail(
+        "invalid_since",
+        "`since` must be an ISO-8601 date or date-time, e.g. 2026-06-01 or 2026-06-01T00:00:00Z.",
+        400,
+      );
+    }
+  }
+
   let items;
   let title;
   let description;
@@ -412,6 +442,7 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
   }
 
   items = filterByTag(items, url.searchParams.get("tag"));
+  items = filterSince(items, sinceMs);
   items = sortAndCap(items);
   const meta = {
     title,
@@ -465,4 +496,5 @@ export const __test = {
   atomFeed,
   escapeXml,
   filterByTag,
+  filterSince,
 };

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -18,6 +18,7 @@ const {
   atomFeed,
   escapeXml,
   filterByTag,
+  filterSince,
 } = __test;
 
 const CHANGELOG = {
@@ -256,6 +257,59 @@ describe("feeds — filterByTag", () => {
 
   test("an item with no tags array is safely skipped", () => {
     assert.deepEqual(filterByTag([{ id: "x" }], "incident"), []);
+  });
+});
+
+describe("feeds — filterSince", () => {
+  const items = [
+    { id: "old", timestamp: "2026-06-10T00:00:00.000Z" },
+    { id: "new", timestamp: "2026-06-20T00:00:00.000Z" },
+    { id: "bad", timestamp: "not-a-date" },
+  ];
+
+  test("a null bound is a no-op (returns the input)", () => {
+    assert.equal(filterSince(items, null), items);
+  });
+
+  test("keeps items at or after the bound; drops unparseable timestamps", () => {
+    const kept = filterSince(items, Date.parse("2026-06-15T00:00:00.000Z"));
+    assert.deepEqual(
+      kept.map((i) => i.id),
+      ["new"],
+    );
+  });
+
+  test("is inclusive of the exact bound", () => {
+    const kept = filterSince(items, Date.parse("2026-06-20T00:00:00.000Z"));
+    assert.deepEqual(
+      kept.map((i) => i.id),
+      ["new"],
+    );
+  });
+});
+
+describe("feeds — ?since= filter", () => {
+  test("a future since yields an empty but valid feed (200)", async () => {
+    const { res, text } = await feed(
+      "/api/v1/feeds/registry.json?since=2030-01-01",
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(JSON.parse(text).items, []);
+  });
+
+  test("a past since keeps items and composes with ?tag=", async () => {
+    const { res, text } = await feed(
+      "/api/v1/feeds/registry.json?since=2000-01-01&tag=registry",
+    );
+    assert.equal(res.status, 200);
+    const items = JSON.parse(text).items;
+    assert.ok(items.length > 0);
+    assert.ok(items.every((it) => (it.tags || []).includes("registry")));
+  });
+
+  test("a malformed since is rejected with 400", async () => {
+    const { res } = await feed("/api/v1/feeds/registry.json?since=notadate");
+    assert.equal(res.status, 400);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds an optional `?since=<ISO-8601>` lower bound to the content feeds (`/api/v1/feeds/registry`, `/incidents`, `/subnets/{netuid}`), alongside the existing `?tag=` filter. It returns only items at or after that instant, so a consumer can poll a focused, **incremental** slice instead of re-fetching and re-diffing the whole window each time.

Closes #2178

## Behavior

- `?since=2026-06-20` or `?since=2026-06-20T00:00:00Z` → only items with `timestamp >= since`.
- **Composes with `?tag=`** — e.g. `?tag=incident&since=<last_seen>`.
- Items are filtered by their existing `timestamp`; an item whose timestamp can't be parsed is dropped (never leaks past an explicit `since`).
- A **malformed `since` is a 400** (via the shared feed error envelope), matching the strict param validation used elsewhere in the API.
- **Absent `since` is a no-op** (the whole feed) — fully backward-compatible.

## Scope

- Self-contained in `src/feeds.mjs` — Worker-computed at request time; no schema/contract/artifact change (feeds aren't part of the typed OpenAPI envelope), so nothing to regenerate.
- Mirrors the existing `filterByTag` helper and the `fail(...)` error path.

## Tests (`tests/feeds.test.mjs`)

- `filterSince` unit tests: null no-op, at/after the bound, inclusivity of the exact bound, dropping unparseable timestamps.
- Handler tests: a future `since` → empty-but-valid 200 feed; a past `since` keeps items and composes with `?tag=`; a malformed `since` → 400.

```
✓ tests/feeds.test.mjs (56 tests)
```

`eslint` and `prettier --check` clean on both files. Full local `vitest` run shows no new failures (only pre-existing Windows-only env issues that pass on Linux CI).