### PR TITLE
feat(api): advertise the public load-balanced RPC on the API homepage

### DIFF
--- a/workers/request-handlers/discovery.mjs
+++ b/workers/request-handlers/discovery.mjs
@@ -206,6 +206,7 @@ const HOMEPAGE_HTML = `<!doctype html>
 <li><a href="/.well-known/agent-skills/index.json">Agent Skills index</a></li>
 <li><a href="/.well-known/agent-tools/index.json">Agent tool specs</a> — paste-ready OpenAI + Anthropic tools</li>
 <li><a href="/api/v1/feeds/registry">Content feeds</a> — registry changes + incidents (RSS / Atom / JSON Feed)</li>
+<li>Public RPC — load-balanced Bittensor RPC (read-only, health-checked, automatic failover): <code>wss://wss.metagraph.sh/finney</code> (mainnet) · <code>wss://wss.metagraph.sh/test</code> (testnet). Live pool: <a href="/api/v1/rpc/pools">/api/v1/rpc/pools</a></li>
 <li><a href="/api/v1">REST API index</a> · <a href="/sitemap.xml">sitemap.xml</a> · <a href="/auth.md">auth.md</a></li>
 <li><a href="https://metagraph.sh">metagraph.sh</a> — human web app</li>
 </ul>


### PR DESCRIPTION
The wss-lb endpoints (`wss://wss.metagraph.sh/finney` + `/test`) were live but **undocumented anywhere discoverable**. This surfaces them on the `api.metagraph.sh` landing page (read-only, health-checked, automatic failover), linking the live pool at `/api/v1/rpc/pools`.

Note: the LB is a **read-only, method-gated light RPC** (block/header/chain + system + runtime-version) — it does *not* expose deep-state methods, and the upstreams are not all archive (verified: deep-block state returns "State already discarded"). True archive RPC is the upcoming first-party node, so this is worded as plain load-balanced RPC. A dedicated human-facing RPC page is a follow-up in the UI repo.

Verified: prettier clean, discovery tests (57) pass, bundle budget unchanged (906 KiB).