### PR TITLE
feat(registry): add 3 SN74 Gittensor per-resource data-artifact surfaces

### DIFF
--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -397,6 +397,75 @@
       },
       "source_urls": ["https://api.gittensor.io/swagger-json"],
       "url": "https://api.gittensor.io/prs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-issue-details",
+      "kind": "data-artifact",
+      "name": "Gittensor issue bounty details",
+      "notes": "Detail record for a single Gittensor issue bounty: GitHub URL, bounty amount, status, and linked repository. The `1` path segment is an example issue ID; any valid Gittensor issue ID returns the same schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "high",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/issues/1/details"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-issue-submissions",
+      "kind": "data-artifact",
+      "name": "Gittensor issue bounty PR submissions",
+      "notes": "Pull request submissions made against a Gittensor issue bounty: PR number, title, author login, repository, and merge status. The `1` path segment is an example issue ID; any valid Gittensor issue ID returns the same schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "high",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/issues/1/submissions"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-repo-miners",
+      "kind": "data-artifact",
+      "name": "Gittensor per-repository miner evaluations",
+      "notes": "Miner evaluations scoped to a single whitelisted repository: UID, credibility score, GitHub username, and any failed-reason flags. The `entrius%2Fgittensor` path segment is an example; any whitelisted repository slug returns the same schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "high",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/repos/entrius%2Fgittensor/miners"
     }
   ],
   "website_url": "https://gittensor.io/"


### PR DESCRIPTION
## What

Adds 3 community-submitted data-artifact surfaces for Gittensor (SN74) per-resource API endpoints that are documented in the public OpenAPI spec but not yet in the registry. These complement the aggregate endpoints already registered (`/issues`, `/miners`, `/prs`) by exposing detail-level data for individual resources.

| Surface ID | Endpoint | Description |
|---|---|---|
| `sn-74-gittensor-issue-details` | `/issues/1/details` | Issue bounty record: GitHub URL, amount, status, repository |
| `sn-74-gittensor-issue-submissions` | `/issues/1/submissions` | PR submissions for a bounty: PR number, title, author, merge status |
| `sn-74-gittensor-repo-miners` | `/repos/entrius%2Fgittensor/miners` | Miner evaluations scoped to one whitelisted repo: UID, credibility, GitHub username |

## Why these endpoints matter

- **Issue detail + submissions** close the loop on the bounty workflow: `/issues` lists all bounties, but there is no registered surface for inspecting a specific bounty or its competing PRs. Tooling that wants to display bounty state needs these two endpoints.
- **Repo miners** is the only way to get per-repository miner evaluation data (credibility scores, failure flags) rather than network-wide aggregates. Critical for maintainers monitoring their repo's contributor health.

## Notes on parameterised paths

The path segments `1` and `entrius%2Fgittensor` are representative examples. The same schema is returned for any valid issue ID or whitelisted repository slug. The probe uses these concrete values so CI can verify liveness.

## Source verification

All three endpoints are documented in the public OpenAPI spec:
- https://api.gittensor.io/swagger-json
- https://api.gittensor.io/swagger (interactive UI)

All verified live at time of submission (HTTP 200, `application/json`).