### PR TITLE
fix(api): null negative last_tx_block in buildChainSigners

### DIFF
--- a/src/chain-analytics.mjs
+++ b/src/chain-analytics.mjs
@@ -28,6 +28,13 @@ function toTao(value) {
   return Math.round(n * 1e9) / 1e9;
 }
 
+// Coerce a block-height cell to a non-negative integer, or null when the value is
+// missing, non-finite, or negative — block numbers are never negative on-chain.
+function toBlockNumber(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : null;
+}
+
 // Merge the two per-UTC-day aggregations (extrinsics tier + blocks tier) into one
 // newest-first daily series. `extrinsicRows` carries extrinsic_count /
 // successful_extrinsics / unique_signers; `blockRows` carries block_count /
@@ -151,9 +158,7 @@ export function buildChainSigners({ window, observedAt = null, rows = [] }) {
       tx_count: toCount(r.tx_count),
       total_fee_tao: toTao(r.total_fee_tao),
       total_tip_tao: toTao(r.total_tip_tao),
-      last_tx_block: Number.isFinite(Number(r.last_tx_block))
-        ? Math.trunc(Number(r.last_tx_block))
-        : null,
+      last_tx_block: toBlockNumber(r.last_tx_block),
     }));
   return {
     schema_version: 1,

--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -414,6 +414,21 @@ test("buildChainSigners maps rows + is cold-stable", () => {
   });
 });
 
+test("buildChainSigners nulls non-finite and negative last_tx_block", () => {
+  const out = buildChainSigners({
+    window: "7d",
+    rows: [
+      { signer: "5A", tx_count: 1, last_tx_block: -99 },
+      { signer: "5B", tx_count: 2, last_tx_block: "nope" },
+      { signer: "5C", tx_count: 3, last_tx_block: 12345 },
+    ],
+  });
+  assert.equal(out.signer_count, 3);
+  assert.equal(out.signers[0].last_tx_block, null);
+  assert.equal(out.signers[1].last_tx_block, null);
+  assert.equal(out.signers[2].last_tx_block, 12345);
+});
+
 test("GET /api/v1/chain/signers ranks by tx_count via the signer GROUP BY", async () => {
   const captured = [];
   const env = {


### PR DESCRIPTION
## Summary

Closes #2183

Guard buildChainSigners so last_tx_block is only emitted for finite, non-negative block heights. Corrupt or negative inputs become null instead of leaking an invalid block number in the chain signers leaderboard.

## What Changed

- Add a toBlockNumber helper alongside the existing D1 cell coercers in chain-analytics.mjs.
- Use it when shaping buildChainSigners rows.
- Add unit coverage for negative and non-finite last_tx_block inputs.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] npm run check
- [ ] npm run validate
- [ ] npm run validate:schemas
- [ ] npm run validate:api
- [ ] npm run validate:openapi
- [ ] npm run validate:types
- [ ] npm run validate:artifact-budgets
- [ ] npm run validate:docs
- [ ] npm run validate:intake
- [ ] npm run validate:workflows
- [ ] npm run worker:test
- [ ] npm run test:coverage
- [ ] npm run scan:public-safety
- [ ] git diff --check

Focused tests (not run locally — no Node 22 in this environment):

- npx vitest run tests/chain-analytics.test.mjs
