### PR TITLE
fix(probe): close the socket on every nodeWebSocketConnector terminal path

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -592,16 +592,36 @@ export function nodeWebSocketConnector(WebSocketImpl = globalThis.WebSocket) {
       const socket = new WebSocketImpl(url);
       const byId = new Map(calls.map((call, index) => [index + 1, call.key]));
       const results = new Map();
-      const timer = setTimeout(() => {
+      let settled = false;
+      const timer = setTimeout(
+        () =>
+          finish(new Error("WebSocket RPC probe timed out"), "TimeoutError"),
+        timeoutMs,
+      );
+
+      // Every terminal path (success, timeout, error, parse-error, premature
+      // close) funnels through finish() so the first event wins, the timer is
+      // always cleared, and the socket is ALWAYS closed — mirroring the Worker
+      // connector's finish() in src/health-prober.mjs (#2074). Before this, the
+      // error path cleared the timer but never closed the socket (leaking a
+      // half-open fd), and there was no close handler, so a server that closed
+      // before all responses arrived hung the probe until the full timeout.
+      function finish(error, name) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
         try {
           socket.close();
         } catch {
-          // Ignore close failures after timeout.
+          // Ignore close failures on a terminal path.
         }
-        const error = new Error("WebSocket RPC probe timed out");
-        error.name = "TimeoutError";
-        reject(error);
-      }, timeoutMs);
+        if (error) {
+          if (name) error.name = name;
+          reject(error);
+        } else {
+          resolve(results);
+        }
+      }
 
       socket.addEventListener("open", () => {
         calls.forEach((call, index) => {
@@ -629,24 +649,23 @@ export function nodeWebSocketConnector(WebSocketImpl = globalThis.WebSocket) {
             rpc_error: body.error || null,
           });
           if (results.size === calls.length) {
-            clearTimeout(timer);
-            socket.close();
-            resolve(results);
+            finish(null);
           }
         } catch (error) {
-          clearTimeout(timer);
-          try {
-            socket.close();
-          } catch {
-            // Ignore close failures after parse failure.
-          }
-          reject(error);
+          finish(error);
         }
       });
 
       socket.addEventListener("error", () => {
-        clearTimeout(timer);
-        reject(new Error("WebSocket RPC connection failed"));
+        finish(new Error("WebSocket RPC connection failed"));
+      });
+
+      // A server that accepts then closes before all responses arrive must
+      // reject promptly instead of hanging until the timeout.
+      socket.addEventListener("close", () => {
+        if (results.size < calls.length) {
+          finish(new Error("WebSocket closed before all responses"));
+        }
       });
     });
 }

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -861,12 +861,46 @@ describe("nodeWebSocketConnector", () => {
     assert.equal(socket.closed, true);
   });
 
-  test("error event rejects the connection", async () => {
+  test("error event rejects the connection AND closes the socket (#2074)", async () => {
     const connect = nodeWebSocketConnector(FakeSocket);
     const promise = connect("wss://rpc.dev", calls, 5000);
     const socket = FakeSocket.last;
     socket.fire("error", {});
     await assert.rejects(() => promise, /WebSocket RPC connection failed/);
+    // The error path previously cleared the timer but never closed the socket,
+    // leaking a half-open fd. Every terminal path must now close.
+    assert.equal(socket.closed, true);
+  });
+
+  test("close before all responses rejects promptly instead of hanging (#2074)", async () => {
+    const connect = nodeWebSocketConnector(FakeSocket);
+    const promise = connect("wss://rpc.dev", calls, 5000);
+    const socket = FakeSocket.last;
+    socket.fire("open");
+    // Only one of the two ids arrives, then the server closes the socket.
+    socket.fire("message", {
+      data: JSON.stringify({ id: 1, result: { number: "0x1" } }),
+    });
+    socket.fire("close", {});
+    await assert.rejects(() => promise, /closed before all responses/);
+  });
+
+  test("close AFTER all responses is a no-op (settled guard, #2074)", async () => {
+    const connect = nodeWebSocketConnector(FakeSocket);
+    const promise = connect("wss://rpc.dev", calls, 5000);
+    const socket = FakeSocket.last;
+    socket.fire("open");
+    socket.fire("message", {
+      data: JSON.stringify({ id: 1, result: { number: "0x1" } }),
+    });
+    socket.fire("message", {
+      data: JSON.stringify({ id: 2, result: { peers: 1 } }),
+    });
+    // A trailing close after the set completed must not flip the resolved
+    // promise into a rejection (first terminal event wins).
+    socket.fire("close", {});
+    const results = await promise;
+    assert.equal(results.size, 2);
   });
 
   test("timeout rejects with a TimeoutError and closes the socket", async () => {


### PR DESCRIPTION
## Summary

- `nodeWebSocketConnector` (the Node build/smoke WSS connector) registered only `open`/`message`/`error` listeners with no settled guard and no `close` handler, diverging from the Worker connector which funnels every terminal path through a settled-guarded `finish()`. Two defects:
  1. **Hang on premature close** — a server that accepted then closed before all `SUBTENSOR_PROBE_CALLS` responses arrived left the Promise pending until the full ~12s timeout (no `close` listener).
  2. **Socket leak on error** — the `error` path cleared the timer but never closed the socket (and clearing the timer disabled the timeout's fallback `close()`), leaving a half-open fd.

## What Changed

- `src/health-probe-core.mjs`: funnel every terminal path — success, timeout, error, parse-error, and a premature close — through a settled-guarded `finish()` that always clears the timer and closes the socket, mirroring `finish()` in `src/health-prober.mjs`. Public behavior preserved: resolve with the `Map`; reject with `TimeoutError` on timeout; reject with `"WebSocket RPC connection failed"` on error; new `"WebSocket closed before all responses"` on premature close. The `try { socket.close() } catch {}` swallow is preserved.
- `tests/health-probe-core.test.mjs`: a close-before-all-responses rejection test, a `socket.closed === true` assertion on the error path, and a trailing-close no-op test (settled guard).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change — internal probe connector; `workerWebSocketConnector` and the probe wall-time cap are untouched.)

## Validation

- [x] `npx vitest run tests/health-probe-core.test.mjs` — 104 passed
- [x] prettier `--check` + eslint clean on changed files
- [x] `git diff --check`

Closes #2074
