### PR TITLE
fix(account-events): sanitise block positions in buildAccountTransfers

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -76,7 +76,7 @@ function toIso(ms) {
 function toBlockNumber(value) {
   if (value == null) return null;
   const n = Number(value);
-  return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : null;
+  return Number.isInteger(n) && n >= 0 ? n : null;
 }
 
 // One D1 account_events row → a clean API event object (#1347 consumes this).

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -93,7 +93,7 @@ export function formatAccountEvent(row) {
     amount_tao: row.amount_tao ?? null,
     alpha_amount: row.alpha_amount ?? null,
     observed_at: toIso(row.observed_at),
-    extrinsic_index: row.extrinsic_index ?? null,
+    extrinsic_index: toBlockNumber(row.extrinsic_index),
   };
 }
 
@@ -407,8 +407,8 @@ export function buildAccountTransfers(
   const transfers = (rows || [])
     .filter((r) => r && typeof r === "object")
     .map((r) => ({
-      block_number: r.block_number ?? null,
-      event_index: r.event_index ?? null,
+      block_number: toBlockNumber(r.block_number),
+      event_index: toBlockNumber(r.event_index),
       from: r.hotkey ?? null,
       to: r.coldkey ?? null,
       amount_tao: r.amount_tao ?? null,

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -372,6 +372,14 @@ test("account builders null invalid block heights and indices", () => {
   assert.equal(transfers.transfers[2].event_index, 2);
   assert.equal(transfers.transfers[2].amount_tao, 3);
   assert.equal(transfers.transfers[2].direction, "sent");
+
+  // Null input preserves null (the value == null branch in toBlockNumber).
+  const nullTransfers = buildAccountTransfers(
+    [{ block_number: null, event_index: null, hotkey: "5A", coldkey: "5B" }],
+    "5A",
+  );
+  assert.equal(nullTransfers.transfers[0].block_number, null);
+  assert.equal(nullTransfers.transfers[0].event_index, null);
 });
 
 test("formatRegistration defaults every sparse field to null/false (null-safe)", () => {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -21,6 +21,7 @@ import {
   rollupAccountEventsDaily,
   pruneAccountEvents,
   validEventRows,
+  buildAccountTransfers,
 } from "../src/account-events.mjs";
 import { encodeCursor } from "../src/cursor.mjs";
 
@@ -310,11 +311,13 @@ test("account builders null invalid block heights and indices", () => {
   const event = formatAccountEvent({
     block_number: -1,
     event_index: -2,
+    extrinsic_index: -3,
     event_kind: "StakeAdded",
     observed_at: 1,
   });
   assert.equal(event.block_number, null);
   assert.equal(event.event_index, null);
+  assert.equal(event.extrinsic_index, null);
 
   const summary = buildAccountSummary("5Hk", {
     agg: { fb: -5, lb: "nope" },
@@ -331,6 +334,22 @@ test("account builders null invalid block heights and indices", () => {
   });
   assert.equal(day.first_block, null);
   assert.equal(day.last_block, 100);
+
+  const transfers = buildAccountTransfers(
+    [
+      {
+        block_number: -5,
+        event_index: -1,
+        hotkey: "5A",
+        coldkey: "5B",
+        amount_tao: 1,
+        observed_at: null,
+      },
+    ],
+    "5A",
+  );
+  assert.equal(transfers.transfers[0].block_number, null);
+  assert.equal(transfers.transfers[0].event_index, null);
 });
 
 test("formatRegistration defaults every sparse field to null/false (null-safe)", () => {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -381,13 +381,13 @@ test("account builders null invalid block heights and indices", () => {
   assert.equal(nullTransfers.transfers[0].block_number, null);
   assert.equal(nullTransfers.transfers[0].event_index, null);
 
-  // Fractional values are truncated toward zero, not rounded.
+  // Fractional values are non-integer and therefore treated as malformed (null).
   const fracTransfers = buildAccountTransfers(
     [{ block_number: 3.7, event_index: 1.9, hotkey: "5A", coldkey: "5B" }],
     "5A",
   );
-  assert.equal(fracTransfers.transfers[0].block_number, 3);
-  assert.equal(fracTransfers.transfers[0].event_index, 1);
+  assert.equal(fracTransfers.transfers[0].block_number, null);
+  assert.equal(fracTransfers.transfers[0].event_index, null);
 });
 
 test("formatRegistration defaults every sparse field to null/false (null-safe)", () => {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -373,13 +373,21 @@ test("account builders null invalid block heights and indices", () => {
   assert.equal(transfers.transfers[2].amount_tao, 3);
   assert.equal(transfers.transfers[2].direction, "sent");
 
-  // Null input preserves null (the value == null branch in toBlockNumber).
+  // Null block_number and event_index are preserved as null in the output.
   const nullTransfers = buildAccountTransfers(
     [{ block_number: null, event_index: null, hotkey: "5A", coldkey: "5B" }],
     "5A",
   );
   assert.equal(nullTransfers.transfers[0].block_number, null);
   assert.equal(nullTransfers.transfers[0].event_index, null);
+
+  // Fractional values are truncated toward zero, not rounded.
+  const fracTransfers = buildAccountTransfers(
+    [{ block_number: 3.7, event_index: 1.9, hotkey: "5A", coldkey: "5B" }],
+    "5A",
+  );
+  assert.equal(fracTransfers.transfers[0].block_number, 3);
+  assert.equal(fracTransfers.transfers[0].event_index, 1);
 });
 
 test("formatRegistration defaults every sparse field to null/false (null-safe)", () => {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -345,11 +345,21 @@ test("account builders null invalid block heights and indices", () => {
         amount_tao: 1,
         observed_at: null,
       },
+      {
+        block_number: Infinity,
+        event_index: NaN,
+        hotkey: "5A",
+        coldkey: "5B",
+        amount_tao: 2,
+        observed_at: null,
+      },
     ],
     "5A",
   );
   assert.equal(transfers.transfers[0].block_number, null);
   assert.equal(transfers.transfers[0].event_index, null);
+  assert.equal(transfers.transfers[1].block_number, null);
+  assert.equal(transfers.transfers[1].event_index, null);
 });
 
 test("formatRegistration defaults every sparse field to null/false (null-safe)", () => {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -370,6 +370,8 @@ test("account builders null invalid block heights and indices", () => {
   assert.equal(transfers.transfers[1].event_index, null);
   assert.equal(transfers.transfers[2].block_number, 10);
   assert.equal(transfers.transfers[2].event_index, 2);
+  assert.equal(transfers.transfers[2].amount_tao, 3);
+  assert.equal(transfers.transfers[2].direction, "sent");
 });
 
 test("formatRegistration defaults every sparse field to null/false (null-safe)", () => {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -353,6 +353,14 @@ test("account builders null invalid block heights and indices", () => {
         amount_tao: 2,
         observed_at: null,
       },
+      {
+        block_number: 10,
+        event_index: 2,
+        hotkey: "5A",
+        coldkey: "5B",
+        amount_tao: 3,
+        observed_at: null,
+      },
     ],
     "5A",
   );
@@ -360,6 +368,8 @@ test("account builders null invalid block heights and indices", () => {
   assert.equal(transfers.transfers[0].event_index, null);
   assert.equal(transfers.transfers[1].block_number, null);
   assert.equal(transfers.transfers[1].event_index, null);
+  assert.equal(transfers.transfers[2].block_number, 10);
+  assert.equal(transfers.transfers[2].event_index, 2);
 });
 
 test("formatRegistration defaults every sparse field to null/false (null-safe)", () => {


### PR DESCRIPTION
## Summary

`buildAccountTransfers` forwarded raw `block_number` and `event_index` values from DB rows using `?? null`, passing negative or non-finite numbers through unchanged. PR #2188 introduced `toBlockNumber` in `src/account-events.mjs` and applied it to `formatAccountEvent`, but the sibling `buildAccountTransfers` mapper was missed. Additionally `extrinsic_index` in `formatAccountEvent` still used raw `?? null` while the other two position fields already used `toBlockNumber`. The helper has also been tightened to reject fractional values (`Number.isInteger`) since chain positions are always non-negative integers.

## What Changed

- `src/account-events.mjs`: tightened `toBlockNumber` to use `Number.isInteger` (rejects fractionals) instead of `Math.trunc`; applied it to `block_number` and `event_index` in `buildAccountTransfers`; applied it to `extrinsic_index` in `formatAccountEvent`
- `tests/account-events.test.mjs`: extended "account builders null invalid block heights and indices" with negative/Infinity/NaN transfer positions, null-preservation, and fractional-rejection cases

## Why it was observably wrong

`buildAccountTransfers` emitted negative or non-finite `block_number` and `event_index` values directly to the API response. `formatAccountEvent` was inconsistent: its `block_number` and `event_index` were guarded but `extrinsic_index` was not. This is the missed-sibling of PR #2188 (which guarded `formatAccountEvent`'s block positions but not the transfer builder or extrinsic index).

## Template Used

- backend-code.md

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No schema/contract change (only nullability of malformed position values corrected; column set and types unchanged).

## Validation

- [x] `npx vitest run tests/account-events.test.mjs` (all passed)
- [x] `npx prettier --check src/account-events.mjs tests/account-events.test.mjs`
- [x] `git diff --check`

Closes #2254