### PR TITLE
fix(feeds): edge-cache live incident feeds

### DIFF
--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { afterEach, describe, test } from "vitest";
 import {
   handleFeedRequest,
   parseFeedPath,
@@ -9,6 +9,27 @@ import {
 } from "../src/feeds.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+let originalCaches;
+afterEach(() => {
+  globalThis.caches = originalCaches;
+});
+
+function installMockCache() {
+  originalCaches = globalThis.caches;
+  const store = new Map();
+  globalThis.caches = {
+    default: {
+      async match(request) {
+        const cached = store.get(request.url);
+        return cached ? cached.clone() : undefined;
+      },
+      async put(request, response) {
+        store.set(request.url, response.clone());
+      },
+    },
+  };
+}
 
 const {
   registryItems,
@@ -600,7 +621,9 @@ describe("feeds — Worker dispatch integration", () => {
     assert.match(await res.text(), /<rss version="2\.0"/);
   });
 
-  test("handleRequest wires incidents feed to loadGlobalIncidentsLedger", async () => {
+  test("handleRequest caches live incidents feed aggregations at the edge", async () => {
+    installMockCache();
+    let recentChecksQueries = 0;
     const env = {
       ...createLocalArtifactEnv(),
       METAGRAPH_HEALTH_DB: {
@@ -608,21 +631,24 @@ describe("feeds — Worker dispatch integration", () => {
           return {
             bind() {
               return {
-                all: () =>
-                  sql.includes("recent_checks")
-                    ? Promise.resolve({
-                        results: [
-                          {
-                            netuid: 7,
-                            surface_id: "allways-api",
-                            surface_key: "allways-api",
-                            started_at: 1781266255266,
-                            ended_at: 1781499480737,
-                            failed_samples: 1945,
-                          },
-                        ],
-                      })
-                    : Promise.resolve({ results: [] }),
+                all: () => {
+                  if (sql.includes("recent_checks")) {
+                    recentChecksQueries += 1;
+                    return Promise.resolve({
+                      results: [
+                        {
+                          netuid: 7,
+                          surface_id: "allways-api",
+                          surface_key: "allways-api",
+                          started_at: 1781266255266,
+                          ended_at: 1781499480737,
+                          failed_samples: 1945,
+                        },
+                      ],
+                    });
+                  }
+                  return Promise.resolve({ results: [] });
+                },
               };
             },
           };
@@ -637,15 +663,36 @@ describe("feeds — Worker dispatch integration", () => {
         },
       },
     };
-    const res = await handleRequest(
+    const ctx = { waitUntil: (promise) => promise };
+    const first = await handleRequest(
       new Request("https://api.metagraph.sh/api/v1/feeds/incidents.json"),
       env,
-      {},
+      ctx,
     );
-    assert.equal(res.status, 200);
-    const parsed = await res.json();
-    assert.ok(parsed.items.length >= 1);
-    assert.ok(parsed.items[0].id.startsWith("incident:"));
+    assert.equal(first.status, 200);
+    assert.ok((await first.json()).items[0].id.startsWith("incident:"));
+    assert.equal(recentChecksQueries, 1);
+
+    const cached = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/feeds/incidents.json?cachebust=1",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(cached.status, 200);
+    assert.equal(recentChecksQueries, 1);
+
+    const head = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/feeds/incidents.json", {
+        method: "HEAD",
+      }),
+      env,
+      ctx,
+    );
+    assert.equal(head.status, 200);
+    assert.equal(await head.text(), "");
+    assert.equal(recentChecksQueries, 1);
   });
 
   test("an unknown feed path is a 404 with the canonical error envelope", async () => {

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { afterEach, describe, test } from "vitest";
+import { afterEach, beforeEach, describe, test } from "vitest";
 import {
   handleFeedRequest,
   parseFeedPath,
@@ -11,12 +11,19 @@ import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 
 let originalCaches;
+beforeEach(() => {
+  originalCaches = globalThis.caches;
+});
+
 afterEach(() => {
-  globalThis.caches = originalCaches;
+  if (originalCaches === undefined) {
+    delete globalThis.caches;
+  } else {
+    globalThis.caches = originalCaches;
+  }
 });
 
 function installMockCache() {
-  originalCaches = globalThis.caches;
   const store = new Map();
   globalThis.caches = {
     default: {
@@ -671,6 +678,8 @@ describe("feeds — Worker dispatch integration", () => {
     );
     assert.equal(first.status, 200);
     assert.ok((await first.json()).items[0].id.startsWith("incident:"));
+    const etag = first.headers.get("etag");
+    assert.ok(etag);
     assert.equal(recentChecksQueries, 1);
 
     const cached = await handleRequest(
@@ -692,6 +701,18 @@ describe("feeds — Worker dispatch integration", () => {
     );
     assert.equal(head.status, 200);
     assert.equal(await head.text(), "");
+    assert.equal(recentChecksQueries, 1);
+
+    const conditionalHead = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/feeds/incidents.json", {
+        method: "HEAD",
+        headers: { "if-none-match": etag },
+      }),
+      env,
+      ctx,
+    );
+    assert.equal(conditionalHead.status, 304);
+    assert.equal(await conditionalHead.text(), "");
     assert.equal(recentChecksQueries, 1);
   });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -175,7 +175,7 @@ import {
   validEconomicsBackfillRows,
 } from "../src/economics-backfill.mjs";
 import { handleMcpRequest } from "../src/mcp-server.mjs";
-import { handleFeedRequest } from "../src/feeds.mjs";
+import { handleFeedRequest, resolveFeedFormat } from "../src/feeds.mjs";
 import { handleBadgeRequest } from "../src/badge.mjs";
 import { handleOgImage } from "../src/og-image.mjs";
 import { handleIconProxy } from "../src/icon-proxy.mjs";
@@ -918,14 +918,40 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // method gate); `/api/*` is run_worker_first so these never fall through to
   // the static assets. Read-only, content-negotiated, edge-cached.
   if (url.pathname.startsWith("/api/v1/feeds/")) {
-    return handleFeedRequest(request, env, url, {
-      readArtifact,
-      errorResponse,
-      loadLiveIncidents: async (feedEnv) => {
-        const { data } = await loadGlobalIncidentsLedger(feedEnv);
-        return data;
-      },
-    });
+    const feedCacheParams = [
+      `format=${encodeURIComponent(
+        resolveFeedFormat(url.pathname, request.headers.get("accept")),
+      )}`,
+    ];
+    const tag = url.searchParams.get("tag");
+    if (tag != null) feedCacheParams.push(`tag=${encodeURIComponent(tag)}`);
+    const feedCachePath = `${url.pathname}?${feedCacheParams.join("&")}`;
+    const feedRequest =
+      request.method === "HEAD"
+        ? new Request(request.url, { method: "GET", headers: request.headers })
+        : request;
+    const response = await withEdgeCache(
+      feedRequest,
+      ctx,
+      env,
+      "feeds",
+      () =>
+        handleFeedRequest(feedRequest, env, url, {
+          readArtifact,
+          errorResponse,
+          loadLiveIncidents: async (feedEnv) => {
+            const { data } = await loadGlobalIncidentsLedger(feedEnv);
+            return data;
+          },
+        }),
+      feedCachePath,
+    );
+    return request.method === "HEAD"
+      ? new Response(null, {
+          status: response.status,
+          headers: response.headers,
+        })
+      : response;
   }
 
   // Embeddable SVG badges at /api/v1/{subnets/{netuid}|providers/{slug}}/


### PR DESCRIPTION
### Motivation
- Public feed requests were wired to call the live D1 global incidents ledger directly, which allowed unauthenticated clients to repeatedly trigger expensive D1 aggregations and KV reads. 
- The canonical `/api/v1/incidents` route is already guarded by `withEdgeCache`, so feeds should reuse the same edge-cache guard to avoid availability/cost amplification.

### Description
- Wrap the `/api/v1/feeds/*` dispatch in `withEdgeCache` so feed responses (including those that require live incidents) are served from the edge cache when available. (changes: `workers/api.mjs`)
- Canonicalize the feed cache key by the negotiated feed `format` and the supported `tag` filter so unrelated cache-busting query strings do not force fresh D1 aggregations. (changes: `workers/api.mjs`)
- Preserve `HEAD` semantics by warming/reading the GET cache entry and returning an empty HEAD response with the same headers. (changes: `workers/api.mjs`)
- Add a regression integration test that installs a mock Cache API and asserts that an initial live incidents request runs the D1 query once, while a cache-busted GET and a subsequent HEAD do not re-run the D1 aggregation. (changes: `tests/feeds.test.mjs`)

### Testing
- Ran formatting and lint checks with `npx prettier --write workers/api.mjs tests/feeds.test.mjs` and `npx eslint workers/api.mjs tests/feeds.test.mjs`, both completed without failing errors. 
- Ran the focused test file with `npx vitest run tests/feeds.test.mjs`, which passed (`54 tests, 54 passed`).
- Executed `git diff --check` to ensure no whitespace/merge issues and observed no reported problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4015111368832c8877c03f8cac36c9)