### PR TITLE
feat(registry): add SN106 Nodexo public inventory subnet-api surface

### DIFF
--- a/registry/subnets/nodexo.json
+++ b/registry/subnets/nodexo.json
@@ -100,6 +100,22 @@
         "submitted_by": "minion1227"
       },
       "notes": "Official Nodexo (SN106) miner/validator/CLI source repo under the github.com/nodexo-ai org linked from the project website."
+    },
+    {
+      "id": "sn-106-nodexo-subnet-api",
+      "name": "Nodexo inventory API",
+      "kind": "subnet-api",
+      "url": "https://nodexo.ai/api/inventory",
+      "provider": "nodexo",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://nodexo.ai/"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "seekmistar01"
+      },
+      "notes": "Public Nodexo (SN106) GPU marketplace inventory API. Returns live JSON offers with GPU model, VRAM, pricing (USDC/hour), availability, and reliability metrics. No auth required."
     }
   ]
 }


### PR DESCRIPTION
## Surface submission

Adds one community surface to **one** subnet file: `registry/subnets/nodexo.json` (SN106, Nodexo).

| Field | Value |
| --- | --- |
| netuid | 106 (Nodexo) |
| kind | `subnet-api` |
| url | `https://nodexo.ai/api/inventory` |
| source_url | `https://nodexo.ai/` |
| provider | `nodexo` (existing, trusted) |
| authority / review | `community` / `community-submitted` |

### What this is

`https://nodexo.ai/api/inventory` is Nodexo's public GPU-marketplace inventory API. It returns live JSON describing the subnet's compute offers — GPU model, VRAM, GPU count, availability, USDC/hour price, reliability metrics, and image cache state — under the subnet's own verified official origin. It fills SN106's open `subnet-api` gap (the registry currently has website, docs, dashboard, and source-repo, but no callable API surface).

### Why it's valid / safe

- **Live & public:** verified `HTTP 200`, `content-type: application/json`, stable across repeated requests; returns real `offers[]`/`metrics` payloads.
- **`auth_required: false`, `public_safe: true`** — no key, cookie, or account needed; no secrets or private data in the response.
- **Ownership proof:** served from `https://nodexo.ai`, which is already the registry's trusted official `website` surface for SN106 (provider `nodexo`). The API is same-origin on that verified domain.
- Health/uptime/latency are intentionally left to the build prober — this surface only declares the endpoint.

### Scope

- Exactly one file changed: `registry/subnets/nodexo.json` (+16 lines, one new entry appended to `surfaces[]`).
- No generated artifacts, scripts, or workflows touched.

### Validation run

```
npm run validate:surface -- registry/subnets/nodexo.json
# Surface validation passed: 5 surface(s) across 1 subnet file(s).
```
