### PR TITLE
refactor(api): centralize pagination + query-param parsing

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -3,7 +3,11 @@
 // (substrate System.Events), NOT Taostats. This module holds the load contract,
 // the daily rollup, the prune, and the row→API shaping (#1347). Pure + exported
 // for tests; the Worker runs the D1 I/O.
-import { clampInt } from "../workers/config.mjs";
+import {
+  FEED_PAGINATION,
+  clampLimit,
+  clampOffset,
+} from "../workers/request-params.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import {
   EXTRINSIC_READ_COLUMNS,
@@ -466,8 +470,8 @@ export async function loadAccountEvents(
   ss58,
   { limit, offset, kind, cursor } = {},
 ) {
-  const lim = clampInt(limit, 100, 1, 1000);
-  const off = clampInt(offset, 0, 0, 1_000_000);
+  const lim = clampLimit(limit, FEED_PAGINATION);
+  const off = clampOffset(offset);
   const params = [ss58, ss58];
   let sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE (${ACCOUNT_EVENT_MATCH})`;
   if (kind) {
@@ -526,8 +530,8 @@ export async function loadAccountHistory(
   ss58,
   { netuid, from, to, limit, offset } = {},
 ) {
-  const lim = clampInt(limit, 100, 1, 1000);
-  const off = clampInt(offset, 0, 0, 1_000_000);
+  const lim = clampLimit(limit, FEED_PAGINATION);
+  const off = clampOffset(offset);
   const params = [ss58];
   let sql = `SELECT ${ACCOUNT_DAY_COLUMNS} FROM account_events_daily WHERE hotkey = ?`;
   if (netuid != null && Number.isInteger(netuid)) {
@@ -552,8 +556,8 @@ export async function loadAccountHistory(
 // SIGNER only (not hotkey/coldkey union) — `extrinsics` carries a single
 // `signer` column. Clamps limit to 1-1000 (default 100); clamps offset.
 export async function loadAccountExtrinsics(d1, ss58, { limit, offset } = {}) {
-  const lim = clampInt(limit, 100, 1, 1000);
-  const off = clampInt(offset, 0, 0, 1_000_000);
+  const lim = clampLimit(limit, FEED_PAGINATION);
+  const off = clampOffset(offset);
   const rows = await d1(
     `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE signer = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT ? OFFSET ?`,
     [ss58, lim, off],
@@ -569,8 +573,8 @@ export async function loadAccountTransfers(
   ss58,
   { direction, limit, offset } = {},
 ) {
-  const lim = clampInt(limit, 100, 1, 1000);
-  const off = clampInt(offset, 0, 0, 1_000_000);
+  const lim = clampLimit(limit, FEED_PAGINATION);
+  const off = clampOffset(offset);
   let sideClause = "(hotkey = ? OR coldkey = ?)";
   let sideParams = [ss58, ss58];
   if (direction === "sent") {

--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -3,7 +3,11 @@
 // chain-direct poller (scripts/fetch-events.py) that fills account_events, NOT
 // Taostats. This module holds the load contract, the row→API shaping, and the
 // retention prune. Pure + exported for tests; the Worker runs the D1 I/O.
-import { clampInt } from "../workers/config.mjs";
+import {
+  BLOCK_PAGINATION,
+  clampLimit,
+  clampOffset,
+} from "../workers/request-params.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 
 // D1 safety-valve: 365-day retention prevents unbounded growth before the
@@ -148,8 +152,8 @@ export function buildBlockFeed(rows, { limit, offset, nextCursor } = {}) {
 // Recent-block feed (newest first) with keyset cursor support (#1851). A cursor
 // takes precedence over offset when present (WHERE block_number < ?).
 export async function loadBlocks(d1, { limit, offset, cursor } = {}) {
-  const lim = clampInt(limit, 50, 1, 100);
-  const off = clampInt(offset, 0, 0, 1_000_000);
+  const lim = clampLimit(limit, BLOCK_PAGINATION);
+  const off = clampOffset(offset);
   const cur = decodeCursor(cursor, 1);
   let rows;
   if (cur) {

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -4,7 +4,11 @@
 // + blocks, NOT Taostats. This module holds the load contract, the row→API
 // shaping, and the retention prune. Pure + exported for tests; the Worker runs
 // the D1 I/O.
-import { clampInt } from "../workers/config.mjs";
+import {
+  BLOCK_PAGINATION,
+  clampLimit,
+  clampOffset,
+} from "../workers/request-params.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 
 // D1 safety-valve: 365-day retention prevents unbounded growth before the
@@ -211,8 +215,8 @@ export async function loadExtrinsics(
   d1,
   { signer, callModule, callFunction, limit, offset, cursor } = {},
 ) {
-  const lim = clampInt(limit, 50, 1, 100);
-  const off = clampInt(offset, 0, 0, 1_000_000);
+  const lim = clampLimit(limit, BLOCK_PAGINATION);
+  const off = clampOffset(offset);
   const conds = [];
   const params = [];
   if (signer) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -11,11 +11,17 @@
 // this module is pure and unit-testable, and so it reuses the exact same
 // R2/ASSETS resolution the REST routes use.
 import {
-  clampInt,
   DAY_MS,
   resolveClientIp,
   SS58_ADDRESS_PATTERN,
 } from "../workers/config.mjs";
+// Aliased: the file-local clampLimit below is the per-tool number-arg clamp, a
+// different contract from the shared pagination-profile clamp used here.
+import {
+  FEED_PAGINATION,
+  clampLimit as clampPageLimit,
+  clampOffset,
+} from "../workers/request-params.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
 import {
@@ -469,8 +475,8 @@ async function loadSubnetConcentrationHistory(ctx, netuid, args) {
 // deprecated fallback. Cold D1 → event_count:0.
 async function loadSubnetEvents(ctx, netuid, { kind, limit, offset, cursor }) {
   const run = mcpD1Runner(ctx);
-  const resolvedLimit = clampInt(limit, 100, 1, 1000);
-  const resolvedOffset = clampInt(offset, 0, 0, 1_000_000);
+  const resolvedLimit = clampPageLimit(limit, FEED_PAGINATION);
+  const resolvedOffset = clampOffset(offset);
   const cur = decodeCursor(cursor, 2);
   const useCursor = Boolean(cur);
   const params = [netuid];

--- a/tests/pagination-parity.test.mjs
+++ b/tests/pagination-parity.test.mjs
@@ -1,0 +1,226 @@
+// Cross-route pagination parity for the centralized request-params parser.
+//
+// The refactor's contract is that every paginated entity/feed route clamps
+// limit/offset through the SAME shared parser with the SAME per-route profile, so
+// a fix in one route can no longer drift from the others. These tests drive every
+// refactored handler with the identical edge inputs (over-cap, below-min, absent,
+// over-cap offset) and assert the bound LIMIT/OFFSET matches the route's profile —
+// the regression that a wrong-profile wiring would introduce, which line coverage
+// alone cannot catch. The handlers are null-safe, so a capturing D1 stub that
+// returns empty rows is enough to read back the bound clamp values.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  BLOCK_PAGINATION,
+  FEED_PAGINATION,
+  MAX_OFFSET,
+  MIN_LIMIT,
+} from "../workers/request-params.mjs";
+import {
+  handleAccountEvents,
+  handleAccountExtrinsics,
+  handleAccountHistory,
+  handleAccountTransfers,
+  handleBlockEvents,
+  handleBlockExtrinsics,
+  handleBlocks,
+  handleExtrinsics,
+  handleSubnetEvents,
+} from "../workers/request-handlers/entities.mjs";
+
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+const NETUID = 7;
+const BLOCK_NUM = 1234;
+
+function req(path) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+function url(path) {
+  return new URL(`https://api.metagraph.sh${path}`);
+}
+
+// A capturing D1 stub: records every (sql, params) and returns empty rows, except
+// the block-ref resolution lookup, which must return a row so the block
+// sub-resource feed query actually runs.
+function capturingEnv() {
+  const calls = [];
+  return {
+    calls,
+    env: {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              calls.push({ sql, params });
+              return {
+                async all() {
+                  if (
+                    /SELECT block_number FROM blocks WHERE block_number = \? LIMIT 1/.test(
+                      sql,
+                    )
+                  ) {
+                    return { results: [{ block_number: BLOCK_NUM }] };
+                  }
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    },
+  };
+}
+
+// The feed query is the one carrying a bound `LIMIT ?` (the ref-resolution lookup
+// uses a literal `LIMIT 1`, so it is excluded).
+function feedCall(calls, feedPattern) {
+  return calls.find((c) => feedPattern.test(c.sql) && /LIMIT \?/.test(c.sql));
+}
+
+// limit + offset are always the last bound params: `... LIMIT ?` (keyset) or
+// `... LIMIT ? OFFSET ?` (offset fallback).
+function boundPage(call) {
+  assert.ok(call, "expected a feed query to run");
+  const p = call.params;
+  return /OFFSET \?\s*$/.test(call.sql)
+    ? { limit: p[p.length - 2], offset: p[p.length - 1] }
+    : { limit: p[p.length - 1], offset: null };
+}
+
+const ROUTES = [
+  {
+    name: "GET /accounts/{ss58}/events",
+    profile: FEED_PAGINATION,
+    feed: /FROM account_events WHERE \(hotkey = \? OR coldkey = \?\)/,
+    invoke: (env, qs) =>
+      handleAccountEvents(
+        req(`/api/v1/accounts/${SS58}/events`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/events?${qs}`),
+      ),
+  },
+  {
+    name: "GET /accounts/{ss58}/history",
+    profile: FEED_PAGINATION,
+    feed: /FROM account_events_daily/,
+    invoke: (env, qs) =>
+      handleAccountHistory(
+        req(`/api/v1/accounts/${SS58}/history`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/history?${qs}`),
+      ),
+  },
+  {
+    name: "GET /accounts/{ss58}/extrinsics",
+    profile: FEED_PAGINATION,
+    feed: /FROM extrinsics WHERE signer = \?/,
+    invoke: (env, qs) =>
+      handleAccountExtrinsics(
+        req(`/api/v1/accounts/${SS58}/extrinsics`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/extrinsics?${qs}`),
+      ),
+  },
+  {
+    name: "GET /accounts/{ss58}/transfers",
+    profile: FEED_PAGINATION,
+    feed: /event_kind = 'Transfer'/,
+    invoke: (env, qs) =>
+      handleAccountTransfers(
+        req(`/api/v1/accounts/${SS58}/transfers`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/transfers?${qs}`),
+      ),
+  },
+  {
+    name: "GET /subnets/{netuid}/events",
+    profile: FEED_PAGINATION,
+    feed: /FROM account_events WHERE netuid = \?/,
+    invoke: (env, qs) =>
+      handleSubnetEvents(
+        req(`/api/v1/subnets/${NETUID}/events`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/events?${qs}`),
+      ),
+  },
+  {
+    name: "GET /blocks/{ref}/events",
+    profile: FEED_PAGINATION,
+    feed: /FROM account_events WHERE block_number = \? ORDER BY event_index ASC/,
+    invoke: (env, qs) =>
+      handleBlockEvents(
+        req(`/api/v1/blocks/${BLOCK_NUM}/events`),
+        env,
+        String(BLOCK_NUM),
+        url(`/api/v1/blocks/${BLOCK_NUM}/events?${qs}`),
+      ),
+  },
+  {
+    name: "GET /blocks",
+    profile: BLOCK_PAGINATION,
+    feed: /FROM blocks ORDER BY block_number DESC/,
+    invoke: (env, qs) =>
+      handleBlocks(req(`/api/v1/blocks`), env, url(`/api/v1/blocks?${qs}`)),
+  },
+  {
+    name: "GET /blocks/{ref}/extrinsics",
+    profile: BLOCK_PAGINATION,
+    feed: /FROM extrinsics WHERE block_number = \? ORDER BY extrinsic_index ASC/,
+    invoke: (env, qs) =>
+      handleBlockExtrinsics(
+        req(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
+        env,
+        String(BLOCK_NUM),
+        url(`/api/v1/blocks/${BLOCK_NUM}/extrinsics?${qs}`),
+      ),
+  },
+  {
+    name: "GET /extrinsics",
+    profile: BLOCK_PAGINATION,
+    feed: /FROM extrinsics ORDER BY block_number DESC, extrinsic_index DESC/,
+    invoke: (env, qs) =>
+      handleExtrinsics(
+        req(`/api/v1/extrinsics`),
+        env,
+        url(`/api/v1/extrinsics?${qs}`),
+      ),
+  },
+];
+
+async function pageFor(route, qs) {
+  const { env, calls } = capturingEnv();
+  await route.invoke(env, qs);
+  return boundPage(feedCall(calls, route.feed));
+}
+
+for (const route of ROUTES) {
+  describe(`pagination parity — ${route.name}`, () => {
+    test("clamps an over-cap limit down to the profile maximum", async () => {
+      const { limit } = await pageFor(route, "limit=99999");
+      assert.equal(limit, route.profile.maxLimit);
+    });
+
+    test("clamps a zero limit up to MIN_LIMIT", async () => {
+      const { limit } = await pageFor(route, "limit=0");
+      assert.equal(limit, MIN_LIMIT);
+    });
+
+    test("falls back to the profile default when limit is absent", async () => {
+      const { limit } = await pageFor(route, "offset=0");
+      assert.equal(limit, route.profile.defaultLimit);
+    });
+
+    test("clamps an over-cap offset down to MAX_OFFSET", async () => {
+      const { offset } = await pageFor(route, "offset=99999999");
+      assert.equal(offset, MAX_OFFSET);
+    });
+  });
+}

--- a/tests/request-params.test.mjs
+++ b/tests/request-params.test.mjs
@@ -1,0 +1,278 @@
+// Unit tests for workers/request-params.mjs — the shared query-parameter parser
+// the entity/feed handlers and their D1 loaders now route every `limit`/`offset`/
+// `cursor` read through. Covers the page-size bounds + profiles, the clamp
+// primitives (missing / non-numeric / negative / over-cap / fractional inputs),
+// the URL pagination triplet, and the YYYY-MM-DD date-range validator. These lock
+// the clamping contract directly: the routes used to inline it per handler, so a
+// single shared parser keeps every paginated route bounding page size identically.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  BLOCK_PAGINATION,
+  DAY_PATTERN,
+  DEFAULT_LIMIT,
+  FEED_PAGINATION,
+  MAX_LIMIT,
+  MAX_OFFSET,
+  MIN_LIMIT,
+  clampLimit,
+  clampOffset,
+  parseDateRange,
+  parseLimitParam,
+  parsePagination,
+} from "../workers/request-params.mjs";
+
+// Build a request URL carrying only the query string under test.
+function url(query) {
+  return new URL(`https://api.metagraph.sh/x${query ? `?${query}` : ""}`);
+}
+
+describe("pagination bounds + profiles", () => {
+  test("exposes the absolute page-size + offset ceilings", () => {
+    assert.equal(MIN_LIMIT, 1);
+    assert.equal(MAX_LIMIT, 1000);
+    assert.equal(MAX_OFFSET, 1_000_000);
+    assert.equal(DEFAULT_LIMIT, 100);
+  });
+
+  test("the feed profile defaults to DEFAULT_LIMIT and caps at MAX_LIMIT", () => {
+    assert.deepEqual(FEED_PAGINATION, { defaultLimit: 100, maxLimit: 1000 });
+    assert.equal(FEED_PAGINATION.defaultLimit, DEFAULT_LIMIT);
+    assert.equal(FEED_PAGINATION.maxLimit, MAX_LIMIT);
+  });
+
+  test("the block profile defaults to 50 and caps tighter than the feed", () => {
+    assert.deepEqual(BLOCK_PAGINATION, { defaultLimit: 50, maxLimit: 100 });
+    assert.ok(BLOCK_PAGINATION.maxLimit < FEED_PAGINATION.maxLimit);
+    assert.ok(BLOCK_PAGINATION.defaultLimit < FEED_PAGINATION.defaultLimit);
+  });
+});
+
+describe("clampLimit", () => {
+  test("falls back to the profile default when missing/blank/non-numeric", () => {
+    assert.equal(clampLimit(null, FEED_PAGINATION), 100);
+    assert.equal(clampLimit("", FEED_PAGINATION), 100);
+    assert.equal(clampLimit("abc", FEED_PAGINATION), 100);
+  });
+
+  test("returns an in-range value unchanged", () => {
+    assert.equal(clampLimit("42", FEED_PAGINATION), 42);
+  });
+
+  test("truncates a fractional value toward zero", () => {
+    assert.equal(clampLimit("99.9", FEED_PAGINATION), 99);
+  });
+
+  test("clamps a zero/negative value up to MIN_LIMIT", () => {
+    assert.equal(clampLimit("0", FEED_PAGINATION), MIN_LIMIT);
+    assert.equal(clampLimit("-5", FEED_PAGINATION), MIN_LIMIT);
+  });
+
+  test("clamps an over-cap value down to the profile maximum", () => {
+    assert.equal(clampLimit("9999", FEED_PAGINATION), MAX_LIMIT);
+    assert.equal(clampLimit("9999", BLOCK_PAGINATION), 100);
+  });
+
+  test("honors a profile's tighter default and in-range value", () => {
+    assert.equal(clampLimit(null, BLOCK_PAGINATION), 50);
+    assert.equal(clampLimit("75", BLOCK_PAGINATION), 75);
+  });
+
+  test("defaults maxLimit to MAX_LIMIT when the profile omits it", () => {
+    assert.equal(clampLimit("9999", { defaultLimit: 100 }), MAX_LIMIT);
+  });
+
+  test("accepts a numeric value (the MCP/loader tool-arg path)", () => {
+    assert.equal(clampLimit(500, FEED_PAGINATION), 500);
+    assert.equal(clampLimit(0, FEED_PAGINATION), MIN_LIMIT);
+  });
+});
+
+describe("clampOffset", () => {
+  test("falls back to 0 when missing/blank/non-numeric", () => {
+    assert.equal(clampOffset(null), 0);
+    assert.equal(clampOffset(""), 0);
+    assert.equal(clampOffset("nope"), 0);
+  });
+
+  test("returns an in-range value unchanged", () => {
+    assert.equal(clampOffset("250"), 250);
+  });
+
+  test("truncates a fractional value toward zero", () => {
+    assert.equal(clampOffset("12.7"), 12);
+  });
+
+  test("clamps a negative value up to 0", () => {
+    assert.equal(clampOffset("-1"), 0);
+  });
+
+  test("clamps an over-cap value down to MAX_OFFSET", () => {
+    assert.equal(clampOffset("99999999"), MAX_OFFSET);
+  });
+
+  test("accepts a numeric value (the MCP/loader tool-arg path)", () => {
+    assert.equal(clampOffset(99), 99);
+  });
+});
+
+describe("parsePagination", () => {
+  test("returns the feed-profile defaults when no params are present", () => {
+    assert.deepEqual(parsePagination(url(""), FEED_PAGINATION), {
+      limit: 100,
+      offset: 0,
+      cursor: null,
+    });
+  });
+
+  test("returns the block-profile defaults when no params are present", () => {
+    assert.deepEqual(parsePagination(url(""), BLOCK_PAGINATION), {
+      limit: 50,
+      offset: 0,
+      cursor: null,
+    });
+  });
+
+  test("clamps limit and offset per the active profile", () => {
+    assert.deepEqual(
+      parsePagination(url("limit=9999&offset=-3"), FEED_PAGINATION),
+      { limit: 1000, offset: 0, cursor: null },
+    );
+    assert.equal(
+      parsePagination(url("limit=9999"), BLOCK_PAGINATION).limit,
+      100,
+    );
+  });
+
+  test("passes the raw cursor token through opaque (never decoded)", () => {
+    assert.equal(
+      parsePagination(url("cursor=150.2"), FEED_PAGINATION).cursor,
+      "150.2",
+    );
+  });
+
+  test("parses limit, offset, and cursor together", () => {
+    assert.deepEqual(
+      parsePagination(url("limit=20&offset=40&cursor=9.9"), FEED_PAGINATION),
+      { limit: 20, offset: 40, cursor: "9.9" },
+    );
+  });
+});
+
+describe("DAY_PATTERN", () => {
+  test("matches a canonical YYYY-MM-DD date", () => {
+    assert.ok(DAY_PATTERN.test("2026-06-28"));
+  });
+
+  test("rejects non-canonical date strings", () => {
+    for (const bad of [
+      "2026-6-1",
+      "26-06-28",
+      "2026/06/28",
+      "June",
+      "2026-06-28T00:00:00",
+      "",
+    ]) {
+      assert.ok(!DAY_PATTERN.test(bad), `expected ${bad} to be rejected`);
+    }
+  });
+
+  test("is format-only — does not range-check the fields", () => {
+    assert.ok(DAY_PATTERN.test("2026-13-40"));
+  });
+});
+
+describe("parseDateRange", () => {
+  test("returns nulls when from/to are absent", () => {
+    assert.deepEqual(parseDateRange(url("")), { from: null, to: null });
+  });
+
+  test("treats a blank from/to as no bound, not an error", () => {
+    assert.deepEqual(parseDateRange(url("from=&to=")), {
+      from: null,
+      to: null,
+    });
+  });
+
+  test("returns valid from/to bounds verbatim", () => {
+    assert.deepEqual(parseDateRange(url("from=2026-06-01&to=2026-06-30")), {
+      from: "2026-06-01",
+      to: "2026-06-30",
+    });
+  });
+
+  test("normalizes a present lower bound with an absent upper bound", () => {
+    assert.deepEqual(parseDateRange(url("from=2026-06-01")), {
+      from: "2026-06-01",
+      to: null,
+    });
+  });
+
+  test("errors on a malformed from bound", () => {
+    const result = parseDateRange(url("from=June"));
+    assert.equal(result.error, "from/to must be YYYY-MM-DD dates.");
+    assert.equal(result.from, undefined);
+  });
+
+  test("errors on a malformed to bound even when from is valid", () => {
+    const result = parseDateRange(url("from=2026-06-01&to=nope"));
+    assert.equal(result.error, "from/to must be YYYY-MM-DD dates.");
+  });
+
+  test("is format-only — accepts a present but out-of-range date", () => {
+    assert.deepEqual(parseDateRange(url("from=2026-13-40")), {
+      from: "2026-13-40",
+      to: null,
+    });
+  });
+});
+
+describe("parseLimitParam", () => {
+  const opts = { defaultLimit: 50, maxLimit: 100 };
+
+  test("falls back to the default when limit is absent", () => {
+    assert.deepEqual(parseLimitParam(url(""), opts), { limit: 50 });
+  });
+
+  test("returns a valid in-range limit", () => {
+    assert.deepEqual(parseLimitParam(url("limit=20"), opts), { limit: 20 });
+  });
+
+  test("rejects a non-numeric limit", () => {
+    const result = parseLimitParam(url("limit=abc1"), opts);
+    assert.deepEqual(result.error, {
+      parameter: "limit",
+      message: "limit must be an integer between 1 and 100.",
+    });
+  });
+
+  test("rejects a leading-zero limit (not a canonical integer)", () => {
+    assert.equal(
+      parseLimitParam(url("limit=001"), opts).error?.parameter,
+      "limit",
+    );
+  });
+
+  test("rejects a blank limit", () => {
+    assert.equal(
+      parseLimitParam(url("limit="), opts).error?.parameter,
+      "limit",
+    );
+  });
+
+  test("rejects an over-cap limit rather than clamping it", () => {
+    assert.equal(
+      parseLimitParam(url("limit=999999"), opts).error?.parameter,
+      "limit",
+    );
+  });
+
+  test("error message reflects the profile's maximum", () => {
+    assert.equal(
+      parseLimitParam(url("limit=999999"), { defaultLimit: 25, maxLimit: 100 })
+        .error.message,
+      "limit must be an integer between 1 and 100.",
+    );
+  });
+});

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -5,6 +5,7 @@
 // `applyQueryFilters` is the single public entry; the rest are internal helpers.
 import { API_QUERY_COLLECTIONS } from "../src/contracts.mjs";
 import { linkHeader } from "./http.mjs";
+import { DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT } from "./request-params.mjs";
 
 const FIELD_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
@@ -295,7 +296,7 @@ function paginateRows(rows, params) {
   const requestedCursor = integerParam(params.get("cursor"));
   const shouldPage = requestedLimit !== null || requestedCursor !== null;
   const limit = shouldPage
-    ? Math.min(Math.max(requestedLimit ?? 100, 1), 1000)
+    ? Math.min(Math.max(requestedLimit ?? DEFAULT_LIMIT, MIN_LIMIT), MAX_LIMIT)
     : rows.length;
   const cursor = Math.min(Math.max(requestedCursor ?? 0, 0), rows.length);
   const next = cursor + limit;
@@ -314,16 +315,19 @@ function paginateRows(rows, params) {
 
 function validateListQuery(params, config) {
   const limit = params.get("limit");
-  if (limit !== null && (integerParam(limit) === null || Number(limit) < 1)) {
+  if (
+    limit !== null &&
+    (integerParam(limit) === null || Number(limit) < MIN_LIMIT)
+  ) {
     return {
       parameter: "limit",
-      message: "limit must be an integer between 1 and 1000.",
+      message: `limit must be an integer between ${MIN_LIMIT} and ${MAX_LIMIT}.`,
     };
   }
-  if (limit !== null && Number(limit) > 1000) {
+  if (limit !== null && Number(limit) > MAX_LIMIT) {
     return {
       parameter: "limit",
-      message: "limit must be an integer between 1 and 1000.",
+      message: `limit must be an integer between ${MIN_LIMIT} and ${MAX_LIMIT}.`,
     };
   }
 

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -29,12 +29,12 @@ import {
   ANALYTICS_WINDOW_PARAM,
   ANALYTICS_WINDOWS,
   DAY_MS,
-  clampInt,
   HEALTH_TREND_WINDOWS,
   MAX_BULK_TREND_ROWS,
   MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
   MAX_INCIDENT_ROWS,
 } from "../config.mjs";
+import { parseLimitParam } from "../request-params.mjs";
 import { errorResponse, ifNoneMatchSatisfied } from "../http.mjs";
 import {
   contractVersion,
@@ -142,19 +142,6 @@ function validateEnumParam(url, parameter, allowedValues) {
     parameter,
     message: `${parameter} must be one of: ${allowedValues.join(", ")}.`,
   };
-}
-
-function validateIntegerParam(url, parameter, min, max) {
-  const raw = url.searchParams.get(parameter);
-  if (raw === null) return null;
-  const value = Number(raw);
-  if (!/^[1-9]\d*$/.test(raw) || value < min || value > max) {
-    return {
-      parameter,
-      message: `${parameter} must be an integer between ${min} and ${max}.`,
-    };
-  }
-  return null;
 }
 
 // Bound an optional free-text filter so an oversized value never reaches D1.
@@ -775,10 +762,12 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
     "module_function",
   ]);
   if (groupByError) return analyticsQueryError(groupByError);
-  const limitError = validateIntegerParam(url, "limit", 1, 100);
+  const { limit, error: limitError } = parseLimitParam(url, {
+    defaultLimit: 50,
+    maxLimit: 100,
+  });
   if (limitError) return analyticsQueryError(limitError);
   const groupBy = url.searchParams.get("group_by") || "module";
-  const limit = clampInt(url.searchParams.get("limit"), 50, 1, 100);
   return withEdgeCache(request, ctx, env, "chain-calls", async () => {
     const cutoff = Date.now() - days * DAY_MS;
     const groupCols =
@@ -838,9 +827,11 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
 export async function handleChainSigners(request, env, url, ctx = {}) {
   const { label, days, error } = analyticsWindow(url, ["limit", "call_module"]);
   if (error) return analyticsQueryError(error);
-  const limitError = validateIntegerParam(url, "limit", 1, 100);
+  const { limit, error: limitError } = parseLimitParam(url, {
+    defaultLimit: 50,
+    maxLimit: 100,
+  });
   if (limitError) return analyticsQueryError(limitError);
-  const limit = clampInt(url.searchParams.get("limit"), 50, 1, 100);
   // Optional pallet scope, backed by idx_extrinsics_call_module_order.
   const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
@@ -899,9 +890,11 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
 export async function handleChainFees(request, env, url, ctx = {}) {
   const { label, days, error } = analyticsWindow(url, ["limit", "call_module"]);
   if (error) return analyticsQueryError(error);
-  const limitError = validateIntegerParam(url, "limit", 1, 100);
+  const { limit, error: limitError } = parseLimitParam(url, {
+    defaultLimit: 25,
+    maxLimit: 100,
+  });
   if (limitError) return analyticsQueryError(limitError);
-  const limit = clampInt(url.searchParams.get("limit"), 25, 1, 100);
   // Optional pallet scope (applies to both the daily series and the payer list),
   // backed by idx_extrinsics_call_module_order.
   const callModule = url.searchParams.get("call_module");

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -18,6 +18,13 @@
 // handlers back and dispatches them from the router.
 
 import { DAY_MS, clampInt, resolveClientIp } from "../config.mjs";
+import {
+  BLOCK_PAGINATION,
+  DAY_PATTERN,
+  FEED_PAGINATION,
+  parseDateRange,
+  parsePagination,
+} from "../request-params.mjs";
 
 import { errorResponse } from "../http.mjs";
 import {
@@ -445,7 +452,6 @@ export async function handleAccountEvents(request, env, ss58, url) {
 // description spells out the contrast with /events in full).
 const ACCOUNT_DAY_COLUMNS =
   "day, netuid, event_count, event_kinds, first_block, last_block";
-const DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 export async function handleAccountHistory(request, env, ss58, url) {
   const validationError = validateQueryParams(url, [
@@ -457,17 +463,10 @@ export async function handleAccountHistory(request, env, ss58, url) {
     "cursor",
   ]);
   if (validationError) return analyticsQueryError(validationError);
-  const from = url.searchParams.get("from");
-  const to = url.searchParams.get("to");
-  if ((from && !DAY_RE.test(from)) || (to && !DAY_RE.test(to))) {
-    return errorResponse(
-      "invalid_param",
-      "from/to must be YYYY-MM-DD dates.",
-      400,
-    );
-  }
-  const limit = clampInt(url.searchParams.get("limit"), 100, 1, 1000);
-  const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
+  const range = parseDateRange(url);
+  if (range.error) return errorResponse("invalid_param", range.error, 400);
+  const { from, to } = range;
+  const { limit, offset, cursor } = parsePagination(url, FEED_PAGINATION);
   const netuid = url.searchParams.get("netuid");
   if (netuid != null && !/^\d+$/.test(netuid)) {
     return errorResponse(
@@ -487,11 +486,11 @@ export async function handleAccountHistory(request, env, ss58, url) {
   // changed) page order. offset stays as a deprecated fallback; cursor wins. A
   // cursor that does not decode to a valid YYYYMMDD day is ignored (falls back to
   // the first page), preserving the never-throw contract.
-  const cur = decodeCursor(url.searchParams.get("cursor"), 2);
+  const cur = decodeCursor(cursor, 2);
   const cursorDay = cur
     ? String(cur[0]).replace(/^(\d{4})(\d{2})(\d{2})$/, "$1-$2-$3")
     : null;
-  const useCursor = Boolean(cursorDay && DAY_RE.test(cursorDay));
+  const useCursor = Boolean(cursorDay && DAY_PATTERN.test(cursorDay));
   const params = [ss58];
   let sql = `SELECT ${ACCOUNT_DAY_COLUMNS} FROM account_events_daily WHERE hotkey = ?`;
   if (netuid != null) {
@@ -519,7 +518,7 @@ export async function handleAccountHistory(request, env, ss58, url) {
   const rows = await d1All(env, sql, params);
   const last = rows.length === limit ? rows[rows.length - 1] : null;
   const nextCursor =
-    last && typeof last.day === "string" && DAY_RE.test(last.day)
+    last && typeof last.day === "string" && DAY_PATTERN.test(last.day)
       ? encodeCursor([Number(last.day.replaceAll("-", "")), last.netuid])
       : null;
   const data = buildAccountHistory(rows, ss58, { limit, offset, nextCursor });
@@ -545,8 +544,7 @@ export async function handleAccountHistory(request, env, ss58, url) {
 export async function handleAccountExtrinsics(request, env, ss58, url) {
   const validationError = validateQueryParams(url, ["limit", "offset"]);
   if (validationError) return analyticsQueryError(validationError);
-  const limit = clampInt(url.searchParams.get("limit"), 100, 1, 1000);
-  const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
+  const { limit, offset } = parsePagination(url, FEED_PAGINATION);
   const rows = await d1All(
     env,
     `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE signer = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT ? OFFSET ?`,
@@ -593,8 +591,7 @@ export async function handleAccountTransfers(request, env, ss58, url) {
       message: `"${direction}" is not a valid direction. Supported: all, sent, received.`,
     });
   }
-  const limit = clampInt(url.searchParams.get("limit"), 100, 1, 1000);
-  const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
+  const { limit, offset, cursor } = parsePagination(url, FEED_PAGINATION);
   // sent => this account is the sender (hotkey=from); received => recipient
   // (coldkey=to); default/all => either side.
   let sideClause = "(hotkey = ? OR coldkey = ?)";
@@ -609,7 +606,7 @@ export async function handleAccountTransfers(request, env, ss58, url) {
   // Keyset (cursor) pagination mirrors loadAccountEvents/handleExtrinsicsFeed: a
   // (block_number, event_index) row-value seek, stable + O(limit) at depth on the
   // large account_events tier. offset stays as a deprecated fallback; cursor wins.
-  const cur = decodeCursor(url.searchParams.get("cursor"), 2);
+  const cur = decodeCursor(cursor, 2);
   const useCursor = Boolean(cur);
   const params = [...sideParams];
   let sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE event_kind = 'Transfer' AND ${sideClause}`;
@@ -674,12 +671,11 @@ export async function handleSubnetEvents(request, env, netuid, url) {
     "cursor",
   ]);
   if (validationError) return analyticsQueryError(validationError);
-  const limit = clampInt(url.searchParams.get("limit"), 100, 1, 1000);
-  const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
+  const { limit, offset, cursor } = parsePagination(url, FEED_PAGINATION);
   const kind = url.searchParams.get("kind");
   // Keyset (cursor) pagination on (block_number, event_index), mirroring
   // loadAccountEvents; offset stays as a deprecated fallback, cursor wins.
-  const cur = decodeCursor(url.searchParams.get("cursor"), 2);
+  const cur = decodeCursor(cursor, 2);
   const useCursor = Boolean(cur);
   const params = [netuid];
   let sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE netuid = ?`;
@@ -915,8 +911,7 @@ export async function handleBlocks(request, env, url) {
     "min_events",
   ]);
   if (validationError) return analyticsQueryError(validationError);
-  const limit = clampInt(url.searchParams.get("limit"), 50, 1, 100);
-  const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
+  const { limit, offset, cursor } = parsePagination(url, BLOCK_PAGINATION);
   const sp = url.searchParams;
   const MAX = Number.MAX_SAFE_INTEGER;
   const intParam = (name) => clampInt(sp.get(name), 0, 0, MAX);
@@ -991,7 +986,7 @@ export async function handleBlocks(request, env, url) {
   // seek into the same conds so it ANDs with the filters (PK-ordered, stable under
   // head inserts). A malformed cursor decodes to null → ignored (falls back to
   // offset), preserving never-throw.
-  const cur = decodeCursor(url.searchParams.get("cursor"), 1);
+  const cur = decodeCursor(cursor, 1);
   const useCursor = Boolean(cur);
   if (useCursor) {
     conds.push("block_number < ?");
@@ -1081,8 +1076,7 @@ export async function handleBlock(request, env, ref) {
 export async function handleBlockExtrinsics(request, env, ref, url) {
   const validationError = validateQueryParams(url, ["limit", "offset"]);
   if (validationError) return analyticsQueryError(validationError);
-  const limit = clampInt(url.searchParams.get("limit"), 50, 1, 100);
-  const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
+  const { limit, offset } = parsePagination(url, BLOCK_PAGINATION);
   const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
   const blockRows = await d1All(
     env,
@@ -1124,8 +1118,7 @@ export async function handleBlockExtrinsics(request, env, ref, url) {
 export async function handleBlockEvents(request, env, ref, url) {
   const validationError = validateQueryParams(url, ["limit", "offset"]);
   if (validationError) return analyticsQueryError(validationError);
-  const limit = clampInt(url.searchParams.get("limit"), 100, 1, 1000);
-  const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
+  const { limit, offset } = parsePagination(url, FEED_PAGINATION);
   const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
   const blockRows = await d1All(
     env,
@@ -1182,8 +1175,7 @@ export async function handleExtrinsics(request, env, url) {
     "to",
   ]);
   if (validationError) return analyticsQueryError(validationError);
-  const limit = clampInt(url.searchParams.get("limit"), 50, 1, 100);
-  const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
+  const { limit, offset, cursor } = parsePagination(url, BLOCK_PAGINATION);
   const sp = url.searchParams;
   const MAX = Number.MAX_SAFE_INTEGER;
   const parseTimeBound = (raw) => {
@@ -1254,7 +1246,7 @@ export async function handleExtrinsics(request, env, url) {
   // Keyset cursor (#1851): a row-value seek on the (block_number, extrinsic_index)
   // PK, ANDed with any active filters. Takes precedence over offset; a malformed
   // cursor decodes to null → ignored. SQLite row-value comparison is PK-covered.
-  const cur = decodeCursor(sp.get("cursor"), 2);
+  const cur = decodeCursor(cursor, 2);
   const useCursor = Boolean(cur);
   if (useCursor) {
     conds.push("(block_number, extrinsic_index) < (?, ?)");

--- a/workers/request-params.mjs
+++ b/workers/request-params.mjs
@@ -1,0 +1,99 @@
+// Shared request query-parameter parsing for the entity/list + feed handlers.
+//
+// Every paginated route used to clamp `limit`/`offset` and read the keyset
+// `cursor` with its own inline `clampInt(...)` calls and literal bounds, so the
+// caps drifted between handlers (and a fix in one route never reached the others).
+// This module is the single place those rules live: the absolute bounds are named
+// constants, the per-route page-size pairs are named profiles, and `parsePagination`
+// returns the same `{ limit, offset, cursor }` shape for every handler. The raw
+// `clampLimit`/`clampOffset` primitives let the shared D1 loaders + MCP tools clamp
+// identically off plain values (they never see a URL).
+//
+// Import-free apart from `clampInt`, so it stays a leaf the request handlers and
+// the src/* loaders can both depend on without a cycle.
+
+import { clampInt } from "./config.mjs";
+
+// Absolute pagination ceilings, shared by every paginated route + tool. A page is
+// never larger than MAX_LIMIT rows, and OFFSET never seeks past MAX_OFFSET (deep
+// pages should use the keyset cursor instead).
+export const MIN_LIMIT = 1;
+export const MAX_LIMIT = 1000;
+export const MAX_OFFSET = 1_000_000;
+// The standard page size when a caller omits `limit` (also the in-memory list
+// collections' default).
+export const DEFAULT_LIMIT = 100;
+
+// Named (default, max) page-size profiles. The standard entity/event feeds default
+// to DEFAULT_LIMIT and cap at MAX_LIMIT; the block-explorer feeds carry wider rows
+// so they default to 50 and cap tighter at 100. Both share the MAX_OFFSET ceiling.
+export const FEED_PAGINATION = {
+  defaultLimit: DEFAULT_LIMIT,
+  maxLimit: MAX_LIMIT,
+};
+export const BLOCK_PAGINATION = { defaultLimit: 50, maxLimit: 100 };
+
+// Clamp a raw limit (a query-param string or a tool-arg number) into
+// [MIN_LIMIT, maxLimit], falling back to defaultLimit when absent/blank/non-finite.
+export function clampLimit(raw, { defaultLimit, maxLimit = MAX_LIMIT } = {}) {
+  return clampInt(raw, defaultLimit, MIN_LIMIT, maxLimit);
+}
+
+// Clamp a raw offset into [0, MAX_OFFSET], falling back to 0 when
+// absent/blank/non-finite.
+export function clampOffset(raw) {
+  return clampInt(raw, 0, 0, MAX_OFFSET);
+}
+
+// Parse the shared pagination triplet from a request URL: a clamped `limit`, a
+// clamped `offset`, and the raw opaque keyset `cursor` (or null) for the caller to
+// decode at its own arity. `options` is a page-size profile ({ defaultLimit,
+// maxLimit }), e.g. FEED_PAGINATION or BLOCK_PAGINATION.
+export function parsePagination(url, options = {}) {
+  const params = url.searchParams;
+  return {
+    limit: clampLimit(params.get("limit"), options),
+    offset: clampOffset(params.get("offset")),
+    cursor: params.get("cursor"),
+  };
+}
+
+// Validate + resolve a `limit` for the analytics routes that REJECT an
+// out-of-range value with a 400 rather than silently clamping it. An absent limit
+// falls back to defaultLimit; a present limit must be a positive integer (no
+// leading zero) of at most maxLimit, else an { error } descriptor is returned for
+// the caller to surface via its query-error helper. Returns { limit } on success.
+export function parseLimitParam(
+  url,
+  { defaultLimit, maxLimit = MAX_LIMIT } = {},
+) {
+  const raw = url.searchParams.get("limit");
+  if (raw === null) return { limit: defaultLimit };
+  if (!/^[1-9]\d*$/.test(raw) || Number(raw) > maxLimit) {
+    return {
+      error: {
+        parameter: "limit",
+        message: `limit must be an integer between ${MIN_LIMIT} and ${maxLimit}.`,
+      },
+    };
+  }
+  return { limit: Number(raw) };
+}
+
+// A bare, anchored YYYY-MM-DD calendar date — the shape the date-bounded feeds use
+// for their TEXT `day` columns (lexicographic = chronological). Format-only: it
+// does not range-check the month/day fields.
+export const DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+// Validate optional YYYY-MM-DD `from`/`to` bounds on a request URL. An absent or
+// blank bound means "no bound" (normalized to null); a present-but-malformed bound
+// returns { error } with the shared message. On success returns { from, to } ready
+// to bind into a `day >= ?` / `day <= ?` range.
+export function parseDateRange(url) {
+  const from = url.searchParams.get("from");
+  const to = url.searchParams.get("to");
+  if ((from && !DAY_PATTERN.test(from)) || (to && !DAY_PATTERN.test(to))) {
+    return { error: "from/to must be YYYY-MM-DD dates." };
+  }
+  return { from: from || null, to: to || null };
+}


### PR DESCRIPTION
## Summary

A single `workers/request-params.mjs` module now owns every paginated route's `limit`, `offset`, and keyset `cursor` parsing, the named page-size bounds, and the YYYY-MM-DD `from`/`to` date validator. The entity, account, block, extrinsic, and chain-analytics feed handlers plus their shared D1 loaders all route through it, so the page-size caps and validation behavior can no longer diverge between routes (the root of the recurring input-validation bug class). Behavior is preserved exactly: every route keeps the same defaults, caps, and reject paths it had before.

Closes #2064

## What Changed

- New `workers/request-params.mjs`: named bounds (`MIN_LIMIT`, `MAX_LIMIT`, `MAX_OFFSET`, `DEFAULT_LIMIT`), named page-size profiles (`FEED_PAGINATION` 100/1000, `BLOCK_PAGINATION` 50/100), `clampLimit`/`clampOffset` primitives, `parsePagination(url, profile)` returning `{ limit, offset, cursor }`, `parseLimitParam` for the analytics routes that reject an out-of-range limit, and `parseDateRange` over the shared `DAY_PATTERN`.
- `workers/request-handlers/entities.mjs`: all nine entity/feed handlers parse pagination through `parsePagination`; account-history `from`/`to` validation moves to `parseDateRange`; the duplicated `DAY_RE` literal is removed.
- Shared D1 loaders (`src/account-events.mjs`, `src/blocks.mjs`, `src/extrinsics.mjs`) and the MCP `loadSubnetEvents` loader clamp through the same primitives, so REST and MCP stay in agreement.
- `workers/request-handlers/analytics.mjs`: the three chain-analytics list routes use `parseLimitParam`, collapsing the repeated `validateIntegerParam` plus `clampInt` idiom and dropping the now-unused `validateIntegerParam`.
- `workers/list-query.mjs`: shares the bound constants instead of repeating the `100`/`1000` literals (its validate-then-reject model is left intact).
- Tests: `tests/request-params.test.mjs` covers the module at full branch coverage (missing, non-numeric, negative, over-cap, fractional, blank, date-range, and reject-limit cases); `tests/pagination-parity.test.mjs` drives every refactored route with identical edge inputs and asserts identical clamping, proving the cross-route contract.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.
      (no contract change; no schema or OpenAPI edits)

## Validation

- [ ] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
