### PR TITLE
feat(api): add account counterparty evidence drilldown

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -62,7 +62,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-counterparty fund-flow rollup for one account — its native-TAO transfers aggregated by counterparty into sent/received/net + count, ranked by total volume (the address relationship view) — computed live from the account_events D1 tier. ?limit (<=100). */
+        /** Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?limit (<=100). */
         get: operations["accountCounterparties"];
         put?: never;
         post?: never;
@@ -1641,6 +1641,41 @@ export interface components {
                 [key: string]: unknown;
             })[];
             counterparty_count: number;
+            /** @description Present only when ?counterparty=<ss58> is supplied. Pair-level transfer evidence for the requested account/counterparty relationship; summary fields cover every matching row in the bounded scan, while transfers is limited by the request limit. */
+            relationship?: {
+                counterparty: string;
+                first_block: number | null;
+                /** Format: date-time */
+                first_seen_at: string | null;
+                last_block: number | null;
+                /** Format: date-time */
+                last_seen_at: string | null;
+                /** @description Maximum number of recent transfer evidence rows returned in transfers. */
+                limit: number;
+                net_tao: number;
+                scan_capped: boolean;
+                schema_version: number;
+                ss58: string;
+                total_received_tao: number;
+                total_sent_tao: number;
+                /** @description Count of all matching account/counterparty transfer rows in the bounded scan, before the evidence list is sliced by limit. */
+                transfer_count: number;
+                /** @description Recent pair transfer evidence rows, sliced to limit. Summary counts and totals may cover more rows than this array contains. */
+                transfers: {
+                    amount_tao: number | null;
+                    block_number: number | null;
+                    /** @enum {string} */
+                    direction: "sent" | "received";
+                    event_index: number | null;
+                    from: string;
+                    netuid: number | null;
+                    /** Format: date-time */
+                    observed_at: string | null;
+                    to: string;
+                }[];
+                /** @description Raw bounded D1 pair rows inspected before malformed rows are skipped. */
+                transfers_scanned: number;
+            };
             scan_capped?: boolean;
             schema_version: number;
             ss58: string;
