### PR TITLE
fix(api): require block for chain-events extrinsic filter

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -1,7 +1,9 @@
 // Unit tests for the Postgres-serving data Worker (workers/data-api.mjs). postgres.js
 // is mocked so the routing + response shaping are tested with no real DB — the live
 // Hyperdrive→Railway path is validated separately.
-import { test, expect, vi } from "vitest";
+import { beforeEach, test, expect, vi } from "vitest";
+
+const sqlCalls = vi.hoisted(() => []);
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -19,7 +21,10 @@ vi.mock("postgres", () => ({
     ];
     // Every tagged-template call (top-level query OR nested fragment) resolves to rows;
     // the handler awaits the outer query and ignores interpolated fragment values.
-    const sql = () => Promise.resolve(rows);
+    const sql = (strings, ...values) => {
+      sqlCalls.push({ text: Array.from(strings).join("?"), values });
+      return Promise.resolve(rows);
+    };
     sql.end = () => Promise.resolve();
     return sql;
   },
@@ -30,6 +35,11 @@ const env = { HYPERDRIVE: { connectionString: "postgres://mock" } };
 const ctx = { waitUntil() {} };
 const req = (path, init) =>
   worker.fetch(new Request(`https://d${path}`, init), env, ctx);
+const queryText = () => sqlCalls.map((call) => call.text).join("\n");
+
+beforeEach(() => {
+  sqlCalls.length = 0;
+});
 
 test("GET /api/v1/blocks/:n/chain-events returns the block's events", async () => {
   const res = await req("/api/v1/blocks/123/chain-events");
@@ -61,9 +71,18 @@ test("chain-events accepts block + extrinsic filters (extrinsic-detail view)", a
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.count).toBe(1);
+  expect(queryText()).toContain("AND block_number =");
+  expect(queryText()).toContain("AND extrinsic_index =");
   // non-numeric filter values are ignored, not errors:
   const res2 = await req("/api/v1/chain-events?block=abc&extrinsic=");
   expect(res2.status).toBe(200);
+});
+
+test("chain-events ignores extrinsic without block to avoid global scans", async () => {
+  const res = await req("/api/v1/chain-events?extrinsic=999999&limit=1");
+  expect(res.status).toBe(200);
+  expect(queryText()).not.toContain("AND extrinsic_index =");
+  expect(queryText()).not.toContain("AND block_number =");
 });
 
 test("POST is rejected with 405", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -68,7 +68,8 @@ export default {
 
       // GET /api/v1/chain-events?pallet=&method=&block=&extrinsic=&before=&limit=
       // recent all-events feed. block= scopes to one block; block=+extrinsic= scopes to
-      // a single extrinsic's emitted events (explorer extrinsic-detail view).
+      // a single extrinsic's emitted events (explorer extrinsic-detail view). Ignore
+      // extrinsic without block to avoid an unindexed global extrinsic_index scan.
       if (url.pathname === "/api/v1/chain-events") {
         const limit = clampLimit(url.searchParams.get("limit"));
         const pallet = url.searchParams.get("pallet");
@@ -80,7 +81,7 @@ export default {
           return Number.isFinite(n) ? n : null;
         };
         const blockN = numParam("block");
-        const extrN = numParam("extrinsic");
+        const extrN = blockN != null ? numParam("extrinsic") : null;
         const beforeBn = numParam("before"); // block_number cursor (exclusive)
         const rows = await sql`
           SELECT block_number, event_index, pallet, method, args, phase, extrinsic_index, observed_at


### PR DESCRIPTION
### Motivation

- The `extrinsic` query parameter was applied independently on `/api/v1/chain-events`, exposing an unindexed extrinsic-only filter that can force large scans of the public `chain_events` table and amplify DB cost/availability risk. 
- The intended extrinsic-detail shape is block-scoped (`block= + extrinsic=`), so the safer behavior is to ignore `extrinsic` unless a numeric `block` is also supplied.

### Description

- Update `workers/data-api.mjs` to parse `extrinsic` only when a numeric `block` is present by changing the parsing to `const extrN = blockN != null ? numParam("extrinsic") : null;` and adding an explanatory comment. 
- The SQL WHERE emission is unchanged, but the `extrinsic_index` predicate is now only interpolated when `block` is present so extrinsic-only requests do not produce an unindexed filter. 
- Add regression coverage in `tests/data-api.test.mjs` that hoists and records tagged-template calls from the mocked `postgres` client and asserts that `block+extrinsic` emits both `block_number` and `extrinsic_index` predicates while `extrinsic` alone emits neither.

### Testing

- Ran unit tests with `npm test -- tests/data-api.test.mjs` (Vitest) and the test file passed (8 tests). 
- Ran `npm run build` and `npm run validate:api` and both completed successfully. 
- Ran linters and safety checks with `npm run lint`, `npm run format:check`, and `npm run scan:public-safety`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ff8e032c4832c9ed2d6191cca368f)