### PR TITLE
fix(api): match REST subnet enum/string filters case-insensitively

### DIFF
--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -255,6 +255,61 @@ describe("list-query sort tie-break", () => {
   });
 });
 
+// #2073: REST enum/string filters were case-sensitive while MCP list_subnets
+// lowercases its args, so ?status=Active returned a 400 the equivalent MCP call
+// would not. Enum + string-equality + array-membership matching is now
+// case-insensitive (the configured vocabularies + stored values are lowercase).
+describe("list-query case-insensitive enum/string filters (#2073)", () => {
+  const data = {
+    subnets: [
+      {
+        netuid: 1,
+        status: "active",
+        subnet_type: "application",
+        categories: ["inference"],
+      },
+      {
+        netuid: 2,
+        status: "inactive",
+        subnet_type: "root",
+        categories: ["training"],
+      },
+    ],
+  };
+  const netuids = (result) => result.data.subnets.map((r) => r.netuid);
+
+  for (const [mixed, lower] of [
+    ["status=Active", "status=active"],
+    ["subnet_type=Application", "subnet_type=application"],
+    ["domain=Inference", "domain=inference"],
+  ]) {
+    test(`?${mixed} returns 200 with the same rows as ?${lower}`, () => {
+      const upper = applyQueryFilters(
+        data,
+        query(`/api/v1/subnets?${mixed}`),
+        "subnets",
+      );
+      const lowerResult = applyQueryFilters(
+        data,
+        query(`/api/v1/subnets?${lower}`),
+        "subnets",
+      );
+      assert.equal(upper.error, undefined, `?${mixed} must not 400`);
+      assert.deepEqual(netuids(upper), [1]);
+      assert.deepEqual(netuids(upper), netuids(lowerResult));
+    });
+  }
+
+  test("a genuinely invalid enum value still errors (400 invalid_query)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?status=Bogus"),
+      "subnets",
+    );
+    assert.equal(result.error.parameter, "status");
+  });
+});
+
 describe("list-query numeric range filters", () => {
   const data = {
     subnets: [

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -129,11 +129,17 @@ function filterRows(rows, params, keys, csvFilters = {}, arrayFilters = {}) {
         return true;
       }
       const expected = params.get(key);
-      // CSV membership filter (e.g. ?netuids=1,7,74 -> match row.netuid).
+      // CSV membership filter (e.g. ?netuids=1,7,74 -> match row.netuid). Numeric
+      // vocabulary - left case-sensitive (the issue scopes netuids out).
       const csvField = csvFilters[key];
       if (csvField) {
         return csvWantedByKey.get(key)?.has(String(row[csvField])) ?? false;
       }
+      // Enum/string filters match case-insensitively (#2073): the configured
+      // vocabularies and stored values are lowercase, so lowercasing the input
+      // restores parity with the MCP list_subnets tool (?domain=Inference,
+      // ?status=Active) without touching the stored row value.
+      const expectedCi = expected.toLowerCase();
       // Array-membership filter over the UNION of one or more array fields
       // (e.g. ?domain=inference -> match row.categories or row.derived_categories).
       const arrayFields = arrayFilters[key];
@@ -141,14 +147,14 @@ function filterRows(rows, params, keys, csvFilters = {}, arrayFilters = {}) {
         return arrayFields.some(
           (field) =>
             Array.isArray(row[field]) &&
-            row[field].map(String).includes(expected),
+            row[field].map((v) => String(v).toLowerCase()).includes(expectedCi),
         );
       }
       const value = row[key];
       if (Array.isArray(value)) {
-        return value.map(String).includes(expected);
+        return value.map((v) => String(v).toLowerCase()).includes(expectedCi);
       }
-      return String(value) === expected;
+      return String(value).toLowerCase() === expectedCi;
     }),
   );
 }
@@ -366,7 +372,11 @@ function validateListQuery(params, config) {
         message: `${key} must be a non-negative integer.`,
       };
     }
-    if (schema.enum && !schema.enum.includes(value)) {
+    // Enum membership is case-insensitive (#2073): the configured vocabularies are
+    // all lowercase, so ?status=Active matches like the MCP list_subnets tool
+    // (which lowercases its args) instead of returning a 400 the equivalent MCP
+    // call would not. A genuinely invalid value still fails after lowercasing.
+    if (schema.enum && !schema.enum.includes(value.toLowerCase())) {
       return {
         parameter: key,
         message: `${key} is not supported for this route.`,


### PR DESCRIPTION
## Summary

- Lowercase enum and string-equality filter inputs in `workers/list-query.mjs` so REST `GET /api/v1/subnets` accepts mixed-case enum values (`?status=Active`, `?subnet_type=Application`, `?domain=Inference`) with the same rows as lowercase forms.
- Restores parity with MCP `list_subnets`, which already lowercases filter args.

Fixes #2073

## Template Used

- Backend/code change

## What Changed

- `validateListQuery`: enum membership check uses `value.toLowerCase()`.
- `filterRows`: string-equality and array-membership comparisons are case-insensitive on the input side; CSV/numeric filters unchanged.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/list-query.test.mjs`
- [x] `git diff --check`