### PR TITLE
test(api): complete block events numeric-ref coverage (#2069)

### DIFF
--- a/tests/block-events.test.mjs
+++ b/tests/block-events.test.mjs
@@ -131,3 +131,17 @@ test("GET /blocks/{number}/events resolves an unknown numeric ref to block_numbe
   assert.equal(body.data.event_count, 0);
   assert.equal(Array.isArray(body.data.events), true);
 });
+
+test("GET /blocks/{number}/events ignores orphaned account_events when block is absent", async () => {
+  const env = dbWith({ events: [ROW], blockNumber: null });
+  const res = await handleRequest(
+    req("/api/v1/blocks/1000000/events"),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.block_number, null);
+  assert.equal(body.data.event_count, 0);
+  assert.deepEqual(body.data.events, []);
+});

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1775,6 +1775,7 @@ describe("handleBlockEvents", () => {
       String(BLOCK_NUM),
       url(`/api/v1/blocks/${BLOCK_NUM}/events`),
     );
+    assert.equal(body.data.block_number, null);
     assert.equal(body.data.event_count, 0);
     assert.deepEqual(body.data.events, []);
   });
@@ -1826,6 +1827,34 @@ describe("handleBlockEvents", () => {
     assert.equal(body.data.block_number, null);
     assert.equal(body.data.event_count, 0);
     assert.deepEqual(body.data.events, []);
+  });
+
+  test("orphaned account_events rows do not bypass blocks existence check", async () => {
+    const { env } = dbWith({ blockEvents: [accountEventRow()] });
+    const body = await json(
+      await handleBlockEvents(
+        req(`/api/v1/blocks/${BLOCK_NUM}/events`),
+        env,
+        String(BLOCK_NUM),
+        url(`/api/v1/blocks/${BLOCK_NUM}/events`),
+      ),
+    );
+    assert.equal(body.data.block_number, null);
+    assert.equal(body.data.event_count, 0);
+    assert.deepEqual(body.data.events, []);
+  });
+
+  test("unknown hash ref yields block_number:null + empty events", async () => {
+    const unknown = `0x${"d".repeat(64)}`;
+    const body = await assertColdSchema(
+      handleBlockEvents,
+      req(`/api/v1/blocks/${unknown}/events`),
+      emptyEnv(),
+      unknown,
+      url(`/api/v1/blocks/${unknown}/events`),
+    );
+    assert.equal(body.data.block_number, null);
+    assert.equal(body.data.event_count, 0);
   });
 
   test("normalizes an uppercase 0x block_hash to lowercase before D1 lookup", async () => {


### PR DESCRIPTION
## Summary

Issue #2069 describes the same bug class fixed in #1953 / #1981: `handleBlockEvents` must resolve numeric `{ref}` values against the `blocks` tier before reading `account_events`, mirroring `handleBlockExtrinsics`.

The handler fix is already on `main` via #1981 (`9931b228`). This PR completes the remaining test coverage called out in #2069 so the contract is fully locked in:

- Cold D1 events path asserts `block_number: null` (parity with extrinsics)
- Unknown hash ref → `block_number: null` + empty events (handler unit tests)
- Orphaned `account_events` rows cannot bypass a missing `blocks` row (integration + unit)

## What changed

- `tests/request-handlers-entities.test.mjs`: symmetric cold-D1, unknown-hash, and orphaned-events assertions for `handleBlockEvents`
- `tests/block-events.test.mjs`: integration test that events in D1 are not served when the block is absent from `blocks`

No handler or API contract changes.

Closes #2069

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes.

## Validation

- [x] `npx vitest run tests/block-events.test.mjs tests/request-handlers-entities.test.mjs -t "handleBlockEvents|blocks/{ref}/events|blocks/{number}/events"` → 16 passed
- [x] `npm run format:check` → clean

