### PR TITLE
feat(api): chain-events activity aggregate (/api/v1/chain-events/stats)

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -91,6 +91,23 @@ test("chain-events rejects method-only feed filters without a block scope", asyn
   expect((await res.json()).error).toMatch(/method filter requires pallet/);
 });
 
+test("chain-events/stats returns the activity aggregate with a clamped window", async () => {
+  const res = await req("/api/v1/chain-events/stats?blocks=500");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.window_blocks).toBe(500);
+  expect(Array.isArray(body.activity)).toBe(true);
+  // window clamps: oversized → 5000, non-numeric → default 1000
+  expect(
+    (await (await req("/api/v1/chain-events/stats?blocks=99999")).json())
+      .window_blocks,
+  ).toBe(5000);
+  expect(
+    (await (await req("/api/v1/chain-events/stats?blocks=abc")).json())
+      .window_blocks,
+  ).toBe(1000);
+});
+
 test("chain-events rejects overlong or non-enumerable pallet/method filters", async () => {
   const res = await req(`/api/v1/chain-events?pallet=${"A".repeat(65)}`);
   expect(res.status).toBe(400);

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -849,6 +849,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // (e.g. a preview deploy without the data Worker).
   if (
     url.pathname === "/api/v1/chain-events" ||
+    url.pathname === "/api/v1/chain-events/stats" ||
     /^\/api\/v1\/blocks\/\d+\/chain-events$/.test(url.pathname)
   ) {
     if (env.DATA_RATE_LIMITER?.limit) {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -122,6 +122,28 @@ export default {
         return json({ count: rows.length, next_before: next, events: rows });
       }
 
+      // GET /api/v1/chain-events/stats?blocks=N — chain-activity aggregate: the
+      // pallet.method event distribution over the most recent N blocks (default
+      // 1000, capped 5000). Bounded window + capped output keep it index-cheap.
+      if (url.pathname === "/api/v1/chain-events/stats") {
+        const blocks = Math.min(
+          Math.max(Number(url.searchParams.get("blocks")) || 1000, 1),
+          5000,
+        );
+        const rows = await sql`
+          SELECT pallet, method, count(*)::int AS count
+          FROM chain_events
+          WHERE block_number > (SELECT max(block_number) FROM chain_events) - ${blocks}
+          GROUP BY pallet, method
+          ORDER BY count DESC
+          LIMIT 100`;
+        return json({
+          window_blocks: blocks,
+          groups: rows.length,
+          activity: rows,
+        });
+      }
+
       return json({ error: "not found" }, 404);
     } catch (err) {
       // Log internally (Wrangler observability) but NEVER leak DB error details


### PR DESCRIPTION
Second of the ship-now wins. The block-explorer API is already rich (blocks / extrinsics / events / accounts / subnets), so the clear gap was an **aggregate 'chain activity' view**.

`GET /api/v1/chain-events/stats?blocks=N` → the pallet.method event distribution over the most recent N blocks (default 1000, capped 5000), top 100 by count — a Taostats-style activity dashboard datasource.

- Bounded window + the `(block_number, event_index)` PK range scan keep it index-cheap; runs under the existing 3s `statement_timeout` and the `DATA_RATE_LIMITER`.
- Served by the data Worker (Hyperdrive); the main Worker routes `/api/v1/chain-events/stats` to it (out-of-contract dynamic route, no schema change).
- Recent-window now; auto-deepens to full history when the archive box backfills.

Verified: prettier clean, 11/11 data-api tests (added a stats + window-clamp case), bundle budget green.