### PR TITLE
fix(probe): fail fast on subtensor transport errors

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -409,38 +409,36 @@ export async function probeSubtensorHttp(url, timeoutMs, options = {}) {
   let contentType = null;
   let genesisHash = null;
 
-  // All five RPC calls are result-independent, so dispatch them concurrently.
-  // Total probe latency collapses from the sum of all call latencies to the
-  // slowest single call. Individual per-call results are preserved as before.
-  const responses = await Promise.all(
-    SUBTENSOR_PROBE_CALLS.map((call, index) =>
-      jsonRpcHttp(url, call.method, call.params, index + 1, timeoutMs, {
+  for (const [index, call] of SUBTENSOR_PROBE_CALLS.entries()) {
+    const response = await jsonRpcHttp(
+      url,
+      call.method,
+      call.params,
+      index + 1,
+      timeoutMs,
+      {
         fetchImpl,
         isUnsafeUrl,
-      }),
-    ),
-  );
+      },
+    );
 
-  for (const [index, call] of SUBTENSOR_PROBE_CALLS.entries()) {
-    const response = responses[index];
     statusCode = response.status_code || statusCode;
     contentType = response.content_type || contentType;
     if (call.key === "genesis" && typeof response.result === "string") {
       genesisHash = response.result;
     }
     methodResults[call.key] = normalizeJsonRpcResult(response);
-  }
 
-  const firstTransportError = responses.find((r) => r.transport_error);
-  if (firstTransportError) {
-    return {
-      ...firstTransportError,
-      content_type: contentType,
-      latency_ms: Math.round(performance.now() - started),
-      method_results: methodResults,
-      status_code: statusCode,
-      verified_at: new Date().toISOString(),
-    };
+    if (response.transport_error) {
+      return {
+        ...response,
+        content_type: contentType,
+        latency_ms: Math.round(performance.now() - started),
+        method_results: methodResults,
+        status_code: statusCode,
+        verified_at: new Date().toISOString(),
+      };
+    }
   }
 
   // chain_verified: true on a matching genesis, false on an explicit mismatch

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -18,7 +18,6 @@ import {
   rollupSubnetStatus,
   normalizeProbeStatus,
   statusForClassification,
-  SUBTENSOR_PROBE_CALLS,
   summarizeRpcProbe,
 } from "../src/health-probe-core.mjs";
 
@@ -591,7 +590,7 @@ describe("probeSubtensorHttp / jsonRpcHttp (HTTP RPC)", () => {
     assert.equal(probe.methods_supported.chain_getBlockHash, true);
   });
 
-  test("transport error: all calls dispatched concurrently, first error returned", async () => {
+  test("transport error: fail-fast after first failed RPC call", async () => {
     let callCount = 0;
     const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
       isUnsafeUrl: async () => false,
@@ -602,11 +601,11 @@ describe("probeSubtensorHttp / jsonRpcHttp (HTTP RPC)", () => {
         throw err;
       },
     });
-    // All SUBTENSOR_PROBE_CALLS are dispatched concurrently — all are attempted.
-    assert.equal(callCount, SUBTENSOR_PROBE_CALLS.length);
+    assert.equal(callCount, 1);
     assert.equal(probe.transport_error, true);
     assert.equal(probe.error_class, "FetchError");
     assert.equal(probe.method_results.chain_getHeader.ok, false);
+    assert.equal(probe.method_results.system_health, undefined);
     // archive_support is omitted entirely in the transport-error branch.
     assert.equal(probe.archive_support, undefined);
   });


### PR DESCRIPTION
### Motivation
- Prevent five-way fan-out of outbound JSON-RPC HTTP calls when a subtensor RPC endpoint fails at the transport layer to avoid amplifying worker outbound concurrency and third-party load.

### Description
- Replaced the concurrent `Promise.all` dispatch of `SUBTENSOR_PROBE_CALLS` with a sequential `for` loop that `await`s each `jsonRpcHttp` call. 
- Implemented fail-fast behavior so the probe returns immediately when a call reports `transport_error`, while preserving collected `method_results`, `status_code`, and `content_type` from calls already performed.
- Updated the corresponding unit test to assert that only the first RPC call is attempted on a transport failure and that later method results remain unset.

### Testing
- Ran the focused test file with `npm test -- tests/health-probe-core.test.mjs` and all tests in that file passed (102 tests, pass).
- Ran `npm run lint` which completed without lint failures.
- Ran `npm run format:check` and Prettier checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a420e49d8c0832c8382459060dcb48c)