### PR TITLE
fix(graphql): set no-store on GraphQL error envelopes

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -917,7 +917,11 @@ export async function handleGraphQLRequest(request, env) {
   return new Response(JSON.stringify(result), {
     status: 200,
     headers: graphqlHeaders({
-      "cache-control": "public, max-age=60, stale-while-revalidate=300",
+      // A GraphQL error is a 200 with a populated `errors` array; never advertise
+      // it as cacheable, or a fronting cache could pin a transient backend failure.
+      "cache-control": result.errors?.length
+        ? "no-store"
+        : "public, max-age=60, stale-while-revalidate=300",
       vary: "Accept-Encoding",
     }),
   });

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -562,6 +562,53 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
   });
 });
 
+describe("handleGraphQLRequest — error envelope is never cacheable", () => {
+  const post = (env) =>
+    handleGraphQLRequest(
+      new Request("https://api.metagraph.sh/api/v1/graphql", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          query: "{ subnets { items { netuid } total } }",
+        }),
+      }),
+      env,
+    );
+
+  test("a clean POST keeps the success cache directive", async () => {
+    const res = await post(emptyEnv);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(
+      res.headers.get("cache-control"),
+      "public, max-age=60, stale-while-revalidate=300",
+    );
+  });
+
+  // A thrown artifact read surfaces in result.errors while execute() stays 200:
+  // readR2 parses the body outside its try/catch, so the rejection propagates.
+  test("a populated result.errors switches to no-store", async () => {
+    const env = {
+      METAGRAPH_R2_LATEST_PREFIX: "latest/",
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return {
+            async json() {
+              throw new Error("corrupt artifact body");
+            },
+          };
+        },
+      },
+    };
+    const res = await post(env);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.ok(body.errors?.length > 0);
+    assert.equal(res.headers.get("cache-control"), "no-store");
+  });
+});
+
 describe("maxDepthRule / maxComplexityRule exports", () => {
   test("GRAPHQL_MAX_DEPTH is a positive integer", () => {
     assert.ok(Number.isInteger(GRAPHQL_MAX_DEPTH) && GRAPHQL_MAX_DEPTH > 0);


### PR DESCRIPTION
## Summary

- A GraphQL `POST` that populated `result.errors` (a resolver hitting a failed KV/D1/R2 read) still returned the success cache directive `public, max-age=60, stale-while-revalidate=300`, so a transient backend error advertised itself as cacheable for 60s and served while stale for a further 300s.
- A GraphQL execution failure always comes back as a standards-compliant `200` envelope with a populated `errors` array, so it slips past the existing norm that only clean `200`s are cached. Emitting `no-store` on that envelope keeps a fronting cache, or a directive-respecting client, from pinning a backend error for the success window.

## What Changed

- `handleGraphQLRequest` now sets `cache-control: no-store` when `result.errors` is populated and keeps the success directive only for a clean result. The status and body stay byte-identical, and the SDL/`GET` response plus the pre-execution `400`/`405`/`413` paths are untouched.
- Added two focused tests in `tests/graphql.test.mjs`: a clean `POST` keeps the success directive, and an errored `POST` (a resolver read that throws, the realistic corrupt-artifact trigger) switches to `no-store`. The errored case fails on the prior code and passes with the fix, and the pair covers both branches of the new conditional.
- No schema, OpenAPI, or contract surface changed, so nothing was regenerated and `validate:contract-drift` stays clean.

Closes #2084

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
