### PR TITLE
fix(network): return mainnet-only 404 before method gate on prefixed routes

### DIFF
--- a/tests/network-routing.test.mjs
+++ b/tests/network-routing.test.mjs
@@ -332,6 +332,34 @@ describe("multi-network routing prefix (Phase 1)", () => {
     assert.equal(subnets.res.status, 200);
   });
 
+  test("mainnet-only routes 404 under testnet for POST as well as GET", async () => {
+    const env = createLocalArtifactEnv();
+    for (const [method, path] of [
+      ["GET", "/api/v1/testnet/graphql"],
+      ["POST", "/api/v1/testnet/graphql"],
+      ["POST", "/api/v1/testnet/ask"],
+      ["GET", "/api/v1/testnet/blocks"],
+    ]) {
+      const { res, body } = await get(env, path, { method });
+      assert.equal(res.status, 404, `${method} ${path}`);
+      assert.equal(body.meta.network, "testnet", `${method} ${path}`);
+      assert.match(
+        body.error.message,
+        /only available on mainnet/i,
+        `${method} ${path}`,
+      );
+    }
+  });
+
+  test("non-mainnet-only POST under a network prefix still returns 405", async () => {
+    const env = createLocalArtifactEnv();
+    const { res, body } = await get(env, "/api/v1/testnet/subnets", {
+      method: "POST",
+    });
+    assert.equal(res.status, 405);
+    assert.equal(body.error.code, "method_not_allowed");
+  });
+
   test("raw artifact: mainnet alias and testnet both serve their partitioned data", async () => {
     const env = createLocalArtifactEnv();
     const mainnet = await get(env, "/metagraph/mainnet/subnets.json");

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1389,6 +1389,24 @@ async function handleNetworkScopedRequest(
   network,
   ctx = {},
 ) {
+  const isApiPath =
+    url.pathname === "/api/v1" || url.pathname.startsWith("/api/v1/");
+
+  // Mainnet-only live/D1 routes 404 under a network prefix regardless of HTTP
+  // method — before the read-only gate so POST does not masquerade as 405.
+  if (
+    isApiPath &&
+    network.id !== "local" &&
+    isMainnetOnlyApiPath(url.pathname)
+  ) {
+    return errorResponse(
+      "not_found",
+      `${url.pathname} is only available on mainnet, not the ${network.id} network.`,
+      404,
+      { network: network.id },
+    );
+  }
+
   if (!["GET", "HEAD"].includes(request.method)) {
     return errorResponse(
       "method_not_allowed",
@@ -1425,7 +1443,7 @@ async function handleNetworkScopedRequest(
     );
   }
 
-  if (url.pathname === "/api/v1" || url.pathname.startsWith("/api/v1/")) {
+  if (isApiPath) {
     if (isMainnetOnlyApiPath(url.pathname)) {
       return errorResponse(
         "not_found",


### PR DESCRIPTION
## Summary

- Evaluate `isMainnetOnlyApiPath` before the read-only method gate in `handleNetworkScopedRequest`.
- Network-prefixed POST/PUT/etc. to mainnet-only paths return the same 404 + `meta.network` as GET.

Closes #2190 

## Why

Agents probing `/api/v1/testnet/graphql` with POST see 405 instead of the documented mainnet-only 404, diverging from sibling GET routes and from bare mainnet behavior.

## Test plan

- [x] `npm test -- tests/network-routing.test.mjs`
- [x] `POST /api/v1/testnet/graphql` → 404, mainnet-only message, `meta.network === "testnet"`
- [x] `GET` on same path unchanged (404 mainnet-only)
- [x] Registry routes under testnet still 200 for GET
