### PR TITLE
fix(api): canonicalize health percentiles and incidents edge-cache keys on window parameter

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -602,7 +602,11 @@ describe("analytics edge cache", () => {
     await Promise.resolve();
     const queriesAfterFirst = queries.length;
 
-    await handleRequest(new Request(`https://api.metagraph.sh${base}`), env, ctx);
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}`),
+      env,
+      ctx,
+    );
     assert.equal(
       queries.length,
       queriesAfterFirst,
@@ -625,7 +629,11 @@ describe("analytics edge cache", () => {
     await Promise.resolve();
     const queriesAfterFirst = queries.length;
 
-    await handleRequest(new Request(`https://api.metagraph.sh${base}`), env, ctx);
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}`),
+      env,
+      ctx,
+    );
     assert.equal(
       queries.length,
       queriesAfterFirst,

--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -587,6 +587,52 @@ describe("analytics edge cache", () => {
     );
   });
 
+  test("health percentiles ?window variants share a single cache entry (canonical key)", async () => {
+    const queries = [];
+    const cache = mockCaches();
+    cache.install();
+    const env = analyticsEnv(queries);
+    const base = "/api/v1/subnets/7/health/percentiles";
+
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}?window=7d`),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    const queriesAfterFirst = queries.length;
+
+    await handleRequest(new Request(`https://api.metagraph.sh${base}`), env, ctx);
+    assert.equal(
+      queries.length,
+      queriesAfterFirst,
+      "no ?window hits cache of ?window=7d",
+    );
+  });
+
+  test("health incidents ?window variants share a single cache entry (canonical key)", async () => {
+    const queries = [];
+    const cache = mockCaches();
+    cache.install();
+    const env = analyticsEnv(queries);
+    const base = "/api/v1/subnets/7/health/incidents";
+
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}?window=7d`),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    const queriesAfterFirst = queries.length;
+
+    await handleRequest(new Request(`https://api.metagraph.sh${base}`), env, ctx);
+    assert.equal(
+      queries.length,
+      queriesAfterFirst,
+      "no ?window hits cache of ?window=7d",
+    );
+  });
+
   test("the 4 additional deterministic routes are now edge-cached (MISS→put under their key, HIT→no D1)", async () => {
     // These routes (global incidents, per-subnet trajectory, per-subnet uptime,
     // registry leaderboards) were edgeCache=0 — they re-ran their D1 aggregation

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -21,6 +21,7 @@ import {
   markD1FallbackResponse,
   analyticsQueryError,
   canonicalAnalyticsCacheRoute,
+  canonicalHealthWindowCachePath,
 } from "../workers/request-handlers/analytics.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
@@ -345,6 +346,45 @@ describe("canonicalAnalyticsCacheRoute", () => {
       canonicalAnalyticsCacheRoute(encoded, ["limit", "call_module"]),
       canonicalAnalyticsCacheRoute(plain, ["limit", "call_module"]),
     );
+  });
+});
+
+describe("canonicalHealthWindowCachePath", () => {
+  test("normalizes bare path to explicit default window", () => {
+    assert.equal(
+      canonicalHealthWindowCachePath(
+        url("/api/v1/subnets/7/health/percentiles"),
+      ),
+      "/api/v1/subnets/7/health/percentiles?window=7d",
+    );
+  });
+
+  test("explicit ?window=7d collapses to same key as bare path", () => {
+    assert.equal(
+      canonicalHealthWindowCachePath(
+        url("/api/v1/subnets/7/health/incidents?window=7d"),
+      ),
+      "/api/v1/subnets/7/health/incidents?window=7d",
+    );
+  });
+
+  test("preserves valid non-default window", () => {
+    assert.equal(
+      canonicalHealthWindowCachePath(
+        url("/api/v1/subnets/7/health/percentiles?window=30d"),
+      ),
+      "/api/v1/subnets/7/health/percentiles?window=30d",
+    );
+  });
+
+  test("falls back to raw search on unknown query param", () => {
+    const raw = "/api/v1/subnets/7/health/incidents?cacheBust=x";
+    assert.equal(canonicalHealthWindowCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid window value", () => {
+    const raw = "/api/v1/subnets/7/health/percentiles?window=bogus";
+    assert.equal(canonicalHealthWindowCachePath(url(raw)), raw);
   });
 });
 

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -554,25 +554,25 @@ export async function handleHealthIncidents(
     env,
     "incidents",
     async () => {
-    const since = Date.now() - days * DAY_MS;
-    const [slaRows, incidentRows] = await Promise.all([
-      d1All(
-        env,
-        `SELECT MAX(surface_id) AS surface_id,
+      const since = Date.now() - days * DAY_MS;
+      const [slaRows, incidentRows] = await Promise.all([
+        d1All(
+          env,
+          `SELECT MAX(surface_id) AS surface_id,
               COALESCE(surface_key, surface_id) AS surface_key,
               COUNT(*) AS total,
               SUM(ok) AS ok_count
        FROM surface_checks
        WHERE netuid = ? AND checked_at >= ?
        GROUP BY COALESCE(surface_key, surface_id)`,
-        [netuid, since],
-      ),
-      // Gap-island grouping in SQL: collapse consecutive failures (gap <= the
-      // incident threshold) into one incident row, then cap per surface_key so
-      // one flappy endpoint cannot starve sibling surfaces in the same subnet.
-      d1All(
-        env,
-        `WITH checks AS (
+          [netuid, since],
+        ),
+        // Gap-island grouping in SQL: collapse consecutive failures (gap <= the
+        // incident threshold) into one incident row, then cap per surface_key so
+        // one flappy endpoint cannot starve sibling surfaces in the same subnet.
+        d1All(
+          env,
+          `WITH checks AS (
          SELECT COALESCE(surface_key, surface_id) AS surface_key,
                 surface_id,
                 checked_at,
@@ -621,39 +621,39 @@ export async function handleHealthIncidents(
        ) ranked
        WHERE rn <= ?
        ORDER BY surface_id, started_at`,
-        [
-          netuid,
-          since,
-          INCIDENT_GAP_MS,
-          MIN_INCIDENT_SAMPLES,
-          MAX_INCIDENT_ROWS,
-        ],
-      ),
-    ]);
-    const meta = await readHealthMetaKv(env);
-    const data = formatIncidents({
-      netuid,
-      window: label,
-      observedAt: meta?.last_run_at || null,
-      slaRows,
-      incidentRows,
-      maxIncidents: MAX_INCIDENT_ROWS,
-    });
-    const response = await envelopeResponse(
-      request,
-      {
-        data,
-        meta: await analyticsMeta(
-          env,
-          `/metagraph/health/incidents/${netuid}.json`,
-          data.observed_at,
+          [
+            netuid,
+            since,
+            INCIDENT_GAP_MS,
+            MIN_INCIDENT_SAMPLES,
+            MAX_INCIDENT_ROWS,
+          ],
         ),
-      },
-      "short",
-    );
-    return hasD1FallbackRows(slaRows, incidentRows)
-      ? markD1FallbackResponse(response)
-      : response;
+      ]);
+      const meta = await readHealthMetaKv(env);
+      const data = formatIncidents({
+        netuid,
+        window: label,
+        observedAt: meta?.last_run_at || null,
+        slaRows,
+        incidentRows,
+        maxIncidents: MAX_INCIDENT_ROWS,
+      });
+      const response = await envelopeResponse(
+        request,
+        {
+          data,
+          meta: await analyticsMeta(
+            env,
+            `/metagraph/health/incidents/${netuid}.json`,
+            data.observed_at,
+          ),
+        },
+        "short",
+      );
+      return hasD1FallbackRows(slaRows, incidentRows)
+        ? markD1FallbackResponse(response)
+        : response;
     },
     canonicalHealthWindowCachePath(url),
   );

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -107,6 +107,17 @@ function canonicalAnalyticsCacheRoute(url, params = []) {
   return `${url.pathname}${query ? `?${query}` : ""}`;
 }
 
