### PR TITLE
fix(data-api): normalize stats block window

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -125,6 +125,15 @@ test("chain-events/stats floors fractional blocks before binding", async () => {
   expect(sqlCalls.at(-1).values).not.toContain(1.5);
 });
 
+test("chain-events/stats preserves minimum block window after flooring", async () => {
+  const res = await req("/api/v1/chain-events/stats?blocks=0.5");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.window_blocks).toBe(1);
+  expect(sqlCalls.at(-1).values).toContain(1);
+  expect(sqlCalls.at(-1).values).not.toContain(0);
+});
+
 test("chain-events rejects overlong or non-enumerable pallet/method filters", async () => {
   const res = await req(`/api/v1/chain-events?pallet=${"A".repeat(65)}`);
   expect(res.status).toBe(400);

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -116,6 +116,15 @@ test("chain-events/stats returns the activity aggregate with a clamped window", 
   ).toBe(1000);
 });
 
+test("chain-events/stats floors fractional blocks before binding", async () => {
+  const res = await req("/api/v1/chain-events/stats?blocks=1.5");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.window_blocks).toBe(1);
+  expect(sqlCalls.at(-1).values).toContain(1);
+  expect(sqlCalls.at(-1).values).not.toContain(1.5);
+});
+
 test("chain-events rejects overlong or non-enumerable pallet/method filters", async () => {
   const res = await req(`/api/v1/chain-events?pallet=${"A".repeat(65)}`);
   expect(res.status).toBe(400);

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -36,6 +36,12 @@ function clampLimit(raw) {
   return Math.min(Math.floor(n), MAX_LIMIT);
 }
 
+function clampStatsBlocks(raw) {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return 1000;
+  return Math.min(Math.floor(n), 5000);
+}
+
 // postgres.js returns BIGINT columns as strings; the D1-backed routes return them
 // as numbers. block_number and observed_at are both < 2^53, so Number(...) is
 // lossless — coerce them per event row for a consistent numeric API shape.
@@ -152,10 +158,7 @@ export default {
       // pallet.method event distribution over the most recent N blocks (default
       // 1000, capped 5000). Bounded window + capped output keep it index-cheap.
       if (url.pathname === "/api/v1/chain-events/stats") {
-        const blocks = Math.min(
-          Math.max(Number(url.searchParams.get("blocks")) || 1000, 1),
-          5000,
-        );
+        const blocks = clampStatsBlocks(url.searchParams.get("blocks"));
         const rows = await sql`
           SELECT pallet, method, count(*)::int AS count
           FROM chain_events

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -39,7 +39,7 @@ function clampLimit(raw) {
 function clampStatsBlocks(raw) {
   const n = Number(raw);
   if (!Number.isFinite(n) || n <= 0) return 1000;
-  return Math.min(Math.floor(n), 5000);
+  return Math.min(Math.max(Math.floor(n), 1), 5000);
 }
 
 // postgres.js returns BIGINT columns as strings; the D1-backed routes return them


### PR DESCRIPTION
### Motivation
- The `/api/v1/chain-events/stats` route previously clamped the `blocks` query parameter but did not normalize it to an integer, allowing fractional values (for example `1.5`) to be bound into BIGINT arithmetic and causing Postgres type/input errors and 502 responses.

### Description
- Add `clampStatsBlocks(raw)` in `workers/data-api.mjs` to validate with `Number.isFinite`, floor the value, and clamp it to the `[1, 5000]` range with a default of `1000`.
- Replace the inline clamping in the stats handler with `clampStatsBlocks(...)`.
- Add regression coverage in `tests/data-api.test.mjs` for fractional values that floor to `1`, including the `0.5` lower-bound case so the route cannot regress to a zero-block window.

### Scope / no-issue rationale
- No linked issue: this is a small maintainer security/availability follow-up found during PR triage, scoped to one query parameter on `/api/v1/chain-events/stats`.
- This is intentionally route-local. It does not change account builders, chain signer rows, schemas, contracts, generated artifacts, or public response shape beyond rejecting fractional SQL binding behavior by normalizing the window.

### Overlap review
- `#2184` / `#2183` sanitize `last_tx_block` in chain signer leaderboard rows. That does not touch `workers/data-api.mjs` or the `chain-events/stats` SQL window parameter.
- `#2188` / `#2187` sanitize account API builder block heights and event indices. That does not touch the chain-events stats route or its `blocks` query parameter.
- This PR is safe to merge independently because it fixes a different input boundary and has focused route-level regression coverage.

### Testing
- `npm test -- tests/data-api.test.mjs` passed locally: 13 tests.
- `git diff --check` passed locally.
- GitHub CI/checks and Codecov are green on the current head.