### PR TITLE
perf(build-artifacts): replace per-row Array.find joins with Maps

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -697,9 +697,7 @@ const candidateIndex = candidates.map((candidate) => ({
   verification:
     fullVerificationByCandidate.get(candidate.id) ||
     fullVerificationResultOrNull(candidate.verification),
-  subnet_name:
-    nativeSnapshot.subnets.find((subnet) => subnet.netuid === candidate.netuid)
-      ?.name || null,
+  subnet_name: nativeByNetuid.get(candidate.netuid)?.name || null,
 }));
 const canonicalCandidateIndex = candidates.map((candidate) => ({
   ...candidate,
@@ -708,9 +706,7 @@ const canonicalCandidateIndex = candidates.map((candidate) => ({
   verification:
     canonicalVerificationByCandidate.get(candidate.id) ||
     fullVerificationResultOrNull(candidate.verification),
-  subnet_name:
-    nativeSnapshot.subnets.find((subnet) => subnet.netuid === candidate.netuid)
-      ?.name || null,
+  subnet_name: nativeByNetuid.get(candidate.netuid)?.name || null,
 }));
 // Dedup'd projections of the candidate index (drop surface-superseded dupes) for
 // the per-subnet detail/profile candidate lists + the enrichment queue (#1002).
@@ -4684,11 +4680,10 @@ function buildSourceHealthArtifact({
     candidateRows,
     (candidate) => candidate.provider || "unknown",
   );
+  const candidateRowsById = new Map(candidateRows.map((row) => [row.id, row]));
   const verificationByProvider = verificationResults.reduce(
     (accumulator, result) => {
-      const candidate = candidateRows.find(
-        (row) => row.id === result.candidate_id,
-      );
+      const candidate = candidateRowsById.get(result.candidate_id);
       const provider = candidate?.provider || "unknown";
       const row = accumulator.get(provider) || {
         provider,


### PR DESCRIPTION
## Summary

Replace O(n·m) Array.find joins with O(1) Map lookups in build-artifacts.mjs to improve build performance.

## What Changed

- Hoist `Map(candidateRows.map(r => [r.id, r]))` in buildSourceHealthArtifact and replace the .find with Map.get
- Replace both `nativeSnapshot.subnets.find(...)?.name` expressions with `nativeByNetuid.get(candidate.netuid)?.name || null`
- Byte-identical output (uniqueness of id/netuid guarantees .find first-match == Map.get)

Fixes #2095

## Registry Safety

- No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state
- Generated artifacts were produced by repo scripts, not hand-edited
- R2-only/high-churn detail artifacts are not committed
- Public API/OpenAPI/schema changes are intentional and documented

## Validation

- `npm run build` produces byte-identical artifacts
- `validate:contract-drift` passes
- No remaining `nativeSnapshot.subnets.find` for subnet_name
- The source-health join is O(1) per result

Made with Cursor