### PR TITLE
fix(api): clamp turnover stability_score and retention so a sub-perfect window never reports a perfect 100/1

### DIFF
--- a/src/turnover.mjs
+++ b/src/turnover.mjs
@@ -12,10 +12,15 @@ export const TURNOVER_READ_COLUMNS =
   "snapshot_date, uid, hotkey, validator_permit";
 
 // Round a retention ratio (always a finite 0..1 jaccard result) to a stable
-// precision.
+// precision WITHOUT letting a sub-perfect ratio round up to an exact 1 — the same
+// invariant `displayUptimeRatio` enforces for uptime (#1799) and `formatUptimePercent`
+// for the badge (#1796): a set that actually churned must never report a flawless
+// `retention: 1`. Only a genuine ratio of exactly 1 (nothing rotated) keeps the
+// perfect value; any sub-1 ratio clamps to the largest dp-decimal value below 1.
 function round(value, dp = 4) {
   const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
+  const rounded = Math.round(value * factor) / factor;
+  return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
 }
 
 // Jaccard similarity |A∩B| / |A∪B| — the retained fraction across two sets. Two
@@ -121,6 +126,16 @@ export function buildTurnover(
   const endIds = new Set([...endMap].map(([uid, hk]) => `${uid}:${hk}`));
   const neuronRetention = jaccard(startIds, endIds);
 
+  // 0–100 composite: the mean of validator-set and neuron retention. Apply the
+  // same anti-overstatement guard as the retention ratios — a sub-perfect mean must
+  // not round up to a perfect 100. A fully-retained validator set plus ~1% neuron
+  // churn yields a mean of ~0.995, and `Math.round(99.5) === 100` would report
+  // flawless stability for a subnet that demonstrably rotated; clamp it to 99. Only
+  // a genuine mean of exactly 1 (nothing rotated) keeps the perfect 100.
+  const meanRetention = (validatorRetention + neuronRetention) / 2;
+  let stabilityScore = Math.round(meanRetention * 100);
+  if (stabilityScore >= 100 && meanRetention < 1) stabilityScore = 99;
+
   return {
     ...base,
     // A single snapshot (start === end) can't show change — flag it so a caller
@@ -135,9 +150,6 @@ export function buildTurnover(
     neurons_end: endMap.size,
     uids_deregistered: deregistered,
     neuron_retention: round(neuronRetention),
-    // 0–100 composite: the mean of validator-set and neuron retention.
-    stability_score: Math.round(
-      ((validatorRetention + neuronRetention) / 2) * 100,
-    ),
+    stability_score: stabilityScore,
   };
 }

--- a/tests/turnover.test.mjs
+++ b/tests/turnover.test.mjs
@@ -268,6 +268,45 @@ describe("buildTurnover — regressions", () => {
     assert.equal(data.neuron_retention, 0);
   });
 
+  test("a sub-perfect retention mean must not round stability_score up to a perfect 100", () => {
+    // A fully-retained validator set (retention 1.0) plus ~1% neuron churn yields a
+    // mean of ~0.995, which a bare Math.round lifts to 100 — reporting flawless
+    // stability for a subnet that demonstrably rotated. Build 100 retained neurons
+    // (one of them a retained validator) and one brand-new neuron at the end:
+    // neuron_retention = 100/101 ≈ 0.9901, mean ≈ 0.99505 → must clamp to 99.
+    const rows = [];
+    for (let uid = 0; uid < 100; uid += 1) {
+      const validator_permit = uid === 0 ? 1 : 0;
+      rows.push({
+        snapshot_date: "2026-05-01",
+        uid,
+        hotkey: `H${uid}`,
+        validator_permit,
+      });
+      rows.push({
+        snapshot_date: "2026-06-01",
+        uid,
+        hotkey: `H${uid}`,
+        validator_permit,
+      });
+    }
+    // A new neuron appears only at the end → union 101, intersection 100.
+    rows.push({
+      snapshot_date: "2026-06-01",
+      uid: 100,
+      hotkey: "Hnew",
+      validator_permit: 0,
+    });
+    const data = buildTurnover(rows, 1, {
+      window: "30d",
+      startDate: "2026-05-01",
+      endDate: "2026-06-01",
+    });
+    assert.equal(data.validator_retention, 1); // the lone validator is retained
+    assert.equal(data.neuron_retention, 0.9901); // 100/101, churned
+    assert.equal(data.stability_score, 99); // clamped, never an overstated 100
+  });
+
   test("a validator that loses its permit counts as exited; its neuron stays retained", () => {
     const rows = [
       {

--- a/tests/turnover.test.mjs
+++ b/tests/turnover.test.mjs
@@ -313,17 +313,30 @@ describe("buildTurnover — regressions", () => {
     // The round() guard must intercept it and return 0.9999 (not 1).
     const rows = [];
     for (let uid = 0; uid < 20000; uid++) {
-      rows.push({ snapshot_date: "2026-05-01", uid, hotkey: `M${uid}`, validator_permit: 0 });
+      rows.push({
+        snapshot_date: "2026-05-01",
+        uid,
+        hotkey: `M${uid}`,
+        validator_permit: 0,
+      });
     }
     for (let uid = 0; uid < 19999; uid++) {
-      rows.push({ snapshot_date: "2026-06-01", uid, hotkey: `M${uid}`, validator_permit: 0 });
+      rows.push({
+        snapshot_date: "2026-06-01",
+        uid,
+        hotkey: `M${uid}`,
+        validator_permit: 0,
+      });
     }
     const data = buildTurnover(rows, 1, {
       window: "30d",
       startDate: "2026-05-01",
       endDate: "2026-06-01",
     });
-    assert.ok(data.neuron_retention < 1, "sub-perfect retention must not round up to 1");
+    assert.ok(
+      data.neuron_retention < 1,
+      "sub-perfect retention must not round up to 1",
+    );
     assert.equal(data.neuron_retention, 0.9999); // clamped; naïve Math.round gives 1
   });
 

--- a/tests/turnover.test.mjs
+++ b/tests/turnover.test.mjs
@@ -307,6 +307,26 @@ describe("buildTurnover — regressions", () => {
     assert.equal(data.stability_score, 99); // clamped, never an overstated 100
   });
 
+  test("neuron_retention rounds to < 1 when sub-perfect jaccard would otherwise round up to 1 (round() clamp path)", () => {
+    // 20000 neurons at start, 19999 at end (1 exits): jaccard = 19999/20000 = 0.99995,
+    // which Math.round(0.99995 * 10000) = 10000 / 10000 = 1 without the clamp.
+    // The round() guard must intercept it and return 0.9999 (not 1).
+    const rows = [];
+    for (let uid = 0; uid < 20000; uid++) {
+      rows.push({ snapshot_date: "2026-05-01", uid, hotkey: `M${uid}`, validator_permit: 0 });
+    }
+    for (let uid = 0; uid < 19999; uid++) {
+      rows.push({ snapshot_date: "2026-06-01", uid, hotkey: `M${uid}`, validator_permit: 0 });
+    }
+    const data = buildTurnover(rows, 1, {
+      window: "30d",
+      startDate: "2026-05-01",
+      endDate: "2026-06-01",
+    });
+    assert.ok(data.neuron_retention < 1, "sub-perfect retention must not round up to 1");
+    assert.equal(data.neuron_retention, 0.9999); // clamped; naïve Math.round gives 1
+  });
+
   test("a validator that loses its permit counts as exited; its neuron stays retained", () => {
     const rows = [
       {


### PR DESCRIPTION
## Summary

- `buildTurnover` reported a flawless `stability_score: 100` (and `*_retention: 1`)
  for a subnet window that actually churned, because the composite and the retention
  ratios used bare rounding that lifts a sub-perfect value up to the perfect sentinel.
- Apply the anti-overstatement invariant the codebase already enforces for uptime —
  `displayUptimeRatio` (`src/reliability.mjs`, #1799) and `formatUptimePercent`
  (`src/badge.mjs`, #1796): a sub-perfect ratio clamps below the perfect value, while
  a genuine exactly-1 mean (single-snapshot / all-miner) still reports `100` / `1`.

Closes #2298

## Template Used

- [x] Backend/code change

## What Changed

- `src/turnover.mjs`: the local `round(value, dp)` helper now clamps a sub-1 jaccard
  to the largest dp-decimal value below 1; `stability_score` is computed from the
  unrounded mean and clamped to `99` when the mean is in `[0.995, 1)` (only an exact
  mean of 1 keeps `100`).
- `tests/turnover.test.mjs`: two regression tests — (1) a fully-retained validator
  set plus ~1% neuron churn (`neuron_retention = 100/101`) must yield
  `stability_score: 99`, not `100`; (2) a jaccard of 19999/20000 = 0.99995 that
  `Math.round` would lift to 1 is clamped to 0.9999 by the new `round()` guard,
  exercising the clamp path independently of `stability_score`. Existing
  genuinely-perfect cases (single snapshot, all-miner) still assert `100` / `1`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No schema
      change — same numeric ranges, only the perfect-value overstatement is removed.)

## Validation

- [x] `npx vitest run tests/turnover.test.mjs` (11 passed)
- [x] `npx prettier --check src/turnover.mjs tests/turnover.test.mjs`
- [x] `npx eslint src/turnover.mjs tests/turnover.test.mjs`
- [x] `git diff --check`

## Test plan

- [x] A churned window never reports `stability_score: 100` or `*_retention: 1`
- [x] A sub-perfect jaccard (19999/20000) that would naïvely round to 1 is clamped to
      0.9999 by the updated `round()` helper — the clamp path is exercised directly
- [x] The single-snapshot and all-miner cases still report `100` / `1` (genuine
      perfect retention)
- [x] All existing turnover tests pass unchanged