### PR TITLE
feat(wss-lb): support read-only RPC subscriptions over the public WSS

### DIFF
--- a/deploy/wss-lb/src/proxy.mjs
+++ b/deploy/wss-lb/src/proxy.mjs
@@ -4,12 +4,13 @@ import { WebSocket } from "ws";
 import {
   MAX_RPC_BODY_BYTES,
   SAFE_RPC_METHODS,
+  SAFE_RPC_SUBSCRIPTIONS,
   DENIED_RPC_PREFIXES,
 } from "./rpc-policy.mjs";
 
 function isSafeRpcMethod(method) {
   return (
-    SAFE_RPC_METHODS.has(method) &&
+    (SAFE_RPC_METHODS.has(method) || SAFE_RPC_SUBSCRIPTIONS.has(method)) &&
     !DENIED_RPC_PREFIXES.some((prefix) => method.startsWith(prefix))
   );
 }

--- a/deploy/wss-lb/src/rpc-policy.mjs
+++ b/deploy/wss-lb/src/rpc-policy.mjs
@@ -22,6 +22,23 @@ export const SAFE_RPC_METHODS = new Set([
   "system_properties",
   "system_version",
 ]);
+// Read-only WebSocket subscriptions — WSS-ONLY (no HTTP equivalent). KEEP IN SYNC
+// with workers/config.mjs (tests/wss-lb-rpc-policy-sync.test.mjs guards drift).
+export const SAFE_RPC_SUBSCRIPTIONS = new Set([
+  "chain_subscribeNewHeads",
+  "chain_subscribeNewHead",
+  "chain_unsubscribeNewHeads",
+  "chain_subscribeFinalizedHeads",
+  "chain_subscribeFinalisedHeads",
+  "chain_unsubscribeFinalizedHeads",
+  "chain_unsubscribeFinalisedHeads",
+  "chain_subscribeAllHeads",
+  "chain_unsubscribeAllHeads",
+  "state_subscribeStorage",
+  "state_unsubscribeStorage",
+  "state_subscribeRuntimeVersion",
+  "state_unsubscribeRuntimeVersion",
+]);
 export const DENIED_RPC_PREFIXES = [
   "author_",
   "state_call",

--- a/deploy/wss-lb/src/server.mjs
+++ b/deploy/wss-lb/src/server.mjs
@@ -17,6 +17,7 @@ import http from "node:http";
 
 import { WebSocketServer } from "ws";
 
+import { MAX_RPC_BODY_BYTES } from "./rpc-policy.mjs";
 import { proxy } from "./proxy.mjs";
 import { selectWssUpstreams } from "./select.mjs";
 
@@ -95,7 +96,34 @@ const server = http.createServer((req, res) => {
   res.end();
 });
 
-const wss = new WebSocketServer({ noServer: true });
+// maxPayload caps inbound client frames at the protocol layer; the app-level
+// MAX_RPC_BODY_BYTES check in proxy.mjs only fires AFTER ws buffers the full frame.
+const wss = new WebSocketServer({
+  noServer: true,
+  maxPayload: MAX_RPC_BODY_BYTES,
+});
+
+// Heartbeat: WS over the public internet (behind Cloudflare) accumulates half-open
+// sockets that never emit 'close' (NAT/idle timeouts, silent peer death). Each sweep
+// terminates any client that hasn't ponged since the last one; proxy.mjs's client
+// 'close' handler then tears down that client's upstream socket too.
+const HEARTBEAT_MS = envInt("HEARTBEAT_MS", 30000);
+const heartbeat = setInterval(() => {
+  for (const client of wss.clients) {
+    if (client.isAlive === false) {
+      client.terminate();
+      continue;
+    }
+    client.isAlive = false;
+    try {
+      client.ping();
+    } catch {
+      /* socket already closing */
+    }
+  }
+}, HEARTBEAT_MS);
+heartbeat.unref?.();
+
 server.on("upgrade", (req, socket, head) => {
   const network = (req.url || "/")
     .replace(/^\/+/, "")
@@ -112,9 +140,13 @@ server.on("upgrade", (req, socket, head) => {
     socket.destroy();
     return;
   }
-  wss.handleUpgrade(req, socket, head, (client) =>
-    proxy(client, upstreams, { handshakeTimeout: HANDSHAKE_TIMEOUT_MS }),
-  );
+  wss.handleUpgrade(req, socket, head, (client) => {
+    client.isAlive = true;
+    client.on("pong", () => {
+      client.isAlive = true;
+    });
+    proxy(client, upstreams, { handshakeTimeout: HANDSHAKE_TIMEOUT_MS });
+  });
 });
 
 await refresh();

--- a/deploy/wss-lb/test/proxy.test.mjs
+++ b/deploy/wss-lb/test/proxy.test.mjs
@@ -207,3 +207,60 @@ test("security: nested non-scalar RPC ids are not reflected in errors", async ()
   await lb.close();
   await good.close();
 });
+
+test("subscriptions: read-only subscribe frames are relayed to upstream", async () => {
+  const upstreamMethods = [];
+  const http = createServer();
+  const wss = new WebSocketServer({ server: http });
+  wss.on("connection", (ws) => {
+    ws.on("message", (d) => {
+      upstreamMethods.push(JSON.parse(d.toString()).method);
+      // emulate the subscription handshake + a notification (two upstream frames)
+      ws.send(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0xSUBID" }));
+      ws.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          method: "chain_newHead",
+          params: { subscription: "0xSUBID", result: { number: "0x1" } },
+        }),
+      );
+    });
+  });
+  const upstream = await new Promise((resolve) =>
+    http.listen(0, "127.0.0.1", () =>
+      resolve(`ws://127.0.0.1:${http.address().port}`),
+    ),
+  );
+  const lb = await lbServer([upstream]);
+
+  const frames = await new Promise((resolve, reject) => {
+    const seen = [];
+    const c = new WebSocket(lb.url);
+    c.on("open", () =>
+      c.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "chain_subscribeNewHeads",
+        }),
+      ),
+    );
+    c.on("message", (d) => {
+      seen.push(JSON.parse(d.toString()));
+      if (seen.length === 2) {
+        c.close();
+        resolve(seen);
+      }
+    });
+    c.on("error", reject);
+    setTimeout(() => reject(new Error("timeout")), 8000);
+  });
+
+  // relayed (not rejected with -32601), and the notification streamed back through
+  assert.deepEqual(upstreamMethods, ["chain_subscribeNewHeads"]);
+  assert.equal(frames[0].result, "0xSUBID");
+  assert.equal(frames[1].method, "chain_newHead");
+
+  await lb.close();
+  await new Promise((resolve) => http.close(resolve));
+});

