### PR TITLE
test(history): guard forward neuron_daily stake rollup invariant

### DIFF
--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -16,6 +16,7 @@ import {
   HISTORY_WINDOWS,
   MAX_HISTORY_POINTS,
 } from "../src/neuron-history.mjs";
+import { buildConcentrationHistory } from "../src/concentration.mjs";
 import { handleRequest, handleScheduled } from "../workers/api.mjs";
 import { NEURON_HISTORY_ROLLUP_CRON } from "../workers/config.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
@@ -244,6 +245,101 @@ describe("rollupNeuronDaily idempotency invariant (#1345)", () => {
     assert.doesNotMatch(seen[0], /\bnetuid = excluded/);
     assert.doesNotMatch(seen[0], /\buid = excluded/);
     assert.match(seen[0], /updated_at = excluded\.updated_at/);
+  });
+});
+
+describe("rollupNeuronDaily stake-column invariant (P7)", () => {
+  // The forward rollup copies `neurons` -> `neuron_daily` verbatim, so stake_tao
+  // MUST be one of the rolled + upserted columns. The historical backfill
+  // (scripts/backfill-neuron-history.py) intentionally deferred per-UID stake to
+  // null, which is the documented historical gap — but the FORWARD path must never
+  // silently drop stake the way the backfill omits it, or the daily
+  // total_stake_tao / stake_gini / stake_nakamoto aggregates go null again. This
+  // locks stake_tao into both the INSERT...SELECT projection and the ON CONFLICT
+  // SET clause so a future column refactor can't regress it.
+  test("rolls stake_tao in the INSERT...SELECT and re-applies it on conflict", async () => {
+    let sql = "";
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(s) {
+          sql = s;
+          return {
+            bind: () => ({
+              run: () => Promise.resolve({ meta: { changes: 1 } }),
+            }),
+          };
+        },
+      },
+    };
+    await rollupNeuronDaily(env, { now: 1 });
+    // Projected from neurons in the INSERT column list...
+    assert.match(sql, /INSERT INTO neuron_daily \([^)]*\bstake_tao\b/);
+    // ...and carried forward on an intra-day re-run.
+    assert.match(sql, /stake_tao = excluded\.stake_tao/);
+  });
+});
+
+describe("stake aggregates surface when the rolled rows carry stake (P7)", () => {
+  // Locks the documented historical behaviour: a day whose neuron_daily rows have
+  // a real per-UID stake distribution yields populated total_stake_tao / stake_gini
+  // / stake_nakamoto, while a day backfilled with stake_tao = null yields nulls —
+  // the exact split observed in production (stake populated from 2026-06-22, the
+  // day the forward rollup began carrying it; null before, from the backfill).
+  test("buildSubnetHistory: SUM(stake) day -> number, null-stake day -> null", () => {
+    const out = buildSubnetHistory(
+      [
+        // A populated forward-rollup day (SQL SUM(stake_tao) is a number).
+        {
+          snapshot_date: "2026-06-22",
+          neuron_count: 2,
+          validator_count: 1,
+          total_stake_tao: 150,
+          total_emission_tao: 3,
+        },
+        // A backfilled day: SUM over all-null stake_tao -> SQLite returns NULL.
+        {
+          snapshot_date: "2026-06-21",
+          neuron_count: 2,
+          validator_count: 1,
+          total_stake_tao: null,
+          total_emission_tao: 3,
+        },
+      ],
+      64,
+      { window: "30d" },
+    );
+    assert.equal(out.points[0].total_stake_tao, 150);
+    assert.equal(out.points[0].total_emission_tao, 3);
+    // The backfilled day keeps emission but nulls stake (the production gap).
+    assert.equal(out.points[1].total_stake_tao, null);
+    assert.equal(out.points[1].total_emission_tao, 3);
+  });
+
+  test("buildConcentrationHistory: stake metrics null on a null-stake day, populated otherwise", () => {
+    const out = buildConcentrationHistory(
+      [
+        // Forward-rollup day: real per-UID stake distribution.
+        { snapshot_date: "2026-06-22", stake_tao: 100, emission_tao: 10 },
+        { snapshot_date: "2026-06-22", stake_tao: 1, emission_tao: 1 },
+        // Backfilled day: stake_tao null, emission present.
+        { snapshot_date: "2026-06-21", stake_tao: null, emission_tao: 10 },
+        { snapshot_date: "2026-06-21", stake_tao: null, emission_tao: 1 },
+      ],
+      64,
+      { window: "30d" },
+    );
+    assert.equal(out.points[0].snapshot_date, "2026-06-22");
+    assert.equal(typeof out.points[0].stake_gini, "number");
+    assert.equal(out.points[0].stake_nakamoto_coefficient, 1);
+    assert.equal(typeof out.points[0].stake_top_10pct_share, "number");
+    // The backfilled day has no stake distribution -> stake metrics null, but
+    // emission metrics still populate (proves it's a stake-data gap, not a builder
+    // bug).
+    assert.equal(out.points[1].snapshot_date, "2026-06-21");
+    assert.equal(out.points[1].stake_gini, null);
+    assert.equal(out.points[1].stake_nakamoto_coefficient, null);
+    assert.equal(out.points[1].stake_top_10pct_share, null);
+    assert.equal(typeof out.points[1].emission_gini, "number");
   });
 });
 


