### PR TITLE
fix(data-api): coerce chain-event bigints to numbers and add pallet-only index

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -93,6 +93,8 @@ CREATE TABLE IF NOT EXISTS chain_events (
   PRIMARY KEY (block_number, event_index)
 );
 CREATE INDEX IF NOT EXISTS idx_ce_pallet_method ON chain_events (pallet, method, block_number DESC);
+-- Pallet-only feed (pallet= without method=): serves the ORDER BY without a full PK scan.
+CREATE INDEX IF NOT EXISTS idx_ce_pallet_block  ON chain_events (pallet, block_number DESC, event_index DESC);
 CREATE INDEX IF NOT EXISTS idx_ce_observed      ON chain_events (observed_at DESC);
 
 -- ---------------------------------------------------------------------------

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -49,6 +49,9 @@ test("GET /api/v1/blocks/:n/chain-events returns the block's events", async () =
   expect(body.count).toBe(1);
   expect(body.events[0].pallet).toBe("System");
   expect(body.events[0].method).toBe("ExtrinsicSuccess");
+  // observed_at is coerced from the postgres.js BIGINT string to a number.
+  expect(body.events[0].observed_at).toBe(100);
+  expect(typeof body.events[0].observed_at).toBe("number");
 });
 
 test("GET /api/v1/chain-events returns the feed with a cursor (filters + before)", async () => {
@@ -58,7 +61,12 @@ test("GET /api/v1/chain-events returns the feed with a cursor (filters + before)
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.count).toBe(1);
-  expect(body.next_before).toBe("123"); // rows.length === limit → cursor is the last row
+  expect(body.next_before).toBe(123); // rows.length === limit → cursor is the last row
+  // BIGINT columns are coerced from postgres.js strings to numbers (D1-route parity).
+  expect(body.events[0].block_number).toBe(123);
+  expect(typeof body.events[0].block_number).toBe("number");
+  expect(body.events[0].observed_at).toBe(100);
+  expect(typeof body.events[0].observed_at).toBe("number");
 });
 
 test("limit is clamped and defaults safely", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -36,6 +36,22 @@ function clampLimit(raw) {
   return Math.min(Math.floor(n), MAX_LIMIT);
 }
 
+// postgres.js returns BIGINT columns as strings; the D1-backed routes return them
+// as numbers. block_number and observed_at are both < 2^53, so Number(...) is
+// lossless — coerce them per event row for a consistent numeric API shape.
+function numberOrNull(v) {
+  return v == null ? null : Number(v);
+}
+function coerceEvent(row) {
+  return {
+    ...row,
+    ...(row.block_number !== undefined
+      ? { block_number: numberOrNull(row.block_number) }
+      : {}),
+    observed_at: numberOrNull(row.observed_at),
+  };
+}
+
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
@@ -69,7 +85,11 @@ export default {
           FROM chain_events
           WHERE block_number = ${bn}
           ORDER BY event_index ASC`;
-        return json({ block_number: bn, count: rows.length, events: rows });
+        return json({
+          block_number: bn,
+          count: rows.length,
+          events: rows.map(coerceEvent),
+        });
       }
 
       // GET /api/v1/chain-events?pallet=&method=&block=&extrinsic=&before=&limit=
@@ -118,8 +138,14 @@ export default {
           ORDER BY block_number DESC, event_index DESC
           LIMIT ${limit}`;
         const next =
-          rows.length === limit ? rows[rows.length - 1].block_number : null;
-        return json({ count: rows.length, next_before: next, events: rows });
+          rows.length === limit
+            ? numberOrNull(rows[rows.length - 1].block_number)
+            : null;
+        return json({
+          count: rows.length,
+          next_before: next,
+          events: rows.map(coerceEvent),
+        });
       }
 
       // GET /api/v1/chain-events/stats?blocks=N — chain-activity aggregate: the


### PR DESCRIPTION
## What

Two small, self-contained data-Worker quick wins.

**1. BIGINT consistency (`workers/data-api.mjs`).** postgres.js returns `BIGINT`
columns (`block_number`, `observed_at`) as **strings**, so the Postgres-backed
chain-events routes served stringified numbers — inconsistent with the D1-backed
routes, which return numbers. A small `coerceEvent` helper now coerces
`block_number` and `observed_at` to `Number(...)` when non-null on each returned
event row, and `next_before` is coerced the same way. Both values are `< 2^53`, so
the conversion is lossless. Applied in the `/api/v1/blocks/:n/chain-events` handler
and the `/api/v1/chain-events` feed handler.

**2. Pallet-only index (`deploy/postgres/schema.sql`).** A `chain-events?pallet=X`
query without a `method=` filter can't use `idx_ce_pallet_method` for its
`ORDER BY block_number DESC, event_index DESC` and falls back to a full backward-PK
scan. Added:

```sql
CREATE INDEX IF NOT EXISTS idx_ce_pallet_block ON chain_events (pallet, block_number DESC, event_index DESC);
```

next to the existing `chain_events` indexes. This is the canonical Postgres schema —
**applying it to prod is a separate manual step** (run the `CREATE INDEX IF NOT
EXISTS` against the live DB; it is idempotent).

## Why

Numeric parity across the D1 and Postgres serving tiers removes a client-side
footgun (string vs number for the same logical field / cursor). The pallet-only
index turns the common pallet-filtered feed from a full PK scan into an index scan.

## Out of contract

No `schemas/` or `src/contracts.mjs` change — no OpenAPI/types regen or client bump.

## Gates run

- `npx prettier --write` on both JS files — clean (`.sql` has no prettier parser, not linted).
- `npx vitest run tests/data-api.test.mjs` — 11/11 pass (updated `next_before` to `123`; added
  number-type assertions for `block_number` / `observed_at`).
- `npm run worker:bundle:budget` — passes (unaffected; targets `workers/api.mjs`, untouched).
