### PR TITLE
feat(api): serve chain_events (all-events) from Postgres via Hyperdrive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "graphql": "^17.0.1",
+        "postgres": "^3.4.9",
         "workers-og": "^0.0.27"
       },
       "devDependencies": {
@@ -3693,6 +3694,19 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/postgres": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.9.tgz",
+      "integrity": "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
   },
   "dependencies": {
     "graphql": "^17.0.1",
+    "postgres": "^3.4.9",
     "workers-og": "^0.0.27"
   },
   "devDependencies": {

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -28,10 +28,11 @@ vi.mock("postgres", () => ({
 const { default: worker } = await import("../workers/data-api.mjs");
 const env = { HYPERDRIVE: { connectionString: "postgres://mock" } };
 const ctx = { waitUntil() {} };
-const req = (path, init) => worker.fetch(new Request(`https://d${path}`, init), env, ctx);
+const req = (path, init) =>
+  worker.fetch(new Request(`https://d${path}`, init), env, ctx);
 
-test("GET /api/v1/blocks/:n/events returns the block's events", async () => {
-  const res = await req("/api/v1/blocks/123/events");
+test("GET /api/v1/blocks/:n/chain-events returns the block's events", async () => {
+  const res = await req("/api/v1/blocks/123/chain-events");
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.block_number).toBe(123);
@@ -41,7 +42,9 @@ test("GET /api/v1/blocks/:n/events returns the block's events", async () => {
 });
 
 test("GET /api/v1/chain-events returns the feed with a cursor (filters + before)", async () => {
-  const res = await req("/api/v1/chain-events?limit=1&pallet=System&method=ExtrinsicSuccess&before=500");
+  const res = await req(
+    "/api/v1/chain-events?limit=1&pallet=System&method=ExtrinsicSuccess&before=500",
+  );
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.count).toBe(1);
@@ -64,6 +67,10 @@ test("unknown path is 404", async () => {
 });
 
 test("missing Hyperdrive binding is 503", async () => {
-  const res = await worker.fetch(new Request("https://d/api/v1/chain-events"), {}, ctx);
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/chain-events"),
+    {},
+    ctx,
+  );
   expect(res.status).toBe(503);
 });

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -1,0 +1,69 @@
+// Unit tests for the Postgres-serving data Worker (workers/data-api.mjs). postgres.js
+// is mocked so the routing + response shaping are tested with no real DB — the live
+// Hyperdrive→Railway path is validated separately.
+import { test, expect, vi } from "vitest";
+
+vi.mock("postgres", () => ({
+  default: () => {
+    const rows = [
+      {
+        block_number: "123",
+        event_index: 0,
+        pallet: "System",
+        method: "ExtrinsicSuccess",
+        args: { x: 1 },
+        phase: "ApplyExtrinsic",
+        extrinsic_index: 2,
+        observed_at: "100",
+      },
+    ];
+    // Every tagged-template call (top-level query OR nested fragment) resolves to rows;
+    // the handler awaits the outer query and ignores interpolated fragment values.
+    const sql = () => Promise.resolve(rows);
+    sql.end = () => Promise.resolve();
+    return sql;
+  },
+}));
+
+const { default: worker } = await import("../workers/data-api.mjs");
+const env = { HYPERDRIVE: { connectionString: "postgres://mock" } };
+const ctx = { waitUntil() {} };
+const req = (path, init) => worker.fetch(new Request(`https://d${path}`, init), env, ctx);
+
+test("GET /api/v1/blocks/:n/events returns the block's events", async () => {
+  const res = await req("/api/v1/blocks/123/events");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.block_number).toBe(123);
+  expect(body.count).toBe(1);
+  expect(body.events[0].pallet).toBe("System");
+  expect(body.events[0].method).toBe("ExtrinsicSuccess");
+});
+
+test("GET /api/v1/chain-events returns the feed with a cursor (filters + before)", async () => {
+  const res = await req("/api/v1/chain-events?limit=1&pallet=System&method=ExtrinsicSuccess&before=500");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.count).toBe(1);
+  expect(body.next_before).toBe("123"); // rows.length === limit → cursor is the last row
+});
+
+test("limit is clamped and defaults safely", async () => {
+  const res = await req("/api/v1/chain-events?limit=99999");
+  expect(res.status).toBe(200); // clamp to MAX_LIMIT, no error
+});
+
+test("POST is rejected with 405", async () => {
+  const res = await req("/api/v1/chain-events", { method: "POST" });
+  expect(res.status).toBe(405);
+});
+
+test("unknown path is 404", async () => {
+  const res = await req("/api/v1/nope");
+  expect(res.status).toBe(404);
+});
+
+test("missing Hyperdrive binding is 503", async () => {
+  const res = await worker.fetch(new Request("https://d/api/v1/chain-events"), {}, ctx);
+  expect(res.status).toBe(503);
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -839,6 +839,21 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     return handleRpcProxyRequest(request, env, url, ctx);
   }
 
+  // Postgres-backed all-events tier (ADR 0013): the dedicated data Worker (DATA_API
+  // service binding) serves chain_events + deep history via Hyperdrive, keeping the
+  // postgres.js driver out of this Worker's bundle. 503 if the binding is absent
+  // (e.g. a preview deploy without the data Worker).
+  if (
+    url.pathname === "/api/v1/chain-events" ||
+    /^\/api\/v1\/blocks\/\d+\/events$/.test(url.pathname)
+  ) {
+    if (env.DATA_API) return env.DATA_API.fetch(request);
+    return new Response(JSON.stringify({ error: "data tier unavailable" }), {
+      status: 503,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
   // Change-feed webhooks: subscription management accepts POST/DELETE/GET, so it
   // must run before the read-only method gate below (like the RPC proxy).
   if (url.pathname.startsWith("/api/v1/webhooks/")) {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -845,7 +845,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // (e.g. a preview deploy without the data Worker).
   if (
     url.pathname === "/api/v1/chain-events" ||
-    /^\/api\/v1\/blocks\/\d+\/events$/.test(url.pathname)
+    /^\/api\/v1\/blocks\/\d+\/chain-events$/.test(url.pathname)
   ) {
     if (env.DATA_API) return env.DATA_API.fetch(request);
     return new Response(JSON.stringify({ error: "data tier unavailable" }), {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -34,7 +34,8 @@ function clampLimit(raw) {
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
-    if (request.method !== "GET") return json({ error: "method not allowed" }, 405);
+    if (request.method !== "GET")
+      return json({ error: "method not allowed" }, 405);
     if (!env.HYPERDRIVE?.connectionString) {
       return json({ error: "hyperdrive binding unavailable" }, 503);
     }
@@ -50,8 +51,11 @@ export default {
     });
 
     try {
-      // GET /api/v1/blocks/:n/events — EVERY event in a block (the all-events tier).
-      const block = url.pathname.match(/^\/api\/v1\/blocks\/(\d+)\/events$/);
+      // GET /api/v1/blocks/:n/chain-events — EVERY event in a block (the all-events
+      // tier). Distinct from the existing /blocks/:ref/events (curated, D1, #1852).
+      const block = url.pathname.match(
+        /^\/api\/v1\/blocks\/(\d+)\/chain-events$/,
+      );
       if (block) {
         const bn = Number(block[1]);
         const rows = await sql`
@@ -68,7 +72,8 @@ export default {
         const pallet = url.searchParams.get("pallet");
         const method = url.searchParams.get("method");
         const before = url.searchParams.get("before"); // block_number cursor (exclusive)
-        const beforeBn = before != null && before !== "" ? Number(before) : null;
+        const beforeBn =
+          before != null && before !== "" ? Number(before) : null;
         const rows = await sql`
           SELECT block_number, event_index, pallet, method, args, phase, extrinsic_index, observed_at
           FROM chain_events
@@ -78,13 +83,17 @@ export default {
             ${method ? sql`AND method = ${method}` : sql``}
           ORDER BY block_number DESC, event_index DESC
           LIMIT ${limit}`;
-        const next = rows.length === limit ? rows[rows.length - 1].block_number : null;
+        const next =
+          rows.length === limit ? rows[rows.length - 1].block_number : null;
         return json({ count: rows.length, next_before: next, events: rows });
       }
 
       return json({ error: "not found" }, 404);
     } catch (err) {
-      return json({ error: "data query failed", detail: String(err).slice(0, 200) }, 502);
+      return json(
+        { error: "data query failed", detail: String(err).slice(0, 200) },
+        502,
+      );
     } finally {
       ctx.waitUntil(sql.end({ timeout: 5 }).catch(() => {}));
     }

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -1,0 +1,92 @@
+// metagraphed data Worker — Postgres-backed serving via Cloudflare Hyperdrive.
+//
+// Kept SEPARATE from the main api.mjs Worker (which is near its bundle budget): the
+// postgres.js driver + the growing Postgres-backed read surface live here, and the
+// main Worker routes the relevant paths in via a service binding (DATA_API). This is
+// the serving half of ADR 0013 — the indexer + Rust backfill write the rich Postgres
+// tiers (chain_events / deep history); this exposes them to the public API.
+//
+// READ-ONLY. Every query is parameterized (postgres.js tagged templates). The
+// connection is opened per request through Hyperdrive (pooled + edge-cached) and
+// closed via ctx.waitUntil so it never blocks the response.
+import postgres from "postgres";
+
+const MAX_LIMIT = 200;
+const DEFAULT_LIMIT = 50;
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "access-control-allow-origin": "*",
+      "cache-control": "public, max-age=10",
+    },
+  });
+}
+
+function clampLimit(raw) {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
+  return Math.min(Math.floor(n), MAX_LIMIT);
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    if (request.method !== "GET") return json({ error: "method not allowed" }, 405);
+    if (!env.HYPERDRIVE?.connectionString) {
+      return json({ error: "hyperdrive binding unavailable" }, 503);
+    }
+
+    // `prepare: false` + `fetch_types: false` are the Hyperdrive-recommended settings:
+    // they avoid per-connection type-introspection round-trips and prepared-statement
+    // state that don't survive the pooler. max:5 keeps us within the origin limit.
+    const sql = postgres(env.HYPERDRIVE.connectionString, {
+      max: 5,
+      prepare: false,
+      fetch_types: false,
+      idle_timeout: 10,
+    });
+
+    try {
+      // GET /api/v1/blocks/:n/events — EVERY event in a block (the all-events tier).
+      const block = url.pathname.match(/^\/api\/v1\/blocks\/(\d+)\/events$/);
+      if (block) {
+        const bn = Number(block[1]);
+        const rows = await sql`
+          SELECT event_index, pallet, method, args, phase, extrinsic_index, observed_at
+          FROM chain_events
+          WHERE block_number = ${bn}
+          ORDER BY event_index ASC`;
+        return json({ block_number: bn, count: rows.length, events: rows });
+      }
+
+      // GET /api/v1/chain-events?pallet=&method=&before=&limit= — recent all-events feed.
+      if (url.pathname === "/api/v1/chain-events") {
+        const limit = clampLimit(url.searchParams.get("limit"));
+        const pallet = url.searchParams.get("pallet");
+        const method = url.searchParams.get("method");
+        const before = url.searchParams.get("before"); // block_number cursor (exclusive)
+        const beforeBn = before != null && before !== "" ? Number(before) : null;
+        const rows = await sql`
+          SELECT block_number, event_index, pallet, method, args, phase, extrinsic_index, observed_at
+          FROM chain_events
+          WHERE TRUE
+            ${beforeBn != null && Number.isFinite(beforeBn) ? sql`AND block_number < ${beforeBn}` : sql``}
+            ${pallet ? sql`AND pallet = ${pallet}` : sql``}
+            ${method ? sql`AND method = ${method}` : sql``}
+          ORDER BY block_number DESC, event_index DESC
+          LIMIT ${limit}`;
+        const next = rows.length === limit ? rows[rows.length - 1].block_number : null;
+        return json({ count: rows.length, next_before: next, events: rows });
+      }
+
+      return json({ error: "not found" }, 404);
+    } catch (err) {
+      return json({ error: "data query failed", detail: String(err).slice(0, 200) }, 502);
+    } finally {
+      ctx.waitUntil(sql.end({ timeout: 5 }).catch(() => {}));
+    }
+  },
+};

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -90,10 +90,10 @@ export default {
 
       return json({ error: "not found" }, 404);
     } catch (err) {
-      return json(
-        { error: "data query failed", detail: String(err).slice(0, 200) },
-        502,
-      );
+      // Log internally (Wrangler observability) but NEVER leak DB error details
+      // (schema, table, or connection info) to API clients.
+      console.error("data-api query failed:", err);
+      return json({ error: "data query failed" }, 502);
     } finally {
       ctx.waitUntil(sql.end({ timeout: 5 }).catch(() => {}));
     }

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -1,0 +1,19 @@
+{
+  // Dedicated Postgres-serving Worker (ADR 0013). Deployed separately from the main
+  // api.mjs Worker so the postgres.js driver + growing read surface don't eat the
+  // main Worker's bundle budget. Reached only via the main Worker's DATA_API service
+  // binding (no public routes of its own). Deploy: wrangler deploy -c wrangler.data.jsonc
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "metagraphed-data-api",
+  "main": "workers/data-api.mjs",
+  "compatibility_date": "2026-06-06",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": { "enabled": true },
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+      "id": "d8c62acb5520402b82d039ec482f7cc3",
+      "localConnectionString": "postgresql://postgres:postgres@localhost:5432/metagraphed"
+    }
+  ]
+}

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -13,7 +13,7 @@
     {
       "binding": "HYPERDRIVE",
       "id": "d8c62acb5520402b82d039ec482f7cc3",
-      "localConnectionString": "postgresql://postgres:postgres@localhost:5432/metagraphed"
-    }
-  ]
+      "localConnectionString": "postgresql://postgres:postgres@localhost:5432/metagraphed",
+    },
+  ],
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -107,6 +107,12 @@
       "migrations_dir": "migrations",
     },
   ],
+  // Postgres-backed serving (ADR 0013): the dedicated data Worker (wrangler.data.jsonc)
+  // owns the postgres.js driver + Hyperdrive binding; this Worker routes the
+  // chain_events / deep-history paths to it, keeping this bundle lean.
+  "services": [
+    { "binding": "DATA_API", "service": "metagraphed-data-api" },
+  ],
   // Cron prober: every 15 minutes probes the operational surfaces into D1/KV
   // (served live); the hourly trigger prunes the D1 time-series. 15 min (96
   // checks/day/surface) is ample for a registry's uptime + incident signal and

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -110,9 +110,7 @@
   // Postgres-backed serving (ADR 0013): the dedicated data Worker (wrangler.data.jsonc)
   // owns the postgres.js driver + Hyperdrive binding; this Worker routes the
   // chain_events / deep-history paths to it, keeping this bundle lean.
-  "services": [
-    { "binding": "DATA_API", "service": "metagraphed-data-api" },
-  ],
+  "services": [{ "binding": "DATA_API", "service": "metagraphed-data-api" }],
   // Cron prober: every 15 minutes probes the operational surfaces into D1/KV
   // (served live); the hourly trigger prunes the D1 time-series. 15 min (96
   // checks/day/surface) is ample for a registry's uptime + incident signal and


### PR DESCRIPTION
## What
The indexer + Rust backfill write the rich Postgres tiers (`chain_events`, deep history), but **nothing served them** — the Worker reads D1. This is the serving half of ADR 0013.

## How
A **dedicated data Worker** (`workers/data-api.mjs` + `wrangler.data.jsonc`) owns the `postgres.js` driver + a **Cloudflare Hyperdrive** binding to Railway Postgres, and serves the all-events tier (read-only):
- `GET /api/v1/blocks/:n/events` — every event in a block
- `GET /api/v1/chain-events` — recent all-events feed (`pallet` / `method` / `before` filters, cursor pagination)

The main Worker routes those paths to it via a `DATA_API` **service binding**. Keeping the driver in a separate Worker leaves the main bundle **unchanged at 905.9 KiB** (it's near budget; postgres.js would push it toward the fail line) while the data layer grows freely.

Queries are parameterized (postgres.js tagged templates); the connection opens per request through Hyperdrive (pooled + edge-cached) and closes via `ctx.waitUntil`.

## Gating
The deep-history cutover of `blocks`/`extrinsics`/`account_events` stays **gated on the backfill** (Postgres ≥ D1), D1 as fallback. `chain_events` is net-new (D1 never had it), so it serves immediately.

## Verification
- 6 unit tests (`tests/data-api.test.mjs`, postgres.js mocked): routing, filters, cursor, 405/404/503.
- Verified **live** against Railway Postgres via the deployed data Worker: block all-events (128 events incl. `DifficultySet`/`CRV3WeightsRevealed`), recent feed (live range, `ExtrinsicFailed` with decoded `dispatch_error`), and pallet/method filters.

## Deploy notes
- Hyperdrive config `metagraphed-core` created (SSL `require` → Railway proxy). The data Worker is deployed (`wrangler deploy -c wrangler.data.jsonc`); on merge the main Worker deploys with the service binding so the canonical domain routes through.
- Follow-up: wire a 2nd Workers Builds project for the data Worker's auto-deploy (currently manual); harden Hyperdrive to a private tunnel (today it uses Railway's already-exposed public proxy).