### PR TITLE
perf(validate): group surfaces by netuid once in validateGeneratedArtifacts

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -934,6 +934,12 @@ async function validateGeneratedArtifacts(
     endpointsArtifact.endpoints || [],
     (endpoint) => endpoint.netuid,
   );
+  // Group surfaces by netuid once (mirrors activeCandidatesByNetuid /
+  // endpointsByNetuid above) instead of re-filtering the full flat list every
+  // subnet iteration — the lone O(netuids x surfaces) scan among pre-grouped
+  // reads (#2097). Map.groupBy preserves order, so the byte-equality assertion
+  // below holds; the `|| []` fallback covers zero-surface overlays.
+  const surfacesByNetuid = Map.groupBy(surfaces, (surface) => surface.netuid);
   const expectedSubnetsByNetuid = new Map(
     nativeSnapshot.subnets.map((nativeSubnet) => [
       nativeSubnet.netuid,
@@ -964,9 +970,7 @@ async function validateGeneratedArtifacts(
       const detailArtifact = await readJson(detailPath);
       const subnetCandidates =
         activeCandidatesByNetuid.get(subnet.netuid) || [];
-      const subnetSurfaces = surfaces.filter(
-        (surface) => surface.netuid === subnet.netuid,
-      );
+      const subnetSurfaces = surfacesByNetuid.get(subnet.netuid) || [];
       const subnetEndpoints = endpointsByNetuid.get(subnet.netuid) || [];
       const expectedDetailArtifact = {
         schema_version: 1,


### PR DESCRIPTION
## Summary

- `validateGeneratedArtifacts` in `scripts/validate.mjs` already groups its per-subnet inputs by netuid up front (`activeCandidatesByNetuid`, `endpointsByNetuid`) and reads them by key in the loop — except `surfaces`. The per-subnet loop re-filtered the entire 429-entry flat surface list every iteration (`surfaces.filter(s => s.netuid === subnet.netuid)`) — the lone linear scan among pre-grouped reads, ≈129 × 429 comparisons/run, O(netuids × surfaces).

## What Changed

- `scripts/validate.mjs`: group surfaces by netuid once with `Map.groupBy` (mirroring `activeCandidatesByNetuid` / `endpointsByNetuid`) and read `surfacesByNetuid.get(subnet.netuid) || []` in the loop. `Map.groupBy` preserves insertion order, so the per-subnet byte-equality assertion still holds; the `|| []` fallback covers zero-surface overlays.

## Output is byte-identical

`npm run validate` passes byte-identically (the per-subnet detail-artifact reproducibility assertion holds for every subnet, including zero-surface ones). No `surfaces.filter(... netuid ...)` remains.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — validator internal grouping; output unchanged.)

## Validation

- [x] `npm run validate` — passed (byte-identical; 129 subnets, 1212 surfaces)
- [x] prettier `--check` + eslint clean on the changed file
- [x] `git diff --check`

Closes #2097
