### PR TITLE
fix(api): harden entity ref parsing against malformed refs

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1965,6 +1965,26 @@ describe("handleBlock", () => {
     assert.ok(idx !== -1, "expected a block_hash lookup");
     assert.equal(captures.params[idx][0], lowerHash);
   });
+
+  test("malformed numeric refs miss instead of resolving another block", async () => {
+    // Number() would coerce each of these (hex, scientific notation, a decimal
+    // point, or an unsafe-integer overflow) to a valid-looking block_number and
+    // resolve the seeded block; strict parsing makes them a miss without ever
+    // issuing the block_number lookup.
+    for (const ref of ["0x1f", "1e3", "12.0", "9007199254740992"]) {
+      const { env, captures } = dbWith({ blockDetail: blockRow() });
+      const body = await json(
+        await handleBlock(req(`/api/v1/blocks/${ref}`), env, ref),
+      );
+      assert.equal(body.data.block, null, `${ref} should miss`);
+      assert.ok(
+        !captures.sql.some((s) =>
+          /FROM blocks WHERE block_number = \?/.test(s),
+        ),
+        `${ref} must not issue a block_number lookup`,
+      );
+    }
+  });
 });
 
 describe("handleBlockExtrinsics", () => {
@@ -2072,6 +2092,31 @@ describe("handleBlockExtrinsics", () => {
     assert.ok(idx !== -1, "expected a block_hash resolution lookup");
     assert.equal(captures.params[idx][0], lowerHash);
   });
+
+  test("malformed numeric refs miss instead of resolving another block", async () => {
+    for (const ref of ["0x1f", "1e3", "9007199254740992"]) {
+      const { env, captures } = dbWith({
+        blockDetail: { block_number: 9 },
+        extrinsics: [extrinsicRow({ block_number: 9 })],
+      });
+      const body = await json(
+        await handleBlockExtrinsics(
+          req(`/api/v1/blocks/${ref}/extrinsics`),
+          env,
+          ref,
+          url(`/api/v1/blocks/${ref}/extrinsics`),
+        ),
+      );
+      assert.equal(body.data.block_number, null, `${ref} should miss`);
+      assert.deepEqual(body.data.extrinsics, []);
+      assert.ok(
+        !captures.sql.some((s) =>
+          /SELECT block_number FROM blocks WHERE block_number = \?/.test(s),
+        ),
+        `${ref} must not resolve a block`,
+      );
+    }
+  });
 });
 
 describe("handleBlockEvents", () => {
@@ -2161,6 +2206,31 @@ describe("handleBlockEvents", () => {
     );
     assert.ok(idx !== -1, "expected a block_hash resolution lookup");
     assert.equal(captures.params[idx][0], lowerHash);
+  });
+
+  test("malformed numeric refs miss instead of resolving another block", async () => {
+    for (const ref of ["0x1f", "1e3", "9007199254740992"]) {
+      const { env, captures } = dbWith({
+        blockDetail: { block_number: 9 },
+        blockEvents: [accountEventRow({ block_number: 9 })],
+      });
+      const body = await json(
+        await handleBlockEvents(
+          req(`/api/v1/blocks/${ref}/events`),
+          env,
+          ref,
+          url(`/api/v1/blocks/${ref}/events`),
+        ),
+      );
+      assert.equal(body.data.block_number, null, `${ref} should miss`);
+      assert.deepEqual(body.data.events, []);
+      assert.ok(
+        !captures.sql.some((s) =>
+          /SELECT block_number FROM blocks WHERE block_number = \?/.test(s),
+        ),
+        `${ref} must not resolve a block`,
+      );
+    }
   });
 });
 
@@ -2439,15 +2509,32 @@ describe("handleExtrinsic", () => {
     assert.equal(body.data.extrinsic.extrinsic_hash, null);
   });
 
