### PR TITLE
feat(mcp): add get_subnet_turnover with shared REST loader

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -89,6 +89,7 @@ import {
   NEURON_DAILY_READ_COLUMNS,
   parseHistoryWindow,
 } from "./neuron-history.mjs";
+import { loadSubnetTurnover } from "./turnover.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import { loadBlocks, loadBlock } from "./blocks.mjs";
 import { loadExtrinsics, loadExtrinsic } from "./extrinsics.mjs";
@@ -123,7 +124,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.6.0";
+export const MCP_SERVER_VERSION = "1.7.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -182,7 +183,8 @@ export const MCP_INSTRUCTIONS =
   "long-term surface uptime history, get_subnet_concentration stake and " +
   "emission decentralization metrics (Gini, HHI, Nakamoto), " +
   "get_subnet_concentration_history the decentralization trend over time, " +
-  "get_registry_leaderboards the live " +
+  "get_subnet_turnover validator-set and registration churn between two " +
+  "boundary snapshots, get_registry_leaderboards the live " +
   "cross-subnet health/economics boards, compare_subnets a side-by-side view " +
   "across structure/economics/health, get_global_incidents recent cross-subnet " +
   "probe failures, get_subnet_metagraph the " +
@@ -1432,6 +1434,38 @@ export const MCP_TOOLS = [
       return loadSubnetConcentrationHistory(mcpD1Runner(ctx), netuid, {
         windowLabel: parsed.label,
         windowDays: parsed.days,
+      });
+    },
+  },
+  {
+    name: "get_subnet_turnover",
+    title: "Get subnet validator turnover",
+    description:
+      "Fetch one subnet's validator-set and registration churn between the " +
+      "start and end neuron_daily snapshots in the requested window (7d, 30d, " +
+      "90d, 1y, or all; default 30d): validators entered/exited, Jaccard " +
+      "retention for validators and neurons, UID deregistrations, and a 0–100 " +
+      "stability score. Use it to see how stable a subnet's participation base " +
+      "is over time. Mirrors GET /api/v1/subnets/{netuid}/turnover.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: ["7d", "30d", "90d", "1y", "all"],
+          description: "History window (default 30d).",
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const { label, days } = requireHistoryWindow(args);
+      return loadSubnetTurnover(mcpD1Runner(ctx), netuid, {
+        windowLabel: label,
+        windowDays: days,
       });
     },
   },
@@ -3355,6 +3389,39 @@ const TOOL_OUTPUT_SCHEMAS = {
         emission_nakamoto_coefficient: ANY,
         emission_top_10pct_share: ANY,
       }),
