### PR TITLE
fix(api): reject non-integer numeric filters on the extrinsics feed

### DIFF
--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -420,7 +420,11 @@ test("GET /extrinsics rejects non-numeric value filters with 400 (#2086)", async
     "block_start=abc",
     "block_end=abc",
   ]) {
-    const res = await handleRequest(req(`/api/v1/extrinsics?${query}`), env, {});
+    const res = await handleRequest(
+      req(`/api/v1/extrinsics?${query}`),
+      env,
+      {},
+    );
     assert.equal(res.status, 400, query);
     const body = await res.json();
     assert.equal(body.ok, false);

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -411,6 +411,22 @@ test("GET /extrinsics clamps limit to <=100 + rejects unsupported params", async
   assert.equal(bad.status, 400);
 });
 
+test("GET /extrinsics rejects non-numeric value filters with 400 (#2086)", async () => {
+  const env = dbWith({ feed: [] });
+  for (const query of [
+    "block=abc",
+    "from=foo",
+    "to=foo",
+    "block_start=abc",
+    "block_end=abc",
+  ]) {
+    const res = await handleRequest(req(`/api/v1/extrinsics?${query}`), env, {});
+    assert.equal(res.status, 400, query);
+    const body = await res.json();
+    assert.equal(body.ok, false);
+  }
+});
+
 test("GET /extrinsics?block=<n> scopes the feed to one block (#1345)", async () => {
   let boundSql;
   const env = {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2402,17 +2402,18 @@ describe("handleExtrinsics", () => {
     assert.ok(/observed_at >= \?/.test(sql));
   });
 
-  test("ignores malformed time filters instead of broadening them", async () => {
+  test("rejects malformed time filters with 400 (#2086)", async () => {
     const { env, captures } = dbWith({ extrinsics: [] });
-    await handleExtrinsics(
+    const res = await handleExtrinsics(
       req("/api/v1/extrinsics"),
       env,
       url("/api/v1/extrinsics?from=abc"),
     );
-    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
-    assert.ok(sql);
-    assert.ok(!/INDEXED BY/.test(sql));
-    assert.ok(!/observed_at >= \?/.test(sql));
+    await errorJson(res);
+    assert.equal(
+      captures.sql.filter((s) => /FROM extrinsics/.test(s)).length,
+      0,
+    );
   });
 
   test("short-circuits impossible future time filters before D1", async () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1362,7 +1362,6 @@ export async function handleExtrinsics(request, env, url) {
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset, cursor } = parsePagination(url, BLOCK_PAGINATION);
   const sp = url.searchParams;
-  const MAX = Number.MAX_SAFE_INTEGER;
   const numericFilters = {};
   for (const param of ["block", "block_start", "block_end", "from", "to"]) {
     const raw = sp.get(param);

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -28,6 +28,7 @@ import {
   DAY_PATTERN,
   FEED_PAGINATION,
   parseDateRange,
+  parseNonNegativeIntParam,
   parsePagination,
 } from "../request-params.mjs";
 
@@ -1362,14 +1363,16 @@ export async function handleExtrinsics(request, env, url) {
   const { limit, offset, cursor } = parsePagination(url, BLOCK_PAGINATION);
   const sp = url.searchParams;
   const MAX = Number.MAX_SAFE_INTEGER;
-  const parseTimeBound = (raw) => {
-    if (raw == null || raw === "") return null;
-    const n = Number(raw);
-    if (!Number.isFinite(n)) return null;
-    return Math.max(0, Math.min(MAX, Math.trunc(n)));
-  };
-  const fromMs = parseTimeBound(sp.get("from"));
-  const toMs = parseTimeBound(sp.get("to"));
+  const numericFilters = {};
+  for (const param of ["block", "block_start", "block_end", "from", "to"]) {
+    const raw = sp.get(param);
+    if (raw === null) continue;
+    const parsed = parseNonNegativeIntParam(raw, param);
+    if (parsed.error) return analyticsQueryError(parsed.error);
+    numericFilters[param] = parsed.value;
+  }
+  const fromMs = numericFilters.from ?? null;
+  const toMs = numericFilters.to ?? null;
   const nowMs = Date.now();
   const observedFloorMs = nowMs - EXTRINSIC_RETENTION_MS;
   // The extrinsics tier is a retained hot window of block timestamps. Reject
@@ -1396,10 +1399,10 @@ export async function handleExtrinsics(request, env, url) {
     conds.push(`${col} = ?`);
     params.push(val);
   };
-  const hasBlockFilter = sp.get("block") != null;
+  const hasBlockFilter = numericFilters.block != null;
   const hasEqualityFilter =
     sp.get("signer") || sp.get("call_module") || sp.get("call_function");
-  if (hasBlockFilter) eq("block_number", clampInt(sp.get("block"), 0, 0, MAX));
+  if (hasBlockFilter) eq("block_number", numericFilters.block);
   if (sp.get("signer")) eq("signer", sp.get("signer"));
   if (sp.get("call_module")) eq("call_module", sp.get("call_module"));
   if (sp.get("call_function")) eq("call_function", sp.get("call_function"));
@@ -1410,14 +1413,14 @@ export async function handleExtrinsics(request, env, url) {
   if (successRaw === "true") eq("success", 1);
   else if (successRaw === "false") eq("success", 0);
   const hasBlockRangeFilter =
-    sp.get("block_start") != null || sp.get("block_end") != null;
-  if (sp.get("block_start") != null) {
+    numericFilters.block_start != null || numericFilters.block_end != null;
+  if (numericFilters.block_start != null) {
     conds.push("block_number >= ?");
-    params.push(clampInt(sp.get("block_start"), 0, 0, MAX));
+    params.push(numericFilters.block_start);
   }
-  if (sp.get("block_end") != null) {
+  if (numericFilters.block_end != null) {
     conds.push("block_number <= ?");
-    params.push(clampInt(sp.get("block_end"), 0, 0, MAX));
+    params.push(numericFilters.block_end);
   }
   if (fromMs != null) {
     conds.push("observed_at >= ?");

--- a/workers/request-params.mjs
+++ b/workers/request-params.mjs
@@ -89,6 +89,30 @@ export const DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 // blank bound means "no bound" (normalized to null); a present-but-malformed bound
 // returns { error } with the shared message. On success returns { from, to } ready
 // to bind into a `day >= ?` / `day <= ?` range.
+// Validate an optional non-negative integer query value. Absent/blank → { value:
+// null }; present-but-non-numeric → { error } for the caller to surface as 400.
+export function parseNonNegativeIntParam(raw, parameter) {
+  if (raw === null || raw === "") return { value: null };
+  if (!/^\d+$/.test(raw)) {
+    return {
+      error: {
+        parameter,
+        message: `${parameter} must be a non-negative integer.`,
+      },
+    };
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) {
+    return {
+      error: {
+        parameter,
+        message: `${parameter} must be a non-negative integer.`,
+      },
+    };
+  }
+  return { value };
+}
+
 export function parseDateRange(url) {
   const from = url.searchParams.get("from");
   const to = url.searchParams.get("to");


### PR DESCRIPTION
## Summary

- Validate `block`, `block_start`, `block_end`, `from`, and `to` as non-negative integers before binding SQL on `GET /api/v1/extrinsics`
- Return 400 for present-but-non-numeric values instead of silently coercing them to 0 via `clampInt`
- Add shared `parseNonNegativeIntParam` helper and regression tests

Fixes #2086

## Template Used

- [x] Backend/code change

## What Changed

- `workers/request-params.mjs`: `parseNonNegativeIntParam`
- `workers/request-handlers/entities.mjs`: strict validation in `handleExtrinsics`
- `tests/extrinsics.test.mjs`, `tests/request-handlers-entities.test.mjs`: 400 regression coverage

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npx vitest run tests/extrinsics.test.mjs tests/request-handlers-entities.test.mjs -t extrinsics`

## Test plan

- [x] `?block=abc`, `?from=foo`, `?to=foo`, `?block_start=abc`, `?block_end=abc` return 400
- [x] Valid numeric filters still produce the same bound SQL as before

Made with [Cursor](https://cursor.com)