-  test("malformed composite id yields extrinsic:null", async () => {
-    const body = await json(
-      await handleExtrinsic(
-        req("/api/v1/extrinsics/not-a-valid-ref"),
-        emptyEnv(),
-        "not-a-valid-ref",
-      ),
-    );
-    assert.equal(body.data.extrinsic, null);
+  test("malformed composite ids miss instead of resolving another extrinsic", async () => {
+    // split("-") + Number() would coerce each of these to a valid-looking
+    // (block, index) and resolve the seeded row; strict parsing makes them a
+    // miss without ever issuing the composite lookup.
+    for (const ref of [
+      "123-45-67",
+      "123-",
+      "-45",
+      "0x1-2",
+      "1e3-2",
+      "9007199254740992-3",
+      "3-9007199254740992",
+      "not-a-valid-ref",
+    ]) {
+      const { env, captures } = dbWith({ extrinsicDetail: extrinsicRow() });
+      const body = await json(
+        await handleExtrinsic(req(`/api/v1/extrinsics/${ref}`), env, ref),
+      );
+      assert.equal(body.data.extrinsic, null, `${ref} should miss`);
+      assert.ok(
+        !captures.sql.some((s) =>
+          /WHERE block_number = \? AND extrinsic_index = \?/.test(s),
+        ),
+        `${ref} must not issue a composite lookup`,
+      );
+    }
   });
 
   test("embeds emitted account_events when extrinsic resolves (#1849)", async () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -108,6 +108,35 @@ function parseBoundedIntParam(url, parameter, { def, min, max }) {
   return { value };
 }
 
+// Resolve a path ref segment to a non-negative chain index, or null when it is
+// not a bare base-10 integer. Number()/parseInt would coerce hex (0x1f),
+// scientific notation (1e3), signs, and trailing garbage to a valid-looking id,
+// resolving a malformed ref to another entity instead of a schema-stable miss.
+function parseRefInt(segment) {
+  if (!/^\d+$/.test(segment)) return null;
+  const value = Number(segment);
+  return Number.isSafeInteger(value) ? value : null;
+}
+
+// Resolve a block {ref} (numeric block_number or 0x block_hash) to its stored
+// block_number via the blocks tier, or null when the ref is malformed or the
+// block is unknown. The numeric ref is parsed strictly, so a non-integer ref is
+// a miss rather than a Number()-coerced lookup of another block. Shared by the
+// block sub-resource handlers, which resolve the ref before reading their rows.
+async function resolveBlockNumber(env, ref) {
+  const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
+  const numericRef = isHash ? null : parseRefInt(ref);
+  if (!isHash && numericRef == null) return null;
+  const rows = await d1All(
+    env,
+    isHash
+      ? `SELECT block_number FROM blocks WHERE block_hash = ? LIMIT 1`
+      : `SELECT block_number FROM blocks WHERE block_number = ? LIMIT 1`,
+    [isHash ? ref.toLowerCase() : numericRef],
+  );
+  return rows[0]?.block_number ?? null;
+}
+
 // --- Per-UID metagraph (#1304/#1305): served live from the neurons D1 tier ---
 // (migration 0007, populated by the refresh-metagraph cron). Null-safe: an
 // unbound/cold D1 returns a schema-stable empty payload, like the other
@@ -1105,6 +1134,9 @@ export async function handleBlocks(request, env, url) {
 // neuron detail route — NEVER 404/throw).
 export async function handleBlock(request, env, ref) {
   const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
+  // A numeric ref must be bare digits; a non-integer ref is a miss (block:null),
+  // never a coerced lookup of another block.
+  const blockNumber = isHash ? null : parseRefInt(ref);
   const sql = isHash
     ? `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_hash = ? LIMIT 1`
     : `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_number = ? LIMIT 1`;
@@ -1112,8 +1144,10 @@ export async function handleBlock(request, env, ref) {
   // and D1 text columns are BINARY-collated, so a mixed/upper-case 0x ref would
   // miss. Normalize the hash ref to lowercase before binding (same for the block-
   // extrinsics, block-events, and extrinsic handlers below).
-  const param = isHash ? ref.toLowerCase() : Number(ref);
-  const rows = await d1All(env, sql, [param]);
+  const rows =
+    isHash || blockNumber != null
+      ? await d1All(env, sql, [isHash ? ref.toLowerCase() : blockNumber])
+      : [];
   // prev/next chain-walk neighbors (#1853): indexed scalar lookups for the
   // nearest STORED block numbers around the resolved height (skips pruned gaps;
   // null at the window edges). Derived from the resolved row's number (works for
@@ -1158,15 +1192,7 @@ export async function handleBlockExtrinsics(request, env, ref, url) {
   if (validationError) return analyticsQueryError(validationError);
   const limit = clampInt(url.searchParams.get("limit"), 50, 1, 100);
   const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
-  const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
-  const blockRows = await d1All(
-    env,
-    isHash
-      ? `SELECT block_number FROM blocks WHERE block_hash = ? LIMIT 1`
-      : `SELECT block_number FROM blocks WHERE block_number = ? LIMIT 1`,
-    [isHash ? ref.toLowerCase() : Number(ref)],
-  );
-  const blockNumber = blockRows[0]?.block_number ?? null;
+  const blockNumber = await resolveBlockNumber(env, ref);
   const rows =
     blockNumber == null
       ? []
@@ -1201,15 +1227,7 @@ export async function handleBlockEvents(request, env, ref, url) {
   if (validationError) return analyticsQueryError(validationError);
   const limit = clampInt(url.searchParams.get("limit"), 100, 1, 1000);
   const offset = clampInt(url.searchParams.get("offset"), 0, 0, 1_000_000);
-  const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
-  const blockRows = await d1All(
-    env,
-    isHash
-      ? `SELECT block_number FROM blocks WHERE block_hash = ? LIMIT 1`
-      : `SELECT block_number FROM blocks WHERE block_number = ? LIMIT 1`,
-    [isHash ? ref.toLowerCase() : Number(ref)],
-  );
-  const blockNumber = blockRows[0]?.block_number ?? null;
+  const blockNumber = await resolveBlockNumber(env, ref);
   const rows =
     blockNumber == null
       ? []
@@ -1403,13 +1421,14 @@ export async function handleExtrinsic(request, env, ref) {
       [ref.toLowerCase()],
     );
   } else {
-    // Composite "<block>-<index>": coerce both halves; a non-finite half is a
-    // miss (extrinsic:null), never a bad bind.
-    const [b, i] = ref.split("-");
-    const blockNumber = Number(b);
-    const extrinsicIndex = Number(i);
+    // Composite "<block>-<index>": exactly two bare-integer halves. split("-")
+    // + Number() would otherwise resolve a malformed ref (123-45-67, 123-, -45,
+    // 0x1-2, 1e3-2) to a wrong-but-valid row instead of a miss (extrinsic:null).
+    const parts = ref.split("-");
+    const blockNumber = parts.length === 2 ? parseRefInt(parts[0]) : null;
+    const extrinsicIndex = parts.length === 2 ? parseRefInt(parts[1]) : null;
     rows =
-      Number.isInteger(blockNumber) && Number.isInteger(extrinsicIndex)
+      blockNumber != null && extrinsicIndex != null
         ? await d1All(
             env,
             `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE block_number = ? AND extrinsic_index = ? LIMIT 1`,


### PR DESCRIPTION
## Summary

The single entity detail handlers resolve a caller supplied ref through Number() or split("-") plus Number(). That lenient coercion turns a malformed ref into a valid looking lookup, so a request can resolve to another entity instead of the null result the handlers already promise. For example extrinsics/123-45-67 resolved to block 123 index 45, and a direct blocks/0x10 coerced to block 16. This replaces the coercion with a strict integer matcher so any malformed ref returns the existing null miss.

Closes #2063

## What Changed

- Added a shared parseRefInt helper next to parseBoundedIntParam, reusing the same /^\d+$/ plus Number.isSafeInteger pattern. It returns null for any segment that is not bare decimal digits (hex, scientific notation, signs, decimals, empty halves, overflow).
- handleExtrinsic composite branch now requires exactly two bare integer halves, so 123-45-67, 123-, -45, 0x1-2, and 1e3-2 return extrinsic:null instead of resolving another row.
- handleBlock, handleBlockExtrinsics, and handleBlockEvents parse the numeric ref strictly, so a malformed numeric ref returns block:null without a coerced block_number lookup.
- The extrinsic_hash branch and the netuid query guard were already strict and stay unchanged. Feed filter coercion (limit, offset, block, from, to) is a separate concern and is left untouched. No contract or schema changed (validate:contract-drift stays green).
- Added regression tests for every malformed shape in the issue table plus the block ref equivalents, asserting the null miss and that no lookup is issued, and confirming valid refs and index 0 still resolve.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
