### PR TITLE
test: harden async D1 loader/writer failure paths

### DIFF
--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -11,6 +11,9 @@ import {
   buildAccountEvents,
   buildAccountSubnets,
   loadAccountSummary,
+  loadAccountEvents,
+  loadAccountHistory,
+  loadAccountSubnets,
   ACCOUNT_ACTIVITY_RECENT_LIMIT,
   eventInsertStatements,
   utcDayBounds,
@@ -18,6 +21,7 @@ import {
   pruneAccountEvents,
   validEventRows,
 } from "../src/account-events.mjs";
+import { encodeCursor } from "../src/cursor.mjs";
 
 test("validEventRows enforces the strict row shape (#1371)", () => {
   assert.deepEqual(validEventRows("not-an-array"), []);
@@ -406,4 +410,262 @@ test("loadAccountSummary bounds signing activity before aggregating", async () =
   assert.ok(/FROM \(SELECT call_module FROM extrinsics/.test(modules.sql));
   assert.ok(/LIMIT \?\) GROUP BY call_module/.test(modules.sql));
   assert.deepEqual(modules.params, ["5Hk", ACCOUNT_ACTIVITY_RECENT_LIMIT]);
+});
+
+// ---- Async loader failure-path coverage ------------------------------------
+// The shared loaders take a (sql, params) => Promise<rows[]> runner. The real
+// d1All swallows a D1 timeout/schema-drift to [] (workers analytics), so from a
+// loader's view a cold store, a timed-out read, and an empty subnet all arrive
+// as []. These assert the loaders stay schema-stable on that empty path and that
+// pagination (offset vs keyset cursor, clamping) is wired correctly.
+
+// A d1 runner that returns [] for every query — the shape d1All hands back on a
+// cold/unbound DB OR a swallowed D1 timeout/schema-drift error.
+const emptyD1 = async () => [];
+
+test("loadAccountEvents is schema-stable when the D1 read yields nothing", async () => {
+  const out = await loadAccountEvents(emptyD1, "5Hk", { limit: 50, offset: 0 });
+  assert.equal(out.schema_version, 1);
+  assert.equal(out.ss58, "5Hk");
+  assert.equal(out.event_count, 0);
+  assert.deepEqual(out.events, []);
+  assert.equal(out.limit, 50); // clamped value still echoed
+  assert.equal(out.offset, 0);
+  assert.equal(out.next_cursor, null); // no full page → no next cursor
+});
+
+test("loadAccountEvents propagates a rejecting D1 runner (no silent swallow)", async () => {
+  // If the injected runner rejects (e.g. a non-swallowed downstream failure),
+  // the loader must not mask it as an empty feed — the caller decides.
+  await assert.rejects(
+    loadAccountEvents(async () => {
+      throw new Error("d1 timeout");
+    }, "5Hk"),
+    /d1 timeout/,
+  );
+});
+
+test("loadAccountEvents clamps limit/offset and matches both account keys", async () => {
+  let captured;
+  await loadAccountEvents(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [];
+    },
+    "5Hk",
+    { limit: 9999, offset: -5 }, // over max / below min
+  );
+  // limit clamps to the 1000 ceiling, offset clamps up to the 0 floor.
+  assert.ok(captured.sql.includes("LIMIT ?"));
+  assert.ok(captured.sql.includes("OFFSET ?"));
+  assert.deepEqual(captured.params, ["5Hk", "5Hk", 1000, 0]);
+});
+
+test("loadAccountEvents applies the ?kind filter as a bound param", async () => {
+  let captured;
+  await loadAccountEvents(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [];
+    },
+    "5Hk",
+    { kind: "StakeAdded" },
+  );
+  assert.ok(/AND event_kind = \?/.test(captured.sql));
+  // [ss58, ss58, kind, limit(default 100), offset(default 0)]
+  assert.deepEqual(captured.params, ["5Hk", "5Hk", "StakeAdded", 100, 0]);
+});
+
+test("loadAccountEvents emits a next_cursor only on a full page", async () => {
+  // A full page (rows.length === limit) → keyset cursor off the last row.
+  const full = await loadAccountEvents(
+    async () => [
+      { block_number: 9, event_index: 2, event_kind: "WeightsSet" },
+      { block_number: 8, event_index: 0, event_kind: "StakeAdded" },
+    ],
+    "5Hk",
+    { limit: 2 },
+  );
+  assert.equal(full.event_count, 2);
+  assert.equal(full.next_cursor, encodeCursor([8, 0]));
+
+  // A partial page (fewer than limit) → end-of-window, no cursor.
+  const partial = await loadAccountEvents(
+    async () => [{ block_number: 9, event_index: 2, event_kind: "WeightsSet" }],
+    "5Hk",
+    { limit: 2 },
+  );
+  assert.equal(partial.next_cursor, null);
+});
+
+test("loadAccountEvents uses a keyset seek (not OFFSET) when a cursor is given", async () => {
+  let captured;
+  await loadAccountEvents(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [];
+    },
+    "5Hk",
+    { cursor: encodeCursor([1000, 3]), limit: 50 },
+  );
+  assert.ok(/\(block_number, event_index\) < \(\?, \?\)/.test(captured.sql));
+  assert.ok(!/OFFSET/.test(captured.sql)); // cursor overrides offset
+  // [ss58, ss58, curBlock, curIndex, limit]
+  assert.deepEqual(captured.params, ["5Hk", "5Hk", 1000, 3, 50]);
+});
+
+test("loadAccountEvents ignores a malformed cursor and falls back to OFFSET", async () => {
+  let captured;
+  await loadAccountEvents(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [];
+    },
+    "5Hk",
+    { cursor: "not-a-cursor", offset: 20 },
+  );
+  assert.ok(/OFFSET \?/.test(captured.sql));
+  assert.ok(!/\(block_number, event_index\) </.test(captured.sql));
+  assert.deepEqual(captured.params, ["5Hk", "5Hk", 100, 20]);
+});
+
+test("loadAccountHistory is schema-stable when the D1 read yields nothing", async () => {
+  const out = await loadAccountHistory(emptyD1, "5Hk", {
+    limit: 25,
+    offset: 0,
+  });
+  assert.equal(out.schema_version, 1);
+  assert.equal(out.ss58, "5Hk");
+  assert.equal(out.day_count, 0);
+  assert.deepEqual(out.days, []);
+  assert.equal(out.limit, 25);
+  assert.equal(out.offset, 0);
+});
+
+test("loadAccountHistory propagates a rejecting D1 runner", async () => {
+  await assert.rejects(
+    loadAccountHistory(async () => {
+      throw new Error("d1 down");
+    }, "5Hk"),
+    /d1 down/,
+  );
+});
+
+test("loadAccountHistory binds netuid/from/to filters and clamps pagination", async () => {
+  let captured;
+  await loadAccountHistory(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [];
+    },
+    "5Hk",
+    { netuid: 7, from: "2026-06-01", to: "2026-06-30", limit: 0, offset: 5 },
+  );
+  assert.ok(/AND netuid = \?/.test(captured.sql));
+  assert.ok(/AND day >= \?/.test(captured.sql));
+  assert.ok(/AND day <= \?/.test(captured.sql));
+  assert.ok(/ORDER BY day DESC LIMIT \? OFFSET \?/.test(captured.sql));
+  // limit 0 is below the floor → clamps to 1; offset 5 passes through.
+  assert.deepEqual(captured.params, [
+    "5Hk",
+    7,
+    "2026-06-01",
+    "2026-06-30",
+    1,
+    5,
+  ]);
+});
+
+test("loadAccountHistory ignores a non-integer netuid filter", async () => {
+  let captured;
+  await loadAccountHistory(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [];
+    },
+    "5Hk",
+    { netuid: 7.5 },
+  );
+  assert.ok(!/AND netuid = \?/.test(captured.sql));
+  assert.deepEqual(captured.params, ["5Hk", 100, 0]);
+});
+
+test("loadAccountHistory maps sparse rollup rows null-safely", async () => {
+  const out = await loadAccountHistory(
+    async () => [
+      { day: "2026-06-24" }, // every other column absent
+      { day: "2026-06-23", netuid: 1, event_count: 4, event_kinds: "" },
+    ],
+    "5Hk",
+  );
+  assert.equal(out.day_count, 2);
+  assert.equal(out.days[0].netuid, null);
+  assert.equal(out.days[0].event_count, null);
+  assert.deepEqual(out.days[0].event_kinds, []); // missing CSV → []
+  assert.deepEqual(out.days[1].event_kinds, []); // empty CSV → []
+});
+
+test("loadAccountSubnets is schema-stable when the D1 read yields nothing", async () => {
+  const out = await loadAccountSubnets(emptyD1, "5Hk");
+  assert.equal(out.schema_version, 1);
+  assert.equal(out.ss58, "5Hk");
+  assert.equal(out.subnet_count, 0);
+  assert.deepEqual(out.subnets, []);
+});
+
+test("loadAccountSubnets propagates a rejecting D1 runner", async () => {
+  await assert.rejects(
+    loadAccountSubnets(async () => {
+      throw new Error("d1 timeout");
+    }, "5Hk"),
+    /d1 timeout/,
+  );
+});
+
+test("loadAccountSubnets reads neurons by hotkey ordered by netuid", async () => {
+  let captured;
+  await loadAccountSubnets(async (sql, params) => {
+    captured = { sql, params };
+    return [];
+  }, "5Hk");
+  assert.ok(/FROM neurons WHERE hotkey = \?/.test(captured.sql));
+  assert.ok(/ORDER BY netuid/.test(captured.sql));
+  assert.deepEqual(captured.params, ["5Hk"]);
+});
+
+test("loadAccountSubnets maps sparse registration rows null-safely", async () => {
+  const out = await loadAccountSubnets(
+    async () => [{ netuid: 7 }], // uid/stake/permit/active absent
+    "5Hk",
+  );
+  assert.equal(out.subnet_count, 1);
+  assert.equal(out.subnets[0].netuid, 7);
+  assert.equal(out.subnets[0].uid, null);
+  assert.equal(out.subnets[0].stake_tao, null);
+  assert.equal(out.subnets[0].validator_permit, false);
+  assert.equal(out.subnets[0].active, false);
+});
+
+test("loadAccountSummary is schema-stable when every parallel read times out to []", async () => {
+  // Mirrors d1All swallowing a timeout/cold store to [] for all six reads.
+  const out = await loadAccountSummary(emptyD1, "5Hk");
+  assert.equal(out.event_count, 0);
+  assert.equal(out.subnet_count, 0);
+  assert.deepEqual(out.registrations, []);
+  assert.deepEqual(out.recent_events, []);
+  assert.equal(out.activity.tx_count, 0);
+});
+
+test("loadAccountSummary propagates when any parallel D1 read rejects", async () => {
+  // Promise.all rejects fast if any one of the six reads throws — the loader
+  // must not swallow that into a falsely-empty summary.
+  let n = 0;
+  await assert.rejects(
+    loadAccountSummary(async () => {
+      n += 1;
+      if (n === 3) throw new Error("d1 read 3 failed");
+      return [];
+    }, "5Hk"),
+    /d1 read 3 failed/,
+  );
 });

