### PR TITLE
feat(registry): add 3 SN74 Gittensor bounty and repo-config data-artifact surfaces

### DIFF
--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -177,7 +177,7 @@
       "id": "gittensory-mcp",
       "kind": "subnet-api",
       "name": "Gittensory MCP (contribution interface)",
-      "notes": "Streamable-HTTP MCP server exposing deterministic, gittensor-native contribution signals (decision pack, check-before-start, preflight, notifications) to a contributor's own agent harness. POST-only JSON-RPC, so recurring read probes are intentionally disabled. Contributor tools are scoped to the authenticated GitHub login.",
+      "notes": "Streamable-HTTP MCP server exposing deterministic, gittensor-native contribution signals (decision pack, check-before-start, preflight, notifications) to a contributor\u0027s own agent harness. POST-only JSON-RPC, so recurring read probes are intentionally disabled. Contributor tools are scoped to the authenticated GitHub login.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -397,6 +397,75 @@
       },
       "source_urls": ["https://api.gittensor.io/swagger-json"],
       "url": "https://api.gittensor.io/prs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-issue-record",
+      "kind": "data-artifact",
+      "name": "Gittensor issue bounty full record",
+      "notes": "Full record for a single Gittensor issue bounty: GitHub URL, bounty amount, target bounty, status, winning PR number, solver SS58 address, and lifecycle timestamps. The `1` path segment is an example issue ID; any valid Gittensor issue ID returns the same schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "high",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/issues/1"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-repo-issue-summary",
+      "kind": "data-artifact",
+      "name": "Gittensor per-repository bounty summary",
+      "notes": "Aggregate bounty statistics scoped to a single whitelisted repository: total, active, and completed bounty counts plus total TAO available and paid out. The `entrius%2Fgittensor` path segment is an example; any whitelisted repository slug returns the same schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "high",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/issues/repo/entrius%2Fgittensor/summary"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-repo-config",
+      "kind": "data-artifact",
+      "name": "Gittensor repository scoring configuration",
+      "notes": "Scoring configuration for a single whitelisted repository: emission share, maintainer cut, label multipliers (bug, feature, enhancement, refactor), and issue discovery share. These values directly affect how PR contributions to this repository are weighted by validators. The `entrius%2Fgittensor` path segment is an example; any whitelisted repository slug returns the same schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "high",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/repos/entrius%2Fgittensor"
     }
   ],
   "website_url": "https://gittensor.io/"


### PR DESCRIPTION
## What

Adds 3 community-submitted data-artifact surfaces for Gittensor (SN74) endpoints that are documented in the public OpenAPI spec but not yet registered. These complement the aggregate surfaces already in the registry by adding per-resource and repo-scoped resolution.

| Surface ID | Endpoint | Description |
|---|---|---|
| `sn-74-gittensor-issue-record` | `/issues/1` | Full issue bounty record: GitHub URL, target/actual bounty, status, winning PR number, solver SS58 address, timestamps |
| `sn-74-gittensor-repo-issue-summary` | `/issues/repo/entrius%2Fgittensor/summary` | Aggregate bounty stats for one repository: active/completed count, total TAO available and paid out |
| `sn-74-gittensor-repo-config` | `/repos/entrius%2Fgittensor` | Scoring configuration for one repository: emission share, maintainer cut, label multipliers, issue discovery share |

## Why these surfaces matter

- **Issue record** (/issues/{id}) returns the canonical issue bounty object - bounty amount, target, status, winning PR, and solver - which is distinct from the already-registered aggregate /issues list and the detail sub-resource /issues/{id}/details. It is the authoritative single-record endpoint for a bounty.
- **Repo issue summary** (/issues/repo/{repo}/summary) is the only endpoint that gives a per-repository view of bounty health (active/completed counts and total TAO paid out). The existing /issues/stats surface covers network-wide aggregates; this one scopes to a single repository.
- **Repo config** (/repos/{repo}) exposes the validator-level scoring weights for one specific repository (emission share, label multipliers, maintainer cut). These values are distinct from the static weight files already registered (/validator/weights/master_repositories.json) because the API reflects the live, per-repo overrides used in scoring.

## Notes on parameterised paths

The path segments `1` and `entrius%2Fgittensor` are representative examples. The same schema is returned for any valid issue ID or whitelisted repository slug. The probes use these concrete values so CI can verify liveness.

## Source verification

All three endpoints are documented in the public OpenAPI spec and verified live at time of submission (HTTP 200, `application/json`):
- https://api.gittensor.io/swagger-json
- https://api.gittensor.io/swagger (interactive UI)