### PR TITLE
fix(api): reject non-integer numeric filters on the blocks feed (#2310)

### DIFF
--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -309,6 +309,24 @@ test("GET /blocks clamps limit to <=100 + rejects unsupported params", async () 
   assert.equal(bad.status, 400);
 });
 
+test("GET /blocks rejects non-integer numeric filters with 400 (#2310)", async () => {
+  const env = dbWith({ feed: [] });
+  for (const query of [
+    "block_start=abc",
+    "block_end=abc",
+    "from=foo",
+    "to=foo",
+    "min_extrinsics=1.5",
+    "min_events=-1",
+    "spec_version=foo",
+  ]) {
+    const res = await handleRequest(req(`/api/v1/blocks?${query}`), env, {});
+    assert.equal(res.status, 400, query);
+    const body = await res.json();
+    assert.equal(body.ok, false, query);
+  }
+});
+
 test("GET /blocks?cursor= seeks by keyset + emits next_cursor (#1851)", async () => {
   let boundSql;
   let boundParams;

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -314,6 +314,7 @@ test("GET /blocks rejects non-integer numeric filters with 400 (#2310)", async (
   for (const query of [
     "block_start=abc",
     "block_end=abc",
+    "block_start=12.9",
     "from=foo",
     "to=foo",
     "min_extrinsics=1.5",
@@ -324,6 +325,7 @@ test("GET /blocks rejects non-integer numeric filters with 400 (#2310)", async (
     assert.equal(res.status, 400, query);
     const body = await res.json();
     assert.equal(body.ok, false, query);
+    assert.equal(body.error.code, "invalid_query", query);
   }
 });
 

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -17,12 +17,7 @@
 // imported straight from the src/* leaf modules + config. api.mjs imports the
 // handlers back and dispatches them from the router.
 
-import {
-  DAY_MS,
-  SS58_ADDRESS_PATTERN,
-  clampInt,
-  resolveClientIp,
-} from "../config.mjs";
+import { DAY_MS, SS58_ADDRESS_PATTERN, resolveClientIp } from "../config.mjs";
 import {
   BLOCK_PAGINATION,
   DAY_PATTERN,
@@ -1084,17 +1079,33 @@ export async function handleBlocks(request, env, url) {
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset, cursor } = parsePagination(url, BLOCK_PAGINATION);
   const sp = url.searchParams;
-  const MAX = Number.MAX_SAFE_INTEGER;
-  const intParam = (name) => clampInt(sp.get(name), 0, 0, MAX);
-  const blockStart =
-    sp.get("block_start") != null ? intParam("block_start") : null;
-  const blockEnd = sp.get("block_end") != null ? intParam("block_end") : null;
-  const from = sp.get("from") != null ? intParam("from") : null;
-  const to = sp.get("to") != null ? intParam("to") : null;
-  const minExtrinsics =
-    sp.get("min_extrinsics") != null ? intParam("min_extrinsics") : null;
-  const minEvents =
-    sp.get("min_events") != null ? intParam("min_events") : null;
+  // Reject non-integer numeric filters with a 400 (mirrors handleExtrinsics /
+  // #2274) instead of silently coercing garbage to the clampInt default: a
+  // ?block_end=abc used to fall back to 0 and serve a wrong (block_number <= 0)
+  // result set rather than an error, and ?block_start=12.9 was silently
+  // truncated.
+  const numericFilters = {};
+  for (const param of [
+    "block_start",
+    "block_end",
+    "from",
+    "to",
+    "min_extrinsics",
+    "min_events",
+    "spec_version",
+  ]) {
+    const raw = sp.get(param);
+    if (raw === null) continue;
+    const parsed = parseNonNegativeIntParam(raw, param);
+    if (parsed.error) return analyticsQueryError(parsed.error);
+    numericFilters[param] = parsed.value;
+  }
+  const blockStart = numericFilters.block_start ?? null;
+  const blockEnd = numericFilters.block_end ?? null;
+  const from = numericFilters.from ?? null;
+  const to = numericFilters.to ?? null;
+  const minExtrinsics = numericFilters.min_extrinsics ?? null;
+  const minEvents = numericFilters.min_events ?? null;
 
   // Inverted indexed ranges and astronomically high per-block count floors are
   // deterministic no-match cases. Short-circuit them before D1 so public callers
@@ -1125,9 +1136,9 @@ export async function handleBlocks(request, env, url) {
     conds.push("author = ?");
     params.push(sp.get("author"));
   }
-  if (sp.get("spec_version") != null) {
+  if (numericFilters.spec_version != null) {
     conds.push("spec_version = ?");
-    params.push(clampInt(sp.get("spec_version"), 0, 0, MAX));
+    params.push(numericFilters.spec_version);
   }
   if (blockStart != null) {
     conds.push("block_number >= ?");

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1079,11 +1079,7 @@ export async function handleBlocks(request, env, url) {
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset, cursor } = parsePagination(url, BLOCK_PAGINATION);
   const sp = url.searchParams;
-  // Reject non-integer numeric filters with a 400 (mirrors handleExtrinsics /
-  // #2274) instead of silently coercing garbage to the clampInt default: a
-  // ?block_end=abc used to fall back to 0 and serve a wrong (block_number <= 0)
-  // result set rather than an error, and ?block_start=12.9 was silently
-  // truncated.
+  // Reject non-integer numeric filters with 400 (mirrors handleExtrinsics / #2274).
   const numericFilters = {};
   for (const param of [
     "block_start",


### PR DESCRIPTION
## Summary

Reject non-integer numeric filters on `GET /api/v1/blocks` with `400 invalid_query` instead of silently coercing garbage to `0` via `clampInt`. Brings the blocks feed to parity with the extrinsics feed (#2274 / #2086).

Fixes #2310

## What Changed

- `handleBlocks` now validates `block_start`, `block_end`, `from`, `to`, `min_extrinsics`, `min_events`, and `spec_version` through `parseNonNegativeIntParam` (same loop as `handleExtrinsics`).
- Removed the `clampInt`-based `intParam` helper from the blocks handler.
- Added regression coverage in `tests/blocks.test.mjs`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npx vitest run tests/blocks.test.mjs tests/request-handlers-entities.test.mjs` (222 passed)
- [x] `git diff --check`