### PR TITLE
perf(build): replace per-row Array.find joins with Maps in build-artifacts

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -697,9 +697,9 @@ const candidateIndex = candidates.map((candidate) => ({
   verification:
     fullVerificationByCandidate.get(candidate.id) ||
     fullVerificationResultOrNull(candidate.verification),
-  subnet_name:
-    nativeSnapshot.subnets.find((subnet) => subnet.netuid === candidate.netuid)
-      ?.name || null,
+  // Native netuid is unique (129/129), so the pre-built nativeByNetuid Map is
+  // byte-identical to the per-candidate native scan it replaces (#2095).
+  subnet_name: nativeByNetuid.get(candidate.netuid)?.name || null,
 }));
 const canonicalCandidateIndex = candidates.map((candidate) => ({
   ...candidate,
@@ -708,9 +708,8 @@ const canonicalCandidateIndex = candidates.map((candidate) => ({
   verification:
     canonicalVerificationByCandidate.get(candidate.id) ||
     fullVerificationResultOrNull(candidate.verification),
-  subnet_name:
-    nativeSnapshot.subnets.find((subnet) => subnet.netuid === candidate.netuid)
-      ?.name || null,
+  // Same Map lookup as candidateIndex above (#2095).
+  subnet_name: nativeByNetuid.get(candidate.netuid)?.name || null,
 }));
 // Dedup'd projections of the candidate index (drop surface-superseded dupes) for
 // the per-subnet detail/profile candidate lists + the enrichment queue (#1002).
@@ -4684,11 +4683,13 @@ function buildSourceHealthArtifact({
     candidateRows,
     (candidate) => candidate.provider || "unknown",
   );
+  // Candidate id is unique, so an id->row Map is byte-identical to the per-result
+  // Array.find first-match it replaces — turning an O(results x candidates) join
+  // (~4.18M comparisons/build) into O(1) per result (#2095).
+  const candidateById = new Map(candidateRows.map((row) => [row.id, row]));
   const verificationByProvider = verificationResults.reduce(
     (accumulator, result) => {
-      const candidate = candidateRows.find(
-        (row) => row.id === result.candidate_id,
-      );
+      const candidate = candidateById.get(result.candidate_id);
       const provider = candidate?.provider || "unknown";
       const row = accumulator.get(provider) || {
         provider,


### PR DESCRIPTION
## Summary

Two hot join surfaces in `scripts/build-artifacts.mjs` used per-row `Array.prototype.find` where an id/netuid Map was available or trivial. This merges both same-pattern fixes (one file).

- **`buildSourceHealthArtifact`** joined each verification result to its candidate with `candidateRows.find(row => row.id === result.candidate_id)` — an O(results × candidates) scan (~**4.18M** comparisons/build, growing quadratically). Candidate `id` is unique, so a hoisted `id -> row` Map is byte-identical and O(1) per result.
- **The candidate index + canonical candidate index** resolved `subnet_name` with `nativeSnapshot.subnets.find(s => s.netuid === candidate.netuid)?.name`. The same array is already grouped into the module-level `nativeByNetuid` Map (built at `:317`); `netuid` is unique (129/129), so `nativeByNetuid.get(...)?.name` is exact.

## What Changed

- `scripts/build-artifacts.mjs` (single file): hoisted `candidateById` Map in `buildSourceHealthArtifact` and replaced the `.find`; replaced both `nativeSnapshot.subnets.find(...)?.name` expressions with `nativeByNetuid.get(candidate.netuid)?.name || null`.

## Output is byte-identical

`npm run build` leaves `candidates.json` and `source-health.json` unchanged (uniqueness of `id`/`netuid` guarantees `.find` first-match == `Map.get`). No `nativeSnapshot.subnets.find` for `subnet_name` remains.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (and are byte-identical — nothing to commit).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — internal build-script perf; output unchanged.)

## Validation

- [x] `npm run build` — no drift in `candidates.json` / `source-health.json`
- [x] `npx vitest run tests/artifacts.test.mjs` — 21 passed (artifact-determinism + internal-consistency guards)
- [x] `npm run validate:contract-drift` — passed
- [x] prettier `--check` + eslint clean; `git diff --check`

Closes #2095
