### PR TITLE
feat(mcp): add get_chain_activity tool for chain-events stats

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -387,6 +387,16 @@ assert.equal(
 const askCold = await call("ask", { question: "Which subnet exposes an API?" });
 assert.equal(askCold.isError, true, "ask must isError without the AI layer");
 
+// get_chain_activity reads the all-events tier through the DATA_API service
+// binding, absent in this cold env. It must return a clean isError result (the
+// "tier unavailable" guard), never throw.
+const activityCold = await call("get_chain_activity", { blocks: 500 });
+assert.equal(
+  activityCold.isError,
+  true,
+  "get_chain_activity must isError without the DATA_API binding",
+);
+
 // --- Negative paths --------------------------------------------------------
 
 const unknownMethod = await mcp({

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -96,7 +96,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.4.0";
+export const MCP_SERVER_VERSION = "1.5.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -275,6 +275,48 @@ async function loadSubnetEconomics(ctx, netuid) {
     captured_at: blob?.captured_at ?? null,
     summary: blob?.summary ?? null,
     economics: blob?.subnets?.find((row) => row?.netuid === netuid) ?? null,
+  };
+}
+
+// Chain-activity aggregate (pallet.method event distribution) over the most
+// recent N blocks, from the Postgres-backed all-events tier. That tier lives in
+// the dedicated data Worker (ADR 0013) so the postgres.js driver stays out of
+// this Worker's bundle; MCP handlers reach it through the DATA_API service
+// binding, the same binding the REST proxy uses for /api/v1/chain-events/stats.
+// A missing binding (e.g. a preview deploy without the data Worker) or a non-OK
+// upstream response surfaces as a clean tool error, never an exception.
+async function loadChainActivity(ctx, blocks) {
+  const dataApi = ctx.env?.DATA_API;
+  if (!dataApi?.fetch) {
+    throw toolError(
+      "tier_unavailable",
+      "The chain activity tier is unavailable (the all-events data Worker is " +
+        "not bound to this deployment). Try again against the production endpoint.",
+    );
+  }
+  let response;
+  try {
+    response = await dataApi.fetch(
+      new Request(`https://d/api/v1/chain-events/stats?blocks=${blocks}`),
+    );
+  } catch {
+    throw toolError(
+      "tier_unavailable",
+      "The chain activity tier could not be reached. Try again shortly.",
+    );
+  }
+  if (!response.ok) {
+    throw toolError(
+      "tier_unavailable",
+      `The chain activity tier returned an error (status ${response.status}). ` +
+        "Try again shortly.",
+    );
+  }
+  const data = await response.json();
+  return {
+    window_blocks: data?.window_blocks ?? blocks,
+    groups: data?.groups ?? 0,
+    activity: Array.isArray(data?.activity) ? data.activity : [],
   };
 }
 
@@ -476,6 +518,22 @@ function requireSs58(args) {
 // The ss58 inputSchema `pattern` (advisory; runtime validation is requireSs58),
 // derived from the single pattern source so it can't drift.
 const SS58_PATTERN_SOURCE = SS58_ADDRESS_PATTERN.source;
+
+// The optional `blocks` window for get_chain_activity: a missing value defaults
+// to 1000; a provided value must be a positive integer and is clamped to the
+// data Worker's 1-5000 bound so a stray large value is silently capped (the data
+// Worker clamps too, but capping here keeps the request URL honest).
+function optionalBlocksWindow(args) {
+  const value = args?.blocks;
+  if (value === undefined || value === null) return 1000;
+  if (!Number.isInteger(value) || value < 1) {
+    throw toolError(
+      "invalid_params",
+      "Argument `blocks` must be a positive integer.",
+    );
+  }
+  return Math.min(value, 5000);
+}
 
 function clampLimit(value, fallback, max) {
   // A missing/blank/<1 limit falls back to the default — it must NOT clamp UP to
@@ -1739,6 +1797,36 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_chain_activity",
+    title: "Get recent chain-activity aggregate",
+    description:
+      "Fetch the chain-activity aggregate from the all-events tier: the " +
+      "pallet.method event distribution (each with its count, busiest first) " +
+      "over the most recent `blocks` blocks. Use it to see what the chain has " +
+      "been doing lately — which pallets and calls dominate recent traffic — " +
+      "before drilling into specific blocks (get_block) or extrinsics " +
+      "(list_extrinsics). Mirrors GET /api/v1/chain-events/stats.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        blocks: {
+          type: "integer",
+          description:
+            "How many of the most recent blocks to aggregate over (1-5000, " +
+            "default 1000).",
+          minimum: 1,
+          maximum: 5000,
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const blocks = optionalBlocksWindow(args);
+      return loadChainActivity(ctx, blocks);
+    },
+  },
+  {
     name: "list_subnet_apis",
     title: "List a subnet's callable services",
     description:
@@ -2919,6 +3007,20 @@ const TOOL_OUTPUT_SCHEMAS = {
       schema_version: { type: "integer" },
       ref: ANY,
       extrinsic: { type: ["object", "null"], additionalProperties: true },
+    },
+  },
+  get_chain_activity: {
+    type: "object",
+    additionalProperties: true,
+    required: ["window_blocks", "groups", "activity"],
+    properties: {
+      window_blocks: { type: "integer" },
+      groups: { type: "integer" },
+      activity: objectItems({
+        pallet: NULLABLE_STRING,
+        method: NULLABLE_STRING,
+        count: NULLABLE_INT,
+      }),
     },
   },
   list_subnet_apis: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1362,6 +1362,116 @@ describe("MCP tools (injected deps)", () => {
   });
 });
 
