### PR TITLE
perf(validate): register OpenAPI components once instead of per route

### DIFF
--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -22,6 +22,41 @@ const ajv = new Ajv2020({
 });
 addFormats(ajv);
 
+// Register the OpenAPI components block ONCE so its 220 schemas are compiled a
+// single time and reused across every route's response/error-envelope validator
+// (#2094). Previously each compile inlined `components: openapi.components`,
+// re-traversing all 220 schemas per call. Route schemas reference components with
+// document-relative `#/components/...` pointers; rebaseComponentRefs redirects
+// those into the registered doc. Mirrors the pattern in validate-schemas.mjs.
+const COMPONENTS_SCHEMA_ID =
+  "https://metagraph.sh/openapi-components.schema.json";
+ajv.addSchema(
+  { $id: COMPONENTS_SCHEMA_ID, components: openapi.components },
+  COMPONENTS_SCHEMA_ID,
+);
+
+function rebaseComponentRefs(node) {
+  if (Array.isArray(node)) {
+    return node.map(rebaseComponentRefs);
+  }
+  if (node && typeof node === "object") {
+    const out = {};
+    for (const [key, value] of Object.entries(node)) {
+      if (
+        key === "$ref" &&
+        typeof value === "string" &&
+        value.startsWith("#/components/")
+      ) {
+        out[key] = `${COMPONENTS_SCHEMA_ID}${value}`;
+      } else {
+        out[key] = rebaseComponentRefs(value);
+      }
+    }
+    return out;
+  }
+  return node;
+}
+
 // The chain-events routes proxy to the Postgres-backed data Worker (DATA_API
 // service binding). It's a separate Worker not present in this harness, so mock it
 // with the bare response shapes it serves (ADR 0013) — api.mjs rewraps them in the
@@ -963,10 +998,7 @@ function validateWorkerResponse(route, body) {
     operation?.responses?.["200"]?.content?.["application/json"]?.schema;
   assert.ok(responseSchema, `${route}: missing OpenAPI 200 schema`);
 
-  const validator = ajv.compile({
-    components: openapi.components,
-    ...responseSchema,
-  });
+  const validator = ajv.compile(rebaseComponentRefs(responseSchema));
   assert.equal(
     validator(body),
     true,
@@ -978,8 +1010,7 @@ function validateWorkerResponse(route, body) {
 
 function validateErrorEnvelope(body) {
   const validator = ajv.compile({
-    components: openapi.components,
-    $ref: "#/components/schemas/ErrorEnvelope",
+    $ref: `${COMPONENTS_SCHEMA_ID}#/components/schemas/ErrorEnvelope`,
   });
   assert.equal(
     validator(body),

--- a/scripts/validate-openapi-examples.mjs
+++ b/scripts/validate-openapi-examples.mjs
@@ -22,6 +22,42 @@ const ajv = new Ajv2020({
 });
 addFormats(ajv);
 
+// Register the OpenAPI components block ONCE so its 220 schemas are compiled a
+// single time and reused across every route (#2094). Previously each route's
+// compile inlined `components: openapi.components`, re-traversing all 220 schemas
+// per route (~94x redundant). Route response schemas reference components with
+// document-relative `#/components/...` pointers; rebaseRefs redirects those into
+// the registered doc so AJV resolves them against the already-compiled schema.
+// Mirrors the addSchema + $ref pattern in validate-schemas.mjs.
+const COMPONENTS_SCHEMA_ID =
+  "https://metagraph.sh/openapi-components.schema.json";
+ajv.addSchema(
+  { $id: COMPONENTS_SCHEMA_ID, components: openapi.components },
+  COMPONENTS_SCHEMA_ID,
+);
+
+function rebaseComponentRefs(node) {
+  if (Array.isArray(node)) {
+    return node.map(rebaseComponentRefs);
+  }
+  if (node && typeof node === "object") {
+    const out = {};
+    for (const [key, value] of Object.entries(node)) {
+      if (
+        key === "$ref" &&
+        typeof value === "string" &&
+        value.startsWith("#/components/")
+      ) {
+        out[key] = `${COMPONENTS_SCHEMA_ID}${value}`;
+      } else {
+        out[key] = rebaseComponentRefs(value);
+      }
+    }
+    return out;
+  }
+  return node;
+}
+
 const errors = [];
 let validated = 0;
 
@@ -40,10 +76,7 @@ for (const route of API_ROUTES) {
     );
     continue;
   }
-  const validator = ajv.compile({
-    components: openapi.components,
-    ...responseSchema,
-  });
+  const validator = ajv.compile(rebaseComponentRefs(responseSchema));
   if (!validator(example)) {
     errors.push(
       `${route.path}: response example failed schema validation: ${ajv.errorsText(


### PR DESCRIPTION
## Summary

Two required CI validators compiled an AJV validator **per route**, each re-inlining the entire `openapi.components` block (220 schemas) via `ajv.compile({ components: openapi.components, ...schema })`. That re-traverses all 220 schemas on every compile:
- `scripts/validate-openapi-examples.mjs` — once per route (~94×).
- `scripts/validate-api.mjs` — `validateWorkerResponse` per route, plus `validateErrorEnvelope`.

`scripts/validate-schemas.mjs` already does this the cheap way (register components once via `addSchema`, compile small `$ref` validators).

## What Changed

- Both scripts now register the components block **once** via `ajv.addSchema` under a stable `$id` (`https://metagraph.sh/openapi-components.schema.json`), matching `validate-schemas.mjs`.
- Each route's 200 response schema is an inline `allOf` with document-relative `#/components/...` refs; a small `rebaseComponentRefs` helper redirects those into the registered doc so AJV resolves them against the already-compiled schema instead of recompiling 220 schemas per route. `validateErrorEnvelope`'s `$ref` is pointed at the registered doc directly.

## Behavior is identical

Both validators produce the same results — they validate the same examples/responses against the same component schemas, only compiled once.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — validator internals only; the contract is unchanged.)

## Validation

- [x] `node scripts/validate-openapi-examples.mjs` — 94/94 routes ship a schema-valid example
- [x] `npm run validate:api` — validated 94 routes
- [x] prettier `--check` + eslint clean on both files
- [x] `git diff --check`

Closes #2094
