### PR TITLE
fix(api): bust metagraph edge cache on neuron snapshot refresh, not health prober

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -563,3 +563,160 @@ describe("analytics edge cache", () => {
     }
   });
 });
+
+const NEURON_CAPTURED_AT = 1_781_500_000_000;
+const NEURON_ROW = {
+  uid: 0,
+  hotkey: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+  coldkey: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+  active: 1,
+  validator_permit: 1,
+  rank: 0.1,
+  trust: 0.9,
+  validator_trust: 0.8,
+  consensus: 0.7,
+  incentive: 0.6,
+  dividends: 0.5,
+  emission_tao: 1,
+  stake_tao: 100,
+  registered_at_block: 1,
+  is_immunity_period: 0,
+  axon: null,
+  block_number: 100,
+  captured_at: NEURON_CAPTURED_AT,
+};
+
+function neuronsEnv(
+  queries,
+  { lastRunAt = LAST_RUN_AT, neuronCapturedAt = NEURON_CAPTURED_AT } = {},
+) {
+  return {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind(...params) {
+            queries.push({ sql, params });
+            if (sql.includes("MAX(captured_at)")) {
+              return {
+                all: () =>
+                  Promise.resolve({
+                    results: [{ captured_at: neuronCapturedAt }],
+                  }),
+              };
+            }
+            if (sql.includes("FROM neurons")) {
+              return {
+                all: () => Promise.resolve({ results: [NEURON_ROW] }),
+              };
+            }
+            return { all: () => Promise.resolve({ results: [] }) };
+          },
+        };
+      },
+    },
+    METAGRAPH_CONTROL: {
+      async get(key) {
+        if (key === "health:meta") {
+          return lastRunAt ? { last_run_at: lastRunAt } : null;
+        }
+        return null;
+      },
+    },
+  };
+}
+
+function expectedStampKey(stamp, keyParts, pathname, search = "") {
+  return `https://edge-cache.metagraph.sh/analytics/${encodeURIComponent(
+    CONTRACT_VERSION,
+  )}/${encodeURIComponent(stamp)}/${keyParts}${pathname}${search}`;
+}
+
+describe("neurons-tier edge cache", () => {
+  test("metagraph/validators/concentration key on neuron captured_at, not health last_run_at", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = neuronsEnv(queries);
+
+    for (const [keyParts, path] of [
+      ["subnet-metagraph", "/api/v1/subnets/7/metagraph"],
+      ["subnet-validators", "/api/v1/subnets/7/validators"],
+      ["subnet-concentration", "/api/v1/subnets/7/concentration"],
+    ]) {
+      await handleRequest(
+        new Request(`https://api.metagraph.sh${path}`),
+        env,
+        ctx,
+      );
+      await Promise.resolve();
+      assert.ok(
+        cache.putKeys.some((key) =>
+          key.includes(encodeURIComponent(String(NEURON_CAPTURED_AT))),
+        ),
+        `${keyParts}: cache key must include neuron captured_at`,
+      );
+      assert.ok(
+        !cache.putKeys.some((key) =>
+          key.includes(encodeURIComponent(LAST_RUN_AT)),
+        ),
+        `${keyParts}: cache key must not use health last_run_at`,
+      );
+    }
+  });
+
+  test("a new neuron captured_at busts cache while health last_run_at is unchanged", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const envA = neuronsEnv(queries, { neuronCapturedAt: NEURON_CAPTURED_AT });
+    const url = "https://api.metagraph.sh/api/v1/subnets/7/metagraph";
+
+    await handleRequest(new Request(url), envA, ctx);
+    await Promise.resolve();
+    assert.deepEqual(cache.putKeys, [
+      expectedStampKey(
+        String(NEURON_CAPTURED_AT),
+        "subnet-metagraph",
+        "/api/v1/subnets/7/metagraph",
+      ),
+    ]);
+
+    const envB = neuronsEnv(queries, {
+      neuronCapturedAt: NEURON_CAPTURED_AT + 60_000,
+    });
+    await handleRequest(new Request(url), envB, ctx);
+    await Promise.resolve();
+    assert.equal(
+      cache.store.size,
+      2,
+      "a newer captured_at must seed a new entry",
+    );
+  });
+
+  test("health percentiles still bust on health last_run_at only", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = neuronsEnv(queries);
+
+    await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles?window=7d",
+      ),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.deepEqual(cache.putKeys, [
+      expectedKey(
+        "percentiles",
+        "/api/v1/subnets/7/health/percentiles",
+        "?window=7d",
+      ),
+    ]);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -50,6 +50,7 @@ import {
   handleHealthPercentiles,
   handleHealthTrends,
   withEdgeCache,
+  withNeuronsEdgeCache,
 } from "./request-handlers/analytics.mjs";
 import {
   loadStagedNeurons,
@@ -1092,15 +1093,21 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       resolved.url.pathname,
     );
     if (concentrationMatch) {
-      // Per-UID range read over the neurons tier, deterministic per cron snapshot
-      // — edge-cache on last_run_at like the sibling metagraph routes.
-      return withEdgeCache(request, ctx, env, "subnet-concentration", () =>
-        handleSubnetConcentration(
-          request,
-          env,
-          Number(concentrationMatch[1]),
-          resolved.url,
-        ),
+      // Per-UID range read over the neurons tier — edge-cache busts on the
+      // subnet's neuron captured_at stamp, not the health prober tick.
+      return withNeuronsEdgeCache(
+        request,
+        ctx,
+        env,
+        Number(concentrationMatch[1]),
+        "subnet-concentration",
+        () =>
+          handleSubnetConcentration(
+            request,
+            env,
+            Number(concentrationMatch[1]),
+            resolved.url,
+          ),
       );
     }
     // Per-UID metagraph (#1304/#1305): computed live from the neurons D1 tier.
@@ -1136,16 +1143,21 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       resolved.url.pathname,
     );
     if (metagraphMatch) {
-      // Full per-subnet metagraph (range read over the neurons tier), deterministic
-      // per cron snapshot — edge-cache on last_run_at; ?validator_permit rides the
-      // search into the key.
-      return withEdgeCache(request, ctx, env, "subnet-metagraph", () =>
-        handleSubnetMetagraph(
-          request,
-          env,
-          Number(metagraphMatch[1]),
-          resolved.url,
-        ),
+      // Full per-subnet metagraph (range read over the neurons tier) — edge-cache
+      // busts on neuron captured_at; ?validator_permit rides the search into the key.
+      return withNeuronsEdgeCache(
+        request,
+        ctx,
+        env,
+        Number(metagraphMatch[1]),
+        "subnet-metagraph",
+        () =>
+          handleSubnetMetagraph(
+            request,
+            env,
+            Number(metagraphMatch[1]),
+            resolved.url,
+          ),
       );
     }
     const neuronMatch = SUBNET_NEURON_PATH_PATTERN.exec(resolved.url.pathname);
@@ -1161,15 +1173,20 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       resolved.url.pathname,
     );
     if (validatorsMatch) {
-      // Validator slice of the metagraph (filtered range read), deterministic per
-      // cron snapshot — edge-cache on last_run_at like the sibling routes.
-      return withEdgeCache(request, ctx, env, "subnet-validators", () =>
-        handleSubnetValidators(
-          request,
-          env,
-          Number(validatorsMatch[1]),
-          resolved.url,
-        ),
+      // Validator slice of the metagraph — edge-cache busts on neuron captured_at.
+      return withNeuronsEdgeCache(
+        request,
+        ctx,
+        env,
+        Number(validatorsMatch[1]),
+        "subnet-validators",
+        () =>
+          handleSubnetValidators(
+            request,
+            env,
+            Number(validatorsMatch[1]),
+            resolved.url,
+          ),
       );
     }
     // Per-subnet chain-event stream (#1345): account_events filtered by netuid.

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -230,13 +230,15 @@ async function analyticsMeta(env, artifactPath, observedAt) {
 // keying, same conditional-GET 304 short-circuit, same ctx.waitUntil put.
 //
 // The key varies on everything that changes the body: contract_version (a deploy
-// can never serve a cross-version payload) + the cron snapshot stamp
-// (`last_run_at`) + the request path (carries netuid) + the canonical search
-// (carries `window`). `keyParts` is the extra namespace segment per route. When
-// the snapshot stamp is cold (null), caching is skipped entirely so a cold-KV
-// empty payload can never seed a stale entry — identical to the overlay cache's
-// `if (lastRunAt)` guard. The cache is transparent: body/shape/headers are
-// whatever buildResponse() produced; only 200s are cached, never errors.
+// can never serve a cross-version payload) + a freshness stamp + the request
+// path (carries netuid) + the canonical search (carries `window`). By default
+// the stamp is the health cron snapshot (`last_run_at`); neurons-tier routes
+// pass `resolveCacheStamp` to bust on neuron `captured_at` instead (#1346).
+// `keyParts` is the extra namespace segment per route. When the stamp is cold
+// (null), caching is skipped entirely so a cold-KV/empty payload can never seed
+// a stale entry — identical to the overlay cache's `if (lastRunAt)` guard. The
+// cache is transparent: body/shape/headers are whatever buildResponse() produced;
+// only 200s are cached, never errors.
 export async function withEdgeCache(
   request,
   ctx,
@@ -244,19 +246,27 @@ export async function withEdgeCache(
   keyParts,
   buildResponse,
   cachePathAndSearch = null,
+  resolveCacheStamp = null,
 ) {
   const cache = request.method === "GET" ? globalThis.caches?.default : null;
-  // Cheap, per-isolate-memoized read of just the snapshot time. On a hit this +
-  // the cache match is the whole request (no D1 aggregation at all).
-  const lastRunAt = cache ? (await readHealthMetaKv(env))?.last_run_at : null;
+  // Cheap freshness read. On a hit this + the cache match is the whole request
+  // (no D1 aggregation at all for the handler body).
+  let stamp = null;
+  if (cache) {
+    if (typeof resolveCacheStamp === "function") {
+      stamp = await resolveCacheStamp(env);
+    } else {
+      stamp = (await readHealthMetaKv(env))?.last_run_at ?? null;
+    }
+  }
   let cacheKey = null;
-  if (cache && lastRunAt) {
+  if (cache && stamp) {
     const url = new URL(request.url);
     const cacheRoute = cachePathAndSearch ?? `${url.pathname}${url.search}`;
     cacheKey = new Request(
       `https://edge-cache.metagraph.sh/analytics/${encodeURIComponent(
         contractVersion(env),
-      )}/${encodeURIComponent(lastRunAt)}/${keyParts}${cacheRoute}`,
+      )}/${encodeURIComponent(stamp)}/${keyParts}${cacheRoute}`,
     );
     const hit = await cache.match(cacheKey);
     if (hit) {
@@ -281,6 +291,41 @@ export async function withEdgeCache(
     ctx?.waitUntil?.(cache.put(cacheKey, response.clone()));
   }
   return response;
+}
+
+// Neurons-tier routes refresh on the ~3-minute events/metagraph cron, not the
+// 15-minute health prober — bust their edge cache on per-subnet snapshot time.
+export async function readSubnetNeuronsCacheStamp(env, netuid) {
+  const rows = await d1All(
+    env,
+    "SELECT MAX(captured_at) AS captured_at FROM neurons WHERE netuid = ?",
+    [netuid],
+  );
+  if (hasD1FallbackRows(rows)) return null;
+  const capturedAt = rows[0]?.captured_at;
+  return Number.isInteger(capturedAt) && capturedAt > 0
+    ? String(capturedAt)
+    : null;
+}
+
+export function withNeuronsEdgeCache(
+  request,
+  ctx,
+  env,
+  netuid,
+  keyParts,
+  buildResponse,
+  cachePathAndSearch = null,
+) {
+  return withEdgeCache(
+    request,
+    ctx,
+    env,
+    keyParts,
+    buildResponse,
+    cachePathAndSearch,
+    (edgeEnv) => readSubnetNeuronsCacheStamp(edgeEnv, netuid),
+  );
 }
 
 // D1-backed 7d/30d daily uptime + latency trends across all subnets. This is a


### PR DESCRIPTION
## Summary

- Key edge cache for neurons-tier routes (`subnet-metagraph`, `subnet-validators`, `subnet-concentration`) on a neurons freshness stamp instead of `health:meta.last_run_at`.
- Source stamp from D1 `MAX(captured_at)` for the subnet, or a lightweight KV pointer updated by `loadStagedNeurons`.
- Add regression test: neuron data changes bust cache without a health prober tick.

Closes #2180 

## Why

Agents polling metagraph/validators for stake and rank can see data up to ~12 minutes stale at the edge despite 3-minute neuron refreshes in D1.

## Test plan

- [x] `npm test -- tests/analytics-edge-cache.test.mjs`
- [ ] Cache hit when stamp unchanged; miss when neuron `captured_at` advances
- [ ] Health-trends routes still bust on `last_run_at` only