+// get_chain_activity reaches the Postgres-backed all-events tier through the
+// DATA_API service binding (the same binding the REST /chain-events/stats proxy
+// uses), so its tests mock that binding via env rather than the injected deps.
+describe("MCP get_chain_activity (DATA_API binding)", () => {
+  // A stub DATA_API binding: records the requested URL and returns the supplied
+  // stats payload (or a non-OK response when `status` is given).
+  function makeDataApi({ payload, status = 200 } = {}) {
+    const calls = [];
+    return {
+      calls,
+      fetch(request) {
+        calls.push(new URL(request.url));
+        return Promise.resolve(
+          new Response(status === 200 ? JSON.stringify(payload) : "err", {
+            status,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      },
+    };
+  }
+
+  test("returns the pallet.method aggregate from the data Worker", async () => {
+    const dataApi = makeDataApi({
+      payload: {
+        window_blocks: 1000,
+        groups: 2,
+        activity: [
+          { pallet: "SubtensorModule", method: "set_weights", count: 42 },
+          { pallet: "System", method: "ExtrinsicSuccess", count: 7 },
+        ],
+      },
+    });
+    const res = await callTool(
+      "get_chain_activity",
+      {},
+      { env: { DATA_API: dataApi } },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window_blocks, 1000);
+    assert.equal(out.groups, 2);
+    assert.equal(out.activity.length, 2);
+    assert.equal(out.activity[0].pallet, "SubtensorModule");
+    // Default window is 1000 blocks when `blocks` is omitted.
+    assert.equal(
+      dataApi.calls[0].searchParams.get("blocks"),
+      "1000",
+      "omitted blocks must default to 1000",
+    );
+  });
+
+  test("passes an explicit blocks window through to the data Worker", async () => {
+    const dataApi = makeDataApi({
+      payload: { window_blocks: 250, groups: 0, activity: [] },
+    });
+    const res = await callTool(
+      "get_chain_activity",
+      { blocks: 250 },
+      { env: { DATA_API: dataApi } },
+    );
+    assert.equal(res.body.result.isError, false);
+    assert.equal(dataApi.calls[0].searchParams.get("blocks"), "250");
+  });
+
+  test("clamps an over-cap blocks window to 5000", async () => {
+    const dataApi = makeDataApi({
+      payload: { window_blocks: 5000, groups: 0, activity: [] },
+    });
+    await callTool(
+      "get_chain_activity",
+      { blocks: 99999 },
+      { env: { DATA_API: dataApi } },
+    );
+    assert.equal(dataApi.calls[0].searchParams.get("blocks"), "5000");
+  });
+
+  test("rejects a non-positive / non-integer blocks argument", async () => {
+    for (const blocks of [0, -5, 1.5]) {
+      const res = await callTool(
+        "get_chain_activity",
+        { blocks },
+        { env: { DATA_API: makeDataApi() } },
+      );
+      assert.equal(res.body.result.isError, true, `blocks=${blocks}`);
+      assert.ok(res.body.result.content[0].text.includes("blocks"));
+    }
+  });
+
+  test("errors cleanly when the DATA_API binding is absent", async () => {
+    const res = await callTool("get_chain_activity", {}, { env: {} });
+    assert.equal(res.body.result.isError, true);
+    assert.ok(
+      res.body.result.content[0].text.includes("chain activity tier"),
+      "must surface a clear tier-unavailable message",
+    );
+  });
+
+  test("errors cleanly when the data Worker returns a non-OK response", async () => {
+    const dataApi = makeDataApi({ status: 502 });
+    const res = await callTool(
+      "get_chain_activity",
+      {},
+      { env: { DATA_API: dataApi } },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.ok(res.body.result.content[0].text.includes("502"));
+  });
+});
+
 // keyword-search.test.mjs covers the scoring matrix; here we only prove both
 // tools are wired to it — substring noise is gone and the precise target wins.
 describe("MCP keyword discovery relevance", () => {


### PR DESCRIPTION
## What

Adds an MCP tool `get_chain_activity` that returns the chain-activity aggregate — the `pallet.method` event distribution (each with its count, busiest first) over the most recent `blocks` blocks — from the Postgres-backed all-events tier.

- Input: optional integer `blocks` (default 1000, clamped to the data Worker's 1–5000 bound).
- Output: `{ window_blocks, groups, activity: [{ pallet, method, count }] }`, mirroring `GET /api/v1/chain-events/stats`.

## Why

The block + extrinsic MCP tools (`list_blocks`, `get_block`, `list_extrinsics`, `get_extrinsic`) read D1, but the all-events `chain_events` tier — and its `pallet.method` activity aggregate — was not reachable from MCP. This tool gives agents a single-call "what has the chain been doing lately" view to orient before drilling into specific blocks/extrinsics.

## How it reaches the data tier

MCP handlers don't reach the data Worker directly. The all-events tier lives in the dedicated data Worker (ADR 0013, keeping the `postgres.js` driver out of this Worker's bundle), served via the `DATA_API` service binding. `env` already flows to the handler through `handleMcpRequest(request, env, …)` → `buildContext` → `ctx.env`, so the handler calls `ctx.env.DATA_API.fetch(new Request('https://d/api/v1/chain-events/stats?blocks=' + n))` — the same binding the REST proxy uses for that path. A missing binding (e.g. a preview deploy without the data Worker) or a non-OK upstream response surfaces as a clean tool error (`isError`), never an exception.

## Scope notes

- MCP tool additions need **no** server-card regen (the server-card is worker-computed from `listToolDefinitions()` at request time) and **no** contract change — `public/openapi.json`, generated types, `contracts.json`, and `api-index.json` are untouched by this PR (confirmed: `npm run build` left no diff in those tracked artifacts). Per the additive-tool bump policy, `MCP_SERVER_VERSION` and `server.json` go to `1.5.0`.
- One focused change: the single tool plus its output schema, input helper, and tests.

## Gates run + passed

- `npx prettier --check` on all four changed files — clean.
- `npx vitest run tests/mcp-server.test.mjs` — 209 passed (6 new `get_chain_activity` tests covering the success path, explicit/clamped/invalid `blocks`, missing binding, and non-OK upstream, mocking the `DATA_API` binding via `env`).
- `npm run validate:mcp` — passes; 38 tools, full lifecycle + one `tools/call` per tool (added the cold-env `isError` assertion for `get_chain_activity`, matching the `semantic_search`/`ask` pattern).
