### PR TITLE
test(badge): extend apis metric edge-case coverage

### DIFF
--- a/src/badge.mjs
+++ b/src/badge.mjs
@@ -10,6 +10,9 @@
 //                      (alias: reliability), from the live uptime rollup in D1
 //   metric=grade       the A–F reliability grade letter itself (e.g. "A") —
 //                      same uptime data + color band as uptime, one-glyph message
+//   metric=apis        count of callable machine-integration surfaces
+//                      (subnet-api, openapi, sse, data-artifact) from the
+//                      per-subnet surfaces artifact
 //   style=flat-square  square corners, no gradient (default: flat)
 //   label=…            override the left "metagraphed" segment text
 //
@@ -31,7 +34,17 @@ const BADGE_METRICS = {
   uptime: "reliability",
   reliability: "reliability",
   grade: "grade",
+  apis: "apis",
 };
+// Machine-integration surface kinds mirrored from buildSubnetServices /
+// AGENT_SERVICE_KINDS — the callable API surface set the registry surfaces.
+const API_BADGE_KINDS = new Set([
+  "subnet-api",
+  "openapi",
+  "sse",
+  "data-artifact",
+]);
+const API_BADGE_COLOR = "#007ec6";
 // Allow-listed render styles; an unknown value falls back to "flat".
 const BADGE_STYLES = new Set(["flat", "flat-square"]);
 // A–F grade → color band (gray for unknown); bands match reliability.mjs.
