### PR TITLE
fix(api): canonicalize concentration history cache key

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -69,6 +69,12 @@ function rowsForSql(sql) {
       },
     ];
   }
+  if (sql.includes("FROM neuron_daily")) {
+    return [
+      { snapshot_date: "2026-06-27", stake_tao: 100, emission_tao: 10 },
+      { snapshot_date: "2026-06-27", stake_tao: 1, emission_tao: 1 },
+    ];
+  }
   return [];
 }
 
@@ -204,6 +210,39 @@ describe("analytics edge cache", () => {
     assert.equal(cache.store.size, 3);
     assert.equal(cache.putKeys.length, 3);
     assert.equal(new Set(cache.putKeys).size, 3);
+  });
+
+  test("concentration history canonicalizes equivalent window query strings before caching", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+    const variants = [
+      "https://api.metagraph.sh/api/v1/subnets/7/concentration/history?window=90d",
+      "https://api.metagraph.sh/api/v1/subnets/7/concentration/history?window=90d&",
+      "https://api.metagraph.sh/api/v1/subnets/7/concentration/history?window=90d&&",
+    ];
+
+    const first = await handleRequest(new Request(variants[0]), env, ctx);
+    await Promise.resolve();
+    assert.equal(first.status, 200);
+    const queriesAfterMiss = queries.length;
+
+    for (const variant of variants.slice(1)) {
+      const hit = await handleRequest(new Request(variant), env, ctx);
+      assert.equal(hit.status, 200);
+    }
+
+    assert.equal(queries.length, queriesAfterMiss);
+    assert.deepEqual(cache.putKeys, [
+      expectedKey(
+        "subnet-concentration-history",
+        "/api/v1/subnets/7/concentration/history",
+        "?window=90d",
+      ),
+    ]);
+    assert.equal(cache.store.size, 1);
   });
 
   test("HIT: a pre-populated cache serves the cached body WITHOUT touching D1", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -67,6 +67,7 @@ import {
   handleSubnetHistory,
   handleSubnetConcentration,
   handleSubnetConcentrationHistory,
+  canonicalSubnetConcentrationHistoryCachePath,
   handleAccount,
   handleAccountHistory,
   handleAccountBalance,
@@ -1127,6 +1128,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
             Number(concentrationHistoryMatch[1]),
             resolved.url,
           ),
+        canonicalSubnetConcentrationHistoryCachePath(resolved.url),
       );
     }
     const concentrationMatch = SUBNET_CONCENTRATION_PATH_PATTERN.exec(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -262,6 +262,16 @@ export async function handleSubnetConcentration(request, env, netuid, url) {
   );
 }
 
+export function canonicalSubnetConcentrationHistoryCachePath(url) {
+  const validationError = validateQueryParams(url, ["window"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const { label, error } = parseConcentrationHistoryWindow(
+    url.searchParams.get("window"),
+  );
+  if (error) return `${url.pathname}${url.search}`;
+  return `${url.pathname}?window=${encodeURIComponent(label)}`;
+}
+
 // GET /api/v1/subnets/{netuid}/concentration/history?window=7d|30d|90d: the per-day
 // stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share)
 // from the dated neuron_daily rollup — "is this subnet centralizing over time?".


### PR DESCRIPTION
### Motivation
- The concentration history route was edge-cached using the raw request path+search, allowing semantically-equivalent query-string variants (e.g. `?window=90d`, `?window=90d&`, `?window=90d&&`) to create distinct cache keys and force repeated expensive D1 reads and CPU work.
- Canonicalize the cache lookup to a normalized `?window=<label>` form for valid requests so equivalent queries share a single cache entry while keeping invalid/unsupported raw queries separate.

### Description
- Add `canonicalSubnetConcentrationHistoryCachePath(url)` in `workers/request-handlers/entities.mjs` to validate and normalize the `window` parameter to a canonical `?window=<label>` cache path, while returning the raw path+search for invalid requests.
- Pass the canonical cache path into `withEdgeCache` for the concentration-history route in `workers/api.mjs` so cache keys are built from the normalized search instead of the raw query string.
- Add regression coverage in `tests/analytics-edge-cache.test.mjs` that mocks `neuron_daily` rows and asserts `?window=90d`, `?window=90d&`, and `?window=90d&&` produce a single cache entry and do not re-run D1.

### Testing
- Ran `npm test -- tests/analytics-edge-cache.test.mjs tests/request-handlers-entities.test.mjs` and all tests passed (159/159).
- Ran `npm run build` and `npm run validate` and both succeeded (artifact build and validators passed).
- Ran `npm run lint` and `npm run format:check` and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a400a1c7270832ca326e98ce09eb25b)