### PR TITLE
feat(api): overlay live health onto served /api/v1/rpc/pools

### DIFF
--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -954,6 +954,23 @@ function d1With(rows) {
 }
 const req = (path) => new Request(`https://api.metagraph.sh${path}`);
 
+// Minimal R2 archive binding that serves a single static rpc/pools.json fixture
+// (the artifact is R2-only, so there is nothing on disk for createLocalArtifactEnv
+// to read). Keyed on `latest/rpc/pools.json`, mirroring latestR2Key().
+function rpcPoolsArchiveFixture(artifact) {
+  return {
+    async get(key) {
+      if (String(key).replace(/^latest\//, "") !== "rpc/pools.json")
+        return null;
+      return {
+        async json() {
+          return artifact;
+        },
+      };
+    },
+  };
+}
+
 describe("worker live health serving", () => {
   test("/api/v1/health serves the live operational summary from KV", async () => {
     const env = createLocalArtifactEnv({
@@ -1094,6 +1111,74 @@ describe("worker live health serving", () => {
       body.data.windows["7d"].subnets[1].points[0].uptime_ratio,
       0.8,
     );
+  });
+
+  test("/api/v1/rpc/pools overlays live KV health so a dead upstream is marked ineligible", async () => {
+    // The static R2 artifact still lists `dead` as pool_eligible (it was healthy
+    // at build time). The wss-lb / proxy route off this served body, so without
+    // the overlay they would keep routing to a node that has been down for ~30 min.
+    const env = createLocalArtifactEnv({
+      METAGRAPH_ARCHIVE: rpcPoolsArchiveFixture({
+        schema_version: 1,
+        generated_at: "1970-01-01T00:00:00.000Z",
+        source: "rpc-endpoint-probes",
+        pools: [
+          {
+            id: "finney-rpc",
+            kind: "subtensor-rpc",
+            endpoints: [
+              { id: "live", pool_eligible: true, status: "ok" },
+              { id: "dead", pool_eligible: true, status: "ok" },
+            ],
+          },
+        ],
+      }),
+      METAGRAPH_CONTROL: kvWith({
+        "health:rpc-pool": {
+          schema_version: 1,
+          last_run_at: FRESH_RUN,
+          endpoints: [
+            { id: "live", status: "ok", consecutive_failures: 0 },
+            // Sustained-down (≥2 consecutive failed prober runs) → drop from pool.
+            { id: "dead", status: "failed", consecutive_failures: 3 },
+          ],
+        },
+      }),
+    });
+    const res = await handleRequest(req("/api/v1/rpc/pools"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.meta.source, "live-cron-prober");
+    assert.equal(body.meta.operational_observed_at, FRESH_RUN);
+    const endpoints = body.data.pools[0].endpoints;
+    const live = endpoints.find((e) => e.id === "live");
+    const dead = endpoints.find((e) => e.id === "dead");
+    assert.equal(live.pool_eligible, true);
+    assert.equal(dead.pool_eligible, false);
+    assert.equal(dead.status, "failed");
+    assert.equal(dead.health_source, "live-cron-prober");
+  });
+
+  test("/api/v1/rpc/pools serves the static artifact when the live KV snapshot is cold", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_ARCHIVE: rpcPoolsArchiveFixture({
+        schema_version: 1,
+        generated_at: "1970-01-01T00:00:00.000Z",
+        source: "rpc-endpoint-probes",
+        pools: [
+          {
+            id: "finney-rpc",
+            endpoints: [{ id: "dead", pool_eligible: true, status: "ok" }],
+          },
+        ],
+      }),
+      // No health:rpc-pool entry → cold live snapshot → static passthrough.
+      METAGRAPH_CONTROL: kvWith({}),
+    });
+    const res = await handleRequest(req("/api/v1/rpc/pools"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.pools[0].endpoints[0].pool_eligible, true);
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -142,6 +142,7 @@ import {
   overlayCatalogDetail,
   overlayCatalogIndex,
   overlayOverviewHealth,
+  overlayRpcPoolEligibility,
   overlaySubnetEconomics,
   overlaySubnetHealth,
   resolveLiveEconomics,
@@ -259,6 +260,7 @@ const LIVE_OVERLAY_ROUTE_IDS = new Set([
   "health",
   "subnet-health",
   "rpc-endpoints",
+  "rpc-pools",
   "freshness",
   "subnet-overview",
   "agent-catalog",
@@ -2911,6 +2913,7 @@ function unknownSubnetHealth(netuid) {
 const ENDPOINT_OVERLAY_EXCLUDED_IDS = new Set([
   "subnet-health",
   "rpc-endpoints",
+  "rpc-pools",
   "freshness",
   "agent-catalog",
   "agent-catalog-subnet",
@@ -2943,6 +2946,32 @@ async function liveHealthOverlay(env, matched, staticData) {
     case "rpc-endpoints": {
       const pool = await readHealthKv(env, KV_HEALTH_RPC_POOL);
       data = mergeRpcEndpoints(staticData, pool);
+      break;
+    }
+    case "rpc-pools": {
+      // The served pool scores feed the public RPC load-balancer (deploy/wss-lb)
+      // and the proxy's pool selection. Overlay the same 15-minute cron health the
+      // HTTP proxy applies (overlayRpcPoolEligibility) so a sustained-down/wrong-chain
+      // upstream baked into the static artifact is marked ineligible instead of being
+      // routed to. Each pool in pools[] shares the per-endpoint shape the overlay
+      // expects; without a live snapshot the pools pass through unchanged.
+      const livePool = await readHealthKv(env, KV_HEALTH_RPC_POOL);
+      if (
+        livePool &&
+        Array.isArray(livePool.endpoints) &&
+        Array.isArray(staticData?.pools)
+      ) {
+        data = {
+          ...staticData,
+          source: "live-cron-prober",
+          operational_observed_at: livePool.last_run_at || null,
+          pools: staticData.pools.map((pool) =>
+            overlayRpcPoolEligibility(pool, livePool),
+          ),
+        };
+      } else {
+        data = null;
+      }
       break;
     }
     case "freshness": {


### PR DESCRIPTION
## What

The served `/api/v1/rpc/pools` body now applies the live-health overlay the HTTP proxy already uses, so pool consumers stop being handed upstreams that are currently down.

- Add an `rpc-pools` case to the live-overlay dispatcher in `workers/api.mjs` (`liveHealthOverlay`). It reads the 15-minute cron RPC-pool health snapshot from KV (`KV_HEALTH_RPC_POOL`) and maps each pool in `pools[]` through `overlayRpcPoolEligibility` — the exact helper the HTTP proxy applies at `workers/request-handlers/rpc-proxy.mjs:492-493`. A sustained-down (>=2 consecutive failed prober runs) or wrong-chain endpoint is flipped to `pool_eligible: false`; with no live snapshot the pools pass through unchanged (static fallback).
- Register `rpc-pools` in `LIVE_OVERLAY_ROUTE_IDS` (so the route is never static-edge-cached and can't seed a stale fallback) and in `ENDPOINT_OVERLAY_EXCLUDED_IDS` (its live composition is keyed on `pools[]`, not the shared per-endpoint list).

## Why

Today `/api/v1/rpc/pools` is served raw from the static R2 artifact with no live-health overlay. The public RPC load-balancer (`deploy/wss-lb/src/server.mjs`, via `selectWssUpstreams` which gates on per-endpoint `pool_eligible`) and the proxy's pool selection route off this body — so a node that went down after the last build stays `pool_eligible` and clients can be routed to an upstream that died ~30 min ago. The HTTP proxy already overlays live health; this brings the served pools to parity.

Out-of-contract — no schema change.

## Gates run + passed

- `npx prettier --write workers/api.mjs tests/health-serving.test.mjs` — clean.
- `npx vitest run tests/health-serving.test.mjs` — 130 passed (2 new: a dead upstream baked `pool_eligible: true` in the static artifact is marked ineligible per the live KV overlay; cold KV snapshot serves the static body unchanged).
- `npm run worker:bundle:budget` — passed (908.2 KiB gzipped, under the 920 KiB warn).

The 12 pre-existing failures in `tests/worker-runtime.test.mjs` (build/economics/query-filter/raw-artifact cases) are unrelated and reproduce on clean `origin/main` — they need built local `public/` artifacts not present in a fresh worktree.