### PR TITLE
fix(health): count subtensor-wss toward sustained-down RPC breaker

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -456,14 +456,19 @@ export async function runHealthProber(env, ctx, overrides = {}) {
     const prior = priorStatus.get(stableLookupKey);
     const lastOkMs = ok ? runAt : (prior?.last_ok ?? null);
     // The sustained-down breaker protects the public RPC pool from repeatedly
-    // routing to unusable endpoints. For RPC surfaces, any non-ok prober run
-    // counts toward that eviction threshold because `degraded` includes
-    // auth-required, rate-limited, transient, and timeout outcomes that are not
-    // necessarily usable by the proxy. Non-RPC degraded runs remain soft signals
-    // and reset the hard-failure streak.
+    // routing to unusable endpoints. For base-layer RPC surfaces, any non-ok
+    // prober run counts toward that eviction threshold because `degraded`
+    // includes auth-required, rate-limited, transient, and timeout outcomes that
+    // are not necessarily usable by the proxy. Both base-layer kinds — HTTP
+    // (`subtensor-rpc`) and WebSocket (`subtensor-wss`) — are proxy-routable and
+    // pooled, so both must count; only matching `subtensor-rpc` let a
+    // persistently-degraded WSS endpoint reset its streak every run and stay
+    // pool_eligible forever. Non-RPC degraded runs remain soft signals and reset
+    // the hard-failure streak.
+    const isBaseLayerRpc =
+      surface.kind === "subtensor-rpc" || surface.kind === "subtensor-wss";
     const countsTowardBreaker =
-      base.status === "failed" ||
-      (surface.kind === "subtensor-rpc" && base.status !== "ok");
+      base.status === "failed" || (isBaseLayerRpc && base.status !== "ok");
     const consecutiveFailures = countsTowardBreaker
       ? (prior?.consecutive_failures ?? 0) + 1
       : 0;

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -610,6 +610,65 @@ describe("runHealthProber", () => {
     assert.equal(rpcUpsert.binds[12], 3);
   });
 
+  test("a degraded subtensor-wss run accrues toward pool eviction", async () => {
+    // Regression for #2072: subtensor-wss is base-layer RPC (proxy-routable,
+    // pooled) exactly like subtensor-rpc, so a persistently-degraded WSS endpoint
+    // must accrue toward the sustained-down breaker. Before the fix the breaker
+    // matched only subtensor-rpc, so a degraded WSS run reset the streak to 0 and
+    // the endpoint stayed pool_eligible forever.
+    const wssSurface = {
+      surface_id: "opentensor-finney-wss",
+      surface_key: "srf-rootwsskey00000",
+      netuid: 0,
+      kind: "subtensor-wss",
+      url: "wss://entrypoint-finney.opentensor.ai",
+      provider: "opentensor",
+      authority: "official",
+      auth_required: false,
+      public_safe: true,
+      subnet_slug: "root",
+      subnet_name: "root",
+      probe: { method: "JSON-RPC", expect: "json" },
+    };
+    const db = makeDb({
+      priorStatus: [
+        {
+          surface_id: "opentensor-finney-wss",
+          surface_key: "srf-rootwsskey00000",
+          last_ok: 1000,
+          consecutive_failures: 2,
+        },
+      ],
+    });
+    // The WSS endpoint probes `degraded` (e.g. rate-limited), not failed.
+    const degradedWssProbe = async () => ({
+      status: "degraded",
+      classification: "rate-limited",
+      latency_ms: null,
+      status_code: 429,
+    });
+
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 50000,
+        db,
+        kv: makeKv(),
+        loadSurfaces: async () => [wssSurface],
+        probeSurface: degradedWssProbe,
+        probeOptions: {},
+      },
+    );
+
+    const wssUpsert = db.calls.batches[0]
+      .filter((s) => /INSERT INTO surface_status/.test(s.sql))
+      .find((s) => s.binds[0] === "opentensor-finney-wss");
+    // binds[12] = consecutive_failures: a degraded base-layer WSS run must bump
+    // 2 -> 3 so the sustained-down breaker can eventually evict it.
+    assert.equal(wssUpsert.binds[12], 3);
+  });
+
   test("no-ops cleanly when there are no operational surfaces", async () => {
     const result = await runHealthProber(
       {},


### PR DESCRIPTION
## Summary

- `countsTowardBreaker` in `src/health-prober.mjs` only matched `subtensor-rpc`, so a persistently-degraded `subtensor-wss` endpoint reset its `consecutive_failures` streak to 0 on every prober run. `sustainedDown` never fired and the endpoint stayed `pool_eligible: true` forever, while an identically-degraded `subtensor-rpc` sibling was correctly evicted.

## What Changed

- `src/health-prober.mjs`: the breaker now counts any non-`ok` run for **both** base-layer RPC kinds — HTTP (`subtensor-rpc`) and WebSocket (`subtensor-wss`) — matching `isBaseLayerEndpoint` in `src/health-serving.mjs`. Non-RPC degraded runs still reset the hard-failure streak (unchanged).
- `tests/health-prober.test.mjs`: added a regression test asserting a degraded `subtensor-wss` run bumps `consecutive_failures` (2 → 3). Mirrors the existing `subtensor-rpc` eviction test.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change — internal prober logic only.)

## Validation

- [x] `npx vitest run tests/health-prober.test.mjs` — 77 passed
- [x] prettier `--check` clean on changed files
- [x] eslint clean on changed files
- [x] `git diff --check`

Closes #2072
