### PR TITLE
fix(api): canonicalize uptime edge-cache key on window parameter

### DIFF
--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -6,14 +6,15 @@ import assert from "node:assert/strict";
 import { describe, test, beforeEach } from "vitest";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import {
+  canonicalCompareCachePath,
+  canonicalUptimeCachePath,
+  composeCompareData,
   configureAnalyticsRoutes,
   handleCompare,
   handleEconomicsTrends,
   handleLeaderboards,
   handleTrajectory,
   handleUptime,
-  composeCompareData,
-  canonicalCompareCachePath,
 } from "../workers/request-handlers/analytics-routes.mjs";
 
 const NETUID = 7;
@@ -444,6 +445,39 @@ describe("canonicalCompareCachePath", () => {
       canonicalCompareCachePath(url("/api/v1/compare?netuids=not-valid")),
       null,
     );
+  });
+});
+
+describe("canonicalUptimeCachePath", () => {
+  test("normalizes bare path to explicit default window", () => {
+    assert.equal(
+      canonicalUptimeCachePath(url("/api/v1/subnets/7/uptime")),
+      "/api/v1/subnets/7/uptime?window=90d",
+    );
+  });
+
+  test("explicit ?window=90d collapses to same key as bare path", () => {
+    assert.equal(
+      canonicalUptimeCachePath(url("/api/v1/subnets/7/uptime?window=90d")),
+      "/api/v1/subnets/7/uptime?window=90d",
+    );
+  });
+
+  test("preserves valid non-default window", () => {
+    assert.equal(
+      canonicalUptimeCachePath(url("/api/v1/subnets/7/uptime?window=1y")),
+      "/api/v1/subnets/7/uptime?window=1y",
+    );
+  });
+
+  test("falls back to raw search on unknown query param", () => {
+    const raw = "/api/v1/subnets/7/uptime?unknown=x";
+    assert.equal(canonicalUptimeCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid window value", () => {
+    const raw = "/api/v1/subnets/7/uptime?window=7d";
+    assert.equal(canonicalUptimeCachePath(url(raw)), raw);
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -84,6 +84,7 @@ import {
 } from "./request-handlers/entities.mjs";
 import {
   canonicalCompareCachePath,
+  canonicalUptimeCachePath,
   configureAnalyticsRoutes,
   handleCompare,
   handleEconomicsTrends,
@@ -1176,8 +1177,13 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     }
     const uptimeMatch = UPTIME_PATH_PATTERN.exec(resolved.url.pathname);
     if (uptimeMatch) {
-      return withEdgeCache(request, ctx, env, "uptime", () =>
-        handleUptime(request, env, Number(uptimeMatch[1]), resolved.url),
+      return withEdgeCache(
+        request,
+        ctx,
+        env,
+        "uptime",
+        () => handleUptime(request, env, Number(uptimeMatch[1]), resolved.url),
+        canonicalUptimeCachePath(resolved.url),
       );
     }
     const concentrationHistoryMatch =

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -200,6 +200,18 @@ export async function handleUptime(request, env, netuid, url) {
   );
 }
 
+// Normalises the uptime URL so that a bare ?-free request and an explicit
+// ?window=90d request both resolve to the same edge-cache entry — mirrors
+// canonicalSubnetConcentrationHistoryCachePath in entities.mjs.
+export function canonicalUptimeCachePath(url) {
+  const validationError = validateQueryParams(url, ["window"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const windowParam = url.searchParams.get("window") || "90d";
+  if (!Object.hasOwn(UPTIME_WINDOWS, windowParam))
+    return `${url.pathname}${url.search}`;
+  return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
+}
+
 async function leaderboardProfilesProjection(env, now = Date.now()) {
   if (
     leaderboardProfilesCache &&


### PR DESCRIPTION
Fixes #2230

## Summary

`/api/v1/subnets/{netuid}/uptime` accepts an optional `?window` query parameter (`90d` or `1y`; default `90d`). Without a canonical cache-path argument, `withEdgeCache` keys on `url.pathname + url.search`, so a bare request (`/uptime`) and an explicit-default request (`/uptime?window=90d`) build **separate edge-cache entries** for the data - doubling origin hits and making cache invalidation unreliable.

## What Changed

- **`workers/request-handlers/analytics-routes.mjs`** - exports `canonicalUptimeCachePath(url)`: normalises a missing or default `90d` window to an explicit `?window=90d`, passes through valid non-default windows (`1y`), and falls back to the raw search string for unknown params or invalid windows (preserving the handler's own 400 path).
- **`workers/api.mjs`** - imports `canonicalUptimeCachePath` and passes it as the sixth argument to `withEdgeCache` on the uptime route.
- **`tests/request-handlers-analytics-routes.test.mjs`** - five new assertions covering bare path, explicit-default, non-default window, unknown param fallback, and invalid window fallback.

## Registry Safety

Read-only change; no D1 schema, KV layout, or R2 path changes. The canonical function is a pure URL normaliser with no side effects.

## Validation

- `npx prettier@3.8.4 --check` passes on all three files.
- `npx vitest run tests/request-handlers-analytics-routes.test.mjs` - 30 tests pass (5 new).