### PR TITLE
fix(api): throttle postgres chain-events queries

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -85,6 +85,19 @@ test("chain-events ignores extrinsic without block to avoid global scans", async
   expect(queryText()).not.toContain("AND block_number =");
 });
 
+test("chain-events rejects method-only feed filters without a block scope", async () => {
+  const res = await req("/api/v1/chain-events?method=ExtrinsicSuccess");
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toMatch(/method filter requires pallet/);
+});
+
+test("chain-events rejects overlong or non-enumerable pallet/method filters", async () => {
+  const res = await req(`/api/v1/chain-events?pallet=${"A".repeat(65)}`);
+  expect(res.status).toBe(400);
+  const punct = await req("/api/v1/chain-events?pallet=System;DROP");
+  expect(punct.status).toBe(400);
+});
+
 test("POST is rejected with 405", async () => {
   const res = await req("/api/v1/chain-events", { method: "POST" });
   expect(res.status).toBe(405);

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -35,6 +35,38 @@ describe("Worker runtime", () => {
     assert.equal((await response.json()).ok, true);
   });
 
+  test("applies a dedicated rate limiter before forwarding chain-events to DATA_API", async () => {
+    let dataCalls = 0;
+    let rateCalls = 0;
+    const response = await handleRequest(
+      new Request("https://metagraph.sh/api/v1/chain-events", {
+        headers: { "cf-connecting-ip": "203.0.113.9" },
+      }),
+      {
+        ...env,
+        DATA_RATE_LIMITER: {
+          limit({ key }) {
+            rateCalls += 1;
+            assert.equal(key, "data:203.0.113.9");
+            return Promise.resolve({ success: false });
+          },
+        },
+        DATA_API: {
+          fetch() {
+            dataCalls += 1;
+            return new Response(JSON.stringify({ ok: true }), { status: 200 });
+          },
+        },
+      },
+      {},
+    );
+    assert.equal(response.status, 429);
+    assert.equal((await response.json()).error.code, "data_rate_limited");
+    assert.equal(response.headers.get("x-ratelimit-limit"), "60");
+    assert.equal(rateCalls, 1);
+    assert.equal(dataCalls, 0);
+  });
+
   test("serves API envelopes with cache and CORS headers", async () => {
     const response = await handleRequest(
       new Request("https://metagraph.sh/api/v1/subnets/7"),

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -851,6 +851,25 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     url.pathname === "/api/v1/chain-events" ||
     /^\/api\/v1\/blocks\/\d+\/chain-events$/.test(url.pathname)
   ) {
+    if (env.DATA_RATE_LIMITER?.limit) {
+      const { success } = await env.DATA_RATE_LIMITER.limit({
+        key: `data:${resolveClientIp(request)}`,
+      });
+      if (!success) {
+        return errorResponse(
+          "data_rate_limited",
+          "Too many data API requests from this client; slow down.",
+          429,
+          {},
+          {
+            "retry-after": "60",
+            "x-ratelimit-limit": "60",
+            "x-ratelimit-policy": "60;w=60",
+            "x-ratelimit-remaining": "0",
+          },
+        );
+      }
+    }
     if (env.DATA_API) return env.DATA_API.fetch(request);
     return new Response(JSON.stringify({ error: "data tier unavailable" }), {
       status: 503,

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -13,6 +13,11 @@ import postgres from "postgres";
 
 const MAX_LIMIT = 200;
 const DEFAULT_LIMIT = 50;
+const FILTER_PATTERN = /^[A-Za-z][A-Za-z0-9_]{0,63}$/;
+
+function validEventFilter(value) {
+  return value == null || value === "" || FILTER_PATTERN.test(value);
+}
 
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -51,6 +56,7 @@ export default {
     });
 
     try {
+      await sql`SET statement_timeout = '3000ms'`;
       // GET /api/v1/blocks/:n/chain-events — EVERY event in a block (the all-events
       // tier). Distinct from the existing /blocks/:ref/events (curated, D1, #1852).
       const block = url.pathname.match(
@@ -74,6 +80,15 @@ export default {
         const limit = clampLimit(url.searchParams.get("limit"));
         const pallet = url.searchParams.get("pallet");
         const method = url.searchParams.get("method");
+        if (!validEventFilter(pallet) || !validEventFilter(method)) {
+          return json(
+            {
+              error:
+                "pallet and method must be 1-64 ASCII letters, digits, or underscores, starting with a letter",
+            },
+            400,
+          );
+        }
         const numParam = (k) => {
           const v = url.searchParams.get(k);
           if (v == null || v === "") return null;
@@ -83,6 +98,14 @@ export default {
         const blockN = numParam("block");
         const extrN = blockN != null ? numParam("extrinsic") : null;
         const beforeBn = numParam("before"); // block_number cursor (exclusive)
+        if (method && !pallet && blockN == null) {
+          return json(
+            {
+              error: "method filter requires pallet unless block is specified",
+            },
+            400,
+          );
+        }
         const rows = await sql`
           SELECT block_number, event_index, pallet, method, args, phase, extrinsic_index, observed_at
           FROM chain_events

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -164,5 +164,17 @@
         "period": 60,
       },
     },
+    // Per-client abuse control for Postgres-backed data API routes. 60
+    // requests / 60s per client IP, paired with strict query validation and DB
+    // statement timeouts in the data Worker. Skipped when the binding is absent
+    // (local dev/CI).
+    {
+      "name": "DATA_RATE_LIMITER",
+      "namespace_id": "1004",
+      "simple": {
+        "limit": 60,
+        "period": 60,
+      },
+    },
   ],
 }


### PR DESCRIPTION
### Motivation
- The public `/api/v1/chain-events` and per-block chain-events routes previously forwarded directly to the Postgres-backed data Worker without per-client throttling or strict filter validation, enabling sustained unauthenticated query traffic to degrade the DB-backed feed.
- The change aims to add abuse controls and lightweight query validation to protect the deep `chain_events` tier while preserving the existing functionality and public API surface.

### Description
- Add a pre-forwarding per-client rate-limit gate in `handleRequest` so calls to `"/api/v1/chain-events"` and `"/api/v1/blocks/:n/chain-events"` consult `env.DATA_RATE_LIMITER` and return a 429 when exceeded. (`workers/api.mjs`).
- Declare a `DATA_RATE_LIMITER` binding in `wrangler.jsonc` with a conservative default of `60` requests per `60s` per client IP to mirror other per-surface bindings. (`wrangler.jsonc`).
- Harden the data Worker by setting a per-request Postgres `statement_timeout`, adding `pallet`/`method` filter validation with a strict pattern, and rejecting method-only feed queries unless scoped to a block, to avoid inefficient table scans. (`workers/data-api.mjs`).
- Add regression tests covering the DATA_API limiter and unsafe filter shapes by extending `tests/worker-runtime.test.mjs` and `tests/data-api.test.mjs` to assert the new 429 and 400 behaviors. (`tests/worker-runtime.test.mjs`, `tests/data-api.test.mjs`).

### Testing
- Ran lint and formatting checks with `npm run lint` and `npm run format:check`, which completed successfully.
- Built artifacts with `npm run build` and validated routes with `npm run validate:api`, both completing successfully after the build step.
- Executed unit tests: `npm test -- tests/data-api.test.mjs` passed (all data-api tests), `npm test -- tests/worker-runtime.test.mjs -t "applies a dedicated rate limiter"` passed, and the full combined run `npm test -- tests/worker-runtime.test.mjs tests/data-api.test.mjs` completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ffa10ed58832c9a7fd2970c0e90a5)