### PR TITLE
perf(build-artifacts): eliminate redundant re-filter/re-group of verification, endpoint, and candidate arrays

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -771,6 +771,7 @@ const overviewSurfacesByNetuid = groupByNetuid(surfaces);
 const endpointsByNetuid = groupByNetuid(endpointResources.endpoints);
 const candidateIndexByNetuid = groupByNetuid(candidateIndex);
 const activeCandidateIndexByNetuid = groupByNetuid(activeCandidateIndex);
+const fullVerificationByNetuid = groupByNetuid(fullVerification.results || []);
 const agentSchemaBySurfaceId = new Map(
   (schemaIndexArtifact.schemas || []).map((entry) => [entry.surface_id, entry]),
 );
@@ -1203,9 +1204,7 @@ await fs.rm(r2ArtifactDir("verification/subnets"), {
   force: true,
 });
 await mapLimit(mergedSubnets, ARTIFACT_WRITE_CONCURRENCY, async (subnet) => {
-  const results = (fullVerification.results || []).filter(
-    (result) => result.netuid === subnet.netuid,
-  );
+  const results = fullVerificationByNetuid.get(subnet.netuid) || [];
   await writeJson(artifactFile(`verification/subnets/${subnet.netuid}.json`), {
     schema_version: 1,
     contract_version: contractVersion,
@@ -1329,9 +1328,7 @@ const overviewGapsByNetuid = new Map(
 const overviewGapPriorities = groupByNetuid(
   curationReview.gap_priorities || [],
 );
-const overviewEndpointsByNetuid = groupByNetuid(endpointResources.endpoints);
 // #1002: overview counts.candidates is a per-subnet count → exclude superseded.
-const overviewCandidatesByNetuid = groupByNetuid(activeCandidateIndex);
 await fs.rm(r2ArtifactDir("overview"), { recursive: true, force: true });
 await mapLimit(mergedSubnets, ARTIFACT_WRITE_CONCURRENCY, async (subnet) => {
   const curationEntry = overviewCurationByNetuid.get(subnet.netuid);
@@ -1351,8 +1348,9 @@ await mapLimit(mergedSubnets, ARTIFACT_WRITE_CONCURRENCY, async (subnet) => {
     gaps: overviewGapsByNetuid.get(subnet.netuid)?.gaps || null,
     counts: {
       surfaces: (overviewSurfacesByNetuid.get(subnet.netuid) || []).length,
-      endpoints: (overviewEndpointsByNetuid.get(subnet.netuid) || []).length,
-      candidates: (overviewCandidatesByNetuid.get(subnet.netuid) || []).length,
+      endpoints: (endpointsByNetuid.get(subnet.netuid) || []).length,
+      candidates: (activeCandidateIndexByNetuid.get(subnet.netuid) || [])
+        .length,
     },
     gap_priorities: overviewGapPriorities.get(subnet.netuid) || [],
   });


### PR DESCRIPTION
## Summary

Eliminate redundant re-filter/re-group of verification, endpoint, and candidate arrays in build-artifacts.mjs to improve build performance.

## What Changed

- Add fullVerificationByNetuid grouping near line 774 and replace the in-loop filter at lines 1206-1208 with Map.get
- Delete redundant overviewEndpointsByNetuid grouping (use existing endpointsByNetuid)
- Delete redundant overviewCandidatesByNetuid grouping (use existing activeCandidateIndexByNetuid)
- Byte-identical output (groupBy preserves input order, so .get(key) yields the same array as the prior .filter())

Fixes #2096

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] npm run build produces byte-identical artifacts
- [x] validate:contract-drift passes (artifact regeneration expected)
- No remaining duplicate groupByNetuid(...) or in-loop .filter(... === subnet.netuid) over fullVerification.results

Made with Cursor