### PR TITLE
feat(api): add block + extrinsic filters to the chain-events feed

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -56,6 +56,16 @@ test("limit is clamped and defaults safely", async () => {
   expect(res.status).toBe(200); // clamp to MAX_LIMIT, no error
 });
 
+test("chain-events accepts block + extrinsic filters (extrinsic-detail view)", async () => {
+  const res = await req("/api/v1/chain-events?block=5870000&extrinsic=3");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.count).toBe(1);
+  // non-numeric filter values are ignored, not errors:
+  const res2 = await req("/api/v1/chain-events?block=abc&extrinsic=");
+  expect(res2.status).toBe(200);
+});
+
 test("POST is rejected with 405", async () => {
   const res = await req("/api/v1/chain-events", { method: "POST" });
   expect(res.status).toBe(405);

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -66,19 +66,29 @@ export default {
         return json({ block_number: bn, count: rows.length, events: rows });
       }
 
-      // GET /api/v1/chain-events?pallet=&method=&before=&limit= — recent all-events feed.
+      // GET /api/v1/chain-events?pallet=&method=&block=&extrinsic=&before=&limit=
+      // recent all-events feed. block= scopes to one block; block=+extrinsic= scopes to
+      // a single extrinsic's emitted events (explorer extrinsic-detail view).
       if (url.pathname === "/api/v1/chain-events") {
         const limit = clampLimit(url.searchParams.get("limit"));
         const pallet = url.searchParams.get("pallet");
         const method = url.searchParams.get("method");
-        const before = url.searchParams.get("before"); // block_number cursor (exclusive)
-        const beforeBn =
-          before != null && before !== "" ? Number(before) : null;
+        const numParam = (k) => {
+          const v = url.searchParams.get(k);
+          if (v == null || v === "") return null;
+          const n = Number(v);
+          return Number.isFinite(n) ? n : null;
+        };
+        const blockN = numParam("block");
+        const extrN = numParam("extrinsic");
+        const beforeBn = numParam("before"); // block_number cursor (exclusive)
         const rows = await sql`
           SELECT block_number, event_index, pallet, method, args, phase, extrinsic_index, observed_at
           FROM chain_events
           WHERE TRUE
-            ${beforeBn != null && Number.isFinite(beforeBn) ? sql`AND block_number < ${beforeBn}` : sql``}
+            ${blockN != null ? sql`AND block_number = ${blockN}` : sql``}
+            ${extrN != null ? sql`AND extrinsic_index = ${extrN}` : sql``}
+            ${beforeBn != null ? sql`AND block_number < ${beforeBn}` : sql``}
             ${pallet ? sql`AND pallet = ${pallet}` : sql``}
             ${method ? sql`AND method = ${method}` : sql``}
           ORDER BY block_number DESC, event_index DESC


### PR DESCRIPTION
Extends the Postgres-backed all-events feed (`GET /api/v1/chain-events`, served by the data Worker via Hyperdrive) with two filters:
- `?block=N` — every event in a block
- `?block=N&extrinsic=I` — a single extrinsic's emitted events (the explorer's extrinsic-detail view)

alongside the existing `pallet`/`method`/`before` filters. Non-numeric values are ignored (not 400s). Queries stay parameterized (postgres.js tagged templates).

Verified live against Railway Postgres: `?block=5870000&extrinsic=3` returns exactly that extrinsic's 3 events. 7 unit tests pass (added a block+extrinsic case). The data Worker is deployed; no main-Worker change (the /chain-events route already proxies to DATA_API).