### PR TITLE
fix(api): canonicalize chain analytics and global incidents edge-cache keys on window parameter

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -587,6 +587,52 @@ describe("analytics edge cache", () => {
     );
   });
 
+  test("chain activity ?window variants share a single cache entry (canonical key)", async () => {
+    const queries = [];
+    const cache = mockCaches();
+    cache.install();
+    const env = analyticsEnv(queries);
+    const base = "/api/v1/chain/activity";
+
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}?window=7d`),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    const queriesAfterFirst = queries.length;
+
+    await handleRequest(new Request(`https://api.metagraph.sh${base}`), env, ctx);
+    assert.equal(
+      queries.length,
+      queriesAfterFirst,
+      "no ?window hits cache of ?window=7d",
+    );
+  });
+
+  test("global incidents ?window variants share a single cache entry (canonical key)", async () => {
+    const queries = [];
+    const cache = mockCaches();
+    cache.install();
+    const env = analyticsEnv(queries);
+    const base = "/api/v1/incidents";
+
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}?window=7d`),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    const queriesAfterFirst = queries.length;
+
+    await handleRequest(new Request(`https://api.metagraph.sh${base}`), env, ctx);
+    assert.equal(
+      queries.length,
+      queriesAfterFirst,
+      "no ?window hits cache of ?window=7d",
+    );
+  });
+
   test("the 4 additional deterministic routes are now edge-cached (MISS→put under their key, HIT→no D1)", async () => {
     // These routes (global incidents, per-subnet trajectory, per-subnet uptime,
     // registry leaderboards) were edgeCache=0 — they re-ran their D1 aggregation

--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -602,7 +602,11 @@ describe("analytics edge cache", () => {
     await Promise.resolve();
     const queriesAfterFirst = queries.length;
 
-    await handleRequest(new Request(`https://api.metagraph.sh${base}`), env, ctx);
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}`),
+      env,
+      ctx,
+    );
     assert.equal(
       queries.length,
       queriesAfterFirst,
@@ -625,7 +629,11 @@ describe("analytics edge cache", () => {
     await Promise.resolve();
     const queriesAfterFirst = queries.length;
 
-    await handleRequest(new Request(`https://api.metagraph.sh${base}`), env, ctx);
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}`),
+      env,
+      ctx,
+    );
     assert.equal(
       queries.length,
       queriesAfterFirst,

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -21,6 +21,7 @@ import {
   markD1FallbackResponse,
   analyticsQueryError,
   canonicalAnalyticsCacheRoute,
+  canonicalHealthWindowCachePath,
 } from "../workers/request-handlers/analytics.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
@@ -345,6 +346,48 @@ describe("canonicalAnalyticsCacheRoute", () => {
       canonicalAnalyticsCacheRoute(encoded, ["limit", "call_module"]),
       canonicalAnalyticsCacheRoute(plain, ["limit", "call_module"]),
     );
+  });
+
+  test("injects default window=7d when window param is omitted", () => {
+    assert.equal(
+      canonicalAnalyticsCacheRoute(url("/api/v1/chain/activity")),
+      "/api/v1/chain/activity?window=7d",
+    );
+    assert.equal(
+      canonicalAnalyticsCacheRoute(
+        url("/api/v1/chain/activity?window=7d"),
+      ),
+      "/api/v1/chain/activity?window=7d",
+    );
+  });
+
+  test("falls back to raw search on invalid window value", () => {
+    const raw = "/api/v1/chain/fees?window=bogus&limit=10";
+    assert.equal(
+      canonicalAnalyticsCacheRoute(url(raw), ["limit", "call_module"]),
+      raw,
+    );
+  });
+});
+
+describe("canonicalHealthWindowCachePath", () => {
+  test("normalizes bare path to explicit default window", () => {
+    assert.equal(
+      canonicalHealthWindowCachePath(url("/api/v1/incidents")),
+      "/api/v1/incidents?window=7d",
+    );
+  });
+
+  test("explicit ?window=7d collapses to same key as bare path", () => {
+    assert.equal(
+      canonicalHealthWindowCachePath(url("/api/v1/incidents?window=7d")),
+      "/api/v1/incidents?window=7d",
+    );
+  });
+
+  test("falls back to raw search on invalid window value", () => {
+    const raw = "/api/v1/incidents?window=bogus";
+    assert.equal(canonicalHealthWindowCachePath(url(raw)), raw);
   });
 });
 

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -354,9 +354,7 @@ describe("canonicalAnalyticsCacheRoute", () => {
       "/api/v1/chain/activity?window=7d",
     );
     assert.equal(
-      canonicalAnalyticsCacheRoute(
-        url("/api/v1/chain/activity?window=7d"),
-      ),
+      canonicalAnalyticsCacheRoute(url("/api/v1/chain/activity?window=7d")),
       "/api/v1/chain/activity?window=7d",
     );
   });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -50,6 +50,7 @@ import {
   handleHealthIncidents,
   handleHealthPercentiles,
   handleHealthTrends,
+  canonicalHealthWindowCachePath,
   withEdgeCache,
   withNeuronsEdgeCache,
 } from "./request-handlers/analytics.mjs";
@@ -1492,8 +1493,13 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       return handleExtrinsics(request, env, resolved.url);
     }
     if (resolved.url.pathname === "/api/v1/incidents") {
-      return withEdgeCache(request, ctx, env, "global-incidents", () =>
-        handleGlobalIncidents(request, env, resolved.url),
+      return withEdgeCache(
+        request,
+        ctx,
+        env,
+        "global-incidents",
+        () => handleGlobalIncidents(request, env, resolved.url),
+        canonicalHealthWindowCachePath(resolved.url),
       );
     }
     if (resolved.url.pathname === "/api/v1/chain/activity") {

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -98,13 +98,34 @@ function validateQueryParams(url, allowedParams) {
 }
 
 function canonicalAnalyticsCacheRoute(url, params = []) {
+  const validationError = validateQueryParams(url, [
+    ANALYTICS_WINDOW_PARAM,
+    ...params,
+  ]);
+  if (validationError) return `${url.pathname}${url.search}`;
+
+  const requested = url.searchParams.get(ANALYTICS_WINDOW_PARAM);
+  if (requested !== null && !ANALYTICS_WINDOWS[requested]) {
+    return `${url.pathname}${url.search}`;
+  }
+
   const search = new URL("https://cache-key.invalid/").searchParams;
-  for (const param of [ANALYTICS_WINDOW_PARAM, ...params]) {
+  search.set(ANALYTICS_WINDOW_PARAM, requested || "7d");
+  for (const param of params) {
     const value = url.searchParams.get(param);
     if (value !== null) search.set(param, value);
   }
   const query = search.toString();
   return `${url.pathname}${query ? `?${query}` : ""}`;
+}
+
+// Normalises windowed analytics URLs with no extra query params (global incidents).
+export function canonicalHealthWindowCachePath(url) {
+  const validationError = validateQueryParams(url, [ANALYTICS_WINDOW_PARAM]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const { label, error } = analyticsWindow(url);
+  if (error) return `${url.pathname}${url.search}`;
+  return `${url.pathname}?window=${encodeURIComponent(label)}`;
 }
 
 function analyticsWindow(url, extraParams = []) {
@@ -744,7 +765,12 @@ export async function handleGlobalIncidents(request, env, url) {
 export async function handleChainActivity(request, env, url, ctx = {}) {
   const { label, days, error } = analyticsWindow(url);
   if (error) return analyticsQueryError(error);
-  return withEdgeCache(request, ctx, env, "chain-activity", async () => {
+  return withEdgeCache(
+    request,
+    ctx,
+    env,
+    "chain-activity",
+    async () => {
     const cutoff = Date.now() - days * DAY_MS;
     // observed_at is epoch-ms; `/ 1000` (SQLite integer division) → unix seconds
     // for strftime's 'unixepoch' UTC bucketer. Values are always bound.
@@ -793,7 +819,9 @@ export async function handleChainActivity(request, env, url, ctx = {}) {
     return hasD1FallbackRows(extrinsicRows, blockRows)
       ? markD1FallbackResponse(response)
       : response;
-  });
+    },
+    canonicalAnalyticsCacheRoute(url),
+  );
 }
 
 // Extrinsic call-mix breakdown (#1989): counts + share per call_module (or
@@ -813,7 +841,12 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
   });
   if (limitError) return analyticsQueryError(limitError);
   const groupBy = url.searchParams.get("group_by") || "module";
-  return withEdgeCache(request, ctx, env, "chain-calls", async () => {
+  return withEdgeCache(
+    request,
+    ctx,
+    env,
+    "chain-calls",
+    async () => {
     const cutoff = Date.now() - days * DAY_MS;
     const groupCols =
       groupBy === "module_function"
@@ -863,7 +896,9 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
     return hasD1FallbackRows(rows, totalRows)
       ? markD1FallbackResponse(response)
       : response;
-  });
+    },
+    canonicalAnalyticsCacheRoute(url, ["group_by", "limit"]),
+  );
 }
 
 // Windowed most-active-account leaderboard (#1990): signers ranked by extrinsic

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -771,54 +771,54 @@ export async function handleChainActivity(request, env, url, ctx = {}) {
     env,
     "chain-activity",
     async () => {
-    const cutoff = Date.now() - days * DAY_MS;
-    // observed_at is epoch-ms; `/ 1000` (SQLite integer division) → unix seconds
-    // for strftime's 'unixepoch' UTC bucketer. Values are always bound.
-    const [extrinsicRows, blockRows] = await Promise.all([
-      d1All(
-        env,
-        `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
+      const cutoff = Date.now() - days * DAY_MS;
+      // observed_at is epoch-ms; `/ 1000` (SQLite integer division) → unix seconds
+      // for strftime's 'unixepoch' UTC bucketer. Values are always bound.
+      const [extrinsicRows, blockRows] = await Promise.all([
+        d1All(
+          env,
+          `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
                 COUNT(*) AS extrinsic_count,
                 SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) AS successful_extrinsics,
                 COUNT(DISTINCT signer) AS unique_signers
          FROM extrinsics
          WHERE observed_at >= ?
          GROUP BY day`,
-        [cutoff],
-      ),
-      d1All(
-        env,
-        `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
+          [cutoff],
+        ),
+        d1All(
+          env,
+          `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
                 COUNT(*) AS block_count,
                 SUM(event_count) AS event_count
          FROM blocks
          WHERE observed_at >= ?
          GROUP BY day`,
-        [cutoff],
-      ),
-    ]);
-    const meta = await readHealthMetaKv(env);
-    const data = buildChainActivity({
-      window: label,
-      observedAt: meta?.last_run_at || null,
-      extrinsicRows,
-      blockRows,
-    });
-    const response = await envelopeResponse(
-      request,
-      {
-        data,
-        meta: await analyticsMeta(
-          env,
-          "/metagraph/chain/activity.json",
-          data.observed_at,
+          [cutoff],
         ),
-      },
-      "short",
-    );
-    return hasD1FallbackRows(extrinsicRows, blockRows)
-      ? markD1FallbackResponse(response)
-      : response;
+      ]);
+      const meta = await readHealthMetaKv(env);
+      const data = buildChainActivity({
+        window: label,
+        observedAt: meta?.last_run_at || null,
+        extrinsicRows,
+        blockRows,
+      });
+      const response = await envelopeResponse(
+        request,
+        {
+          data,
+          meta: await analyticsMeta(
+            env,
+            "/metagraph/chain/activity.json",
+            data.observed_at,
+          ),
+        },
+        "short",
+      );
+      return hasD1FallbackRows(extrinsicRows, blockRows)
+        ? markD1FallbackResponse(response)
+        : response;
     },
     canonicalAnalyticsCacheRoute(url),
   );
@@ -847,55 +847,55 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
     env,
     "chain-calls",
     async () => {
-    const cutoff = Date.now() - days * DAY_MS;
-    const groupCols =
-      groupBy === "module_function"
-        ? "call_module, call_function"
-        : "call_module";
-    const selectCols =
-      groupBy === "module_function"
-        ? "call_module, call_function"
-        : "call_module";
-    const [rows, totalRows] = await Promise.all([
-      d1All(
-        env,
-        `SELECT ${selectCols}, COUNT(*) AS count
+      const cutoff = Date.now() - days * DAY_MS;
+      const groupCols =
+        groupBy === "module_function"
+          ? "call_module, call_function"
+          : "call_module";
+      const selectCols =
+        groupBy === "module_function"
+          ? "call_module, call_function"
+          : "call_module";
+      const [rows, totalRows] = await Promise.all([
+        d1All(
+          env,
+          `SELECT ${selectCols}, COUNT(*) AS count
          FROM extrinsics
          WHERE observed_at >= ? AND call_module IS NOT NULL
          GROUP BY ${groupCols}
          ORDER BY count DESC
          LIMIT ?`,
-        [cutoff, limit],
-      ),
-      d1All(
-        env,
-        `SELECT COUNT(*) AS total FROM extrinsics WHERE observed_at >= ?`,
-        [cutoff],
-      ),
-    ]);
-    const meta = await readHealthMetaKv(env);
-    const data = buildChainCalls({
-      window: label,
-      groupBy,
-      observedAt: meta?.last_run_at || null,
-      total: totalRows?.[0]?.total ?? 0,
-      rows,
-    });
-    const response = await envelopeResponse(
-      request,
-      {
-        data,
-        meta: await analyticsMeta(
-          env,
-          "/metagraph/chain/calls.json",
-          data.observed_at,
+          [cutoff, limit],
         ),
-      },
-      "short",
-    );
-    return hasD1FallbackRows(rows, totalRows)
-      ? markD1FallbackResponse(response)
-      : response;
+        d1All(
+          env,
+          `SELECT COUNT(*) AS total FROM extrinsics WHERE observed_at >= ?`,
+          [cutoff],
+        ),
+      ]);
+      const meta = await readHealthMetaKv(env);
+      const data = buildChainCalls({
+        window: label,
+        groupBy,
+        observedAt: meta?.last_run_at || null,
+        total: totalRows?.[0]?.total ?? 0,
+        rows,
+      });
+      const response = await envelopeResponse(
+        request,
+        {
+          data,
+          meta: await analyticsMeta(
+            env,
+            "/metagraph/chain/calls.json",
+            data.observed_at,
+          ),
+        },
+        "short",
+      );
+      return hasD1FallbackRows(rows, totalRows)
+        ? markD1FallbackResponse(response)
+        : response;
     },
     canonicalAnalyticsCacheRoute(url, ["group_by", "limit"]),
   );


### PR DESCRIPTION
## Summary

Fixes #2276

Canonicalize the resolved `window` label into edge-cache keys for chain analytics routes and global incidents so bare requests and explicit `?window=7d` requests share one cache entry.

## What Changed

- Update `canonicalAnalyticsCacheRoute` to always emit the resolved window label (default `7d`)
- Add `canonicalHealthWindowCachePath` for window-only routes (global incidents wrapper)
- Pass canonical paths to `handleChainActivity`, `handleChainCalls`, and the global-incidents `withEdgeCache` wrapper
- Unit + edge-cache integration tests for the canonical key contract

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [x] `npm run worker:test` (targeted vitest: analytics handlers + edge-cache)
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [x] `git diff --check`