### PR TITLE
perf(api): parallelize the four R2-staged loaders in the fast-load cron

### DIFF
--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -726,10 +726,11 @@ describe("handleScheduled dispatch", () => {
     }
   });
 
-  test("fast-load cron drains BOTH staged files then returns the marker (audit #9)", async () => {
-    // REGRESSION: the EVENTS_LOAD_CRON tick must still run both loaders (one R2 .get
-    // per staged key) AND early-return the fast-load marker without falling through
-    // to the prober/prune.
+  test("fast-load cron drains ALL FOUR staged files then returns the marker (audit #9)", async () => {
+    // REGRESSION: the EVENTS_LOAD_CRON tick must still run all four loaders (one R2
+    // .get per staged key) AND early-return the fast-load marker without falling
+    // through to the prober/prune. The loaders run concurrently (#2092) but the
+    // observable contract is unchanged: every staged key is read on this tick.
     const getKeys = [];
     const env = {
       METAGRAPH_HEALTH_DB: makeDb(),
@@ -743,14 +744,51 @@ describe("handleScheduled dispatch", () => {
     };
     const result = await handleScheduled({ cron: EVENTS_LOAD_CRON }, env, {});
     assert.deepEqual(result, { ok: true, fast_load: true });
-    assert.ok(
-      getKeys.includes("metagraph/neurons-pending.json"),
-      "loadStagedNeurons read its staged key on the fast-load tick",
-    );
-    assert.ok(
-      getKeys.includes("events/account-events-pending.json"),
-      "loadStagedEvents read its staged key on the fast-load tick",
-    );
+    for (const stagedKey of [
+      "metagraph/neurons-pending.json", // loadStagedNeurons (#1303)
+      "events/account-events-pending.json", // loadStagedEvents (#1346)
+      "events/blocks-pending.json", // loadStagedBlocks (#1345)
+      "events/extrinsics-pending.json", // loadStagedExtrinsics (#1345)
+    ]) {
+      assert.ok(
+        getKeys.includes(stagedKey),
+        `the fast-load tick read staged key ${stagedKey}`,
+      );
+    }
+  });
+
+  test("fast-load cron isolates a single staged-loader failure (#2092)", async () => {
+    // The concurrent drain uses Promise.allSettled, so one loader rejecting (here
+    // the blocks loader's R2 .get throws) must NOT stop the other three or change
+    // the fast-load marker — the same isolation the serial `.catch(() => {})` gave.
+    const getKeys = [];
+    const env = {
+      METAGRAPH_HEALTH_DB: makeDb(),
+      METAGRAPH_ARCHIVE: {
+        async get(key) {
+          getKeys.push(key);
+          if (key === "events/blocks-pending.json") {
+            throw new Error("R2 unavailable for blocks");
+          }
+          return null;
+        },
+      },
+      METAGRAPH_STAGING_SIGNING_KEY: "test-secret",
+    };
+    const result = await handleScheduled({ cron: EVENTS_LOAD_CRON }, env, {});
+    // Marker unchanged despite the rejection.
+    assert.deepEqual(result, { ok: true, fast_load: true });
+    // The three healthy loaders still read their staged keys.
+    for (const stagedKey of [
+      "metagraph/neurons-pending.json",
+      "events/account-events-pending.json",
+      "events/extrinsics-pending.json",
+    ]) {
+      assert.ok(
+        getKeys.includes(stagedKey),
+        `loader for ${stagedKey} still ran despite the blocks-loader failure`,
+      );
+    }
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -729,23 +729,24 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
   // the cross-cron concurrency entirely. Each loader stays isolated (`.catch`) so a
   // load failure never affects the early-return below.
   if (cron === EVENTS_LOAD_CRON) {
-    // Token-free per-UID metagraph load (#1303): pick up any R2-staged neuron
-    // snapshot and load it via the D1 binding; it then self-deletes.
-    await loadStagedNeurons(env).catch(() => {});
-    // Token-free chain-event load (#1346): pick up any R2-staged event batch from
-    // the first-party poller and load it via the binding.
-    await loadStagedEvents(env).catch(() => {});
-    // Block-explorer hot window (#1345): pick up any R2-staged `blocks` sidecar
-    // (same poller, same staging key convention) and load it via the binding. In
-    // the SAME cron so the staged-R2 drain stays gated to one cron (no cross-cron
-    // clobber); .catch-isolated so a block-load failure never affects the others.
-    await loadStagedBlocks(env).catch(() => {});
-    // Block-explorer extrinsic slice (#1345): pick up any R2-staged `extrinsics`
-    // sidecar (same poller, same staging key convention) and load it via the
-    // binding. In the SAME cron so the staged-R2 drain stays gated to one cron (no
-    // cross-cron clobber); .catch-isolated so an extrinsic-load failure never
-    // affects the others.
-    await loadStagedExtrinsics(env).catch(() => {});
+    // Drain the four R2-staged batches concurrently (#2092). Each loader is
+    // independent and I/O-bound (R2 GET + chunked db.batch() + delete/put) over a
+    // distinct R2 key + D1 table with no shared mutable state, so overlapping
+    // their I/O cuts the */3 tick's wall-clock from the sum of all four to the
+    // slowest single loader. allSettled preserves the per-loader isolation the
+    // serial `.catch(() => {})` gave: one rejection never stops the others or
+    // changes the marker. The cross-cron clobber rationale above is unaffected —
+    // the drain stays gated to THIS single owning cron, so there is still exactly
+    // one writer per staged key.
+    //   - loadStagedNeurons: token-free per-UID metagraph load (#1303)
+    //   - loadStagedEvents:  token-free chain-event load (#1346)
+    //   - loadStagedBlocks / loadStagedExtrinsics: block-explorer hot window (#1345)
+    await Promise.allSettled([
+      loadStagedNeurons(env),
+      loadStagedEvents(env),
+      loadStagedBlocks(env),
+      loadStagedExtrinsics(env),
+    ]);
     return { ok: true, fast_load: true };
   }
   if (cron === HEALTH_PRUNE_CRON) {


### PR DESCRIPTION
## Summary

- The `*/3` fast-load cron (`EVENTS_LOAD_CRON`) drained its four R2-staged loaders **strictly serially** (`await loadStaged*(env).catch(() => {})` ×4), so every tick paid the sum of all four as wall-clock latency though none depends on another's result.

## What Changed

- `workers/api.mjs`: replaced the four serial awaits with a single `Promise.allSettled([...])`. The loaders are independent and I/O-bound over distinct R2 keys (`STAGED_*_KEY`) and D1 tables with no shared mutable state, so overlapping their I/O cuts the tick's wall-clock to the slowest single loader. `allSettled` preserves the per-loader isolation the previous `.catch(() => {})` gave — one rejection never stops the others or changes the `{ ok: true, fast_load: true }` marker.
- The cross-cron clobber invariant is **unchanged**: the drain stays gated to the single owning `EVENTS_LOAD_CRON` tick, so there is still exactly one writer per staged key. Rationale comments preserved.
- `tests/health-prober.test.mjs`: extended the fast-load test to assert **all four** staged keys are read; added a test that a single loader rejection (blocks R2 `.get` throws) doesn't stop the other three or change the marker.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change — internal cron scheduling only.)

## Validation

- [x] `npx vitest run tests/health-prober.test.mjs` — 77 passed
- [x] `npx vitest run tests/load-staged-events.test.mjs tests/api-coverage.test.mjs` — 154 passed
- [x] prettier `--check` + eslint clean on changed files
- [x] `git diff --check`

Closes #2092
