### PR TITLE
feat(mcp): add MCP tools for live REST routes lacking MCP parity

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -10,7 +10,12 @@
 // Artifact/KV reads are injected (`deps.readArtifact`, `deps.readHealthKv`) so
 // this module is pure and unit-testable, and so it reuses the exact same
 // R2/ASSETS resolution the REST routes use.
-import { resolveClientIp, SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
+import {
+  clampInt,
+  DAY_MS,
+  resolveClientIp,
+  SS58_ADDRESS_PATTERN,
+} from "../workers/config.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
 import {
@@ -42,6 +47,7 @@ import {
   LEADERBOARD_BOARDS,
   loadSubnetReliability,
   loadSubnetTrajectory,
+  mergeFreshness,
   overlayCatalogDetail,
   overlayCatalogIndex,
   overlayOverviewHealth,
@@ -56,6 +62,8 @@ import {
   loadSubnetValidators,
 } from "./metagraph-neurons.mjs";
 import {
+  ACCOUNT_EVENT_COLUMNS,
+  buildSubnetEvents,
   loadAccountSummary,
   loadAccountEvents,
   loadAccountSubnets,
@@ -63,6 +71,19 @@ import {
   loadAccountExtrinsics,
   loadAccountTransfers,
 } from "./account-events.mjs";
+import {
+  buildNeuronHistory,
+  buildSubnetHistory,
+  MAX_HISTORY_POINTS,
+  NEURON_DAILY_READ_COLUMNS,
+  parseHistoryWindow,
+} from "./neuron-history.mjs";
+import {
+  buildConcentrationHistory,
+  CONCENTRATION_HISTORY_ROW_CAP,
+  parseConcentrationHistoryWindow,
+} from "./concentration.mjs";
+import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import { loadBlocks, loadBlock } from "./blocks.mjs";
 import { loadExtrinsics, loadExtrinsic } from "./extrinsics.mjs";
 import {
@@ -96,7 +117,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.5.0";
+export const MCP_SERVER_VERSION = "1.6.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -350,6 +371,149 @@ async function mcpObservedAt(ctx) {
   if (!ctx.readHealthKv) return null;
   const meta = await ctx.readHealthKv(ctx.env, KV_HEALTH_META);
   return meta?.last_run_at || null;
+}
+
+// Resolve + validate a history window arg (7d|30d|90d|1y|all) the way the REST
+// /history routes do, mapping a bad value to a clean tool error. Returns the
+// parsed {label, days} (days is null for the unbounded `all` window).
+function requireHistoryWindow(args) {
+  const { label, days, error } = parseHistoryWindow(args?.window);
+  if (error) {
+    throw toolError("invalid_params", error.message);
+  }
+  return { label, days };
+}
+
+// Day-cutoff (YYYY-MM-DD) for a window's `days`, matching the REST handlers'
+// JS-computed cutoff bound against the dated `snapshot_date` column.
+function historyCutoff(days) {
+  return new Date(Date.now() - days * DAY_MS).toISOString().slice(0, 10);
+}
+
+// One subnet's per-day aggregate history — mirrors handleSubnetHistory: a GROUP
+// BY snapshot_date read over the neuron_daily rollup, newest first, bounded by
+// MAX_HISTORY_POINTS, shaped by buildSubnetHistory. A cold/absent D1 yields the
+// schema-stable point_count:0 payload (never throws).
+async function loadSubnetHistory(ctx, netuid, { label, days }) {
+  const run = mcpD1Runner(ctx);
+  const params = [netuid];
+  let sql =
+    "SELECT snapshot_date, COUNT(*) AS neuron_count, " +
+    "SUM(validator_permit) AS validator_count, " +
+    "SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao " +
+    "FROM neuron_daily WHERE netuid = ?";
+  if (days != null) {
+    sql += " AND snapshot_date >= ?";
+    params.push(historyCutoff(days));
+  }
+  sql += " GROUP BY snapshot_date ORDER BY snapshot_date DESC LIMIT ?";
+  params.push(MAX_HISTORY_POINTS);
+  const rows = await run(sql, params);
+  return buildSubnetHistory(rows, netuid, { window: label });
+}
+
+// One UID's per-day time series — mirrors handleNeuronHistory: neuron_daily rows
+// for (netuid, uid), newest first, bounded, shaped by buildNeuronHistory. Cold D1
+// → point_count:0.
+async function loadNeuronHistory(ctx, netuid, uid, { label, days }) {
+  const run = mcpD1Runner(ctx);
+  const params = [netuid, uid];
+  let sql = `SELECT ${NEURON_DAILY_READ_COLUMNS} FROM neuron_daily WHERE netuid = ? AND uid = ?`;
+  if (days != null) {
+    sql += " AND snapshot_date >= ?";
+    params.push(historyCutoff(days));
+  }
+  sql += " ORDER BY snapshot_date DESC LIMIT ?";
+  params.push(MAX_HISTORY_POINTS);
+  const rows = await run(sql, params);
+  return buildNeuronHistory(rows, netuid, uid, { window: label });
+}
+
+// One subnet's per-day concentration trend — mirrors
+// handleSubnetConcentrationHistory: the raw per-UID neuron_daily distribution
+// (each day re-computed into Gini/Nakamoto/top-10%), bounded by the row cap and
+// shaped by buildConcentrationHistory. Window is the smaller 7d|30d|90d set.
+async function loadSubnetConcentrationHistory(ctx, netuid, args) {
+  const { label, days, error } = parseConcentrationHistoryWindow(args?.window);
+  if (error) {
+    throw toolError("invalid_params", error.message);
+  }
+  const run = mcpD1Runner(ctx);
+  const rows = await run(
+    "SELECT snapshot_date, stake_tao, emission_tao FROM neuron_daily WHERE netuid = ? AND snapshot_date >= ? ORDER BY snapshot_date DESC LIMIT ?",
+    [netuid, historyCutoff(days), CONCENTRATION_HISTORY_ROW_CAP],
+  );
+  return buildConcentrationHistory(rows, netuid, {
+    window: label,
+    capped: rows.length >= CONCENTRATION_HISTORY_ROW_CAP,
+  });
+}
+
+// One subnet's first-party chain-event stream — mirrors handleSubnetEvents:
+// account_events filtered by netuid, newest first, optional kind filter, keyset
+// (cursor) pagination on (block_number, event_index) with offset as the
+// deprecated fallback. Cold D1 → event_count:0.
+async function loadSubnetEvents(ctx, netuid, { kind, limit, offset, cursor }) {
+  const run = mcpD1Runner(ctx);
+  const resolvedLimit = clampInt(limit, 100, 1, 1000);
+  const resolvedOffset = clampInt(offset, 0, 0, 1_000_000);
+  const cur = decodeCursor(cursor, 2);
+  const useCursor = Boolean(cur);
+  const params = [netuid];
+  let sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE netuid = ?`;
+  if (kind) {
+    sql += " AND event_kind = ?";
+    params.push(kind);
+  }
+  if (useCursor) {
+    sql += " AND (block_number, event_index) < (?, ?)";
+    params.push(cur[0], cur[1]);
+  }
+  sql += " ORDER BY block_number DESC, event_index DESC LIMIT ?";
+  params.push(resolvedLimit);
+  if (!useCursor) {
+    sql += " OFFSET ?";
+    params.push(resolvedOffset);
+  }
+  const rows = await run(sql, params);
+  const last = rows.length === resolvedLimit ? rows[rows.length - 1] : null;
+  const nextCursor = last
+    ? encodeCursor([last.block_number, last.event_index])
+    : null;
+  return buildSubnetEvents(rows, netuid, {
+    limit: resolvedLimit,
+    offset: resolvedOffset,
+    nextCursor,
+  });
+}
+
+// One provider's detail + (optionally) its endpoints, mirroring GET
+// /api/v1/providers/{slug}{,/endpoints}. Both are artifact-backed; the endpoints
+// artifact is optional (a provider may have no endpoints artifact), so a missing
+// one degrades to endpoints:null rather than failing the whole call. The detail
+// artifact missing is a real not_found (loadArtifactData maps it).
+async function loadProviderDetail(ctx, slug, includeEndpoints) {
+  const detail = await loadArtifactData(
+    ctx,
+    `/metagraph/providers/${slug}.json`,
+  );
+  if (!includeEndpoints) return detail;
+  const endpoints = await loadOptionalArtifact(
+    ctx,
+    `/metagraph/providers/${slug}/endpoints.json`,
+  );
+  return { provider: detail, endpoints };
+}
+
+// The freshness/staleness state, mirroring GET /api/v1/freshness: the committed
+// freshness artifact overlaid with the live 15-minute prober's last_run_at
+// (mergeFreshness) so the surface-health source reads `current` like the REST
+// route. With no live meta the committed artifact passes through unchanged.
+async function loadFreshness(ctx) {
+  const base = await loadArtifactData(ctx, "/metagraph/freshness.json");
+  if (!ctx.readHealthKv) return base;
+  const meta = await ctx.readHealthKv(ctx.env, KV_HEALTH_META);
+  return mergeFreshness(base, meta) ?? base;
 }
 
 async function loadEconomicsSubnetRows(ctx) {
@@ -1392,6 +1556,149 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_subnet_history",
+    title: "Get a subnet's daily history",
+    description:
+      "Fetch one subnet's per-day history from the neuron_daily rollup: neuron " +
+      "count, validator count, total stake (TAO) and total emission (TAO) per " +
+      "snapshot_date, newest first. Choose the window (7d, 30d, 90d, 1y, all; " +
+      "default 30d). Use it to chart how a subnet's size, stake, and emission " +
+      "have moved over time. Mirrors GET /api/v1/subnets/{netuid}/history.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: ["7d", "30d", "90d", "1y", "all"],
+          description: "History window (default 30d).",
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      return loadSubnetHistory(ctx, netuid, requireHistoryWindow(args));
+    },
+  },
+  {
+    name: "get_subnet_concentration_history",
+    title: "Get a subnet's concentration history",
+    description:
+      "Fetch one subnet's per-day stake & emission concentration trend from the " +
+      "dated neuron_daily distribution: Gini, Nakamoto coefficient, and top-10% " +
+      "share for both stake and emission per snapshot_date, newest first. Choose " +
+      "the window (7d, 30d, 90d; default 30d). Use it to answer 'is this subnet " +
+      "centralizing over time?'. Mirrors " +
+      "GET /api/v1/subnets/{netuid}/concentration/history.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: ["7d", "30d", "90d"],
+          description: "History window (default 30d).",
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      return loadSubnetConcentrationHistory(ctx, netuid, args);
+    },
+  },
+  {
+    name: "get_neuron_history",
+    title: "Get one neuron's daily history",
+    description:
+      "Fetch a single neuron's per-day time series in one subnet by its UID, from " +
+      "the neuron_daily rollup: stake, rank, trust, consensus, incentive, " +
+      "dividends, emission, validator permit, and axon per snapshot_date, newest " +
+      "first. Choose the window (7d, 30d, 90d, 1y, all; default 30d). Use it to " +
+      "track how one miner or validator has performed over time. Mirrors " +
+      "GET /api/v1/subnets/{netuid}/neurons/{uid}/history.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        uid: {
+          type: "integer",
+          description: "The neuron UID within the subnet.",
+          minimum: 0,
+        },
+        window: {
+          type: "string",
+          enum: ["7d", "30d", "90d", "1y", "all"],
+          description: "History window (default 30d).",
+        },
+      },
+      required: ["netuid", "uid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const uid = requireNonNegativeInt(args, "uid");
+      return loadNeuronHistory(ctx, netuid, uid, requireHistoryWindow(args));
+    },
+  },
+  {
+    name: "get_subnet_events",
+    title: "Get a subnet's chain-event stream",
+    description:
+      "Fetch the paginated first-party chain-event stream for one subnet by its " +
+      "netuid, newest first: each event's kind, block, UID, hot/cold keys, " +
+      "amount, and timestamp. Optionally filter by event kind (e.g. StakeAdded, " +
+      "NeuronRegistered, AxonServed, WeightsSet) and page with limit (1-1000, " +
+      "default 100) / offset, or follow next_cursor for stable keyset pagination. " +
+      "Use it to watch what is happening on one subnet right now. Events are " +
+      "decoded directly from the chain. Mirrors GET /api/v1/subnets/{netuid}/events.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        kind: {
+          type: "string",
+          description:
+            "Optional event-kind filter, e.g. 'StakeAdded' or 'WeightsSet'. " +
+            "Omit for all kinds; an unknown kind simply matches nothing.",
+        },
+        limit: {
+          type: "integer",
+          description: "Max events to return (1-1000, default 100).",
+          minimum: 1,
+          maximum: 1000,
+        },
+        offset: {
+          type: "integer",
+          description: "Pagination offset into the stream. Default 0.",
+          minimum: 0,
+        },
+        cursor: {
+          type: "string",
+          description:
+            "Opaque keyset cursor from a previous response's next_cursor; takes " +
+            "precedence over offset for stable deep pagination.",
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const kind = optionalString(args, "kind");
+      const cursor = optionalString(args, "cursor");
+      return loadSubnetEvents(ctx, netuid, {
+        kind,
+        limit: args?.limit,
+        offset: args?.offset,
+        cursor,
+      });
+    },
+  },
+  {
     name: "get_account",
     title: "Get a cross-subnet account summary",
     description:
@@ -1956,6 +2263,139 @@ export const MCP_TOOLS = [
       }
       const artifactId = await resolveArtifactSurfaceId(ctx, surfaceId);
       return loadArtifactData(ctx, `/metagraph/fixtures/${artifactId}.json`);
+    },
+  },
+  {
+    name: "get_provider_detail",
+    title: "Get one provider's detail",
+    description:
+      "Fetch one provider/source by its slug: its identity, authority, the " +
+      "subnets and surfaces it backs, and its catalogued endpoints. A provider is " +
+      "an operator or service that publishes one or more subnet surfaces (e.g. an " +
+      "API host or RPC operator). Set include_endpoints to also attach its full " +
+      "endpoint list (per-endpoint health is overlaid live on the REST route; the " +
+      "MCP detail serves the catalogued endpoints). Mirrors " +
+      "GET /api/v1/providers/{slug} (+ /endpoints). Discover slugs via the " +
+      "providers list at /metagraph/providers.json.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slug: {
+          type: "string",
+          description:
+            "Provider slug (slug-style), e.g. 'datura' or 'rayonlabs'.",
+        },
+        include_endpoints: {
+          type: "boolean",
+          description:
+            "When true, also attach the provider's catalogued endpoints under " +
+            "`endpoints` (the detail moves under `provider`). Default false.",
+        },
+      },
+      required: ["slug"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const slug = requireString(args, "slug");
+      // slug is part of an R2 key path; reject anything that could escape the
+      // providers/ namespace.
+      if (!/^[A-Za-z0-9._:-]+$/.test(slug)) {
+        throw toolError("invalid_params", "slug contains invalid characters.");
+      }
+      return loadProviderDetail(
+        ctx,
+        slug,
+        optionalBoolean(args, "include_endpoints"),
+      );
+    },
+  },
+  {
+    name: "list_fixtures",
+    title: "List captured live fixtures",
+    description:
+      "Fetch the index of captured live request/response fixtures: which subnet " +
+      "surfaces carry a sanitized real sample, with capture status and metadata. " +
+      "Use it to discover which surfaces have a fixture, then fetch one with " +
+      "get_fixture. Mirrors GET /api/v1/fixtures.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadArtifactData(ctx, "/metagraph/fixtures.json");
+    },
+  },
+  {
+    name: "list_schemas",
+    title: "List captured API schemas",
+    description:
+      "Fetch the index of captured OpenAPI/Swagger schema snapshots across " +
+      "subnets: which surfaces publish a machine-readable schema, its hash, and " +
+      "drift status (new/unchanged/changed). Use it to discover which surfaces " +
+      "have a schema, then fetch one with get_api_schema. Mirrors " +
+      "GET /api/v1/schemas.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadArtifactData(ctx, "/metagraph/schemas/index.json");
+    },
+  },
+  {
+    name: "get_lineage",
+    title: "Get cross-network subnet lineage",
+    description:
+      "Fetch the maintainer-approved cross-network subnet lineage: which testnet " +
+      "subnets have graduated to mainnet (mainnet ↔ testnet pairs with the match " +
+      "evidence), plus any flagged broken links. Use it to map a mainnet subnet " +
+      "to its testnet counterpart or vice versa. Mirrors GET /api/v1/lineage.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadArtifactData(ctx, "/metagraph/lineage.json");
+    },
+  },
+  {
+    name: "get_freshness",
+    title: "Get registry data freshness",
+    description:
+      "Fetch the registry's freshness and staleness state: per-source last-" +
+      "captured timestamps, staleness windows, and current status for each data " +
+      "lane (adapter snapshots, the chain-event index, operational surface " +
+      "health, etc.). The operational surface-health source is overlaid with the " +
+      "live 15-minute prober's last run. Use it to judge how current the data is " +
+      "before relying on it. Mirrors GET /api/v1/freshness.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadFreshness(ctx);
+    },
+  },
+  {
+    name: "get_source_health",
+    title: "Get per-provider source health",
+    description:
+      "Fetch the per-provider source-health rollup: for each provider/source, " +
+      "the count of candidate surfaces and how they classify (live / redirected " +
+      "/ dead), endpoint and RPC-endpoint counts, verification-result count, and " +
+      "an overall status. Use it to see which providers are publishing healthy, " +
+      "still-reachable surfaces. Mirrors GET /api/v1/source-health.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadArtifactData(ctx, "/metagraph/source-health.json");
     },
   },
   {
@@ -2874,6 +3314,72 @@ const TOOL_OUTPUT_SCHEMAS = {
       neuron: { type: ["object", "null"] },
     },
   },
+  get_subnet_history: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "point_count", "points"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      point_count: { type: "integer" },
+      points: objectItems({
+        snapshot_date: NULLABLE_STRING,
+        neuron_count: NULLABLE_INT,
+        validator_count: NULLABLE_INT,
+        total_stake_tao: ANY,
+        total_emission_tao: ANY,
+      }),
+    },
+  },
+  get_subnet_concentration_history: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "point_count", "points"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      point_count: { type: "integer" },
+      points: objectItems({
+        snapshot_date: NULLABLE_STRING,
+        neuron_count: NULLABLE_INT,
+        stake_gini: ANY,
+        stake_nakamoto_coefficient: ANY,
+        stake_top_10pct_share: ANY,
+        emission_gini: ANY,
+        emission_nakamoto_coefficient: ANY,
+        emission_top_10pct_share: ANY,
+      }),
+    },
+  },
+  get_neuron_history: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "uid", "point_count", "points"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      uid: { type: "integer" },
+      window: NULLABLE_STRING,
+      point_count: { type: "integer" },
+      points: { type: "array", items: { type: "object" } },
+    },
+  },
+  get_subnet_events: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "event_count", "events"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      event_count: { type: "integer" },
+      limit: NULLABLE_INT,
+      offset: NULLABLE_INT,
+      next_cursor: NULLABLE_STRING,
+      events: objectItems(ACCOUNT_EVENT_ITEM),
+    },
+  },
   get_account: {
     type: "object",
     additionalProperties: true,
@@ -3075,6 +3581,78 @@ const TOOL_OUTPUT_SCHEMAS = {
     additionalProperties: true,
     required: ["surface_id"],
     properties: { surface_id: { type: "string" } },
+  },
+  get_provider_detail: {
+    // Two shapes: the bare provider detail (default) or {provider, endpoints}
+    // when include_endpoints is set. Both are operator-controlled artifact
+    // payloads, so nothing is required; the keys below describe each shape when
+    // present.
+    type: "object",
+    additionalProperties: true,
+    required: [],
+    properties: {
+      id: NULLABLE_STRING,
+      slug: NULLABLE_STRING,
+      name: NULLABLE_STRING,
+      authority: NULLABLE_STRING,
+      kind: NULLABLE_STRING,
+      provider: { type: ["object", "null"] },
+      endpoints: { type: ["object", "array", "null"] },
+    },
+  },
+  list_fixtures: {
+    type: "object",
+    additionalProperties: true,
+    required: [],
+    properties: {
+      candidate_count: { type: "integer" },
+      coverage: { type: "array", items: { type: "object" } },
+      generated_at: NULLABLE_STRING,
+    },
+  },
+  list_schemas: {
+    type: "object",
+    additionalProperties: true,
+    required: [],
+    properties: {
+      schemas: { type: "array", items: { type: "object" } },
+      observed_at: NULLABLE_STRING,
+      generated_at: NULLABLE_STRING,
+      notes: NULLABLE_STRING,
+    },
+  },
+  get_lineage: {
+    type: "object",
+    additionalProperties: true,
+    required: [],
+    properties: {
+      link_count: { type: "integer" },
+      graduated_subnet_count: { type: "integer" },
+      broken_link_count: { type: "integer" },
+      links: { type: "array", items: { type: "object" } },
+      broken_links: { type: "array", items: { type: "object" } },
+      generated_at: NULLABLE_STRING,
+    },
+  },
+  get_freshness: {
+    type: "object",
+    additionalProperties: true,
+    required: ["sources"],
+    properties: {
+      schema_version: { type: "integer" },
+      sources: { type: "array", items: { type: "object" } },
+      summary: { type: ["object", "null"] },
+      generated_at: NULLABLE_STRING,
+    },
+  },
+  get_source_health: {
+    type: "object",
+    additionalProperties: true,
+    required: ["providers"],
+    properties: {
+      providers: { type: "array", items: { type: "object" } },
+      generated_at: NULLABLE_STRING,
+    },
   },
   get_agent_catalog: {
     // Two shapes: the global index (no netuid) and a single-subnet catalog

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4517,3 +4517,439 @@ describe("MCP tool-input validation — typed errors, never a throw (#742)", () 
     assert.equal(res.body.error.code, -32601);
   });
 });
+
+// MCP↔REST parity tools (#393): per-subnet history/concentration-history, per-UID
+// neuron history, the subnet chain-event stream, the provider detail, and the
+// discovery-bundle artifact reads. Each mirrors its existing REST route's
+// data-access (mcpD1Runner over the same SQL, or loadArtifactData over the same
+// artifact) so an agent reaches the same data through MCP.
+describe("MCP parity tools — subnet history / events (D1-backed)", () => {
+  // A neuron_daily row shaped like NEURON_DAILY_READ_COLUMNS (snapshot_date +
+  // the live NEURON_COLUMNS) so buildNeuronHistory/buildSubnetHistory consume it.
+  function neuronDailyRow(date, uid, overrides = {}) {
+    return {
+      snapshot_date: date,
+      uid,
+      hotkey: `hk-${uid}`,
+      coldkey: `ck-${uid}`,
+      active: 1,
+      validator_permit: uid === 0 ? 1 : 0,
+      rank: 0.5,
+      trust: 0.5,
+      validator_trust: 0.5,
+      consensus: 0.5,
+      incentive: 0.4,
+      dividends: 0.1,
+      emission_tao: 1.25,
+      stake_tao: 1000,
+      registered_at_block: 100,
+      is_immunity_period: 0,
+      axon: null,
+      block_number: 8454388,
+      captured_at: 1750000000000,
+      ...overrides,
+    };
+  }
+
+  // A D1 binding routing by SQL shape over neuron_daily + account_events, so the
+  // parity loaders' WHERE/GROUP-BY clauses get realistic rows. `capture` records
+  // each bound (sql, params) so a test can assert what reached the query.
+  function parityD1(
+    { dailyAgg, dailyRows, concentrationRows, events } = {},
+    capture = [],
+  ) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                all() {
+                  if (/FROM neuron_daily/.test(sql)) {
+                    if (/GROUP BY snapshot_date/.test(sql))
+                      return Promise.resolve({ results: dailyAgg || [] });
+                    if (
+                      /SELECT snapshot_date, stake_tao, emission_tao/.test(sql)
+                    )
+                      return Promise.resolve({
+                        results: concentrationRows || [],
+                      });
+                    return Promise.resolve({ results: dailyRows || [] });
+                  }
+                  if (/FROM account_events/.test(sql))
+                    return Promise.resolve({ results: events || [] });
+                  return Promise.resolve({ results: [] });
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("get_subnet_history returns the per-day aggregate series newest-first", async () => {
+    const capture = [];
+    const env = parityD1(
+      {
+        dailyAgg: [
+          {
+            snapshot_date: "2026-06-26",
+            neuron_count: 256,
+            validator_count: 9,
+            total_stake_tao: 2_500_000,
+            total_emission_tao: 81,
+          },
+          {
+            snapshot_date: "2026-06-25",
+            neuron_count: 255,
+            validator_count: 9,
+            total_stake_tao: 2_400_000,
+            total_emission_tao: 80,
+          },
+        ],
+      },
+      capture,
+    );
+    const res = await callTool(
+      "get_subnet_history",
+      { netuid: 1, window: "7d" },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 1);
+    assert.equal(out.window, "7d");
+    assert.equal(out.point_count, 2);
+    assert.equal(out.points[0].snapshot_date, "2026-06-26");
+    assert.equal(out.points[0].neuron_count, 256);
+    // The window cutoff reached the SQL as a bound YYYY-MM-DD param.
+    const q = capture.find((c) => /GROUP BY snapshot_date/.test(c.sql));
+    assert.ok(q.params.some((p) => /^\d{4}-\d{2}-\d{2}$/.test(p)));
+  });
+
+  test("get_subnet_history (all) omits the date cutoff bind", async () => {
+    const capture = [];
+    const env = parityD1({ dailyAgg: [] }, capture);
+    const res = await callTool(
+      "get_subnet_history",
+      { netuid: 1, window: "all" },
+      { env },
+    );
+    assert.equal(res.body.result.structuredContent.window, "all");
+    const q = capture.find((c) => /GROUP BY snapshot_date/.test(c.sql));
+    // Only netuid + MAX_HISTORY_POINTS limit are bound, no date cutoff.
+    assert.equal(q.params.length, 2);
+    assert.ok(!q.params.some((p) => /^\d{4}-\d{2}-\d{2}$/.test(p)));
+  });
+
+  test("get_subnet_history defaults to the 30d window when omitted", async () => {
+    const env = parityD1({ dailyAgg: [] });
+    const res = await callTool("get_subnet_history", { netuid: 1 }, { env });
+    assert.equal(res.body.result.structuredContent.window, "30d");
+  });
+
+  test("get_subnet_history rejects an unknown window", async () => {
+    const res = await callTool("get_subnet_history", {
+      netuid: 1,
+      window: "5d",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_neuron_history returns one UID's per-day series", async () => {
+    const env = parityD1({
+      dailyRows: [
+        neuronDailyRow("2026-06-26", 3, { stake_tao: 1200, rank: 0.9 }),
+        neuronDailyRow("2026-06-25", 3, { stake_tao: 1100, rank: 0.8 }),
+      ],
+    });
+    const res = await callTool(
+      "get_neuron_history",
+      { netuid: 1, uid: 3, window: "30d" },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 1);
+    assert.equal(out.uid, 3);
+    assert.equal(out.point_count, 2);
+    assert.equal(out.points[0].snapshot_date, "2026-06-26");
+    assert.equal(out.points[0].stake_tao, 1200);
+  });
+
+  test("get_neuron_history requires a non-negative uid", async () => {
+    const res = await callTool("get_neuron_history", { netuid: 1 });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /uid/);
+  });
+
+  test("get_subnet_concentration_history builds the per-day trend", async () => {
+    const env = parityD1({
+      concentrationRows: [
+        { snapshot_date: "2026-06-26", stake_tao: 100, emission_tao: 10 },
+        { snapshot_date: "2026-06-26", stake_tao: 50, emission_tao: 5 },
+        { snapshot_date: "2026-06-25", stake_tao: 80, emission_tao: 8 },
+        { snapshot_date: "2026-06-25", stake_tao: 40, emission_tao: 4 },
+      ],
+    });
+    const res = await callTool(
+      "get_subnet_concentration_history",
+      { netuid: 1, window: "30d" },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 1);
+    assert.equal(out.window, "30d");
+    assert.equal(out.point_count, 2);
+    assert.equal(out.points[0].snapshot_date, "2026-06-26");
+    assert.equal(out.points[0].neuron_count, 2);
+    assert.equal(typeof out.points[0].stake_gini, "number");
+  });
+
+  test("get_subnet_concentration_history rejects the 1y window (smaller set)", async () => {
+    const res = await callTool("get_subnet_concentration_history", {
+      netuid: 1,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_subnet_events filters by kind and paginates with a cursor", async () => {
+    const capture = [];
+    const env = parityD1(
+      {
+        events: [
+          {
+            block_number: 8502402,
+            event_index: 1,
+            event_kind: "WeightsSet",
+            hotkey: null,
+            coldkey: null,
+            netuid: 1,
+            uid: 226,
+            amount_tao: null,
+            alpha_amount: null,
+            observed_at: 1751081952000,
+            extrinsic_index: null,
+          },
+        ],
+      },
+      capture,
+    );
+    const res = await callTool(
+      "get_subnet_events",
+      { netuid: 1, kind: "WeightsSet", limit: 1 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 1);
+    assert.equal(out.event_count, 1);
+    assert.equal(out.limit, 1);
+    assert.equal(out.events[0].event_kind, "WeightsSet");
+    // A full page yields a non-null keyset cursor.
+    assert.equal(typeof out.next_cursor, "string");
+    // The kind filter reaches the SQL as a bound param (never interpolated).
+    const q = capture.find((c) => /FROM account_events/.test(c.sql));
+    assert.ok(/AND event_kind = \?/.test(q.sql));
+    assert.ok(q.params.includes("WeightsSet"));
+  });
+
+  test("get_subnet_events clamps an over-range limit like the REST route", async () => {
+    const capture = [];
+    const env = parityD1({ events: [] }, capture);
+    const res = await callTool(
+      "get_subnet_events",
+      { netuid: 1, limit: 5000 },
+      { env },
+    );
+    assert.equal(res.body.result.structuredContent.limit, 1000);
+    const q = capture.find((c) => /FROM account_events/.test(c.sql));
+    assert.ok(q.params.includes(1000));
+  });
+
+  test("the parity history/events tools degrade to empty payloads on cold D1", async () => {
+    const history = await callTool("get_subnet_history", { netuid: 1 });
+    assert.equal(history.body.result.isError, false);
+    assert.equal(history.body.result.structuredContent.point_count, 0);
+
+    const neuronHistory = await callTool("get_neuron_history", {
+      netuid: 1,
+      uid: 0,
+    });
+    assert.equal(neuronHistory.body.result.structuredContent.point_count, 0);
+
+    const concentration = await callTool("get_subnet_concentration_history", {
+      netuid: 1,
+    });
+    assert.equal(concentration.body.result.structuredContent.point_count, 0);
+
+    const events = await callTool("get_subnet_events", { netuid: 1 });
+    assert.equal(events.body.result.structuredContent.event_count, 0);
+    assert.equal(events.body.result.structuredContent.next_cursor, null);
+  });
+
+  test("the parity history/events tools reject a negative netuid", async () => {
+    for (const name of [
+      "get_subnet_history",
+      "get_subnet_concentration_history",
+      "get_subnet_events",
+    ]) {
+      const res = await callTool(name, { netuid: -1 });
+      assert.equal(res.body.result.isError, true, `${name} must reject -1`);
+    }
+  });
+});
+
+describe("MCP parity tools — provider + discovery bundle (artifact-backed)", () => {
+  test("get_provider_detail returns the provider artifact (no endpoints by default)", async () => {
+    const deps = makeDeps({
+      "/metagraph/providers/datura.json": {
+        id: "datura",
+        slug: "datura",
+        name: "Datura",
+        authority: "official",
+      },
+    });
+    const res = await callTool(
+      "get_provider_detail",
+      { slug: "datura" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.slug, "datura");
+    assert.equal(out.name, "Datura");
+    // No endpoints wrapper unless include_endpoints was set.
+    assert.equal("provider" in out, false);
+  });
+
+  test("get_provider_detail attaches endpoints when include_endpoints is set", async () => {
+    const deps = makeDeps({
+      "/metagraph/providers/datura.json": { slug: "datura", name: "Datura" },
+      "/metagraph/providers/datura/endpoints.json": {
+        endpoints: [{ surface_id: "datura-api", url: "https://x" }],
+      },
+    });
+    const res = await callTool(
+      "get_provider_detail",
+      { slug: "datura", include_endpoints: true },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.provider.slug, "datura");
+    assert.equal(out.endpoints.endpoints[0].surface_id, "datura-api");
+  });
+
+  test("get_provider_detail null-fills endpoints when the artifact is absent", async () => {
+    const deps = makeDeps({
+      "/metagraph/providers/lonely.json": { slug: "lonely" },
+    });
+    const res = await callTool(
+      "get_provider_detail",
+      { slug: "lonely", include_endpoints: true },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.provider.slug, "lonely");
+    assert.equal(out.endpoints, null);
+  });
+
+  test("get_provider_detail is not_found when the provider artifact is missing", async () => {
+    const res = await callTool("get_provider_detail", { slug: "ghost" });
+    assert.equal(res.body.result.isError, true);
+    assert.equal(res.body.result.structuredContent.error.code, "not_found");
+  });
+
+  test("get_provider_detail rejects a slug that could escape the namespace", async () => {
+    const res = await callTool("get_provider_detail", { slug: "../secrets" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /invalid characters/);
+  });
+
+  test("list_fixtures returns the fixtures index artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/fixtures.json": {
+        candidate_count: 2,
+        coverage: [{ surface_id: "a", status: "captured" }],
+      },
+    });
+    const res = await callTool("list_fixtures", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.candidate_count, 2);
+    assert.equal(out.coverage[0].surface_id, "a");
+  });
+
+  test("list_schemas returns the schemas index artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/schemas/index.json": {
+        schemas: [{ netuid: 6, drift_status: "new" }],
+      },
+    });
+    const res = await callTool("list_schemas", {}, { deps });
+    assert.equal(
+      res.body.result.structuredContent.schemas[0].drift_status,
+      "new",
+    );
+  });
+
+  test("get_lineage returns the lineage artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/lineage.json": {
+        link_count: 1,
+        graduated_subnet_count: 1,
+        broken_link_count: 0,
+        links: [{ mainnet_netuid: 1, testnet_netuid: 1 }],
+        broken_links: [],
+      },
+    });
+    const res = await callTool("get_lineage", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.link_count, 1);
+    assert.equal(out.links[0].mainnet_netuid, 1);
+  });
+
+  test("get_source_health returns the source-health artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/source-health.json": {
+        providers: [{ id: "datura", status: "ok", endpoint_count: 3 }],
+      },
+    });
+    const res = await callTool("get_source_health", {}, { deps });
+    assert.equal(res.body.result.structuredContent.providers[0].status, "ok");
+  });
+
+  test("get_freshness overlays the live prober run onto surface-health", async () => {
+    const deps = makeDeps(
+      {
+        "/metagraph/freshness.json": {
+          schema_version: 1,
+          sources: [
+            { id: "surface-health", status: "stale", timestamp: "old" },
+            { id: "adapter-snapshots", status: "captured" },
+          ],
+          summary: {},
+        },
+      },
+      { "health:meta": { last_run_at: FRESH_RUN } },
+    );
+    const res = await callTool("get_freshness", {}, { deps });
+    const out = res.body.result.structuredContent;
+    const surfaceHealth = out.sources.find((s) => s.id === "surface-health");
+    assert.equal(surfaceHealth.status, "current");
+    assert.equal(surfaceHealth.timestamp, FRESH_RUN);
+    assert.equal(out.summary.health_probe_as_of, FRESH_RUN);
+  });
+
+  test("get_freshness passes the committed artifact through with no live meta", async () => {
+    const deps = makeDeps({
+      "/metagraph/freshness.json": {
+        schema_version: 1,
+        sources: [{ id: "surface-health", status: "stale" }],
+      },
+    });
+    const res = await callTool("get_freshness", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.sources[0].status, "stale");
+  });
+});


### PR DESCRIPTION
## What

metagraphed is agent-reached, but several live + contracted REST routes had **no MCP tool**, so an agent on the MCP server couldn't reach that data. This adds ten read-only MCP tools over those existing routes, copying the exact shape of the existing tools and reusing the **same data-access each route's handler uses**.

D1-backed (run the same SQL as the REST handler over `mcpD1Runner`, schema-stable empties on a cold store):
- `get_subnet_history` → `/api/v1/subnets/{netuid}/history` (daily neuron/validator counts + stake/emission; window `7d|30d|90d|1y|all`)
- `get_subnet_concentration_history` → `/api/v1/subnets/{netuid}/concentration/history` (daily Gini/Nakamoto/top-10% for stake + emission; window `7d|30d|90d`)
- `get_neuron_history` → `/api/v1/subnets/{netuid}/neurons/{uid}/history` (per-UID daily stake/rank/emission/…)
- `get_subnet_events` → `/api/v1/subnets/{netuid}/events` (kind filter, limit/offset, keyset cursor)

Artifact-backed (read the same R2 artifact via `loadArtifactData`):
- `get_provider_detail` → `/api/v1/providers/{slug}` (+ `/endpoints` when `include_endpoints` is set)
- `list_fixtures` → `/api/v1/fixtures`
- `list_schemas` → `/api/v1/schemas`
- `get_lineage` → `/api/v1/lineage`
- `get_freshness` → `/api/v1/freshness` (overlays the live 15-min prober run via `mergeFreshness`, like the route)
- `get_source_health` → `/api/v1/source-health`

The history/concentration/event loaders replicate the SQL from `workers/request-handlers/entities.mjs` over the MCP module's injected `mcpD1Runner` (which yields `[]` on a cold/error DB — the same never-throw contract the REST tiers use), keeping the pure MCP module self-contained and leaving the Worker handler untouched.

## Why

Closes the MCP↔REST parity gap: every one of these is a contracted, live route, so an agent should be able to reach it through the MCP tool surface, not only over HTTP. Output schemas are added for each new tool (validated by `validate:mcp`), and the OpenAI/Anthropic/index agent-tool projections pick them up automatically.

`MCP_SERVER_VERSION` + `server.json` bumped `1.5.0 → 1.6.0` (additive minor, per the bump policy).

### Skipped
- **`get_account_balance`** (`/api/v1/accounts/{ss58}/balance`): intentionally **not** added. Unlike the other routes it is a live finney-RPC fan-out with its own SS58 base58 decode, KV cache, and per-IP rate limiter, all bound to the Worker request context (`FINNEY_RPC_URL`, `METAGRAPH_CONTROL`). It is not reachable through the pure MCP module's injected deps without pulling Worker-only machinery into it, so it is left out of this batch.

## Gates run (all green)
- `npm run validate:mcp` → 48 tools, lifecycle + all tools/call ✓
- `npx vitest run tests/mcp-server.test.mjs tests/agent-tool-specs.test.mjs` → 237 passed ✓ (33 new parity-tool tests)
- `npm run validate:contract-drift` → passed ✓ (`npm run build` yields no tracked-artifact diff — MCP additions don't change the OpenAPI contract)
- `npx prettier --write` on the changed files ✓
- `npx eslint` on the changed files ✓