### PR TITLE
fix(api): canonicalize leaderboards edge-cache key on limit parameter

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -699,7 +699,7 @@ describe("analytics edge cache", () => {
       {
         keyParts: "leaderboards",
         path: "/api/v1/registry/leaderboards",
-        search: "",
+        search: "?limit=20",
       },
       {
         keyParts: "global-incidents",

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -8,6 +8,7 @@ import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import {
   canonicalCompareCachePath,
   canonicalEconomicsTrendsCachePath,
+  canonicalLeaderboardsCachePath,
   canonicalUptimeCachePath,
   composeCompareData,
   configureAnalyticsRoutes,
@@ -516,6 +517,43 @@ describe("canonicalEconomicsTrendsCachePath", () => {
   test("falls back to raw search on invalid window value", () => {
     const raw = "/api/v1/economics/trends?window=bogus";
     assert.equal(canonicalEconomicsTrendsCachePath(url(raw)), raw);
+  });
+});
+
+describe("canonicalLeaderboardsCachePath", () => {
+  test("normalizes bare path to explicit default limit", () => {
+    assert.equal(
+      canonicalLeaderboardsCachePath(url("/api/v1/registry/leaderboards")),
+      "/api/v1/registry/leaderboards?limit=20",
+    );
+  });
+
+  test("explicit ?limit=20 collapses to same key as bare path", () => {
+    assert.equal(
+      canonicalLeaderboardsCachePath(
+        url("/api/v1/registry/leaderboards?limit=20"),
+      ),
+      "/api/v1/registry/leaderboards?limit=20",
+    );
+  });
+
+  test("preserves valid board + non-default limit", () => {
+    assert.equal(
+      canonicalLeaderboardsCachePath(
+        url("/api/v1/registry/leaderboards?board=healthiest&limit=10"),
+      ),
+      "/api/v1/registry/leaderboards?board=healthiest&limit=10",
+    );
+  });
+
+  test("falls back to raw search on invalid limit", () => {
+    const raw = "/api/v1/registry/leaderboards?limit=0";
+    assert.equal(canonicalLeaderboardsCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on unknown board", () => {
+    const raw = "/api/v1/registry/leaderboards?board=not-a-board";
+    assert.equal(canonicalLeaderboardsCachePath(url(raw)), raw);
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -90,6 +90,7 @@ import {
 import {
   canonicalCompareCachePath,
   canonicalEconomicsTrendsCachePath,
+  canonicalLeaderboardsCachePath,
   canonicalUptimeCachePath,
   configureAnalyticsRoutes,
   handleCompare,
@@ -1113,8 +1114,13 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     // Deterministic per-cron-tick D1 leaderboard; edge-cache keyed on the health
     // snapshot's last_run_at (auto-busts on the next probe) like the sibling
     // analytics routes, so a polling/cross-colo burst doesn't re-run the SQL.
-    return withEdgeCache(request, ctx, env, "leaderboards", () =>
-      handleLeaderboards(request, env, url),
+    return withEdgeCache(
+      request,
+      ctx,
+      env,
+      "leaderboards",
+      () => handleLeaderboards(request, env, url),
+      canonicalLeaderboardsCachePath(url),
     );
   }
 

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -223,6 +223,29 @@ export function canonicalEconomicsTrendsCachePath(url) {
   return `${url.pathname}?window=${encodeURIComponent(label)}`;
 }
 
+// Normalises the leaderboards URL so that a bare ?-free request and an explicit
+// ?limit=20 request both resolve to the same edge-cache entry — mirrors
+// canonicalCompareCachePath and canonicalUptimeCachePath.
+export function canonicalLeaderboardsCachePath(url) {
+  const validationError = validateQueryParams(url, ["board", "limit"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const limit = url.searchParams.get("limit");
+  if (
+    limit !== null &&
+    (!/^\d+$/.test(limit) || Number(limit) < 1 || Number(limit) > 100)
+  ) {
+    return `${url.pathname}${url.search}`;
+  }
+  const board = url.searchParams.get("board");
+  if (board && !LEADERBOARD_BOARDS.includes(board)) {
+    return `${url.pathname}${url.search}`;
+  }
+  const cap = Math.max(1, Math.min(100, Number(limit) || 20));
+  const params = [`limit=${cap}`];
+  if (board) params.unshift(`board=${encodeURIComponent(board)}`);
+  return `${url.pathname}?${params.join("&")}`;
+}
+
 async function leaderboardProfilesProjection(env, now = Date.now()) {
   if (
     leaderboardProfilesCache &&


### PR DESCRIPTION
## Summary

- Add `canonicalLeaderboardsCachePath` so bare requests and explicit `?limit=20` share one edge-cache slot on `/api/v1/registry/leaderboards`.

Fixes #2281

## What Changed

- `workers/request-handlers/analytics-routes.mjs`: new `canonicalLeaderboardsCachePath` helper normalises the default limit (20) and optional `board` filter into the cache key.
- `workers/api.mjs`: pass the canonical path as the 5th arg to `withEdgeCache` for the leaderboards route.
- `tests/request-handlers-analytics-routes.test.mjs`: regression tests for the canonical path helper.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npx vitest run tests/request-handlers-analytics-routes.test.mjs`

Made with [Cursor](https://cursor.com)