### PR TITLE
fix(feeds): set CORS headers on the public content feeds

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -21,7 +21,11 @@
 // (e.g. ?since=2026-06-01 or ?since=2026-06-01T00:00:00Z), for incremental
 // polling; it composes with `?tag=`. A malformed `since` is a 400.
 
-import { ifNoneMatchSatisfied, weakEtag } from "../workers/http.mjs";
+import {
+  EXPOSED_RESPONSE_HEADERS_VALUE,
+  ifNoneMatchSatisfied,
+  weakEtag,
+} from "../workers/http.mjs";
 
 const SITE_URL = "https://metagraph.sh";
 const API_URL = "https://api.metagraph.sh";
@@ -404,7 +408,12 @@ function parseSinceParam(value) {
 function feedError(code, message, status) {
   return new Response(JSON.stringify({ ok: false, error: { code, message } }), {
     status,
-    headers: { "content-type": "application/json; charset=utf-8" },
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      // Public feeds are a cross-origin surface (browser feed readers / agents),
+      // so errors must be CORS-readable like every sibling response (#2078).
+      "access-control-allow-origin": "*",
+    },
   });
 }
 
@@ -521,6 +530,12 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
     vary: "Accept",
     "x-content-type-options": "nosniff",
     etag,
+    // Feeds are meant for cross-origin consumption (JSON Feed in browser JS, the
+    // discovery Link header on /api/v1/subnets). Without CORS, cross-origin
+    // clients can't read the body or the etag for conditional polling. Mirror the
+    // canonical apiHeaders CORS pair so the 200/304/HEAD paths are readable.
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": EXPOSED_RESPONSE_HEADERS_VALUE,
   };
   // Unchanged poll → cheap 304, same validators, no body.
   if (ifNoneMatchSatisfied(request, etag)) {

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -513,6 +513,34 @@ describe("feeds — handleFeedRequest", () => {
     assert.equal(bad.status, 404);
   });
 
+  test("feeds are CORS-readable on success, 304, and error paths", async () => {
+    // Public feeds are a cross-origin surface (browser JSON Feed readers / agents
+    // discovering them via the Link header), so every path must carry
+    // access-control-allow-origin like the sibling responses — it was omitted.
+    const ok = await feed("/api/v1/feeds/registry.json");
+    assert.equal(ok.res.status, 200);
+    assert.equal(ok.res.headers.get("access-control-allow-origin"), "*");
+    // The etag must be exposed so cross-origin clients can poll conditionally.
+    assert.match(
+      ok.res.headers.get("access-control-expose-headers") || "",
+      /etag/,
+    );
+
+    const etag = ok.res.headers.get("etag");
+    const notModified = await feed("/api/v1/feeds/registry.json", {
+      ifNoneMatch: etag,
+    });
+    assert.equal(notModified.res.status, 304);
+    assert.equal(
+      notModified.res.headers.get("access-control-allow-origin"),
+      "*",
+    );
+
+    const { res: err } = await feed("/api/v1/feeds/nope");
+    assert.equal(err.status, 404);
+    assert.equal(err.headers.get("access-control-allow-origin"), "*");
+  });
+
   test("HEAD returns headers with no body", async () => {
     const { res, text } = await feed("/api/v1/feeds/registry", {
       method: "HEAD",


### PR DESCRIPTION
## Summary

- The public content feeds (`/api/v1/feeds/*` — RSS 2.0 / Atom 1.0 / JSON Feed 1.1) set **no** `access-control-allow-origin` on any path (200, 304, HEAD, or `feedError`). A cross-origin browser client therefore cannot read them — even though feeds are an explicitly cross-origin surface: JSON Feed is consumed by browser JS, and the discovery `Link` header is advertised on `/api/v1/subnets` for browser/agent discovery.
- Every sibling response sets CORS: `apiHeaders` via `exposeCustomResponseHeaders`, `badge.mjs`, and `icon-proxy` (whose 304/405 ACAO gap was just closed in #2078). Feeds were the remaining gap.

## What Changed

- `src/feeds.mjs`: add `access-control-allow-origin: *` to the feed success/304/HEAD response and to `feedError`, plus `access-control-expose-headers` (the canonical `EXPOSED_RESPONSE_HEADERS_VALUE`) so cross-origin clients can read the `etag` for conditional polling. Mirrors the `apiHeaders` CORS pair.
- `tests/feeds.test.mjs`: regression test asserting CORS on the success, 304, and error paths (and that `etag` is in the expose-list).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (Additive response headers only — no body/contract change; brings feeds in line with the documented CORS posture of every other public response.)

## Validation

- [x] `npx vitest run tests/feeds.test.mjs` — 64 passed
- [x] `npx vitest run tests/api-coverage.test.mjs tests/worker-runtime.test.mjs tests/network-routing.test.mjs` — green
- [x] prettier `--check` + eslint clean on changed files
- [x] `git diff --check`
