### PR TITLE
fix(api): parse entity refs with a strict integer matcher

### DIFF
--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.mjs";
 import {
+  handleBlock,
+  handleBlockEvents,
+  handleBlockExtrinsics,
+} from "../workers/request-handlers/entities.mjs";
+import {
   BLOCK_INSERT_COLUMNS,
   BLOCK_READ_COLUMNS,
   BLOCK_RETENTION_MS,
@@ -428,6 +433,80 @@ test("GET /blocks is schema-stable when D1 is cold (never 404)", async () => {
   const body = await res.json();
   assert.equal(body.data.block_count, 0);
   assert.equal(Array.isArray(body.data.blocks), true);
+});
+
+// #2063: a non-hash block ref must be a strict decimal block_number. The route
+// regex (/^...(\d+|0x...)$/) gates these at the router, so this hardens the three
+// block HANDLERS themselves (defense in depth) — the layer the issue verifies —
+// by calling each directly with a malformed ref. The mock returns the SAME detail
+// row for any block WHERE (matched by SQL shape, not bind values), so a malformed
+// ref that still issued the query would surface that row; the strict matcher must
+// instead skip the query.
+const BAD_BLOCK_REFS = [
+  "0x1", // short hex (old Number("0x1") === 1, resolved block 1)
+  "1e3", // scientific notation (old Number("1e3") === 1000)
+  "12-3", // composite-shaped (old Number("12-3") === NaN, but never a clean guard)
+  " 5", // leading whitespace (old Number(" 5") === 5)
+  "99999999999999999999", // all-digits but overflows MAX_SAFE_INTEGER → 1e20
+];
+
+for (const badRef of BAD_BLOCK_REFS) {
+  test(`handleBlock("${badRef}") is a clean miss, not a coerced row (#2063)`, async () => {
+    const env = dbWith({
+      detail: { block_number: 1, block_hash: "0xabc", observed_at: 5 },
+    });
+    const res = await handleBlock(req(`/api/v1/blocks/${badRef}`), env, badRef);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(
+      body.data.block,
+      null,
+      `block ref "${badRef}" must not resolve`,
+    );
+  });
+
+  test(`handleBlockExtrinsics("${badRef}") is a clean miss (#2063)`, async () => {
+    const env = dbWith({
+      detail: { block_number: 1 },
+      feed: [{ block_number: 1, extrinsic_index: 0, observed_at: 5 }],
+    });
+    const res = await handleBlockExtrinsics(
+      req(`/api/v1/blocks/${badRef}/extrinsics`),
+      env,
+      badRef,
+      new URL(`https://api.metagraph.sh/api/v1/blocks/${badRef}/extrinsics`),
+    );
+    const body = await res.json();
+    assert.equal(body.data.block_number, null);
+    assert.deepEqual(body.data.extrinsics, []);
+  });
+
+  test(`handleBlockEvents("${badRef}") is a clean miss (#2063)`, async () => {
+    const env = dbWith({
+      detail: { block_number: 1 },
+      feed: [{ block_number: 1, event_index: 0, observed_at: 5 }],
+    });
+    const res = await handleBlockEvents(
+      req(`/api/v1/blocks/${badRef}/events`),
+      env,
+      badRef,
+      new URL(`https://api.metagraph.sh/api/v1/blocks/${badRef}/events`),
+    );
+    const body = await res.json();
+    assert.equal(body.data.block_number, null);
+    assert.deepEqual(body.data.events, []);
+  });
+}
+
+// A well-formed numeric ref still resolves (the strict matcher must not
+// over-reject the canonical decimal form).
+test("handleBlock resolves a well-formed numeric ref (#2063 regression guard)", async () => {
+  const env = dbWith({
+    detail: { block_number: 1234, block_hash: "0xabc", observed_at: 5 },
+  });
+  const res = await handleBlock(req("/api/v1/blocks/1234"), env, "1234");
+  const body = await res.json();
+  assert.equal(body.data.block.block_number, 1234);
 });
 
 test("GET /blocks/{number}/extrinsics returns the block's extrinsics (#1845)", async () => {

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.mjs";
+import { handleExtrinsic } from "../workers/request-handlers/entities.mjs";
 import {
   EXTRINSIC_INSERT_COLUMNS,
   EXTRINSIC_READ_COLUMNS,
@@ -615,6 +616,75 @@ test("GET /extrinsics/{ref} embeds the events the extrinsic emitted (#1849)", as
   assert.equal(body.data.events.length, 1);
   assert.equal(body.data.events[0].event_kind, "StakeAdded");
   assert.equal(body.data.events[0].extrinsic_index, 2);
+});
+
+// #2063: the composite "<block>-<index>" parser used split("-") + Number(),
+// which resolved several malformed refs to a wrong-but-VALID row. The route regex
+// (/^...\d+-\d+$/) gates these at the router, so this hardens the HANDLER itself
+// (defense in depth) — the layer the issue verifies — by calling handleExtrinsic
+// directly with the malformed ref. The mock returns the SAME detail row for any
+// composite WHERE (it matches by SQL shape, not bind values), so a malformed ref
+// that still issued the query would surface that row; the strict matcher must
+// instead skip the query → extrinsic:null.
+for (const badRef of [
+  "1234-3-5", // extra segment (old split dropped "5", resolved 1234-3)
+  "1234-", // empty index half (old Number("") === 0, resolved 1234-0)
+  "-3", // empty block half (old Number("") === 0, resolved 0-3)
+  "0x1-2", // hex (old Number("0x1") === 1, resolved 1-2)
+  "1e3-2", // scientific notation (old Number("1e3") === 1000, resolved 1000-2)
+  "99999999999999999999-3", // block half overflows MAX_SAFE_INTEGER → 1e20
+]) {
+  test(`handleExtrinsic("${badRef}") is a clean miss, not a coerced row (#2063)`, async () => {
+    const env = dbWith({
+      detail: {
+        block_number: 1234,
+        extrinsic_index: 3,
+        extrinsic_hash: null,
+        call_module: "Timestamp",
+        call_function: "set",
+        success: 1,
+        observed_at: 1750009000000,
+      },
+    });
+    const res = await handleExtrinsic(
+      req(`/api/v1/extrinsics/${badRef}`),
+      env,
+      badRef,
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.ref, badRef);
+    assert.equal(
+      body.data.extrinsic,
+      null,
+      `malformed composite ref "${badRef}" must not resolve to a row`,
+    );
+    assert.deepEqual(body.data.events, []);
+  });
+}
+
+// A well-formed composite ref still resolves (the strict matcher must not
+// over-reject the canonical "<block>-<index>" form).
+test("handleExtrinsic resolves a well-formed composite ref (#2063 regression guard)", async () => {
+  const env = dbWith({
+    detail: {
+      block_number: 1234,
+      extrinsic_index: 3,
+      extrinsic_hash: null,
+      call_module: "Timestamp",
+      call_function: "set",
+      success: 1,
+      observed_at: 1750009000000,
+    },
+  });
+  const res = await handleExtrinsic(
+    req("/api/v1/extrinsics/1234-3"),
+    env,
+    "1234-3",
+  );
+  const body = await res.json();
+  assert.equal(body.data.extrinsic.block_number, 1234);
+  assert.equal(body.data.extrinsic.extrinsic_index, 3);
 });
 
 test("GET /extrinsics is schema-stable when D1 is cold (never 404)", async () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -108,20 +108,14 @@ function parseBoundedIntParam(url, parameter, { def, min, max }) {
   return { value };
 }
 
-// Strict path-ref parsers (#2063). Entity refs (block number/hash, extrinsic
-// hash, composite `<block>-<index>`) are user-supplied path segments. Parsing
-// them with Number()/parseInt is too lenient: `Number("0x1")`, `Number("1e3")`,
-// `Number("")`, and `"123-45".split("-")` on extra/empty halves all coerce a
-// malformed ref into a wrong-but-VALID row instead of a clean miss — the same
-// failure class fixed for the netuid/artifact/transfer refs in #1949/#1950/#1953.
-// Match the strict `/^\d+$/` + Number.isSafeInteger convention used by
-// parseBoundedIntParam above and DAY_RE below: reject hex, scientific notation,
-// signs, whitespace, empty halves, and extra segments at the source.
+// Strict path-ref parsers: Number()/split("-") coerce a malformed ref (hex,
+// 1e3, empty/extra halves) into a wrong-but-valid lookup; require bare decimal
+// segments + Number.isSafeInteger (same convention as parseBoundedIntParam).
 const STRICT_UINT_RE = /^\d+$/;
 const COMPOSITE_REF_RE = /^(\d+)-(\d+)$/;
 
-// A strict non-negative block_number, or null when the ref is not a clean
-// decimal integer (so callers skip the lookup and serve the schema-stable miss).
+// A strict non-negative block_number, or null for a non-decimal ref (so the
+// caller skips the lookup and serves the schema-stable miss).
 function strictBlockNumber(ref) {
   if (!STRICT_UINT_RE.test(ref)) return null;
   const value = Number(ref);
@@ -1436,11 +1430,9 @@ export async function handleExtrinsic(request, env, ref) {
       [ref.toLowerCase()],
     );
   } else {
-    // Composite "<block>-<index>": exactly two strict decimal halves. The old
-    // split("-") + Number() accepted "123-45-67" (extra segment dropped), "123-"
-    // / "-45" (Number("")===0), "0x1-2" (hex), and "1e3-2" (sci notation),
-    // resolving each to a wrong-but-valid row; the strict matcher makes all of
-    // them a clean miss (extrinsic:null), never a bad bind.
+    // Composite "<block>-<index>": exactly two strict decimal halves, so a
+    // malformed ref (extra segment, empty half, hex, sci-notation) is a clean
+    // miss (extrinsic:null) rather than a coerced wrong-but-valid row.
     const composite = COMPOSITE_REF_RE.exec(ref);
     const blockNumber = composite ? Number(composite[1]) : NaN;
     const extrinsicIndex = composite ? Number(composite[2]) : NaN;

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -108,6 +108,26 @@ function parseBoundedIntParam(url, parameter, { def, min, max }) {
   return { value };
 }
 
+// Strict path-ref parsers (#2063). Entity refs (block number/hash, extrinsic
+// hash, composite `<block>-<index>`) are user-supplied path segments. Parsing
+// them with Number()/parseInt is too lenient: `Number("0x1")`, `Number("1e3")`,
+// `Number("")`, and `"123-45".split("-")` on extra/empty halves all coerce a
+// malformed ref into a wrong-but-VALID row instead of a clean miss — the same
+// failure class fixed for the netuid/artifact/transfer refs in #1949/#1950/#1953.
+// Match the strict `/^\d+$/` + Number.isSafeInteger convention used by
+// parseBoundedIntParam above and DAY_RE below: reject hex, scientific notation,
+// signs, whitespace, empty halves, and extra segments at the source.
+const STRICT_UINT_RE = /^\d+$/;
+const COMPOSITE_REF_RE = /^(\d+)-(\d+)$/;
+
+// A strict non-negative block_number, or null when the ref is not a clean
+// decimal integer (so callers skip the lookup and serve the schema-stable miss).
+function strictBlockNumber(ref) {
+  if (!STRICT_UINT_RE.test(ref)) return null;
+  const value = Number(ref);
+  return Number.isSafeInteger(value) ? value : null;
+}
+
 // --- Per-UID metagraph (#1304/#1305): served live from the neurons D1 tier ---
 // (migration 0007, populated by the refresh-metagraph cron). Null-safe: an
 // unbound/cold D1 returns a schema-stable empty payload, like the other
@@ -1105,6 +1125,9 @@ export async function handleBlocks(request, env, url) {
 // neuron detail route — NEVER 404/throw).
 export async function handleBlock(request, env, ref) {
   const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
+  // A non-hash ref must be a strict decimal block_number; anything else (0x-short,
+  // 1e3, signs, empty) is a guaranteed miss, never a Number()-coerced wrong row.
+  const blockNumber = isHash ? null : strictBlockNumber(ref);
   const sql = isHash
     ? `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_hash = ? LIMIT 1`
     : `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_number = ? LIMIT 1`;
@@ -1112,8 +1135,10 @@ export async function handleBlock(request, env, ref) {
   // and D1 text columns are BINARY-collated, so a mixed/upper-case 0x ref would
   // miss. Normalize the hash ref to lowercase before binding (same for the block-
   // extrinsics, block-events, and extrinsic handlers below).
-  const param = isHash ? ref.toLowerCase() : Number(ref);
-  const rows = await d1All(env, sql, [param]);
+  const rows =
+    isHash || blockNumber !== null
+      ? await d1All(env, sql, [isHash ? ref.toLowerCase() : blockNumber])
+      : [];
   // prev/next chain-walk neighbors (#1853): indexed scalar lookups for the
   // nearest STORED block numbers around the resolved height (skips pruned gaps;
   // null at the window edges). Derived from the resolved row's number (works for
@@ -1159,13 +1184,17 @@ export async function handleBlockExtrinsics(request, env, ref, url) {
   const limit = clampInt(url.searchParams.get("limit"), 50, 1, 100);
   const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
   const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
-  const blockRows = await d1All(
-    env,
-    isHash
-      ? `SELECT block_number FROM blocks WHERE block_hash = ? LIMIT 1`
-      : `SELECT block_number FROM blocks WHERE block_number = ? LIMIT 1`,
-    [isHash ? ref.toLowerCase() : Number(ref)],
-  );
+  const refBlockNumber = isHash ? null : strictBlockNumber(ref);
+  const blockRows =
+    isHash || refBlockNumber !== null
+      ? await d1All(
+          env,
+          isHash
+            ? `SELECT block_number FROM blocks WHERE block_hash = ? LIMIT 1`
+            : `SELECT block_number FROM blocks WHERE block_number = ? LIMIT 1`,
+          [isHash ? ref.toLowerCase() : refBlockNumber],
+        )
+      : [];
   const blockNumber = blockRows[0]?.block_number ?? null;
   const rows =
     blockNumber == null
@@ -1202,13 +1231,17 @@ export async function handleBlockEvents(request, env, ref, url) {
   const limit = clampInt(url.searchParams.get("limit"), 100, 1, 1000);
   const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
   const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
-  const blockRows = await d1All(
-    env,
-    isHash
-      ? `SELECT block_number FROM blocks WHERE block_hash = ? LIMIT 1`
-      : `SELECT block_number FROM blocks WHERE block_number = ? LIMIT 1`,
-    [isHash ? ref.toLowerCase() : Number(ref)],
-  );
+  const refBlockNumber = isHash ? null : strictBlockNumber(ref);
+  const blockRows =
+    isHash || refBlockNumber !== null
+      ? await d1All(
+          env,
+          isHash
+            ? `SELECT block_number FROM blocks WHERE block_hash = ? LIMIT 1`
+            : `SELECT block_number FROM blocks WHERE block_number = ? LIMIT 1`,
+          [isHash ? ref.toLowerCase() : refBlockNumber],
+        )
+      : [];
   const blockNumber = blockRows[0]?.block_number ?? null;
   const rows =
     blockNumber == null
@@ -1403,13 +1436,18 @@ export async function handleExtrinsic(request, env, ref) {
       [ref.toLowerCase()],
     );
   } else {
-    // Composite "<block>-<index>": coerce both halves; a non-finite half is a
-    // miss (extrinsic:null), never a bad bind.
-    const [b, i] = ref.split("-");
-    const blockNumber = Number(b);
-    const extrinsicIndex = Number(i);
+    // Composite "<block>-<index>": exactly two strict decimal halves. The old
+    // split("-") + Number() accepted "123-45-67" (extra segment dropped), "123-"
+    // / "-45" (Number("")===0), "0x1-2" (hex), and "1e3-2" (sci notation),
+    // resolving each to a wrong-but-valid row; the strict matcher makes all of
+    // them a clean miss (extrinsic:null), never a bad bind.
+    const composite = COMPOSITE_REF_RE.exec(ref);
+    const blockNumber = composite ? Number(composite[1]) : NaN;
+    const extrinsicIndex = composite ? Number(composite[2]) : NaN;
     rows =
-      Number.isInteger(blockNumber) && Number.isInteger(extrinsicIndex)
+      composite &&
+      Number.isSafeInteger(blockNumber) &&
+      Number.isSafeInteger(extrinsicIndex)
         ? await d1All(
             env,
             `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE block_number = ? AND extrinsic_index = ? LIMIT 1`,


### PR DESCRIPTION
## Summary

- The composite extrinsic ref parser (`handleExtrinsic`) used `ref.split("-")` + `Number()`, and the block-ref parsers (`handleBlock`, `handleBlockExtrinsics`, `handleBlockEvents`) used `Number(ref)`. Both coerce a **malformed ref into a wrong-but-valid lookup** instead of a clean miss:

  | input | old result | correct |
  |---|---|---|
  | `123-45-67` | block 123, index 45 (extra segment dropped) | miss |
  | `123-` / `-45` | index/block 0 (`Number("") === 0`) | miss |
  | `0x1-2` | block 1, index 2 (`Number` accepts hex) | miss |
  | `1e3-2` | block 1000 (`Number` accepts sci notation) | miss |
  | oversized digits | `Number` rounds past `MAX_SAFE_INTEGER` | miss |

## What Changed

- `workers/request-handlers/entities.mjs`: added `strictBlockNumber()` and `COMPOSITE_REF_RE`, requiring exact decimal segments + `Number.isSafeInteger` — mirroring the `/^\d+$/` + `Number.isSafeInteger` convention already used by `parseBoundedIntParam`. `handleBlock`, `handleBlockExtrinsics`, `handleBlockEvents`, and `handleExtrinsic` now skip the D1 lookup for a non-strict ref and serve the existing schema-stable miss (`block`/`extrinsic: null`) — never 404/throw. This hardens the **handlers themselves** (defense in depth) independent of the route-level regex.
- `tests/extrinsics.test.mjs`, `tests/blocks.test.mjs`: handler-level regression tests for each malformed shape (the route regex gates them, so the handlers are exercised directly) plus a well-formed ref that must still resolve.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change — malformed refs already returned the schema-stable null; this makes the coerced-wrong-row cases miss instead.)

## Validation

- [x] `npx vitest run tests/blocks.test.mjs tests/extrinsics.test.mjs` — 79 passed
- [x] `npx vitest run tests/request-handlers-entities.test.mjs tests/data-api.test.mjs tests/block-events.test.mjs` — 177 passed
- [x] prettier `--check` + eslint clean on changed files
- [x] `git diff --check`
