### PR TITLE
fix(mcp): enforce DATA_RATE_LIMITER for get_chain_activity

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -286,6 +286,8 @@ async function loadSubnetEconomics(ctx, netuid) {
 // A missing binding (e.g. a preview deploy without the data Worker) or a non-OK
 // upstream response surfaces as a clean tool error, never an exception.
 async function loadChainActivity(ctx, blocks) {
+  // Optional in previews/local runs; production binds this beside DATA_API so
+  // MCP calls pay the same data-tier rate limit as REST proxy calls.
   if (ctx.env?.DATA_RATE_LIMITER?.limit) {
     const { success } = await ctx.env.DATA_RATE_LIMITER.limit({
       key: `data:${ctx.clientIp}`,

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -286,6 +286,18 @@ async function loadSubnetEconomics(ctx, netuid) {
 // A missing binding (e.g. a preview deploy without the data Worker) or a non-OK
 // upstream response surfaces as a clean tool error, never an exception.
 async function loadChainActivity(ctx, blocks) {
+  if (ctx.env?.DATA_RATE_LIMITER?.limit) {
+    const { success } = await ctx.env.DATA_RATE_LIMITER.limit({
+      key: `data:${ctx.clientIp}`,
+    });
+    if (!success) {
+      throw toolError(
+        "data_rate_limited",
+        "Too many data API requests from this client; slow down.",
+      );
+    }
+  }
+
   const dataApi = ctx.env?.DATA_API;
   if (!dataApi?.fetch) {
     throw toolError(

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1457,7 +1457,7 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
     const dataApi = makeDataApi({
       payload: { window_blocks: 1000, groups: 0, activity: [] },
     });
-    let limiterCalls = 0;
+    const limiterKeys = [];
     const res = await rpc(
       [
         {
@@ -1477,8 +1477,8 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
         env: {
           DATA_API: dataApi,
           DATA_RATE_LIMITER: {
-            async limit() {
-              limiterCalls += 1;
+            async limit({ key }) {
+              limiterKeys.push(key);
               return { success: true };
             },
           },
@@ -1487,7 +1487,7 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
     );
     assert.equal(res.status, 200);
     assert.equal(res.body.length, 2);
-    assert.equal(limiterCalls, 2);
+    assert.deepEqual(limiterKeys, ["data:anonymous", "data:anonymous"]);
     assert.equal(dataApi.calls.length, 2);
   });
 

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1427,6 +1427,70 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
     assert.equal(dataApi.calls[0].searchParams.get("blocks"), "250");
   });
 
+  test("applies the data API limiter before fetching chain activity", async () => {
+    const dataApi = makeDataApi({
+      payload: { window_blocks: 1000, groups: 0, activity: [] },
+    });
+    const limiterKeys = [];
+    const res = await callTool(
+      "get_chain_activity",
+      {},
+      {
+        env: {
+          DATA_API: dataApi,
+          DATA_RATE_LIMITER: {
+            async limit({ key }) {
+              limiterKeys.push(key);
+              return { success: false };
+            },
+          },
+        },
+      },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /Too many data API requests/);
+    assert.deepEqual(limiterKeys, ["data:anonymous"]);
+    assert.equal(dataApi.calls.length, 0);
+  });
+
+  test("charges the data API limiter for each batched chain activity call", async () => {
+    const dataApi = makeDataApi({
+      payload: { window_blocks: 1000, groups: 0, activity: [] },
+    });
+    let limiterCalls = 0;
+    const res = await rpc(
+      [
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "get_chain_activity", arguments: {} },
+        },
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "get_chain_activity", arguments: {} },
+        },
+      ],
+      {
+        env: {
+          DATA_API: dataApi,
+          DATA_RATE_LIMITER: {
+            async limit() {
+              limiterCalls += 1;
+              return { success: true };
+            },
+          },
+        },
+      },
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.body.length, 2);
+    assert.equal(limiterCalls, 2);
+    assert.equal(dataApi.calls.length, 2);
+  });
+
   test("clamps an over-cap blocks window to 5000", async () => {
     const dataApi = makeDataApi({
       payload: { window_blocks: 5000, groups: 0, activity: [] },


### PR DESCRIPTION
### Motivation
- The public MCP tool `get_chain_activity` previously called the `DATA_API` service binding directly, bypassing the REST `DATA_RATE_LIMITER` and enabling request amplification (JSON-RPC batches) against the Postgres-backed data tier, creating an availability/cost amplification risk.

### Description
- Add a pre-fetch `DATA_RATE_LIMITER` check in `loadChainActivity(ctx, blocks)` that calls `env.DATA_RATE_LIMITER.limit({ key: `data:${ctx.clientIp}` })` and surfaces a `data_rate_limited` `toolError` when denied.
- Preserve the original `DATA_API.fetch()` flow and upstream error handling when the limiter allows the request.
- Add regression tests to `tests/mcp-server.test.mjs` that assert a denied limiter prevents `DATA_API.fetch()` and that JSON-RPC batches charge the data limiter once per `get_chain_activity` call.
- Adjust test expectations to reflect the resolved client key used when no explicit client IP is present.

### Testing
- Ran the focused test suite with `npx vitest run tests/mcp-server.test.mjs -t "MCP get_chain_activity"`, and the added/related tests passed.
- Ran `npm run lint` and `npm run format:check`, both of which succeeded.
- Attempted `npm run validate:mcp`, which failed in this local checkout due to missing MCP artifact/environment preconditions unrelated to this change (validator environment/fixtures), not due to the rate-limit change.

Files changed: `src/mcp-server.mjs`, `tests/mcp-server.test.mjs`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a405b55510c832cb6ef0000eae21d6b)