### PR TITLE
fix(api): reject non-integer numeric filters on the extrinsics feed

### DIFF
--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -410,6 +410,40 @@ test("GET /extrinsics clamps limit to <=100 + rejects unsupported params", async
   assert.equal(bad.status, 400);
 });
 
+// #2086: the five numeric value filters were parsed with clampInt/parseTimeBound,
+// which silently coerce a non-numeric value (?block=abc -> 0; ?from=foo -> dropped)
+// and return a 200 with the wrong/empty page. They must now reject with a 400.
+for (const qs of [
+  "block=abc",
+  "block=-1",
+  "block=1.5",
+  "block_start=foo",
+  "block_end=bar",
+  "from=notanumber",
+  "to=12e3",
+]) {
+  test(`GET /extrinsics?${qs} rejects the non-integer value filter with 400 (#2086)`, async () => {
+    const env = dbWith({ feed: [] });
+    const res = await handleRequest(req(`/api/v1/extrinsics?${qs}`), env, {});
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.error.code, "invalid_param");
+    assert.match(body.error.message, /must be a non-negative integer/);
+  });
+}
+
+test("GET /extrinsics still accepts valid numeric value filters (#2086 guard)", async () => {
+  const env = dbWith({ feed: [] });
+  const res = await handleRequest(
+    req(
+      "/api/v1/extrinsics?block_start=100&block_end=200&from=0&to=9999999999999",
+    ),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+});
+
 test("GET /extrinsics?block=<n> scopes the feed to one block (#1345)", async () => {
   let boundSql;
   const env = {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2232,17 +2232,24 @@ describe("handleExtrinsics", () => {
     assert.ok(/observed_at >= \?/.test(sql));
   });
 
-  test("ignores malformed time filters instead of broadening them", async () => {
+  test("rejects a malformed time filter with 400 instead of silently dropping it (#2086)", async () => {
+    // Previously a non-numeric ?from was coerced/dropped (parseTimeBound -> null),
+    // silently broadening the query and returning a 200 with no signal. It now
+    // fails fast with 400 invalid_param, and never reaches D1.
     const { env, captures } = dbWith({ extrinsics: [] });
-    await handleExtrinsics(
+    const res = await handleExtrinsics(
       req("/api/v1/extrinsics"),
       env,
       url("/api/v1/extrinsics?from=abc"),
     );
-    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(sql);
-    assert.ok(!/INDEXED BY/.test(sql));
-    assert.ok(!/observed_at >= \?/.test(sql));
+    const body = await errorJson(res);
+    assert.equal(body.error.code, "invalid_param");
+    assert.match(body.error.message, /from must be a non-negative integer/);
+    assert.equal(
+      captures.sql.filter((s) => /FROM extrinsics/.test(s)).length,
+      0,
+      "a malformed filter must be rejected before any D1 read",
+    );
   });
 
   test("short-circuits impossible future time filters before D1", async () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1257,6 +1257,22 @@ export async function handleExtrinsics(request, env, url) {
     "to",
   ]);
   if (validationError) return analyticsQueryError(validationError);
+  // Numeric VALUE filters must be non-negative integers (#2086). clampInt /
+  // parseTimeBound silently coerce a non-numeric value (?block=abc -> 0 =>
+  // block_number = 0; ?from=foo -> NaN => bound dropped), so the client gets a
+  // 200 with the wrong/empty page and no signal. Reject present-but-non-integer
+  // values up front with a 400, matching the sibling handleAccountHistory. limit/
+  // offset keep clampInt — they are bounded UI controls, not value filters.
+  for (const name of ["block", "block_start", "block_end", "from", "to"]) {
+    const raw = url.searchParams.get(name);
+    if (raw != null && !/^\d+$/.test(raw)) {
+      return errorResponse(
+        "invalid_param",
+        `${name} must be a non-negative integer.`,
+        400,
+      );
+    }
+  }
   const limit = clampInt(url.searchParams.get("limit"), 50, 1, 100);
   const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
   const sp = url.searchParams;


### PR DESCRIPTION
## Summary

- `handleExtrinsics` (`GET /api/v1/extrinsics`) parsed its five numeric value filters — `block`, `block_start`, `block_end`, `from`, `to` — with `clampInt`/`parseTimeBound`, which **silently coerce** a non-numeric value: `?block=abc` became `WHERE block_number = 0`, `?from=foo` dropped the lower bound. The client got a `200` with the wrong/empty page and no signal — inconsistent with the sibling `handleAccountHistory`, which validates its value filters and returns a `400`.

## What Changed

- `workers/request-handlers/entities.mjs`: reject any present-but-non-integer value filter up front with `errorResponse("invalid_param", "<name> must be a non-negative integer.", 400)`, matching `handleAccountHistory`. `limit`/`offset` keep `clampInt` (bounded UI controls, not value filters); valid inputs are unchanged.
- `tests/extrinsics.test.mjs`: tests asserting each malformed value filter (`block=abc`, `block=-1`, `block=1.5`, `block_start=foo`, `block_end=bar`, `from=notanumber`, `to=12e3`) returns `400 invalid_param`, plus a guard that valid numeric filters still return `200`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (Tightens input validation to 400 on malformed value filters; valid requests unchanged.)

## Validation

- [x] `npx vitest run tests/extrinsics.test.mjs` — 34 passed
- [x] `npx vitest run tests/network-routing.test.mjs tests/data-api.test.mjs tests/invariants-contracts.test.mjs` — 49 passed
- [x] prettier `--check` + eslint clean on changed files
- [x] `git diff --check`

Closes #2086
