### PR TITLE
fix(api): reject invalid counterparty limits

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1451,6 +1451,22 @@ describe("handleAccountCounterparties", () => {
     await errorJson(res);
   });
 
+  test("rejects malformed and out-of-range limits before D1 work", async () => {
+    for (const limit of ["random_nonce", "Infinity", "0", "101", "10.5"]) {
+      const captures = { sql: [], params: [] };
+      const { env } = dbWith({ captures, transfers: [transferEventRow()] });
+      const res = await handleAccountCounterparties(
+        req(`/api/v1/accounts/${SS58}/counterparties?limit=${limit}`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/counterparties?limit=${limit}`),
+      );
+      const body = await errorJson(res);
+      assert.equal(body.error.code, "invalid_query");
+      assert.equal(captures.sql.length, 0);
+    }
+  });
+
   test("returns schema-stable empty rollup on cold D1", async () => {
     const body = await assertColdSchema(
       handleAccountCounterparties,

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -85,6 +85,29 @@ import { TURNOVER_READ_COLUMNS, buildTurnover } from "../../src/turnover.mjs";
 
 const MAX_BLOCK_COUNT_FILTER = 1_000_000;
 
+function parseBoundedIntParam(url, parameter, { def, min, max }) {
+  const raw = url.searchParams.get(parameter);
+  if (raw == null || raw === "") return { value: def };
+  if (!/^\d+$/.test(raw)) {
+    return {
+      error: {
+        parameter,
+        message: `${parameter} must be an integer from ${min} to ${max}.`,
+      },
+    };
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    return {
+      error: {
+        parameter,
+        message: `${parameter} must be an integer from ${min} to ${max}.`,
+      },
+    };
+  }
+  return { value };
+}
+
 // --- Per-UID metagraph (#1304/#1305): served live from the neurons D1 tier ---
 // (migration 0007, populated by the refresh-metagraph cron). Null-safe: an
 // unbound/cold D1 returns a schema-stable empty payload, like the other
@@ -658,7 +681,13 @@ export async function handleAccountTransfers(request, env, ss58, url) {
 export async function handleAccountCounterparties(request, env, ss58, url) {
   const validationError = validateQueryParams(url, ["limit"]);
   if (validationError) return analyticsQueryError(validationError);
-  const limit = clampInt(url.searchParams.get("limit"), 20, 1, 100);
+  const parsedLimit = parseBoundedIntParam(url, "limit", {
+    def: 20,
+    min: 1,
+    max: 100,
+  });
+  if (parsedLimit.error) return analyticsQueryError(parsedLimit.error);
+  const limit = parsedLimit.value;
   const rows = await d1All(
     env,
     `SELECT ${COUNTERPARTIES_READ_COLUMNS} FROM account_events WHERE event_kind = 'Transfer' AND (hotkey = ? OR coldkey = ?) ORDER BY block_number DESC LIMIT ?`,


### PR DESCRIPTION
### Motivation
- The account counterparties route accepted absent/malformed/non-finite `limit` values and silently defaulted them, while still performing the fixed 5000-row D1 transfer scan and returning a publicly cacheable 200 response, enabling URL-keyed cache-bypass and cost-amplification attacks.
- The endpoint must validate and reject non-integer or out-of-range `limit` values before any D1 work or public caching to avoid unbounded distinct URLs for the same expensive computation.

### Description
- Add a bounded integer parser `parseBoundedIntParam(url, parameter, { def, min, max })` that rejects malformed, non-integer, fractional, and out-of-range values while preserving a default for absent/blank parameters.
- Replace the previous `clampInt(...)` use in `handleAccountCounterparties` with `parseBoundedIntParam` and return a 400-style analytics query error when validation fails, so no D1 read is performed for invalid inputs.
- Add a regression test `tests/request-handlers-entities.test.mjs` that asserts malformed (`random_nonce`, `Infinity`), fractional (`10.5`), and out-of-range (`0`, `101`) `limit` values are rejected and that no D1 SQL was executed for those requests.
- Preserve existing behavior for absent/blank `limit` (default `20`) and keep the transfer scan cap unchanged (`COUNTERPARTIES_SCAN_CAP` still used for the read).

### Testing
- Ran the targeted unit suite: `npm test -- tests/request-handlers-entities.test.mjs`, which passed (159 tests passed).
- Ran formatting and lint checks: `npm run format:check` and `npm run lint`, both passed.
- Built generated artifacts with `npm run build` and ran repository validators with `npm run validate`, both completed successfully after the build.
- The new regression test verifies invalid `limit` values return `invalid_query` and that `captures.sql.length === 0`, proving no D1 work occurred for malformed/out-of-range inputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41109b5778832ca4302c6703bab680)