### PR TITLE
chore(api): data Worker — smart placement + traces

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -8,7 +8,23 @@
   "main": "workers/data-api.mjs",
   "compatibility_date": "2026-06-06",
   "compatibility_flags": ["nodejs_compat"],
-  "observability": { "enabled": true },
+  // Smart placement: run the Worker close to the Hyperdrive origin (Railway Postgres)
+  // to minimize the per-request DB round-trip, not at the nearest edge to the client.
+  "placement": { "mode": "smart" },
+  // Full observability — logs AND traces (matches the main Worker).
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "invocation_logs": true,
+    },
+    "traces": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+    },
+  },
   "hyperdrive": [
     {
       "binding": "HYPERDRIVE",


### PR DESCRIPTION
Adds `placement: { mode: smart }` (run the data Worker near the Railway Postgres / Hyperdrive origin to minimize the per-request DB round-trip) and full observability (logs **and** traces, matching the main Worker) to `wrangler.data.jsonc`. Redeployed.