### PR TITLE
feat(registry): add 7 undocumented SN74 Gittensor API data-artifacts

### DIFF
--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -397,6 +397,167 @@
       },
       "source_urls": ["https://api.gittensor.io/swagger-json"],
       "url": "https://api.gittensor.io/prs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-prices",
+      "kind": "data-artifact",
+      "name": "Gittensor TAO and Alpha token prices",
+      "notes": "Live TAO and Alpha token price feed including market cap, 24h volume, and percent change. Sourced from CoinMarketCap via the Gittensor API.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "high",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/prices"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-prices-history",
+      "kind": "data-artifact",
+      "name": "Gittensor historical TAO and Alpha token prices",
+      "notes": "Time-series price history for TAO and Alpha tokens. Each entry includes price, market cap, 24h volume, and percent change at that timestamp. Configurable via ?days= query parameter.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "high",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/prices/history"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-commits",
+      "kind": "data-artifact",
+      "name": "Gittensor PR commit log",
+      "notes": "Paginated log of merged pull requests including PR number, title, miner hotkey, additions, deletions, commit count, label, repository, and merge timestamp. Useful for auditing contribution history.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "high",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/commits"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-lines-total",
+      "kind": "data-artifact",
+      "name": "Gittensor total lines committed",
+      "notes": "Single-value aggregate of total lines committed across all whitelisted repositories on the network. Supports optional time-window filtering via query parameters.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "high",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/lines/total"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-lines-trend",
+      "kind": "data-artifact",
+      "name": "Gittensor historical lines committed trend",
+      "notes": "Daily time-series of total lines committed to whitelisted repositories. Each entry has a date and linesCommitted count. Useful for visualising network contribution growth over time.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "high",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/lines/hist-trend"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-repos-commits",
+      "kind": "data-artifact",
+      "name": "Gittensor top repositories by commit activity",
+      "notes": "Ranked list of whitelisted repositories with their emission share, commit count, total additions, deletions, and lines changed. Useful for identifying the most active repositories on the network.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "high",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/repos/commits"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-config",
+      "kind": "data-artifact",
+      "name": "Gittensor validator scoring configuration",
+      "notes": "Machine-readable export of the active validator scoring constants: language file scoring weights, PR base score, contribution bonus cap, unique PR boost, and time-decay parameters. Complements the static weight JSON files in the source repo.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "high",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/configurations/general"
     }
   ],
   "website_url": "https://gittensor.io/"

--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -450,7 +450,7 @@
       "id": "sn-74-gittensor-commits",
       "kind": "data-artifact",
       "name": "Gittensor PR commit log",
-      "notes": "Paginated log of merged pull requests including PR number, title, miner hotkey, additions, deletions, commit count, label, repository, and merge timestamp. Useful for auditing contribution history.",
+      "notes": "Paginated log of merged pull requests including PR number, title, miner identifier, additions, deletions, commit count, label, repository, and merge timestamp. Useful for auditing contribution history.",
       "probe": {
         "enabled": true,
         "expect": "json",


### PR DESCRIPTION
## What

Adds 7 community-submitted data-artifact surfaces to the Gittensor (SN74) manifest, covering API endpoints exposed by pi.gittensor.io that are fully documented in the OpenAPI schema but not yet in the registry.

| Surface ID | Endpoint | Description |
|---|---|---|
| sn-74-gittensor-prices | /dash/prices | Live TAO and Alpha token prices (price, market cap, 24h volume, % change) |
| sn-74-gittensor-prices-history | /dash/prices/history | Historical price time-series for TAO and Alpha tokens |
| sn-74-gittensor-commits | /dash/commits | Paginated PR commit log: hotkey, PR title, additions/deletions, merge timestamp |
| sn-74-gittensor-lines-total | /dash/lines/total | Aggregate total lines committed across all whitelisted repositories |
| sn-74-gittensor-lines-trend | /dash/lines/hist-trend | Daily time-series of lines committed - tracks network contribution growth |
| sn-74-gittensor-repos-commits | /dash/repos/commits | Top repos ranked by emission share, commit count, and lines changed |
| sn-74-gittensor-config | /configurations/general | Live export of active validator scoring constants (base scores, bonuses, decay params) |

## Why these surfaces matter

- **Prices** - the only way to get live TAO/Alpha pricing directly from the Gittensor API; useful for tooling that shows earnings in fiat terms.
- **Commits + lines** - network-level contribution analytics; gives a picture of total throughput and growth trajectory.
- **Repos commits** - shows which whitelisted repositories are most active and how emission shares correlate with commit volume.
- **Config** - machine-readable live snapshot of the scoring constants that drive reward calculation, complementing the static weight JSON files already in the registry.

## Source verification

All 7 endpoints are documented in the public OpenAPI spec:
- https://api.gittensor.io/swagger-json
- https://api.gittensor.io/swagger (interactive UI)

All verified live at time of submission (HTTP 200, JSON Content-Type, no auth required).