### PR TITLE
test: close branch-coverage gaps in hot runtime files

### DIFF
--- a/tests/account-events-branch-coverage.test.mjs
+++ b/tests/account-events-branch-coverage.test.mjs
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  formatAccountEvent,
+  formatAccountActivity,
+  buildSubnetEvents,
+  buildBlockEvents,
+  formatAccountDay,
+  buildAccountHistory,
+  buildAccountTransfers,
+  pruneAccountEvents,
+  loadAccountTransfers,
+} from "../src/account-events.mjs";
+
+// Local D1 (sql, params) => rows runner factory — captures every call so a test
+// can assert the WHERE clause + bound params it produced. Mirrors the loader
+// runner contract: a cold store yields [].
+function makeD1(rowsBySql = []) {
+  const calls = [];
+  const d1 = async (sql, params) => {
+    calls.push({ sql, params });
+    return rowsBySql.shift() ?? [];
+  };
+  d1.calls = calls;
+  return d1;
+}
+
+describe("formatAccountEvent block_number fallback", () => {
+  test("formatAccountEvent falls back block_number to null when nullish", () => {
+    // A row object lacking block_number must surface null (the right arm of
+    // `row.block_number ?? null`), not undefined.
+    const out = formatAccountEvent({ event_kind: "StakeAdded" });
+    assert.equal(out.block_number, null);
+    assert.equal(out.event_kind, "StakeAdded");
+  });
+});
+
+describe("formatAccountActivity count fallback", () => {
+  test("formatAccountActivity defaults a module count to 0 when absent", () => {
+    // A module row with call_module but no count must surface count:0 (the right
+    // arm of `m.count ?? 0`), never undefined.
+    const out = formatAccountActivity({ tx_count: 2 }, [
+      { call_module: "SubtensorModule" },
+    ]);
+    assert.equal(out.modules_called.length, 1);
+    assert.equal(out.modules_called[0].count, 0);
+    assert.equal(out.tx_count, 2);
+  });
+});
+
+describe("buildSubnetEvents", () => {
+  test("buildSubnetEvents is schema-stable for a cold/unknown subnet", () => {
+    // No rows + no options → empty feed, null pagination markers.
+    const out = buildSubnetEvents(null, 99);
+    assert.equal(out.event_count, 0);
+    assert.deepEqual(out.events, []);
+    assert.equal(out.limit, null);
+    assert.equal(out.offset, null);
+    assert.equal(out.next_cursor, null);
+  });
+});
+
+describe("buildBlockEvents", () => {
+  test("buildBlockEvents is schema-stable for a cold/unknown ref", () => {
+    // null rows + undefined ref/blockNumber → schema-stable zero (null markers).
+    const out = buildBlockEvents(null, undefined, undefined);
+    assert.equal(out.ref, null);
+    assert.equal(out.block_number, null);
+    assert.equal(out.event_count, 0);
+    assert.deepEqual(out.events, []);
+    assert.equal(out.limit, null);
+    assert.equal(out.offset, null);
+  });
+});
+
+describe("formatAccountDay", () => {
+  test("formatAccountDay yields empty kinds + null day for a sparse row", () => {
+    // Non-string event_kinds → the `typeof === string && length>0` guard is false
+    // → [] (the false arm). An object lacking `day` exercises the null fallback
+    // of `day ?? null`, and other absent fields fall back to null too.
+    const out = formatAccountDay({ event_kinds: "" });
+    assert.deepEqual(out.event_kinds, []);
+    assert.equal(out.day, null);
+    assert.equal(out.netuid, null);
+    assert.equal(out.event_count, null);
+    assert.equal(out.first_block, null);
+    assert.equal(out.last_block, null);
+  });
+
+  test("formatAccountDay is null-safe on junk rows", () => {
+    assert.equal(formatAccountDay(null), null);
+    assert.equal(formatAccountDay("x"), null);
+  });
+});
+
+describe("buildAccountHistory", () => {
+  test("buildAccountHistory is schema-stable for a coldkey-only/cold store", () => {
+    const out = buildAccountHistory(undefined, "5Hk");
+    assert.equal(out.day_count, 0);
+    assert.deepEqual(out.days, []);
+    assert.equal(out.limit, null);
+    assert.equal(out.offset, null);
+    assert.equal(out.next_cursor, null);
+  });
+});
+
+describe("buildAccountTransfers", () => {
+  test("buildAccountTransfers derives direction=received when coldkey matches", () => {
+    // hotkey !== ss58 but coldkey === ss58 → received (the middle ternary arm).
+    const out = buildAccountTransfers(
+      [{ hotkey: "5Other", coldkey: "5Hk" }],
+      "5Hk",
+    );
+    assert.equal(out.transfers[0].direction, "received");
+  });
+
+  test("buildAccountTransfers yields direction=null when neither key matches", () => {
+    // hotkey !== ss58 AND coldkey !== ss58 → null (the else arm of both ternaries).
+    const out = buildAccountTransfers([{ hotkey: "5A", coldkey: "5B" }], "5Hk");
+    assert.equal(out.transfers[0].direction, null);
+  });
+
+  test("buildAccountTransfers falls back from/to to null when keys absent", () => {
+    // A transfer row lacking hotkey/coldkey must surface from:null and to:null
+    // (the right arms of `r.hotkey ?? null` / `r.coldkey ?? null`), and with
+    // neither key matching ss58 the direction is null.
+    const out = buildAccountTransfers([{ amount_tao: 2 }], "5Hk");
+    const t = out.transfers[0];
+    assert.equal(t.from, null);
+    assert.equal(t.to, null);
+    assert.equal(t.direction, null);
+    assert.equal(t.amount_tao, 2);
+  });
+
+  test("buildAccountTransfers drops non-object rows and is cold-safe", () => {
+    // The `r && typeof r === object` filter drops junk; null rows → empty feed.
+    const out = buildAccountTransfers([null, "x", 7], "5Hk");
+    assert.equal(out.transfer_count, 0);
+    assert.deepEqual(out.transfers, []);
+    const cold = buildAccountTransfers(null, "5Hk");
+    assert.equal(cold.transfer_count, 0);
+    assert.equal(cold.limit, null);
+    assert.equal(cold.offset, null);
+    assert.equal(cold.next_cursor, null);
+  });
+});
+
+describe("pruneAccountEvents changes fallback", () => {
+  test("pruneAccountEvents reports changes:null when meta is absent", async () => {
+    // result.meta?.changes nullish → the right arm of `?? null` (changes:null).
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return { bind: () => ({ run: async () => ({}) }) };
+        },
+      },
+    };
+    const r = await pruneAccountEvents(env, { now: () => 0 });
+    assert.equal(r.pruned, true);
+    assert.equal(r.changes, null);
+  });
+});
+
+describe("loadAccountTransfers direction clauses", () => {
+  test("loadAccountTransfers narrows to hotkey for direction=sent", async () => {
+    const d1 = makeD1([[]]);
+    await loadAccountTransfers(d1, "5Hk", { direction: "sent" });
+    const { sql, params } = d1.calls[0];
+    assert.ok(/hotkey = \?/.test(sql));
+    assert.ok(!/coldkey = \?/.test(sql)); // only the sent (hotkey) side clause
+    // sideParams=[ss58] then lim, off bound.
+    assert.deepEqual(params, ["5Hk", 100, 0]);
+  });
+
+  test("loadAccountTransfers unions both sides when direction is absent", async () => {
+    const d1 = makeD1([[{ block_number: 1, hotkey: "5Hk", observed_at: 1 }]]);
+    const out = await loadAccountTransfers(d1, "5Hk", {});
+    const { sql, params } = d1.calls[0];
+    assert.ok(/\(hotkey = \? OR coldkey = \?\)/.test(sql));
+    assert.deepEqual(params, ["5Hk", "5Hk", 100, 0]);
+    assert.equal(out.transfer_count, 1);
+  });
+});

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -1,0 +1,1196 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const MCP_URL = "https://api.metagraph.sh/mcp";
+
+// Fresh prober run time for live KV fixtures — resolveLiveHealth/economics
+// freshness windows reject anything older than ~25 min.
+const FRESH_RUN = new Date(Date.now() - 60_000).toISOString();
+
+// Build injectable deps with controlled artifact + KV responses (mirror helper).
+function makeDeps(artifacts = {}, kv = {}) {
+  return {
+    readArtifact(_env, path) {
+      if (Object.prototype.hasOwnProperty.call(artifacts, path)) {
+        return Promise.resolve({
+          ok: true,
+          data: artifacts[path],
+          source: "test",
+          storage_tier: "git",
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        code: "artifact_not_found",
+        message: `Artifact not found: ${path}`,
+      });
+    },
+    readHealthKv(_env, key) {
+      return Promise.resolve(
+        Object.prototype.hasOwnProperty.call(kv, key) ? kv[key] : null,
+      );
+    },
+  };
+}
+
+async function rpc(
+  payload,
+  { deps = makeDeps(), env = {}, method = "POST", headers } = {},
+) {
+  const request = new Request(MCP_URL, {
+    method,
+    headers: headers || { "content-type": "application/json" },
+    body: method === "POST" ? JSON.stringify(payload) : undefined,
+  });
+  const response = await handleMcpRequest(request, env, deps);
+  const text = await response.text();
+  return {
+    status: response.status,
+    headers: response.headers,
+    body: text ? JSON.parse(text) : null,
+  };
+}
+
+function callTool(name, args, opts) {
+  return rpc(
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: args },
+    },
+    opts,
+  );
+}
+
+// A minimal AI env whose vector query returns the given subnet netuids in order;
+// `aiInput` flags an input-validation error that runAi maps to invalid_params.
+function aiEnvWithMatches(netuids, { embedError, vectorError } = {}) {
+  return {
+    METAGRAPH_ENABLE_AI: "true",
+    AI: {
+      run(_model, input) {
+        if (input?.text) {
+          if (embedError) return Promise.reject(embedError);
+          const n = Array.isArray(input.text) ? input.text.length : 1;
+          return Promise.resolve({
+            data: Array.from({ length: n }, () => new Array(1024).fill(0.02)),
+          });
+        }
+        return Promise.resolve({ response: "answer [1]." });
+      },
+    },
+    VECTORIZE: {
+      query() {
+        if (vectorError) return Promise.reject(vectorError);
+        return Promise.resolve({
+          matches: netuids.map((n, i) => ({
+            id: `subnet:${n}`,
+            score: 0.9 - i * 0.01,
+            metadata: {
+              type: "subnet",
+              netuid: n,
+              slug: `sn-${n}`,
+              title: `Subnet ${n}`,
+              subtitle: "summary",
+            },
+          })),
+        });
+      },
+    },
+  };
+}
+
+// ── coverageDepthTarget / coverageDepthMatches fallbacks ───────────
+describe("list_enrichment_targets — row fallback + filter branches", () => {
+  // A scorecard row missing every optional field exercises the `|| []`, `?? 0`,
+  // `|| {}`, and `|| null` defaults in coverageDepthTarget, and a row whose
+  // top_gaps/top_gap_codes are absent exercises coverageDepthMatches defaults.
+  const sparseScorecard = {
+    generated_at: "2026-06-01T00:00:00Z",
+    coverage_depth_version: 2,
+    rows: [
+      {
+        netuid: 42,
+        slug: "sparse",
+        name: "Sparse",
+        tier: "needs-evidence",
+        score: 5,
+        priority_score: 9,
+        agent_status: "blocked",
+        blocker_level: "missing-data",
+        // No top_gap_codes, no top_gaps, no recommended_next_action, no dimensions.
+      },
+    ],
+    ranked_queue: [{ rank: 1, netuid: 42 }],
+  };
+
+  test("maps a row with no optional fields to schema-stable defaults", async () => {
+    const res = await callTool(
+      "list_enrichment_targets",
+      {},
+      { deps: makeDeps({ "/metagraph/coverage-depth.json": sparseScorecard }) },
+    );
+    const out = res.body.result.structuredContent;
+    const target = out.targets[0];
+    assert.equal(target.netuid, 42);
+    assert.equal(target.rank, 1);
+    // top_gap_codes || [], top_gaps || [], recommended_next_action || null.
+    assert.deepEqual(target.top_gap_codes, []);
+    assert.deepEqual(target.top_gaps, []);
+    assert.equal(target.recommended_next_action, null);
+    // dimensions defaults: counts ?? 0, arrays/objects || [] / {}.
+    assert.equal(target.dimensions.callable_service_count, 0);
+    assert.deepEqual(target.dimensions.service_kinds, []);
+    assert.equal(target.dimensions.schema_service_count, 0);
+    assert.equal(target.dimensions.schema_missing_count, 0);
+    assert.equal(target.dimensions.fixture_available_count, 0);
+    assert.deepEqual(target.dimensions.fixture_status_counts, {});
+    assert.equal(target.dimensions.example_count, 0);
+    assert.equal(target.dimensions.sdk_count, 0);
+    assert.equal(target.dimensions.candidate_operational_count, 0);
+    assert.equal(target.dimensions.official_surface_count, 0);
+    assert.equal(target.dimensions.provider_claimed_surface_count, 0);
+    // Echoes generated_at + version from the scorecard.
+    assert.equal(out.generated_at, "2026-06-01T00:00:00Z");
+    assert.equal(out.coverage_depth_version, 2);
+  });
+
+  test("maps top_gaps entries to {code,severity,field,next_action}", async () => {
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        rows: [
+          {
+            netuid: 7,
+            slug: "g",
+            name: "G",
+            tier: "machine-usable",
+            score: 50,
+            priority_score: 60,
+            agent_status: "callable",
+            blocker_level: "none",
+            top_gap_codes: ["missing-schema"],
+            top_gaps: [
+              {
+                code: "missing-schema",
+                severity: "needs-review",
+                field: "schemas",
+                next_action: "capture schema",
+              },
+            ],
+            recommended_next_action: "capture schema",
+            dimensions: {
+              callable_service_count: 2,
+              service_kinds: ["openapi"],
+              fixture_status_counts: { ok: 1 },
+            },
+          },
+        ],
+        ranked_queue: [{ rank: 1, netuid: 7 }],
+      },
+    });
+    const res = await callTool("list_enrichment_targets", {}, { deps });
+    const gap = res.body.result.structuredContent.targets[0].top_gaps[0];
+    assert.deepEqual(gap, {
+      code: "missing-schema",
+      severity: "needs-review",
+      field: "schemas",
+      next_action: "capture schema",
+    });
+  });
+
+  test("tier + severity filters exclude a non-matching row", async () => {
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        rows: [
+          {
+            netuid: 7,
+            slug: "g",
+            name: "G",
+            tier: "machine-usable",
+            score: 50,
+            priority_score: 60,
+            agent_status: "callable",
+            blocker_level: "none",
+            top_gap_codes: ["missing-schema"],
+            top_gaps: [{ code: "missing-schema", severity: "needs-review" }],
+          },
+        ],
+        ranked_queue: [{ rank: 1, netuid: 7 }],
+      },
+    });
+    // tier filter mismatches → coverageDepthMatches returns false on the tier arm.
+    const wrongTier = await callTool(
+      "list_enrichment_targets",
+      { tier: "agent-ready" },
+      { deps },
+    );
+    assert.equal(wrongTier.body.result.structuredContent.returned, 0);
+
+    // severity filter mismatches → false on the severity .some() arm.
+    const wrongSeverity = await callTool(
+      "list_enrichment_targets",
+      { severity: "hard" },
+      { deps },
+    );
+    assert.equal(wrongSeverity.body.result.structuredContent.returned, 0);
+
+    // Matching tier + severity passes both arms.
+    const ok = await callTool(
+      "list_enrichment_targets",
+      { tier: "machine-usable", severity: "needs-review" },
+      { deps },
+    );
+    assert.equal(ok.body.result.structuredContent.returned, 1);
+  });
+
+  test("rejects a malformed gap_code with invalid_params", async () => {
+    // optionalGapCode rejects an uppercase/space code (not /^[a-z0-9-]+$/).
+    const res = await callTool(
+      "list_enrichment_targets",
+      { gap_code: "Bad Code!" },
+      { deps: makeDeps({ "/metagraph/coverage-depth.json": sparseScorecard }) },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /gap_code/);
+  });
+
+  test("scorecard with no rows/ranked_queue returns empty targets", async () => {
+    // rows not array → []; ranked_queue not array → []; null generated_at/version.
+    const res = await callTool(
+      "list_enrichment_targets",
+      {},
+      { deps: makeDeps({ "/metagraph/coverage-depth.json": {} }) },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total_rows, 0);
+    assert.equal(out.queue_count, 0);
+    assert.equal(out.returned, 0);
+    assert.equal(out.generated_at, null);
+    assert.equal(out.coverage_depth_version, null);
+  });
+
+  test("a ranked_queue entry with no scorecard row falls back to the entry itself", async () => {
+    // rowsByNetuid has no row for netuid 5, so the queue entry (which carries a
+    // netuid) is used as the row; entries without an integer netuid are filtered.
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        rows: [],
+        ranked_queue: [
+          { rank: 1, netuid: 5, tier: "hard-blocked", score: 1 },
+          { rank: 2 }, // no netuid → filtered out
+        ],
+      },
+    });
+    const res = await callTool("list_enrichment_targets", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.targets[0].netuid, 5);
+    assert.equal(out.targets[0].rank, 1);
+  });
+
+  test("netuid filter returns that subnet's row with rank null, errors when absent", async () => {
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": sparseScorecard,
+    });
+    const row = await callTool(
+      "list_enrichment_targets",
+      { netuid: 42 },
+      { deps },
+    );
+    assert.equal(row.body.result.structuredContent.targets[0].netuid, 42);
+    assert.equal(row.body.result.structuredContent.targets[0].rank, null);
+
+    const missing = await callTool(
+      "list_enrichment_targets",
+      { netuid: 999 },
+      { deps },
+    );
+    assert.equal(missing.body.result.isError, true);
+    assert.match(missing.body.result.content[0].text, /No coverage-depth/);
+  });
+});
+
+// ── search_subnets / list_subnets filter fallbacks ─
+describe("search + list filter/fallback branches", () => {
+  test("search_subnets skips a doc whose tokens is not an array", async () => {
+    // scoreDocument's `Array.isArray(doc.tokens) ? doc.tokens : []` false arm,
+    // and the docs `Array.isArray(index.documents)` guard.
+    const deps = makeDeps({
+      "/metagraph/search.json": {
+        documents: [
+          {
+            type: "subnet",
+            netuid: 1,
+            slug: "a",
+            title: "Alpha",
+            subtitle: "alpha sub",
+            tokens: "not-an-array",
+          },
+        ],
+      },
+    });
+    const res = await callTool("search_subnets", { query: "alpha" }, { deps });
+    const out = res.body.result.structuredContent;
+    // Still scores via name/slug; tokens default to [].
+    assert.equal(out.results[0].netuid, 1);
+  });
+
+  test("search_subnets returns empty when documents is not an array", async () => {
+    const deps = makeDeps({ "/metagraph/search.json": { documents: null } });
+    const res = await callTool("search_subnets", { query: "x" }, { deps });
+    assert.equal(res.body.result.structuredContent.total, 0);
+  });
+
+  test("list_subnets returns empty subnets when the index has no array", async () => {
+    // `Array.isArray(index.subnets) ? index.subnets : []` false arm.
+    const deps = makeDeps({ "/metagraph/subnets.json": { subnets: null } });
+    const res = await callTool("list_subnets", {}, { deps });
+    assert.equal(res.body.result.structuredContent.total, 0);
+  });
+
+  test("list_subnets status + subnet_type filters coerce missing fields", async () => {
+    // Rows with no status / subnet_type exercise String(... || "") on the false
+    // side of each filter; the matching row passes both.
+    const deps = makeDeps({
+      "/metagraph/subnets.json": {
+        subnets: [
+          {
+            netuid: 1,
+            name: "A",
+            status: "active",
+            subnet_type: "application",
+          },
+          { netuid: 2, name: "B" }, // no status, no subnet_type
+        ],
+      },
+    });
+    const byStatus = await callTool(
+      "list_subnets",
+      { status: "active" },
+      { deps },
+    );
+    assert.equal(byStatus.body.result.structuredContent.total, 1);
+    assert.equal(byStatus.body.result.structuredContent.subnets[0].netuid, 1);
+
+    const byType = await callTool(
+      "list_subnets",
+      { subnet_type: "application" },
+      { deps },
+    );
+    assert.equal(byType.body.result.structuredContent.total, 1);
+  });
+
+  test("list_subnets maps a row missing slug/name/scores to nulls", async () => {
+    // The mapper fallbacks: slug ?? null, title ?? null, non-number readiness /
+    // surface_count → null.
+    const deps = makeDeps({
+      "/metagraph/subnets.json": {
+        subnets: [
+          {
+            netuid: 3,
+            integration_readiness: "high",
+            surface_count: "many",
+          },
+        ],
+      },
+    });
+    const res = await callTool("list_subnets", {}, { deps });
+    const sub = res.body.result.structuredContent.subnets[0];
+    assert.equal(sub.slug, null);
+    assert.equal(sub.title, null);
+    assert.equal(sub.integration_readiness, null);
+    assert.equal(sub.surface_count, null);
+  });
+});
+
+// ── find_subnets_by_capability sort tie-breaks ────────────────────
+describe("find_subnets_by_capability — sort tie-break arms", () => {
+  test("equal scores tie-break by integration_readiness then callable_count", async () => {
+    // Two subnets with the same keyword score force the secondary comparator
+    // (integration_readiness) and, when equal, the tertiary (callable_count).
+    const deps = makeDeps({
+      "/metagraph/agent-catalog.json": {
+        subnets: [
+          {
+            netuid: 1,
+            slug: "data-a",
+            name: "data",
+            categories: ["data"],
+            service_kinds: ["subnet-api"],
+            callable_count: 2,
+            integration_readiness: 50,
+          },
+          {
+            netuid: 2,
+            slug: "data-b",
+            name: "data",
+            categories: ["data"],
+            service_kinds: ["subnet-api"],
+            callable_count: 9,
+            integration_readiness: 90,
+          },
+          {
+            netuid: 3,
+            slug: "data-c",
+            name: "data",
+            categories: ["data"],
+            service_kinds: ["subnet-api"],
+            callable_count: 4,
+            integration_readiness: 90,
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "find_subnets_by_capability",
+      { capability: "data" },
+      { deps },
+    );
+    const order = res.body.result.structuredContent.results.map(
+      (r) => r.netuid,
+    );
+    // 2 and 3 share readiness 90 → callable_count desc (9 then 4); 1 last.
+    assert.deepEqual(order, [2, 3, 1]);
+  });
+});
+
+// ── window / board default + profiles fallback ─
+describe("analytics tools — default windows + profiles fallback", () => {
+  test("get_registry_leaderboards falls back to [] when profiles is absent", async () => {
+    // `(...).profiles || []` false arm: a profiles.json with no `profiles` key.
+    const deps = makeDeps({
+      "/metagraph/profiles.json": {},
+      "/metagraph/economics.json": { subnets: [] },
+    });
+    const res = await callTool(
+      "get_registry_leaderboards",
+      { limit: 3 },
+      { deps },
+    );
+    assert.equal(res.body.result.isError, false);
+    assert.ok(typeof res.body.result.structuredContent.boards === "object");
+  });
+
+  test("compare_subnets falls back to [] when profiles is absent", async () => {
+    const deps = makeDeps({
+      "/metagraph/profiles.json": {},
+      "/metagraph/economics.json": { subnets: [] },
+    });
+    const res = await callTool(
+      "compare_subnets",
+      { netuids: [1], dimensions: ["structure"] },
+      { deps },
+    );
+    assert.equal(res.body.result.isError, false);
+    assert.deepEqual(res.body.result.structuredContent.requested_netuids, [1]);
+  });
+
+  test("get_global_incidents defaults to the 7d window when omitted", async () => {
+    // args.window === undefined skips the invalid-params guard; default "7d".
+    const res = await callTool(
+      "get_global_incidents",
+      {},
+      { deps: makeDeps({}, { "health:meta": { last_run_at: FRESH_RUN } }) },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.observed_at, FRESH_RUN);
+  });
+});
+
+// ── mcpObservedAt readHealthKv-missing ─────────────────────────────────
+describe("mcpObservedAt — readHealthKv missing returns null observed_at", () => {
+  test("get_subnet_uptime reports observed_at null when no readHealthKv dep", async () => {
+    // ctx.readHealthKv is undefined → mcpObservedAt returns null immediately.
+    const depsNoKvFn = {
+      readArtifact() {
+        return Promise.resolve({ ok: true, data: {} });
+      },
+    };
+    const res = await callTool(
+      "get_subnet_uptime",
+      { netuid: 7 },
+      { deps: depsNoKvFn },
+    );
+    assert.equal(res.body.result.structuredContent.observed_at, null);
+  });
+});
+
+// ── loadEconomicsSubnetRows R2 fallback ────────────────────────────────
+describe("find_subnet_opportunities + leaderboards — economics R2 fallback", () => {
+  test("get_registry_leaderboards tolerates economics blob with no subnets array", async () => {
+    // `Array.isArray(blob?.subnets) ? blob.subnets : []` false arm.
+    const deps = makeDeps({
+      "/metagraph/profiles.json": { profiles: [] },
+      "/metagraph/economics.json": {},
+    });
+    const res = await callTool("get_registry_leaderboards", {}, { deps });
+    assert.equal(res.body.result.isError, false);
+  });
+});
+
+// ── list_subnet_apis fallbacks ────────────────────────────
+describe("list_subnet_apis — detail fallback fields", () => {
+  test("falls back to the requested netuid + empty services when detail is bare", async () => {
+    // detail.netuid ?? netuid, services not array → 0, data.services || [].
+    const deps = makeDeps({ "/metagraph/agent-catalog/7.json": {} });
+    const res = await callTool("list_subnet_apis", { netuid: 7 }, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.service_count, 0);
+    assert.deepEqual(out.services, []);
+    assert.equal(out.operational_observed_at, null);
+    assert.equal(out.health_source, "unavailable");
+  });
+});
+
+// ── get_best_rpc_endpoint helpers ────────────────────────────────
+describe("get_best_rpc_endpoint — dedupe, scoring + field fallbacks", () => {
+  test("dedupes by id keeping the best score and maps absent fields to null", async () => {
+    // Two pools share endpoint 'a' (one ineligible, one eligible higher score)
+    // and a lower-score 'a' so the `(score||0) > (existing.score||0)` arm fires.
+    // 'b' carries no url/provider/kind/score/latency → each `?? null` fallback.
+    const deps = makeDeps({
+      "/metagraph/rpc/pools.json": {
+        pools: {
+          0: {
+            endpoints: [
+              {
+                id: "a",
+                url: "wss://a.example",
+                score: 10,
+                pool_eligible: true,
+                latency_ms: 50,
+              },
+              { id: "b", pool_eligible: true },
+              { id: "c", pool_eligible: false, score: 99 },
+            ],
+          },
+          1: {
+            endpoints: [
+              {
+                id: "a",
+                url: "wss://a-better.example",
+                score: 80,
+                pool_eligible: true,
+                latency_ms: 40,
+              },
+            ],
+          },
+        },
+      },
+    });
+    const res = await callTool("get_best_rpc_endpoint", { limit: 5 }, { deps });
+    const out = res.body.result.structuredContent;
+    // 'a' deduped (best score 80) + 'b'; 'c' ineligible. live_health false.
+    assert.equal(out.eligible_count, 2);
+    assert.equal(out.live_health, false);
+    const a = out.endpoints.find((e) => e.id === "a");
+    assert.equal(a.url, "wss://a-better.example");
+    assert.equal(a.score, 80);
+    const b = out.endpoints.find((e) => e.id === "b");
+    assert.equal(b.url, null);
+    assert.equal(b.provider, null);
+    assert.equal(b.kind, null);
+    assert.equal(b.score, null);
+    assert.equal(b.latency_ms, null);
+    // Network is always finney; layer defaults to bittensor-base.
+    assert.equal(b.network, "finney");
+    assert.equal(b.layer, "bittensor-base");
+  });
+
+  test("sorts equal-score endpoints by ascending latency (Infinity for missing)", async () => {
+    // Two eligible same-score endpoints: the one with a latency sorts before the
+    // one without (?? Infinity). Exercises the latency tie-break comparator arm.
+    const deps = makeDeps({
+      "/metagraph/rpc/pools.json": {
+        pools: {
+          0: {
+            endpoints: [
+              { id: "slow", score: 5, pool_eligible: true },
+              { id: "fast", score: 5, pool_eligible: true, latency_ms: 12 },
+            ],
+          },
+        },
+      },
+    });
+    const res = await callTool("get_best_rpc_endpoint", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.endpoints[0].id, "fast");
+  });
+
+  test("tolerates a pool whose endpoints field is absent", async () => {
+    // overlaid.endpoints || [] false arm: a pool object with no endpoints array.
+    const deps = makeDeps({
+      "/metagraph/rpc/pools.json": { pools: { 0: {} } },
+    });
+    const res = await callTool("get_best_rpc_endpoint", {}, { deps });
+    assert.equal(res.body.result.structuredContent.eligible_count, 0);
+  });
+});
+
+// ── how_do_i_call snippet / fixture branches ───────────────
+describe("how_do_i_call — snippet fallback + fixture content-type branches", () => {
+  test("falls back to stored snippets when generateServiceSnippets returns nothing", async () => {
+    // A service with no base_url makes generateServiceSnippets return null, so
+    // `|| s.snippets` is used; with neither it becomes null.
+    const deps = makeDeps({
+      "/metagraph/agent-catalog/7.json": {
+        netuid: 7,
+        name: "Data",
+        slug: "sn-7",
+        integration_readiness: 70,
+        services: [
+          {
+            surface_id: "sn-7-api",
+            kind: "subnet-api",
+            capability: "Data API",
+            base_url: null,
+            auth_required: false,
+            auth_schemes: [],
+            schema_artifact: null,
+            schema_url: null,
+            eligibility: { callable: true },
+            snippets: { curl: "stored-curl" },
+            fixture: {
+              artifact_path: "/metagraph/fixtures/sn-7-api.json",
+              captured_at: "2026-06-18T00:00:00Z",
+              response: { status: 200, content_type: "application/json" },
+            },
+          },
+        ],
+      },
+    });
+    const res = await callTool("how_do_i_call", { netuid: 7 }, { deps });
+    const svc = res.body.result.structuredContent.services[0];
+    // generateServiceSnippets(null base_url) → null → falls back to stored.
+    assert.deepEqual(svc.snippets, { curl: "stored-curl" });
+    // fixture available branch: response_status + content_type read.
+    assert.equal(svc.fixture.available, true);
+    assert.equal(svc.fixture.response_status, 200);
+    assert.equal(svc.fixture.content_type, "application/json");
+  });
+
+  test("a fixture with no response object yields null status/content_type", async () => {
+    // s.fixture.response?.status ?? null and content_type ?? null false arms.
+    const deps = makeDeps({
+      "/metagraph/agent-catalog/7.json": {
+        netuid: 7,
+        name: "Data",
+        slug: "sn-7",
+        integration_readiness: 70,
+        services: [
+          {
+            surface_id: "sn-7-api",
+            kind: "subnet-api",
+            capability: "Data API",
+            base_url: "https://api.data.io",
+            auth_required: false,
+            auth_schemes: [],
+            schema_artifact: null,
+            schema_url: null,
+            eligibility: { callable: true },
+            fixture: { artifact_path: "/p.json", captured_at: "2026-06-18" },
+          },
+        ],
+      },
+    });
+    const res = await callTool("how_do_i_call", { netuid: 7 }, { deps });
+    const fx = res.body.result.structuredContent.services[0].fixture;
+    assert.equal(fx.available, true);
+    assert.equal(fx.response_status, null);
+    assert.equal(fx.content_type, null);
+  });
+});
+
+// ── verify_integration — surface resolution ─────────────────────────────────
+describe("verify_integration — surface resolution branches", () => {
+  test("tolerates an operational-surfaces artifact with no surfaces array", async () => {
+    // `Array.isArray(catalog?.surfaces) ? catalog.surfaces : []` false arm.
+    const deps = makeDeps({ "/metagraph/operational-surfaces.json": {} });
+    const res = await callTool("verify_integration", { netuid: 5 }, { deps });
+    assert.equal(res.body.result.isError, true);
+  });
+});
+
+// ── resource cursor + uri parsing ───────────────────────────────
+describe("resources — cursor decode + uri parsing edge arms", () => {
+  test("resources/list ignores a non-numeric cursor (decodes to 0)", async () => {
+    // decodeResourceCursor: a non-integer cursor → 0, so page one is returned.
+    const subnets = Array.from({ length: 3 }, (_, i) => ({
+      netuid: i,
+      name: `SN${i}`,
+    }));
+    const deps = makeDeps({ "/metagraph/subnets.json": { subnets } });
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/list",
+        params: { cursor: "not-a-number" },
+      },
+      { deps },
+    );
+    const uris = res.body.result.resources.map((r) => r.uri);
+    assert.ok(uris.includes("metagraph://subnet/0"));
+  });
+
+  test("resources/read rejects a metagraph uri with no slash after the type", async () => {
+    // parseResourceUri: rest.indexOf('/') < 0 → null → invalid_params.
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "resources/read",
+      params: { uri: "metagraph://justtype" },
+    });
+    assert.equal(res.body.error.code, -32602);
+  });
+});
+
+// ── prompts/get argument default ──────────────────────────────────────
+describe("prompts/get — arguments default to empty object", () => {
+  test("a prompt invoked with no arguments object reports the missing required arg", async () => {
+    // params.arguments is undefined → `|| {}`; the required arg is then missing.
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "prompts/get",
+      params: { name: "integrate_with_subnet" },
+    });
+    assert.equal(res.body.error.code, -32602);
+    assert.match(res.body.error.message, /Missing required prompt argument/);
+  });
+});
+
+// ── callTool unknown-tool + arguments default ─────────────────────────
+describe("tools/call — arguments default + unknown tool", () => {
+  test("a tools/call with no arguments object still runs the handler", async () => {
+    // params.arguments undefined → `|| {}`; registry_summary needs no args.
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "registry_summary" },
+      },
+      { deps: makeDeps({ "/metagraph/registry-summary.json": { ok: 1 } }) },
+    );
+    assert.equal(res.body.result.isError, false);
+    assert.equal(res.body.result.structuredContent.ok, 1);
+  });
+});
+
+// ── dispatch notification short-circuits for each method ─────────
+describe("dispatchMessage — notification arms across methods", () => {
+  test("resources/templates/list, resources/read, prompts/list, prompts/get as notifications return 202", async () => {
+    // Each `isNotification ? null : ...` true arm — no id on an otherwise-valid
+    // method drops the message (no response object), so the batch yields 202.
+    for (const message of [
+      { jsonrpc: "2.0", method: "resources/templates/list" },
+      {
+        jsonrpc: "2.0",
+        method: "resources/read",
+        params: { uri: "metagraph://subnet/7" },
+      },
+      { jsonrpc: "2.0", method: "prompts/list" },
+      {
+        jsonrpc: "2.0",
+        method: "prompts/get",
+        params: { name: "integrate_with_subnet", arguments: { netuid: 7 } },
+      },
+      { jsonrpc: "2.0", method: "tools/call", params: { name: "ping" } },
+    ]) {
+      const res = await rpc(message);
+      assert.equal(res.status, 202, `${message.method} as notification → 202`);
+    }
+  });
+});
+
+// ── rate limiter + body-size guards ─────────────────────────────
+describe("handleMcpRequest — rate limiter success + content-length guard", () => {
+  test("the RPC_RATE_LIMITER fallback allows the request when success is true", async () => {
+    // enforceMcpRateLimit: env.MCP_RATE_LIMITER absent → RPC_RATE_LIMITER used;
+    // success: true → returns null (no 429) and the request proceeds.
+    let seenKey;
+    const env = {
+      RPC_RATE_LIMITER: {
+        async limit({ key }) {
+          seenKey = key;
+          return { success: true };
+        },
+      },
+    };
+    const res = await rpc({ jsonrpc: "2.0", id: 1, method: "ping" }, { env });
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body.result, {});
+    assert.equal(typeof seenKey, "string");
+  });
+
+  test("a request whose content-length exceeds the cap is rejected with 413", async () => {
+    // contentLength > MAX_MCP_BODY_BYTES short-circuits before reading the body.
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(64 * 1024 + 1),
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    const response = await handleMcpRequest(request, {}, makeDeps());
+    assert.equal(response.status, 413);
+    const body = await response.json();
+    assert.equal(body.error.code, -32600);
+  });
+});
+
+// ── resolveNetuid index fallback ───────────────────────────────────────
+describe("resolveNetuid — subnets index array fallback", () => {
+  test("how_do_i_call resolves a slug when subnets.json has no array", async () => {
+    // `Array.isArray(index.subnets) ? index.subnets : []` false arm → no match.
+    const deps = makeDeps({
+      "/metagraph/subnets.json": { subnets: null },
+    });
+    const res = await callTool("how_do_i_call", { subnet: "ghost" }, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /No subnet matches/);
+  });
+});
+
+// ── extra targeted arms ──────────────────────────────────────────────────────
+describe("AI tools — runAi re-throws a non-input AI fault", () => {
+  test("semantic_search wraps a Vectorize rejection as an internal error", async () => {
+    // semanticSearch rejects with a plain (non-aiInput) Error → runAi re-throws
+    // → callTool's internal-error path (sanitized isError, code internal_error).
+    const env = aiEnvWithMatches([1], {
+      vectorError: new Error("vectorize exploded"),
+    });
+    const res = await callTool("semantic_search", { query: "images" }, { env });
+    assert.equal(res.body.result.isError, true);
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "internal_error",
+    );
+    assert.ok(!JSON.stringify(res.body).includes("vectorize exploded"));
+  });
+});
+
+describe("find_subnet_for_task — keyword callability filter arms", () => {
+  test("keyword ranking drops a non-callable scored doc and tie-breaks equal scores by netuid", async () => {
+    // doc 9 scores>0 but is NOT in the catalog (dropped → isCallable false arm);
+    // docs 2 and 1 score equally and are callable → the sort comparator's
+    // `b.relevance - a.relevance || a.netuid - b.netuid` exercises BOTH arms:
+    // the relevance term (vs the dropped/other doc) and the netuid tie-break.
+    const equalToken = ["dataword"];
+    const deps = makeDeps({
+      "/metagraph/search.json": {
+        documents: [
+          {
+            type: "subnet",
+            netuid: 2,
+            slug: "sn-2",
+            title: "Two",
+            subtitle: "x",
+            tokens: equalToken,
+          },
+          {
+            type: "subnet",
+            netuid: 1,
+            slug: "sn-1",
+            title: "One",
+            subtitle: "x",
+            tokens: equalToken,
+          },
+          {
+            type: "subnet",
+            netuid: 9,
+            slug: "sn-9",
+            title: "Nine",
+            subtitle: "x",
+            tokens: equalToken,
+          },
+        ],
+      },
+      "/metagraph/agent-catalog.json": {
+        subnets: [
+          {
+            netuid: 1,
+            name: "One",
+            slug: "sn-1",
+            categories: [],
+            integration_readiness: 80,
+            callable_count: 1,
+            service_kinds: ["openapi"],
+            base_url: "https://one.io",
+            health: "operational",
+          },
+          {
+            netuid: 2,
+            name: "Two",
+            slug: "sn-2",
+            categories: [],
+            integration_readiness: 80,
+            callable_count: 1,
+            service_kinds: ["openapi"],
+            base_url: "https://two.io",
+            health: "operational",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "find_subnet_for_task",
+      { task: "dataword" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.discovery, "keyword");
+    assert.equal(out.count, 2);
+    // Equal relevance → ascending netuid tie-break: 1 then 2; 9 dropped.
+    assert.deepEqual(
+      out.results.map((r) => r.netuid),
+      [1, 2],
+    );
+  });
+});
+
+describe("list_enrichment_targets — gap_code + severity matcher arms", () => {
+  const scorecard = {
+    rows: [
+      {
+        netuid: 7,
+        slug: "g",
+        name: "G",
+        tier: "machine-usable",
+        score: 50,
+        priority_score: 60,
+        agent_status: "callable",
+        blocker_level: "none",
+        top_gap_codes: ["missing-fixture"],
+        top_gaps: [{ code: "missing-fixture", severity: "missing-data" }],
+      },
+    ],
+    ranked_queue: [{ rank: 1, netuid: 7 }],
+  };
+
+  test("a matching gap_code passes the includes() arm; a non-matching one fails it", async () => {
+    const deps = makeDeps({ "/metagraph/coverage-depth.json": scorecard });
+    const hit = await callTool(
+      "list_enrichment_targets",
+      { gap_code: "missing-fixture" },
+      { deps },
+    );
+    assert.equal(hit.body.result.structuredContent.returned, 1);
+
+    const miss = await callTool(
+      "list_enrichment_targets",
+      { gap_code: "missing-schema" },
+      { deps },
+    );
+    assert.equal(miss.body.result.structuredContent.returned, 0);
+  });
+
+  test("gap_code/severity filters default absent code/gap lists to [] before matching", async () => {
+    // A row with NO top_gap_codes and NO top_gaps: the gapCode filter hits the
+    // `(row.top_gap_codes || [])` [] fallback and the severity filter hits
+    // the `(row.top_gaps || [])` [] fallback. Both exclude the row.
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        rows: [
+          {
+            netuid: 7,
+            slug: "bare",
+            name: "Bare",
+            tier: "machine-usable",
+            score: 50,
+            priority_score: 60,
+            agent_status: "callable",
+            blocker_level: "none",
+          },
+        ],
+        ranked_queue: [{ rank: 1, netuid: 7 }],
+      },
+    });
+    const byCode = await callTool(
+      "list_enrichment_targets",
+      { gap_code: "missing-fixture" },
+      { deps },
+    );
+    assert.equal(byCode.body.result.structuredContent.returned, 0);
+
+    const bySeverity = await callTool(
+      "list_enrichment_targets",
+      { severity: "missing-data" },
+      { deps },
+    );
+    assert.equal(bySeverity.body.result.structuredContent.returned, 0);
+  });
+
+  test("a matching severity passes the some() arm", async () => {
+    const deps = makeDeps({ "/metagraph/coverage-depth.json": scorecard });
+    const hit = await callTool(
+      "list_enrichment_targets",
+      { severity: "missing-data" },
+      { deps },
+    );
+    assert.equal(hit.body.result.structuredContent.returned, 1);
+  });
+
+  test("a ranked_queue entry with no rank field maps rank to null", async () => {
+    // entry.rank ?? null right arm.
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        rows: [
+          {
+            netuid: 7,
+            slug: "g",
+            name: "G",
+            tier: "machine-usable",
+            score: 50,
+            priority_score: 60,
+            agent_status: "callable",
+            blocker_level: "none",
+          },
+        ],
+        ranked_queue: [{ netuid: 7 }], // no rank
+      },
+    });
+    const res = await callTool("list_enrichment_targets", {}, { deps });
+    assert.equal(res.body.result.structuredContent.targets[0].rank, null);
+  });
+});
+
+describe("find_subnets_by_capability — catalog subnets fallback", () => {
+  test("tolerates an agent-catalog with no subnets array", async () => {
+    // `Array.isArray(catalog.subnets) ? catalog.subnets : []` false arm.
+    const deps = makeDeps({
+      "/metagraph/agent-catalog.json": { subnets: null },
+    });
+    const res = await callTool(
+      "find_subnets_by_capability",
+      { capability: "data" },
+      { deps },
+    );
+    assert.equal(res.body.result.structuredContent.total, 0);
+  });
+});
+
+describe("get_best_rpc_endpoint — keep-existing + comparator arms", () => {
+  test("dedupes scoreless duplicates and orders equal/scoreless endpoints by latency", async () => {
+    // 'a': two scoreless eligible instances — the second does NOT beat the first
+    //  (both `score || 0` → 0, not >), so the keep-existing arm fires and
+    //  both `score || 0` fallbacks are exercised in the comparator.
+    // 'd' (no score, latency 5) vs 'a' (no score, latency 20): the latency
+    //  tie-break with `?? Infinity` orders 'd' first.
+    // 'e' (no score, no latency → Infinity) sorts last.
+    const deps = makeDeps({
+      "/metagraph/rpc/pools.json": {
+        pools: {
+          0: {
+            endpoints: [
+              {
+                id: "a",
+                url: "wss://a.example",
+                pool_eligible: true,
+                latency_ms: 20,
+              },
+              {
+                id: "d",
+                url: "wss://d.example",
+                pool_eligible: true,
+                latency_ms: 5,
+              },
+              { id: "e", url: "wss://e.example", pool_eligible: true },
+            ],
+          },
+          1: {
+            endpoints: [
+              {
+                id: "a",
+                url: "wss://a-dupe.example",
+                pool_eligible: true,
+                latency_ms: 1,
+              },
+            ],
+          },
+        },
+      },
+    });
+    const res = await callTool("get_best_rpc_endpoint", { limit: 5 }, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.eligible_count, 3);
+    // Scoreless 'a' kept its first instance (url unchanged).
+    const a = out.endpoints.find((e) => e.id === "a");
+    assert.equal(a.url, "wss://a.example");
+    // Equal (zero) score → latency asc: d(5) before a before e(Infinity).
+    assert.deepEqual(
+      out.endpoints.map((e) => e.id),
+      ["d", "a", "e"],
+    );
+  });
+});
+
+describe("how_do_i_call — snippets fall through to null", () => {
+  test("a callable service with no base_url and no stored snippets yields snippets null", async () => {
+    // generateServiceSnippets(null) → null, no s.snippets → `|| null` final arm.
+    const deps = makeDeps({
+      "/metagraph/agent-catalog/7.json": {
+        netuid: 7,
+        name: "Data",
+        slug: "sn-7",
+        integration_readiness: 70,
+        services: [
+          {
+            surface_id: "sn-7-api",
+            kind: "subnet-api",
+            capability: "Data API",
+            base_url: null,
+            auth_required: false,
+            auth_schemes: [],
+            schema_artifact: null,
+            schema_url: null,
+            eligibility: { callable: true },
+          },
+        ],
+      },
+    });
+    const res = await callTool("how_do_i_call", { netuid: 7 }, { deps });
+    assert.equal(res.body.result.structuredContent.services[0].snippets, null);
+  });
+});
+
+// ── rankSubnetsForTask keyword docs fallback ───────────────────────────
+describe("rankSubnetsForTask — keyword docs array fallback", () => {
+  test("find_subnet_for_task tolerates a search index with no documents array", async () => {
+    // `Array.isArray(index.documents) ? index.documents : []` false arm.
+    const deps = makeDeps({
+      "/metagraph/search.json": { documents: null },
+      "/metagraph/agent-catalog.json": {
+        subnets: [
+          {
+            netuid: 1,
+            name: "One",
+            slug: "sn-1",
+            categories: [],
+            integration_readiness: 80,
+            callable_count: 1,
+            service_kinds: ["openapi"],
+            base_url: "https://one.io",
+            health: "operational",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "find_subnet_for_task",
+      { task: "anything" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.discovery, "keyword");
+    assert.equal(out.count, 0);
+    assert.match(out.note, /No callable subnet/);
+  });
+});

--- a/tests/request-handlers-rpc-proxy-branch-coverage.test.mjs
+++ b/tests/request-handlers-rpc-proxy-branch-coverage.test.mjs
@@ -1,0 +1,598 @@
+// Branch-coverage tests for workers/request-handlers/rpc-proxy.mjs: drives the
+// malformed-input fallbacks, error envelopes, cache-policy arms, the failover
+// edge branches (truncated/no-tee bodies, empty endpoint list), and the
+// usage-telemetry `?? null` arms that the primary suite leaves uncovered.
+
+import assert from "node:assert/strict";
+import { describe, test, beforeEach } from "vitest";
+import {
+  configureRpcProxy,
+  handleRpcProxyRequest,
+  handleSurfaceVerify,
+  proxyWithFailover,
+  rpcCachePolicy,
+} from "../workers/request-handlers/rpc-proxy.mjs";
+
+const OBSERVED_AT = "2026-06-24T12:00:00.000Z";
+
+// Origins in TRUSTED_RPC_UPSTREAM_ORIGINS (mirrors the failover suite).
+const SAFE_A = "https://bittensor-finney.api.onfinality.io/public";
+const SAFE_B = "https://bittensor-public.nodies.app/rpc";
+const UNSAFE = "https://evil.example.com/rpc";
+
+const ep = (id, endpointUrl, extra = {}) => ({
+  id,
+  url: endpointUrl,
+  provider: "fixture",
+  pool_eligible: true,
+  score: 100,
+  status: "ok",
+  ...extra,
+});
+
+// A finney pool whose single endpoint is upstream-safe; used by proxy tests.
+const poolWith = (...endpoints) => ({
+  pools: [{ id: "finney-rpc", endpoints }],
+});
+
+function req(path, init) {
+  return new Request(`https://api.metagraph.sh${path}`, init);
+}
+
+function url(path) {
+  return new URL(`https://api.metagraph.sh${path}`);
+}
+
+async function errorJson(res, status) {
+  assert.equal(res.status, status, `expected ${status}, got ${res.status}`);
+  const body = await res.json();
+  assert.equal(body.ok, false);
+  return body;
+}
+
+// Fresh env per call so readRpcPoolArtifact's per-env memo never cross-reads
+// (it keys the cache on the env object identity).
+function rpcEnv(pool, overrides = {}) {
+  return {
+    METAGRAPH_ENABLE_RPC_PROXY: "true",
+    ASSETS: {
+      async fetch(request) {
+        const target = new URL(request.url);
+        if (target.pathname === "/metagraph/rpc/pools.json") {
+          return Response.json(pool);
+        }
+        return new Response("{}", { status: 404 });
+      },
+    },
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return {
+          async json() {
+            return pool;
+          },
+        };
+      },
+    },
+    ...overrides,
+  };
+}
+
+// A scripted fetch stub returning the i-th reply (thunk-or-response).
+function scriptedFetch(...replies) {
+  const calls = [];
+  const fn = async (target) => {
+    const reply = replies[calls.length];
+    calls.push(target);
+    if (typeof reply === "function") return reply();
+    return reply;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const jsonResponse = (status, body) => ({
+  status,
+  async text() {
+    return typeof body === "string" ? body : JSON.stringify(body);
+  },
+});
+
+// A minimal Cache-API double so the proxy's cacheable path is exercised.
+function fakeCache() {
+  const store = new Map();
+  return {
+    store,
+    async match(key) {
+      // Real Cache.match hands back a fresh response each time; clone so a
+      // prior consumer never drains the stored body.
+      const stored = store.get(key.url);
+      return stored ? stored.clone() : undefined;
+    },
+    async put(key, response) {
+      store.set(key.url, response);
+    },
+  };
+}
+
+// In-isolate health-db double capturing the events recordRpcUsage binds, so a
+// test can assert the `?? null` fallback arms fired for missing fields.
+function captureDb() {
+  const events = [];
+  return {
+    events,
+    prepare() {
+      return {
+        bind(...args) {
+          events.push(args);
+          return {
+            run() {
+              return Promise.resolve({});
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+beforeEach(() => {
+  configureRpcProxy({
+    readHealthMetaKv: async () => ({ last_run_at: OBSERVED_AT }),
+  });
+});
+
+describe("rpcCachePolicy arms", () => {
+  test("chain_getBlockHash with a non-array params is not cacheable", () => {
+    // params is an object → the `Array.isArray(params) ? params : []` else arm.
+    const policy = rpcCachePolicy("chain_getBlockHash", { not: "array" });
+    assert.deepEqual(policy, { cacheable: false, ttl: 0 });
+  });
+
+  test("chain_getBlockHash caches a numeric-string block argument via regex", () => {
+    // String "100" → the `/^\d+$/.test(String(args[0]))` regex arm.
+    const policy = rpcCachePolicy("chain_getBlockHash", ["100"]);
+    assert.deepEqual(policy, { cacheable: true, ttl: 3600 });
+  });
+
+  test("chain_getBlockHash with a non-numeric string is not cacheable", () => {
+    const policy = rpcCachePolicy("chain_getBlockHash", ["latest"]);
+    assert.deepEqual(policy, { cacheable: false, ttl: 0 });
+  });
+
+  test("quasi-static method is cacheable regardless of params shape", () => {
+    const policy = rpcCachePolicy("system_chain", { ignored: true });
+    assert.deepEqual(policy, { cacheable: true, ttl: 300 });
+  });
+});
+
+describe("handleRpcProxyRequest routing fallbacks", () => {
+  const rpcPost = (path, body) =>
+    req(path, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "cf-connecting-ip": "203.0.113.20",
+      },
+      body: JSON.stringify(body),
+    });
+
+  test("empty network segment falls back to the (none) unsupported error", async () => {
+    // pathname "/rpc" → split("/")[3] is undefined → `|| ""` empty network.
+    const res = await handleRpcProxyRequest(
+      rpcPost("/rpc", { jsonrpc: "2.0", id: 1, method: "system_health" }),
+      rpcEnv(poolWith(ep("a", SAFE_A))),
+      url("/rpc"),
+    );
+    const body = await errorJson(res, 404);
+    assert.equal(body.error.code, "rpc_network_unsupported");
+    assert.ok(body.error.message.includes("(none)"));
+  });
+
+  test("a pools-less artifact yields no static pool and a 503", async () => {
+    // pools key absent → `(poolArtifact.data.pools || [])` empty → no endpoints.
+    const res = await handleRpcProxyRequest(
+      rpcPost("/rpc/v1/finney", {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "system_health",
+      }),
+      rpcEnv({}),
+      url("/rpc/v1/finney"),
+    );
+    const body = await errorJson(res, 503);
+    assert.equal(body.error.code, "rpc_endpoint_unavailable");
+    assert.equal(body.meta.pool_id, "finney-rpc");
+  });
+
+  test("an unsafe endpoint with no id reports a null endpoint_id", async () => {
+    // The sole eligible endpoint is unsafe and has no id → the detail
+    // `unsafeEndpoint.id || null` takes the null arm.
+    const idless = {
+      url: UNSAFE,
+      provider: "fixture",
+      pool_eligible: true,
+      score: 100,
+      status: "ok",
+    };
+    const res = await handleRpcProxyRequest(
+      rpcPost("/rpc/v1/finney", {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "system_health",
+      }),
+      rpcEnv(poolWith(idless)),
+      url("/rpc/v1/finney"),
+    );
+    const body = await errorJson(res, 502);
+    assert.equal(body.error.code, "rpc_endpoint_unsafe");
+    assert.equal(body.meta.endpoint_id, null);
+  });
+});
+
+describe("handleRpcProxyRequest telemetry + cache path", () => {
+  const rpcPost = (body) =>
+    req("/rpc/v1/finney", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "cf-connecting-ip": "203.0.113.20",
+      },
+      body: JSON.stringify(body),
+    });
+
+  test("records a null endpoint_id telemetry event when all upstreams fail", async () => {
+    // Drives the served-event recordRpcUsage with a 502 bare response: the
+    // attempts header is absent so `Number(null) || candidates.length`
+    // supplies the attempt count, and endpoint_id falls back through `?? null`.
+    const db = captureDb();
+    const ctx = { waitUntil: () => {} };
+    const original = globalThis.fetch;
+    globalThis.fetch = scriptedFetch(
+      () => {
+        throw new Error("net");
+      },
+      () => {
+        throw new Error("net");
+      },
+    );
+    try {
+      const res = await handleRpcProxyRequest(
+        rpcPost({ jsonrpc: "2.0", id: 1, method: "system_health" }),
+        rpcEnv(poolWith(ep("a", SAFE_A), ep("b", SAFE_B)), {
+          METAGRAPH_HEALTH_DB: db,
+        }),
+        url("/rpc/v1/finney"),
+        ctx,
+      );
+      const body = await errorJson(res, 502);
+      assert.equal(body.error.code, "rpc_upstream_unavailable");
+      // The served telemetry event was bound: endpoint_id null, attempts = 2.
+      const served = db.events.at(-1);
+      assert.equal(served[2], null); // endpoint_id ?? null
+      assert.equal(served[6], 2); // attempts || candidates.length
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("caches a successful quasi-static result and rebuilds the id on a hit", async () => {
+    // system_chain is cacheable with non-array params → rpcCacheKey's `: []`
+    // arm; the stored result is replayed with THIS request's id.
+    const cache = fakeCache();
+    const ctx = { waitUntil: (p) => p };
+    const originalCaches = globalThis.caches;
+    const originalFetch = globalThis.fetch;
+    globalThis.caches = { default: cache };
+    globalThis.fetch = scriptedFetch(
+      jsonResponse(200, { jsonrpc: "2.0", id: 999, result: "bittensor" }),
+    );
+    try {
+      const env = rpcEnv(poolWith(ep("a", SAFE_A)));
+      // First call: cache miss → upstream served, result stored.
+      const miss = await handleRpcProxyRequest(
+        req("/rpc/v1/finney", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "cf-connecting-ip": "203.0.113.20",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "system_chain",
+            params: { trailing: true },
+          }),
+        }),
+        env,
+        url("/rpc/v1/finney"),
+        ctx,
+      );
+      assert.equal(miss.status, 200);
+      assert.equal(miss.headers.get("x-metagraph-rpc-cache"), "miss");
+      assert.equal(cache.store.size, 1);
+
+      // Second call (fresh env so the upstream is never re-hit): cache hit
+      // rebuilds the envelope with id 42, never replaying the primer's id 999.
+      globalThis.fetch = scriptedFetch(() => {
+        throw new Error("upstream must not be hit on a cache hit");
+      });
+      const hit = await handleRpcProxyRequest(
+        req("/rpc/v1/finney", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "cf-connecting-ip": "203.0.113.20",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 42,
+            method: "system_chain",
+            params: { trailing: true },
+          }),
+        }),
+        rpcEnv(poolWith(ep("a", SAFE_A))),
+        url("/rpc/v1/finney"),
+        ctx,
+      );
+      assert.equal(hit.status, 200);
+      assert.equal(hit.headers.get("x-metagraph-rpc-cache"), "hit");
+      const hitBody = await hit.json();
+      assert.equal(hitBody.id, 42);
+      assert.equal(hitBody.result, "bittensor");
+
+      // Third call: a request WITHOUT an `id` → rpcResultEnvelope omits the id
+      // field entirely (the `hasOwnProperty(requestBody, "id")` false arm, 713).
+      const idless = await handleRpcProxyRequest(
+        req("/rpc/v1/finney", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "cf-connecting-ip": "203.0.113.20",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            method: "system_chain",
+            params: { trailing: true },
+          }),
+        }),
+        rpcEnv(poolWith(ep("a", SAFE_A))),
+        url("/rpc/v1/finney"),
+        ctx,
+      );
+      assert.equal(idless.headers.get("x-metagraph-rpc-cache"), "hit");
+      const idlessBody = await idless.json();
+      assert.equal(
+        Object.prototype.hasOwnProperty.call(idlessBody, "id"),
+        false,
+      );
+      assert.equal(idlessBody.result, "bittensor");
+    } finally {
+      globalThis.caches = originalCaches;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("a cacheable miss with an oversized body skips caching (truncated)", async () => {
+    // proxyWithFailover tees the >64 KiB upstream: its own inspection truncates
+    // and hands the client the un-consumed live half. The handler then re-inspects
+    // (response.clone) and sees truncated → the `if (!inspect.truncated)` guard
+    //  is false, so the oversized result is streamed back but never cached.
+    const cache = fakeCache();
+    const ctx = { waitUntil: () => {} };
+    const originalCaches = globalThis.caches;
+    const originalFetch = globalThis.fetch;
+    globalThis.caches = { default: cache };
+    // A clean tee-able stream emitting > 64 KiB of valid JSON in chunks.
+    const chunk = new TextEncoder().encode("x".repeat(40 * 1024));
+    let pulls = 0;
+    const bigBody = new globalThis.ReadableStream({
+      pull(controller) {
+        pulls += 1;
+        if (pulls <= 2) {
+          controller.enqueue(chunk);
+          return;
+        }
+        controller.close();
+      },
+    });
+    globalThis.fetch = scriptedFetch(
+      new Response(bigBody, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    try {
+      const res = await handleRpcProxyRequest(
+        req("/rpc/v1/finney", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "cf-connecting-ip": "203.0.113.20",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "system_chain",
+          }),
+        }),
+        rpcEnv(poolWith(ep("a", SAFE_A))),
+        url("/rpc/v1/finney"),
+        ctx,
+      );
+      assert.equal(res.status, 200);
+      assert.equal(res.headers.get("x-metagraph-rpc-cache"), "miss");
+      // The oversized body is too large to classify/cache → store stays empty.
+      assert.equal(cache.store.size, 0);
+    } finally {
+      globalThis.caches = originalCaches;
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("proxyWithFailover edge branches", () => {
+  const base = { bodyText: "{}", poolId: "finney-rpc", healthMap: new Map() };
+
+  test("an empty endpoint list returns a 502 with a null last_reason", async () => {
+    // limit = 0 → the loop never runs → attempts stays empty so
+    // `attempts.at(-1)?.reason || null` yields null.
+    const res = await proxyWithFailover([], {
+      ...base,
+      fetchFn: scriptedFetch(),
+    });
+    assert.equal(res.status, 502);
+    const body = await res.json();
+    assert.equal(body.error.code, "rpc_upstream_unavailable");
+    assert.deepEqual(body.meta.attempts, []);
+    assert.equal(body.meta.last_reason, null);
+  });
+
+  test("a non-tee upstream body over the limit skips parse and streams the slice", async () => {
+    // A plain response object (no body.tee) over 64 KiB → readResponseTextWithLimit
+    // reports truncated → the `if (!inspect.truncated)` guard is skipped
+    // (never parsed for a transient JSON-RPC error) and the bounded slice is
+    // returned, clearing the breaker on a reachable success.
+    const huge = "x".repeat(70 * 1024);
+    const fetchFn = scriptedFetch({
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "content-type": "application/json" }),
+      async text() {
+        return huge;
+      },
+    });
+    const res = await proxyWithFailover([ep("a", SAFE_A)], {
+      ...base,
+      fetchFn,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-rpc-endpoint-id"), "a");
+    const text = await res.text();
+    // Body is bounded to the 64 KiB classification limit, not the full 70 KiB.
+    assert.equal(text.length, 64 * 1024);
+  });
+});
+
+describe("handleSurfaceVerify alias + cache branches", () => {
+  // A catalog/env whose surfaces never match so the alias lookup is consulted.
+  function verifyEnv(aliasOk) {
+    return {
+      ASSETS: {
+        async fetch(request) {
+          const target = new URL(request.url);
+          if (target.pathname === "/metagraph/operational-surfaces.json") {
+            return Response.json({ surfaces: [] });
+          }
+          // SURFACE_ALIASES_PATH artifact: ok or 404 depending on the test.
+          if (aliasOk) {
+            return Response.json({});
+          }
+          return new Response("nope", { status: 404 });
+        },
+      },
+    };
+  }
+
+  const verifyReq = req("/api/v1/surfaces/ghost/verify", {
+    headers: { "cf-connecting-ip": "203.0.113.10" },
+  });
+
+  test("consults the alias artifact when the direct lookup misses", async () => {
+    // catalog.ok with no match → `!surface` true → alias read (ok) → re-lookup
+    // still misses → 404 surface_not_found. Exercises the aliases.ok arm.
+    let fetched = false;
+    const original = globalThis.fetch;
+    globalThis.fetch = async () => {
+      fetched = true;
+      return new Response("{}", { status: 200 });
+    };
+    try {
+      const res = await handleSurfaceVerify(
+        verifyReq,
+        verifyEnv(true),
+        "ghost",
+      );
+      const body = await errorJson(res, 404);
+      assert.equal(body.error.code, "surface_not_found");
+      assert.equal(body.meta.surface_id, "ghost");
+      // No outbound probe for an unresolved surface.
+      assert.equal(fetched, false);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("a missing alias artifact still yields surface_not_found", async () => {
+    const res = await handleSurfaceVerify(verifyReq, verifyEnv(false), "ghost");
+    const body = await errorJson(res, 404);
+    assert.equal(body.error.code, "surface_not_found");
+  });
+
+  test("an under-limit verify client passes the limiter and proceeds", async () => {
+    // RPC_RATE_LIMITER present + success:true → the `if (!success)` false arm:
+    // no 429 short-circuit, the handler continues to the catalog lookup.
+    const env = verifyEnv(false);
+    env.RPC_RATE_LIMITER = { limit: async () => ({ success: true }) };
+    const res = await handleSurfaceVerify(verifyReq, env, "ghost");
+    // Still 404 (the surface does not exist) — but the limiter did NOT reject.
+    const body = await errorJson(res, 404);
+    assert.equal(body.error.code, "surface_not_found");
+  });
+
+  test("a matched surface lacking a surface_key falls back to its surface_id", async () => {
+    // findSurface matches on surface_id; with no surface_key the canonical id
+    // is `surface.surface_key || surface.surface_id` → the surface_id arm.
+    const matchEnv = {
+      // No Cache API binding so the cache match/put path is skipped and the
+      // probe runs directly through the stubbed fetch.
+      ASSETS: {
+        async fetch(request) {
+          const target = new URL(request.url);
+          if (target.pathname === "/metagraph/operational-surfaces.json") {
+            return Response.json({
+              surfaces: [
+                {
+                  surface_id: "keyless-surface",
+                  kind: "subnet-api",
+                  url: "https://keyless.example.com/health",
+                  provider: "fixture",
+                  auth_required: false,
+                  public_safe: true,
+                  probe: { expect: "json", method: "GET", timeout_ms: 10000 },
+                },
+              ],
+            });
+          }
+          return new Response("nope", { status: 404 });
+        },
+      },
+    };
+    const originalCaches = globalThis.caches;
+    const originalFetch = globalThis.fetch;
+    globalThis.caches = undefined; // no Cache API → skip the 60s cache layer
+    globalThis.fetch = async () =>
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    try {
+      const res = await handleSurfaceVerify(
+        req("/api/v1/surfaces/keyless-surface/verify", {
+          headers: { "cf-connecting-ip": "203.0.113.10" },
+        }),
+        matchEnv,
+        "keyless-surface",
+        {},
+      );
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.ok, true);
+      assert.equal(body.data.surface_id, "keyless-surface");
+      assert.equal(body.data.surface_key, null);
+      assert.equal(body.data.from_cache, false);
+    } finally {
+      globalThis.caches = originalCaches;
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/tests/scripts-lib-branch-coverage.test.mjs
+++ b/tests/scripts-lib-branch-coverage.test.mjs
@@ -1,0 +1,570 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  buildEvidenceSubjectNetuidIndex,
+  netuidForEvidenceClaim,
+  loadSubnets,
+  stripJsonComments,
+  artifactOutputPath,
+  createLocalArtifactEnv,
+  sanitizeOpenApiDocument,
+  safeFetch,
+  sanitizeFixtureBody,
+  fixtureCaptureFailureReason,
+  surfaceFixtureReference,
+  normalizePublicHttpUrl,
+  socialAccounts,
+  registrySurfaceKey,
+  isHtmlContentType,
+  buildSubnetLineageLinks,
+  clusterDomainFromUrl,
+  registrableHostDomain,
+  buildProvenanceReviewQueue,
+  deriveAuthDetail,
+  publishedAt,
+  staleOperationalKinds,
+} from "../scripts/lib.mjs";
+
+describe("buildEvidenceSubjectNetuidIndex", () => {
+  test("indexes subnet/surface/candidate subjects and skips non-integer netuids", () => {
+    const index = buildEvidenceSubjectNetuidIndex({
+      subnets: [{ netuid: 4 }, { netuid: 1.5 }, { netuid: null }],
+      surfaces: [{ id: "all-ways-api", netuid: 7 }],
+      candidates: [{ id: "cand-1", netuid: 12 }],
+    });
+    // subnet:4 stored; the float / null netuid rows are rejected by the
+    // Number.isInteger guard and never indexed.
+    assert.equal(index.get("subnet:4"), 4);
+    assert.equal(index.get("surface:all-ways-api"), 7);
+    assert.equal(index.get("candidate:cand-1"), 12);
+    assert.equal(index.has("subnet:1.5"), false);
+    assert.equal(index.has("subnet:null"), false);
+  });
+
+  test("tolerates explicitly null subject lists via the `|| []` guards", () => {
+    const index = buildEvidenceSubjectNetuidIndex({
+      subnets: null,
+      surfaces: null,
+      candidates: null,
+    });
+    assert.equal(index.size, 0);
+  });
+});
+
+describe("netuidForEvidenceClaim", () => {
+  test("falls back to parsing the subject when the index misses", () => {
+    assert.equal(netuidForEvidenceClaim({ subject: "subnet:42" }), 42);
+    assert.equal(netuidForEvidenceClaim({ subject: "sn-7-openapi" }), 7);
+    assert.equal(netuidForEvidenceClaim({}), null);
+  });
+});
+
+describe("registry loaders (filesystem-backed)", () => {
+  test("loadSubnets returns subnets sorted by netuid then slug", async () => {
+    const subnets = await loadSubnets();
+    assert.ok(Array.isArray(subnets) && subnets.length > 0);
+    for (let i = 1; i < subnets.length; i += 1) {
+      const prev = subnets[i - 1];
+      const cur = subnets[i];
+      // netuid asc, with slug as the tiebreak (exercises both comparator arms).
+      assert.ok(
+        prev.netuid < cur.netuid ||
+          (prev.netuid === cur.netuid &&
+            prev.slug.localeCompare(cur.slug) <= 0),
+      );
+    }
+  });
+});
+
+describe("stripJsonComments", () => {
+  test("tolerates a dangling backslash at the very end of input (?? '' arms)", () => {
+    // The backslash is the final char, so `next` is undefined and the
+    // `next ?? ""` escape-append arms take the "" branch.
+    // Walk both passes by giving a string region that reaches end mid-escape.
+    assert.equal(typeof stripJsonComments('"a\\'), "string");
+    assert.equal(typeof stripJsonComments('{"a":"b",}\\'), "string");
+  });
+});
+
+describe("artifactOutputPath", () => {
+  test("routes a git-tier artifact to the public metagraph root (else arm)", () => {
+    const out = artifactOutputPath("contracts.json");
+    assert.ok(out.endsWith("contracts.json"));
+    assert.ok(out.includes("public"));
+  });
+});
+
+describe("createLocalArtifactEnv", () => {
+  test("ASSETS.fetch serves a non-json asset as octet-stream", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await env.ASSETS.fetch(
+      new Request("https://local/favicon.svg"),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "application/octet-stream");
+  });
+});
+
+describe("sanitizeOpenApiDocument", () => {
+  test("recurses into arrays and drops undefined entries", () => {
+    // Array branch: an undefined nested result is filtered out.
+    const out = sanitizeOpenApiDocument([
+      { url: "https://api.example.com/v1" },
+      "https://example.com/ok",
+    ]);
+    assert.deepEqual(out, [
+      { url: "https://api.example.com/v1" },
+      "https://example.com/ok",
+    ]);
+  });
+
+  test("returns non-string scalars unchanged", () => {
+    assert.equal(sanitizeOpenApiDocument(7), 7);
+    assert.equal(sanitizeOpenApiDocument(true), true);
+    assert.equal(sanitizeOpenApiDocument(null), null);
+  });
+
+  test("runs the `String(key || '')` falsy arm for an empty-string key", () => {
+    // The empty-string key flows through isSchemaExtensionKey (exercising the
+    // `key || ""` falsy arm), then sanitizeSchemaKey yields "" → the key is
+    // dropped by the `!sanitizedKey` guard. The retained sibling proves the
+    // walk completed rather than throwing.
+    const out = sanitizeOpenApiDocument({
+      "": "x",
+      keep: "https://example.com/ok",
+    });
+    assert.equal("" in out, false);
+    assert.equal(out.keep, "https://example.com/ok");
+  });
+
+  test("recurses into a non-object server entry (sanitizeSchemaServer fallback)", () => {
+    // A string inside servers[] is not a {url} object → sanitizeSchemaServer
+    // delegates straight to sanitizeOpenApiDocument.
+    const out = sanitizeOpenApiDocument({
+      servers: ["https://api.example.com/ok", { url: "/relative" }],
+    });
+    assert.deepEqual(out.servers, [
+      "https://api.example.com/ok",
+      { url: "/relative" },
+    ]);
+  });
+
+  test("drops a plain object property whose value is undefined", () => {
+    // nested === undefined → sanitizeOpenApiDocument returns undefined → the
+    // property is dropped by the `sanitizedNested === undefined` guard.
+    const out = sanitizeOpenApiDocument({ keep: "x", gone: undefined });
+    assert.equal(out.keep, "x");
+    assert.equal("gone" in out, false);
+  });
+});
+
+describe("safeFetch (error envelope)", () => {
+  test("returns a generic error envelope when fetch throws (non-abort)", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw new TypeError("boom-network");
+    };
+    try {
+      // A loopback IP literal is its own DNS answer (no resolver needed) and
+      // is public-shaped enough to reach the fetch() call, which throws — the
+      // catch maps a non-AbortError to error.message.
+      const out = await safeFetch("https://8.8.8.8/x");
+      assert.equal(out.ok, false);
+      assert.equal(out.error, "boom-network");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("maps an AbortError to the 'timeout' error string", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      throw err;
+    };
+    try {
+      const out = await safeFetch("https://8.8.8.8/x");
+      assert.equal(out.ok, false);
+      assert.equal(out.error, "timeout");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});
+
+describe("sanitizeFixtureBody", () => {
+  test("appends a +N-more-keys marker once the key budget is exceeded", () => {
+    const big = {};
+    for (let i = 0; i < 5; i += 1) big[`k${i}`] = i;
+    const out = sanitizeFixtureBody(big, { maxKeys: 2 });
+    // first two keys kept; the overflow marker is appended.
+    assert.equal(out.k0, 0);
+    assert.equal(out.k1, 1);
+    assert.equal("k2" in out, false);
+    assert.equal(out["…"], "[+3 more keys]");
+  });
+});
+
+describe("fixtureCaptureFailureReason", () => {
+  test("maps each known error name to its reason and unknowns to a default", () => {
+    assert.equal(
+      fixtureCaptureFailureReason({ name: "SyntaxError" }),
+      "invalid json response",
+    );
+    assert.equal(
+      fixtureCaptureFailureReason({ name: "AbortError" }),
+      "request timed out",
+    );
+    assert.equal(
+      fixtureCaptureFailureReason({ name: "FixtureCaptureLimitError" }),
+      "response exceeds byte limit",
+    );
+    assert.equal(
+      fixtureCaptureFailureReason({ name: "TypeError" }),
+      "request failed",
+    );
+    assert.equal(
+      fixtureCaptureFailureReason({ name: "OtherError" }),
+      "capture failed",
+    );
+    assert.equal(fixtureCaptureFailureReason(null), "capture failed");
+  });
+});
+
+describe("surfaceFixtureReference (missing optional fields)", () => {
+  test("nulls request.url and response.status/content_type when malformed", () => {
+    // request.method non-string → "GET"; request.url non-string → null;
+    // response.status non-integer → null; content_type non-string → null.
+    const ref = surfaceFixtureReference("sn-1-x", {
+      request: { method: 42, url: 99 },
+      response: { status: "200", content_type: 5 },
+    });
+    assert.equal(ref.request.method, "GET");
+    assert.equal(ref.request.url, null);
+    assert.equal(ref.response.status, null);
+    assert.equal(ref.response.content_type, null);
+    assert.equal(ref.captured_at, null);
+  });
+
+  test("falls back to empty request/response objects when omitted", () => {
+    const ref = surfaceFixtureReference("sn-2-y", {});
+    assert.equal(ref.request.method, "GET");
+    assert.equal(ref.request.url, null);
+    assert.equal(ref.response.status, null);
+    assert.equal(ref.artifact_path, "/metagraph/fixtures/sn-2-y.json");
+  });
+});
+
+describe("normalizePublicHttpUrl", () => {
+  test("rejects a ws(s) URL that normalizePublicUrl accepts", () => {
+    // normalizePublicUrl passes wss:, but the http-only guard rejects it.
+    assert.equal(normalizePublicHttpUrl("wss://stream.example.io/feed"), null);
+  });
+});
+
+describe("socialAccounts (placeholder URL skip)", () => {
+  test("skips an extracted social URL that reads as placeholder junk", () => {
+    // 'deprecated' is a placeholder identity token, so the matched x.com URL is
+    // skipped, leaving no social accounts.
+    const out = socialAccounts("follow https://x.com/deprecated-team");
+    assert.equal(out, null);
+  });
+
+  test("still extracts a legitimate handle alongside a skipped junk one", () => {
+    const out = socialAccounts(
+      "https://x.com/example.com_junk and https://t.me/realchan",
+    );
+    // the x.com URL carries the 'example.com' placeholder token → skipped;
+    // the telegram one survives.
+    assert.deepEqual(out, { telegram: "https://t.me/realchan" });
+  });
+});
+
+describe("registrySurfaceKey / subnetSurfaceKey", () => {
+  test("falls back through netuid/kind/url defaults for a sparse entry", () => {
+    // entry with no netuid, no kind, and an unnormalizable url exercises all
+    // three `?? / ||` fallback arms.
+    assert.equal(
+      registrySurfaceKey({ url: "not a url" }),
+      "unknown|unknown|not a url",
+    );
+    assert.equal(registrySurfaceKey({}), "unknown|unknown|unknown");
+  });
+});
+
+describe("isHtmlContentType / isJsonContentType", () => {
+  test("detects html and tolerates non-string input", () => {
+    assert.equal(isHtmlContentType("text/html; charset=utf-8"), true);
+    assert.equal(isHtmlContentType("application/json"), false);
+    assert.equal(isHtmlContentType(null), false);
+    assert.equal(isHtmlContentType(42), false);
+  });
+});
+
+describe("buildSubnetLineageLinks (broken-link arms)", () => {
+  const sub = (netuid, name) => ({
+    netuid,
+    name,
+    raw_name: name,
+    chain_identity: { subnet_name: name },
+  });
+
+  test("records null source/target netuids on a wholly malformed approval", () => {
+    const broken = [];
+    const links = buildSubnetLineageLinks(
+      [sub(1, "A")],
+      [sub(2, "B")],
+      [{ matched_by: "github_repo" }], // no netuids at all
+      broken,
+    );
+    assert.deepEqual(links, []);
+    // both `Number.isInteger(...) ? ... : null` arms take the null branch;
+    // reason invalid-approval.
+    assert.deepEqual(broken, [
+      { source_netuid: null, target_netuid: null, reason: "invalid-approval" },
+    ]);
+  });
+
+  test("accepts mainnet_/testnet_ netuid aliases (the ?? fallback arms)", () => {
+    const links = buildSubnetLineageLinks(
+      [sub(1, "A")],
+      [sub(2, "B")],
+      [{ mainnet_netuid: 1, testnet_netuid: 2, matched_by: "chain_name" }],
+    );
+    assert.deepEqual(links, [
+      { source_netuid: 1, target_netuid: 2, matched_by: "chain_name" },
+    ]);
+  });
+
+  test("surfaces a source-netuid-missing approval", () => {
+    const broken = [];
+    buildSubnetLineageLinks(
+      [sub(1, "A")],
+      [sub(2, "B")],
+      [{ source_netuid: 99, target_netuid: 2, matched_by: "github_repo" }],
+      broken,
+    );
+    assert.deepEqual(broken, [
+      { source_netuid: 99, target_netuid: 2, reason: "source-netuid-missing" },
+    ]);
+  });
+
+  test("dedupes a repeated identical approval", () => {
+    const links = buildSubnetLineageLinks(
+      [sub(1, "A")],
+      [sub(2, "B")],
+      [
+        { source_netuid: 1, target_netuid: 2, matched_by: "chain_name" },
+        { source_netuid: 1, target_netuid: 2, matched_by: "github_repo" },
+      ],
+    );
+    // second (duplicate netuid pair) is skipped by the seen-set guard.
+    assert.deepEqual(links, [
+      { source_netuid: 1, target_netuid: 2, matched_by: "chain_name" },
+    ]);
+  });
+
+  test("tiebreaks equal source_netuid links by target_netuid", () => {
+    // one source maps to two distinct targets → the primary comparator returns
+    // 0, so the `|| a.target_netuid - b.target_netuid` arm decides the order.
+    const links = buildSubnetLineageLinks(
+      [sub(1, "A")],
+      [sub(3, "C"), sub(2, "B")],
+      [
+        { source_netuid: 1, target_netuid: 3, matched_by: "chain_name" },
+        { source_netuid: 1, target_netuid: 2, matched_by: "github_repo" },
+      ],
+    );
+    assert.deepEqual(
+      links.map((l) => l.target_netuid),
+      [2, 3],
+    );
+  });
+
+  test("defaults approvedLinks to [] when passed null", () => {
+    // null approvals → the `approvedLinks || []` guard yields an empty loop.
+    assert.deepEqual(
+      buildSubnetLineageLinks([sub(1, "A")], [sub(2, "B")], null),
+      [],
+    );
+  });
+});
+
+describe("clusterDomainFromUrl (appspot tenant arms)", () => {
+  test("returns null for a bare proj-less appspot.com", () => {
+    // appspot.com with <3 labels → null.
+    assert.equal(clusterDomainFromUrl("https://appspot.com"), null);
+  });
+
+  test("returns the single label for a one-label host", () => {
+    // labels.length < 2 → `return host || null`; host is truthy here.
+    assert.equal(clusterDomainFromUrl("https://localhost/x"), "localhost");
+  });
+
+  test("returns null when the host strips to empty", () => {
+    // "www." hostname → strip leading www. → "" → labels [] → length < 2 →
+    // `host || null` with an empty host takes the null arm.
+    assert.equal(clusterDomainFromUrl("https://www./"), null);
+  });
+});
+
+describe("registrableHostDomain (last-two-label fallback)", () => {
+  test("falls back to last-two labels when cluster resolution yields null", () => {
+    // A bare multi-tenant suffix (no tenant) makes clusterDomainFromUrl return
+    // null, so the `?? labels.slice(-2)` fallback runs.
+    assert.equal(registrableHostDomain("pages.dev"), "pages.dev");
+    assert.equal(registrableHostDomain("github.io"), "github.io");
+  });
+
+  test("returns the single label unchanged when there is no dot", () => {
+    // <2 labels → the `: host` arm of the inner ternary.
+    assert.equal(registrableHostDomain("localhost"), "localhost");
+  });
+});
+
+describe("buildProvenanceReviewQueue", () => {
+  const candidate = {
+    id: "c-openapi",
+    netuid: 7,
+    kind: "openapi",
+    url: "https://api.team.io/openapi.json",
+    source_type: "openapi-probe",
+    slug: "sn-7-team",
+  };
+  const native = {
+    netuid: 7,
+    chain_identity: { subnet_url: "https://team.io" },
+  };
+  const verification = {
+    candidate_id: "c-openapi",
+    classification: "live",
+    quality_signals: { content_type_matches_kind: true },
+  };
+
+  test("queues a provenance-strong subnet absent from the subnets level map", () => {
+    // subnets=[] → both levelByNetuid.get and slugByNetuid.get miss, so the
+    // `?? entry.slug` / `?? null` fallbacks run.
+    const out = buildProvenanceReviewQueue({
+      candidates: [candidate],
+      nativeSubnets: [native],
+      verificationResults: [verification],
+      subnets: [],
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.queue.length, 1);
+    const [row] = out.queue;
+    assert.equal(row.netuid, 7);
+    assert.equal(row.slug, "sn-7-team"); // entry.slug fallback
+    assert.equal(row.current_level, null); // ?? null fallback
+    assert.deepEqual(row.kinds, ["openapi"]);
+    assert.equal(row.domain, "team.io");
+    assert.match(row.rationale, /Strong provenance/);
+  });
+
+  test("synthesizes an sn-<netuid> slug when neither map nor entry has one", () => {
+    const out = buildProvenanceReviewQueue({
+      candidates: [{ ...candidate, slug: undefined }],
+      nativeSubnets: [native],
+      verificationResults: [verification],
+      subnets: [],
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+    assert.equal(out.queue[0].slug, "sn-7");
+  });
+
+  test("maps a known subnet that has no curation block (level `?? null` arm)", () => {
+    // subnet present in the level map but with no curation → the
+    // `subnet.curation?.level ?? null` fallback yields null, and
+    // the slug map hits (so slugByNetuid wins over entry.slug).
+    const out = buildProvenanceReviewQueue({
+      candidates: [candidate],
+      nativeSubnets: [native],
+      verificationResults: [verification],
+      subnets: [{ netuid: 7, slug: "registry-slug" }],
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+    assert.equal(out.queue.length, 1);
+    assert.equal(out.queue[0].current_level, null);
+    assert.equal(out.queue[0].slug, "registry-slug");
+  });
+});
+
+describe("deriveAuthDetail (selection + default arms)", () => {
+  test("apiKey with an unrecognized `in` defaults the location to header", () => {
+    //  false arm: `in` not in [header,query,cookie] → "header".
+    const out = deriveAuthDetail({
+      k: { type: "apiKey", in: "body", name: "X-Key" },
+    });
+    assert.equal(out.location, "header");
+    assert.equal(out.scheme, "api-key");
+  });
+
+  test("http with no scheme defaults to bearer (the `|| ''` arm)", () => {
+    // String(pick.scheme || "") falsy arm, then non-basic → bearer.
+    const out = deriveAuthDetail({ b: { type: "http" } });
+    assert.equal(out.scheme, "bearer");
+    assert.equal(out.value_format, "Bearer <token>");
+  });
+
+  test("a scheme entry with no type falls through to null", () => {
+    // entries[0] is picked, type = String(undefined || "") = "" via the
+    // `|| ""` arm, matches no branch → null.
+    assert.equal(deriveAuthDetail({ only: { foo: 1 } }), null);
+  });
+
+  test("oauth2 with a flow lacking both URLs falls back to scheme.tokenUrl", () => {
+    // The clientCredentials flow has neither tokenUrl nor authorizationUrl, so
+    // both in-loop guards take their false arm, then the
+    // top-level scheme.tokenUrl resolves.
+    const out = deriveAuthDetail({
+      o: {
+        type: "oauth2",
+        flows: { clientCredentials: {} },
+        tokenUrl: "https://auth.example.com/token",
+      },
+    });
+    assert.equal(out.token_url, "https://auth.example.com/token");
+  });
+});
+
+describe("publishedAt", () => {
+  test("returns the trimmed env value or null when unset", () => {
+    const prev = process.env.METAGRAPH_PUBLISHED_AT;
+    try {
+      process.env.METAGRAPH_PUBLISHED_AT = "  2026-06-27T00:00:00Z  ";
+      assert.equal(publishedAt(), "2026-06-27T00:00:00Z");
+      delete process.env.METAGRAPH_PUBLISHED_AT;
+      assert.equal(publishedAt(), null);
+      process.env.METAGRAPH_PUBLISHED_AT = "   ";
+      assert.equal(publishedAt(), null);
+    } finally {
+      if (prev === undefined) delete process.env.METAGRAPH_PUBLISHED_AT;
+      else process.env.METAGRAPH_PUBLISHED_AT = prev;
+    }
+  });
+});
+
+describe("staleOperationalKinds", () => {
+  const ref = "2026-06-24T00:00:00Z";
+
+  test("treats a kind with a row that has no last_ok as unverified → stale", () => {
+    // row.status ok but last_ok missing → okMs NaN → not verifiedFresh.
+    const stale = staleOperationalKinds({
+      operationalKinds: ["openapi"],
+      healthByKind: new Map([["openapi", [{ status: "ok", last_ok: null }]]]),
+      probeFinishedAt: ref,
+    });
+    assert.equal(stale.has("openapi"), true);
+  });
+
+  test("defaults operationalKinds to [] when omitted", () => {
+    const stale = staleOperationalKinds({
+      operationalKinds: null,
+      healthByKind: { openapi: [{ status: "ok", last_ok: ref }] },
+      probeFinishedAt: ref,
+    });
+    assert.equal(stale.size, 0);
+  });
+});


### PR DESCRIPTION
## Summary

The gated runtime set already carries very high line coverage, but branch coverage trailed on four frequently hit files, so the error and edge paths (cold or empty stores, malformed input fallbacks, error envelopes) stayed unexercised. This change adds focused coverage for those reachable branches. It is test only, with no production code change.

## What Changed

Four new vitest files under `tests/`, each targeting one hot file and mirroring the conventions of its closest existing suite (node:assert/strict, describe/test, the local env and dependency injection helpers):

- `tests/account-events-branch-coverage.test.mjs` covers the subnet, block, and day builders, the transfer direction logic, the prune changes fallback, and the loader direction clauses.
- `tests/request-handlers-rpc-proxy-branch-coverage.test.mjs` covers the cache policy arms, network routing and unsafe endpoint envelopes, failover edge cases (empty pool, oversized or unteeable bodies), and surface verify resolution.
- `tests/mcp-server-branch-coverage.test.mjs` covers enrichment target fallbacks, search and list filters, rpc endpoint dedupe and ordering, snippet and fixture branches, and the dispatch and rate limit guards.
- `tests/scripts-lib-branch-coverage.test.mjs` covers the text sanitizers, url and identity guards, lineage and provenance builders, fixture and auth helpers, and the freshness resolver.

Every test exercises at least one branch arm the existing suite left uncovered. The branch arms that remain uncovered on the rpc proxy file are defensive paths gated behind the trusted origin allowlist, which only holds public hosts, so the private address detection can never be reached, plus the non exported usage recorder fallbacks. Neither can be driven without changing production code, so they are left as is.

### Per file branch coverage

| File | Before | After |
| --- | --- | --- |
| `src/account-events.mjs` | 84.68% | 100% |
| `workers/request-handlers/rpc-proxy.mjs` | 87.06% | 92.31% |
| `src/mcp-server.mjs` | 87.57% | 98.94% |
| `scripts/lib.mjs` | 89.98% | 98.97% |

Closes #2066

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
