### PR TITLE
fix(api): clamp per-day uptime_ratio in formatUptime below 1

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1108,7 +1108,10 @@ export function formatUptime({
       day: row.day,
       samples: Number(row.samples) || 0,
       ok_count: Number(row.ok_count) || 0,
-      uptime_ratio: row.uptime_ratio == null ? null : Number(row.uptime_ratio),
+      uptime_ratio:
+        Number(row.samples) > 0
+          ? displayUptimeRatio(Number(row.ok_count) / Number(row.samples))
+          : null,
       avg_latency_ms: roundInt(row.avg_latency_ms),
       latency_sample_count: Number(row.latency_samples) || 0,
       latency_ms: {

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -2270,6 +2270,28 @@ describe("formatUptime (daily uptime history)", () => {
     assert.equal(out.observed_at, ts);
   });
 
+  test("clamps per-day uptime_ratio that SQL ROUND rounds up to 1 for sub-perfect days", () => {
+    const out = formatUptime({
+      netuid: 7,
+      window: "90d",
+      rows: [
+        {
+          surface_id: "a",
+          day: "2026-06-12",
+          samples: 25000,
+          ok_count: 24999,
+          uptime_ratio: 1, // SQL ROUND(24999/25000, 4) = 1.0
+          avg_latency_ms: 50,
+          status: "degraded",
+        },
+      ],
+    });
+    // per-day series must not show 1 when samples < ok_count
+    assert.equal(out.surfaces[0].days[0].uptime_ratio, 0.9999);
+    // window-wide ratio must also be clamped
+    assert.equal(out.surfaces[0].uptime_ratio, 0.9999);
+  });
+
   test("handles null ratios/latency, missing status, zero samples, and no window", () => {
     const out = formatUptime({
       netuid: 7,


### PR DESCRIPTION
## Summary

- `formatUptime` stored each per-day series entry uptime_ratio from the SQL-precomputed `ROUND(SUM(ok_count)/SUM(samples),4)` value. SQLite `ROUND(0.99996,4)=1.0` so a surface with 24999/25000 ok samples yielded `uptime_ratio:1` in the per-day array while `status:degraded` was correctly set -- an inconsistency in the API response.
- Sibling of #2025 / PR #2045 which fixed the window-wide ratio but missed the per-day entry.

## What Changed

- `src/health-serving.mjs`: compute per-day `uptime_ratio` from raw `ok_count/samples` through `displayUptimeRatio` (consistent with the window-wide computation at line ~1133) instead of copying the SQL-rounded value.
- `tests/health-serving.test.mjs`: regression test asserting 24999/25000 per-day row yields `uptime_ratio: 0.9999`, not `1`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None.)

## Validation

- [x] `npm run check`
- [x] `npm run test:coverage` (131/131 pass)

Fixes #2223