### PR TITLE
fix(api): canonicalize economics-trends edge-cache key on window parameter

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -587,6 +587,33 @@ describe("analytics edge cache", () => {
     );
   });
 
+  test("economics-trends ?window variants share a single cache entry (canonical key)", async () => {
+    const queries = [];
+    const cache = mockCaches();
+    cache.install();
+    const env = analyticsEnv(queries);
+    const base = "/api/v1/economics/trends";
+
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}?window=30d`),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    const queriesAfterFirst = queries.length;
+
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}`),
+      env,
+      ctx,
+    );
+    assert.equal(
+      queries.length,
+      queriesAfterFirst,
+      "no ?window hits cache of ?window=30d",
+    );
+  });
+
   test("the 4 additional deterministic routes are now edge-cached (MISS→put under their key, HIT→no D1)", async () => {
     // These routes (global incidents, per-subnet trajectory, per-subnet uptime,
     // registry leaderboards) were edgeCache=0 — they re-ran their D1 aggregation

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -485,9 +485,7 @@ describe("canonicalUptimeCachePath", () => {
 describe("canonicalEconomicsTrendsCachePath", () => {
   test("normalizes bare path to explicit default window", () => {
     assert.equal(
-      canonicalEconomicsTrendsCachePath(
-        url("/api/v1/economics/trends"),
-      ),
+      canonicalEconomicsTrendsCachePath(url("/api/v1/economics/trends")),
       "/api/v1/economics/trends?window=30d",
     );
   });

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -7,6 +7,7 @@ import { describe, test, beforeEach } from "vitest";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import {
   canonicalCompareCachePath,
+  canonicalEconomicsTrendsCachePath,
   canonicalUptimeCachePath,
   composeCompareData,
   configureAnalyticsRoutes,
@@ -478,6 +479,45 @@ describe("canonicalUptimeCachePath", () => {
   test("falls back to raw search on invalid window value", () => {
     const raw = "/api/v1/subnets/7/uptime?window=7d";
     assert.equal(canonicalUptimeCachePath(url(raw)), raw);
+  });
+});
+
+describe("canonicalEconomicsTrendsCachePath", () => {
+  test("normalizes bare path to explicit default window", () => {
+    assert.equal(
+      canonicalEconomicsTrendsCachePath(
+        url("/api/v1/economics/trends"),
+      ),
+      "/api/v1/economics/trends?window=30d",
+    );
+  });
+
+  test("explicit ?window=30d collapses to same key as bare path", () => {
+    assert.equal(
+      canonicalEconomicsTrendsCachePath(
+        url("/api/v1/economics/trends?window=30d"),
+      ),
+      "/api/v1/economics/trends?window=30d",
+    );
+  });
+
+  test("preserves valid non-default window", () => {
+    assert.equal(
+      canonicalEconomicsTrendsCachePath(
+        url("/api/v1/economics/trends?window=7d"),
+      ),
+      "/api/v1/economics/trends?window=7d",
+    );
+  });
+
+  test("falls back to raw search on unknown query param", () => {
+    const raw = "/api/v1/economics/trends?unknown=x";
+    assert.equal(canonicalEconomicsTrendsCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid window value", () => {
+    const raw = "/api/v1/economics/trends?window=bogus";
+    assert.equal(canonicalEconomicsTrendsCachePath(url(raw)), raw);
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -88,6 +88,7 @@ import {
 } from "./request-handlers/entities.mjs";
 import {
   canonicalCompareCachePath,
+  canonicalEconomicsTrendsCachePath,
   canonicalUptimeCachePath,
   configureAnalyticsRoutes,
   handleCompare,
@@ -1512,8 +1513,13 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     // (GROUP-BY-day over subnet_snapshots) — edge-cache on last_run_at like the
     // sibling history/trajectory routes; ?window rides the search into the key.
     if (resolved.url.pathname === "/api/v1/economics/trends") {
-      return withEdgeCache(request, ctx, env, "economics-trends", () =>
-        handleEconomicsTrends(request, env, resolved.url),
+      return withEdgeCache(
+        request,
+        ctx,
+        env,
+        "economics-trends",
+        () => handleEconomicsTrends(request, env, resolved.url),
+        canonicalEconomicsTrendsCachePath(resolved.url),
       );
     }
     return handleApiRequest(request, env, resolved.url, DEFAULT_NETWORK, ctx);

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -212,6 +212,17 @@ export function canonicalUptimeCachePath(url) {
   return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
 }
 
+// Normalises the economics-trends URL so that a bare ?-free request and an explicit
+// ?window=30d request both resolve to the same edge-cache entry — mirrors
+// canonicalSubnetHistoryCachePath in entities.mjs.
+export function canonicalEconomicsTrendsCachePath(url) {
+  const validationError = validateQueryParams(url, ["window"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const { label, error } = parseHistoryWindow(url.searchParams.get("window"));
+  if (error) return `${url.pathname}${url.search}`;
+  return `${url.pathname}?window=${encodeURIComponent(label)}`;
+}
+
 async function leaderboardProfilesProjection(env, now = Date.now()) {
   if (
     leaderboardProfilesCache &&


### PR DESCRIPTION
## Summary

- Add `canonicalEconomicsTrendsCachePath` so bare `/api/v1/economics/trends` and explicit `?window=30d` share one edge-cache entry
- Wire the canonical path into the economics-trends `withEdgeCache` call site
- Add unit + edge-cache integration regression tests

Fixes #2272

## Template Used

- [x] Backend/code change

## What Changed

- `workers/request-handlers/analytics-routes.mjs`: new `canonicalEconomicsTrendsCachePath`
- `workers/api.mjs`: pass canonical cache path to `withEdgeCache` for economics-trends
- `tests/request-handlers-analytics-routes.test.mjs`, `tests/analytics-edge-cache.test.mjs`: regression coverage

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npx vitest run tests/analytics-edge-cache.test.mjs tests/request-handlers-analytics-routes.test.mjs`

## Test plan

- [x] Bare economics-trends path and `?window=30d` hit the same edge-cache key
- [x] Invalid window values still fall back to raw search (no canonicalization)

Made with [Cursor](https://cursor.com)