### PR TITLE
fix(api): reject keyset cursor parts above MAX_SAFE_INTEGER in encode/decodeCursor

### DIFF
--- a/src/cursor.mjs
+++ b/src/cursor.mjs
@@ -12,11 +12,13 @@
 // over D1. Callers should treat the token as opaque. Exposed as `?cursor=` + a
 // `next_cursor` body field.
 
-// Encode an array of non-negative integers into a cursor token. Returns null for
-// an empty/invalid input (the caller then emits no next_cursor).
+// Encode an array of non-negative SAFE integers into a cursor token. Returns null
+// for an empty/invalid input (the caller then emits no next_cursor). Parts must be
+// safe integers — a value above Number.MAX_SAFE_INTEGER can't survive the
+// Number()/round-trip the decoder performs, so it is not a representable cursor.
 export function encodeCursor(parts) {
   if (!Array.isArray(parts) || parts.length === 0) return null;
-  if (parts.some((p) => !Number.isInteger(p) || p < 0)) return null;
+  if (parts.some((p) => !Number.isSafeInteger(p) || p < 0)) return null;
   return parts.join(".");
 }
 
@@ -31,7 +33,13 @@ export function decodeCursor(raw, arity) {
   for (const s of segs) {
     if (!/^\d+$/.test(s)) return null;
     const n = Number(s);
-    if (!Number.isInteger(n) || n < 0) return null;
+    // Reject parts outside the SAFE integer range — `/^\d+$/` admits arbitrarily
+    // long digit strings, and `Number()` silently rounds anything above
+    // MAX_SAFE_INTEGER (e.g. "9007199254740993" -> 9007199254740992), which
+    // `Number.isInteger` would still accept and hand back as a corrupted seek key.
+    // Mirror the offset-pagination sibling `integerParam` (workers/list-query.mjs),
+    // which gates on `Number.isSafeInteger`, so an out-of-range cursor is ignored.
+    if (!Number.isSafeInteger(n) || n < 0) return null;
     parts.push(n);
   }
   return parts;

--- a/tests/cursor.test.mjs
+++ b/tests/cursor.test.mjs
@@ -47,6 +47,11 @@ test("decodeCursor rejects parts above MAX_SAFE_INTEGER (no silent Number() roun
   assert.equal(decodeCursor(unsafe, 1), null);
   assert.equal(decodeCursor(`1.${unsafe}`, 2), null);
   assert.equal(decodeCursor(`${unsafe}.2`, 2), null);
+  // The exact first unsafe integer (2^53 = MAX_SAFE_INTEGER + 1) is also rejected.
+  // It IS exactly representable in IEEE-754 but fails Number.isSafeInteger, so
+  // the gate rejects it just as decisively as a visibly-rounded value.
+  const firstUnsafe = String(Number.MAX_SAFE_INTEGER + 1); // "9007199254740992"
+  assert.equal(decodeCursor(firstUnsafe, 1), null);
   // The exact MAX_SAFE_INTEGER boundary is still a valid, representable cursor.
   const safe = String(Number.MAX_SAFE_INTEGER); // "9007199254740991"
   assert.deepEqual(decodeCursor(safe, 1), [Number.MAX_SAFE_INTEGER]);

--- a/tests/cursor.test.mjs
+++ b/tests/cursor.test.mjs
@@ -38,3 +38,26 @@ test("decodeCursor returns null on malformed/garbage/arity-mismatch", () => {
   assert.equal(decodeCursor(encodeCursor([1, 2]), 1), null); // 2-part token as 1
   assert.equal(decodeCursor("-1.2", 2), null); // negative
 });
+
+test("decodeCursor rejects parts above MAX_SAFE_INTEGER (no silent Number() rounding)", () => {
+  // `/^\d+$/` admits arbitrarily long digit strings; Number() rounds anything past
+  // MAX_SAFE_INTEGER (2^53 - 1), so "9007199254740993" parses to 9007199254740992 —
+  // a corrupted seek key. It must be rejected, not silently rounded and accepted.
+  const unsafe = "9007199254740993"; // MAX_SAFE_INTEGER + 2, not exactly representable
+  assert.equal(decodeCursor(unsafe, 1), null);
+  assert.equal(decodeCursor(`1.${unsafe}`, 2), null);
+  assert.equal(decodeCursor(`${unsafe}.2`, 2), null);
+  // The exact MAX_SAFE_INTEGER boundary is still a valid, representable cursor.
+  const safe = String(Number.MAX_SAFE_INTEGER); // "9007199254740991"
+  assert.deepEqual(decodeCursor(safe, 1), [Number.MAX_SAFE_INTEGER]);
+});
+
+test("encodeCursor rejects a part above MAX_SAFE_INTEGER", () => {
+  assert.equal(encodeCursor([2 ** 53]), null); // 9007199254740992, unsafe
+  assert.equal(encodeCursor([1, 2 ** 53]), null);
+  // The boundary value itself still round-trips.
+  assert.equal(
+    encodeCursor([Number.MAX_SAFE_INTEGER]),
+    String(Number.MAX_SAFE_INTEGER),
+  );
+});


### PR DESCRIPTION
## Summary

- `decodeCursor` matched each `?cursor=` segment with `/^\d+$/` (any digit length)
  and then gated on `Number.isInteger`, so a part above `Number.MAX_SAFE_INTEGER`
  (e.g. `9007199254740993`) was silently rounded by `Number()` to `9007199254740992`
  and accepted as a corrupted seek key — paging from the wrong boundary instead of
  the codec's documented "ignore a malformed cursor and fall back" behaviour.
- Gate both `encodeCursor` and `decodeCursor` on `Number.isSafeInteger`, matching the
  offset-pagination sibling `integerParam` in `workers/list-query.mjs`, which already
  rejects non-safe integers.

Closes #2300

## Template Used

- [x] Backend/code change

## What Changed

- `src/cursor.mjs`: `encodeCursor` / `decodeCursor` now reject parts outside the safe
  integer range (`Number.isSafeInteger`), so an out-of-range cursor returns `null`
  (the handler ignores it) rather than a silently-rounded value.
- `tests/cursor.test.mjs`: regression tests — a segment above `MAX_SAFE_INTEGER`
  decodes to `null` and `encodeCursor` rejects an unsafe part, while the exact
  `MAX_SAFE_INTEGER` boundary and existing safe values still round-trip.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No schema
      change — only previously-corrupt out-of-range cursors are now rejected, the same
      as any other malformed cursor.)

## Validation

- [x] `npx vitest run tests/cursor.test.mjs` (7 passed)
- [x] `npx prettier --check src/cursor.mjs tests/cursor.test.mjs`
- [x] `npx eslint src/cursor.mjs tests/cursor.test.mjs`
- [x] `git diff --check`

## Test plan

- [x] `decodeCursor("9007199254740993", 1)` and the multi-part variants return `null`
- [x] `encodeCursor([2 ** 53])` returns `null`
- [x] The exact `MAX_SAFE_INTEGER` boundary and existing safe cursors still round-trip
