### PR TITLE
fix(api): index counterparty relationship lookups

### DIFF
--- a/migrations/0026_account_events_transfer_pair_index.sql
+++ b/migrations/0026_account_events_transfer_pair_index.sql
@@ -1,0 +1,6 @@
+-- Counterparty relationship drilldowns read native-TAO Transfer rows for one
+-- ordered account pair (and the reverse pair) newest-first. The single-party
+-- hotkey/coldkey indexes can still force large residual scans for popular
+-- accounts, so keep this pair lookup seekable for the public API route.
+CREATE INDEX IF NOT EXISTS idx_account_events_transfer_pair
+  ON account_events (event_kind, hotkey, coldkey, block_number, event_index);

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -305,10 +305,11 @@ function dbWith({
                   ) {
                     return { results: blockEvents || [] };
                   }
-                  // Account/counterparty pair detail: bounded Transfer scan for
-                  // both directions between two specific SS58 addresses.
+                  // Account/counterparty pair detail: two indexed pair seeks
+                  // (forward + reverse), then one bounded newest-first merge.
                   if (
-                    /event_kind = 'Transfer' AND \(\(hotkey = \? AND coldkey = \?\) OR \(hotkey = \? AND coldkey = \?\)\)/.test(
+                    /UNION ALL/.test(sql) &&
+                    /event_kind = 'Transfer' AND hotkey = \? AND coldkey = \?/.test(
                       sql,
                     )
                   ) {
@@ -1680,12 +1681,13 @@ describe("handleAccountCounterparties relationship drilldown", () => {
     assert.equal(body.data.relationship.net_tao, -6);
     assert.equal(body.data.relationship.transfers.length, 1);
     assert.equal(body.data.relationship.transfers[0].direction, "received");
-    const idx = captures.sql.findIndex((s) =>
-      /\(\(hotkey = \? AND coldkey = \?\) OR \(hotkey = \? AND coldkey = \?\)\)/.test(
-        s,
-      ),
+    const idx = captures.sql.findIndex(
+      (s) =>
+        /UNION ALL/.test(s) &&
+        /event_kind = 'Transfer' AND hotkey = \? AND coldkey = \?/.test(s),
     );
     assert.ok(idx !== -1);
+    assert.equal(captures.sql[idx].includes(" OR "), false);
     assert.deepEqual(captures.params[idx].slice(0, 4), [
       SS58,
       COUNTERPARTY,

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -738,7 +738,7 @@ export async function handleAccountCounterparties(request, env, ss58, url) {
     }
     const rows = await d1All(
       env,
-      `SELECT ${COUNTERPARTY_RELATIONSHIP_READ_COLUMNS} FROM account_events WHERE event_kind = 'Transfer' AND ((hotkey = ? AND coldkey = ?) OR (hotkey = ? AND coldkey = ?)) ORDER BY block_number DESC, event_index DESC LIMIT ?`,
+      `SELECT ${COUNTERPARTY_RELATIONSHIP_READ_COLUMNS} FROM (SELECT ${COUNTERPARTY_RELATIONSHIP_READ_COLUMNS} FROM account_events WHERE event_kind = 'Transfer' AND hotkey = ? AND coldkey = ? UNION ALL SELECT ${COUNTERPARTY_RELATIONSHIP_READ_COLUMNS} FROM account_events WHERE event_kind = 'Transfer' AND hotkey = ? AND coldkey = ?) ORDER BY block_number DESC, event_index DESC LIMIT ?`,
       [
         ss58,
         counterparty,


### PR DESCRIPTION
### Motivation
- The public `?counterparty` drilldown could force expensive D1 scans because the handler issued a pair lookup using an `OR` predicate while the schema only had single-party indexes, allowing large residual scans through popular single-key indexes and enabling cost-amplification attacks.
- The change aims to make pair lookups seekable by exact account pair and avoid unbounded row walking while preserving behavior and result limits.

### Description
- Add a new D1 migration `migrations/0026_account_events_transfer_pair_index.sql` that creates `idx_account_events_transfer_pair` on `(event_kind, hotkey, coldkey, block_number, event_index)` to support efficient pair seeks.
- Replace the single `OR` predicate pair query in `workers/request-handlers/entities.mjs` with two explicit pair seeks joined by `UNION ALL`, preserving `ORDER BY block_number DESC, event_index DESC` and the existing scan/return limit.
- Update `tests/request-handlers-entities.test.mjs` to mock and assert the new `UNION ALL` query shape and to verify the pair-seek query is used instead of the old `OR` form.
- Preserve the existing client-visible behavior and the `COUNTERPARTY_RELATIONSHIP_SCAN_CAP` result cap.

### Testing
- Ran the focused unit tests `npm test -- tests/request-handlers-entities.test.mjs` and all tests in that file passed (172 tests).
- Ran the migrations validation `npm run validate:migrations` and the new migration was validated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a420fe496ac832cb573600f8ac5ee55)