### PR TITLE
refactor(entities): extract canonicalWindowedCachePath helper; fix turnover window cache deduplication

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -287,6 +287,40 @@ describe("analytics edge cache", () => {
     assert.equal(cache.store.size, 1);
   });
 
+  test("turnover: explicit ?window=30d populates cache; omitted window is a HIT", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+
+    // Explicit ?window=30d is the canonical form — cache MISS, populates.
+    const first = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/turnover?window=30d",
+      ),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(first.status, 200);
+    const queriesAfterMiss = queries.length;
+
+    // Omitted window resolves to the same 30d key — must be a HIT (no D1).
+    const hit = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/subnets/7/turnover"),
+      env,
+      ctx,
+    );
+    assert.equal(hit.status, 200);
+    assert.equal(
+      queries.length,
+      queriesAfterMiss,
+      "omitted window must reuse the ?window=30d cache slot (no D1 queries)",
+    );
+    assert.equal(cache.store.size, 1);
+  });
+
   test("HIT: a pre-populated cache serves the cached body WITHOUT touching D1", async () => {
     originalCaches = globalThis.caches;
     const cache = mockCaches();

--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -245,6 +245,48 @@ describe("analytics edge cache", () => {
     assert.equal(cache.store.size, 1);
   });
 
+  test("turnover canonicalizes omitted and explicit default window to the same cache key", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+
+    // No ?window — should resolve to the 30d default and cache at ?window=30d.
+    const first = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/subnets/7/turnover"),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(first.status, 200);
+    const queriesAfterMiss = queries.length;
+
+    // Explicit ?window=30d is the canonical form — must be a cache HIT (no new D1).
+    const hit = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/turnover?window=30d",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(hit.status, 200);
+    assert.equal(
+      queries.length,
+      queriesAfterMiss,
+      "explicit ?window=30d must be a cache HIT (no D1 queries)",
+    );
+
+    assert.deepEqual(cache.putKeys, [
+      expectedKey(
+        "subnet-turnover",
+        "/api/v1/subnets/7/turnover",
+        "?window=30d",
+      ),
+    ]);
+    assert.equal(cache.store.size, 1);
+  });
+
   test("HIT: a pre-populated cache serves the cached body WITHOUT touching D1", async () => {
     originalCaches = globalThis.caches;
     const cache = mockCaches();

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1096,6 +1096,13 @@ describe("handleSubnetTurnover", () => {
       assert.equal(key, "/api/v1/subnets/1/turnover?window=7d");
     });
 
+    test("accepts 1y window (parseHistoryWindow-only value, rejected by concentration parser)", () => {
+      const key = canonicalSubnetTurnoverCachePath(
+        new URL("https://api.metagraph.sh/api/v1/subnets/1/turnover?window=1y"),
+      );
+      assert.equal(key, "/api/v1/subnets/1/turnover?window=1y");
+    });
+
     test("returns raw search on an invalid window value", () => {
       const raw = "/api/v1/subnets/1/turnover?window=bogus";
       const key = canonicalSubnetTurnoverCachePath(

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -30,6 +30,7 @@ import {
   handleBlockEvents,
   handleExtrinsics,
   handleExtrinsic,
+  canonicalSubnetTurnoverCachePath,
 } from "../workers/request-handlers/entities.mjs";
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
@@ -1072,6 +1073,44 @@ describe("handleSubnetTurnover", () => {
     );
     assert.ok(idx !== -1);
     assert.equal(captures.params[idx][0], NETUID);
+  });
+
+  describe("canonicalSubnetTurnoverCachePath", () => {
+    test("omitted window and explicit ?window=30d produce the same cache key", () => {
+      const noWindow = canonicalSubnetTurnoverCachePath(
+        new URL("https://api.metagraph.sh/api/v1/subnets/1/turnover"),
+      );
+      const explicit30d = canonicalSubnetTurnoverCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/1/turnover?window=30d",
+        ),
+      );
+      assert.equal(noWindow, explicit30d);
+      assert.equal(noWindow, "/api/v1/subnets/1/turnover?window=30d");
+    });
+
+    test("preserves a non-default valid window label", () => {
+      const key = canonicalSubnetTurnoverCachePath(
+        new URL("https://api.metagraph.sh/api/v1/subnets/1/turnover?window=7d"),
+      );
+      assert.equal(key, "/api/v1/subnets/1/turnover?window=7d");
+    });
+
+    test("returns raw search on an invalid window value", () => {
+      const raw = "/api/v1/subnets/1/turnover?window=bogus";
+      const key = canonicalSubnetTurnoverCachePath(
+        new URL(`https://api.metagraph.sh${raw}`),
+      );
+      assert.equal(key, raw);
+    });
+
+    test("returns raw search on an unsupported query parameter", () => {
+      const raw = "/api/v1/subnets/1/turnover?unknown=1";
+      const key = canonicalSubnetTurnoverCachePath(
+        new URL(`https://api.metagraph.sh${raw}`),
+      );
+      assert.equal(key, raw);
+    });
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -70,6 +70,7 @@ import {
   handleSubnetConcentrationHistory,
   canonicalSubnetConcentrationHistoryCachePath,
   handleSubnetTurnover,
+  canonicalSubnetTurnoverCachePath,
   handleAccount,
   handleAccountHistory,
   handleAccountBalance,
@@ -1262,13 +1263,19 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     if (turnoverMatch) {
       // Boundary-snapshot diff over the neuron_daily rollup, deterministic per
       // cron snapshot — edge-cache like the sibling history routes.
-      return withEdgeCache(request, ctx, env, "subnet-turnover", () =>
-        handleSubnetTurnover(
-          request,
-          env,
-          Number(turnoverMatch[1]),
-          resolved.url,
-        ),
+      return withEdgeCache(
+        request,
+        ctx,
+        env,
+        "subnet-turnover",
+        () =>
+          handleSubnetTurnover(
+            request,
+            env,
+            Number(turnoverMatch[1]),
+            resolved.url,
+          ),
+        canonicalSubnetTurnoverCachePath(resolved.url),
       );
     }
     // Per-UID metagraph (#1304/#1305): computed live from the neurons D1 tier.

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -292,26 +292,27 @@ export async function handleSubnetConcentration(request, env, netuid, url) {
   );
 }
 
-export function canonicalSubnetConcentrationHistoryCachePath(url) {
+// Shared helper: build a canonical edge-cache key for any windowed route by
+// normalising the ?window= query parameter through the route-specific parse
+// function, so that an omitted window and an explicit default-value window map
+// to the same cache slot.
+function canonicalWindowedCachePath(url, parseWindow) {
   const validationError = validateQueryParams(url, ["window"]);
   if (validationError) return `${url.pathname}${url.search}`;
-  const { label, error } = parseConcentrationHistoryWindow(
-    url.searchParams.get("window"),
-  );
+  const { label, error } = parseWindow(url.searchParams.get("window"));
   if (error) return `${url.pathname}${url.search}`;
   return `${url.pathname}?window=${encodeURIComponent(label)}`;
 }
 
-// Canonical edge-cache key for the subnet turnover route: normalise the ?window=
-// parameter so that an omitted window (defaults to 30d via parseHistoryWindow) and
-// an explicit ?window=30d map to the same cache slot, matching the pattern already
-// used by canonicalSubnetConcentrationHistoryCachePath for the sibling history route.
+export function canonicalSubnetConcentrationHistoryCachePath(url) {
+  return canonicalWindowedCachePath(url, parseConcentrationHistoryWindow);
+}
+
+// Canonical edge-cache key for the subnet-turnover route (?window= via
+// parseHistoryWindow). Distinct from canonicalSubnetConcentrationHistoryCachePath
+// which uses a different parse function (parseConcentrationHistoryWindow).
 export function canonicalSubnetTurnoverCachePath(url) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return `${url.pathname}${url.search}`;
-  const { label, error } = parseHistoryWindow(url.searchParams.get("window"));
-  if (error) return `${url.pathname}${url.search}`;
-  return `${url.pathname}?window=${encodeURIComponent(label)}`;
+  return canonicalWindowedCachePath(url, parseHistoryWindow);
 }
 
 // GET /api/v1/subnets/{netuid}/concentration/history?window=7d|30d|90d: the per-day

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -302,6 +302,18 @@ export function canonicalSubnetConcentrationHistoryCachePath(url) {
   return `${url.pathname}?window=${encodeURIComponent(label)}`;
 }
 
+// Canonical edge-cache key for the subnet turnover route: normalise the ?window=
+// parameter so that an omitted window (defaults to 30d via parseHistoryWindow) and
+// an explicit ?window=30d map to the same cache slot, matching the pattern already
+// used by canonicalSubnetConcentrationHistoryCachePath for the sibling history route.
+export function canonicalSubnetTurnoverCachePath(url) {
+  const validationError = validateQueryParams(url, ["window"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const { label, error } = parseHistoryWindow(url.searchParams.get("window"));
+  if (error) return `${url.pathname}${url.search}`;
+  return `${url.pathname}?window=${encodeURIComponent(label)}`;
+}
+
 // GET /api/v1/subnets/{netuid}/concentration/history?window=7d|30d|90d: the per-day
 // stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share)
 // from the dated neuron_daily rollup — "is this subnet centralizing over time?".


### PR DESCRIPTION
## Summary

`GET /api/v1/subnets/{netuid}/turnover` accepted a `?window=` query parameter but did not normalise it in the edge-cache key. An omitted `?window=` (which defaults to `30d` via `parseHistoryWindow`) and an explicit `?window=30d` produced the same response but stored it under two distinct cache keys, causing redundant D1 reads and divergent TTL windows. This is the missed sibling of `canonicalSubnetConcentrationHistoryCachePath` which already solves the same problem for the concentration-history route.

## What Changed

- `workers/request-handlers/entities.mjs`: extracted a private `canonicalWindowedCachePath(url, parseWindow)` helper that eliminates the repeated validate/parse/encode sequence; refactored `canonicalSubnetConcentrationHistoryCachePath` to use it; added `canonicalSubnetTurnoverCachePath` (uses `parseHistoryWindow`, accepts `7d`/`30d`/`90d`/`1y`/`all`)
- `workers/api.mjs`: wired `canonicalSubnetTurnoverCachePath` as the fifth argument to the turnover `withEdgeCache` call
- `tests/request-handlers-entities.test.mjs`: added `canonicalSubnetTurnoverCachePath` unit tests (omitted-vs-explicit-30d deduplication, 7d non-default, 1y to confirm `parseHistoryWindow` parser, invalid window, unsupported param)
- `tests/request-handlers-entities.test.mjs`: added route-level integration tests confirming the public cache hits in both request orders

## Why it was observably wrong

Without a canonical path, `?window=30d` and no `?window=` stored responses in separate edge-cache slots. A warm-cache hit for the explicit form would miss for the default form (and vice versa), doubling D1 read pressure and allowing the two slots to drift in their TTL windows. `canonicalSubnetConcentrationHistoryCachePath` already addresses this for the concentration-history sibling route; the turnover route was missed.

## Template Used

- backend-code.md

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No schema/contract change (edge-cache key normalisation only; response shape and SQL unchanged).

## Validation

- [x] `npx vitest run tests/request-handlers-entities.test.mjs` (all passed)
- [x] `npx prettier --check workers/request-handlers/entities.mjs workers/api.mjs tests/request-handlers-entities.test.mjs`
- [x] `git diff --check`

Closes #2251