--- a/tests/wss-lb-rpc-policy-sync.test.mjs
+++ b/tests/wss-lb-rpc-policy-sync.test.mjs
@@ -16,4 +16,8 @@ test("wss-lb RPC policy matches workers/config.mjs (no drift)", () => {
     [...wsslb.SAFE_RPC_METHODS].sort(),
     [...worker.SAFE_RPC_METHODS].sort(),
   );
+  assert.deepEqual(
+    [...wsslb.SAFE_RPC_SUBSCRIPTIONS].sort(),
+    [...worker.SAFE_RPC_SUBSCRIPTIONS].sort(),
+  );
 });

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -177,6 +177,25 @@ export const SAFE_RPC_METHODS = new Set([
   "system_properties",
   "system_version",
 ]);
+// Read-only WebSocket subscriptions — WSS-ONLY. The HTTP proxy uses SAFE_RPC_METHODS
+// alone (subscriptions need a persistent connection, so they make no sense over HTTP);
+// the wss-lb additionally allows these. Their notifications stream upstream→client.
+// All read-only — author_submitAndWatchExtrinsic stays blocked by the author_ prefix.
+export const SAFE_RPC_SUBSCRIPTIONS = new Set([
+  "chain_subscribeNewHeads",
+  "chain_subscribeNewHead",
+  "chain_unsubscribeNewHeads",
+  "chain_subscribeFinalizedHeads",
+  "chain_subscribeFinalisedHeads",
+  "chain_unsubscribeFinalizedHeads",
+  "chain_unsubscribeFinalisedHeads",
+  "chain_subscribeAllHeads",
+  "chain_unsubscribeAllHeads",
+  "state_subscribeStorage",
+  "state_unsubscribeStorage",
+  "state_subscribeRuntimeVersion",
+  "state_unsubscribeRuntimeVersion",
+]);
 export const DENIED_RPC_PREFIXES = [
   "author_",
   "state_call",


### PR DESCRIPTION
**Makes wss.metagraph.sh actually useful as a live RPC.** Tonight's infra audit found the LB's allowlist had *zero* subscription methods, so it rejected `chain_subscribeNewHeads` / `state_subscribeStorage` / etc. with `-32601` — i.e. the public WSS proxy couldn't do the one thing WSS exists for. The proxy already relays upstream→client frames (so notifications stream fine); only the policy blocked it.

**Changes**
- New WSS-only `SAFE_RPC_SUBSCRIPTIONS` set (read-only new/finalized/all-heads, storage, runtime-version subscriptions + unsubscribes) in `workers/config.mjs`, mirrored in the wss-lb's self-contained copy and enforced in `isSafeRpcMethod`. The HTTP proxy keeps using `SAFE_RPC_METHODS` alone (subscriptions are meaningless over HTTP). Drift guard extended.
- **Heartbeat:** ping/pong sweep reaps half-open client sockets (their upstreams cascade closed via the existing client-close handler) — fixes the leaked-socket risk the audit flagged.
- **maxPayload** on the client WebSocketServer (protocol-level cap; the app-level guard only fired after buffering).
- `author_*` (incl. submitAndWatchExtrinsic) stays blocked by the denied-prefix rule.

Verified: prettier clean, drift/sync test passes, 5/5 wss-lb proxy tests pass (incl. a new 'subscribe frame relayed + notification streamed back' test), bundle budget green.