+// Normalises per-subnet health analytics URLs so a bare ?-free request and an
+// explicit ?window=7d request both resolve to the same edge-cache entry — mirrors
+// canonicalUptimeCachePath in analytics-routes.mjs.
+export function canonicalHealthWindowCachePath(url) {
+  const validationError = validateQueryParams(url, [ANALYTICS_WINDOW_PARAM]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const { label, error } = analyticsWindow(url);
+  if (error) return `${url.pathname}${url.search}`;
+  return `${url.pathname}?window=${encodeURIComponent(label)}`;
+}
+
 function analyticsWindow(url, extraParams = []) {
   const validationError = validateQueryParams(url, [
     ANALYTICS_WINDOW_PARAM,
@@ -483,41 +494,48 @@ export async function handleHealthPercentiles(
 ) {
   const { label, days, error } = analyticsWindow(url);
   if (error) return analyticsQueryError(error);
-  return withEdgeCache(request, ctx, env, "percentiles", async () => {
-    const rows = await d1All(
-      env,
-      `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
+  return withEdgeCache(
+    request,
+    ctx,
+    env,
+    "percentiles",
+    async () => {
+      const rows = await d1All(
+        env,
+        `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
      SELECT MAX(surface_id) AS surface_id,
             surface_key,
             ${latencyStatColumns()}
      FROM ranked
      GROUP BY surface_key
      HAVING MAX(lat_cnt) > 0`,
-      [netuid, Date.now() - days * DAY_MS],
-    );
-    const meta = await readHealthMetaKv(env);
-    const data = formatPercentiles({
-      netuid,
-      window: label,
-      observedAt: meta?.last_run_at || null,
-      rows,
-    });
-    const response = await envelopeResponse(
-      request,
-      {
-        data,
-        meta: await analyticsMeta(
-          env,
-          `/metagraph/health/percentiles/${netuid}.json`,
-          data.observed_at,
-        ),
-      },
-      "short",
-    );
-    return hasD1FallbackRows(rows)
-      ? markD1FallbackResponse(response)
-      : response;
-  });
+        [netuid, Date.now() - days * DAY_MS],
+      );
+      const meta = await readHealthMetaKv(env);
+      const data = formatPercentiles({
+        netuid,
+        window: label,
+        observedAt: meta?.last_run_at || null,
+        rows,
+      });
+      const response = await envelopeResponse(
+        request,
+        {
+          data,
+          meta: await analyticsMeta(
+            env,
+            `/metagraph/health/percentiles/${netuid}.json`,
+            data.observed_at,
+          ),
+        },
+        "short",
+      );
+      return hasD1FallbackRows(rows)
+        ? markD1FallbackResponse(response)
+        : response;
+    },
+    canonicalHealthWindowCachePath(url),
+  );
 }
 
 // SLA + reconstructed downtime incidents per surface.
@@ -530,7 +548,12 @@ export async function handleHealthIncidents(
 ) {
   const { label, days, error } = analyticsWindow(url);
   if (error) return analyticsQueryError(error);
-  return withEdgeCache(request, ctx, env, "incidents", async () => {
+  return withEdgeCache(
+    request,
+    ctx,
+    env,
+    "incidents",
+    async () => {
     const since = Date.now() - days * DAY_MS;
     const [slaRows, incidentRows] = await Promise.all([
       d1All(
@@ -631,7 +654,9 @@ export async function handleHealthIncidents(
     return hasD1FallbackRows(slaRows, incidentRows)
       ? markD1FallbackResponse(response)
       : response;
-  });
+    },
+    canonicalHealthWindowCachePath(url),
+  );
 }
 
 // Global, cross-subnet incident ledger — the same gap-island grouping as the


### PR DESCRIPTION
## Summary

Fixes #2275

Canonicalize the resolved `window` label into the edge-cache key for per-subnet health percentiles and incidents so bare requests and explicit `?window=7d` requests share one cache entry.

## What Changed

- Add `canonicalHealthWindowCachePath` in `workers/request-handlers/analytics.mjs`
- Pass the canonical path to `withEdgeCache` in `handleHealthPercentiles` and `handleHealthIncidents`
- Unit + edge-cache integration tests for the canonical key contract

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [x] `npm run worker:test` (targeted vitest: analytics handlers + edge-cache)
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [x] `git diff --check`