### PR TITLE
fix(feeds): validate `since` as strict ISO

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -393,8 +393,10 @@ function parseSinceParam(value) {
           const sign = zone[0] === "-" ? -1 : 1;
           const hours = Number(zone.slice(1, 3));
           const minutes = Number(zone.slice(4, 6));
+          if (hours > 23 || minutes > 59) return Number.NaN;
           return sign * (hours * 60 + minutes) * 60_000;
         })();
+  if (Number.isNaN(offsetMs)) return Number.NaN;
 
   return utcMs - offsetMs;
 }

--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -349,6 +349,56 @@ export function parseFeedPath(pathname) {
   return null;
 }
 
+// Strictly parse the public `?since=` contract instead of delegating validation
+// to Date.parse(), which accepts implementation-defined inputs and normalizes
+// overflow dates. Accepted forms are an ISO calendar date (UTC midnight) or an
+// ISO date-time with an explicit UTC/offset designator.
+function parseSinceParam(value) {
+  const raw = String(value);
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    const ms = Date.UTC(Number(year), Number(month) - 1, Number(day));
+    return new Date(ms).toISOString().slice(0, 10) === raw ? ms : Number.NaN;
+  }
+
+  const match =
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+)?(Z|[+-]\d{2}:\d{2})$/.exec(
+      raw,
+    );
+  if (!match) return Number.NaN;
+
+  const [, year, month, day, hour, minute, second, fraction = "", zone] = match;
+  const date = `${year}-${month}-${day}`;
+  const dateMs = Date.UTC(Number(year), Number(month) - 1, Number(day));
+  if (new Date(dateMs).toISOString().slice(0, 10) !== date) return Number.NaN;
+
+  const hourNumber = Number(hour);
+  const minuteNumber = Number(minute);
+  const secondNumber = Number(second);
+  if (hourNumber > 23 || minuteNumber > 59 || secondNumber > 59) {
+    return Number.NaN;
+  }
+
+  const normalizedFraction = fraction
+    ? fraction.slice(0, 4).padEnd(4, "0")
+    : ".000";
+  const utcMs = Date.parse(
+    `${date}T${hour}:${minute}:${second}${normalizedFraction}Z`,
+  );
+  const offsetMs =
+    zone === "Z"
+      ? 0
+      : (() => {
+          const sign = zone[0] === "-" ? -1 : 1;
+          const hours = Number(zone.slice(1, 3));
+          const minutes = Number(zone.slice(4, 6));
+          return sign * (hours * 60 + minutes) * 60_000;
+        })();
+
+  return utcMs - offsetMs;
+}
+
 function feedError(code, message, status) {
   return new Response(JSON.stringify({ ok: false, error: { code, message } }), {
     status,
@@ -399,7 +449,7 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
   let sinceMs = null;
   const sinceParam = url.searchParams.get("since");
   if (sinceParam != null) {
-    sinceMs = Date.parse(sinceParam);
+    sinceMs = parseSinceParam(sinceParam);
     if (Number.isNaN(sinceMs)) {
       return fail(
         "invalid_since",
@@ -504,4 +554,5 @@ export const __test = {
   escapeXml,
   filterByTag,
   filterSince,
+  parseSinceParam,
 };

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -47,6 +47,7 @@ const {
   escapeXml,
   filterByTag,
   filterSince,
+  parseSinceParam,
 } = __test;
 
 const CHANGELOG = {
@@ -301,6 +302,34 @@ describe("feeds — filterByTag", () => {
   });
 });
 
+describe("feeds — parseSinceParam", () => {
+  test("accepts strict ISO dates and date-times", () => {
+    assert.equal(
+      new Date(parseSinceParam("2026-06-01")).toISOString(),
+      "2026-06-01T00:00:00.000Z",
+    );
+    assert.equal(
+      new Date(parseSinceParam("2026-06-01T01:02:03Z")).toISOString(),
+      "2026-06-01T01:02:03.000Z",
+    );
+    assert.equal(
+      new Date(parseSinceParam("2026-06-01T01:02:03.123+02:30")).toISOString(),
+      "2026-05-31T22:32:03.123Z",
+    );
+  });
+
+  test("rejects Date.parse-permissive malformed or non-ISO values", () => {
+    for (const value of [
+      "1",
+      "2026-02-31",
+      "Tue, 01 Jun 2026 00:00:00 GMT",
+      "2026-06-01T00:00:00",
+    ]) {
+      assert.ok(Number.isNaN(parseSinceParam(value)), value);
+    }
+  });
+});
+
 describe("feeds — filterSince", () => {
   const items = [
     { id: "old", timestamp: "2026-06-10T00:00:00.000Z" },
@@ -349,8 +378,17 @@ describe("feeds — ?since= filter", () => {
   });
 
   test("a malformed since is rejected with 400", async () => {
-    const { res } = await feed("/api/v1/feeds/registry.json?since=notadate");
-    assert.equal(res.status, 400);
+    for (const value of [
+      "notadate",
+      "1",
+      "2026-02-31",
+      "Tue, 01 Jun 2026 00:00:00 GMT",
+    ]) {
+      const { res } = await feed(
+        `/api/v1/feeds/registry.json?since=${encodeURIComponent(value)}`,
+      );
+      assert.equal(res.status, 400, value);
+    }
   });
 });
 

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -316,12 +316,21 @@ describe("feeds — parseSinceParam", () => {
       new Date(parseSinceParam("2026-06-01T01:02:03.123+02:30")).toISOString(),
       "2026-05-31T22:32:03.123Z",
     );
+    assert.equal(
+      new Date(parseSinceParam("2026-06-01T01:02:03-02:30")).toISOString(),
+      "2026-06-01T03:32:03.000Z",
+    );
   });
 
   test("rejects Date.parse-permissive malformed or non-ISO values", () => {
     for (const value of [
       "1",
       "2026-02-31",
+      "2026-06-01T24:00:00Z",
+      "2026-06-01T00:60:00Z",
+      "2026-06-01T00:00:60Z",
+      "2026-06-01T00:00:00+24:00",
+      "2026-06-01T00:00:00+02:60",
       "Tue, 01 Jun 2026 00:00:00 GMT",
       "2026-06-01T00:00:00",
     ]) {


### PR DESCRIPTION
### Motivation
- The public `?since=` feed parameter was validated only with `Date.parse()`, which accepts permissive/non-ISO inputs (numeric strings, RFC-2822, overflow dates) and can silently change feed results instead of returning the intended `invalid_since` 400.

### Description
- Add `parseSinceParam(value)` to strictly accept either an ISO calendar date (`YYYY-MM-DD`) or an ISO date-time with an explicit zone/offset and to reject permissive/non-ISO inputs. 
- Use `parseSinceParam` in `handleFeedRequest` in place of `Date.parse()` for the `since` query param so malformed values produce the existing `invalid_since` 400 behavior. 
- Export `parseSinceParam` to `__test` and add focused unit tests verifying accepted strict ISO values and rejection of permissive/malformed inputs, and extend handler tests to exercise those malformed cases. 
- Files changed: `src/feeds.mjs` and `tests/feeds.test.mjs` and code was formatted to match project style. 

### Testing
- Ran unit tests with `npm test -- --run tests/feeds.test.mjs` and all tests passed. 
- Verified formatting with `npm run format:check -- src/feeds.mjs tests/feeds.test.mjs` which passed. 
- Ran lint with `npm run lint -- src/feeds.mjs tests/feeds.test.mjs` which passed. 
- Built artifacts with `npm run build` which completed successfully. 
- Validated the API surface with `npm run validate:api` which validated the Worker routes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41084b9688832ca778d7c7bde12348)