### PR TITLE
fix(api): canonicalize subnet-history edge-cache key on window parameter

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -546,6 +546,47 @@ describe("analytics edge cache", () => {
     assert.equal(cachedBody, uncachedBody);
   });
 
+  test("subnet-history ?window variants share a single cache entry (canonical key)", async () => {
+    const queries = [];
+    const cache = mockCaches();
+    cache.install();
+    const env = analyticsEnv(queries);
+    const base = "/api/v1/subnets/7/history";
+
+    // First request with explicit default window — caches under ?window=30d.
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}?window=30d`),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    const queriesAfterFirst = queries.length;
+
+    // Trailing-amp variant must be a cache HIT (same canonical key).
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}?window=30d&`),
+      env,
+      ctx,
+    );
+    assert.equal(
+      queries.length,
+      queriesAfterFirst,
+      "?window=30d& hits cache of ?window=30d",
+    );
+
+    // Omitting window entirely defaults to 30d — also a cache HIT.
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}`),
+      env,
+      ctx,
+    );
+    assert.equal(
+      queries.length,
+      queriesAfterFirst,
+      "no ?window hits cache of ?window=30d",
+    );
+  });
+
   test("the 4 additional deterministic routes are now edge-cached (MISS→put under their key, HIT→no D1)", async () => {
     // These routes (global incidents, per-subnet trajectory, per-subnet uptime,
     // registry leaderboards) were edgeCache=0 — they re-ran their D1 aggregation

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -28,6 +28,7 @@ import {
   handleBlockEvents,
   handleExtrinsics,
   handleExtrinsic,
+  canonicalSubnetHistoryCachePath,
 } from "../workers/request-handlers/entities.mjs";
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
@@ -2663,6 +2664,27 @@ describe("envelope + meta contracts (#1900)", () => {
 async function resHasEtag(res) {
   return Boolean(res.headers.get("etag"));
 }
+
+describe("canonicalSubnetHistoryCachePath", () => {
+  test("returns canonical key for valid window param", () => {
+    assert.equal(
+      canonicalSubnetHistoryCachePath(
+        url("/api/v1/subnets/7/history?window=30d"),
+      ),
+      "/api/v1/subnets/7/history?window=30d",
+    );
+  });
+
+  test("falls back to raw url when unknown query param is present", () => {
+    const raw = "/api/v1/subnets/7/history?window=30d&extra=junk";
+    assert.equal(canonicalSubnetHistoryCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw url when window value is invalid", () => {
+    const raw = "/api/v1/subnets/7/history?window=invalid";
+    assert.equal(canonicalSubnetHistoryCachePath(url(raw)), raw);
+  });
+});
 
 // Fixture documentation: each factory above mirrors the D1 column contracts used
 // by workers/request-handlers/entities.mjs. When adding a new handler test,

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -67,6 +67,7 @@ import {
   handleSubnetHistory,
   handleSubnetConcentration,
   handleSubnetConcentrationHistory,
+  canonicalSubnetHistoryCachePath,
   canonicalSubnetConcentrationHistoryCachePath,
   handleAccount,
   handleAccountHistory,
@@ -1188,13 +1189,19 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       // GROUP BY daily aggregation, deterministic per cron snapshot — edge-cache
       // on last_run_at like the sibling analytics routes (pathname carries the
       // netuid, search carries ?window). Cheap single-row lookups stay uncached.
-      return withEdgeCache(request, ctx, env, "subnet-history", () =>
-        handleSubnetHistory(
-          request,
-          env,
-          Number(subnetHistoryMatch[1]),
-          resolved.url,
-        ),
+      return withEdgeCache(
+        request,
+        ctx,
+        env,
+        "subnet-history",
+        () =>
+          handleSubnetHistory(
+            request,
+            env,
+            Number(subnetHistoryMatch[1]),
+            resolved.url,
+          ),
+        canonicalSubnetHistoryCachePath(resolved.url),
       );
     }
     const metagraphMatch = SUBNET_METAGRAPH_PATH_PATTERN.exec(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -262,6 +262,14 @@ export async function handleSubnetConcentration(request, env, netuid, url) {
   );
 }
 
+export function canonicalSubnetHistoryCachePath(url) {
+  const validationError = validateQueryParams(url, ["window"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const { label, error } = parseHistoryWindow(url.searchParams.get("window"));
+  if (error) return `${url.pathname}${url.search}`;
+  return `${url.pathname}?window=${encodeURIComponent(label)}`;
+}
+
 export function canonicalSubnetConcentrationHistoryCachePath(url) {
   const validationError = validateQueryParams(url, ["window"]);
   if (validationError) return `${url.pathname}${url.search}`;


### PR DESCRIPTION
## Summary

- The subnet-history route (/api/v1/subnets/{netuid}/history?window=) accepted a ?window= parameter but its withEdgeCache call used raw url.search as the cache key. Semantically-equivalent variants (?window=30d, ?window=30d&, omitted window defaulting to 30d) each produced a distinct cache entry and re-ran the D1 aggregation unnecessarily.
- Sibling of PR #2195 (concentration-history canonicalization).

## What Changed

- `workers/request-handlers/entities.mjs`: add `canonicalSubnetHistoryCachePath(url)` mirroring `canonicalSubnetConcentrationHistoryCachePath` but using `parseHistoryWindow`.
- `workers/api.mjs`: import the new function and pass it as the `cachePathAndSearch` argument to the subnet-history `withEdgeCache` call.
- `tests/analytics-edge-cache.test.mjs`: regression test asserting `?window=30d`, `?window=30d&`, and no `?window` all hit the same cache entry.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None.)

## Validation

- [x] `npm run check`
- [x] `npm run test:coverage` (15/15 analytics-edge-cache tests pass)

Fixes #2225