### PR TITLE
fix(api): sanitize block heights in account builders

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -53,12 +53,20 @@ function toIso(ms) {
   return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
 }
 
+// Coerce a block height or index cell to a non-negative integer, or null when
+// missing, non-finite, or negative — chain positions are never negative.
+function toBlockNumber(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : null;
+}
+
 // One D1 account_events row → a clean API event object (#1347 consumes this).
 export function formatAccountEvent(row) {
   if (!row || typeof row !== "object") return null;
   return {
-    block_number: row.block_number ?? null,
-    event_index: row.event_index ?? null,
+    block_number: toBlockNumber(row.block_number),
+    event_index: toBlockNumber(row.event_index),
     event_kind: row.event_kind ?? null,
     hotkey: row.hotkey ?? null,
     coldkey: row.coldkey ?? null,
@@ -221,7 +229,7 @@ export function formatAccountActivity(agg, modules) {
   const a = agg || {};
   return {
     tx_count: a.tx_count ?? 0,
-    last_tx_block: a.last_tx_block ?? null,
+    last_tx_block: toBlockNumber(a.last_tx_block),
     last_tx_at: toIso(a.last_tx_at),
     total_fee_tao: a.total_fee_tao ?? null,
     modules_called: (modules || [])
@@ -240,8 +248,8 @@ export function buildAccountSummary(
     ss58,
     event_count: a.c ?? 0,
     subnet_count: a.sc ?? 0,
-    first_block: a.fb ?? null,
-    last_block: a.lb ?? null,
+    first_block: toBlockNumber(a.fb),
+    last_block: toBlockNumber(a.lb),
     first_seen_at: toIso(a.fo),
     last_seen_at: toIso(a.lo),
     event_kinds: (kinds || [])
@@ -328,8 +336,8 @@ export function formatAccountDay(row) {
       typeof row.event_kinds === "string" && row.event_kinds.length > 0
         ? row.event_kinds.split(",").filter(Boolean)
         : [],
-    first_block: row.first_block ?? null,
-    last_block: row.last_block ?? null,
+    first_block: toBlockNumber(row.first_block),
+    last_block: toBlockNumber(row.last_block),
   };
 }
 

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -6,6 +6,7 @@ import {
   INDEXED_EVENT_KINDS,
   EVENT_RETENTION_MS,
   formatAccountEvent,
+  formatAccountDay,
   formatRegistration,
   buildAccountSummary,
   buildAccountEvents,
@@ -299,6 +300,33 @@ test("buildAccountSummary threads the signing activity sub-object (#1847)", () =
   // the {call_module:null} row is dropped
   assert.equal(out.activity.modules_called.length, 1);
   assert.equal(out.activity.modules_called[0].call_module, "SubtensorModule");
+});
+
+test("account builders null invalid block heights and indices", () => {
+  const event = formatAccountEvent({
+    block_number: -1,
+    event_index: -2,
+    event_kind: "StakeAdded",
+    observed_at: 1,
+  });
+  assert.equal(event.block_number, null);
+  assert.equal(event.event_index, null);
+
+  const summary = buildAccountSummary("5Hk", {
+    agg: { fb: -5, lb: "nope" },
+    activity: { last_tx_block: -99 },
+  });
+  assert.equal(summary.first_block, null);
+  assert.equal(summary.last_block, null);
+  assert.equal(summary.activity.last_tx_block, null);
+
+  const day = formatAccountDay({
+    day: "2026-01-01",
+    first_block: -1,
+    last_block: 100,
+  });
+  assert.equal(day.first_block, null);
+  assert.equal(day.last_block, 100);
 });
 
 test("formatRegistration defaults every sparse field to null/false (null-safe)", () => {


### PR DESCRIPTION
## Summary

Closes #2187

Sanitize block heights and event indices across the account API builders so negative or non-finite values never leak into summary, activity, history, or event payloads.

## What Changed

- Add a toBlockNumber helper in account-events.mjs for finite, non-negative block positions.
- Apply it in formatAccountEvent, formatAccountActivity, buildAccountSummary, and formatAccountDay.
- Add unit coverage for negative and non-finite inputs.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] npm run check
- [ ] npm run validate
- [ ] npm run validate:schemas
- [ ] npm run validate:api
- [ ] npm run validate:openapi
- [ ] npm run validate:types
- [ ] npm run validate:artifact-budgets
- [ ] npm run validate:docs
- [ ] npm run validate:intake
- [ ] npm run validate:workflows
- [ ] npm run worker:test
- [ ] npm run test:coverage
- [ ] npm run scan:public-safety
- [ ] git diff --check

Focused tests (not run locally — no Node 22 in this environment):

- npx vitest run tests/account-events.test.mjs