@@ -5147,7 +5182,7 @@ export interface operations {
                      *       "data": {
                      *         "artifact_contracts": [
                      *           {
-                     *             "contract_version": "2026-06-06.1",
+                     *             "contract_version": "2026-06-29.1",
                      *             "id": "example",
                      *             "path": "/metagraph/example.json",
                      *             "schema_ref": "#/components/schemas/Example",
@@ -5155,7 +5190,7 @@ export interface operations {
                      *           }
                      *         ],
                      *         "base_path": "/api/v1",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "openapi_url": "/api/v1/openapi.json",
@@ -5192,7 +5227,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5323,13 +5358,13 @@ export interface operations {
                      *           }
                      *         ],
                      *         "schema_version": 1,
-                     *         "ss58": "example",
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *         "subnet_count": 1
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5428,12 +5463,12 @@ export interface operations {
                      *         "balance_tao": 0.5,
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
-                     *         "ss58": "example"
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5509,6 +5544,7 @@ export interface operations {
     accountCounterparties: {
         parameters: {
             query?: {
+                counterparty?: string;
                 limit?: number;
             };
             header?: never;
@@ -5533,21 +5569,54 @@ export interface operations {
                      *       "data": {
                      *         "counterparties": [
                      *           {
-                     *             "address": "example"
+                     *             "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "last_block": 5000000,
+                     *             "net_tao": -0.5,
+                     *             "received_tao": 0,
+                     *             "sent_tao": 0.5,
+                     *             "transfer_count": 1
                      *           }
                      *         ],
                      *         "counterparty_count": 1,
+                     *         "relationship": {
+                     *           "counterparty": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *           "first_block": 5000000,
+                     *           "first_seen_at": "2026-06-01T00:00:00.000Z",
+                     *           "last_block": 5000000,
+                     *           "last_seen_at": "2026-06-01T00:00:00.000Z",
+                     *           "limit": 1,
+                     *           "net_tao": -0.5,
+                     *           "scan_capped": false,
+                     *           "schema_version": 1,
+                     *           "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                     *           "total_received_tao": 0,
+                     *           "total_sent_tao": 0.5,
+                     *           "transfer_count": 1,
+                     *           "transfers": [
+                     *             {
+                     *               "amount_tao": 0.5,
+                     *               "block_number": 5000000,
+                     *               "direction": "sent",
+                     *               "event_index": 1,
+                     *               "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                     *               "netuid": 7,
+                     *               "observed_at": "2026-06-01T00:00:00.000Z",
+                     *               "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ"
+                     *             }
+                     *           ],
+                     *           "transfers_scanned": 1
+                     *         },
                      *         "scan_capped": false,
                      *         "schema_version": 1,
-                     *         "ss58": "example",
-                     *         "total_received_tao": 0.5,
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                     *         "total_received_tao": 0,
                      *         "total_sent_tao": 0.5,
                      *         "transfers_scanned": 1
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5659,12 +5728,12 @@ export interface operations {
                      *         "next_cursor": "example",
                      *         "offset": 1,
                      *         "schema_version": 1,
-                     *         "ss58": "example"
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5773,12 +5842,12 @@ export interface operations {
                      *         "limit": 1,
                      *         "offset": 1,
                      *         "schema_version": 1,
-                     *         "ss58": "example"
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5890,12 +5959,12 @@ export interface operations {
                      *         "next_cursor": "example",
                      *         "offset": 1,
                      *         "schema_version": 1,
-                     *         "ss58": "example"
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5992,7 +6061,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "schema_version": 1,
-                     *         "ss58": "example",
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *         "subnet_count": 1,
                      *         "subnets": [
                      *           {
@@ -6003,7 +6072,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6107,20 +6176,20 @@ export interface operations {
                      *         "next_cursor": "example",
                      *         "offset": 1,
                      *         "schema_version": 1,
-                     *         "ss58": "example",
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *         "transfer_count": 1,
                      *         "transfers": [
                      *           {
                      *             "block_number": 5000000,
-                     *             "from": "example",
-                     *             "to": "example"
+                     *             "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                     *             "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ"
                      *           }
                      *         ]
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6216,7 +6285,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "extensions": {
                      *           "example": {}
                      *         },
@@ -6231,7 +6300,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6349,7 +6418,7 @@ export interface operations {
                      *         ],
                      *         "blocker_summary": {},
                      *         "callable_service_count": 1,
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -6365,7 +6434,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6481,7 +6550,7 @@ export interface operations {
                      *           "example"
                      *         ],
                      *         "completeness_score": 100,
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "integration_readiness": 1,
                      *         "name": "Example Subnet",
@@ -6509,7 +6578,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6604,7 +6673,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "content_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "copyable_agent": {
                      *           "description": "Example description.",
                      *           "title": "Example Subnet",
@@ -6640,7 +6709,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6760,7 +6829,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6874,7 +6943,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6984,7 +7053,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7099,7 +7168,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7214,7 +7283,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7320,7 +7389,7 @@ export interface operations {
                      *         "artifact_count": 1,
                      *         "artifact_size_bytes": 1,
                      *         "candidate_count": 1,
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "provider_count": 1,
@@ -7332,7 +7401,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7453,7 +7522,7 @@ export interface operations {
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1
@@ -7461,7 +7530,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7576,7 +7645,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7685,7 +7754,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7800,7 +7869,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7916,7 +7985,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8040,7 +8109,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8155,7 +8224,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8260,7 +8329,7 @@ export interface operations {
                      *             "example"
                      *           ]
                      *         },
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -8289,7 +8358,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8407,7 +8476,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8503,7 +8572,7 @@ export interface operations {
                      *       "data": {
                      *         "artifacts": [
                      *           {
-                     *             "contract_version": "2026-06-06.1",
+                     *             "contract_version": "2026-06-29.1",
                      *             "id": "example",
                      *             "path": "/metagraph/example.json",
                      *             "schema_ref": "#/components/schemas/Example",
@@ -8511,7 +8580,7 @@ export interface operations {
                      *           }
                      *         ],
                      *         "base_path": "/metagraph",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "name": "Example Subnet",
                      *         "notes": "Example description.",
@@ -8524,7 +8593,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8632,7 +8701,7 @@ export interface operations {
                      *           "score_distribution": {},
                      *           "scored_subnet_count": 1
                      *         },
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "curated_overlay_count": 1,
                      *         "curation_level_counts": {
                      *           "example": 1
@@ -8659,7 +8728,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8766,7 +8835,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "coverage_depth_version": 1,
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
@@ -8856,7 +8925,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8960,7 +9029,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "curation": [
                      *           {
                      *             "candidate_count": 1,
@@ -8993,7 +9062,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9099,7 +9168,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "captured_at": "2026-06-01T00:00:00.000Z",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "network": "example",
                      *         "notes": "Example description.",
@@ -9139,7 +9208,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9248,7 +9317,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9356,7 +9425,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "incidents": [
                      *           {
@@ -9400,7 +9469,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9504,7 +9573,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "disabled_proxy_contract": {
                      *           "allowed_methods": [
                      *             "GET"
@@ -9570,7 +9639,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9679,7 +9748,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "endpoints": [
                      *           {
                      *             "auth_required": true,
@@ -9727,7 +9796,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9842,7 +9911,7 @@ export interface operations {
                      *             "support_summary": "Example description."
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1
@@ -9850,7 +9919,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9972,7 +10041,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10093,7 +10162,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10188,7 +10257,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "candidate_count": 1,
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "coverage": [
                      *           {
                      *             "netuid": 7,
@@ -10215,7 +10284,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10309,7 +10378,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -10351,7 +10420,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10456,7 +10525,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "gaps": [
                      *           {
                      *             "coverage_level": "native-only",
@@ -10484,7 +10553,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10588,7 +10657,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "global": {},
                      *         "health_source": "probe-derived",
@@ -10610,7 +10679,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10719,7 +10788,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "date": "2026-06-01",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
@@ -10746,7 +10815,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10872,7 +10941,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10994,7 +11063,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -11096,7 +11165,7 @@ export interface operations {
                      *             "target_netuid": 7
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "graduated_subnet_count": 1,
                      *         "link_count": 1,
@@ -11120,7 +11189,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -11226,7 +11295,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -11335,7 +11404,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "profiles": [
@@ -11483,7 +11552,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -11588,7 +11657,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "providers": [
@@ -11606,7 +11675,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -11702,7 +11771,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "provider": {
@@ -11733,7 +11802,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -11843,7 +11912,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "endpoints": [
                      *           {
                      *             "auth_required": true,
@@ -11897,7 +11966,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12007,7 +12076,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12101,7 +12170,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "counts": {
                      *           "candidates": 1,
                      *           "endpoints": 1,
@@ -12130,7 +12199,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12266,7 +12335,7 @@ export interface operations {
                      *             "suggested_next_action": "example"
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -12285,7 +12354,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12393,7 +12462,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "entries": [
                      *           {
                      *             "candidate_evidence_by_kind": {},
@@ -12444,7 +12513,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12558,7 +12627,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "queue": [
@@ -12652,7 +12721,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12768,7 +12837,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "groups": [
                      *           {
@@ -12873,7 +12942,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12978,7 +13047,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "priorities": [
@@ -13003,7 +13072,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13111,7 +13180,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "profiles": [
@@ -13200,7 +13269,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13309,7 +13378,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "endpoints": [
                      *           {
                      *             "chain": "bittensor",
@@ -13340,7 +13409,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13434,7 +13503,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "disabled_proxy_contract": {
                      *           "allowed_methods": [
                      *             "GET"
@@ -13500,7 +13569,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13638,7 +13707,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13732,7 +13801,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -13749,7 +13818,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13852,7 +13921,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "document_count": 1,
                      *         "documents": [
                      *           {
@@ -13872,7 +13941,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13975,7 +14044,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "document_count": 1,
                      *         "documents": [
                      *           {
@@ -13992,7 +14061,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -14086,7 +14155,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "providers": [
@@ -14117,7 +14186,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -14220,7 +14289,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -14246,7 +14315,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -14370,7 +14439,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "network": "finney",
                      *         "notes": "Example description.",
@@ -14381,7 +14450,7 @@ export interface operations {
                      *           "method": "GET",
                      *           "package": "example",
                      *           "rpc_family": "example",
-                     *           "version": "2026-06-06.1"
+                     *           "version": "2026-06-29.1"
                      *         },
                      *         "subnets": [
                      *           {
@@ -14399,7 +14468,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -14525,7 +14594,7 @@ export interface operations {
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "economics": {
                      *           "alpha_in_pool": 0.5,
                      *           "alpha_out_pool": 0.5,
@@ -14678,7 +14747,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -14800,7 +14869,7 @@ export interface operations {
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1
@@ -14808,7 +14877,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -14984,7 +15053,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15095,7 +15164,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15205,7 +15274,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "endpoints": [
                      *           {
                      *             "auth_required": true,
@@ -15256,7 +15325,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15372,7 +15441,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15489,7 +15558,7 @@ export interface operations {
                      *             "support_summary": "Example description."
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1
@@ -15497,7 +15566,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15603,7 +15672,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "enrichment_queue": [
                      *           {
                      *             "adapter_score": 100,
@@ -15703,7 +15772,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15811,7 +15880,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "health_source": "probe-derived",
                      *         "name": "Example Subnet",
@@ -15847,7 +15916,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15971,7 +16040,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16085,7 +16154,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16206,7 +16275,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16317,7 +16386,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16433,7 +16502,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16556,7 +16625,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16669,7 +16738,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16765,7 +16834,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "counts": {
                      *           "candidates": 1,
                      *           "endpoints": 1,
@@ -16962,7 +17031,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -17073,7 +17142,7 @@ export interface operations {
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "endpoints": [
                      *           {
                      *             "auth_required": true,
@@ -17334,7 +17403,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -17440,7 +17509,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -17460,7 +17529,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -17571,7 +17640,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -17689,7 +17758,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -17823,7 +17892,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -17937,7 +18006,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -18042,7 +18111,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -18062,7 +18131,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1,763 +1,763 @@
 {
   "artifact_contracts": [
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "contracts",
       "path": "/metagraph/contracts.json",
       "schema_ref": "#/components/schemas/ContractsArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "providers",
       "path": "/metagraph/providers.json",
       "schema_ref": "#/components/schemas/ProvidersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "provider-detail",
       "path": "/metagraph/providers/{slug}.json",
       "schema_ref": "#/components/schemas/ProviderArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",
       "schema_ref": "#/components/schemas/ProviderEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "api-index",
       "path": "/metagraph/api-index.json",
       "schema_ref": "#/components/schemas/ApiIndexArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "openapi",
       "path": "/metagraph/openapi.json",
       "schema_ref": "#/components/schemas/OpenApiArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "type-definitions",
       "path": "/metagraph/types.d.ts",
       "schema_ref": null,
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "changelog",
       "path": "/metagraph/changelog.json",
       "schema_ref": "#/components/schemas/ChangelogArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnets",
       "path": "/metagraph/subnets.json",
       "schema_ref": "#/components/schemas/SubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "metagraph-latest",
       "path": "/metagraph/metagraph/latest.json",
       "schema_ref": "#/components/schemas/SubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-detail",
       "path": "/metagraph/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-overview",
       "path": "/metagraph/overview/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetOverviewArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "profiles",
       "path": "/metagraph/profiles.json",
       "schema_ref": "#/components/schemas/SubnetProfilesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "profile-detail",
       "path": "/metagraph/profiles/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetProfileArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "surfaces",
       "path": "/metagraph/surfaces.json",
       "schema_ref": "#/components/schemas/SurfacesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "surface-aliases",
       "path": "/metagraph/surface-aliases.json",
       "schema_ref": "#/components/schemas/SurfaceAliasesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "surfaces-subnet",
       "path": "/metagraph/surfaces/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetSurfacesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "endpoints",
       "path": "/metagraph/endpoints.json",
       "schema_ref": "#/components/schemas/EndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "endpoints-subnet",
       "path": "/metagraph/endpoints/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "candidates",
       "path": "/metagraph/candidates.json",
       "schema_ref": "#/components/schemas/CandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "candidates-subnet",
       "path": "/metagraph/candidates/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetCandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "review-queue",
       "path": "/metagraph/review-queue.json",
       "schema_ref": "#/components/schemas/ReviewQueueArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "search",
       "path": "/metagraph/search.json",
       "schema_ref": "#/components/schemas/SearchArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "search-index",
       "path": "/metagraph/search-index.json",
       "schema_ref": "#/components/schemas/SearchIndexArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "coverage",
       "path": "/metagraph/coverage.json",
       "schema_ref": "#/components/schemas/CoverageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "coverage-depth",
       "path": "/metagraph/coverage-depth.json",
       "schema_ref": "#/components/schemas/CoverageDepthArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "economics",
       "path": "/metagraph/economics.json",
       "schema_ref": "#/components/schemas/EconomicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "economics-trends",
       "path": "/metagraph/economics/trends.json",
       "schema_ref": "#/components/schemas/EconomicsTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "registry-summary",
       "path": "/metagraph/registry-summary.json",
       "schema_ref": "#/components/schemas/RegistrySummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "lineage",
       "path": "/metagraph/lineage.json",
       "schema_ref": "#/components/schemas/LineageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "fixtures-index",
       "path": "/metagraph/fixtures.json",
       "schema_ref": "#/components/schemas/FixturesIndexArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "agent-resources",
       "path": "/metagraph/agent-resources.json",
       "schema_ref": "#/components/schemas/AgentResourcesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "fixture-detail",
       "path": "/metagraph/fixtures/{surface_id}.json",
       "schema_ref": "#/components/schemas/JsonObject",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "curation",
       "path": "/metagraph/curation.json",
       "schema_ref": "#/components/schemas/CurationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "gaps",
       "path": "/metagraph/gaps.json",
       "schema_ref": "#/components/schemas/GapsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "verification",
       "path": "/metagraph/verification/latest.json",
       "schema_ref": "#/components/schemas/VerificationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "verification-subnet",
       "path": "/metagraph/verification/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetVerificationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "freshness",
       "path": "/metagraph/freshness.json",
       "schema_ref": "#/components/schemas/FreshnessArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "source-health",
       "path": "/metagraph/source-health.json",
       "schema_ref": "#/components/schemas/SourceHealthArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "source-snapshots",
       "path": "/metagraph/source-snapshots.json",
       "schema_ref": "#/components/schemas/SourceSnapshotsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "evidence-ledger",
       "path": "/metagraph/evidence-ledger.json",
       "schema_ref": "#/components/schemas/EvidenceLedgerArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "evidence-subnet",
       "path": "/metagraph/evidence/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetEvidenceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "health-latest",
       "path": "/metagraph/health/latest.json",
       "schema_ref": "#/components/schemas/HealthLatestArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "health-summary",
       "path": "/metagraph/health/summary.json",
       "schema_ref": "#/components/schemas/HealthSummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "health-history",
       "path": "/metagraph/health/history/{date}.json",
       "schema_ref": "#/components/schemas/HealthHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "health-subnet",
       "path": "/metagraph/health/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthSubnetArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "health-badge",
       "path": "/metagraph/health/badges/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthBadgeArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "health-trends",
       "path": "/metagraph/health/trends/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "health-trends-bulk",
       "path": "/metagraph/health/trends.json",
       "schema_ref": "#/components/schemas/BulkHealthTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "health-percentiles",
       "path": "/metagraph/health/percentiles/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthPercentilesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "health-incidents",
       "path": "/metagraph/health/incidents/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-trajectory",
       "path": "/metagraph/subnets/{netuid}/trajectory.json",
       "schema_ref": "#/components/schemas/SubnetTrajectoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-concentration",
       "path": "/metagraph/subnets/{netuid}/concentration.json",
       "schema_ref": "#/components/schemas/SubnetConcentrationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-concentration-history",
       "path": "/metagraph/subnets/{netuid}/concentration/history.json",
       "schema_ref": "#/components/schemas/SubnetConcentrationHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-turnover",
       "path": "/metagraph/subnets/{netuid}/turnover.json",
       "schema_ref": "#/components/schemas/SubnetTurnoverArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-metagraph",
       "path": "/metagraph/subnets/{netuid}/metagraph.json",
       "schema_ref": "#/components/schemas/SubnetMetagraphArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-neuron",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}.json",
       "schema_ref": "#/components/schemas/NeuronDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-validators",
       "path": "/metagraph/subnets/{netuid}/validators.json",
       "schema_ref": "#/components/schemas/SubnetValidatorsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-events",
       "path": "/metagraph/subnets/{netuid}/events.json",
       "schema_ref": "#/components/schemas/SubnetEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-neuron-history",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}/history.json",
       "schema_ref": "#/components/schemas/NeuronHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-history",
       "path": "/metagraph/subnets/{netuid}/history.json",
       "schema_ref": "#/components/schemas/SubnetHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "account-summary",
       "path": "/metagraph/accounts/{ss58}.json",
       "schema_ref": "#/components/schemas/AccountSummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "account-events",
       "path": "/metagraph/accounts/{ss58}/events.json",
       "schema_ref": "#/components/schemas/AccountEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "account-history",
       "path": "/metagraph/accounts/{ss58}/history.json",
       "schema_ref": "#/components/schemas/AccountHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "account-extrinsics",
       "path": "/metagraph/accounts/{ss58}/extrinsics.json",
       "schema_ref": "#/components/schemas/AccountExtrinsicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "account-transfers",
       "path": "/metagraph/accounts/{ss58}/transfers.json",
       "schema_ref": "#/components/schemas/AccountTransfersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "account-counterparties",
       "path": "/metagraph/accounts/{ss58}/counterparties.json",
       "schema_ref": "#/components/schemas/AccountCounterpartiesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "account-subnets",
       "path": "/metagraph/accounts/{ss58}/subnets.json",
       "schema_ref": "#/components/schemas/AccountSubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "account-balance",
       "path": "/metagraph/accounts/{ss58}/balance.json",
       "schema_ref": "#/components/schemas/AccountBalanceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "blocks-feed",
       "path": "/metagraph/blocks.json",
       "schema_ref": "#/components/schemas/BlocksFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "block-detail",
       "path": "/metagraph/blocks/{ref}.json",
       "schema_ref": "#/components/schemas/BlockDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "block-extrinsics",
       "path": "/metagraph/blocks/{ref}/extrinsics.json",
       "schema_ref": "#/components/schemas/BlockExtrinsicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "block-events",
       "path": "/metagraph/blocks/{ref}/events.json",
       "schema_ref": "#/components/schemas/BlockEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "chain-events-feed",
       "path": "/metagraph/chain-events.json",
       "schema_ref": "#/components/schemas/ChainEventsFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "block-chain-events",
       "path": "/metagraph/blocks/{ref}/chain-events.json",
       "schema_ref": "#/components/schemas/BlockChainEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "chain-events-stats",
       "path": "/metagraph/chain-events/stats.json",
       "schema_ref": "#/components/schemas/ChainEventsStatsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "extrinsics-feed",
       "path": "/metagraph/extrinsics.json",
       "schema_ref": "#/components/schemas/ExtrinsicsFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "extrinsic-detail",
       "path": "/metagraph/extrinsics/{hash}.json",
       "schema_ref": "#/components/schemas/ExtrinsicDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "chain-activity",
       "path": "/metagraph/chain/activity.json",
       "schema_ref": "#/components/schemas/ChainActivityArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "chain-calls",
       "path": "/metagraph/chain/calls.json",
       "schema_ref": "#/components/schemas/ChainCallsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "chain-signers",
       "path": "/metagraph/chain/signers.json",
       "schema_ref": "#/components/schemas/ChainSignersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "chain-fees",
       "path": "/metagraph/chain/fees.json",
       "schema_ref": "#/components/schemas/ChainFeesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-uptime",
       "path": "/metagraph/subnets/{netuid}/uptime.json",
       "schema_ref": "#/components/schemas/UptimeArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "global-incidents",
       "path": "/metagraph/incidents.json",
       "schema_ref": "#/components/schemas/GlobalIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",
       "schema_ref": "#/components/schemas/RegistryLeaderboardsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "compare",
       "path": "/metagraph/compare.json",
       "schema_ref": "#/components/schemas/CompareArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "rpc-usage",
       "path": "/metagraph/rpc/usage.json",
       "schema_ref": "#/components/schemas/RpcUsageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
       "schema_ref": "#/components/schemas/RpcEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "rpc-pools",
       "path": "/metagraph/rpc/pools.json",
       "schema_ref": "#/components/schemas/RpcPoolsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "endpoint-pools",
       "path": "/metagraph/endpoint-pools.json",
       "schema_ref": "#/components/schemas/EndpointPoolsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "endpoint-incidents",
       "path": "/metagraph/endpoint-incidents.json",
       "schema_ref": "#/components/schemas/EndpointIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "operational-surfaces",
       "path": "/metagraph/operational-surfaces.json",
       "schema_ref": "#/components/schemas/OperationalSurfacesArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "agent-catalog",
       "path": "/metagraph/agent-catalog.json",
       "schema_ref": "#/components/schemas/AgentCatalogArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "agent-catalog-subnet",
       "path": "/metagraph/agent-catalog/{netuid}.json",
       "schema_ref": "#/components/schemas/AgentCatalogSubnetArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",
       "schema_ref": "#/components/schemas/SchemaDriftArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "schema-index",
       "path": "/metagraph/schemas/index.json",
       "schema_ref": "#/components/schemas/SchemaIndexArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "schema-snapshot",
       "path": "/metagraph/schemas/{surface_id}.json",
       "schema_ref": "#/components/schemas/JsonObject",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",
       "schema_ref": "#/components/schemas/AdapterArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "r2-manifest",
       "path": "/metagraph/r2-manifest.json",
       "schema_ref": "#/components/schemas/R2ManifestArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "review-curation",
       "path": "/metagraph/review/curation.json",
       "schema_ref": "#/components/schemas/ReviewCurationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "review-gap-priorities",
       "path": "/metagraph/review/gap-priorities.json",
       "schema_ref": "#/components/schemas/ReviewGapPrioritiesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "subnet-gaps",
       "path": "/metagraph/review/gaps/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetGapsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "review-profile-completeness",
       "path": "/metagraph/review/profile-completeness.json",
       "schema_ref": "#/components/schemas/ReviewProfileCompletenessArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "review-adapter-candidates",
       "path": "/metagraph/review/adapter-candidates.json",
       "schema_ref": "#/components/schemas/ReviewAdapterCandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "review-enrichment-queue",
       "path": "/metagraph/review/enrichment-queue.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentQueueArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "review-enrichment-evidence",
       "path": "/metagraph/review/enrichment-evidence.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentEvidenceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "review-enrichment-targets",
       "path": "/metagraph/review/enrichment-targets.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentTargetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
       "schema_ref": "#/components/schemas/ReviewDecisionsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "id": "build-summary",
       "path": "/metagraph/build-summary.json",
       "schema_ref": "#/components/schemas/BuildSummaryArtifact",
@@ -765,7 +765,7 @@
     }
   ],
   "base_path": "/api/v1",
-  "contract_version": "2026-06-06.1",
+  "contract_version": "2026-06-29.1",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "openapi_url": "/api/v1/openapi.json",
   "primary_domain": "api.metagraph.sh",
@@ -4591,7 +4591,7 @@
     {
       "artifact_path": "/metagraph/accounts/{ss58}/counterparties.json",
       "cache": "short",
-      "description": "Fetch the per-counterparty fund-flow rollup for one account — its native-TAO transfers aggregated by counterparty into sent/received/net + count, ranked by total volume (the address relationship view) — computed live from the account_events D1 tier. ?limit (<=100).",
+      "description": "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?limit (<=100).",
       "id": "account-counterparties",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/counterparties",
@@ -4599,6 +4599,13 @@
       "query_collection": null,
       "query_filter_names": [],
       "query_parameters": [
+        {
+          "name": "counterparty",
+          "schema": {
+            "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
+            "type": "string"
+          }
+        },
         {
           "name": "limit",
           "schema": {

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -2,7 +2,7 @@
   "artifacts": [
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Public artifact contract metadata for metagraph.sh consumers.",
       "id": "contracts",
       "path": "/metagraph/contracts.json",
@@ -11,7 +11,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Provider/source registry.",
       "id": "providers",
       "path": "/metagraph/providers.json",
@@ -20,7 +20,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Per-provider detail payload.",
       "id": "provider-detail",
       "path": "/metagraph/providers/{slug}.json",
@@ -29,7 +29,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Endpoint resources for one provider or operator.",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",
@@ -38,7 +38,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Clean API route index for metagraph.sh consumers.",
       "id": "api-index",
       "path": "/metagraph/api-index.json",
@@ -47,7 +47,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "OpenAPI 3.1 contract for the metagraph.sh backend API.",
       "id": "openapi",
       "path": "/metagraph/openapi.json",
@@ -56,7 +56,7 @@
     },
     {
       "content_type": "text/plain; charset=utf-8",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Generated TypeScript definitions for metagraph.sh backend consumers.",
       "id": "type-definitions",
       "path": "/metagraph/types.d.ts",
@@ -65,7 +65,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Reviewable generated artifact and subnet-change summary.",
       "id": "changelog",
       "path": "/metagraph/changelog.json",
@@ -74,7 +74,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "All active Finney subnets with compact registry metadata.",
       "id": "subnets",
       "path": "/metagraph/subnets.json",
@@ -83,7 +83,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Latest normalized all-subnet metagraph index with chain-native state and registry coverage metadata.",
       "id": "metagraph-latest",
       "path": "/metagraph/metagraph/latest.json",
@@ -92,7 +92,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Per-subnet detail payload.",
       "id": "subnet-detail",
       "path": "/metagraph/subnets/{netuid}.json",
@@ -101,7 +101,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Composed per-subnet overview: profile + health + curation + gaps + counts.",
       "id": "subnet-overview",
       "path": "/metagraph/overview/{netuid}.json",
@@ -110,7 +110,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Public-safe subnet identity and completeness profiles.",
       "id": "profiles",
       "path": "/metagraph/profiles.json",
@@ -119,7 +119,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Per-subnet public-safe profile detail.",
       "id": "profile-detail",
       "path": "/metagraph/profiles/{netuid}.json",
@@ -128,7 +128,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Curated public interface surfaces only.",
       "id": "surfaces",
       "path": "/metagraph/surfaces.json",
@@ -137,7 +137,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Deprecated surface display-id aliases mapped to stable surface keys for renamed surfaces.",
       "id": "surface-aliases",
       "path": "/metagraph/surface-aliases.json",
@@ -146,7 +146,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Curated public interface surfaces for one subnet.",
       "id": "surfaces-subnet",
       "path": "/metagraph/surfaces/{netuid}.json",
@@ -155,7 +155,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Generalized endpoint/resource registry derived from curated surfaces and probe observations.",
       "id": "endpoints",
       "path": "/metagraph/endpoints.json",
@@ -164,7 +164,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Generalized endpoint/resource registry for one subnet.",
       "id": "endpoints-subnet",
       "path": "/metagraph/endpoints/{netuid}.json",
@@ -173,7 +173,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Unpromoted candidate surfaces from public discovery.",
       "id": "candidates",
       "path": "/metagraph/candidates.json",
@@ -182,7 +182,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Unpromoted candidate surfaces for one subnet.",
       "id": "candidates-subnet",
       "path": "/metagraph/candidates/{netuid}.json",
@@ -191,7 +191,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Candidate surfaces queued for maintainer review.",
       "id": "review-queue",
       "path": "/metagraph/review-queue.json",
@@ -200,7 +200,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Compact search index for subnets, surfaces, and providers.",
       "id": "search",
       "path": "/metagraph/search.json",
@@ -209,7 +209,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Slim search index (the same documents as search.json without the per-document token blobs) for fast browser typeahead and listing.",
       "id": "search-index",
       "path": "/metagraph/search-index.json",
@@ -218,7 +218,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Registry coverage counts and source precedence.",
       "id": "coverage",
       "path": "/metagraph/coverage.json",
@@ -227,7 +227,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Machine-usable coverage depth scorecard with per-subnet readiness dimensions and a ranked enrichment queue.",
       "id": "coverage-depth",
       "path": "/metagraph/coverage-depth.json",
@@ -236,7 +236,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Per-subnet validator and economic metrics from the chain: validator/miner counts, total + max stake, registration cost, alpha price, and derived price-weighted emission share.",
       "id": "economics",
       "path": "/metagraph/economics.json",
@@ -245,7 +245,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Network-wide economics time series (#1307) aggregated per UTC day across all subnets from the daily subnet_snapshots D1 rollup (the same source the per-subnet trajectory reads), served live at /api/v1/economics/trends (no static file).",
       "id": "economics-trends",
       "path": "/metagraph/economics/trends.json",
@@ -254,7 +254,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Registry-wide summary: completeness rollup, top subnets, level counts, latest changes.",
       "id": "registry-summary",
       "path": "/metagraph/registry-summary.json",
@@ -263,7 +263,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Cross-network subnet lineage: maintainer-approved mainnet ↔ testnet pairs with reviewed match evidence.",
       "id": "lineage",
       "path": "/metagraph/lineage.json",
@@ -272,7 +272,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Index of captured live request/response fixtures (which surfaces carry a sanitized sample).",
       "id": "fixtures-index",
       "path": "/metagraph/fixtures.json",
@@ -281,7 +281,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Machine index of every AI resource: the copyable agent, the MCP server + tools, the skill, llms.txt, OpenAPI, and the agent-facing APIs.",
       "id": "agent-resources",
       "path": "/metagraph/agent-resources.json",
@@ -290,7 +290,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "A captured, sanitized live request/response sample for one surface.",
       "id": "fixture-detail",
       "path": "/metagraph/fixtures/{surface_id}.json",
@@ -299,7 +299,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Curation state and gaps for every active subnet.",
       "id": "curation",
       "path": "/metagraph/curation.json",
@@ -308,7 +308,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Missing public interface facets by subnet.",
       "id": "gaps",
       "path": "/metagraph/gaps.json",
@@ -317,7 +317,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Latest candidate verification snapshot.",
       "id": "verification",
       "path": "/metagraph/verification/latest.json",
@@ -326,7 +326,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Latest candidate verification snapshot for one subnet.",
       "id": "verification-subnet",
       "path": "/metagraph/verification/subnets/{netuid}.json",
@@ -335,7 +335,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Freshness and staleness summary for generated backend data.",
       "id": "freshness",
       "path": "/metagraph/freshness.json",
@@ -344,7 +344,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Upstream source and provider health summary.",
       "id": "source-health",
       "path": "/metagraph/source-health.json",
@@ -353,7 +353,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Compact hashes and counts for canonical source inputs.",
       "id": "source-snapshots",
       "path": "/metagraph/source-snapshots.json",
@@ -362,7 +362,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Public evidence ledger for subnet and surface claims.",
       "id": "evidence-ledger",
       "path": "/metagraph/evidence-ledger.json",
@@ -371,7 +371,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Public evidence ledger claims for one subnet.",
       "id": "evidence-subnet",
       "path": "/metagraph/evidence/{netuid}.json",
@@ -380,7 +380,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Latest surface health snapshot.",
       "id": "health-latest",
       "path": "/metagraph/health/latest.json",
@@ -389,7 +389,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Global and per-subnet health rollup.",
       "id": "health-summary",
       "path": "/metagraph/health/summary.json",
@@ -398,7 +398,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Compact daily health-history snapshot.",
       "id": "health-history",
       "path": "/metagraph/health/history/{date}.json",
@@ -407,7 +407,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Per-subnet health payload for metagraph.sh consumers.",
       "id": "health-subnet",
       "path": "/metagraph/health/subnets/{netuid}.json",
@@ -416,7 +416,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Badge data contract for status rendering.",
       "id": "health-badge",
       "path": "/metagraph/health/badges/{netuid}.json",
@@ -425,7 +425,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Computed 7d/30d uptime + success-only latency trends (mean, p50/p95/p99 tail, and healthy-sample count) for one subnet's operational surfaces. Served live from D1 at /api/v1/subnets/{netuid}/health/trends (no static file).",
       "id": "health-trends",
       "path": "/metagraph/health/trends/{netuid}.json",
@@ -434,7 +434,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Compact all-subnet 7d/30d daily uptime + success-only latency trend matrix (mean + healthy-sample count). Served live from D1 at /api/v1/health/trends (no static file).",
       "id": "health-trends-bulk",
       "path": "/metagraph/health/trends.json",
@@ -443,7 +443,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Latency percentiles (p50/p95/p99 + avg/min/max) per operational surface for one subnet, computed live from D1 at /api/v1/subnets/{netuid}/health/percentiles (no static file).",
       "id": "health-percentiles",
       "path": "/metagraph/health/percentiles/{netuid}.json",
@@ -452,7 +452,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "SLA (uptime ratio) and reconstructed downtime incidents per operational surface for one subnet, computed live from D1 at /api/v1/subnets/{netuid}/health/incidents (no static file).",
       "id": "health-incidents",
       "path": "/metagraph/health/incidents/{netuid}.json",
@@ -461,7 +461,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Week-over-week structural trajectory (completeness + surface/endpoint counts) for one subnet from daily snapshots, served live from D1 at /api/v1/subnets/{netuid}/trajectory (no static file).",
       "id": "subnet-trajectory",
       "path": "/metagraph/subnets/{netuid}/trajectory.json",
@@ -470,7 +470,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Stake & emission concentration metrics (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) for one subnet across three lenses — per-UID, per-entity (coldkeys collapsed to the true control distribution), and validator-only consensus power — served live from the neurons D1 tier at /api/v1/subnets/{netuid}/concentration (no static file).",
       "id": "subnet-concentration",
       "path": "/metagraph/subnets/{netuid}/concentration.json",
@@ -479,7 +479,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/concentration/history (no static file).",
       "id": "subnet-concentration-history",
       "path": "/metagraph/subnets/{netuid}/concentration/history.json",
@@ -488,7 +488,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + Jaccard retention, UID deregistrations, and a 0-100 stability score — served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/turnover (no static file).",
       "id": "subnet-turnover",
       "path": "/metagraph/subnets/{netuid}/turnover.json",
@@ -497,7 +497,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Per-UID metagraph (stake, trust, consensus, incentive, dividends, emission, validator_permit, rank, axon) for one subnet, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/metagraph (no static file).",
       "id": "subnet-metagraph",
       "path": "/metagraph/subnets/{netuid}/metagraph.json",
@@ -506,7 +506,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "A single neuron's metagraph state by UID, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/neurons/{uid} (no static file).",
       "id": "subnet-neuron",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}.json",
@@ -515,7 +515,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Validators (validator_permit) of one subnet ranked by stake, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/validators (no static file).",
       "id": "subnet-validators",
       "path": "/metagraph/subnets/{netuid}/validators.json",
@@ -524,7 +524,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "First-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, served live from the account_events D1 tier filtered by netuid at /api/v1/subnets/{netuid}/events (no static file).",
       "id": "subnet-events",
       "path": "/metagraph/subnets/{netuid}/events.json",
@@ -533,7 +533,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Per-UID daily metagraph history (stake/trust/emission/rank over time) for one UID, served live from the neuron_daily D1 rollup tier at /api/v1/subnets/{netuid}/neurons/{uid}/history (no static file).",
       "id": "subnet-neuron-history",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}/history.json",
@@ -542,7 +542,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Per-subnet daily aggregate history (neuron/validator counts + stake/emission totals) for one subnet, served live from the neuron_daily D1 rollup tier at /api/v1/subnets/{netuid}/history (no static file).",
       "id": "subnet-history",
       "path": "/metagraph/subnets/{netuid}/history.json",
@@ -551,7 +551,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Cross-subnet activity summary for one account (hotkey or coldkey): chain-event aggregates joined to current registrations, served live from D1 at /api/v1/accounts/{ss58} (no static file).",
       "id": "account-summary",
       "path": "/metagraph/accounts/{ss58}.json",
@@ -560,7 +560,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events (no static file).",
       "id": "account-events",
       "path": "/metagraph/accounts/{ss58}/events.json",
@@ -569,7 +569,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Durable per-day activity series for one account (hotkey-keyed, newest day first), served live from the account_events_daily rollup at /api/v1/accounts/{ss58}/history (no static file).",
       "id": "account-history",
       "path": "/metagraph/accounts/{ss58}/history.json",
@@ -578,7 +578,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Paginated extrinsics this account signed (by signer), newest first, served live from the extrinsics D1 tier at /api/v1/accounts/{ss58}/extrinsics (no static file).",
       "id": "account-extrinsics",
       "path": "/metagraph/accounts/{ss58}/extrinsics.json",
@@ -587,7 +587,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers (no static file).",
       "id": "account-transfers",
       "path": "/metagraph/accounts/{ss58}/transfers.json",
@@ -596,8 +596,8 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
-      "description": "Per-counterparty fund-flow rollup for one account — its native-TAO transfers aggregated by counterparty into sent/received/net + count, ranked by total volume — served live from the account_events D1 tier at /api/v1/accounts/{ss58}/counterparties (no static file).",
+      "contract_version": "2026-06-29.1",
+      "description": "Per-counterparty fund-flow rollup for one account, with optional ?counterparty=<ss58> relationship evidence — native-TAO transfers from the account_events D1 tier at /api/v1/accounts/{ss58}/counterparties (no static file).",
       "id": "account-counterparties",
       "path": "/metagraph/accounts/{ss58}/counterparties.json",
       "schema_ref": "#/components/schemas/AccountCounterpartiesArtifact",
@@ -605,7 +605,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "The subnets where an account's hotkey is currently registered, served live from the neurons D1 tier at /api/v1/accounts/{ss58}/subnets (no static file).",
       "id": "account-subnets",
       "path": "/metagraph/accounts/{ss58}/subnets.json",
@@ -614,7 +614,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Live TAO balance (free+reserved, in TAO) for a finney account, queried from the RPC at request time with 60s KV cache. balance_tao is null on RPC failure. (#1818)",
       "id": "account-balance",
       "path": "/metagraph/accounts/{ss58}/balance.json",
@@ -623,7 +623,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "The recent-block feed (newest first) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks (no static file).",
       "id": "blocks-feed",
       "path": "/metagraph/blocks.json",
@@ -632,7 +632,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks/{ref} (no static file).",
       "id": "block-detail",
       "path": "/metagraph/blocks/{ref}.json",
@@ -641,7 +641,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "The extrinsics in one block (by numeric block_number or 0x block_hash), in natural order, served live from the first-party extrinsics D1 tier at /api/v1/blocks/{ref}/extrinsics (no static file).",
       "id": "block-extrinsics",
       "path": "/metagraph/blocks/{ref}/extrinsics.json",
@@ -650,7 +650,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "The decoded chain events in one block (by numeric block_number or 0x block_hash), in natural order, served live from the first-party account_events D1 tier filtered by block_number at /api/v1/blocks/{ref}/events (no static file).",
       "id": "block-events",
       "path": "/metagraph/blocks/{ref}/events.json",
@@ -659,7 +659,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events (no static file). Distinct from the curated account-attributed event stream; empty before the all-events backfill runs.",
       "id": "chain-events-feed",
       "path": "/metagraph/chain-events.json",
@@ -668,7 +668,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Every raw pallet-level event in one block (event_index ascending) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/blocks/{ref}/chain-events (no static file). Distinct from /blocks/{ref}/events (the curated account-attributed D1 stream).",
       "id": "block-chain-events",
       "path": "/metagraph/blocks/{ref}/chain-events.json",
@@ -677,7 +677,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Chain-activity aggregate (pallet.method event distribution over the most recent N blocks) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events/stats (no static file) and consumed by the get_chain_activity MCP tool.",
       "id": "chain-events-stats",
       "path": "/metagraph/chain-events/stats.json",
@@ -686,7 +686,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "The recent-extrinsic feed (newest first) for the block explorer (#1345), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics (no static file).",
       "id": "extrinsics-feed",
       "path": "/metagraph/extrinsics.json",
@@ -695,7 +695,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics/{hash} (no static file).",
       "id": "extrinsic-detail",
       "path": "/metagraph/extrinsics/{hash}.json",
@@ -704,7 +704,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Daily network-activity aggregates (extrinsic/event/block counts, success rate, unique signers) over a 7d or 30d window for the block explorer (#1987), computed live from the first-party chain D1 tiers at /api/v1/chain/activity (no static file).",
       "id": "chain-activity",
       "path": "/metagraph/chain/activity.json",
@@ -713,7 +713,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Extrinsic call-mix breakdown (count + share per call_module / call_function) over a 7d or 30d window for the block explorer (#1989), computed live from the first-party extrinsics D1 tier at /api/v1/chain/calls (no static file).",
       "id": "chain-calls",
       "path": "/metagraph/chain/calls.json",
@@ -722,7 +722,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Windowed most-active-account leaderboard (signers ranked by extrinsic count, with fees/tips + newest block) over a 7d or 30d window for the block explorer (#1990), computed live from the first-party extrinsics D1 tier at /api/v1/chain/signers (no static file).",
       "id": "chain-signers",
       "path": "/metagraph/chain/signers.json",
@@ -731,7 +731,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Fee/tip market analytics (daily totals + averages and a top-fee-payer list) over a 7d or 30d window for the block explorer (#1988), computed live from the first-party extrinsics D1 tier at /api/v1/chain/fees (no static file).",
       "id": "chain-fees",
       "path": "/metagraph/chain/fees.json",
@@ -740,7 +740,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Long-term daily uptime history per operational surface for one subnet (90d/1y window), served live from the surface_uptime_daily D1 rollup (no static file).",
       "id": "subnet-uptime",
       "path": "/metagraph/subnets/{netuid}/uptime.json",
@@ -749,7 +749,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window, served live from D1 at /api/v1/incidents (no static file).",
       "id": "global-incidents",
       "path": "/metagraph/incidents.json",
@@ -758,7 +758,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Registry leaderboards — operational (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable) and economic opportunity (open-slots, cheapest-registration, highest-emission, validator-headroom) — computed live from D1 + registry projections + the economics tier at /api/v1/registry/leaderboards (no static file).",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",
@@ -767,7 +767,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Cross-subnet comparison — registry structure (completeness + surface counts), the live economics tier, and the live per-subnet health rollup placed side by side for the requested netuids in requested order — computed live from registry projections + the economics tier + D1 at /api/v1/compare (no static file).",
       "id": "compare",
       "path": "/metagraph/compare.json",
@@ -776,7 +776,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets) over a 7d/30d window, computed live from the rpc_proxy_events telemetry at /api/v1/rpc/usage (no static file).",
       "id": "rpc-usage",
       "path": "/metagraph/rpc/usage.json",
@@ -785,7 +785,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Bittensor base-layer RPC endpoint registry and probe status.",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
@@ -794,7 +794,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Endpoint pool scoring for future read-only RPC routing.",
       "id": "rpc-pools",
       "path": "/metagraph/rpc/pools.json",
@@ -803,7 +803,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Generalized endpoint pool scoring for future read-only routing.",
       "id": "endpoint-pools",
       "path": "/metagraph/endpoint-pools.json",
@@ -812,7 +812,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Probe-derived endpoint incident summary and active endpoint failures.",
       "id": "endpoint-incidents",
       "path": "/metagraph/endpoint-incidents.json",
@@ -821,7 +821,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Operational surfaces (RPC/WSS/subnet-api/SSE/data-artifact) probed live by the cron health prober; input list for the 15-minute scheduled prober.",
       "id": "operational-surfaces",
       "path": "/metagraph/operational-surfaces.json",
@@ -830,7 +830,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Compact index of subnets exposing callable services (subnet-api/openapi/sse/data-artifact) — the machine-readable 'which subnet does X + how to call it' index for AI agents.",
       "id": "agent-catalog",
       "path": "/metagraph/agent-catalog.json",
@@ -839,7 +839,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Per-subnet agent capability catalog: each callable service with its base URL, auth, machine-readable schema, and live-build health/eligibility.",
       "id": "agent-catalog-subnet",
       "path": "/metagraph/agent-catalog/{netuid}.json",
@@ -848,7 +848,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "OpenAPI schema snapshot/drift status.",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",
@@ -857,7 +857,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Index of captured machine-readable schemas.",
       "id": "schema-index",
       "path": "/metagraph/schemas/index.json",
@@ -866,7 +866,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Captured machine-readable OpenAPI/Swagger schema snapshot detail.",
       "id": "schema-snapshot",
       "path": "/metagraph/schemas/{surface_id}.json",
@@ -875,7 +875,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Adapter-backed public metrics by subnet slug.",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",
@@ -884,7 +884,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "R2 upload manifest for generated artifact history.",
       "id": "r2-manifest",
       "path": "/metagraph/r2-manifest.json",
@@ -893,7 +893,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Maintainer curation and adapter candidate report.",
       "id": "review-curation",
       "path": "/metagraph/review/curation.json",
@@ -902,7 +902,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Subnet interface gap priorities.",
       "id": "review-gap-priorities",
       "path": "/metagraph/review/gap-priorities.json",
@@ -911,7 +911,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Interface gap priorities and enrichment queue for one subnet.",
       "id": "subnet-gaps",
       "path": "/metagraph/review/gaps/{netuid}.json",
@@ -920,7 +920,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Profile completeness and contributor targeting report.",
       "id": "review-profile-completeness",
       "path": "/metagraph/review/profile-completeness.json",
@@ -929,7 +929,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Subnets worth deeper adapter work.",
       "id": "review-adapter-candidates",
       "path": "/metagraph/review/adapter-candidates.json",
@@ -938,7 +938,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Prioritized all-subnet enrichment work queue for contributor-safe registry improvements.",
       "id": "review-enrichment-queue",
       "path": "/metagraph/review/enrichment-queue.json",
@@ -947,7 +947,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Detailed candidate evidence by missing or contributor-target surface kind for enrichment work.",
       "id": "review-enrichment-evidence",
       "path": "/metagraph/review/enrichment-evidence.json",
@@ -956,7 +956,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Contributor-oriented enrichment target pack grouped by submission kind, review route, and evidence action.",
       "id": "review-enrichment-targets",
       "path": "/metagraph/review/enrichment-targets.json",
@@ -965,7 +965,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Public-safe maintainer review decision ledger.",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
@@ -974,7 +974,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-06.1",
+      "contract_version": "2026-06-29.1",
       "description": "Generated build summary.",
       "id": "build-summary",
       "path": "/metagraph/build-summary.json",
@@ -983,7 +983,7 @@
     }
   ],
   "base_path": "/metagraph",
-  "contract_version": "2026-06-06.1",
+  "contract_version": "2026-06-29.1",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "name": "Metagraphed public backend artifact contract",
   "notes": [

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -114,6 +114,7 @@
               "additionalProperties": true,
               "properties": {
                 "address": {
+                  "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
                   "type": "string"
                 },
                 "last_block": {
@@ -147,6 +148,161 @@
             "minimum": 0,
             "type": "integer"
           },
+          "relationship": {
+            "additionalProperties": false,
+            "description": "Present only when ?counterparty=<ss58> is supplied. Pair-level transfer evidence for the requested account/counterparty relationship; summary fields cover every matching row in the bounded scan, while transfers is limited by the request limit.",
+            "properties": {
+              "counterparty": {
+                "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
+                "type": "string"
+              },
+              "first_block": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "first_seen_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "last_block": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "last_seen_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "limit": {
+                "description": "Maximum number of recent transfer evidence rows returned in transfers.",
+                "maximum": 100,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "net_tao": {
+                "type": "number"
+              },
+              "scan_capped": {
+                "type": "boolean"
+              },
+              "schema_version": {
+                "type": "integer"
+              },
+              "ss58": {
+                "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
+                "type": "string"
+              },
+              "total_received_tao": {
+                "type": "number"
+              },
+              "total_sent_tao": {
+                "type": "number"
+              },
+              "transfer_count": {
+                "description": "Count of all matching account/counterparty transfer rows in the bounded scan, before the evidence list is sliced by limit.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "transfers": {
+                "description": "Recent pair transfer evidence rows, sliced to limit. Summary counts and totals may cover more rows than this array contains.",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "amount_tao": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "block_number": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "direction": {
+                      "enum": [
+                        "sent",
+                        "received"
+                      ],
+                      "type": "string"
+                    },
+                    "event_index": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "from": {
+                      "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
+                      "type": "string"
+                    },
+                    "netuid": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "observed_at": {
+                      "format": "date-time",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "to": {
+                      "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "block_number",
+                    "event_index",
+                    "netuid",
+                    "from",
+                    "to",
+                    "amount_tao",
+                    "direction",
+                    "observed_at"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "transfers_scanned": {
+                "description": "Raw bounded D1 pair rows inspected before malformed rows are skipped.",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "schema_version",
+              "ss58",
+              "counterparty",
+              "transfer_count",
+              "transfers_scanned",
+              "scan_capped",
+              "total_sent_tao",
+              "total_received_tao",
+              "net_tao",
+              "first_block",
+              "last_block",
+              "first_seen_at",
+              "last_seen_at",
+              "limit",
+              "transfers"
+            ],
+            "type": "object"
+          },
           "scan_capped": {
             "type": "boolean"
           },
@@ -154,6 +310,7 @@
             "type": "integer"
           },
           "ss58": {
+            "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
             "type": "string"
           },
           "total_received_tao": {
@@ -14135,7 +14292,7 @@
   "info": {
     "description": "Public, read-only API over canonical Metagraphed registry artifacts for Bittensor subnet interfaces. **No authentication** — every operation is an unauthenticated GET. Responses use a stable JSON envelope `{ ok, schema_version, data, meta }` (errors: `{ ok: false, error }`) and carry `ETag` + `Cache-Control` for conditional caching. Rate-limited per client. Multi-network: insert a `/{network}/` segment after `/api/v1/` (mainnet is the default — omit it) to read testnet data, e.g. `/api/v1/testnet/subnets`. Testnet exposes the subset of routes that have data; `/api/v1/lineage` tracks which testnet subnets have graduated.",
     "title": "Metagraphed API",
-    "version": "2026-06-06.1"
+    "version": "2026-06-29.1"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -14151,7 +14308,7 @@
                   "data": {
                     "artifact_contracts": [
                       {
-                        "contract_version": "2026-06-06.1",
+                        "contract_version": "2026-06-29.1",
                         "id": "example",
                         "path": "/metagraph/example.json",
                         "schema_ref": "#/components/schemas/Example",
@@ -14159,7 +14316,7 @@
                       }
                     ],
                     "base_path": "/api/v1",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "openapi_url": "/api/v1/openapi.json",
@@ -14196,7 +14353,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -14352,13 +14509,13 @@
                       }
                     ],
                     "schema_version": 1,
-                    "ss58": "example",
+                    "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                     "subnet_count": 1
                   },
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -14483,12 +14640,12 @@
                     "balance_tao": 0.5,
                     "queried_at": "2026-06-01T00:00:00.000Z",
                     "schema_version": 1,
-                    "ss58": "example"
+                    "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
                   },
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -14604,6 +14761,15 @@
           },
           {
             "in": "query",
+            "name": "counterparty",
+            "required": false,
+            "schema": {
+              "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -14621,21 +14787,54 @@
                   "data": {
                     "counterparties": [
                       {
-                        "address": "example"
+                        "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                        "last_block": 5000000,
+                        "net_tao": -0.5,
+                        "received_tao": 0,
+                        "sent_tao": 0.5,
+                        "transfer_count": 1
                       }
                     ],
                     "counterparty_count": 1,
+                    "relationship": {
+                      "counterparty": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                      "first_block": 5000000,
+                      "first_seen_at": "2026-06-01T00:00:00.000Z",
+                      "last_block": 5000000,
+                      "last_seen_at": "2026-06-01T00:00:00.000Z",
+                      "limit": 1,
+                      "net_tao": -0.5,
+                      "scan_capped": false,
+                      "schema_version": 1,
+                      "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                      "total_received_tao": 0,
+                      "total_sent_tao": 0.5,
+                      "transfer_count": 1,
+                      "transfers": [
+                        {
+                          "amount_tao": 0.5,
+                          "block_number": 5000000,
+                          "direction": "sent",
+                          "event_index": 1,
+                          "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                          "netuid": 7,
+                          "observed_at": "2026-06-01T00:00:00.000Z",
+                          "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ"
+                        }
+                      ],
+                      "transfers_scanned": 1
+                    },
                     "scan_capped": false,
                     "schema_version": 1,
-                    "ss58": "example",
-                    "total_received_tao": 0.5,
+                    "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                    "total_received_tao": 0,
                     "total_sent_tao": 0.5,
                     "transfers_scanned": 1
                   },
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -14731,7 +14930,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the per-counterparty fund-flow rollup for one account — its native-TAO transfers aggregated by counterparty into sent/received/net + count, ranked by total volume (the address relationship view) — computed live from the account_events D1 tier. ?limit (<=100).",
+        "summary": "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?limit (<=100).",
         "tags": [
           "accounts",
           "analytics"
@@ -14803,12 +15002,12 @@
                     "next_cursor": "example",
                     "offset": 1,
                     "schema_version": 1,
-                    "ss58": "example"
+                    "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
                   },
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -14959,12 +15158,12 @@
                     "limit": 1,
                     "offset": 1,
                     "schema_version": 1,
-                    "ss58": "example"
+                    "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
                   },
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -15142,12 +15341,12 @@
                     "next_cursor": "example",
                     "offset": 1,
                     "schema_version": 1,
-                    "ss58": "example"
+                    "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
                   },
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -15270,7 +15469,7 @@
                 "example": {
                   "data": {
                     "schema_version": 1,
-                    "ss58": "example",
+                    "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                     "subnet_count": 1,
                     "subnets": [
                       {
@@ -15281,7 +15480,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -15439,20 +15638,20 @@
                     "next_cursor": "example",
                     "offset": 1,
                     "schema_version": 1,
-                    "ss58": "example",
+                    "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                     "transfer_count": 1,
                     "transfers": [
                       {
                         "block_number": 5000000,
-                        "from": "example",
-                        "to": "example"
+                        "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                        "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ"
                       }
                     ]
                   },
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -15575,7 +15774,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "extensions": {
                       "example": {}
                     },
@@ -15590,7 +15789,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -15726,7 +15925,7 @@
                     ],
                     "blocker_summary": {},
                     "callable_service_count": 1,
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "schema_version": 1,
@@ -15742,7 +15941,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -15885,7 +16084,7 @@
                       "example"
                     ],
                     "completeness_score": 100,
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "integration_readiness": 1,
                     "name": "Example Subnet",
@@ -15913,7 +16112,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -16027,7 +16226,7 @@
                 "example": {
                   "data": {
                     "content_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "copyable_agent": {
                       "description": "Example description.",
                       "title": "Example Subnet",
@@ -16063,7 +16262,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -16288,7 +16487,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -16428,7 +16627,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -16564,7 +16763,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -16722,7 +16921,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -16879,7 +17078,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -17004,7 +17203,7 @@
                     "artifact_count": 1,
                     "artifact_size_bytes": 1,
                     "candidate_count": 1,
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "provider_count": 1,
@@ -17016,7 +17215,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -17259,7 +17458,7 @@
                         "url": "https://api.metagraph.sh/example"
                       }
                     ],
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "schema_version": 1
@@ -17267,7 +17466,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -17449,7 +17648,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -17586,7 +17785,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -17731,7 +17930,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -17897,7 +18096,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -18068,7 +18267,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -18230,7 +18429,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -18354,7 +18553,7 @@
                         "example"
                       ]
                     },
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "schema_version": 1,
@@ -18383,7 +18582,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -18535,7 +18734,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -18651,7 +18850,7 @@
                   "data": {
                     "artifacts": [
                       {
-                        "contract_version": "2026-06-06.1",
+                        "contract_version": "2026-06-29.1",
                         "id": "example",
                         "path": "/metagraph/example.json",
                         "schema_ref": "#/components/schemas/Example",
@@ -18659,7 +18858,7 @@
                       }
                     ],
                     "base_path": "/metagraph",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "name": "Example Subnet",
                     "notes": "Example description.",
@@ -18672,7 +18871,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -18798,7 +18997,7 @@
                       "score_distribution": {},
                       "scored_subnet_count": 1
                     },
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "curated_overlay_count": 1,
                     "curation_level_counts": {
                       "example": 1
@@ -18825,7 +19024,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -19058,7 +19257,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "coverage_depth_version": 1,
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
@@ -19148,7 +19347,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -19340,7 +19539,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "curation": [
                       {
                         "candidate_count": 1,
@@ -19373,7 +19572,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -19581,7 +19780,7 @@
                 "example": {
                   "data": {
                     "captured_at": "2026-06-01T00:00:00.000Z",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "network": "example",
                     "notes": "Example description.",
@@ -19621,7 +19820,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -19762,7 +19961,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -20016,7 +20215,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "incidents": [
                       {
@@ -20060,7 +20259,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -20250,7 +20449,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "disabled_proxy_contract": {
                       "allowed_methods": [
                         "GET"
@@ -20316,7 +20515,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -20587,7 +20786,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "endpoints": [
                       {
                         "auth_required": true,
@@ -20635,7 +20834,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -20823,7 +21022,7 @@
                         "support_summary": "Example description."
                       }
                     ],
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "schema_version": 1
@@ -20831,7 +21030,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -21067,7 +21266,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -21214,7 +21413,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -21328,7 +21527,7 @@
                 "example": {
                   "data": {
                     "candidate_count": 1,
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "coverage": [
                       {
                         "netuid": 7,
@@ -21355,7 +21554,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -21468,7 +21667,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "schema_version": 1,
@@ -21510,7 +21709,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -21717,7 +21916,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "gaps": [
                       {
                         "coverage_level": "native-only",
@@ -21745,7 +21944,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -21943,7 +22142,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "global": {},
                     "health_source": "probe-derived",
@@ -21965,7 +22164,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -22225,7 +22424,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "date": "2026-06-01",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
@@ -22252,7 +22451,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -22396,7 +22595,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -22548,7 +22747,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -22669,7 +22868,7 @@
                         "target_netuid": 7
                       }
                     ],
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "graduated_subnet_count": 1,
                     "link_count": 1,
@@ -22693,7 +22892,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -22818,7 +23017,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -23073,7 +23272,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "profiles": [
@@ -23221,7 +23420,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -23427,7 +23626,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "providers": [
@@ -23445,7 +23644,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -23567,7 +23766,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "provider": {
@@ -23598,7 +23797,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -23870,7 +24069,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "endpoints": [
                       {
                         "auth_required": true,
@@ -23924,7 +24123,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -24081,7 +24280,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -24195,7 +24394,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "counts": {
                       "candidates": 1,
                       "endpoints": 1,
@@ -24224,7 +24423,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -24520,7 +24719,7 @@
                         "suggested_next_action": "example"
                       }
                     ],
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "schema_version": 1,
@@ -24539,7 +24738,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -24805,7 +25004,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "entries": [
                       {
                         "candidate_evidence_by_kind": {},
@@ -24856,7 +25055,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -25209,7 +25408,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "queue": [
@@ -25303,7 +25502,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -25684,7 +25883,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "groups": [
                       {
@@ -25789,7 +25988,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -25996,7 +26195,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "priorities": [
@@ -26021,7 +26220,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -26288,7 +26487,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "profiles": [
@@ -26377,7 +26576,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -26650,7 +26849,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "endpoints": [
                       {
                         "chain": "bittensor",
@@ -26681,7 +26880,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -26793,7 +26992,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "disabled_proxy_contract": {
                       "allowed_methods": [
                         "GET"
@@ -26859,7 +27058,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -27026,7 +27225,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -27140,7 +27339,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "schema_version": 1,
@@ -27157,7 +27356,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -27333,7 +27532,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "document_count": 1,
                     "documents": [
                       {
@@ -27353,7 +27552,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -27529,7 +27728,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "document_count": 1,
                     "documents": [
                       {
@@ -27546,7 +27745,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -27658,7 +27857,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "providers": [
@@ -27689,7 +27888,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -27865,7 +28064,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "schema_version": 1,
@@ -27891,7 +28090,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -28284,7 +28483,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "network": "finney",
                     "notes": "Example description.",
@@ -28295,7 +28494,7 @@
                       "method": "GET",
                       "package": "example",
                       "rpc_family": "example",
-                      "version": "2026-06-06.1"
+                      "version": "2026-06-29.1"
                     },
                     "subnets": [
                       {
@@ -28313,7 +28512,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -28465,7 +28664,7 @@
                         "url": "https://api.metagraph.sh/example"
                       }
                     ],
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "economics": {
                       "alpha_in_pool": 0.5,
                       "alpha_out_pool": 0.5,
@@ -28618,7 +28817,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -28861,7 +29060,7 @@
                         "url": "https://api.metagraph.sh/example"
                       }
                     ],
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "schema_version": 1
@@ -28869,7 +29068,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -29072,7 +29271,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -29221,7 +29420,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -29493,7 +29692,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "endpoints": [
                       {
                         "auth_required": true,
@@ -29544,7 +29743,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -29710,7 +29909,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -29908,7 +30107,7 @@
                         "support_summary": "Example description."
                       }
                     ],
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "schema_version": 1
@@ -29916,7 +30115,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -30122,7 +30321,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "enrichment_queue": [
                       {
                         "adapter_score": 100,
@@ -30222,7 +30421,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -30475,7 +30674,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "health_source": "probe-derived",
                     "name": "Example Subnet",
@@ -30511,7 +30710,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -30672,7 +30871,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -30824,7 +31023,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -30973,7 +31172,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -31124,7 +31323,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -31276,7 +31475,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -31434,7 +31633,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -31595,7 +31794,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -31718,7 +31917,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "counts": {
                       "candidates": 1,
                       "endpoints": 1,
@@ -31915,7 +32114,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -32054,7 +32253,7 @@
                         "url": "https://api.metagraph.sh/example"
                       }
                     ],
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "endpoints": [
                       {
                         "auth_required": true,
@@ -32315,7 +32514,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -32526,7 +32725,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "schema_version": 1,
@@ -32546,7 +32745,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -32684,7 +32883,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -32842,7 +33041,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -33013,7 +33212,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -33155,7 +33354,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -33366,7 +33565,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "notes": "Example description.",
                     "schema_version": 1,
@@ -33386,7 +33585,7 @@
                   "meta": {
                     "artifact_path": "example",
                     "cache": "short",
-                    "contract_version": "2026-06-06.1",
+                    "contract_version": "2026-06-29.1",
                     "generated_at": "2026-06-01T00:00:00.000Z",
                     "pagination": {
                       "collection": "example",
@@ -33498,7 +33697,7 @@
   ],
   "x-metagraphed": {
     "canonical_artifact_base_path": "/metagraph",
-    "contract_version": "2026-06-06.1",
+    "contract_version": "2026-06-29.1",
     "generated_at": "1970-01-01T00:00:00.000Z",
     "notes": "OpenAPI describes Worker response envelopes and canonical artifact payloads. Raw /metagraph JSON remains the reviewed source contract.",
     "schema_version": 1

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -62,7 +62,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-counterparty fund-flow rollup for one account — its native-TAO transfers aggregated by counterparty into sent/received/net + count, ranked by total volume (the address relationship view) — computed live from the account_events D1 tier. ?limit (<=100). */
+        /** Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?limit (<=100). */
         get: operations["accountCounterparties"];
         put?: never;
         post?: never;
@@ -1641,6 +1641,41 @@ export interface components {
                 [key: string]: unknown;
             })[];
             counterparty_count: number;
+            /** @description Present only when ?counterparty=<ss58> is supplied. Pair-level transfer evidence for the requested account/counterparty relationship; summary fields cover every matching row in the bounded scan, while transfers is limited by the request limit. */
+            relationship?: {
+                counterparty: string;
+                first_block: number | null;
+                /** Format: date-time */
+                first_seen_at: string | null;
+                last_block: number | null;
+                /** Format: date-time */
+                last_seen_at: string | null;
+                /** @description Maximum number of recent transfer evidence rows returned in transfers. */
+                limit: number;
+                net_tao: number;
+                scan_capped: boolean;
+                schema_version: number;
+                ss58: string;
+                total_received_tao: number;
+                total_sent_tao: number;
+                /** @description Count of all matching account/counterparty transfer rows in the bounded scan, before the evidence list is sliced by limit. */
+                transfer_count: number;
+                /** @description Recent pair transfer evidence rows, sliced to limit. Summary counts and totals may cover more rows than this array contains. */
+                transfers: {
+                    amount_tao: number | null;
+                    block_number: number | null;
+                    /** @enum {string} */
+                    direction: "sent" | "received";
+                    event_index: number | null;
+                    from: string;
+                    netuid: number | null;
+                    /** Format: date-time */
+                    observed_at: string | null;
+                    to: string;
+                }[];
+                /** @description Raw bounded D1 pair rows inspected before malformed rows are skipped. */
+                transfers_scanned: number;
+            };
             scan_capped?: boolean;
             schema_version: number;
             ss58: string;
@@ -5147,7 +5182,7 @@ export interface operations {
                      *       "data": {
                      *         "artifact_contracts": [
                      *           {
-                     *             "contract_version": "2026-06-06.1",
+                     *             "contract_version": "2026-06-29.1",
                      *             "id": "example",
                      *             "path": "/metagraph/example.json",
                      *             "schema_ref": "#/components/schemas/Example",
@@ -5155,7 +5190,7 @@ export interface operations {
                      *           }
                      *         ],
                      *         "base_path": "/api/v1",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "openapi_url": "/api/v1/openapi.json",
@@ -5192,7 +5227,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5323,13 +5358,13 @@ export interface operations {
                      *           }
                      *         ],
                      *         "schema_version": 1,
-                     *         "ss58": "example",
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *         "subnet_count": 1
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5428,12 +5463,12 @@ export interface operations {
                      *         "balance_tao": 0.5,
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
-                     *         "ss58": "example"
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5509,6 +5544,7 @@ export interface operations {
     accountCounterparties: {
         parameters: {
             query?: {
+                counterparty?: string;
                 limit?: number;
             };
             header?: never;
@@ -5533,21 +5569,54 @@ export interface operations {
                      *       "data": {
                      *         "counterparties": [
                      *           {
-                     *             "address": "example"
+                     *             "address": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *             "last_block": 5000000,
+                     *             "net_tao": -0.5,
+                     *             "received_tao": 0,
+                     *             "sent_tao": 0.5,
+                     *             "transfer_count": 1
                      *           }
                      *         ],
                      *         "counterparty_count": 1,
+                     *         "relationship": {
+                     *           "counterparty": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+                     *           "first_block": 5000000,
+                     *           "first_seen_at": "2026-06-01T00:00:00.000Z",
+                     *           "last_block": 5000000,
+                     *           "last_seen_at": "2026-06-01T00:00:00.000Z",
+                     *           "limit": 1,
+                     *           "net_tao": -0.5,
+                     *           "scan_capped": false,
+                     *           "schema_version": 1,
+                     *           "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                     *           "total_received_tao": 0,
+                     *           "total_sent_tao": 0.5,
+                     *           "transfer_count": 1,
+                     *           "transfers": [
+                     *             {
+                     *               "amount_tao": 0.5,
+                     *               "block_number": 5000000,
+                     *               "direction": "sent",
+                     *               "event_index": 1,
+                     *               "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                     *               "netuid": 7,
+                     *               "observed_at": "2026-06-01T00:00:00.000Z",
+                     *               "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ"
+                     *             }
+                     *           ],
+                     *           "transfers_scanned": 1
+                     *         },
                      *         "scan_capped": false,
                      *         "schema_version": 1,
-                     *         "ss58": "example",
-                     *         "total_received_tao": 0.5,
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                     *         "total_received_tao": 0,
                      *         "total_sent_tao": 0.5,
                      *         "transfers_scanned": 1
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5659,12 +5728,12 @@ export interface operations {
                      *         "next_cursor": "example",
                      *         "offset": 1,
                      *         "schema_version": 1,
-                     *         "ss58": "example"
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5773,12 +5842,12 @@ export interface operations {
                      *         "limit": 1,
                      *         "offset": 1,
                      *         "schema_version": 1,
-                     *         "ss58": "example"
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5890,12 +5959,12 @@ export interface operations {
                      *         "next_cursor": "example",
                      *         "offset": 1,
                      *         "schema_version": 1,
-                     *         "ss58": "example"
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -5992,7 +6061,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "schema_version": 1,
-                     *         "ss58": "example",
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *         "subnet_count": 1,
                      *         "subnets": [
                      *           {
@@ -6003,7 +6072,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6107,20 +6176,20 @@ export interface operations {
                      *         "next_cursor": "example",
                      *         "offset": 1,
                      *         "schema_version": 1,
-                     *         "ss58": "example",
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *         "transfer_count": 1,
                      *         "transfers": [
                      *           {
                      *             "block_number": 5000000,
-                     *             "from": "example",
-                     *             "to": "example"
+                     *             "from": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                     *             "to": "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ"
                      *           }
                      *         ]
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6216,7 +6285,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "extensions": {
                      *           "example": {}
                      *         },
@@ -6231,7 +6300,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6349,7 +6418,7 @@ export interface operations {
                      *         ],
                      *         "blocker_summary": {},
                      *         "callable_service_count": 1,
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -6365,7 +6434,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6481,7 +6550,7 @@ export interface operations {
                      *           "example"
                      *         ],
                      *         "completeness_score": 100,
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "integration_readiness": 1,
                      *         "name": "Example Subnet",
@@ -6509,7 +6578,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6604,7 +6673,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "content_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "copyable_agent": {
                      *           "description": "Example description.",
                      *           "title": "Example Subnet",
@@ -6640,7 +6709,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6760,7 +6829,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6874,7 +6943,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -6984,7 +7053,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7099,7 +7168,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7214,7 +7283,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7320,7 +7389,7 @@ export interface operations {
                      *         "artifact_count": 1,
                      *         "artifact_size_bytes": 1,
                      *         "candidate_count": 1,
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "provider_count": 1,
@@ -7332,7 +7401,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7453,7 +7522,7 @@ export interface operations {
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1
@@ -7461,7 +7530,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7576,7 +7645,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7685,7 +7754,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7800,7 +7869,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -7916,7 +7985,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8040,7 +8109,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8155,7 +8224,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8260,7 +8329,7 @@ export interface operations {
                      *             "example"
                      *           ]
                      *         },
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -8289,7 +8358,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8407,7 +8476,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8503,7 +8572,7 @@ export interface operations {
                      *       "data": {
                      *         "artifacts": [
                      *           {
-                     *             "contract_version": "2026-06-06.1",
+                     *             "contract_version": "2026-06-29.1",
                      *             "id": "example",
                      *             "path": "/metagraph/example.json",
                      *             "schema_ref": "#/components/schemas/Example",
@@ -8511,7 +8580,7 @@ export interface operations {
                      *           }
                      *         ],
                      *         "base_path": "/metagraph",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "name": "Example Subnet",
                      *         "notes": "Example description.",
@@ -8524,7 +8593,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8632,7 +8701,7 @@ export interface operations {
                      *           "score_distribution": {},
                      *           "scored_subnet_count": 1
                      *         },
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "curated_overlay_count": 1,
                      *         "curation_level_counts": {
                      *           "example": 1
@@ -8659,7 +8728,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8766,7 +8835,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "coverage_depth_version": 1,
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
@@ -8856,7 +8925,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -8960,7 +9029,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "curation": [
                      *           {
                      *             "candidate_count": 1,
@@ -8993,7 +9062,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9099,7 +9168,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "captured_at": "2026-06-01T00:00:00.000Z",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "network": "example",
                      *         "notes": "Example description.",
@@ -9139,7 +9208,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9248,7 +9317,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9356,7 +9425,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "incidents": [
                      *           {
@@ -9400,7 +9469,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9504,7 +9573,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "disabled_proxy_contract": {
                      *           "allowed_methods": [
                      *             "GET"
@@ -9570,7 +9639,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9679,7 +9748,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "endpoints": [
                      *           {
                      *             "auth_required": true,
@@ -9727,7 +9796,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9842,7 +9911,7 @@ export interface operations {
                      *             "support_summary": "Example description."
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1
@@ -9850,7 +9919,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -9972,7 +10041,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10093,7 +10162,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10188,7 +10257,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "candidate_count": 1,
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "coverage": [
                      *           {
                      *             "netuid": 7,
@@ -10215,7 +10284,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10309,7 +10378,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -10351,7 +10420,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10456,7 +10525,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "gaps": [
                      *           {
                      *             "coverage_level": "native-only",
@@ -10484,7 +10553,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10588,7 +10657,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "global": {},
                      *         "health_source": "probe-derived",
@@ -10610,7 +10679,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10719,7 +10788,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "date": "2026-06-01",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
@@ -10746,7 +10815,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10872,7 +10941,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -10994,7 +11063,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -11096,7 +11165,7 @@ export interface operations {
                      *             "target_netuid": 7
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "graduated_subnet_count": 1,
                      *         "link_count": 1,
@@ -11120,7 +11189,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -11226,7 +11295,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -11335,7 +11404,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "profiles": [
@@ -11483,7 +11552,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -11588,7 +11657,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "providers": [
@@ -11606,7 +11675,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -11702,7 +11771,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "provider": {
@@ -11733,7 +11802,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -11843,7 +11912,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "endpoints": [
                      *           {
                      *             "auth_required": true,
@@ -11897,7 +11966,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12007,7 +12076,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12101,7 +12170,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "counts": {
                      *           "candidates": 1,
                      *           "endpoints": 1,
@@ -12130,7 +12199,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12266,7 +12335,7 @@ export interface operations {
                      *             "suggested_next_action": "example"
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -12285,7 +12354,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12393,7 +12462,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "entries": [
                      *           {
                      *             "candidate_evidence_by_kind": {},
@@ -12444,7 +12513,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12558,7 +12627,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "queue": [
@@ -12652,7 +12721,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12768,7 +12837,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "groups": [
                      *           {
@@ -12873,7 +12942,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -12978,7 +13047,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "priorities": [
@@ -13003,7 +13072,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13111,7 +13180,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "profiles": [
@@ -13200,7 +13269,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13309,7 +13378,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "endpoints": [
                      *           {
                      *             "chain": "bittensor",
@@ -13340,7 +13409,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13434,7 +13503,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "disabled_proxy_contract": {
                      *           "allowed_methods": [
                      *             "GET"
@@ -13500,7 +13569,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13638,7 +13707,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13732,7 +13801,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -13749,7 +13818,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13852,7 +13921,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "document_count": 1,
                      *         "documents": [
                      *           {
@@ -13872,7 +13941,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -13975,7 +14044,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "document_count": 1,
                      *         "documents": [
                      *           {
@@ -13992,7 +14061,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -14086,7 +14155,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "providers": [
@@ -14117,7 +14186,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -14220,7 +14289,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -14246,7 +14315,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -14370,7 +14439,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "network": "finney",
                      *         "notes": "Example description.",
@@ -14381,7 +14450,7 @@ export interface operations {
                      *           "method": "GET",
                      *           "package": "example",
                      *           "rpc_family": "example",
-                     *           "version": "2026-06-06.1"
+                     *           "version": "2026-06-29.1"
                      *         },
                      *         "subnets": [
                      *           {
@@ -14399,7 +14468,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -14525,7 +14594,7 @@ export interface operations {
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "economics": {
                      *           "alpha_in_pool": 0.5,
                      *           "alpha_out_pool": 0.5,
@@ -14678,7 +14747,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -14800,7 +14869,7 @@ export interface operations {
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1
@@ -14808,7 +14877,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -14984,7 +15053,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15095,7 +15164,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15205,7 +15274,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "endpoints": [
                      *           {
                      *             "auth_required": true,
@@ -15256,7 +15325,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15372,7 +15441,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15489,7 +15558,7 @@ export interface operations {
                      *             "support_summary": "Example description."
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1
@@ -15497,7 +15566,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15603,7 +15672,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "enrichment_queue": [
                      *           {
                      *             "adapter_score": 100,
@@ -15703,7 +15772,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15811,7 +15880,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "health_source": "probe-derived",
                      *         "name": "Example Subnet",
@@ -15847,7 +15916,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -15971,7 +16040,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16085,7 +16154,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16206,7 +16275,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16317,7 +16386,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16433,7 +16502,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16556,7 +16625,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16669,7 +16738,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -16765,7 +16834,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "counts": {
                      *           "candidates": 1,
                      *           "endpoints": 1,
@@ -16962,7 +17031,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -17073,7 +17142,7 @@ export interface operations {
                      *             "url": "https://api.metagraph.sh/example"
                      *           }
                      *         ],
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "endpoints": [
                      *           {
                      *             "auth_required": true,
@@ -17334,7 +17403,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -17440,7 +17509,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -17460,7 +17529,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -17571,7 +17640,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -17689,7 +17758,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -17823,7 +17892,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -17937,7 +18006,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
@@ -18042,7 +18111,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "schema_version": 1,
@@ -18062,7 +18131,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "example",
                      *         "cache": "short",
-                     *         "contract_version": "2026-06-06.1",
+                     *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -100,6 +100,7 @@
               "additionalProperties": true,
               "properties": {
                 "address": {
+                  "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
                   "type": "string"
                 },
                 "last_block": {
@@ -133,6 +134,161 @@
             "minimum": 0,
             "type": "integer"
           },
+          "relationship": {
+            "additionalProperties": false,
+            "description": "Present only when ?counterparty=<ss58> is supplied. Pair-level transfer evidence for the requested account/counterparty relationship; summary fields cover every matching row in the bounded scan, while transfers is limited by the request limit.",
+            "properties": {
+              "counterparty": {
+                "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
+                "type": "string"
+              },
+              "first_block": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "first_seen_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "last_block": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "last_seen_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "limit": {
+                "description": "Maximum number of recent transfer evidence rows returned in transfers.",
+                "maximum": 100,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "net_tao": {
+                "type": "number"
+              },
+              "scan_capped": {
+                "type": "boolean"
+              },
+              "schema_version": {
+                "type": "integer"
+              },
+              "ss58": {
+                "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
+                "type": "string"
+              },
+              "total_received_tao": {
+                "type": "number"
+              },
+              "total_sent_tao": {
+                "type": "number"
+              },
+              "transfer_count": {
+                "description": "Count of all matching account/counterparty transfer rows in the bounded scan, before the evidence list is sliced by limit.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "transfers": {
+                "description": "Recent pair transfer evidence rows, sliced to limit. Summary counts and totals may cover more rows than this array contains.",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "amount_tao": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "block_number": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "direction": {
+                      "enum": [
+                        "sent",
+                        "received"
+                      ],
+                      "type": "string"
+                    },
+                    "event_index": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "from": {
+                      "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
+                      "type": "string"
+                    },
+                    "netuid": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "observed_at": {
+                      "format": "date-time",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "to": {
+                      "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "block_number",
+                    "event_index",
+                    "netuid",
+                    "from",
+                    "to",
+                    "amount_tao",
+                    "direction",
+                    "observed_at"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "transfers_scanned": {
+                "description": "Raw bounded D1 pair rows inspected before malformed rows are skipped.",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "schema_version",
+              "ss58",
+              "counterparty",
+              "transfer_count",
+              "transfers_scanned",
+              "scan_capped",
+              "total_sent_tao",
+              "total_received_tao",
+              "net_tao",
+              "first_block",
+              "last_block",
+              "first_seen_at",
+              "last_seen_at",
+              "limit",
+              "transfers"
+            ],
+            "type": "object"
+          },
           "scan_capped": {
             "type": "boolean"
           },
@@ -140,6 +296,7 @@
             "type": "integer"
           },
           "ss58": {
+            "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
             "type": "string"
           },
           "total_received_tao": {

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1749,7 +1749,10 @@
         ],
         "properties": {
           "schema_version": { "type": "integer" },
-          "ss58": { "type": "string" },
+          "ss58": {
+            "type": "string",
+            "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$"
+          },
           "counterparty_count": { "type": "integer", "minimum": 0 },
           "transfers_scanned": { "type": "integer", "minimum": 0 },
           "scan_capped": { "type": "boolean" },
@@ -1762,12 +1765,118 @@
               "additionalProperties": true,
               "required": ["address"],
               "properties": {
-                "address": { "type": "string" },
+                "address": {
+                  "type": "string",
+                  "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$"
+                },
                 "sent_tao": { "type": "number" },
                 "received_tao": { "type": "number" },
                 "net_tao": { "type": "number" },
                 "transfer_count": { "type": "integer", "minimum": 0 },
                 "last_block": { "type": ["integer", "null"] }
+              }
+            }
+          },
+          "relationship": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Present only when ?counterparty=<ss58> is supplied. Pair-level transfer evidence for the requested account/counterparty relationship; summary fields cover every matching row in the bounded scan, while transfers is limited by the request limit.",
+            "required": [
+              "schema_version",
+              "ss58",
+              "counterparty",
+              "transfer_count",
+              "transfers_scanned",
+              "scan_capped",
+              "total_sent_tao",
+              "total_received_tao",
+              "net_tao",
+              "first_block",
+              "last_block",
+              "first_seen_at",
+              "last_seen_at",
+              "limit",
+              "transfers"
+            ],
+            "properties": {
+              "schema_version": { "type": "integer" },
+              "ss58": {
+                "type": "string",
+                "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$"
+              },
+              "counterparty": {
+                "type": "string",
+                "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$"
+              },
+              "transfer_count": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Count of all matching account/counterparty transfer rows in the bounded scan, before the evidence list is sliced by limit."
+              },
+              "transfers_scanned": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Raw bounded D1 pair rows inspected before malformed rows are skipped."
+              },
+              "scan_capped": { "type": "boolean" },
+              "total_sent_tao": { "type": "number" },
+              "total_received_tao": { "type": "number" },
+              "net_tao": { "type": "number" },
+              "first_block": { "type": ["integer", "null"] },
+              "last_block": { "type": ["integer", "null"] },
+              "first_seen_at": {
+                "type": ["string", "null"],
+                "format": "date-time"
+              },
+              "last_seen_at": {
+                "type": ["string", "null"],
+                "format": "date-time"
+              },
+              "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100,
+                "description": "Maximum number of recent transfer evidence rows returned in transfers."
+              },
+              "transfers": {
+                "type": "array",
+                "description": "Recent pair transfer evidence rows, sliced to limit. Summary counts and totals may cover more rows than this array contains.",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "block_number",
+                    "event_index",
+                    "netuid",
+                    "from",
+                    "to",
+                    "amount_tao",
+                    "direction",
+                    "observed_at"
+                  ],
+                  "properties": {
+                    "block_number": { "type": ["integer", "null"] },
+                    "event_index": { "type": ["integer", "null"] },
+                    "netuid": { "type": ["integer", "null"] },
+                    "from": {
+                      "type": "string",
+                      "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$"
+                    },
+                    "to": {
+                      "type": "string",
+                      "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$"
+                    },
+                    "amount_tao": { "type": ["number", "null"] },
+                    "direction": {
+                      "type": "string",
+                      "enum": ["sent", "received"]
+                    },
+                    "observed_at": {
+                      "type": ["string", "null"],
+                      "format": "date-time"
+                    }
+                  }
+                }
               }
             }
           }

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
 import path from "node:path";
-import { API_ROUTES, compileRoutePattern } from "../src/contracts.mjs";
+import {
+  API_ROUTES,
+  CONTRACT_VERSION,
+  compileRoutePattern,
+} from "../src/contracts.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import {
   createLocalArtifactEnv,
@@ -783,7 +787,7 @@ for (const [route, assertion] of checks) {
   assert.ok(response.headers.get("etag"), `${route}: missing ETag`);
   assert.equal(
     response.headers.get("x-metagraph-contract-version"),
-    "2026-06-06.1",
+    CONTRACT_VERSION,
     `${route}: missing contract header`,
   );
   const body = await response.json();
@@ -931,7 +935,7 @@ const r2Fallback = await handleRequest(
           async json() {
             return {
               schema_version: 1,
-              contract_version: "2026-06-06.1",
+              contract_version: CONTRACT_VERSION,
               generated_at: "1970-01-01T00:00:00.000Z",
               source: "generated-artifact-diff",
             };

--- a/scripts/worker-test.mjs
+++ b/scripts/worker-test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "./lib.mjs";
 
@@ -99,7 +100,7 @@ const r2Fallback = await handleRequest(
           async json() {
             return {
               schema_version: 1,
-              contract_version: "2026-06-06.1",
+              contract_version: CONTRACT_VERSION,
               generated_at: "1970-01-01T00:00:00.000Z",
               source: "generated-artifact-diff",
             };
@@ -166,7 +167,7 @@ for (const unsafeUrl of [
   try {
     const unsafePoolArtifact = {
       schema_version: 1,
-      contract_version: "2026-06-06.1",
+      contract_version: CONTRACT_VERSION,
       generated_at: "1970-01-01T00:00:00.000Z",
       pools: [
         {
@@ -258,7 +259,7 @@ globalThis.fetch = async (url, init) => {
 try {
   const safePoolArtifact = {
     schema_version: 1,
-    contract_version: "2026-06-06.1",
+    contract_version: CONTRACT_VERSION,
     generated_at: "1970-01-01T00:00:00.000Z",
     pools: [
       {

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2,7 +2,7 @@ import { artifactStorageTierForPath } from "./artifact-storage.mjs";
 import { DOMAIN_TAGS } from "./domain-tags.mjs";
 import { sampleFromSchema } from "./openapi-sample.mjs";
 
-export const CONTRACT_VERSION = "2026-06-06.1";
+export const CONTRACT_VERSION = "2026-06-29.1";
 export const SCHEMA_VERSION = 1;
 // The API + artifacts are served from the api subdomain; the bare apex
 // (metagraph.sh) is the metagraphed-ui UI. PRIMARY_DOMAIN drives the OpenAPI
@@ -1005,7 +1005,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "account-counterparties",
     "/metagraph/accounts/{ss58}/counterparties.json",
-    "Per-counterparty fund-flow rollup for one account — its native-TAO transfers aggregated by counterparty into sent/received/net + count, ranked by total volume — served live from the account_events D1 tier at /api/v1/accounts/{ss58}/counterparties (no static file).",
+    "Per-counterparty fund-flow rollup for one account, with optional ?counterparty=<ss58> relationship evidence — native-TAO transfers from the account_events D1 tier at /api/v1/accounts/{ss58}/counterparties (no static file).",
     "AccountCounterpartiesArtifact",
   ),
   artifact(
@@ -1912,10 +1912,16 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/counterparties",
     "/metagraph/accounts/{ss58}/counterparties.json",
-    "Fetch the per-counterparty fund-flow rollup for one account — its native-TAO transfers aggregated by counterparty into sent/received/net + count, ranked by total volume (the address relationship view) — computed live from the account_events D1 tier. ?limit (<=100).",
+    "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?limit (<=100).",
     "short",
     ["accounts", "analytics"],
-    [{ name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } }],
+    [
+      {
+        name: "counterparty",
+        schema: { type: "string", pattern: "^[1-9A-HJ-NP-Za-km-z]{47,48}$" },
+      },
+      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
+    ],
     [{ name: "ss58", schema: { type: "string" } }],
   ),
   route(

--- a/src/counterparties.mjs
+++ b/src/counterparties.mjs
@@ -11,9 +11,13 @@
 export const COUNTERPARTIES_READ_COLUMNS =
   "hotkey, coldkey, amount_tao, block_number";
 
+export const COUNTERPARTY_RELATIONSHIP_READ_COLUMNS =
+  "block_number, event_index, hotkey, coldkey, netuid, amount_tao, observed_at";
+
 // Bound the transfer scan so a hot wallet can't force an unbounded read. Rows are
 // read newest-first; the summary flags when the cap truncated older history.
 export const COUNTERPARTIES_SCAN_CAP = 5000;
+export const COUNTERPARTY_RELATIONSHIP_SCAN_CAP = 5000;
 
 // Coerce one raw cell to a finite number (or 0) for summation.
 function numeric(value) {
@@ -27,6 +31,28 @@ function round(value, dp = 9) {
   if (!Number.isFinite(value)) return 0;
   const factor = 10 ** dp;
   return Math.round(value * factor) / factor;
+}
+
+function nullableNumber(value) {
+  if (value == null || value === "") return null;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? round(n) : null;
+}
+
+function nullableInteger(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : null;
+}
+
+function nullableTimestamp(value) {
+  if (value == null) return null;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function toIso(timestamp) {
+  return timestamp == null ? null : new Date(timestamp).toISOString();
 }
 
 // Aggregate an account's Transfer rows into per-counterparty fund flow: for each
@@ -115,5 +141,82 @@ export function buildCounterparties(rows, ss58, { limit = 20 } = {}) {
     total_sent_tao: round(totalSent),
     total_received_tao: round(totalReceived),
     counterparties: ranked.slice(0, cap),
+  };
+}
+
+// Drill into ONE account/counterparty relationship. The handler reads a bounded
+// newest-first pair scan; this builder summarizes that scan and returns the first
+// `limit` transfer rows as evidence, preserving the account-relative direction.
+export function buildCounterpartyRelationship(
+  rows,
+  ss58,
+  counterparty,
+  { limit = 50 } = {},
+) {
+  const list = Array.isArray(rows) ? rows : [];
+  const transfers = [];
+  let totalSent = 0;
+  let totalReceived = 0;
+  let firstBlock = null;
+  let lastBlock = null;
+  let firstObserved = null;
+  let lastObserved = null;
+
+  for (const row of list) {
+    if (ss58 === counterparty) continue;
+    if (!row || typeof row !== "object") continue;
+    const from = row.hotkey ?? null;
+    const to = row.coldkey ?? null;
+    const sent = from === ss58 && to === counterparty;
+    const received = from === counterparty && to === ss58;
+    if (!sent && !received) continue;
+
+    const amount = nullableNumber(row.amount_tao);
+    if (amount == null) continue;
+    if (sent) totalSent += amount;
+    if (received) totalReceived += amount;
+
+    const block = nullableInteger(row.block_number);
+    if (block != null) {
+      firstBlock = firstBlock == null ? block : Math.min(firstBlock, block);
+      lastBlock = lastBlock == null ? block : Math.max(lastBlock, block);
+    }
+    const observed = nullableTimestamp(row.observed_at);
+    if (observed != null) {
+      firstObserved =
+        firstObserved == null ? observed : Math.min(firstObserved, observed);
+      lastObserved =
+        lastObserved == null ? observed : Math.max(lastObserved, observed);
+    }
+
+    transfers.push({
+      block_number: block,
+      event_index: nullableInteger(row.event_index),
+      netuid: nullableInteger(row.netuid),
+      from,
+      to,
+      amount_tao: amount,
+      direction: sent ? "sent" : "received",
+      observed_at: toIso(observed),
+    });
+  }
+
+  const cap = Math.max(1, Math.min(limit, 100));
+  return {
+    schema_version: 1,
+    ss58,
+    counterparty,
+    transfer_count: transfers.length,
+    transfers_scanned: list.length,
+    scan_capped: list.length >= COUNTERPARTY_RELATIONSHIP_SCAN_CAP,
+    total_sent_tao: round(totalSent),
+    total_received_tao: round(totalReceived),
+    net_tao: round(totalReceived - totalSent),
+    first_block: firstBlock,
+    last_block: lastBlock,
+    first_seen_at: toIso(firstObserved),
+    last_seen_at: toIso(lastObserved),
+    limit: cap,
+    transfers: transfers.slice(0, cap),
   };
 }

--- a/src/openapi-sample.mjs
+++ b/src/openapi-sample.mjs
@@ -14,11 +14,19 @@ const OPTIONAL_DEPTH = 3;
 const MAX_DEPTH = 8;
 const ISO = "2026-06-01T00:00:00.000Z";
 const HEX64 = "a3f1".repeat(16); // 64 hex chars, matches ^[a-f0-9]{64}$
+const SAMPLE_SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+const SAMPLE_COUNTERPARTY_SS58 =
+  "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ";
 
-function valueForPattern(pattern) {
+function valueForPattern(pattern, name = "") {
+  const n = String(name || "").toLowerCase();
   switch (pattern) {
     case "^[a-f0-9]{64}$":
       return HEX64;
+    case "^[1-9A-HJ-NP-Za-km-z]{47,48}$":
+      return /counterparty|^to$|address/.test(n)
+        ? SAMPLE_COUNTERPARTY_SS58
+        : SAMPLE_SS58;
     case "^\\d{4}-\\d{2}-\\d{2}$":
       return "2026-06-01";
     case "^[a-z0-9][a-z0-9-]*$":
@@ -52,13 +60,15 @@ function seededString(name) {
   }
   if (/(^day$|^date$)/.test(n)) return "2026-06-01";
   if (/window/.test(n)) return "30d";
+  if (n === "ss58" || n === "from") return SAMPLE_SS58;
+  if (n === "counterparty" || n === "to") return SAMPLE_COUNTERPARTY_SS58;
   if (/slug/.test(n)) return "example-subnet";
   if (/(^name$|title|subnet_name|display_name)/.test(n))
     return "Example Subnet";
   if (/(description|^notes$|instructions|summary$)/.test(n)) {
     return "Example description.";
   }
-  if (/version/.test(n)) return "2026-06-06.1";
+  if (/version/.test(n)) return "2026-06-29.1";
   if (/(provider|operator)/.test(n)) return "example-provider";
   if (/(content_hash|_hash$|^hash$)/.test(n)) return HEX64;
   if (/health_source/.test(n)) return "probe-derived";
@@ -97,6 +107,88 @@ function seededBoolean(name) {
   return /(required|^enabled$|public_safe|^ok$|supported)/.test(
     String(name || "").toLowerCase(),
   );
+}
+
+function sampleAmount(value) {
+  const amount = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(amount) ? amount : 0;
+}
+
+function normalizeCounterpartyRelationshipSample(out) {
+  if (
+    !out ||
+    typeof out !== "object" ||
+    !Array.isArray(out.transfers) ||
+    !("counterparty" in out) ||
+    !("total_sent_tao" in out) ||
+    !("total_received_tao" in out) ||
+    !("net_tao" in out)
+  ) {
+    return out;
+  }
+
+  let totalSent = 0;
+  let totalReceived = 0;
+  let transferCount = 0;
+  for (const transfer of out.transfers) {
+    if (!transfer || typeof transfer !== "object") continue;
+    const amount = sampleAmount(transfer.amount_tao);
+    if (transfer.direction === "sent") {
+      totalSent += amount;
+      transferCount += 1;
+    } else if (transfer.direction === "received") {
+      totalReceived += amount;
+      transferCount += 1;
+    }
+  }
+
+  out.total_sent_tao = totalSent;
+  out.total_received_tao = totalReceived;
+  out.net_tao = totalReceived - totalSent;
+  out.transfer_count = transferCount;
+  return out;
+}
+
+function normalizeAccountCounterpartiesSample(out) {
+  if (
+    !out ||
+    typeof out !== "object" ||
+    !out.relationship ||
+    typeof out.relationship !== "object" ||
+    !Array.isArray(out.counterparties)
+  ) {
+    return out;
+  }
+
+  const relationship = normalizeCounterpartyRelationshipSample(
+    out.relationship,
+  );
+  out.relationship = relationship;
+  out.total_sent_tao = relationship.total_sent_tao;
+  out.total_received_tao = relationship.total_received_tao;
+  out.transfers_scanned = relationship.transfers_scanned;
+  out.scan_capped = relationship.scan_capped;
+  out.counterparties =
+    relationship.transfer_count === 0
+      ? []
+      : [
+          {
+            address: relationship.counterparty,
+            sent_tao: relationship.total_sent_tao,
+            received_tao: relationship.total_received_tao,
+            net_tao: relationship.net_tao,
+            transfer_count: relationship.transfer_count,
+            last_block: relationship.last_block,
+          },
+        ];
+  out.counterparty_count = out.counterparties.length;
+  return out;
+}
+
+function normalizeObjectSample(out) {
+  normalizeCounterpartyRelationshipSample(out);
+  normalizeAccountCounterpartiesSample(out);
+  return out;
 }
 
 function pickType(type) {
@@ -221,7 +313,7 @@ export function sampleFromSchema(
         activeRefs,
       );
     }
-    return out;
+    return normalizeObjectSample(out);
   }
 
   if (type === "array") {
@@ -238,7 +330,7 @@ export function sampleFromSchema(
   }
 
   if (type === "string") {
-    if (schema.pattern) return valueForPattern(schema.pattern);
+    if (schema.pattern) return valueForPattern(schema.pattern, name);
     if (schema.format === "uri") return "https://api.metagraph.sh/example";
     if (schema.format === "date-time") return ISO;
     return seededString(name);

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -28,6 +28,7 @@ import {
   registrySurfaceKey,
   isSurfaceStale,
 } from "../scripts/lib.mjs";
+import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import { handleRequest } from "../workers/api.mjs";
 
 // The committed digests the forged-build tests snapshot + restore (so a forged
@@ -2414,7 +2415,7 @@ test("Worker API serves public artifact envelopes", async () => {
   assert.equal(response.headers.get("access-control-allow-origin"), "*");
   assert.equal(
     response.headers.get("x-metagraph-contract-version"),
-    "2026-06-06.1",
+    CONTRACT_VERSION,
   );
   const body = await response.json();
   assert.equal(body.ok, true);

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -19,7 +19,7 @@ import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
 
 describe("public contract registry", () => {
   test("keeps API routes and artifacts unique", () => {
-    assert.equal(CONTRACT_VERSION, "2026-06-06.1");
+    assert.equal(CONTRACT_VERSION, "2026-06-29.1");
     assert.equal(CACHE_SECONDS.short, 60);
     assert.equal(
       new Set(API_ROUTES.map((route) => route.id)).size,

--- a/tests/counterparties.test.mjs
+++ b/tests/counterparties.test.mjs
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   buildCounterparties,
+  buildCounterpartyRelationship,
   COUNTERPARTIES_SCAN_CAP,
+  COUNTERPARTY_RELATIONSHIP_SCAN_CAP,
 } from "../src/counterparties.mjs";
 
 const ME = "ME";
@@ -101,6 +103,209 @@ describe("buildCounterparties", () => {
     assert.equal(data.scan_capped, true);
     assert.equal(data.counterparty_count, COUNTERPARTIES_SCAN_CAP);
     assert.equal(data.counterparties.length, 10);
+  });
+});
+
+describe("buildCounterpartyRelationship", () => {
+  test("cold / empty / non-array rows yield a schema-stable empty relationship", () => {
+    for (const rows of [[], null, undefined]) {
+      const data = buildCounterpartyRelationship(rows, ME, "A", {});
+      assert.equal(data.ss58, ME);
+      assert.equal(data.counterparty, "A");
+      assert.equal(data.transfer_count, 0);
+      assert.equal(data.transfers_scanned, 0);
+      assert.equal(data.scan_capped, false);
+      assert.equal(data.total_sent_tao, 0);
+      assert.equal(data.total_received_tao, 0);
+      assert.equal(data.net_tao, 0);
+      assert.equal(data.first_block, null);
+      assert.equal(data.last_block, null);
+      assert.deepEqual(data.transfers, []);
+    }
+  });
+
+  test("summarizes one pair and preserves newest-first transfer evidence", () => {
+    const data = buildCounterpartyRelationship(
+      [
+        {
+          block_number: 12,
+          event_index: 2,
+          hotkey: "A",
+          coldkey: "ME",
+          netuid: "7",
+          amount_tao: 30,
+          observed_at: Date.UTC(2026, 5, 3),
+        },
+        {
+          block_number: 10,
+          event_index: 1,
+          hotkey: "ME",
+          coldkey: "A",
+          netuid: null,
+          amount_tao: 100,
+          observed_at: Date.UTC(2026, 5, 1),
+        },
+        {
+          block_number: 9,
+          event_index: 1,
+          hotkey: "ME",
+          coldkey: "B",
+          amount_tao: 5,
+        },
+      ],
+      ME,
+      "A",
+      { limit: 10 },
+    );
+    assert.equal(data.transfer_count, 2);
+    assert.equal(data.transfers_scanned, 3);
+    assert.equal(data.total_sent_tao, 100);
+    assert.equal(data.total_received_tao, 30);
+    assert.equal(data.net_tao, -70);
+    assert.equal(data.first_block, 10);
+    assert.equal(data.last_block, 12);
+    assert.equal(data.first_seen_at, "2026-06-01T00:00:00.000Z");
+    assert.equal(data.last_seen_at, "2026-06-03T00:00:00.000Z");
+    assert.equal(data.transfers[0].direction, "received");
+    assert.equal(data.transfers[0].netuid, 7);
+    assert.equal(data.transfers[0].from, "A");
+    assert.equal(data.transfers[0].to, ME);
+    assert.equal(data.transfers[1].direction, "sent");
+  });
+
+  test("does not summarize same-address relationships", () => {
+    const data = buildCounterpartyRelationship(
+      [
+        {
+          block_number: 12,
+          event_index: 2,
+          hotkey: ME,
+          coldkey: ME,
+          netuid: 7,
+          amount_tao: 30,
+          observed_at: Date.UTC(2026, 5, 3),
+        },
+      ],
+      ME,
+      ME,
+      { limit: 10 },
+    );
+    assert.equal(data.transfer_count, 0);
+    assert.equal(data.transfers_scanned, 1);
+    assert.equal(data.total_sent_tao, 0);
+    assert.equal(data.total_received_tao, 0);
+    assert.deepEqual(data.transfers, []);
+  });
+
+  test("skips malformed transfer amounts without poisoning totals", () => {
+    const data = buildCounterpartyRelationship(
+      [
+        {
+          block_number: "not-a-block",
+          event_index: -1,
+          hotkey: ME,
+          coldkey: "A",
+          netuid: undefined,
+          amount_tao: "bad",
+          observed_at: "not-a-date",
+        },
+      ],
+      ME,
+      "A",
+      {},
+    );
+    assert.equal(data.transfer_count, 0);
+    assert.equal(data.transfers_scanned, 1);
+    assert.equal(data.total_sent_tao, 0);
+    assert.equal(data.first_block, null);
+    assert.equal(data.last_block, null);
+    assert.equal(data.first_seen_at, null);
+    assert.equal(data.last_seen_at, null);
+    assert.deepEqual(data.transfers, []);
+  });
+
+  test("skips sparse pair rows while preserving valid string and null evidence cells", () => {
+    const data = buildCounterpartyRelationship(
+      [
+        null,
+        { hotkey: null, coldkey: "A", amount_tao: 5 },
+        { hotkey: ME, coldkey: null, amount_tao: 5 },
+        {
+          block_number: null,
+          event_index: null,
+          hotkey: ME,
+          coldkey: "A",
+          netuid: "7",
+          amount_tao: "2.5",
+          observed_at: Date.UTC(2026, 5, 1),
+        },
+        {
+          block_number: "not-a-block",
+          event_index: -1,
+          hotkey: ME,
+          coldkey: "A",
+          netuid: "not-a-netuid",
+          amount_tao: 3,
+          observed_at: "not-a-date",
+        },
+        {
+          block_number: 5,
+          event_index: 1,
+          hotkey: "A",
+          coldkey: ME,
+          netuid: 7,
+          amount_tao: "7.5",
+          observed_at: String(Date.UTC(2026, 5, 2)),
+        },
+        {
+          block_number: 6,
+          event_index: 2,
+          hotkey: ME,
+          coldkey: "A",
+          netuid: 8,
+          amount_tao: "",
+          observed_at: "not-a-date",
+        },
+      ],
+      ME,
+      "A",
+      {},
+    );
+    assert.equal(data.transfers_scanned, 7);
+    assert.equal(data.transfer_count, 3);
+    assert.equal(data.total_sent_tao, 5.5);
+    assert.equal(data.total_received_tao, 7.5);
+    assert.equal(data.first_block, 5);
+    assert.equal(data.last_block, 5);
+    assert.equal(data.first_seen_at, "2026-06-01T00:00:00.000Z");
+    assert.equal(data.last_seen_at, "2026-06-02T00:00:00.000Z");
+    assert.equal(data.transfers[0].amount_tao, 2.5);
+    assert.equal(data.transfers[0].event_index, null);
+    assert.equal(data.transfers[0].netuid, 7);
+    assert.equal(data.transfers[1].amount_tao, 3);
+    assert.equal(data.transfers[1].block_number, null);
+    assert.equal(data.transfers[1].event_index, null);
+    assert.equal(data.transfers[1].netuid, null);
+    assert.equal(data.transfers[1].observed_at, null);
+    assert.equal(data.transfers[2].amount_tao, 7.5);
+  });
+
+  test("limits evidence rows while summary counts the full bounded scan", () => {
+    const rows = Array.from(
+      { length: COUNTERPARTY_RELATIONSHIP_SCAN_CAP },
+      (_, i) => ({
+        block_number: i,
+        event_index: 0,
+        hotkey: "ME",
+        coldkey: "A",
+        amount_tao: 1,
+      }),
+    );
+    const data = buildCounterpartyRelationship(rows, ME, "A", { limit: 2 });
+    assert.equal(data.transfer_count, COUNTERPARTY_RELATIONSHIP_SCAN_CAP);
+    assert.equal(data.scan_capped, true);
+    assert.equal(data.total_sent_tao, COUNTERPARTY_RELATIONSHIP_SCAN_CAP);
+    assert.equal(data.transfers.length, 2);
   });
 });
 

--- a/tests/openapi-sample.test.mjs
+++ b/tests/openapi-sample.test.mjs
@@ -93,6 +93,10 @@ describe("sampleFromSchema", () => {
       status: "ok",
       grade: "A",
       method: "GET",
+      ss58: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+      from: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+      counterparty: "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+      to: "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
       surface_id: "example",
       unmatched_field: "example",
     };
@@ -117,6 +121,17 @@ describe("sampleFromSchema", () => {
     assert.equal(
       s({ type: "string", pattern: "^\\d{4}-\\d{2}-\\d{2}$" }),
       "2026-06-01",
+    );
+    assert.equal(
+      s({ type: "string", pattern: "^[1-9A-HJ-NP-Za-km-z]{47,48}$" }, "ss58"),
+      "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+    );
+    assert.equal(
+      s(
+        { type: "string", pattern: "^[1-9A-HJ-NP-Za-km-z]{47,48}$" },
+        "counterparty",
+      ),
+      "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
     );
     assert.match(
       s({ type: "string", pattern: "^[a-z0-9][a-z0-9-]*$" }),
@@ -189,12 +204,158 @@ describe("sampleFromSchema", () => {
     // description/summary-style string fields
     assert.equal(s({ type: "string" }, "description"), "Example description.");
     assert.equal(s({ type: "string" }, "summary"), "Example description.");
-    assert.equal(s({ type: "string" }, "version"), "2026-06-06.1");
+    assert.equal(s({ type: "string" }, "version"), "2026-06-29.1");
     // clamp DOWN to maximum (block seeds high, capped here)
     assert.equal(s({ type: "integer", maximum: 3 }, "block"), 3);
     // allOf whose only member is a scalar -> returns that scalar
     assert.equal(s({ allOf: [{ const: "x" }] }), "x");
     assert.equal(s({ allOf: [{ type: "string" }] }), "example");
+  });
+
+  test("counterparty relationship samples keep totals consistent with evidence", () => {
+    const ss58Pattern = "^[1-9A-HJ-NP-Za-km-z]{47,48}$";
+    const relationshipSchema = {
+      type: "object",
+      required: [
+        "schema_version",
+        "ss58",
+        "counterparty",
+        "transfer_count",
+        "transfers_scanned",
+        "scan_capped",
+        "total_sent_tao",
+        "total_received_tao",
+        "net_tao",
+        "first_block",
+        "last_block",
+        "limit",
+        "transfers",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string", pattern: ss58Pattern },
+        counterparty: { type: "string", pattern: ss58Pattern },
+        transfer_count: { type: "integer" },
+        transfers_scanned: { type: "integer" },
+        scan_capped: { type: "boolean" },
+        total_sent_tao: { type: "number" },
+        total_received_tao: { type: "number" },
+        net_tao: { type: "number" },
+        first_block: { type: ["integer", "null"] },
+        last_block: { type: ["integer", "null"] },
+        limit: { type: "integer" },
+        transfers: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["from", "to", "amount_tao", "direction"],
+            properties: {
+              from: { type: "string", pattern: ss58Pattern },
+              to: { type: "string", pattern: ss58Pattern },
+              amount_tao: { type: "number" },
+              direction: { enum: ["sent", "received"] },
+            },
+          },
+        },
+      },
+    };
+    const accountCounterpartiesSchema = {
+      type: "object",
+      required: [
+        "schema_version",
+        "ss58",
+        "counterparty_count",
+        "counterparties",
+        "transfers_scanned",
+        "scan_capped",
+        "total_sent_tao",
+        "total_received_tao",
+        "relationship",
+      ],
+      properties: {
+        schema_version: { type: "integer" },
+        ss58: { type: "string", pattern: ss58Pattern },
+        counterparty_count: { type: "integer" },
+        counterparties: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["address"],
+            properties: {
+              address: { type: "string", pattern: ss58Pattern },
+              sent_tao: { type: "number" },
+              received_tao: { type: "number" },
+              net_tao: { type: "number" },
+              transfer_count: { type: "integer" },
+              last_block: { type: ["integer", "null"] },
+            },
+          },
+        },
+        transfers_scanned: { type: "integer" },
+        scan_capped: { type: "boolean" },
+        total_sent_tao: { type: "number" },
+        total_received_tao: { type: "number" },
+        relationship: relationshipSchema,
+      },
+    };
+    const sample = s(accountCounterpartiesSchema, "data");
+
+    assert.equal(sample.relationship.transfers[0].direction, "sent");
+    assert.equal(sample.relationship.total_sent_tao, 0.5);
+    assert.equal(sample.relationship.total_received_tao, 0);
+    assert.equal(sample.relationship.net_tao, -0.5);
+    assert.equal(sample.total_sent_tao, 0.5);
+    assert.equal(sample.total_received_tao, 0);
+    assert.deepEqual(sample.counterparties, [
+      {
+        address: "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ",
+        sent_tao: 0.5,
+        received_tao: 0,
+        net_tao: -0.5,
+        transfer_count: 1,
+        last_block: 5000000,
+      },
+    ]);
+
+    const receivedRelationshipSchema = JSON.parse(
+      JSON.stringify(relationshipSchema),
+    );
+    receivedRelationshipSchema.properties.transfers.items.properties.direction.enum =
+      ["received", "sent"];
+    const receivedSample = s(receivedRelationshipSchema, "relationship");
+    assert.equal(receivedSample.transfers[0].direction, "received");
+    assert.equal(receivedSample.total_sent_tao, 0);
+    assert.equal(receivedSample.total_received_tao, 0.5);
+    assert.equal(receivedSample.net_tao, 0.5);
+
+    const badAmountRelationshipSchema = JSON.parse(
+      JSON.stringify(relationshipSchema),
+    );
+    badAmountRelationshipSchema.properties.transfers.items.properties.amount_tao =
+      { const: "bad" };
+    const badAmountSample = s(badAmountRelationshipSchema, "relationship");
+    assert.equal(badAmountSample.total_sent_tao, 0);
+    assert.equal(badAmountSample.transfer_count, 1);
+
+    const ignoredDirectionSchema = JSON.parse(
+      JSON.stringify(relationshipSchema),
+    );
+    ignoredDirectionSchema.properties.transfers.items.properties.direction.enum =
+      ["ignored"];
+    const ignoredSample = s(ignoredDirectionSchema, "relationship");
+    assert.equal(ignoredSample.transfer_count, 0);
+    assert.equal(ignoredSample.total_sent_tao, 0);
+    assert.equal(ignoredSample.total_received_tao, 0);
+
+    const emptyAccountSchema = JSON.parse(
+      JSON.stringify(accountCounterpartiesSchema),
+    );
+    emptyAccountSchema.properties.relationship.properties.transfers.items = {
+      type: "null",
+    };
+    const emptySample = s(emptyAccountSchema, "data");
+    assert.equal(emptySample.relationship.transfer_count, 0);
+    assert.deepEqual(emptySample.counterparties, []);
   });
 
   test("bounds recursion: deep objects drop optionals, deep arrays bottom out", () => {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -5,7 +5,11 @@
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { buildOpenApiArtifact } from "../src/contracts.mjs";
 import { encodeCursor } from "../src/cursor.mjs";
+import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
 import {
   handleSubnetMetagraph,
   handleNeuron,
@@ -34,6 +38,7 @@ import {
 } from "../workers/request-handlers/entities.mjs";
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+const COUNTERPARTY = "5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ";
 const HASH = `0x${"a".repeat(64)}`;
 const NETUID = 7;
 const UID = 3;
@@ -197,6 +202,7 @@ function dbWith({
   accountEvents,
   accountEventsDaily,
   transfers,
+  relationshipTransfers,
   subnetEvents,
   blockEvents,
   extrinsicEvents,
@@ -297,6 +303,15 @@ function dbWith({
                     )
                   ) {
                     return { results: blockEvents || [] };
+                  }
+                  // Account/counterparty pair detail: bounded Transfer scan for
+                  // both directions between two specific SS58 addresses.
+                  if (
+                    /event_kind = 'Transfer' AND \(\(hotkey = \? AND coldkey = \?\) OR \(hotkey = \? AND coldkey = \?\)\)/.test(
+                      sql,
+                    )
+                  ) {
+                    return { results: relationshipTransfers || [] };
                   }
                   // Native transfer feed.
                   if (/event_kind = 'Transfer'/.test(sql)) {
@@ -421,6 +436,22 @@ async function assertColdSchema(handlerFn, ...args) {
   const body = await res.json();
   assert.equal(body.ok, true);
   return body;
+}
+
+async function assertValidComponent(componentName, data) {
+  const generatedAt = "2026-06-24T12:00:00.000Z";
+  const openapi = buildOpenApiArtifact(
+    generatedAt,
+    await loadOpenApiComponentSchemas(generatedAt),
+  );
+  const ajv = new Ajv2020({ strict: false, allErrors: true });
+  addFormats(ajv);
+  const validate = ajv.compile({
+    $id: `https://metagraph.sh/test/${componentName}.json`,
+    components: openapi.components,
+    $ref: `#/components/schemas/${componentName}`,
+  });
+  assert.equal(validate(data), true, ajv.errorsText(validate.errors));
 }
 
 // An env whose D1 read REJECTS (schema drift / "no such column" / connection
@@ -1507,6 +1538,115 @@ describe("handleAccountCounterparties", () => {
     assert.ok(idx !== -1);
     assert.equal(captures.params[idx][0], SS58);
     assert.equal(captures.params[idx][1], SS58);
+  });
+});
+
+describe("handleAccountCounterparties relationship drilldown", () => {
+  test("rejects malformed counterparty and limits before D1 work", async () => {
+    for (const counterparty of ["not-ss58", SS58]) {
+      const captures = { sql: [], params: [] };
+      const { env } = dbWith({ captures });
+      const res = await handleAccountCounterparties(
+        req(`/api/v1/accounts/${SS58}/counterparties`),
+        env,
+        SS58,
+        url(
+          `/api/v1/accounts/${SS58}/counterparties?counterparty=${counterparty}`,
+        ),
+      );
+      const body = await errorJson(res);
+      assert.equal(body.error.code, "invalid_query");
+      assert.equal(body.meta.parameter, "counterparty");
+      assert.equal(captures.sql.length, 0);
+    }
+
+    for (const limit of ["random_nonce", "Infinity", "0", "101", "10.5"]) {
+      const captures = { sql: [], params: [] };
+      const { env } = dbWith({ captures });
+      const res = await handleAccountCounterparties(
+        req(`/api/v1/accounts/${SS58}/counterparties`),
+        env,
+        SS58,
+        url(
+          `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}&limit=${limit}`,
+        ),
+      );
+      const body = await errorJson(res);
+      assert.equal(body.error.code, "invalid_query");
+      assert.equal(captures.sql.length, 0);
+    }
+  });
+
+  test("returns schema-stable empty pair detail on cold D1", async () => {
+    const body = await assertColdSchema(
+      handleAccountCounterparties,
+      req(`/api/v1/accounts/${SS58}/counterparties`),
+      emptyEnv(),
+      SS58,
+      url(
+        `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}`,
+      ),
+    );
+    assert.equal(body.data.ss58, SS58);
+    assert.equal(body.data.counterparty_count, 0);
+    assert.deepEqual(body.data.counterparties, []);
+    assert.equal(body.data.relationship.counterparty, COUNTERPARTY);
+    assert.equal(body.data.relationship.transfer_count, 0);
+    assert.deepEqual(body.data.relationship.transfers, []);
+  });
+
+  test("returns pair-level fund-flow detail and recent transfer evidence", async () => {
+    const { env, captures } = dbWith({
+      relationshipTransfers: [
+        transferEventRow({
+          block_number: 20,
+          event_index: 2,
+          hotkey: COUNTERPARTY,
+          coldkey: SS58,
+          amount_tao: 4,
+          observed_at: Date.UTC(2026, 5, 2),
+        }),
+        transferEventRow({
+          block_number: 10,
+          event_index: 1,
+          hotkey: SS58,
+          coldkey: COUNTERPARTY,
+          amount_tao: 10,
+          observed_at: Date.UTC(2026, 5, 1),
+        }),
+      ],
+    });
+    const body = await json(
+      await handleAccountCounterparties(
+        req(`/api/v1/accounts/${SS58}/counterparties`),
+        env,
+        SS58,
+        url(
+          `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}&limit=1`,
+        ),
+      ),
+    );
+    assert.equal(body.data.counterparty_count, 1);
+    assert.equal(body.data.counterparties[0].address, COUNTERPARTY);
+    assert.equal(body.data.relationship.transfer_count, 2);
+    assert.equal(body.data.total_sent_tao, 10);
+    assert.equal(body.data.total_received_tao, 4);
+    assert.equal(body.data.relationship.net_tao, -6);
+    assert.equal(body.data.relationship.transfers.length, 1);
+    assert.equal(body.data.relationship.transfers[0].direction, "received");
+    const idx = captures.sql.findIndex((s) =>
+      /\(\(hotkey = \? AND coldkey = \?\) OR \(hotkey = \? AND coldkey = \?\)\)/.test(
+        s,
+      ),
+    );
+    assert.ok(idx !== -1);
+    assert.deepEqual(captures.params[idx].slice(0, 4), [
+      SS58,
+      COUNTERPARTY,
+      COUNTERPARTY,
+      SS58,
+    ]);
+    await assertValidComponent("AccountCounterpartiesArtifact", body.data);
   });
 });
 

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -594,7 +594,7 @@ describe("Worker runtime", () => {
     const r2KeysRequested = [];
     const schemaSnapshot = {
       schema_version: 1,
-      contract_version: "2026-06-06.1",
+      contract_version: CONTRACT_VERSION,
       generated_at: "1970-01-01T00:00:00.000Z",
       observed_at: "2999-01-01T00:00:00.000Z",
       surface_id: "example-openapi",
@@ -874,7 +874,7 @@ describe("Worker runtime", () => {
               async json() {
                 return {
                   schema_version: 1,
-                  contract_version: "2026-06-06.1",
+                  contract_version: CONTRACT_VERSION,
                   generated_at: "1970-01-01T00:00:00.000Z",
                   source: "generated-artifact-diff",
                 };
@@ -1282,7 +1282,7 @@ describe("Worker runtime", () => {
     try {
       const rpcPoolArtifact = {
         schema_version: 1,
-        contract_version: "2026-06-06.1",
+        contract_version: CONTRACT_VERSION,
         generated_at: "1970-01-01T00:00:00.000Z",
         pools: [
           {
@@ -1688,7 +1688,7 @@ describe("Worker runtime", () => {
       );
       assert.equal(store.size, 1, "ignored query params share one cache entry");
       assert.deepEqual(cachePutKeys, [
-        "https://edge-cache.metagraph.sh/overlay/mainnet/2026-06-06.1/2026-06-18T00%3A00%3A00.000Z/api/v1/endpoints",
+        `https://edge-cache.metagraph.sh/overlay/mainnet/${CONTRACT_VERSION}/2026-06-18T00%3A00%3A00.000Z/api/v1/endpoints`,
       ]);
     } finally {
       globalThis.caches = originalCaches;

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -17,7 +17,12 @@
 // imported straight from the src/* leaf modules + config. api.mjs imports the
 // handlers back and dispatches them from the router.
 
-import { DAY_MS, clampInt, resolveClientIp } from "../config.mjs";
+import {
+  DAY_MS,
+  SS58_ADDRESS_PATTERN,
+  clampInt,
+  resolveClientIp,
+} from "../config.mjs";
 import {
   BLOCK_PAGINATION,
   DAY_PATTERN,
@@ -86,6 +91,9 @@ import {
 import {
   COUNTERPARTIES_READ_COLUMNS,
   COUNTERPARTIES_SCAN_CAP,
+  COUNTERPARTY_RELATIONSHIP_READ_COLUMNS,
+  COUNTERPARTY_RELATIONSHIP_SCAN_CAP,
+  buildCounterpartyRelationship,
   buildCounterparties,
 } from "../../src/counterparties.mjs";
 import { TURNOVER_READ_COLUMNS, buildTurnover } from "../../src/turnover.mjs";
@@ -692,21 +700,87 @@ export async function handleAccountTransfers(request, env, ss58, url) {
 }
 
 // GET /api/v1/accounts/{ss58}/counterparties?limit=N: who this account transacts
-// with — the account's recent account_events Transfers aggregated per counterparty
-// into sent / received / net flow + count, ranked by total volume (the address
-// "relationship" view). The transfer scan is bounded (newest-first); the summary
-// flags truncation. Cold/absent store → 200 with counterparties:[] (schema-stable,
-// never 404), mirroring the sibling account routes.
+// with. Add ?counterparty=<ss58> to return a focused relationship drilldown on
+// the same route without expanding the public path surface.
 export async function handleAccountCounterparties(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, ["limit"]);
+  const validationError = validateQueryParams(url, ["counterparty", "limit"]);
   if (validationError) return analyticsQueryError(validationError);
+  const counterparty = url.searchParams.get("counterparty");
   const parsedLimit = parseBoundedIntParam(url, "limit", {
-    def: 20,
+    def: counterparty == null ? 20 : 50,
     min: 1,
     max: 100,
   });
   if (parsedLimit.error) return analyticsQueryError(parsedLimit.error);
   const limit = parsedLimit.value;
+  if (counterparty != null) {
+    if (!SS58_ADDRESS_PATTERN.test(counterparty)) {
+      return analyticsQueryError({
+        parameter: "counterparty",
+        message: "counterparty must be a valid SS58 account address.",
+      });
+    }
+    if (ss58 === counterparty) {
+      return analyticsQueryError({
+        parameter: "counterparty",
+        message: "counterparty must differ from ss58.",
+      });
+    }
+    const rows = await d1All(
+      env,
+      `SELECT ${COUNTERPARTY_RELATIONSHIP_READ_COLUMNS} FROM account_events WHERE event_kind = 'Transfer' AND ((hotkey = ? AND coldkey = ?) OR (hotkey = ? AND coldkey = ?)) ORDER BY block_number DESC, event_index DESC LIMIT ?`,
+      [
+        ss58,
+        counterparty,
+        counterparty,
+        ss58,
+        COUNTERPARTY_RELATIONSHIP_SCAN_CAP,
+      ],
+    );
+    const relationship = buildCounterpartyRelationship(
+      rows,
+      ss58,
+      counterparty,
+      {
+        limit,
+      },
+    );
+    const counterpartyRow =
+      relationship.transfer_count === 0
+        ? []
+        : [
+            {
+              address: counterparty,
+              sent_tao: relationship.total_sent_tao,
+              received_tao: relationship.total_received_tao,
+              net_tao: relationship.net_tao,
+              transfer_count: relationship.transfer_count,
+              last_block: relationship.last_block,
+            },
+          ];
+    return envelopeResponse(
+      request,
+      {
+        data: {
+          schema_version: 1,
+          ss58,
+          counterparty_count: counterpartyRow.length,
+          transfers_scanned: relationship.transfers_scanned,
+          scan_capped: relationship.scan_capped,
+          total_sent_tao: relationship.total_sent_tao,
+          total_received_tao: relationship.total_received_tao,
+          counterparties: counterpartyRow,
+          relationship,
+        },
+        meta: await accountMeta(
+          env,
+          `/metagraph/accounts/${ss58}/counterparties.json`,
+          relationship.last_seen_at,
+        ),
+      },
+      "short",
+    );
+  }
   const rows = await d1All(
     env,
     `SELECT ${COUNTERPARTIES_READ_COLUMNS} FROM account_events WHERE event_kind = 'Transfer' AND (hotkey = ? OR coldkey = ?) ORDER BY block_number DESC LIMIT ?`,


### PR DESCRIPTION
## Summary
Adds a focused account/counterparty evidence drilldown mode to the existing account counterparty rollup route.

Closes #2267
Refs #2237

## What changed
- Extended `GET /api/v1/accounts/{ss58}/counterparties` with `?counterparty=<ss58>` for pair-level native-TAO transfer totals and recent transfer evidence.
- Added the optional `data.relationship` payload to the canonical `AccountCounterpartiesArtifact` schema, including the bounded evidence row shape and the distinction between total `transfer_count` and limited `transfers` evidence.
- Bumped the public contract metadata to `2026-06-29.1` and regenerated OpenAPI, API index, contracts, and generated TypeScript artifacts from the schema source.
- Kept the existing route/artifact surface; no new public route path, storage tier, router registration, or docs row is added.
- Rejects malformed or same-address counterparty requests before D1 work.
- Skips malformed/non-numeric amount rows from relationship transfer totals and evidence counts, while still reporting scan volume.
- Normalizes relationship evidence `netuid` values to `integer|null`.
- Generates schema-valid OpenAPI samples with distinct account and counterparty SS58 addresses.
- Compares observed timestamps numerically before formatting first/last seen values.
- Added pure builder, request-handler, sample-generation, and schema-validation coverage for cold, invalid, same-address, scan-capped, sparse, malformed, and happy-path relationship drilldowns.

## Why
Explorer users can inspect evidence behind one account/counterparty relationship without expanding the public API surface or leaving generated clients unaware of the emitted payload.

## Validation
- `npm run build`
- `npm run test:coverage`
- `npx vitest run tests/counterparties.test.mjs tests/request-handlers-entities.test.mjs`
- `npm run validate`
- `npm run validate:contract-drift`
- `npm run validate:schemas`
- `npm run validate:api`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:openapi-examples`
- `npm run validate:generated-client`
- `npm run validate:client-sdk-sync`
- `npm run validate:committed-seed`
- `npm run validate:mcp`
- `npm run validate:ai`
- `npm run validate:schema-enums`
- `npm run validate:artifact-budgets`
- `npm run validate:docs`
- `npm run validate:intake`
- `npm run validate:private-boundary`
- `npm run validate:workflows`
- `npm run validate:migrations`
- `npm run scan:public-safety`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## Notes
- The branch diff is 19 files after the required contract-version regeneration, with the drilldown kept on the existing counterparties endpoint.
- The branch is rebased onto current `main` and kept as one focused commit.
