### PR TITLE
fix(api): route handleHealthTrends D1 reads through d1All for error logging

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1374,6 +1374,47 @@ describe("health trends D1 error handling", () => {
     assert.equal(body.data.windows["7d"].uptime_ratio, null);
   });
 
+  test("logs the swallowed D1 error via the [d1All] dark-serve contract (#2076)", async () => {
+    // Regression: handleHealthTrends previously inlined db.prepare().bind().all()
+    // with a BARE catch that returned [] silently — re-introducing the dark-serve
+    // failure the [d1All] logging exists to catch. Reading through d1All now logs
+    // every swallowed failure, so a prod schema drift is diagnosable.
+    const env = createLocalArtifactEnv({
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  throw new Error("no such column: surface_key");
+                },
+              };
+            },
+          };
+        },
+      },
+    });
+    const calls = [];
+    const original = console.error;
+    console.error = (...args) => calls.push(args);
+    try {
+      const res = await handleRequest(
+        req("/api/v1/subnets/0/health/trends"),
+        env,
+        {},
+      );
+      assert.equal(res.status, 200);
+    } finally {
+      console.error = original;
+    }
+    const logged = calls.find((args) => args[0] === "[d1All]");
+    assert.ok(
+      logged,
+      "the swallowed trends D1 error must be logged with the [d1All] prefix",
+    );
+    assert.match(String(logged[1]), /no such column/);
+  });
+
   test("bulk route returns a schema-stable empty payload when D1 throws", async () => {
     const env = createLocalArtifactEnv({
       METAGRAPH_HEALTH_DB: {

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -422,22 +422,19 @@ export async function handleHealthTrends(request, env, netuid, url, ctx = {}) {
   const validationError = validateQueryParams(url, []);
   if (validationError) return analyticsQueryError(validationError);
   return withEdgeCache(request, ctx, env, "trends", async () => {
-    const db = env.METAGRAPH_HEALTH_DB;
     const nowMs = Date.now();
     const windows = {};
     // The per-window aggregations are independent — run them in parallel (one D1
     // round-trip each) like handleHealthPercentiles/handleLeaderboards, rather than
-    // serializing the two with an await-in-loop.
+    // serializing the two with an await-in-loop. Read through the shared d1All so a
+    // failure is logged + marked as a D1 fallback (the dark-serve log contract) —
+    // the inline bare catch this replaced swallowed errors silently, the exact
+    // failure mode the [d1All] logging exists to prevent.
     const windowRows = await Promise.all(
       Object.entries(HEALTH_TREND_WINDOWS).map(async ([label, days]) => {
-        if (!db?.prepare) {
-          return [label, markD1FallbackRows([])];
-        }
-        try {
-          const result = await withTimeout(
-            db
-              .prepare(
-                `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
+        const rows = await d1All(
+          env,
+          `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
              SELECT MAX(surface_id) AS surface_id,
                     surface_key,
                     COUNT(*) AS total,
@@ -445,15 +442,9 @@ export async function handleHealthTrends(request, env, netuid, url, ctx = {}) {
                     ${latencyStatColumns({ includeMinMax: false })}
              FROM ranked
              GROUP BY surface_key`,
-              )
-              .bind(netuid, nowMs - days * DAY_MS)
-              .all(),
-            d1TimeoutMs(env),
-          );
-          return [label, result?.results || []];
-        } catch {
-          return [label, markD1FallbackRows([])];
-        }
+          [netuid, nowMs - days * DAY_MS],
+        );
+        return [label, rows];
       }),
     );
     for (const [label, rows] of windowRows) {


### PR DESCRIPTION
## Summary

- `handleHealthTrends` inlined `db.prepare(...).bind(...).all()` inside `Promise.all` with a **bare catch** (`} catch { return [label, markD1FallbackRows([])] }`) that returned `[]` and logged nothing — re-introducing the silent dark-serve failure the `[d1All]` logging was added to prevent. A swallowed `no such column` (prod schema drift) could dark-serve the trends tier for days unnoticed. Every other analytics route reads through `d1All` and inherits that logging — this one didn't.

## What Changed

- `workers/request-handlers/analytics.mjs`: each per-window aggregation now reads through the shared `d1All(env, sql, params)` (same module), which already owns the binding check, timeout, fallback marking, **and** the `[d1All]` error log. Behavior is identical (no-db / error → marked fallback rows; success → `result.results`) except the swallowed error is now logged.
- `tests/api-coverage.test.mjs`: added a regression test asserting a swallowed trends D1 error is logged with the `[d1All]` prefix (spies on `console.error`).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change — internal read path + logging only.)

## Validation

- [x] `npx vitest run tests/api-coverage.test.mjs tests/request-handlers-analytics.test.mjs tests/analytics.test.mjs tests/analytics-edge-cache.test.mjs` — 308 passed
- [x] prettier `--check` + eslint clean on changed files
- [x] `git diff --check`

Closes #2076
