### PR TITLE
feat(mcp): min_/max_ numeric range filters on list_subnets

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -836,6 +836,43 @@ function sortSubnets(rows, field, order) {
   });
 }
 
+// Inclusive numeric range bounds list_subnets accepts, each mapping a `min_`/
+// `max_` arg to a numeric row field — the MCP mirror of the REST list endpoint's
+// `range_filters` (contracts.mjs), generalizing the original one-off `min_readiness`
+// into symmetric min/max bounds over every numeric field the tool exposes. The
+// `readiness` alias is kept for `integration_readiness` so existing `min_readiness`
+// callers are unaffected.
+const LIST_SUBNETS_RANGE_BOUNDS = [
+  { arg: "min_readiness", field: "integration_readiness", op: "min" },
+  { arg: "max_readiness", field: "integration_readiness", op: "max" },
+  { arg: "min_surface_count", field: "surface_count", op: "min" },
+  { arg: "max_surface_count", field: "surface_count", op: "max" },
+  { arg: "min_netuid", field: "netuid", op: "min" },
+  { arg: "max_netuid", field: "netuid", op: "max" },
+];
+
+// Drop rows outside any requested inclusive bound. A row whose field is absent or
+// non-numeric cannot satisfy a bound, so it is excluded once any bound on that
+// field is set — identical to rangeFilterRows in workers/list-query.mjs. Only
+// finite numeric args count (tools/call does not enforce inputSchema types).
+function rangeFilterSubnets(rows, args) {
+  const bounds = LIST_SUBNETS_RANGE_BOUNDS.filter(({ arg }) =>
+    Number.isFinite(args?.[arg]),
+  ).map(({ field, op, arg }) => ({ field, op, limit: args[arg] }));
+  if (bounds.length === 0) {
+    return rows;
+  }
+  return rows.filter((row) =>
+    bounds.every(({ field, op, limit }) => {
+      const value = row[field];
+      if (typeof value !== "number") {
+        return false;
+      }
+      return op === "min" ? value >= limit : value <= limit;
+    }),
+  );
+}
+
 // A search.json document → keywordScore shape: title/slug are identity; subtitle
 // and tokens (which already fold in categories/service kinds) are recall-only.
 function scoreDocument(doc, terms) {
@@ -1032,6 +1069,34 @@ export const MCP_TOOLS = [
           minimum: 0,
           maximum: 100,
         },
+        max_readiness: {
+          type: "integer",
+          description:
+            "Only subnets whose integration_readiness is <= this (0-100).",
+          minimum: 0,
+          maximum: 100,
+        },
+        min_surface_count: {
+          type: "integer",
+          description:
+            "Only subnets with at least this many callable surfaces.",
+          minimum: 0,
+        },
+        max_surface_count: {
+          type: "integer",
+          description: "Only subnets with at most this many callable surfaces.",
+          minimum: 0,
+        },
+        min_netuid: {
+          type: "integer",
+          description: "Only subnets whose netuid is >= this.",
+          minimum: 0,
+        },
+        max_netuid: {
+          type: "integer",
+          description: "Only subnets whose netuid is <= this.",
+          minimum: 0,
+        },
         sort: {
           type: "string",
           enum: LIST_SUBNETS_SORT_FIELDS,
@@ -1063,22 +1128,13 @@ export const MCP_TOOLS = [
         typeof args?.domain === "string"
           ? args.domain.trim().toLowerCase()
           : null;
-      const minReadiness = Number.isFinite(args?.min_readiness)
-        ? args.min_readiness
-        : null;
-      const filtered = all.filter((subnet) => {
+      const categorical = all.filter((subnet) => {
         if (status && String(subnet.status || "").toLowerCase() !== status) {
           return false;
         }
         if (
           subnetType &&
           String(subnet.subnet_type || "").toLowerCase() !== subnetType
-        ) {
-          return false;
-        }
-        if (
-          minReadiness !== null &&
-          !(Number(subnet.integration_readiness) >= minReadiness)
         ) {
           return false;
         }
@@ -1095,6 +1151,9 @@ export const MCP_TOOLS = [
         }
         return true;
       });
+      // Apply the inclusive numeric range bounds (min_/max_) after the
+      // categorical filters, mirroring the REST list endpoint's filter order.
+      const filtered = rangeFilterSubnets(categorical, args);
       // Sort the filtered list before paging; unscored subnets sort last and
       // equal values tie-break by netuid for a stable page (sortSubnets).
       const sort = optionalEnum(args, "sort", LIST_SUBNETS_SORT_FIELDS);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -2844,6 +2844,67 @@ describe("list_subnets", () => {
     assert.equal(byDomain.subnets[0].netuid, 8);
   });
 
+  // Fixture readiness: {0:15, 7:90, 8:0}; surface_count: {0:17, 7:4, 8:0}.
+  const rangeNetuids = (out) =>
+    out.subnets.map((s) => s.netuid).sort((a, b) => a - b);
+
+  test("max_readiness keeps rows <= the bound (complement of min_readiness)", async () => {
+    const out = (
+      await callTool("list_subnets", { max_readiness: 50 }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(out), [0, 8]); // 15 and 0 pass; 90 drops
+  });
+
+  test("min_readiness + max_readiness form an inclusive range", async () => {
+    const out = (
+      await callTool(
+        "list_subnets",
+        { min_readiness: 10, max_readiness: 50 },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(out), [0]); // only readiness 15 is in [10,50]
+  });
+
+  test("min_/max_surface_count bound the callable-surface count", async () => {
+    const atLeast5 = (
+      await callTool("list_subnets", { min_surface_count: 5 }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(atLeast5), [0]); // only 17 >= 5
+
+    const atMost4 = (
+      await callTool("list_subnets", { max_surface_count: 4 }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(atMost4), [7, 8]); // 4 and 0
+  });
+
+  test("min_/max_netuid bound the id range", async () => {
+    const out = (
+      await callTool("list_subnets", { min_netuid: 1, max_netuid: 7 }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(out), [7]); // 0 below, 8 above
+  });
+
+  test("a row whose bounded field is absent or non-numeric is excluded", async () => {
+    const localDeps = makeDeps({
+      "/metagraph/subnets.json": {
+        subnets: [
+          { netuid: 1, slug: "a", name: "A", surface_count: 6 },
+          { netuid: 2, slug: "b", name: "B" }, // surface_count absent
+          { netuid: 3, slug: "c", name: "C", surface_count: "lots" }, // non-numeric
+        ],
+      },
+    });
+    const out = (
+      await callTool(
+        "list_subnets",
+        { min_surface_count: 0 },
+        { deps: localDeps },
+      )
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(out), [1]); // 2 (absent) and 3 (non-numeric) drop even at min 0
+  });
+
   test("sort by integration_readiness desc returns the most ready first + echoes order", async () => {
     const out = (
       await callTool(


### PR DESCRIPTION
## Summary

Re-applies the MCP `list_subnets` range filters onto current `main` (prior PR #1968 was closed for a base conflict — maintainer asked to rebase and reopen). Re-verified non-duplicate: `main` still has only the one-off `min_readiness`.

`list_subnets` had only `min_readiness` — no upper bound, and no range over the other numeric fields it returns and sorts by. This generalizes it into symmetric inclusive `min_`/`max_` bounds, mirroring the REST list endpoints' `range_filters` (which were introduced as the generalization of "the one-off hand-rolled min_readiness the MCP list_subnets tool did"). Extends the sort/order parity work in #1608.

New args: `max_readiness`, `min_surface_count`, `max_surface_count`, `min_netuid`, `max_netuid`. A row whose bounded field is absent or non-numeric is excluded once a bound is set — identical to `rangeFilterRows` in `workers/list-query.mjs`. `min_readiness` keeps its existing behaviour (now routed through the shared `rangeFilterSubnets` helper).

## Changes
- `src/mcp-server.mjs`: `LIST_SUBNETS_RANGE_BOUNDS` + `rangeFilterSubnets` helper wired into the handler after the categorical filters; the 5 new args added to the tool `inputSchema`. No server-card regen (worker-computed, per CONTRIBUTING).
- `tests/mcp-server.test.mjs`: cover max bound, min+max range, surface_count and netuid ranges, and the absent/non-numeric exclusion rule.

## Validation
- `npm run lint`, `npm run format:check`, `node scripts/validate-mcp.mjs` (49 tools) — green
- `npx vitest run tests/mcp-server.test.mjs` — 245 passed; new lines fully covered

Closes #1967