### PR TITLE
fix(feeds): include `since` in feed edge-cache key

### DIFF
--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -770,6 +770,84 @@ describe("feeds — Worker dispatch integration", () => {
     assert.equal(recentChecksQueries, 1);
   });
 
+  test("handleRequest keys edge-cached feeds by since", async () => {
+    installMockCache();
+    let recentChecksQueries = 0;
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind() {
+              return {
+                all: () => {
+                  if (sql.includes("recent_checks")) {
+                    recentChecksQueries += 1;
+                    return Promise.resolve({
+                      results: [
+                        {
+                          netuid: 7,
+                          surface_id: "allways-api",
+                          surface_key: "allways-api",
+                          started_at: 1781266255266,
+                          ended_at: 1781499480737,
+                          failed_samples: 1945,
+                        },
+                      ],
+                    });
+                  }
+                  return Promise.resolve({ results: [] });
+                },
+              };
+            },
+          };
+        },
+      },
+      METAGRAPH_CONTROL: {
+        async get(key) {
+          if (key === "health:meta") {
+            return { last_run_at: "2026-06-15T00:00:00.000Z" };
+          }
+          return null;
+        },
+      },
+    };
+    const ctx = { waitUntil: (promise) => promise };
+
+    const future = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/feeds/incidents.json?since=2099-01-01",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(future.status, 200);
+    assert.deepEqual((await future.json()).items, []);
+    assert.equal(recentChecksQueries, 1);
+
+    const unfiltered = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/feeds/incidents.json"),
+      env,
+      ctx,
+    );
+    assert.equal(unfiltered.status, 200);
+    assert.ok((await unfiltered.json()).items.length > 0);
+    assert.equal(recentChecksQueries, 2);
+
+    const invalid = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/feeds/incidents.json?since=notadate",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(invalid.status, 400);
+    assert.equal(
+      invalid.headers.get("x-metagraph-error-code"),
+      "invalid_since",
+    );
+  });
+
   test("an unknown feed path is a 404 with the canonical error envelope", async () => {
     const env = createLocalArtifactEnv();
     const res = await handleRequest(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -997,6 +997,10 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     ];
     const tag = url.searchParams.get("tag");
     if (tag != null) feedCacheParams.push(`tag=${encodeURIComponent(tag)}`);
+    const since = url.searchParams.get("since");
+    if (since != null) {
+      feedCacheParams.push(`since=${encodeURIComponent(since)}`);
+    }
     const feedCachePath = `${url.pathname}?${feedCacheParams.join("&")}`;
     const feedRequest =
       request.method === "HEAD"


### PR DESCRIPTION
### Motivation
- The feed edge-cache canonicalization omitted the `since` query parameter even though `since` changes the response body, which allows unauthenticated clients to poison shared cached feed variants or receive cached responses that should be rejected. 
- The change ensures filtered, unfiltered, and malformed-`since` requests are isolated in the edge cache so validation and filtering are always applied before a cached response can be reused.

### Description
- Append `since` (when present) to the canonical feed cache parameters and include it in the `feedCachePath` used by `withEdgeCache` in `workers/api.mjs` so cache keys vary by `format`, `tag`, and `since`.
- Add a regression test `handleRequest keys edge-cached feeds by since` to `tests/feeds.test.mjs` that installs a mock cache, warms the edge cache with a future `since`, verifies an unfiltered request rebuilds (not served from the filtered cache), and verifies a malformed `since` still returns a `400` and the canonical error envelope.
- Apply code-style formatting to the modified test file to satisfy the repo's `prettier` rules.

### Testing
- Ran `git diff --check` with no issues.
- Ran `npm run lint` and the linter passed.
- Ran `npm run format:check` (after formatting) and formatting passed.
- Ran `npm test -- tests/feeds.test.mjs` and the test file passed (61 tests passed).
- Ran `npm run build` and the build succeeded.
- Ran `npm run validate` and the repository validators completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41070ab8d8832cbcf9d05d13846e0d)