### PR TITLE
fix(wss-lb): disallow state_subscribeStorage on public WSS proxy

### DIFF
--- a/deploy/wss-lb/src/rpc-policy.mjs
+++ b/deploy/wss-lb/src/rpc-policy.mjs
@@ -24,6 +24,8 @@ export const SAFE_RPC_METHODS = new Set([
 ]);
 // Read-only WebSocket subscriptions — WSS-ONLY (no HTTP equivalent). KEEP IN SYNC
 // with workers/config.mjs (tests/wss-lb-rpc-policy-sync.test.mjs guards drift).
+// Deliberately excludes persistent storage subscriptions, which can create
+// unbounded upstream watcher state for arbitrary keys.
 export const SAFE_RPC_SUBSCRIPTIONS = new Set([
   "chain_subscribeNewHeads",
   "chain_subscribeNewHead",
@@ -34,8 +36,6 @@ export const SAFE_RPC_SUBSCRIPTIONS = new Set([
   "chain_unsubscribeFinalisedHeads",
   "chain_subscribeAllHeads",
   "chain_unsubscribeAllHeads",
-  "state_subscribeStorage",
-  "state_unsubscribeStorage",
   "state_subscribeRuntimeVersion",
   "state_unsubscribeRuntimeVersion",
 ]);

--- a/deploy/wss-lb/test/proxy.test.mjs
+++ b/deploy/wss-lb/test/proxy.test.mjs
@@ -208,6 +208,54 @@ test("security: nested non-scalar RPC ids are not reflected in errors", async ()
   await good.close();
 });
 
+test("security: storage subscriptions are rejected before reaching upstream", async () => {
+  const upstreamMessages = [];
+  const http = createServer();
+  const wss = new WebSocketServer({ server: http });
+  wss.on("connection", (ws) => {
+    ws.on("message", (d) => {
+      upstreamMessages.push(d.toString());
+      ws.send(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "accepted" }));
+    });
+  });
+  const upstream = await new Promise((resolve) =>
+    http.listen(0, "127.0.0.1", () =>
+      resolve(`ws://127.0.0.1:${http.address().port}`),
+    ),
+  );
+  const lb = await lbServer([upstream]);
+
+  const reply = await new Promise((resolve, reject) => {
+    const c = new WebSocket(lb.url);
+    c.on("open", () =>
+      c.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "state_subscribeStorage",
+          params: [["0x" + "00".repeat(32)]],
+        }),
+      ),
+    );
+    c.on("message", (d) => {
+      c.close();
+      resolve(JSON.parse(d.toString()));
+    });
+    c.on("error", reject);
+    setTimeout(() => reject(new Error("timeout")), 8000);
+  });
+
+  assert.equal(reply.error?.code, -32601);
+  assert.equal(
+    reply.error?.message,
+    "RPC method is not allowed through this proxy: state_subscribeStorage",
+  );
+  assert.deepEqual(upstreamMessages, []);
+
+  await lb.close();
+  await new Promise((resolve) => http.close(resolve));
+});
+
 test("subscriptions: read-only subscribe frames are relayed to upstream", async () => {
   const upstreamMethods = [];
   const http = createServer();

--- a/deploy/wss-lb/test/proxy.test.mjs
+++ b/deploy/wss-lb/test/proxy.test.mjs
@@ -225,30 +225,45 @@ test("security: storage subscriptions are rejected before reaching upstream", as
   );
   const lb = await lbServer([upstream]);
 
-  const reply = await new Promise((resolve, reject) => {
-    const c = new WebSocket(lb.url);
-    c.on("open", () =>
-      c.send(
-        JSON.stringify({
-          jsonrpc: "2.0",
-          id: 1,
-          method: "state_subscribeStorage",
-          params: [["0x" + "00".repeat(32)]],
-        }),
-      ),
-    );
-    c.on("message", (d) => {
-      c.close();
-      resolve(JSON.parse(d.toString()));
+  async function rejectedStorageReply(method, params) {
+    return await new Promise((resolve, reject) => {
+      const c = new WebSocket(lb.url);
+      c.on("open", () =>
+        c.send(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method,
+            params,
+          }),
+        ),
+      );
+      c.on("message", (d) => {
+        c.close();
+        resolve(JSON.parse(d.toString()));
+      });
+      c.on("error", reject);
+      setTimeout(() => reject(new Error("timeout")), 8000);
     });
-    c.on("error", reject);
-    setTimeout(() => reject(new Error("timeout")), 8000);
-  });
+  }
 
-  assert.equal(reply.error?.code, -32601);
+  const subscribeReply = await rejectedStorageReply("state_subscribeStorage", [
+    ["0x" + "00".repeat(32)],
+  ]);
+  const unsubscribeReply = await rejectedStorageReply(
+    "state_unsubscribeStorage",
+    ["0xSUBID"],
+  );
+
+  assert.equal(subscribeReply.error?.code, -32601);
   assert.equal(
-    reply.error?.message,
+    subscribeReply.error?.message,
     "RPC method is not allowed through this proxy: state_subscribeStorage",
+  );
+  assert.equal(unsubscribeReply.error?.code, -32601);
+  assert.equal(
+    unsubscribeReply.error?.message,
+    "RPC method is not allowed through this proxy: state_unsubscribeStorage",
   );
   assert.deepEqual(upstreamMessages, []);
 
@@ -281,8 +296,7 @@ test("subscriptions: read-only subscribe frames are relayed to upstream", async 
   );
   const lb = await lbServer([upstream]);
 
-  const frames = await new Promise((resolve, reject) => {
-    const seen = [];
+  const seen = await new Promise((resolve, reject) => {
     const c = new WebSocket(lb.url);
     c.on("open", () =>
       c.send(
@@ -293,21 +307,27 @@ test("subscriptions: read-only subscribe frames are relayed to upstream", async 
         }),
       ),
     );
+    const messages = [];
     c.on("message", (d) => {
-      seen.push(JSON.parse(d.toString()));
-      if (seen.length === 2) {
+      messages.push(JSON.parse(d.toString()));
+      if (messages.length === 2) {
         c.close();
-        resolve(seen);
+        resolve(messages);
       }
     });
     c.on("error", reject);
     setTimeout(() => reject(new Error("timeout")), 8000);
   });
 
-  // relayed (not rejected with -32601), and the notification streamed back through
   assert.deepEqual(upstreamMethods, ["chain_subscribeNewHeads"]);
-  assert.equal(frames[0].result, "0xSUBID");
-  assert.equal(frames[1].method, "chain_newHead");
+  assert.deepEqual(seen, [
+    { jsonrpc: "2.0", id: 1, result: "0xSUBID" },
+    {
+      jsonrpc: "2.0",
+      method: "chain_newHead",
+      params: { subscription: "0xSUBID", result: { number: "0x1" } },
+    },
+  ]);
 
   await lb.close();
   await new Promise((resolve) => http.close(resolve));

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -180,7 +180,9 @@ export const SAFE_RPC_METHODS = new Set([
 // Read-only WebSocket subscriptions — WSS-ONLY. The HTTP proxy uses SAFE_RPC_METHODS
 // alone (subscriptions need a persistent connection, so they make no sense over HTTP);
 // the wss-lb additionally allows these. Their notifications stream upstream→client.
-// All read-only — author_submitAndWatchExtrinsic stays blocked by the author_ prefix.
+// Deliberately excludes persistent storage subscriptions, which can create
+// unbounded upstream watcher state for arbitrary keys. All allowed entries are
+// read-only — author_submitAndWatchExtrinsic stays blocked by the author_ prefix.
 export const SAFE_RPC_SUBSCRIPTIONS = new Set([
   "chain_subscribeNewHeads",
   "chain_subscribeNewHead",
@@ -191,8 +193,6 @@ export const SAFE_RPC_SUBSCRIPTIONS = new Set([
   "chain_unsubscribeFinalisedHeads",
   "chain_subscribeAllHeads",
   "chain_unsubscribeAllHeads",
-  "state_subscribeStorage",
-  "state_unsubscribeStorage",
   "state_subscribeRuntimeVersion",
   "state_unsubscribeRuntimeVersion",
 ]);

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -181,8 +181,9 @@ export const SAFE_RPC_METHODS = new Set([
 // alone (subscriptions need a persistent connection, so they make no sense over HTTP);
 // the wss-lb additionally allows these. Their notifications stream upstream→client.
 // Deliberately excludes persistent storage subscriptions, which can create
-// unbounded upstream watcher state for arbitrary keys. All allowed entries are
-// read-only — author_submitAndWatchExtrinsic stays blocked by the author_ prefix.
+// unbounded upstream watcher state for arbitrary keys.
+// All allowed entries are read-only; author_submitAndWatchExtrinsic stays blocked
+// by the author_ prefix.
 export const SAFE_RPC_SUBSCRIPTIONS = new Set([
   "chain_subscribeNewHeads",
   "chain_subscribeNewHead",


### PR DESCRIPTION
### Motivation
- The public WSS proxy previously allowed `state_subscribeStorage`, which creates persistent upstream storage watchers for arbitrary keys and can be trivially abused to amplify load and hold upstream resources indefinitely. 
- The intent of this change is to remove persistent storage subscriptions from the public WSS allowlist while preserving bounded, read-only head/runtime subscriptions.

### Description
- Removed `state_subscribeStorage` and `state_unsubscribeStorage` from the WSS-only `SAFE_RPC_SUBSCRIPTIONS` list in both the standalone load‑balancer policy (`deploy/wss-lb/src/rpc-policy.mjs`) and the Worker config (`workers/config.mjs`).
- Added a clarifying comment documenting that persistent storage subscriptions are deliberately excluded because they can create unbounded upstream watcher state. 
- Added a regression test (`deploy/wss-lb/test/proxy.test.mjs`) that asserts `state_subscribeStorage` is rejected with `-32601` and that no frames for that method are forwarded to the upstream.
- Kept the policy drift sync test in place to ensure the standalone wss-lb policy remains consistent with the Worker config.

### Testing
- Ran formatting check: `npx prettier --check deploy/wss-lb/src/rpc-policy.mjs deploy/wss-lb/test/proxy.test.mjs workers/config.mjs`, which passed. 
- Executed the wss-lb node tests: `node --test deploy/wss-lb/test/*.mjs`, and all wss-lb tests (including the new storage-subscription rejection test) passed. 
- Ran the drift sync test: `npx vitest run tests/wss-lb-rpc-policy-sync.test.mjs`, which passed, and ran `npm run validate:private-boundary`, which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40475f94a0832cb0dd2d9db38961f7)