--- a/tests/economics-backfill.test.mjs
+++ b/tests/economics-backfill.test.mjs
@@ -182,6 +182,91 @@ test("handleRequest routes POST /api/v1/internal/backfill-economics", async () =
   assert.equal(res.status, 503);
 });
 
+// ---- Writer failure-path coverage (D1 batch) -------------------------------
+// The backfill writer is economicsSnapshotUpsertStatements + db.batch. The
+// handler runs the batch WITHOUT a try/catch, so a D1 failure during the upsert
+// must surface (reject) — never be swallowed into a false 200. These harden that
+// path plus the all-invalid no-batch short-circuit.
+
+test("economics backfill surfaces a D1 batch failure instead of a false 200", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return { bind: (...v) => ({ sql, v }) };
+      },
+      async batch() {
+        throw new Error("D1_ERROR: database is locked");
+      },
+    },
+  };
+  // One valid row → the writer reaches db.batch, which rejects; the handler
+  // does not catch it, so the rejection propagates to the caller (the runtime
+  // turns it into a 500), proving no swallow-to-200.
+  await assert.rejects(
+    handleEconomicsBackfill(post([row()], { secret: SECRET }), env),
+    /database is locked/,
+  );
+});
+
+test("economics backfill issues no batch when every row is invalid (no D1 call)", async () => {
+  let batched = 0;
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return { bind: (...v) => ({ sql, v }) };
+      },
+      async batch() {
+        batched += 1;
+      },
+    },
+  };
+  // All rows fail validEconomicsBackfillRows → rows.length === 0 → no db.batch.
+  const res = await handleEconomicsBackfill(
+    post([{ netuid: -1 }, { snapshot_date: "bad" }], { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.received, 2);
+  assert.equal(body.inserted, 0);
+  assert.equal(batched, 0); // short-circuited before touching D1
+});
+
+test("economicsSnapshotUpsertStatements emits one bound statement per valid row", () => {
+  // Writer-shape contract: N valid rows → N parameterized statements, each with
+  // exactly 4 bound values (no interpolation), so a batch is sized to the input.
+  const db = { prepare: (sql) => ({ bind: (...v) => ({ sql, v }) }) };
+  const valid = validEconomicsBackfillRows([
+    row(),
+    row({ netuid: 9, snapshot_date: "2025-12-02", alpha_price_tao: 0.5 }),
+  ]);
+  const stmts = economicsSnapshotUpsertStatements(db, valid);
+  assert.equal(stmts.length, 2);
+  for (const s of stmts) assert.equal(s.v.length, 4);
+});
+
+test("economicsSnapshotUpsertStatements no-ops on an empty row set", () => {
+  const db = { prepare: (sql) => ({ bind: (...v) => ({ sql, v }) }) };
+  assert.deepEqual(economicsSnapshotUpsertStatements(db, []), []);
+});
+
+test("economicsSnapshotUpsertStatements treats a NaN captured_at as missing", () => {
+  // A non-finite captured_at must fall back to the snapshot day's UTC midnight,
+  // not bind NaN into the row (which would poison the time column).
+  const db = { prepare: (sql) => ({ bind: (...v) => ({ sql, v }) }) };
+  const stmts = economicsSnapshotUpsertStatements(db, [
+    {
+      netuid: 8,
+      snapshot_date: "2025-12-01",
+      alpha_price_tao: 0.1,
+      captured_at: Number.NaN,
+    },
+  ]);
+  assert.equal(stmts[0].v[3], Date.parse("2025-12-01T00:00:00Z"));
+});
+
 test("validEconomicsBackfillRows + upsert: captured_at falls back to the snapshot day", () => {
   const valid = validEconomicsBackfillRows([
     { netuid: 8, snapshot_date: "2025-12-01", alpha_price_tao: 0.1 }, // no captured_at

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -405,6 +405,28 @@ async function assertColdSchema(handlerFn, ...args) {
   return body;
 }
 
+// An env whose D1 read REJECTS (schema drift / "no such column" / connection
+// failure). d1All catches this and degrades to [] — the handler must stay 200 +
+// schema-stable, never propagate the throw or 404. Bound (a real prepared
+// statement chain) so .prepare().bind().all() exists and only .all() rejects.
+function dbThrows(message = "no such column") {
+  return {
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        return {
+          bind() {
+            return {
+              async all() {
+                throw new Error(message);
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
 describe("handleSubnetMetagraph", () => {
   test("rejects an unsupported query param with 400", async () => {
     const res = await handleSubnetMetagraph(
@@ -782,6 +804,50 @@ describe("handleSubnetConcentration", () => {
     assert.ok(/validator_permit/.test(captures.sql[idx]));
     assert.equal(captures.params[idx][0], NETUID);
   });
+
+  test("degrades to schema-stable null blocks when the D1 read throws", async () => {
+    // A bound DB whose .all() rejects (schema drift) — d1All swallows it to [],
+    // so the handler still answers 200 with null metric blocks, never 5xx/404.
+    const res = await handleSubnetConcentration(
+      req(`/api/v1/subnets/${NETUID}/concentration`),
+      dbThrows("no such column: validator_permit"),
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/concentration`),
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.netuid, NETUID);
+    assert.equal(body.data.neuron_count, 0);
+    assert.equal(body.data.stake, null);
+    assert.equal(body.data.emission, null);
+    assert.equal(body.data.validator_stake, null);
+    assert.equal(body.data.captured_at, null);
+  });
+
+  test("is null-safe on sparse / all-zero neuron rows (null metric blocks)", async () => {
+    // Rows present but carrying no positive distribution (zero stake/emission,
+    // missing coldkeys) → neuron_count reflects the rows, every metric block null.
+    const { env } = dbWith({
+      neurons: [
+        neuronRow({ stake_tao: 0, emission_tao: 0, coldkey: null }),
+        neuronRow({ uid: 1, stake_tao: 0, emission_tao: 0, coldkey: "" }),
+      ],
+    });
+    const body = await json(
+      await handleSubnetConcentration(
+        req(`/api/v1/subnets/${NETUID}/concentration`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/concentration`),
+      ),
+    );
+    assert.equal(body.data.neuron_count, 2);
+    assert.equal(body.data.entity_count, 2); // two missing-coldkey singletons
+    assert.equal(body.data.stake, null); // no positive stake → null block
+    assert.equal(body.data.emission, null);
+    assert.equal(body.data.validator_stake, null);
+  });
 });
 
 describe("handleSubnetConcentrationHistory", () => {
@@ -847,6 +913,69 @@ describe("handleSubnetConcentrationHistory", () => {
     );
     assert.ok(idx !== -1);
     assert.equal(captures.params[idx][0], NETUID);
+  });
+
+  test("degrades to an empty series when the D1 read throws", async () => {
+    // d1All swallows the rejecting read to []; the trend stays 200 + points:[].
+    const res = await handleSubnetConcentrationHistory(
+      req(`/api/v1/subnets/${NETUID}/concentration/history`),
+      dbThrows("d1 timeout"),
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/concentration/history?window=7d`),
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.netuid, NETUID);
+    assert.equal(body.data.window, "7d");
+    assert.equal(body.data.point_count, 0);
+    assert.deepEqual(body.data.points, []);
+  });
+
+  test("binds the windowed read with a row cap and an ISO date cutoff", async () => {
+    // The raw per-UID read is bounded by CONCENTRATION_HISTORY_ROW_CAP and a
+    // window-derived YYYY-MM-DD cutoff — assert both are bound (params, not SQL).
+    const { env, captures } = dbWith({ neuronDailyHistory: [] });
+    await handleSubnetConcentrationHistory(
+      req(`/api/v1/subnets/${NETUID}/concentration/history`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/concentration/history?window=30d`),
+    );
+    const idx = captures.sql.findIndex((s) =>
+      /FROM neuron_daily WHERE netuid = \? AND snapshot_date >= \? ORDER BY snapshot_date DESC LIMIT \?/.test(
+        s,
+      ),
+    );
+    assert.ok(idx !== -1);
+    const [boundNetuid, cutoff, cap] = captures.params[idx];
+    assert.equal(boundNetuid, NETUID);
+    assert.match(cutoff, /^\d{4}-\d{2}-\d{2}$/); // ISO day cutoff
+    assert.equal(cap, 50_000); // CONCENTRATION_HISTORY_ROW_CAP
+  });
+
+  test("skips dateless rows and is null-safe on sparse history rows", async () => {
+    const { env } = dbWith({
+      neuronDailyHistory: [
+        { snapshot_date: null, stake_tao: 5 }, // dropped (no date)
+        { snapshot_date: "2026-06-27" }, // present but no value columns
+        { snapshot_date: "2026-06-27", stake_tao: 0, emission_tao: 0 },
+      ],
+    });
+    const body = await json(
+      await handleSubnetConcentrationHistory(
+        req(`/api/v1/subnets/${NETUID}/concentration/history`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/concentration/history?window=7d`),
+      ),
+    );
+    assert.equal(body.data.point_count, 1); // only the dated day
+    assert.equal(body.data.points[0].snapshot_date, "2026-06-27");
+    assert.equal(body.data.points[0].neuron_count, 2);
+    // No positive distribution in that day → null per-metric fields, not throws.
+    assert.equal(body.data.points[0].stake_gini, null);
+    assert.equal(body.data.points[0].emission_gini, null);
   });
 });
 


### PR DESCRIPTION
## What

Adds failure-path unit coverage for the async D1 loaders/writers an audit flagged as thin. **Test-only** — no source, schema, or contract changes, so the batch stays conflict-free.

### `tests/account-events.test.mjs` (loaders)
- `loadAccountEvents` / `loadAccountHistory` / `loadAccountSubnets` / `loadAccountSummary`:
  - D1-timeout/cold read degrades to a schema-stable zero payload (the shape `d1All` hands back when it swallows a timeout/schema-drift to `[]`).
  - A *rejecting* runner propagates (no silent swallow into a falsely-empty result) — including `Promise.all` fast-reject in `loadAccountSummary`.
  - Sparse-row null safety, `?kind` bound filtering, and offset-vs-keyset-**cursor** pagination with limit/offset clamping (and malformed-cursor fallback to OFFSET).

### `tests/economics-backfill.test.mjs` (writer)
- A D1 `batch` failure during the upsert **surfaces** (rejects) instead of returning a false `200` — the handler runs the batch without a try/catch, and this locks that in.
- An all-invalid row set short-circuits before any `db.batch` call.
- Per-row statement sizing + NaN `captured_at` fallback to the snapshot day's UTC midnight.

### `tests/request-handlers-entities.test.mjs` (concentration loaders)
- A rejecting D1 read degrades to a `200` schema-stable null block / empty series (never 5xx/404), via the inline `d1All` reads in `handleSubnetConcentration` / `handleSubnetConcentrationHistory`.
- Sparse / all-zero neuron rows yield null metric blocks; dateless history rows are skipped.
- The windowed history read binds the ISO date cutoff + `CONCENTRATION_HISTORY_ROW_CAP` (params, not interpolated).

## Why

These async D1 read/write paths had happy-path + cold-store coverage but thin coverage of the *error* paths — a swallowed/rejecting D1 read and a writer batch failure. This pins down that the loaders stay schema-stable on a swallowed timeout, never mask a hard rejection, and that the backfill writer fails loudly rather than reporting a false success.

## Gates run
- `npx prettier --check` on the three touched files — clean.
- `npx vitest run` on the three files — **208 passed**.
- No `src/`, `schemas/`, `workers/api.mjs`, or `src/mcp-server.mjs` changes, so the build/contract-drift/client-sdk/mcp/bundle-budget gates do not apply.