### PR TITLE
fix(api): canonicalize subnet-metagraph edge-cache key on validator_permit

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -36,6 +36,7 @@ import {
   handleExtrinsic,
   canonicalSubnetHistoryCachePath,
   canonicalSubnetTurnoverCachePath,
+  canonicalSubnetMetagraphCachePath,
 } from "../workers/request-handlers/entities.mjs";
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
@@ -1146,6 +1147,38 @@ describe("handleSubnetTurnover", () => {
     test("returns raw search on an unsupported query parameter", () => {
       const raw = "/api/v1/subnets/1/turnover?unknown=1";
       const key = canonicalSubnetTurnoverCachePath(
+        new URL(`https://api.metagraph.sh${raw}`),
+      );
+      assert.equal(key, raw);
+    });
+  });
+
+  describe("canonicalSubnetMetagraphCachePath", () => {
+    test("omitted validator_permit and explicit =false produce the same cache key", () => {
+      const bare = canonicalSubnetMetagraphCachePath(
+        new URL("https://api.metagraph.sh/api/v1/subnets/1/metagraph"),
+      );
+      const explicitFalse = canonicalSubnetMetagraphCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/1/metagraph?validator_permit=false",
+        ),
+      );
+      assert.equal(bare, explicitFalse);
+      assert.equal(bare, "/api/v1/subnets/1/metagraph");
+    });
+
+    test("preserves validator_permit=true filter in the cache key", () => {
+      const key = canonicalSubnetMetagraphCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/1/metagraph?validator_permit=true",
+        ),
+      );
+      assert.equal(key, "/api/v1/subnets/1/metagraph?validator_permit=true");
+    });
+
+    test("returns raw search on an unsupported query parameter", () => {
+      const raw = "/api/v1/subnets/1/metagraph?unknown=1";
+      const key = canonicalSubnetMetagraphCachePath(
         new URL(`https://api.metagraph.sh${raw}`),
       );
       assert.equal(key, raw);

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -72,6 +72,7 @@ import {
   canonicalSubnetConcentrationHistoryCachePath,
   handleSubnetTurnover,
   canonicalSubnetTurnoverCachePath,
+  canonicalSubnetMetagraphCachePath,
   handleAccount,
   handleAccountHistory,
   handleAccountBalance,
@@ -1340,6 +1341,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
             Number(metagraphMatch[1]),
             resolved.url,
           ),
+        canonicalSubnetMetagraphCachePath(resolved.url),
       );
     }
     const neuronMatch = SUBNET_NEURON_PATH_PATTERN.exec(resolved.url.pathname);

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -348,6 +348,18 @@ export function canonicalSubnetTurnoverCachePath(url) {
   return canonicalWindowedCachePath(url, parseHistoryWindow);
 }
 
+// Canonical edge-cache key for the subnet-metagraph route. Only
+// ?validator_permit=true changes the response; omission and =false both serve
+// the full metagraph and must share one cache slot.
+export function canonicalSubnetMetagraphCachePath(url) {
+  const validationError = validateQueryParams(url, ["validator_permit"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const validatorsOnly = url.searchParams.get("validator_permit") === "true";
+  return validatorsOnly
+    ? `${url.pathname}?validator_permit=true`
+    : url.pathname;
+}
+
 // GET /api/v1/subnets/{netuid}/concentration/history?window=7d|30d|90d: the per-day
 // stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share)
 // from the dated neuron_daily rollup — "is this subnet centralizing over time?".


### PR DESCRIPTION
## Summary

- Add `canonicalSubnetMetagraphCachePath` so omitted `validator_permit` and explicit `?validator_permit=false` share one neurons-tier edge-cache slot on `/api/v1/subnets/{netuid}/metagraph`.

Fixes #2282

## What Changed

- `workers/request-handlers/entities.mjs`: new `canonicalSubnetMetagraphCachePath` helper — only `validator_permit=true` is included in the cache key.
- `workers/api.mjs`: pass the canonical path as the 6th arg to `withNeuronsEdgeCache` for the metagraph route.
- `tests/request-handlers-entities.test.mjs`: regression tests for the canonical path helper.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npx vitest run tests/request-handlers-entities.test.mjs -t canonicalSubnetMetagraphCachePath`

Made with [Cursor](https://cursor.com)