### PR TITLE
fix(backup): avoid upload failure deadlock

### DIFF
--- a/deploy/backup/backup-postgres.sh
+++ b/deploy/backup/backup-postgres.sh
@@ -26,6 +26,8 @@ KEY="${PREFIX}/metagraphed-${TS}.sql.gz"
 
 echo "backup: pg_dump | gzip -> s3://${R2_BUCKET}/${KEY}"
 # Stream pg_dump through gzip without landing the raw dump on container disk.
+# The compressed dump does land in TMPDIR before upload; size the service's
+# ephemeral disk for the compressed backup, not the raw database dump.
 # Keep the upload as a separate step so early aws CLI/config failures cannot
 # deadlock the dump/gzip FIFO chain before the script observes them.
 # Use explicit process waits instead of a shell pipeline: POSIX sh reports

--- a/deploy/backup/backup-postgres.sh
+++ b/deploy/backup/backup-postgres.sh
@@ -25,21 +25,21 @@ TS="$(date -u +%Y%m%dT%H%M%SZ)"
 KEY="${PREFIX}/metagraphed-${TS}.sql.gz"
 
 echo "backup: pg_dump | gzip -> s3://${R2_BUCKET}/${KEY}"
-# Stream straight through — never lands the full dump on the container disk.
-# Use explicit FIFOs/process waits instead of a shell pipeline: POSIX sh reports
+# Stream pg_dump through gzip without landing the raw dump on container disk.
+# Keep the upload as a separate step so early aws CLI/config failures cannot
+# deadlock the dump/gzip FIFO chain before the script observes them.
+# Use explicit process waits instead of a shell pipeline: POSIX sh reports
 # only the last command's status for pipelines, which can hide pg_dump failures.
 TMPDIR="$(mktemp -d)"
 RAW_FIFO="${TMPDIR}/dump.sql"
-GZ_FIFO="${TMPDIR}/dump.sql.gz"
+GZ_FILE="${TMPDIR}/dump.sql.gz"
 cleanup() {
   rm -rf "$TMPDIR"
 }
 trap cleanup EXIT HUP INT TERM
-mkfifo "$RAW_FIFO" "$GZ_FIFO"
+mkfifo "$RAW_FIFO"
 
-aws s3 cp "$GZ_FIFO" "s3://${R2_BUCKET}/${KEY}" --endpoint-url "$R2_ENDPOINT" &
-AWS_PID=$!
-gzip -9 <"$RAW_FIFO" >"$GZ_FIFO" &
+gzip -9 <"$RAW_FIFO" >"$GZ_FILE" &
 GZIP_PID=$!
 pg_dump --no-owner --no-privileges "$DATABASE_URL" >"$RAW_FIFO" &
 PG_DUMP_PID=$!
@@ -53,11 +53,11 @@ if ! wait "$GZIP_PID"; then
   echo "backup failed: gzip exited nonzero" >&2
   STATUS=1
 fi
-if ! wait "$AWS_PID"; then
-  echo "backup failed: aws upload exited nonzero" >&2
-  STATUS=1
-fi
 if [ "$STATUS" -ne 0 ]; then
   exit "$STATUS"
+fi
+if ! aws s3 cp "$GZ_FILE" "s3://${R2_BUCKET}/${KEY}" --endpoint-url "$R2_ENDPOINT"; then
+  echo "backup failed: aws upload exited nonzero" >&2
+  exit 1
 fi
 echo "backup complete: s3://${R2_BUCKET}/${KEY}"

--- a/tests/backup-postgres.test.mjs
+++ b/tests/backup-postgres.test.mjs
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
-  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -17,7 +17,17 @@ function writeExecutable(filePath, content) {
   chmodSync(filePath, 0o755);
 }
 