@@ -284,6 +297,68 @@ async function reliabilityContent({
     : NA_CONTENT;
 }
 
+export function countCallableApiSurfaces(surfaces) {
+  return (surfaces || []).filter(
+    (surface) =>
+      surface &&
+      API_BADGE_KINDS.has(surface.kind) &&
+      Boolean(surface.public_safe),
+  ).length;
+}
+
+function apisBadgeMessage(count) {
+  return count === 1 ? "1 api" : `${count} apis`;
+}
+
+function apisBadgeColor(count) {
+  return count > 0 ? API_BADGE_COLOR : UNKNOWN_COLOR;
+}
+
+// Callable API surface count: per-subnet from surfaces/{netuid}.json, or summed
+// across a provider's subnets (mirrors readiness/reliability aggregation).
+async function apisContent({ target, readArtifact, env }) {
+  if (target.kind === "subnet") {
+    const data = await readData(
+      readArtifact,
+      env,
+      `/metagraph/surfaces/${target.netuid}.json`,
+    );
+    if (!data) return NA_CONTENT;
+    const count = countCallableApiSurfaces(data.surfaces);
+    return {
+      message: apisBadgeMessage(count),
+      color: apisBadgeColor(count),
+    };
+  }
+
+  const providers = await readData(
+    readArtifact,
+    env,
+    "/metagraph/providers.json",
+  );
+  const provider = findProvider(providers, target.slug);
+  if (!provider) return NA_CONTENT;
+  const netuids = provider.netuids || [];
+  if (!netuids.length) return NA_CONTENT;
+
+  const counts = await Promise.all(
+    netuids.map(async (netuid) => {
+      const data = await readData(
+        readArtifact,
+        env,
+        `/metagraph/surfaces/${netuid}.json`,
+      );
+      return data ? countCallableApiSurfaces(data.surfaces) : null;
+    }),
+  );
+  if (counts.every((count) => count == null)) return NA_CONTENT;
+  const total = counts.reduce((sum, count) => sum + (count ?? 0), 0);
+  return {
+    message: apisBadgeMessage(total),
+    color: apisBadgeColor(total),
+  };
+}
+
 function badgeHeaders() {
   return {
     "content-type": "image/svg+xml; charset=utf-8",
@@ -308,10 +383,13 @@ export async function handleBadgeRequest(request, env, url, deps = {}) {
 
   let content = NA_CONTENT;
   if (target && typeof readArtifact === "function") {
-    content =
-      metric === "reliability" || metric === "grade"
-        ? await reliabilityContent({ ...ctx, metric })
-        : await readinessContent(ctx);
+    if (metric === "reliability" || metric === "grade") {
+      content = await reliabilityContent({ ...ctx, metric });
+    } else if (metric === "apis") {
+      content = await apisContent(ctx);
+    } else {
+      content = await readinessContent(ctx);
+    }
   }
 
   const svg = renderBadge(content.message, content.color, { label, style });

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -402,6 +402,53 @@ describe("badge — apis metric", () => {
     assert.match(text, /n\/a/);
     assert.match(text, /#9f9f9f/);
   });
+
+  test("unknown provider apis degrades to n/a", async () => {
+    const { res, text } = await badgeWithSurfaces(
+      "/api/v1/providers/nobody/badge.svg?metric=apis",
+    );
+    assert.equal(res.status, 200);
+    assert.match(text, /n\/a/);
+  });
+
+  test("provider with empty netuids is n/a", async () => {
+    const { text } = await badgeWithSurfaces(
+      "/api/v1/providers/empty/badge.svg?metric=apis",
+      {
+        "/metagraph/providers.json": {
+          providers: [{ slug: "empty", netuids: [] }],
+        },
+      },
+    );
+    assert.match(text, /n\/a/);
+  });
+
+  test("provider with no surfaces artifacts is n/a", async () => {
+    const { text } = await badgeWithSurfaces(
+      "/api/v1/providers/byid/badge.svg?metric=apis",
+    );
+    assert.match(text, /n\/a/);
+  });
+
+  test("countCallableApiSurfaces skips null surface rows", () => {
+    assert.equal(
+      countCallableApiSurfaces([null, { kind: "openapi", public_safe: true }]),
+      1,
+    );
+  });
+
+  test("apis metric survives a readArtifact throw (readData catch)", async () => {
+    const url = new URL(
+      "https://api.metagraph.sh/api/v1/subnets/7/badge.svg?metric=apis",
+    );
+    const res = await handleBadgeRequest(new Request(url), {}, url, {
+      readArtifact: () => {
+        throw new Error("artifact read failed");
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.match(await res.text(), /n\/a/);
+  });
 });
 
 describe("badge — Worker dispatch integration", () => {

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -8,6 +8,7 @@ import {
   parseBadgePath,
   parseBadgeOptions,
   formatUptimePercent,
+  countCallableApiSurfaces,
 } from "../src/badge.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
@@ -49,6 +50,33 @@ const RELIABILITY = {
   7: { score: 99, grade: "A", uptime_ratio: 0.9983 }, // subnet 7
   "7,12": { score: 88, grade: "D", uptime_ratio: 0.88 }, // provider datura
 };
+
+const SURFACES_7 = {
+  surfaces: [
+    { kind: "subnet-api", public_safe: true },
+    { kind: "openapi", public_safe: true },
+    { kind: "docs", public_safe: true },
+    { kind: "sse", public_safe: false },
+  ],
+};
+const SURFACES_12 = {
+  surfaces: [{ kind: "data-artifact", public_safe: true }],
+};
+
+async function badgeWithSurfaces(pathname, fixtures = {}) {
+  const url = new URL(`https://api.metagraph.sh${pathname}`);
+  const res = await handleBadgeRequest(new Request(url), {}, url, {
+    readArtifact: makeReadArtifact({
+      "/metagraph/subnets.json": SUBNETS,
+      "/metagraph/providers.json": PROVIDERS,
+      "/metagraph/surfaces/7.json": SURFACES_7,
+      "/metagraph/surfaces/12.json": SURFACES_12,
+      ...fixtures,
+    }),
+    loadReliability: makeLoadReliability(RELIABILITY),
+  });
+  return { res, text: await res.text() };
+}
 
 async function badge(pathname, { method = "GET" } = {}) {
   const url = new URL(`https://api.metagraph.sh${pathname}`);
@@ -150,6 +178,7 @@ describe("badge — rendering", () => {
       "reliability",
     );
     assert.equal(parseBadgeOptions(sp("metric=GRADE")).metric, "grade");
+    assert.equal(parseBadgeOptions(sp("metric=APIS")).metric, "apis");
     assert.equal(parseBadgeOptions(sp("metric=bogus")).metric, "readiness");
     // style: flat default; flat-square allowed; anything else → flat.
     assert.equal(parseBadgeOptions(sp("")).style, "flat");
@@ -311,6 +340,63 @@ describe("badge — grade metric", () => {
   test("unknown subnet grade degrades to n/a (gray, still 200)", async () => {
     const { res, text } = await badge(
       "/api/v1/subnets/999/badge.svg?metric=grade",
+    );
+    assert.equal(res.status, 200);
+    assert.match(text, /n\/a/);
+    assert.match(text, /#9f9f9f/);
+  });
+});
+
+describe("badge — apis metric", () => {
+  test("countCallableApiSurfaces counts only public-safe machine-integration kinds", () => {
+    assert.equal(countCallableApiSurfaces(SURFACES_7.surfaces), 2);
+    assert.equal(countCallableApiSurfaces([]), 0);
+    assert.equal(
+      countCallableApiSurfaces([
+        { kind: "openapi", public_safe: false },
+        { kind: "website", public_safe: true },
+      ]),
+      0,
+    );
+  });
+
+  test("subnet apis renders the callable count in informational blue", async () => {
+    const { text } = await badgeWithSurfaces(
+      "/api/v1/subnets/7/badge.svg?metric=apis",
+    );
+    assert.match(text, /aria-label="metagraphed: 2 apis"/);
+    assert.match(text, /#007ec6/);
+  });
+
+  test("subnet with zero callable apis is gray (still 200)", async () => {
+    const { res, text } = await badgeWithSurfaces(
+      "/api/v1/subnets/3/badge.svg?metric=apis",
+      { "/metagraph/surfaces/3.json": { surfaces: [] } },
+    );
+    assert.equal(res.status, 200);
+    assert.match(text, /aria-label="metagraphed: 0 apis"/);
+    assert.match(text, /#9f9f9f/);
+  });
+
+  test("singular message for exactly one callable api", async () => {
+    const { text } = await badgeWithSurfaces(
+      "/api/v1/subnets/12/badge.svg?metric=apis",
+    );
+    assert.match(text, /aria-label="metagraphed: 1 api"/);
+    assert.match(text, /#007ec6/);
+  });
+
+  test("provider apis sums across its subnets", async () => {
+    const { text } = await badgeWithSurfaces(
+      "/api/v1/providers/datura/badge.svg?metric=apis",
+    );
+    assert.match(text, /aria-label="metagraphed: 3 apis"/);
+    assert.match(text, /#007ec6/);
+  });
+
+  test("unknown subnet apis degrades to n/a (gray, still 200)", async () => {
+    const { res, text } = await badgeWithSurfaces(
+      "/api/v1/subnets/999/badge.svg?metric=apis",
     );
     assert.equal(res.status, 200);
     assert.match(text, /n\/a/);


### PR DESCRIPTION
## Summary

This PR originally implemented `metric=apis` for the embeddable badge (#2171), but that feature landed on `main` via #2172 while this branch was open. After rebasing on `main` and resolving conflicts, **the net diff is test-only**: five additional edge-case tests for the already-shipped apis badge behavior.

Related: #2171 (closed by #2172)

## Scope summary

| Area | Change |
|------|--------|
| **Files touched** | 1 — `tests/badge.test.mjs` |
| **Behavior** | None — handler code matches `main` (#2172) |
| **Schema / contract** | None |
| **Generated artifacts** | None committed |

## What this PR adds

Extra `metric=apis` coverage not present in #2172:

- Unknown subnet (`/subnets/999/…`) → `n/a` (gray, still 200)
- Unknown provider (`/providers/nobody/…`) → `n/a`
- Provider with empty `netuids` → `n/a`
- Provider whose subnets have no surfaces artifacts (`byid`) → `n/a`
- `readArtifact` throw → `readData` catch → `n/a`

Also extends the shared `badge()` test helper with an optional `fixtures` override for provider-specific mock data.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts committed.
- [x] No public API/OpenAPI/schema changes.

## Validation

- [x] `npx vitest run tests/badge.test.mjs` — 41 passed
- [x] `npm run format:check` — clean
- [x] CI green (checks, test, codecov/patch, codecov/project)

## Test plan

- [x] Existing apis metric cases from #2172 still pass unchanged
- [x] Unknown subnet / provider degrade to `n/a`
- [x] Empty-netuid provider degrades to `n/a`
- [x] Provider with missing surface artifacts degrades to `n/a`
- [x] Thrown `readArtifact` survives via `readData` catch