+    },
+  },
+  get_subnet_turnover: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "netuid",
+      "comparable",
+      "validators_start",
+      "validators_end",
+      "validators_entered",
+      "validators_exited",
+      "neurons_start",
+      "neurons_end",
+      "uids_deregistered",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      start_date: NULLABLE_STRING,
+      end_date: NULLABLE_STRING,
+      comparable: { type: "boolean" },
+      validators_start: { type: "integer" },
+      validators_end: { type: "integer" },
+      validators_entered: { type: "integer" },
+      validators_exited: { type: "integer" },
+      validator_retention: { type: ["number", "null"] },
+      neurons_start: { type: "integer" },
+      neurons_end: { type: "integer" },
+      uids_deregistered: { type: "integer" },
+      neuron_retention: { type: ["number", "null"] },
+      stability_score: { type: ["integer", "null"] },
     },
   },
   get_subnet_uptime: {

--- a/src/turnover.mjs
+++ b/src/turnover.mjs
@@ -11,6 +11,8 @@
 export const TURNOVER_READ_COLUMNS =
   "snapshot_date, uid, hotkey, validator_permit";
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 // Round a retention ratio (always a finite 0..1 jaccard result) to a stable
 // precision.
 function round(value, dp = 4) {
@@ -140,4 +142,39 @@ export function buildTurnover(
       ((validatorRetention + neuronRetention) / 2) * 100,
     ),
   };
+}
+
+// One subnet's validator-set & registration churn — shared by the REST route and
+// MCP tool: MIN/MAX the window's boundary snapshot_dates on neuron_daily, read
+// exactly those two days' rows, shape with buildTurnover. Cold D1 → comparable:false.
+export async function loadSubnetTurnover(
+  d1,
+  netuid,
+  { windowLabel, windowDays },
+) {
+  let boundsSql =
+    "SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date FROM neuron_daily WHERE netuid = ?";
+  const boundsParams = [netuid];
+  if (windowDays != null) {
+    const cutoff = new Date(Date.now() - windowDays * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
+    boundsSql += " AND snapshot_date >= ?";
+    boundsParams.push(cutoff);
+  }
+  const bounds = await d1(boundsSql, boundsParams);
+  const startDate = bounds[0]?.start_date ?? null;
+  const endDate = bounds[0]?.end_date ?? null;
+  const rows =
+    startDate == null || endDate == null
+      ? []
+      : await d1(
+          `SELECT ${TURNOVER_READ_COLUMNS} FROM neuron_daily WHERE netuid = ? AND snapshot_date IN (?, ?) ORDER BY snapshot_date ASC, uid ASC`,
+          [netuid, startDate, endDate],
+        );
+  return buildTurnover(rows, netuid, {
+    window: windowLabel,
+    startDate,
+    endDate,
+  });
 }

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3384,6 +3384,8 @@ describe("MCP economics + metagraph data tools", () => {
     growthSamples = [],
     rpcRows = [],
     neuronDaily = [],
+    turnoverBounds = [],
+    turnoverRows = [],
   } = {}) {
     return {
       prepare(sql) {
@@ -3408,6 +3410,12 @@ describe("MCP economics + metagraph data tools", () => {
                   return Promise.resolve({ results: snapshots });
                 }
                 if (sql.includes("FROM neuron_daily")) {
+                  if (/MIN\(snapshot_date\) AS start_date/.test(sql)) {
+                    return Promise.resolve({ results: turnoverBounds });
+                  }
+                  if (/snapshot_date IN/.test(sql)) {
+                    return Promise.resolve({ results: turnoverRows });
+                  }
                   return Promise.resolve({ results: neuronDaily });
                 }
                 if (sql.includes("FROM surface_uptime_daily")) {
@@ -3624,6 +3632,121 @@ describe("MCP economics + metagraph data tools", () => {
     });
     assert.equal(res.body.result.isError, true);
     assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("get_subnet_turnover returns schema-stable empty on cold D1", async () => {
+    const res = await callTool("get_subnet_turnover", { netuid: 7 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.window, "30d");
+    assert.equal(out.comparable, false);
+    assert.equal(out.validator_retention, null);
+    assert.equal(out.stability_score, null);
+  });
+
+  test("get_subnet_turnover computes validator churn between boundary snapshots", async () => {
+    const res = await callTool(
+      "get_subnet_turnover",
+      { netuid: 9, window: "30d" },
+      {
+        env: {
+          METAGRAPH_HEALTH_DB: metagraphD1({
+            turnoverBounds: [
+              { start_date: "2026-06-01", end_date: "2026-06-30" },
+            ],
+            turnoverRows: [
+              {
+                snapshot_date: "2026-06-01",
+                uid: 0,
+                hotkey: "V1",
+                validator_permit: 1,
+              },
+              {
+                snapshot_date: "2026-06-01",
+                uid: 1,
+                hotkey: "V2",
+                validator_permit: 1,
+              },
+              {
+                snapshot_date: "2026-06-01",
+                uid: 2,
+                hotkey: "M1",
+                validator_permit: 0,
+              },
+              {
+                snapshot_date: "2026-06-30",
+                uid: 0,
+                hotkey: "V1",
+                validator_permit: 1,
+              },
+              {
+                snapshot_date: "2026-06-30",
+                uid: 1,
+                hotkey: "V3",
+                validator_permit: 1,
+              },
+              {
+                snapshot_date: "2026-06-30",
+                uid: 2,
+                hotkey: "M1",
+                validator_permit: 0,
+              },
+            ],
+          }),
+        },
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.comparable, true);
+    assert.equal(out.start_date, "2026-06-01");
+    assert.equal(out.end_date, "2026-06-30");
+    assert.equal(out.validators_entered, 1);
+    assert.equal(out.validators_exited, 1);
+    assert.equal(out.uids_deregistered, 1);
+    assert.equal(out.stability_score, 42);
+  });
+
+  test("get_subnet_turnover rejects an invalid window", async () => {
+    const res = await callTool("get_subnet_turnover", {
+      netuid: 7,
+      window: "400d",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("get_subnet_turnover accepts the all window without a date cutoff", async () => {
+    const res = await callTool(
+      "get_subnet_turnover",
+      { netuid: 9, window: "all" },
+      {
+        env: {
+          METAGRAPH_HEALTH_DB: metagraphD1({
+            turnoverBounds: [
+              { start_date: "2026-06-01", end_date: "2026-06-30" },
+            ],
+            turnoverRows: [
+              {
+                snapshot_date: "2026-06-01",
+                uid: 0,
+                hotkey: "V1",
+                validator_permit: 1,
+              },
+              {
+                snapshot_date: "2026-06-30",
+                uid: 0,
+                hotkey: "V1",
+                validator_permit: 1,
+              },
+            ],
+          }),
+        },
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "all");
+    assert.equal(out.comparable, true);
+    assert.equal(out.validator_retention, 1);
   });
 
   test("the D1-backed tools degrade to schema-stable empty payloads when D1 is cold", async () => {

--- a/tests/turnover.test.mjs
+++ b/tests/turnover.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
-import { buildTurnover } from "../src/turnover.mjs";
+import { describe, test, vi } from "vitest";
+import { buildTurnover, loadSubnetTurnover } from "../src/turnover.mjs";
 
 describe("buildTurnover", () => {
   test("cold / empty / non-array / no-window inputs yield a schema-stable empty block", () => {
@@ -192,6 +192,135 @@ describe("buildTurnover", () => {
     assert.equal(data.validators_end, 1); // V1
     assert.equal(data.neurons_start, 0);
     assert.equal(data.neurons_end, 1);
+  });
+});
+
+describe("turnover loaders", () => {
+  function d1(rowsBySql = {}, captures = { sql: [], params: [] }) {
+    return async (sql, params) => {
+      captures.sql.push(sql);
+      captures.params.push(params);
+      for (const [pattern, rows] of Object.entries(rowsBySql)) {
+        if (new RegExp(pattern).test(sql)) return rows;
+      }
+      return [];
+    };
+  }
+
+  test("loadSubnetTurnover returns schema-stable empty on cold D1", async () => {
+    const data = await loadSubnetTurnover(d1(), 7, {
+      windowLabel: "30d",
+      windowDays: 30,
+    });
+    assert.equal(data.netuid, 7);
+    assert.equal(data.window, "30d");
+    assert.equal(data.comparable, false);
+    assert.equal(data.validator_retention, null);
+    assert.equal(data.stability_score, null);
+  });
+
+  test("loadSubnetTurnover computes churn between boundary snapshots", async () => {
+    const data = await loadSubnetTurnover(
+      d1({
+        "MIN\\(snapshot_date\\)": [
+          { start_date: "2026-06-01", end_date: "2026-06-30" },
+        ],
+        "snapshot_date IN": [
+          {
+            snapshot_date: "2026-06-01",
+            uid: 0,
+            hotkey: "V1",
+            validator_permit: 1,
+          },
+          {
+            snapshot_date: "2026-06-01",
+            uid: 1,
+            hotkey: "V2",
+            validator_permit: 1,
+          },
+          {
+            snapshot_date: "2026-06-01",
+            uid: 2,
+            hotkey: "M1",
+            validator_permit: 0,
+          },
+          {
+            snapshot_date: "2026-06-30",
+            uid: 0,
+            hotkey: "V1",
+            validator_permit: 1,
+          },
+          {
+            snapshot_date: "2026-06-30",
+            uid: 1,
+            hotkey: "V3",
+            validator_permit: 1,
+          },
+          {
+            snapshot_date: "2026-06-30",
+            uid: 2,
+            hotkey: "M1",
+            validator_permit: 0,
+          },
+        ],
+      }),
+      9,
+      { windowLabel: "30d", windowDays: 30 },
+    );
+    assert.equal(data.comparable, true);
+    assert.equal(data.start_date, "2026-06-01");
+    assert.equal(data.end_date, "2026-06-30");
+    assert.equal(data.validators_entered, 1);
+    assert.equal(data.validators_exited, 1);
+    assert.equal(data.uids_deregistered, 1);
+    assert.equal(data.stability_score, 42);
+  });
+
+  test("loadSubnetTurnover omits the date cutoff for the all window", async () => {
+    const captures = { sql: [], params: [] };
+    await loadSubnetTurnover(
+      d1(
+        {
+          "MIN\\(snapshot_date\\)": [
+            { start_date: "2026-06-01", end_date: "2026-06-30" },
+          ],
+          "snapshot_date IN": [],
+        },
+        captures,
+      ),
+      9,
+      { windowLabel: "all", windowDays: null },
+    );
+    assert.match(captures.sql[0], /MIN\(snapshot_date\)/);
+    assert.deepEqual(captures.params[0], [9]);
+    assert.doesNotMatch(captures.sql[0], /snapshot_date >=/);
+  });
+
+  test("loadSubnetTurnover binds the exact 30d cutoff date", async () => {
+    const fixedNow = new Date("2026-06-30T12:00:00.000Z");
+    const captures = { sql: [], params: [] };
+    try {
+      vi.useFakeTimers();
+      vi.setSystemTime(fixedNow);
+      await loadSubnetTurnover(
+        d1(
+          {
+            "MIN\\(snapshot_date\\)": [
+              { start_date: "2026-05-31", end_date: "2026-06-30" },
+            ],
+            "snapshot_date IN": [],
+          },
+          captures,
+        ),
+        9,
+        { windowLabel: "30d", windowDays: 30 },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+    assert.equal(captures.params[0][0], 9);
+    assert.equal(captures.params[0][1], "2026-05-31");
+    assert.deepEqual(captures.params[1], [9, "2026-05-31", "2026-06-30"]);
   });
 });
 

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -97,7 +97,7 @@ import {
   buildCounterpartyRelationship,
   buildCounterparties,
 } from "../../src/counterparties.mjs";
-import { TURNOVER_READ_COLUMNS, buildTurnover } from "../../src/turnover.mjs";
+import { loadSubnetTurnover } from "../../src/turnover.mjs";
 
 const MAX_BLOCK_COUNT_FILTER = 1_000_000;
 
@@ -406,31 +406,9 @@ export async function handleSubnetTurnover(request, env, netuid, url) {
     url.searchParams.get("window"),
   );
   if (error) return analyticsQueryError(error);
-  let boundsSql =
-    "SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date FROM neuron_daily WHERE netuid = ?";
-  const boundsParams = [netuid];
-  if (days != null) {
-    const cutoff = new Date(Date.now() - days * DAY_MS)
-      .toISOString()
-      .slice(0, 10);
-    boundsSql += " AND snapshot_date >= ?";
-    boundsParams.push(cutoff);
-  }
-  const bounds = await d1All(env, boundsSql, boundsParams);
-  const startDate = bounds[0]?.start_date ?? null;
-  const endDate = bounds[0]?.end_date ?? null;
-  const rows =
-    startDate == null || endDate == null
-      ? []
-      : await d1All(
-          env,
-          `SELECT ${TURNOVER_READ_COLUMNS} FROM neuron_daily WHERE netuid = ? AND snapshot_date IN (?, ?)`,
-          [netuid, startDate, endDate],
-        );
-  const data = buildTurnover(rows, netuid, {
-    window: label,
-    startDate,
-    endDate,
+  const data = await loadSubnetTurnover(d1Runner(env), netuid, {
+    windowLabel: label,
+    windowDays: days,
   });
   return envelopeResponse(
     request,
@@ -439,7 +417,7 @@ export async function handleSubnetTurnover(request, env, netuid, url) {
       meta: await metagraphMeta(
         env,
         `/metagraph/subnets/${netuid}/turnover.json`,
-        endDate,
+        data.end_date,
       ),
     },
     "short",


### PR DESCRIPTION
## Summary

Supersedes #2265 (closed for merge conflict + duplicated turnover SQL).

- Adds `get_subnet_turnover` MCP tool, mirroring `GET /api/v1/subnets/{netuid}/turnover` for validator-set and registration churn (entered/exited validators, Jaccard retention, deregistrations, stability score).
- Introduces `loadSubnetTurnover` in `src/turnover.mjs` and routes **both** the REST handler and MCP tool through it, so the D1 boundary-query/read contract lives in one place.
- Bumps MCP server version to **1.7.0**.

## Test plan

- [x] `npm test -- tests/turnover.test.mjs tests/mcp-server.test.mjs tests/request-handlers-entities.test.mjs -t turnover`
- [x] `npm run validate:mcp`
- [x] Loader unit tests: cold D1, happy-path churn, `all` window, exact 30d cutoff (fake timers)
- [x] MCP `callTool` integration tests: cold D1, happy path, invalid window, `all` window
- [x] REST `handleSubnetTurnover` tests still pass via shared loader


Made with [Cursor](https://cursor.com)