### PR TITLE
fix(api): drop incomplete oldest day in buildEconomicsTrends when row cap is reached

### DIFF
--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -309,7 +309,7 @@ export function buildNeuronHistory(rows, netuid, uid, { window } = {}) {
 // stake-weighted mean + median alpha price can be computed here. Rows arrive newest
 // first; the output preserves that order. Null-safe throughout — a metric is null
 // for a day only when NO subnet reported it.
-export function buildEconomicsTrends(rows, { window } = {}) {
+export function buildEconomicsTrends(rows, { window, capped } = {}) {
   const byDay = new Map(); // snapshot_date -> accumulator (insertion order = newest first)
   for (const r of rows || []) {
     const day = r.snapshot_date;
@@ -363,7 +363,7 @@ export function buildEconomicsTrends(rows, { window } = {}) {
       }
     }
   }
-  const days = [...byDay.entries()].map(([snapshot_date, acc]) => ({
+  let days = [...byDay.entries()].map(([snapshot_date, acc]) => ({
     snapshot_date,
     subnet_count: acc.subnet_count,
     total_stake_tao: acc.stake_seen ? roundTao(acc.stake_sum) : null,
@@ -379,6 +379,11 @@ export function buildEconomicsTrends(rows, { window } = {}) {
         ? roundShare(acc.emission_sum / acc.emission_seen)
         : null,
   }));
+  // When the row cap was reached, the oldest day may be incomplete (only the
+  // subnets whose rows fit before the LIMIT are included). Drop it so the
+  // response never serves a partially-aggregated network snapshot — mirrors
+  // buildConcentrationHistory's capped guard.
+  if (capped && days.length > 1) days = days.slice(0, -1);
   return {
     schema_version: 1,
     window: window ?? null,

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -293,6 +293,49 @@ describe("history builders", () => {
     assert.deepEqual(out.days, []);
     assert.equal(out.window, null);
   });
+
+  test("buildEconomicsTrends drops the oldest day when capped=true to avoid a partial network snapshot", () => {
+    // Simulate the row cap being reached: three days where the oldest (2026-06-01)
+    // is incomplete because the LIMIT cut it off mid-subnet. With capped=true the
+    // builder must drop that day; without it all three are served.
+    const rows = [
+      {
+        snapshot_date: "2026-06-03",
+        total_stake_tao: 500,
+        alpha_price_tao: 0.05,
+        validator_count: 10,
+        miner_count: 40,
+        emission_share: 0.05,
+      },
+      {
+        snapshot_date: "2026-06-02",
+        total_stake_tao: 400,
+        alpha_price_tao: 0.04,
+        validator_count: 8,
+        miner_count: 30,
+        emission_share: 0.04,
+      },
+      // incomplete oldest day — only one of many subnets present
+      {
+        snapshot_date: "2026-06-01",
+        total_stake_tao: 50,
+        alpha_price_tao: 0.01,
+        validator_count: 1,
+        miner_count: 5,
+        emission_share: 0.01,
+      },
+    ];
+    const capped = buildEconomicsTrends(rows, { window: "7d", capped: true });
+    assert.equal(capped.day_count, 2);
+    assert.equal(capped.days[0].snapshot_date, "2026-06-03");
+    assert.equal(capped.days[1].snapshot_date, "2026-06-02");
+
+    const uncapped = buildEconomicsTrends(rows, {
+      window: "7d",
+      capped: false,
+    });
+    assert.equal(uncapped.day_count, 3);
+  });
 });
 
 describe("rollupNeuronDaily idempotency invariant (#1345)", () => {

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -120,7 +120,10 @@ export async function handleEconomicsTrends(request, env, url) {
   sql += " ORDER BY snapshot_date DESC LIMIT ?";
   params.push(ECONOMICS_TRENDS_ROW_CAP);
   const rows = await d1All(env, sql, params);
-  const data = buildEconomicsTrends(rows, { window: label });
+  const data = buildEconomicsTrends(rows, {
+    window: label,
+    capped: rows.length >= ECONOMICS_TRENDS_ROW_CAP,
+  });
   return envelopeWithD1Fallback(
     request,
     {


### PR DESCRIPTION
## Summary

When handleEconomicsTrends hits ECONOMICS_TRENDS_ROW_CAP (60 000 rows), the SQL ORDER BY snapshot_date DESC LIMIT 60000 truncates the oldest rows first. The oldest snapshot_date in the result may therefore only contain a subset of subnets - the rest were cut off. uildEconomicsTrends then serves that partial day as a full network aggregate, understating 	otal_stake_tao, alidator_count, miner_count, lpha_price_tao_weighted, and mean_emission_share for that day.

## What Changed

- src/neuron-history.mjs - uildEconomicsTrends now accepts a capped option; when true and there are multiple days, it drops the last (oldest) day before building the result, mirroring the identical guard in uildConcentrationHistory.
- workers/request-handlers/analytics-routes.mjs - handleEconomicsTrends passes capped: rows.length >= ECONOMICS_TRENDS_ROW_CAP to the builder.
- 	ests/neuron-history.test.mjs - new test asserts the oldest day is dropped when capped=true and retained when capped=false.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] \
pm run check\
- [x] \
pm run validate\
- [x] \
pm run validate:schemas\
- [x] \
pm run validate:api\
- [x] \
pm run validate:openapi\
- [x] \
pm run validate:types\
- [x] \
pm run validate:artifact-budgets\
- [x] \
pm run validate:docs\
- [x] \
pm run validate:intake\
- [x] \
pm run validate:workflows\
- [x] \
pm run worker:test\
- [x] \
pm run test:coverage\
- [x] \
pm run scan:public-safety\
- [x] \git diff --check\

Fixes #2227