### PR DESCRIPTION
## What

Two related items: a regression guard for the daily stake rollup (P7) and a conservative ops-triage pass over the degraded/dead health surfaces (P1/P8).

### P7 — daily stake-tier rollup

The history endpoints (`/api/v1/subnets/{netuid}/history`, `/concentration/history`) return `total_stake_tao` / `stake_gini` / `stake_nakamoto_coefficient` = `null` for snapshot dates before a hard cutover (subnet 64: null through 2026-06-21, populated from 2026-06-22), while `emission_*` are populated throughout.

**Diagnosis — this is a data-provenance gap, not a live-code bug:**

- The forward rollup `rollupNeuronDaily` (`src/neuron-history.mjs`) does `INSERT INTO neuron_daily ... SELECT <NEURON_INSERT_COLUMNS> ... FROM neurons WHERE captured_at = MAX(...)`. `stake_tao` is in `NEURON_INSERT_COLUMNS` (`src/metagraph-neurons.mjs:29`), so every day the rollup writes carries per-UID stake.
- The serving path is correct too: `handleSubnetHistory` does `SUM(stake_tao) AS total_stake_tao`, and `buildConcentrationHistory` derives stake Gini/Nakamoto from each row's `stake_tao` (`src/concentration.mjs`). Both work — recent dates are fully populated.
- The historical nulls come from `scripts/backfill-neuron-history.py`, which **intentionally** sets `stake_tao = None` (line 246, documented at lines 22-24): per-UID dTAO stake is runtime-only (childkey/TaoWeight alpha math), not a value the cheap batched raw-storage backfill (`state_queryStorageAt` over metric vectors) can read. The runtime `get_metagraph_info`/`total_stake` path the live native fetch uses (`scripts/fetch-metagraph-native.py:109,133`) is ~18-25s/subnet and has a ~8-month decode floor, which is exactly why the backfill avoided it.
- Cross-check: the independent subnet-level economics rollup (`subnet_snapshots.total_stake_tao`, migration 0008) shows the **same** cutover in `/subnets/64/trajectory` (null through 2026-06-21, populated 2026-06-22+). So there is no alternate historical source for stake before forward capture began — even the dedicated economics tier lacks it.

**Change:** rather than fabricate a "fix" to a path that is already correct, this adds a regression guard so the forward invariant can never silently regress the way the backfill omits stake:
- `rollupNeuronDaily` must always project `stake_tao` in the INSERT...SELECT and re-apply it on the ON CONFLICT upsert.
- `buildSubnetHistory` / `buildConcentrationHistory` surface stake on stake-carrying days and `null` on null-stake days (locks the documented historical split and proves it's a data gap, not a builder bug — emission still populates on the same null-stake day).

### NOTE — required one-time prod data operation (not run here)

Filling historical stake before the forward-capture cutover requires a **one-time backfill re-run with per-UID stake capture** (e.g. an opt-in `total_stake` overlay via the runtime metagraph API for the ~8-month decodable window, or offline dTAO alpha→TAO derivation). This is a prod data job, not a code path, and is deliberately **not** executed in this PR. No forward code is broken; new days are correct.

### P1/P8 — ops triage (no data changed; all conservative)

Probed every degraded/dead surface directly. None is a provable registry-data error, so nothing was edited:

- **Subnet 64 (Chutes), 3 degraded data-artifacts** — `api.chutes.ai/chutes/{boosted,utilization,gpu_count_history}` all return `200 application/json` with valid payloads (0.8-1.1 MB on two of them). The `degraded` is a probe-time/latency blip on large bodies from the edge, not a bad URL. Registry URLs + `expect: json` config are correct → unchanged.
- **SignalPlus dead candidate** — `github.com/EfficientFrontier-SignalPlus/EfficientFrontier` genuinely 404s, but it lives in the **generated** artifact `registry/candidates/generated/public-sources.json`, machine-discovered from on-chain `SubnetIdentitiesV3` metadata. Editing it violates the never-hand-edit-generated rule and would be clobbered by the next sync (the bad URL is on-chain, not ours). The real SN53 repo (`github.com/oxylok/53-EfficientFrontier`, 200) is already a correct live surface in `registry/subnets/efficientfrontier.json` → unchanged. The probe correctly keeps the candidate `dead`/unpromoted.
- **Ridges rate-limited** — `www.ridges.ai/` returns `429` from Vercel (genuine upstream throttling, already documented in `registry/providers/ridges.json`). Its source-repo (`github.com/ridgesai/ridges`) and subnet-api (`agent-upload.ridges.ai/retrieval/top-agents`) are both 200 → unchanged.

## Why

Lock the forward stake-rollup invariant against a recurrence of the silent-null class, and accurately attribute the historical null-stake to backfill provenance (with the prod re-run noted) rather than masking it with a no-op code change. The ops triage confirms the probe-derived health is working as designed — the degraded/dead states are upstream/probe-timing, not stale registry data.

## Gates run
- `npx prettier --check tests/neuron-history.test.mjs` — clean
- `npx vitest run tests/neuron-history.test.mjs tests/concentration.test.mjs tests/request-handlers-entities.test.mjs` — 204/204 pass (3 new)

No `schemas/`, `src/contracts.mjs`, `src/mcp-server.mjs`, or `workers/api.mjs` changes, so contract/mcp/bundle-budget gates do not apply.
