### PR TITLE
fix(health): block CGNAT 100.64.0.0/10 in the probe SSRF guard (#2312)

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -60,6 +60,9 @@ const UNSAFE_HOST_PATTERNS = [
   /^192\.168\./,
   /^169\.254\./,
   /^0\./,
+  // 100.64.0.0/10 CGNAT — blocked by the webhook + build SSRF guards; the probe
+  // literal guard must stay in parity (issue #2312).
+  /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./,
   /^::1$/,
   /^::$/,
   // fe80::/10 link-local + fec0::/10 deprecated site-local (RFC 3879) — the whole

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -100,6 +100,8 @@ describe("isUnsafePublicUrl", () => {
       "http://10.1.2.3/x",
       "http://192.168.0.1/x",
       "http://169.254.169.254/latest",
+      "http://100.64.0.1/x",
+      "http://100.127.255.255/x",
       "http://172.16.0.1/x",
       "http://172.31.255.255/x",
       "https://service.local/x",


### PR DESCRIPTION
## Summary

Block the CGNAT `100.64.0.0/10` range in the health prober's literal SSRF guard (`isUnsafePublicUrl`), matching the webhook and build guards that already reject these addresses.

Fixes #2312

## What Changed

- Added the `100.64.0.0/10` host pattern to `UNSAFE_HOST_PATTERNS` in `src/health-probe-core.mjs` (same regex as `src/webhooks.mjs`).
- Extended the `isUnsafePublicUrl` regression suite in `tests/health-probe-core.test.mjs`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npx vitest run tests/health-probe-core.test.mjs` (104 passed)
- [x] `git diff --check`