### PR TITLE
perf(mcp): dispatch JSON-RPC batch members concurrently

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -4493,11 +4493,17 @@ export async function handleMcpRequest(request, env = {}, deps = {}) {
         400,
       );
     }
-    const responses = [];
-    for (const message of body) {
-      const response = await dispatchMessage(message, ctx);
-      if (response) responses.push(response);
-    }
+    // Dispatch independent batch members concurrently (#2060): JSON-RPC 2.0
+    // correlates responses by `id`, not position, and the handlers are read-only
+    // over D1/artifacts with no shared mutable `ctx` state, so a batch's
+    // wall-clock becomes the slowest member instead of the sum. Fan-out stays
+    // bounded by the MAX_MCP_BATCH_LENGTH check above. Promise.all preserves order
+    // and the null filter drops notifications, so the 202-on-all-notifications
+    // path is unchanged.
+    const settled = await Promise.all(
+      body.map((message) => dispatchMessage(message, ctx)),
+    );
+    const responses = settled.filter(Boolean);
     if (responses.length === 0) {
       return new Response(null, { status: 202, headers: MCP_HEADERS });
     }

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -619,6 +619,32 @@ describe("MCP transport handling", () => {
     assert.equal(res.status, 202);
   });
 
+  test("a concurrently-dispatched mixed batch correlates responses by id, not position (#2060)", async () => {
+    // Requests interleaved with notifications. The batch is now dispatched
+    // concurrently (Promise.all), so correctness must hold via the JSON-RPC `id`
+    // correlation regardless of completion order: every request id appears
+    // exactly once and the notifications are dropped.
+    const res = await rpc([
+      { jsonrpc: "2.0", id: 10, method: "tools/list" },
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      { jsonrpc: "2.0", id: 20, method: "ping" },
+      { jsonrpc: "2.0", method: "notifications/cancelled" },
+      { jsonrpc: "2.0", id: 30, method: "ping" },
+    ]);
+    assert.ok(Array.isArray(res.body));
+    assert.equal(res.body.length, 3, "three requests → three responses");
+    assert.deepEqual(
+      res.body.map((r) => r.id).sort((a, b) => a - b),
+      [10, 20, 30],
+      "every request id is present exactly once",
+    );
+    // Each response is correlated to its own request by id (not by array slot).
+    const byId = new Map(res.body.map((r) => [r.id, r]));
+    assert.ok(Array.isArray(byId.get(10).result.tools), "id 10 → tools/list");
+    assert.deepEqual(byId.get(20).result, {}, "id 20 → ping result");
+    assert.deepEqual(byId.get(30).result, {}, "id 30 → ping result");
+  });
+
   test("an empty batch is an invalid request", async () => {
     const res = await rpc([]);
     assert.equal(res.status, 400);


### PR DESCRIPTION
## Summary

- The MCP endpoint processed legacy JSON-RPC **batches** serially (`for (const message of body) { await dispatchMessage(...) }`), so a batch of N members took the **sum** of the per-member latencies instead of the **max**. JSON-RPC 2.0 correlates responses by `id` (not position), and the handlers are read-only over D1/artifacts with no shared mutable `ctx` state, so members can run concurrently.

## What Changed

- `src/mcp-server.mjs`: dispatch batch members with `Promise.all(body.map(m => dispatchMessage(m, ctx)))` and `filter(Boolean)` the null responses. Preserved:
  - response/`id` correlation (responses carry their own id; `Promise.all` also preserves order),
  - notification filtering (null responses dropped),
  - 202-on-all-notifications (empty filtered set → 202),
  - the `MAX_MCP_BATCH_LENGTH` cap (checked before dispatch — the fan-out bound).
- Verified `ctx` (`{ env, domain, clientIp, readArtifact, readHealthKv }`) is read-only — no `ctx.* =` mutations anywhere in the dispatch path.
- `tests/mcp-server.test.mjs`: added a test asserting a concurrently-dispatched mixed batch (requests interleaved with notifications) correlates each response to its request by `id` and drops the notifications.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change — MCP server card is worker-computed; batch semantics unchanged, only concurrency.)

## Validation

- [x] `npx vitest run tests/mcp-server.test.mjs` — 241 passed
- [x] prettier `--check` + eslint clean on changed files
- [x] `git diff --check`

Closes #2060
