### PR TITLE
feat(api): negation filters (not_) on list endpoints

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -7481,6 +7481,10 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -8809,6 +8813,10 @@ export interface operations {
                 agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
                 blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
                 q?: string;
+                not_netuid?: number;
+                not_tier?: "agent-ready" | "machine-usable" | "candidate-review" | "needs-evidence" | "hard-blocked" | "missing-interface";
+                not_agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
+                not_blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9003,6 +9011,8 @@ export interface operations {
             query?: {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
+                not_netuid?: number;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9141,6 +9151,8 @@ export interface operations {
                 netuid?: number;
                 registration_allowed?: "true" | "false";
                 q?: string;
+                not_netuid?: number;
+                not_registration_allowed?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9399,6 +9411,12 @@ export interface operations {
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 severity?: "critical" | "warning" | "info";
                 state?: "active" | "resolved";
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
+                not_severity?: "critical" | "warning" | "info";
+                not_state?: "active" | "resolved";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9547,6 +9565,8 @@ export interface operations {
             query?: {
                 id?: string;
                 kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
+                not_id?: string;
+                not_kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9722,6 +9742,13 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_netuid?: number;
+                not_pool_eligible?: "true" | "false";
+                not_provider?: string;
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10499,6 +10526,9 @@ export interface operations {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_netuid?: number;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10631,6 +10661,8 @@ export interface operations {
             query?: {
                 netuid?: number;
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_netuid?: number;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10760,6 +10792,11 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
+                not_classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11378,6 +11415,12 @@ export interface operations {
                 confidence?: "low" | "medium" | "high";
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
                 q?: string;
+                not_netuid?: number;
+                not_subnet_type?: "root" | "application";
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_review_state?: string;
+                not_confidence?: "low" | "medium" | "high";
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11631,6 +11674,9 @@ export interface operations {
                 id?: string;
                 kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
                 authority?: "community" | "official" | "provider-claimed" | "registry-observed";
+                not_id?: string;
+                not_kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
+                not_authority?: "community" | "official" | "provider-claimed" | "registry-observed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11884,6 +11930,12 @@ export interface operations {
                 pool_eligible?: "true" | "false";
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_netuid?: number;
+                not_pool_eligible?: "true" | "false";
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12281,6 +12333,12 @@ export interface operations {
                 operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 reason_codes?: string;
                 recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
+                not_netuid?: number;
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_candidate_api_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_reason_codes?: string;
+                not_recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12436,6 +12494,11 @@ export interface operations {
                 missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 netuid?: number;
                 q?: string;
+                not_direct_submission_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                not_lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                not_missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_netuid?: number;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12601,6 +12664,17 @@ export interface operations {
                 review_state?: string;
                 manual_review_required?: "true" | "false";
                 q?: string;
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_direct_submission_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                not_identity_level?: "none" | "directory" | "partial" | "complete";
+                not_lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                not_missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_netuid?: number;
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                not_reason_codes?: string;
+                not_review_state?: string;
+                not_manual_review_required?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12811,6 +12885,19 @@ export interface operations {
                 target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 target_type?: "surface-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 q?: string;
+                not_auto_review_candidate?: "true" | "false";
+                not_evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                not_identity_level?: "none" | "directory" | "partial" | "complete";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                not_manual_review_required?: "true" | "false";
+                not_missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_netuid?: number;
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                not_reason_codes?: string;
+                not_submission_route?: "direct-candidate-pr" | "adapter-request" | "maintainer-review" | "status-report";
+                not_target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
+                not_target_type?: "surface-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13021,6 +13108,9 @@ export interface operations {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                not_netuid?: number;
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_review_state?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13154,6 +13244,12 @@ export interface operations {
                 identity_level?: "none" | "directory" | "partial" | "complete";
                 identity_promotion_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 native_name_quality?: "chain" | "placeholder" | "empty";
+                not_netuid?: number;
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                not_confidence?: "low" | "medium" | "high";
+                not_identity_level?: "none" | "directory" | "partial" | "complete";
+                not_identity_promotion_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_native_name_quality?: "chain" | "placeholder" | "empty";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13352,6 +13448,13 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_netuid?: number;
+                not_pool_eligible?: "true" | "false";
+                not_provider?: string;
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -14413,6 +14516,13 @@ export interface operations {
                 max_surface_count?: number;
                 min_tempo?: number;
                 max_tempo?: number;
+                not_netuid?: number;
+                not_netuids?: string;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_domain?: "agents" | "compute" | "data" | "finance" | "inference" | "media" | "prediction" | "privacy" | "robotics" | "science" | "search" | "security" | "storage" | "training";
+                not_status?: "active" | "inactive";
+                not_subnet_type?: "root" | "application";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -14826,6 +14936,9 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15246,6 +15359,12 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_pool_eligible?: "true" | "false";
+                not_provider?: string;
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15644,6 +15763,8 @@ export interface operations {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_review_state?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15852,6 +15973,10 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
+                not_classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -17481,6 +17606,8 @@ export interface operations {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -18085,6 +18212,9 @@ export interface operations {
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -986,6 +986,88 @@
           }
         },
         {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_netuids",
+          "schema": {
+            "maxLength": 767,
+            "pattern": "^\\d{1,5}(,\\d{1,5}){0,127}$",
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_coverage_level",
+          "schema": {
+            "enum": [
+              "native-only",
+              "manifested",
+              "probed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "community-seeded",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_domain",
+          "schema": {
+            "enum": [
+              "agents",
+              "compute",
+              "data",
+              "finance",
+              "inference",
+              "media",
+              "prediction",
+              "privacy",
+              "robotics",
+              "science",
+              "search",
+              "security",
+              "storage",
+              "training"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "active",
+              "inactive"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_subnet_type",
+          "schema": {
+            "enum": [
+              "root",
+              "application"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1135,6 +1217,67 @@
         {
           "name": "q",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_subnet_type",
+          "schema": {
+            "enum": [
+              "root",
+              "application"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "community-seeded",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_review_state",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_confidence",
+          "schema": {
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_profile_level",
+          "schema": {
+            "enum": [
+              "directory-only",
+              "identity-partial",
+              "identity-complete",
+              "operational",
+              "adapter-backed"
+            ],
             "type": "string"
           }
         },
@@ -1290,6 +1433,41 @@
           }
         },
         {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1375,6 +1553,34 @@
         },
         {
           "name": "provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
           "schema": {
             "type": "string"
           }
@@ -1519,6 +1725,89 @@
         },
         {
           "name": "status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_layer",
+          "schema": {
+            "enum": [
+              "bittensor-base",
+              "data-provider",
+              "docs-provider",
+              "subnet-app"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_pool_eligible",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_publication_state",
+          "schema": {
+            "enum": [
+              "candidate",
+              "verified",
+              "monitored",
+              "pool-eligible",
+              "disabled",
+              "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
           "schema": {
             "enum": [
               "ok",
@@ -1677,6 +1966,82 @@
           }
         },
         {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_layer",
+          "schema": {
+            "enum": [
+              "bittensor-base",
+              "data-provider",
+              "docs-provider",
+              "subnet-app"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_pool_eligible",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_publication_state",
+          "schema": {
+            "enum": [
+              "candidate",
+              "verified",
+              "monitored",
+              "pool-eligible",
+              "disabled",
+              "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1782,6 +2147,55 @@
         },
         {
           "name": "state",
+          "schema": {
+            "enum": [
+              "schema-invalid",
+              "schema-valid",
+              "maintainer-review",
+              "verified",
+              "stale",
+              "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_state",
           "schema": {
             "enum": [
               "schema-invalid",
@@ -1902,6 +2316,48 @@
           }
         },
         {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_state",
+          "schema": {
+            "enum": [
+              "schema-invalid",
+              "schema-valid",
+              "maintainer-review",
+              "verified",
+              "stale",
+              "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1987,6 +2443,37 @@
         },
         {
           "name": "authority",
+          "schema": {
+            "enum": [
+              "community",
+              "official",
+              "provider-claimed",
+              "registry-observed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_id",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "data-provider",
+              "docs-provider",
+              "infrastructure-provider",
+              "registry",
+              "subnet-team"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_authority",
           "schema": {
             "enum": [
               "community",
@@ -2152,6 +2639,83 @@
           }
         },
         {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_layer",
+          "schema": {
+            "enum": [
+              "bittensor-base",
+              "data-provider",
+              "docs-provider",
+              "subnet-app"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_pool_eligible",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_publication_state",
+          "schema": {
+            "enum": [
+              "candidate",
+              "verified",
+              "monitored",
+              "pool-eligible",
+              "disabled",
+              "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2285,6 +2849,52 @@
           }
         },
         {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_tier",
+          "schema": {
+            "enum": [
+              "agent-ready",
+              "machine-usable",
+              "candidate-review",
+              "needs-evidence",
+              "hard-blocked",
+              "missing-interface"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_agent_status",
+          "schema": {
+            "enum": [
+              "callable",
+              "base-layer",
+              "candidate",
+              "needs-evidence",
+              "blocked"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_blocker_level",
+          "schema": {
+            "enum": [
+              "none",
+              "hard-blocked",
+              "needs-review",
+              "missing-data"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2368,6 +2978,23 @@
         {
           "name": "q",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_registration_allowed",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
             "type": "string"
           }
         },
@@ -2535,6 +3162,24 @@
           }
         },
         {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_coverage_level",
+          "schema": {
+            "enum": [
+              "native-only",
+              "manifested",
+              "probed"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2616,6 +3261,38 @@
         },
         {
           "name": "curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "community-seeded",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_coverage_level",
+          "schema": {
+            "enum": [
+              "native-only",
+              "manifested",
+              "probed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_curation_level",
           "schema": {
             "enum": [
               "native",
@@ -2719,6 +3396,33 @@
           }
         },
         {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "community-seeded",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_review_state",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2799,6 +3503,26 @@
         },
         {
           "name": "review_state",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "community-seeded",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_review_state",
           "schema": {
             "type": "string"
           }
@@ -2939,6 +3663,82 @@
         },
         {
           "name": "native_name_quality",
+          "schema": {
+            "enum": [
+              "chain",
+              "placeholder",
+              "empty"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_profile_level",
+          "schema": {
+            "enum": [
+              "directory-only",
+              "identity-partial",
+              "identity-complete",
+              "operational",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_confidence",
+          "schema": {
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_identity_level",
+          "schema": {
+            "enum": [
+              "none",
+              "directory",
+              "partial",
+              "complete"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_identity_promotion_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_native_name_quality",
           "schema": {
             "enum": [
               "chain",
@@ -3096,6 +3896,89 @@
         },
         {
           "name": "recommended_adapter_kind",
+          "schema": {
+            "enum": [
+              "custom-adapter",
+              "data-artifact-adapter",
+              "generic-openapi-or-custom",
+              "stream-adapter"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "community-seeded",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_candidate_api_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_operational_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_reason_codes",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_recommended_adapter_kind",
           "schema": {
             "enum": [
               "custom-adapter",
@@ -3327,6 +4210,145 @@
           }
         },
         {
+          "name": "not_curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "community-seeded",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_direct_submission_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_evidence_action",
+          "schema": {
+            "enum": [
+              "submit-new-evidence",
+              "verify-existing-evidence",
+              "replace-stale-evidence",
+              "review-existing-evidence",
+              "maintainer-review-existing-evidence",
+              "monitor"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_identity_level",
+          "schema": {
+            "enum": [
+              "none",
+              "directory",
+              "partial",
+              "complete"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_lane",
+          "schema": {
+            "enum": [
+              "direct-submission",
+              "maintainer-review",
+              "adapter-candidate",
+              "monitoring-followup",
+              "baseline-monitoring"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_missing_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_profile_level",
+          "schema": {
+            "enum": [
+              "directory-only",
+              "identity-partial",
+              "identity-complete",
+              "operational",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_reason_codes",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_review_state",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_manual_review_required",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -3486,6 +4508,84 @@
           "name": "q",
           "schema": {
             "type": "string"
+          }
+        },
+        {
+          "name": "not_direct_submission_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_evidence_action",
+          "schema": {
+            "enum": [
+              "submit-new-evidence",
+              "verify-existing-evidence",
+              "replace-stale-evidence",
+              "review-existing-evidence",
+              "maintainer-review-existing-evidence",
+              "monitor"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_lane",
+          "schema": {
+            "enum": [
+              "direct-submission",
+              "maintainer-review",
+              "adapter-candidate",
+              "monitoring-followup",
+              "baseline-monitoring"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_missing_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
           }
         },
         {
@@ -3736,6 +4836,174 @@
           }
         },
         {
+          "name": "not_auto_review_candidate",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_evidence_action",
+          "schema": {
+            "enum": [
+              "submit-new-evidence",
+              "verify-existing-evidence",
+              "replace-stale-evidence",
+              "review-existing-evidence",
+              "maintainer-review-existing-evidence",
+              "monitor"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_identity_level",
+          "schema": {
+            "enum": [
+              "none",
+              "directory",
+              "partial",
+              "complete"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_lane",
+          "schema": {
+            "enum": [
+              "direct-submission",
+              "maintainer-review",
+              "adapter-candidate",
+              "monitoring-followup",
+              "baseline-monitoring"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_manual_review_required",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_missing_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_profile_level",
+          "schema": {
+            "enum": [
+              "directory-only",
+              "identity-partial",
+              "identity-complete",
+              "operational",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_reason_codes",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_submission_route",
+          "schema": {
+            "enum": [
+              "direct-candidate-pr",
+              "adapter-request",
+              "maintainer-review",
+              "status-report"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_target_action",
+          "schema": {
+            "enum": [
+              "submit-new-candidate",
+              "replace-stale-candidate",
+              "verify-existing-candidate",
+              "review-existing-candidate",
+              "adapter-review",
+              "maintainer-review",
+              "monitoring-followup"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_target_type",
+          "schema": {
+            "enum": [
+              "surface-candidate",
+              "adapter-review",
+              "maintainer-review",
+              "monitoring-followup"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -3814,6 +5082,25 @@
         },
         {
           "name": "status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_status",
           "schema": {
             "enum": [
               "ok",
@@ -3962,6 +5249,72 @@
           }
         },
         {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_classification",
+          "schema": {
+            "enum": [
+              "auth-required",
+              "content-mismatch",
+              "dead",
+              "live",
+              "rate-limited",
+              "redirected",
+              "timeout",
+              "transient",
+              "unsupported",
+              "unsafe",
+              "wrong-chain"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -4073,6 +5426,65 @@
         },
         {
           "name": "classification",
+          "schema": {
+            "enum": [
+              "auth-required",
+              "content-mismatch",
+              "dead",
+              "live",
+              "rate-limited",
+              "redirected",
+              "timeout",
+              "transient",
+              "unsupported",
+              "unsafe",
+              "wrong-chain"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_classification",
           "schema": {
             "enum": [
               "auth-required",
@@ -5578,6 +6990,89 @@
           }
         },
         {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_layer",
+          "schema": {
+            "enum": [
+              "bittensor-base",
+              "data-provider",
+              "docs-provider",
+              "subnet-app"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_pool_eligible",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_publication_state",
+          "schema": {
+            "enum": [
+              "candidate",
+              "verified",
+              "monitored",
+              "pool-eligible",
+              "disabled",
+              "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -5664,6 +7159,23 @@
         },
         {
           "name": "kind",
+          "schema": {
+            "enum": [
+              "subtensor-rpc",
+              "subtensor-wss",
+              "archive"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_id",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_kind",
           "schema": {
             "enum": [
               "subtensor-rpc",
@@ -5798,6 +7310,74 @@
         },
         {
           "name": "state",
+          "schema": {
+            "enum": [
+              "active",
+              "resolved"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_kind",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_severity",
+          "schema": {
+            "enum": [
+              "critical",
+              "warning",
+              "info"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_state",
           "schema": {
             "enum": [
               "active",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -17380,6 +17380,63 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "schema-invalid",
+                "schema-valid",
+                "maintainer-review",
+                "verified",
+                "stale",
+                "rejected"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -19194,6 +19251,60 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_tier",
+            "required": false,
+            "schema": {
+              "enum": [
+                "agent-ready",
+                "machine-usable",
+                "candidate-review",
+                "needs-evidence",
+                "hard-blocked",
+                "missing-interface"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_agent_status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "callable",
+                "base-layer",
+                "candidate",
+                "needs-evidence",
+                "blocked"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_blocker_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "none",
+                "hard-blocked",
+                "needs-review",
+                "missing-data"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -19479,6 +19590,28 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_coverage_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native-only",
+                "manifested",
+                "probed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -19704,6 +19837,27 @@
             "name": "q",
             "required": false,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_registration_allowed",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
               "type": "string"
             }
           },
@@ -20150,6 +20304,86 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_severity",
+            "required": false,
+            "schema": {
+              "enum": [
+                "critical",
+                "warning",
+                "info"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "active",
+                "resolved"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -20377,6 +20611,27 @@
           {
             "in": "query",
             "name": "kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "subtensor-rpc",
+                "subtensor-wss",
+                "archive"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
             "required": false,
             "schema": {
               "enum": [
@@ -20707,6 +20962,103 @@
           {
             "in": "query",
             "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_layer",
+            "required": false,
+            "schema": {
+              "enum": [
+                "bittensor-base",
+                "data-provider",
+                "docs-provider",
+                "subnet-app"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_pool_eligible",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_publication_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "candidate",
+                "verified",
+                "monitored",
+                "pool-eligible",
+                "disabled",
+                "rejected"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
             "required": false,
             "schema": {
               "enum": [
@@ -21855,6 +22207,44 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_coverage_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native-only",
+                "manifested",
+                "probed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "community-seeded",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -22062,6 +22452,29 @@
           {
             "in": "query",
             "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
             "required": false,
             "schema": {
               "enum": [
@@ -22337,6 +22750,82 @@
           {
             "in": "query",
             "name": "classification",
+            "required": false,
+            "schema": {
+              "enum": [
+                "auth-required",
+                "content-mismatch",
+                "dead",
+                "live",
+                "rate-limited",
+                "redirected",
+                "timeout",
+                "transient",
+                "unsupported",
+                "unsafe",
+                "wrong-chain"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_classification",
             "required": false,
             "schema": {
               "enum": [
@@ -23206,6 +23695,79 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_subnet_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "root",
+                "application"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "community-seeded",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_review_state",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_confidence",
+            "required": false,
+            "schema": {
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_profile_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "directory-only",
+                "identity-partial",
+                "identity-complete",
+                "operational",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -23553,6 +24115,43 @@
           {
             "in": "query",
             "name": "authority",
+            "required": false,
+            "schema": {
+              "enum": [
+                "community",
+                "official",
+                "provider-claimed",
+                "registry-observed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "data-provider",
+                "docs-provider",
+                "infrastructure-provider",
+                "registry",
+                "subnet-team"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_authority",
             "required": false,
             "schema": {
               "enum": [
@@ -23990,6 +24589,95 @@
           {
             "in": "query",
             "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_layer",
+            "required": false,
+            "schema": {
+              "enum": [
+                "bittensor-base",
+                "data-provider",
+                "docs-provider",
+                "subnet-app"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_pool_eligible",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_publication_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "candidate",
+                "verified",
+                "monitored",
+                "pool-eligible",
+                "disabled",
+                "rejected"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
             "required": false,
             "schema": {
               "enum": [
@@ -24626,6 +25314,101 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "community-seeded",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_candidate_api_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_operational_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_reason_codes",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_recommended_adapter_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "custom-adapter",
+                "data-artifact-adapter",
+                "generic-openapi-or-custom",
+                "stream-adapter"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -24939,6 +25722,94 @@
             "required": false,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_direct_submission_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_evidence_action",
+            "required": false,
+            "schema": {
+              "enum": [
+                "submit-new-evidence",
+                "verify-existing-evidence",
+                "replace-stale-evidence",
+                "review-existing-evidence",
+                "maintainer-review-existing-evidence",
+                "monitor"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_lane",
+            "required": false,
+            "schema": {
+              "enum": [
+                "direct-submission",
+                "maintainer-review",
+                "adapter-candidate",
+                "monitoring-followup",
+                "baseline-monitoring"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_missing_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
             }
           },
           {
@@ -25329,6 +26200,167 @@
             "name": "q",
             "required": false,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "community-seeded",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_direct_submission_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_evidence_action",
+            "required": false,
+            "schema": {
+              "enum": [
+                "submit-new-evidence",
+                "verify-existing-evidence",
+                "replace-stale-evidence",
+                "review-existing-evidence",
+                "maintainer-review-existing-evidence",
+                "monitor"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_identity_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "none",
+                "directory",
+                "partial",
+                "complete"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_lane",
+            "required": false,
+            "schema": {
+              "enum": [
+                "direct-submission",
+                "maintainer-review",
+                "adapter-candidate",
+                "monitoring-followup",
+                "baseline-monitoring"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_missing_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_profile_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "directory-only",
+                "identity-partial",
+                "identity-complete",
+                "operational",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_reason_codes",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_review_state",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_manual_review_required",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
               "type": "string"
             }
           },
@@ -25814,6 +26846,200 @@
           },
           {
             "in": "query",
+            "name": "not_auto_review_candidate",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_evidence_action",
+            "required": false,
+            "schema": {
+              "enum": [
+                "submit-new-evidence",
+                "verify-existing-evidence",
+                "replace-stale-evidence",
+                "review-existing-evidence",
+                "maintainer-review-existing-evidence",
+                "monitor"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_identity_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "none",
+                "directory",
+                "partial",
+                "complete"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_lane",
+            "required": false,
+            "schema": {
+              "enum": [
+                "direct-submission",
+                "maintainer-review",
+                "adapter-candidate",
+                "monitoring-followup",
+                "baseline-monitoring"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_manual_review_required",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_missing_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_profile_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "directory-only",
+                "identity-partial",
+                "identity-complete",
+                "operational",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_reason_codes",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_submission_route",
+            "required": false,
+            "schema": {
+              "enum": [
+                "direct-candidate-pr",
+                "adapter-request",
+                "maintainer-review",
+                "status-report"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_target_action",
+            "required": false,
+            "schema": {
+              "enum": [
+                "submit-new-candidate",
+                "replace-stale-candidate",
+                "verify-existing-candidate",
+                "review-existing-candidate",
+                "adapter-review",
+                "maintainer-review",
+                "monitoring-followup"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_target_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "surface-candidate",
+                "adapter-review",
+                "maintainer-review",
+                "monitoring-followup"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -26131,6 +27357,39 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "community-seeded",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_review_state",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -26405,6 +27664,94 @@
           {
             "in": "query",
             "name": "native_name_quality",
+            "required": false,
+            "schema": {
+              "enum": [
+                "chain",
+                "placeholder",
+                "empty"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_profile_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "directory-only",
+                "identity-partial",
+                "identity-complete",
+                "operational",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_confidence",
+            "required": false,
+            "schema": {
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_identity_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "none",
+                "directory",
+                "partial",
+                "complete"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_identity_promotion_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_native_name_quality",
             "required": false,
             "schema": {
               "enum": [
@@ -26770,6 +28117,103 @@
           {
             "in": "query",
             "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_layer",
+            "required": false,
+            "schema": {
+              "enum": [
+                "bittensor-base",
+                "data-provider",
+                "docs-provider",
+                "subnet-app"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_pool_eligible",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_publication_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "candidate",
+                "verified",
+                "monitored",
+                "pool-eligible",
+                "disabled",
+                "rejected"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
             "required": false,
             "schema": {
               "enum": [
@@ -28414,6 +29858,102 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuids",
+            "required": false,
+            "schema": {
+              "maxLength": 767,
+              "pattern": "^\\d{1,5}(,\\d{1,5}){0,127}$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_coverage_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native-only",
+                "manifested",
+                "probed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "community-seeded",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_domain",
+            "required": false,
+            "schema": {
+              "enum": [
+                "agents",
+                "compute",
+                "data",
+                "finance",
+                "inference",
+                "media",
+                "prediction",
+                "privacy",
+                "robotics",
+                "science",
+                "search",
+                "security",
+                "storage",
+                "training"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "active",
+                "inactive"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_subnet_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "root",
+                "application"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -28967,6 +30507,54 @@
           {
             "in": "query",
             "name": "state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "schema-invalid",
+                "schema-valid",
+                "maintainer-review",
+                "verified",
+                "stale",
+                "rejected"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_state",
             "required": false,
             "schema": {
               "enum": [
@@ -29626,6 +31214,94 @@
           },
           {
             "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_layer",
+            "required": false,
+            "schema": {
+              "enum": [
+                "bittensor-base",
+                "data-provider",
+                "docs-provider",
+                "subnet-app"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_pool_eligible",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_publication_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "candidate",
+                "verified",
+                "monitored",
+                "pool-eligible",
+                "disabled",
+                "rejected"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -30257,6 +31933,30 @@
           },
           {
             "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "community-seeded",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_review_state",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -30587,6 +32287,73 @@
           {
             "in": "query",
             "name": "classification",
+            "required": false,
+            "schema": {
+              "enum": [
+                "auth-required",
+                "content-mismatch",
+                "dead",
+                "live",
+                "rate-limited",
+                "redirected",
+                "timeout",
+                "transient",
+                "unsupported",
+                "unsafe",
+                "wrong-chain"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_classification",
             "required": false,
             "schema": {
               "enum": [
@@ -32664,6 +34431,38 @@
           },
           {
             "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -33497,6 +35296,47 @@
           {
             "in": "query",
             "name": "provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_provider",
             "required": false,
             "schema": {
               "type": "string"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7481,6 +7481,10 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -8809,6 +8813,10 @@ export interface operations {
                 agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
                 blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
                 q?: string;
+                not_netuid?: number;
+                not_tier?: "agent-ready" | "machine-usable" | "candidate-review" | "needs-evidence" | "hard-blocked" | "missing-interface";
+                not_agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
+                not_blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9003,6 +9011,8 @@ export interface operations {
             query?: {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
+                not_netuid?: number;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9141,6 +9151,8 @@ export interface operations {
                 netuid?: number;
                 registration_allowed?: "true" | "false";
                 q?: string;
+                not_netuid?: number;
+                not_registration_allowed?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9399,6 +9411,12 @@ export interface operations {
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 severity?: "critical" | "warning" | "info";
                 state?: "active" | "resolved";
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
+                not_severity?: "critical" | "warning" | "info";
+                not_state?: "active" | "resolved";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9547,6 +9565,8 @@ export interface operations {
             query?: {
                 id?: string;
                 kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
+                not_id?: string;
+                not_kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9722,6 +9742,13 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_netuid?: number;
+                not_pool_eligible?: "true" | "false";
+                not_provider?: string;
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10499,6 +10526,9 @@ export interface operations {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_netuid?: number;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10631,6 +10661,8 @@ export interface operations {
             query?: {
                 netuid?: number;
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_netuid?: number;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10760,6 +10792,11 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
+                not_classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11378,6 +11415,12 @@ export interface operations {
                 confidence?: "low" | "medium" | "high";
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
                 q?: string;
+                not_netuid?: number;
+                not_subnet_type?: "root" | "application";
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_review_state?: string;
+                not_confidence?: "low" | "medium" | "high";
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11631,6 +11674,9 @@ export interface operations {
                 id?: string;
                 kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
                 authority?: "community" | "official" | "provider-claimed" | "registry-observed";
+                not_id?: string;
+                not_kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
+                not_authority?: "community" | "official" | "provider-claimed" | "registry-observed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11884,6 +11930,12 @@ export interface operations {
                 pool_eligible?: "true" | "false";
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_netuid?: number;
+                not_pool_eligible?: "true" | "false";
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12281,6 +12333,12 @@ export interface operations {
                 operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 reason_codes?: string;
                 recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
+                not_netuid?: number;
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_candidate_api_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_reason_codes?: string;
+                not_recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12436,6 +12494,11 @@ export interface operations {
                 missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 netuid?: number;
                 q?: string;
+                not_direct_submission_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                not_lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                not_missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_netuid?: number;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12601,6 +12664,17 @@ export interface operations {
                 review_state?: string;
                 manual_review_required?: "true" | "false";
                 q?: string;
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_direct_submission_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                not_identity_level?: "none" | "directory" | "partial" | "complete";
+                not_lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                not_missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_netuid?: number;
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                not_reason_codes?: string;
+                not_review_state?: string;
+                not_manual_review_required?: "true" | "false";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12811,6 +12885,19 @@ export interface operations {
                 target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 target_type?: "surface-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 q?: string;
+                not_auto_review_candidate?: "true" | "false";
+                not_evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                not_identity_level?: "none" | "directory" | "partial" | "complete";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                not_manual_review_required?: "true" | "false";
+                not_missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_netuid?: number;
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                not_reason_codes?: string;
+                not_submission_route?: "direct-candidate-pr" | "adapter-request" | "maintainer-review" | "status-report";
+                not_target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
+                not_target_type?: "surface-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13021,6 +13108,9 @@ export interface operations {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                not_netuid?: number;
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_review_state?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13154,6 +13244,12 @@ export interface operations {
                 identity_level?: "none" | "directory" | "partial" | "complete";
                 identity_promotion_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 native_name_quality?: "chain" | "placeholder" | "empty";
+                not_netuid?: number;
+                not_profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
+                not_confidence?: "low" | "medium" | "high";
+                not_identity_level?: "none" | "directory" | "partial" | "complete";
+                not_identity_promotion_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_native_name_quality?: "chain" | "placeholder" | "empty";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13352,6 +13448,13 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_netuid?: number;
+                not_pool_eligible?: "true" | "false";
+                not_provider?: string;
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -14413,6 +14516,13 @@ export interface operations {
                 max_surface_count?: number;
                 min_tempo?: number;
                 max_tempo?: number;
+                not_netuid?: number;
+                not_netuids?: string;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_domain?: "agents" | "compute" | "data" | "finance" | "inference" | "media" | "prediction" | "privacy" | "robotics" | "science" | "search" | "security" | "storage" | "training";
+                not_status?: "active" | "inactive";
+                not_subnet_type?: "root" | "application";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -14826,6 +14936,9 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15246,6 +15359,12 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_layer?: "bittensor-base" | "data-provider" | "docs-provider" | "subnet-app";
+                not_pool_eligible?: "true" | "false";
+                not_provider?: string;
+                not_publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15644,6 +15763,8 @@ export interface operations {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_review_state?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15852,6 +15973,10 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
+                not_status?: "ok" | "degraded" | "failed" | "unknown";
+                not_classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -17481,6 +17606,8 @@ export interface operations {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -18085,6 +18212,9 @@ export interface operations {
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                not_netuid?: number;
+                not_kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                not_provider?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/scripts/ci-verify-submitted-artifacts.mjs
+++ b/scripts/ci-verify-submitted-artifacts.mjs
@@ -186,6 +186,10 @@ function gitShow(ref) {
   return execFileSync("git", ["show", ref], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
+    // Generated artifacts (e.g. openapi.json) can exceed Node's 1 MiB default
+    // stdout cap; without a larger buffer git show throws ENOBUFS and the
+    // committed artifact reads as "unreadable".
+    maxBuffer: 256 * 1024 * 1024,
   });
 }
 

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2744,6 +2744,12 @@ function listQuery(collection, options = {}) {
     { name: `min_${field}`, schema: { type: "number" } },
     { name: `max_${field}`, schema: { type: "number" } },
   ]);
+  // Each equality filter F → a `not_F` exclusion parameter accepting the same
+  // values: `?not_F=v` returns the complement of `?F=v`.
+  const negationParameters = filterParameters.map((parameter) => ({
+    name: `not_${parameter.name}`,
+    schema: parameter.schema,
+  }));
   return {
     collection,
     filterNames: filterParameters.map((parameter) => parameter.name),
@@ -2751,6 +2757,7 @@ function listQuery(collection, options = {}) {
       ...filterParameters,
       ...searchParameters,
       ...rangeParameters,
+      ...negationParameters,
       {
         name: "fields",
         schema: fieldListSchema,

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -633,3 +633,169 @@ describe("list-query paginationLinkHeader canonicalization", () => {
     assert.equal(next.searchParams.get("sort"), "netuid");
   });
 });
+
+describe("list-query negation (exclusion) filters", () => {
+  const data = {
+    subnets: [
+      {
+        netuid: 1,
+        status: "active",
+        subnet_type: "application",
+        categories: ["agents"],
+      },
+      {
+        netuid: 2,
+        status: "inactive",
+        subnet_type: "application",
+        derived_categories: ["compute"],
+      },
+      {
+        netuid: 3,
+        status: "active",
+        subnet_type: "root",
+        categories: ["data", "agents"],
+      },
+      { netuid: 4 }, // none of the filter fields present
+    ],
+  };
+  const netuids = (result) => result.data.subnets.map((r) => r.netuid);
+
+  test("not_<scalar> drops rows matching the value (complement of equality)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_status=active"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [2, 4]);
+  });
+
+  test("a row missing the field is never excluded", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_subnet_type=application"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [3, 4]);
+  });
+
+  test("multiple not_ params AND together", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_status=active&not_subnet_type=application"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [4]);
+  });
+
+  test("not_<csv-membership> drops rows whose mapped field is in the set", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_netuids=1,3"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [2, 4]);
+  });
+
+  test("not_<array-membership> drops rows whose array union contains the value", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_domain=agents"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [2, 4]);
+  });
+
+  test("not_F is the exact complement of F (the two partition the rows)", () => {
+    const included = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?status=active"),
+      "subnets",
+    );
+    const excluded = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_status=active"),
+      "subnets",
+    );
+    assert.deepEqual(
+      [...netuids(included), ...netuids(excluded)].sort(),
+      [1, 2, 3, 4],
+    );
+  });
+
+  test("not_ composes with sort and order", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_subnet_type=root&sort=netuid&order=desc"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [4, 2, 1]);
+  });
+
+  test("an array-valued field excludes when the value is a member of the array", () => {
+    const arrayData = {
+      subnets: [
+        { netuid: 1, subnet_type: ["application", "root"] },
+        { netuid: 2, subnet_type: "application" },
+      ],
+    };
+    const result = applyQueryFilters(
+      arrayData,
+      query("/api/v1/subnets?not_subnet_type=root"),
+      "subnets",
+    );
+    assert.deepEqual(
+      result.data.subnets.map((r) => r.netuid),
+      [2],
+    );
+  });
+
+  test("no not_ param is a no-op (every row passes)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?sort=netuid"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [1, 2, 3, 4]);
+  });
+
+  test("an invalid not_<enum> value is a query error naming the not_ param", () => {
+    const bad = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_status=bogus"),
+      "subnets",
+    );
+    assert.equal(bad.error.parameter, "not_status");
+    assert.match(bad.error.message, /not supported for this route/);
+  });
+
+  test("an invalid not_<integer> value is a query error", () => {
+    const bad = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_netuid=-1"),
+      "subnets",
+    );
+    assert.equal(bad.error.parameter, "not_netuid");
+    assert.match(bad.error.message, /must be a non-negative integer/);
+  });
+
+  test("a malformed not_<pattern> value is a query error", () => {
+    const bad = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_netuids=abc"),
+      "subnets",
+    );
+    assert.equal(bad.error.parameter, "not_netuids");
+    assert.match(bad.error.message, /not in the expected format/);
+  });
+
+  test("an over-length not_<maxLength> value is a query error", () => {
+    const tooLong = `1${",1".repeat(400)}`;
+    const bad = applyQueryFilters(
+      data,
+      query(`/api/v1/subnets?not_netuids=${tooLong}`),
+      "subnets",
+    );
+    assert.equal(bad.error.parameter, "not_netuids");
+    assert.match(bad.error.message, /too long/);
+  });
+});

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -53,6 +53,9 @@ function listQueryParamNames(queryCollection, queryFilterNames = []) {
   ]);
   const csvNames = Object.keys(config.csv_filters || {});
   const arrayNames = Object.keys(config.array_filters || {});
+  // Every equality filter F also accepts its `not_F` exclusion variant, so the
+  // canonical cache key must distinguish them.
+  const negationNames = filterNames.map((name) => `not_${name}`);
   return [
     "q",
     "fields",
@@ -64,6 +67,7 @@ function listQueryParamNames(queryCollection, queryFilterNames = []) {
     ...csvNames,
     ...arrayNames,
     ...rangeNames,
+    ...negationNames,
   ];
 }
 
@@ -180,6 +184,54 @@ function rangeFilterRows(rows, params, rangeFields) {
   );
 }
 
+// Exclusion (negation) filter: for each configured filter field F, `?not_F=v`
+// drops exactly the rows that the inclusion filter `?F=v` would keep — the
+// logical complement of filterRows, field for field (CSV-membership,
+// array-membership, and scalar/array equality all mirrored). A row that does
+// not match v is kept. Validation has already confirmed each present not_F value
+// satisfies F's schema.
+function excludeFilterRows(
+  rows,
+  params,
+  keys,
+  csvFilters = {},
+  arrayFilters = {},
+) {
+  const csvUnwantedByKey = new Map(
+    keys
+      .filter((key) => csvFilters[key] && params.has(`not_${key}`))
+      .map((key) => [key, new Set(params.get(`not_${key}`).split(","))]),
+  );
+  const exclusions = keys.filter((key) => params.has(`not_${key}`));
+  if (exclusions.length === 0) {
+    return rows;
+  }
+  return rows.filter((row) =>
+    exclusions.every((key) => {
+      const expected = params.get(`not_${key}`);
+      // CSV-membership negation: drop a row whose mapped field is in the set.
+      const csvField = csvFilters[key];
+      if (csvField) {
+        return !csvUnwantedByKey.get(key).has(String(row[csvField]));
+      }
+      // Array-membership negation over the UNION of one or more array fields.
+      const arrayFields = arrayFilters[key];
+      if (arrayFields) {
+        return !arrayFields.some(
+          (field) =>
+            Array.isArray(row[field]) &&
+            row[field].map(String).includes(expected),
+        );
+      }
+      const value = row[key];
+      if (Array.isArray(value)) {
+        return !value.map(String).includes(expected);
+      }
+      return String(value) !== expected;
+    }),
+  );
+}
+
 function applyListTransform(data, params, config) {
   const queryError = validateListQuery(params, config);
   if (queryError) {
@@ -191,16 +243,22 @@ function applyListTransform(data, params, config) {
     return { error: projection.error };
   }
   const filterKeys = Object.keys(config.filters);
-  const filtered = rangeFilterRows(
-    filterRows(
-      searchRows(data[key], params, config.search_keys),
+  const filtered = excludeFilterRows(
+    rangeFilterRows(
+      filterRows(
+        searchRows(data[key], params, config.search_keys),
+        params,
+        filterKeys,
+        config.csv_filters,
+        config.array_filters,
+      ),
       params,
-      filterKeys,
-      config.csv_filters,
-      config.array_filters,
+      config.range_filters,
     ),
     params,
-    config.range_filters,
+    filterKeys,
+    config.csv_filters,
+    config.array_filters,
   );
   const sorted = sortRows(filtered, params);
   const paginated = paginateRows(sorted, params);
@@ -313,6 +371,37 @@ function paginateRows(rows, params) {
   };
 }
 
+// Validate one equality-filter value against its field schema. `parameter` is
+// the actual query-param name (the field `F` or its negation `not_F`) so the
+// error message names the param the client sent. Returns an error object or null.
+function validateFilterValue(parameter, value, schema) {
+  if (schema.type === "integer" && integerParam(value) === null) {
+    return {
+      parameter,
+      message: `${parameter} must be a non-negative integer.`,
+    };
+  }
+  if (schema.enum && !schema.enum.includes(value)) {
+    return {
+      parameter,
+      message: `${parameter} is not supported for this route.`,
+    };
+  }
+  if (schema.maxLength && value.length > schema.maxLength) {
+    return {
+      parameter,
+      message: `${parameter} is too long.`,
+    };
+  }
+  if (schema.pattern && !new RegExp(schema.pattern).test(value)) {
+    return {
+      parameter,
+      message: `${parameter} is not in the expected format.`,
+    };
+  }
+  return null;
+}
+
 function validateListQuery(params, config) {
   const limit = params.get("limit");
   if (
@@ -355,34 +444,21 @@ function validateListQuery(params, config) {
     };
   }
 
+  // Each equality filter field validates its inclusion param (`F`) and its
+  // exclusion param (`not_F`) against the same schema.
   for (const [key, schema] of Object.entries(config.filters)) {
-    if (!params.has(key)) {
-      continue;
-    }
-    const value = params.get(key);
-    if (schema.type === "integer" && integerParam(value) === null) {
-      return {
-        parameter: key,
-        message: `${key} must be a non-negative integer.`,
-      };
-    }
-    if (schema.enum && !schema.enum.includes(value)) {
-      return {
-        parameter: key,
-        message: `${key} is not supported for this route.`,
-      };
-    }
-    if (schema.maxLength && value.length > schema.maxLength) {
-      return {
-        parameter: key,
-        message: `${key} is too long.`,
-      };
-    }
-    if (schema.pattern && !new RegExp(schema.pattern).test(value)) {
-      return {
-        parameter: key,
-        message: `${key} is not in the expected format.`,
-      };
+    for (const parameter of [key, `not_${key}`]) {
+      if (!params.has(parameter)) {
+        continue;
+      }
+      const error = validateFilterValue(
+        parameter,
+        params.get(parameter),
+        schema,
+      );
+      if (error) {
+        return error;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Re-applies the list-query negation filter onto current `main` (the prior PR #1947 was closed for a base conflict — maintainer asked to rebase and reopen). The change is unchanged in intent and re-verified non-duplicate: `main` still has no `not_`/negation support.

The list-query engine supported exact-equality, CSV-membership, array-membership, inclusive numeric range (`min_`/`max_`), `q` search, sort, and cursor pagination — but no way to **exclude** rows matching a value. This adds a generic `not_<field>` parameter for each configured filter field: `?not_F=v` returns the exact complement of `?F=v`, mirroring the CSV/array/scalar match field-for-field and validated against the same schema. It derives from the existing `filters` allow-list, is **registered in the canonical edge-cache key** (`listQueryParamNames`), and applies across every list collection — parallel to the `min_`/`max_` range filters.

## Changes
- `workers/list-query.mjs`: `excludeFilterRows` (negation pass wired after the range filter), a `validateFilterValue` helper validating both `F` and `not_F` against one schema, and `not_F` registered in `listQueryParamNames` for cache canonicalization.
- `src/contracts.mjs`: emit a `not_F` query parameter for every filter field.
- Regenerated `openapi.json`, `api-index.json`, and generated type declarations.
- `tests/list-query.test.mjs`: 13 cases (scalar/CSV/array negation, absent-field rule, multi-`not_` AND, exact-complement partition, composition with sort, four validation branches).

## Validation
- `npm run lint`, `npm run format:check`, `npm run validate:contract-drift`, `npm run validate:openapi` (94 routes) — green
- `npx vitest run tests/list-query.test.mjs` — 57 passed; new lines fully covered
- No `packages/client` bump (handled post-merge by the sync-client-version workflow, per CONTRIBUTING)

Closes #1946

## Note: artifact-verifier fix included

The 130 new `not_` parameters push `public/metagraph/openapi.json` just past 1 MiB (1,078,964 bytes). That exposed a latent ENOBUFS bug in `scripts/ci-verify-submitted-artifacts.mjs`: its `gitShow` helper used `execFileSync` with Node's default 1 MiB stdout cap, so reading the committed >1 MiB artifact threw and it reported the file as "unreadable" (the `Verify submitted public artifacts are reproducible` step). Raised `maxBuffer` to 256 MiB — a pure robustness fix that doesn't weaken the content comparison. Its test (`tests/ci-artifact-verifier.test.mjs`) still passes.