### PR TITLE
fix(api): canonicalize health percentiles and incidents edge-cache keys on window parameter

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -690,6 +690,128 @@ describe("analytics edge cache", () => {
     );
   });
 
+  test("health percentiles: bare path populates cache; explicit ?window=7d is a HIT", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+    const base = "/api/v1/subnets/7/health/percentiles";
+
+    const miss = await handleRequest(
+      new Request(`https://api.metagraph.sh${base}`),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(miss.status, 200);
+    const queriesAfterMiss = queries.length;
+
+    const hit = await handleRequest(
+      new Request(`https://api.metagraph.sh${base}?window=7d`),
+      env,
+      ctx,
+    );
+    assert.equal(hit.status, 200);
+    assert.equal(
+      queries.length,
+      queriesAfterMiss,
+      "explicit ?window=7d must be a cache HIT after bare request",
+    );
+    assert.deepEqual(cache.putKeys, [
+      expectedKey("percentiles", base, "?window=7d"),
+    ]);
+  });
+
+  test("health percentiles: explicit ?window=7d populates cache; bare path is a HIT", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+    const base = "/api/v1/subnets/7/health/percentiles";
+
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}?window=7d`),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    const queriesAfterFirst = queries.length;
+
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}`),
+      env,
+      ctx,
+    );
+    assert.equal(
+      queries.length,
+      queriesAfterFirst,
+      "bare path must be a cache HIT after explicit ?window=7d",
+    );
+  });
+
+  test("health incidents: bare path populates cache; explicit ?window=7d is a HIT", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+    const base = "/api/v1/subnets/7/health/incidents";
+
+    const miss = await handleRequest(
+      new Request(`https://api.metagraph.sh${base}`),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(miss.status, 200);
+    const queriesAfterMiss = queries.length;
+
+    const hit = await handleRequest(
+      new Request(`https://api.metagraph.sh${base}?window=7d`),
+      env,
+      ctx,
+    );
+    assert.equal(hit.status, 200);
+    assert.equal(
+      queries.length,
+      queriesAfterMiss,
+      "explicit ?window=7d must be a cache HIT after bare request",
+    );
+    assert.deepEqual(cache.putKeys, [
+      expectedKey("incidents", base, "?window=7d"),
+    ]);
+  });
+
+  test("health incidents: explicit ?window=7d populates cache; bare path is a HIT", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+    const base = "/api/v1/subnets/7/health/incidents";
+
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}?window=7d`),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    const queriesAfterFirst = queries.length;
+
+    await handleRequest(
+      new Request(`https://api.metagraph.sh${base}`),
+      env,
+      ctx,
+    );
+    assert.equal(
+      queries.length,
+      queriesAfterFirst,
+      "bare path must be a cache HIT after explicit ?window=7d",
+    );
+  });
+
   test("the 4 additional deterministic routes are now edge-cached (MISS→put under their key, HIT→no D1)", async () => {
     // These routes (global incidents, per-subnet trajectory, per-subnet uptime,
     // registry leaderboards) were edgeCache=0 — they re-ran their D1 aggregation

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -21,12 +21,14 @@ import {
   markD1FallbackResponse,
   analyticsQueryError,
   canonicalAnalyticsCacheRoute,
+  canonicalHealthWindowCachePath,
 } from "../workers/request-handlers/analytics.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import {
   ANALYTICS_WINDOW_PARAM,
   ANALYTICS_WINDOWS,
+  DEFAULT_ANALYTICS_WINDOW,
 } from "../workers/config.mjs";
 
 configureAnalytics({
@@ -345,6 +347,45 @@ describe("canonicalAnalyticsCacheRoute", () => {
       canonicalAnalyticsCacheRoute(encoded, ["limit", "call_module"]),
       canonicalAnalyticsCacheRoute(plain, ["limit", "call_module"]),
     );
+  });
+});
+
+describe("canonicalHealthWindowCachePath", () => {
+  test("normalizes bare path to explicit default window", () => {
+    assert.equal(
+      canonicalHealthWindowCachePath(
+        url("/api/v1/subnets/7/health/percentiles"),
+      ),
+      `/api/v1/subnets/7/health/percentiles?window=${DEFAULT_ANALYTICS_WINDOW}`,
+    );
+  });
+
+  test("explicit default window collapses to same key as bare path", () => {
+    assert.equal(
+      canonicalHealthWindowCachePath(
+        url("/api/v1/subnets/7/health/incidents?window=7d"),
+      ),
+      `/api/v1/subnets/7/health/incidents?window=${DEFAULT_ANALYTICS_WINDOW}`,
+    );
+  });
+
+  test("preserves valid non-default window", () => {
+    assert.equal(
+      canonicalHealthWindowCachePath(
+        url("/api/v1/subnets/7/health/percentiles?window=30d"),
+      ),
+      "/api/v1/subnets/7/health/percentiles?window=30d",
+    );
+  });
+
+  test("falls back to raw search on unknown query param", () => {
+    const raw = "/api/v1/subnets/7/health/incidents?cacheBust=x";
+    assert.equal(canonicalHealthWindowCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid window value", () => {
+    const raw = "/api/v1/subnets/7/health/percentiles?window=bogus";
+    assert.equal(canonicalHealthWindowCachePath(url(raw)), raw);
   });
 });
 

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -127,6 +127,7 @@ export const UPTIME_WINDOWS = { "90d": 90, "1y": 365 };
 export const MAX_UPTIME_ROWS = 10000;
 export const MAX_BULK_TREND_ROWS = 10000;
 export const ANALYTICS_WINDOWS = { "7d": 7, "30d": 30 };
+export const DEFAULT_ANALYTICS_WINDOW = "7d";
 export const ANALYTICS_WINDOW_PARAM = "window";
 export const RPC_USAGE_BUCKETS = {
   "7d": { granularity: "1h", bucketMs: 60 * 60 * 1000, maxBuckets: 7 * 24 },

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -28,6 +28,7 @@
 import {
   ANALYTICS_WINDOW_PARAM,
   ANALYTICS_WINDOWS,
+  DEFAULT_ANALYTICS_WINDOW,
   DAY_MS,
   HEALTH_TREND_WINDOWS,
   MAX_BULK_TREND_ROWS,
@@ -124,8 +125,19 @@ function analyticsWindow(url, extraParams = []) {
     };
   }
 
-  const label = requested || "7d";
+  const label = requested || DEFAULT_ANALYTICS_WINDOW;
   return { label, days: ANALYTICS_WINDOWS[label] };
+}
+
+// Normalizes per-subnet health analytics URLs so a bare ?-free request and an
+// explicit ?window=7d request both resolve to the same edge-cache entry — mirrors
+// canonicalEconomicsTrendsCachePath in analytics-routes.mjs.
+export function canonicalHealthWindowCachePath(url) {
+  const validationError = validateQueryParams(url, [ANALYTICS_WINDOW_PARAM]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const { label, error } = analyticsWindow(url);
+  if (error) return `${url.pathname}${url.search}`;
+  return `${url.pathname}?window=${encodeURIComponent(label)}`;
 }
 
 function analyticsQueryError(error) {
@@ -483,41 +495,48 @@ export async function handleHealthPercentiles(
 ) {
   const { label, days, error } = analyticsWindow(url);
   if (error) return analyticsQueryError(error);
-  return withEdgeCache(request, ctx, env, "percentiles", async () => {
-    const rows = await d1All(
-      env,
-      `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
+  return withEdgeCache(
+    request,
+    ctx,
+    env,
+    "percentiles",
+    async () => {
+      const rows = await d1All(
+        env,
+        `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
      SELECT MAX(surface_id) AS surface_id,
             surface_key,
             ${latencyStatColumns()}
      FROM ranked
      GROUP BY surface_key
      HAVING MAX(lat_cnt) > 0`,
-      [netuid, Date.now() - days * DAY_MS],
-    );
-    const meta = await readHealthMetaKv(env);
-    const data = formatPercentiles({
-      netuid,
-      window: label,
-      observedAt: meta?.last_run_at || null,
-      rows,
-    });
-    const response = await envelopeResponse(
-      request,
-      {
-        data,
-        meta: await analyticsMeta(
-          env,
-          `/metagraph/health/percentiles/${netuid}.json`,
-          data.observed_at,
-        ),
-      },
-      "short",
-    );
-    return hasD1FallbackRows(rows)
-      ? markD1FallbackResponse(response)
-      : response;
-  });
+        [netuid, Date.now() - days * DAY_MS],
+      );
+      const meta = await readHealthMetaKv(env);
+      const data = formatPercentiles({
+        netuid,
+        window: label,
+        observedAt: meta?.last_run_at || null,
+        rows,
+      });
+      const response = await envelopeResponse(
+        request,
+        {
+          data,
+          meta: await analyticsMeta(
+            env,
+            `/metagraph/health/percentiles/${netuid}.json`,
+            data.observed_at,
+          ),
+        },
+        "short",
+      );
+      return hasD1FallbackRows(rows)
+        ? markD1FallbackResponse(response)
+        : response;
+    },
+    canonicalHealthWindowCachePath(url),
+  );
 }
 
 // SLA + reconstructed downtime incidents per surface.
@@ -530,26 +549,31 @@ export async function handleHealthIncidents(
 ) {
   const { label, days, error } = analyticsWindow(url);
   if (error) return analyticsQueryError(error);
-  return withEdgeCache(request, ctx, env, "incidents", async () => {
-    const since = Date.now() - days * DAY_MS;
-    const [slaRows, incidentRows] = await Promise.all([
-      d1All(
-        env,
-        `SELECT MAX(surface_id) AS surface_id,
+  return withEdgeCache(
+    request,
+    ctx,
+    env,
+    "incidents",
+    async () => {
+      const since = Date.now() - days * DAY_MS;
+      const [slaRows, incidentRows] = await Promise.all([
+        d1All(
+          env,
+          `SELECT MAX(surface_id) AS surface_id,
               COALESCE(surface_key, surface_id) AS surface_key,
               COUNT(*) AS total,
               SUM(ok) AS ok_count
        FROM surface_checks
        WHERE netuid = ? AND checked_at >= ?
        GROUP BY COALESCE(surface_key, surface_id)`,
-        [netuid, since],
-      ),
-      // Gap-island grouping in SQL: collapse consecutive failures (gap <= the
-      // incident threshold) into one incident row, then cap per surface_key so
-      // one flappy endpoint cannot starve sibling surfaces in the same subnet.
-      d1All(
-        env,
-        `WITH checks AS (
+          [netuid, since],
+        ),
+        // Gap-island grouping in SQL: collapse consecutive failures (gap <= the
+        // incident threshold) into one incident row, then cap per surface_key so
+        // one flappy endpoint cannot starve sibling surfaces in the same subnet.
+        d1All(
+          env,
+          `WITH checks AS (
          SELECT COALESCE(surface_key, surface_id) AS surface_key,
                 surface_id,
                 checked_at,
@@ -598,40 +622,42 @@ export async function handleHealthIncidents(
        ) ranked
        WHERE rn <= ?
        ORDER BY surface_id, started_at`,
-        [
-          netuid,
-          since,
-          INCIDENT_GAP_MS,
-          MIN_INCIDENT_SAMPLES,
-          MAX_INCIDENT_ROWS,
-        ],
-      ),
-    ]);
-    const meta = await readHealthMetaKv(env);
-    const data = formatIncidents({
-      netuid,
-      window: label,
-      observedAt: meta?.last_run_at || null,
-      slaRows,
-      incidentRows,
-      maxIncidents: MAX_INCIDENT_ROWS,
-    });
-    const response = await envelopeResponse(
-      request,
-      {
-        data,
-        meta: await analyticsMeta(
-          env,
-          `/metagraph/health/incidents/${netuid}.json`,
-          data.observed_at,
+          [
+            netuid,
+            since,
+            INCIDENT_GAP_MS,
+            MIN_INCIDENT_SAMPLES,
+            MAX_INCIDENT_ROWS,
+          ],
         ),
-      },
-      "short",
-    );
-    return hasD1FallbackRows(slaRows, incidentRows)
-      ? markD1FallbackResponse(response)
-      : response;
-  });
+      ]);
+      const meta = await readHealthMetaKv(env);
+      const data = formatIncidents({
+        netuid,
+        window: label,
+        observedAt: meta?.last_run_at || null,
+        slaRows,
+        incidentRows,
+        maxIncidents: MAX_INCIDENT_ROWS,
+      });
+      const response = await envelopeResponse(
+        request,
+        {
+          data,
+          meta: await analyticsMeta(
+            env,
+            `/metagraph/health/incidents/${netuid}.json`,
+            data.observed_at,
+          ),
+        },
+        "short",
+      );
+      return hasD1FallbackRows(slaRows, incidentRows)
+        ? markD1FallbackResponse(response)
+        : response;
+    },
+    canonicalHealthWindowCachePath(url),
+  );
 }
 
 // Global, cross-subnet incident ledger — the same gap-island grouping as the


### PR DESCRIPTION
## Summary

Fixes #2285

Canonicalize the resolved `window` label into the edge-cache key for per-subnet health percentiles and incidents. Uses `DEFAULT_ANALYTICS_WINDOW` from config (not a hard-coded literal) and adds bidirectional bare/explicit cache reuse tests per maintainer feedback on #2278.

## What Changed

- Add `DEFAULT_ANALYTICS_WINDOW` in `workers/config.mjs`
- Add `canonicalHealthWindowCachePath` derived from `analyticsWindow`
- Pass the canonical path to `withEdgeCache` in `handleHealthPercentiles` and `handleHealthIncidents`
- Unit + bidirectional edge-cache integration tests

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run check` (prettier on touched files)
- [x] `npm run worker:test` (vitest: analytics handlers + edge-cache)
- [x] `git diff --check`