-function runBackupWithMocks(pgDumpScript) {
+function runBackupWithMocks(
+  pgDumpScript,
+  awsScript = `#!/usr/bin/env sh
+set -eu
+if [ "$1" != "s3" ] || [ "$2" != "cp" ]; then
+  exit 2
+fi
+cat "$3" > "$FAKE_UPLOAD_PATH"
+`,
+  options = {},
+) {
   const temporaryDirectory = mkdtempSync(
     path.join(tmpdir(), "metagraphed-backup-test-"),
   );
@@ -25,20 +35,12 @@ function runBackupWithMocks(pgDumpScript) {
   const uploadPath = path.join(temporaryDirectory, "uploaded.sql.gz");
   mkdirp(binDirectory);
   writeExecutable(path.join(binDirectory, "pg_dump"), pgDumpScript);
-  writeExecutable(
-    path.join(binDirectory, "aws"),
-    `#!/usr/bin/env sh
-set -eu
-if [ "$1" != "s3" ] || [ "$2" != "cp" ]; then
-  exit 2
-fi
-cat "$3" > "$FAKE_UPLOAD_PATH"
-`,
-  );
+  writeExecutable(path.join(binDirectory, "aws"), awsScript);
 
   const result = spawnSync("sh", ["deploy/backup/backup-postgres.sh"], {
     cwd: process.cwd(),
     encoding: "utf8",
+    ...options,
     env: {
       ...process.env,
       AWS_ACCESS_KEY_ID: "test-key",
@@ -71,7 +73,34 @@ exit 42
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /backup failed: pg_dump exited nonzero/);
     assert.doesNotMatch(result.stdout, /backup complete/);
-    assert.ok(readFileSync(uploadPath).length > 0);
+    assert.equal(existsSync(uploadPath), false);
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("backup script fails promptly when aws exits before upload", () => {
+  const { result, temporaryDirectory, uploadPath } = runBackupWithMocks(
+    `#!/usr/bin/env sh
+python3 - <<'PY'
+import sys
+for _ in range(1024):
+    sys.stdout.write("x" * 1024)
+PY
+`,
+    `#!/usr/bin/env sh
+echo 'aws mock: immediate CLI/config failure' >&2
+exit 64
+`,
+    { timeout: 2000 },
+  );
+
+  try {
+    assert.notEqual(result.status, null);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /backup failed: aws upload exited nonzero/);
+    assert.doesNotMatch(result.stdout, /backup complete/);
+    assert.equal(existsSync(uploadPath), false);
   } finally {
     rmSync(temporaryDirectory, { recursive: true, force: true });
   }

--- a/tests/backup-postgres.test.mjs
+++ b/tests/backup-postgres.test.mjs
@@ -82,11 +82,7 @@ exit 42
 test("backup script fails promptly when aws exits before upload", () => {
   const { result, temporaryDirectory, uploadPath } = runBackupWithMocks(
     `#!/usr/bin/env sh
-python3 - <<'PY'
-import sys
-for _ in range(1024):
-    sys.stdout.write("x" * 1024)
-PY
+dd if=/dev/zero bs=1024 count=1024 2>/dev/null
 `,
     `#!/usr/bin/env sh
 echo 'aws mock: immediate CLI/config failure' >&2


### PR DESCRIPTION
### Motivation
- The FIFO-based backup flow could deadlock if the `aws` upload process exited early, because `gzip` and `pg_dump` could block on FIFO opens/writes before the script observed the upload failure. 
- The goal is to ensure the backup job fails promptly on downstream upload errors while preserving detection of incomplete `pg_dump` output.

### Description
- Replace the second compressed FIFO with a temporary compressed file (`GZ_FILE`) and keep the raw FIFO for `pg_dump` → `gzip` streaming to avoid a reader-only FIFO deadlock. 
- Run `gzip` and `pg_dump` as background processes and keep explicit `wait` checks for their exit statuses so incomplete dumps are detected before any upload. 
- Perform the `aws s3 cp` upload as a separate synchronous step after `pg_dump`/`gzip` succeed and fail fast if the upload command exits nonzero. 
- Update `tests/backup-postgres.test.mjs` to allow injectable `aws` mocks and add a regression test that simulates an immediate `aws` CLI/config failure to verify the script exits promptly and does not produce a (partial) uploaded file.

### Testing
- Ran `npx vitest run tests/backup-postgres.test.mjs`, which executed the two backup tests and both passed. 
- Ran `git diff --check` to ensure no whitespace/check issues were introduced and it reported clean.
- The change is covered by the new regression test that simulates an immediate `aws` failure and verifies the script exits without hanging and without leaving an uploaded artifact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a403be481cc832c8054518e12b7996d)