### PR TITLE
feat(api): sort + filter the subnets collection by integration_readiness

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -14334,6 +14334,8 @@ export interface operations {
                 max_block?: number;
                 min_candidate_count?: number;
                 max_candidate_count?: number;
+                min_integration_readiness?: number;
+                max_integration_readiness?: number;
                 min_mechanism_count?: number;
                 max_mechanism_count?: number;
                 min_participant_count?: number;
@@ -14348,7 +14350,7 @@ export interface operations {
                 limit?: number;
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
-                sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
+                sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "integration_readiness" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
             };

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -926,6 +926,18 @@
           }
         },
         {
+          "name": "min_integration_readiness",
+          "schema": {
+            "type": "number"
+          }
+        },
+        {
+          "name": "max_integration_readiness",
+          "schema": {
+            "type": "number"
+          }
+        },
+        {
           "name": "min_mechanism_count",
           "schema": {
             "type": "number"
@@ -1016,6 +1028,7 @@
               "candidate_count",
               "coverage_level",
               "curation_level",
+              "integration_readiness",
               "mechanism_count",
               "name",
               "netuid",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -28135,6 +28135,22 @@
           },
           {
             "in": "query",
+            "name": "min_integration_readiness",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "max_integration_readiness",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
             "name": "min_mechanism_count",
             "required": false,
             "schema": {
@@ -28252,6 +28268,7 @@
                 "candidate_count",
                 "coverage_level",
                 "curation_level",
+                "integration_readiness",
                 "mechanism_count",
                 "name",
                 "netuid",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -14334,6 +14334,8 @@ export interface operations {
                 max_block?: number;
                 min_candidate_count?: number;
                 max_candidate_count?: number;
+                min_integration_readiness?: number;
+                max_integration_readiness?: number;
                 min_mechanism_count?: number;
                 max_mechanism_count?: number;
                 min_participant_count?: number;
@@ -14348,7 +14350,7 @@ export interface operations {
                 limit?: number;
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
-                sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
+                sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "integration_readiness" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
             };

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -582,6 +582,7 @@ export const API_QUERY_COLLECTIONS = {
       "candidate_count",
       "coverage_level",
       "curation_level",
+      "integration_readiness",
       "mechanism_count",
       "name",
       "netuid",
@@ -593,9 +594,12 @@ export const API_QUERY_COLLECTIONS = {
       "tempo",
     ],
     // Inclusive numeric range filters: ?min_surface_count=5&max_tempo=360, etc.
+    // integration_readiness generalizes the one-off min_readiness the MCP
+    // list_subnets tool exposes, so REST can rank/threshold by the same field.
     rangeFilters: [
       "block",
       "candidate_count",
+      "integration_readiness",
       "mechanism_count",
       "participant_count",
       "probed_surface_count",

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -377,6 +377,41 @@ describe("list-query numeric range filters", () => {
   });
 });
 
+// #2085: integration_readiness was sortable/filterable via MCP list_subnets but
+// not on the equivalent REST subnets collection. After wiring it into the
+// contract's sort + rangeFilters, the generic list-query engine reads row[key]
+// and must rank/threshold by it just like the other numeric fields.
+describe("list-query integration_readiness (#2085)", () => {
+  const data = {
+    subnets: [
+      { netuid: 1, integration_readiness: 40 },
+      { netuid: 2, integration_readiness: 90 },
+      { netuid: 3, integration_readiness: 65 },
+      { netuid: 4 }, // field absent → sorts last, filtered out by min_
+    ],
+  };
+  const netuids = (result) => result.data.subnets.map((r) => r.netuid);
+
+  test("?sort=integration_readiness&order=desc ranks by the field", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?sort=integration_readiness&order=desc"),
+      "subnets",
+    );
+    // 90, 65, 40 desc, then the row missing the field last.
+    assert.deepEqual(netuids(result), [2, 3, 1, 4]);
+  });
+
+  test("?min_integration_readiness=N keeps rows >= the bound (inclusive)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?min_integration_readiness=65"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [2, 3]);
+  });
+});
+
 describe("list-query pagination Link header", () => {
   test("first page: next + last only (no earlier page exists)", () => {
     const links = parseLink(pageLink("/api/v1/subnets?sort=netuid&limit=2"));


### PR DESCRIPTION
## Summary

- `integration_readiness` is the deterministic 0-100 score written onto every served `/metagraph/subnets.json` row. MCP `list_subnets` lets an agent sort by it and threshold via `min_readiness`, but the equivalent REST `GET /api/v1/subnets` exposed it in **neither** `sort` nor `rangeFilters` — so `?sort=integration_readiness` was rejected by `validateListQuery` and `?min_integration_readiness=N` was ignored. An agent could rank/threshold by readiness via MCP but could not reproduce that query over REST.

## What Changed

- `src/contracts.mjs`: added `"integration_readiness"` to the `subnets` collection's `sort` and `rangeFilters`. The list-query engine reads `row[key]` generically (`workers/list-query.mjs`), so **no runtime change** is needed — this is purely a contract surface addition.
- Regenerated contract artifacts via `npm run build`: `public/metagraph/openapi.json`, `public/metagraph/api-index.json`, `generated/metagraphed-api.d.ts`, `public/metagraph/types.d.ts`.
- `tests/list-query.test.mjs`: added a test asserting `?sort=integration_readiness&order=desc` ranks by the field (rows missing it sort last) and `?min_integration_readiness=N` thresholds inclusively.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by `npm run build`, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed (operational-surfaces.json / r2-manifest.json churn reverted).
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run validate` — passed
- [x] `npm run validate:contract-drift` — passed
- [x] `npm run validate:api` / `validate:openapi` / `validate:types` / `validate:schemas` — passed
- [x] `npm run validate:client-sdk-sync` — in sync (client version bump left to the post-merge sync-client-version workflow)
- [x] `npx vitest run tests/list-query.test.mjs tests/invariants-contracts.test.mjs tests/mcp-server.test.mjs tests/api-coverage.test.mjs` — 438 passed
- [x] prettier `--check` + eslint clean; `git diff --check`

Closes #2085
