### PR TITLE
fix(blocks): strict-validate non-hash ref in loadBlock for MCP get_block

### DIFF
--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -172,16 +172,34 @@ export async function loadBlocks(d1, { limit, offset, cursor } = {}) {
   return buildBlockFeed(rows, { limit: lim, offset: off, nextCursor });
 }
 
+// A strict non-negative block_number, or null for a non-decimal ref — so a
+// malformed ref (0x-short, 1e3, signs, leading space, oversized digits) is a
+// clean miss rather than a Number()-coerced wrong-but-valid lookup. Mirrors the
+// REST route's strictBlockNumber guard (#2063/#2241); this shared MCP get_block
+// loader was the missed sibling. Kept local because src/ is a leaf and must not
+// import the worker request handler.
+function strictBlockNumber(ref) {
+  if (!/^\d+$/.test(String(ref))) return null;
+  const value = Number(ref);
+  return Number.isSafeInteger(value) ? value : null;
+}
+
 // Per-block detail by numeric block_number or 0x block_hash. Includes nearest
 // stored neighbors (prev_block_number, next_block_number) for chain-walk nav
 // (#1853). Returns block:null when the ref is unknown or the store is cold —
 // never throws (schema-stable zero, mirrors the REST route).
 export async function loadBlock(d1, ref) {
   const isHash = /^0x[0-9a-fA-F]{64}$/.test(String(ref));
+  const blockNumber = isHash ? null : strictBlockNumber(ref);
+  // A non-hash ref that isn't a strict, safe-integer block_number can never match
+  // a stored row — skip the lookup and serve the schema-stable miss.
+  if (!isHash && blockNumber === null) {
+    return buildBlock(undefined, ref);
+  }
   const sql = isHash
     ? `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_hash = ? LIMIT 1`
     : `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_number = ? LIMIT 1`;
-  const param = isHash ? String(ref) : Number(ref);
+  const param = isHash ? String(ref) : blockNumber;
   const rows = await d1(sql, [param]);
   let prev = null;
   let next = null;

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -14,6 +14,7 @@ import {
   buildBlock,
   buildBlockFeed,
   formatBlock,
+  loadBlock,
   pruneBlocks,
   validBlockRows,
 } from "../src/blocks.mjs";
@@ -599,4 +600,84 @@ test("GET /blocks/{ref}/extrinsics rejects an unsupported query param (#1845)", 
     {},
   );
   assert.equal(res.status, 400);
+});
+
+// ---- loadBlock strict ref (MCP get_block) ----------------------------------
+// The shared loader behind the MCP get_block tool must mirror the REST route's
+// strictBlockNumber guard: a non-hash ref that isn't a strict, safe-integer
+// block_number is a clean miss, never a Number()-coerced wrong-but-valid lookup.
+
+// A d1 runner that records every query and answers the block_number SELECT with
+// the row whose number is bound — so a coercion bug surfaces as a wrong-but-valid
+// hit instead of the expected miss.
+function recordingDb(known = new Set()) {
+  const calls = [];
+  const d1 = async (sql, params) => {
+    calls.push({ sql, params });
+    if (/WHERE block_number = \?/.test(sql)) {
+      const n = params[0];
+      return known.has(n)
+        ? [{ block_number: n, block_hash: `0x${"a".repeat(64)}` }]
+        : [];
+    }
+    return [];
+  };
+  return { d1, calls };
+}
+
+test("loadBlock treats a malformed non-hash ref as a clean miss (#2314)", async () => {
+  // Each of these would Number()-coerce to a stored block_number under the old
+  // path (0x1->1, 1e3->1000, ' 5'->5); the strict guard must reject them.
+  const bad = [
+    "0x1",
+    "1e3",
+    " 5",
+    "12-3",
+    "+7",
+    "0x1f",
+    "99999999999999999999",
+  ];
+  for (const ref of bad) {
+    const { d1, calls } = recordingDb(new Set([1, 5, 7, 31, 1000]));
+    const out = await loadBlock(d1, ref);
+    assert.equal(out.block, null, `ref ${ref} must miss`);
+    assert.equal(out.ref, ref);
+    assert.equal(
+      calls.some((c) => /WHERE block_number = \?/.test(c.sql)),
+      false,
+      `ref ${ref} must skip the block_number lookup`,
+    );
+  }
+});
+
+test("loadBlock still resolves a well-formed numeric ref (#2314)", async () => {
+  const { d1, calls } = recordingDb(new Set([42]));
+  const out = await loadBlock(d1, "42");
+  assert.equal(out.block.block_number, 42);
+  assert.equal(
+    calls.some(
+      (c) => /WHERE block_number = \?/.test(c.sql) && c.params[0] === 42,
+    ),
+    true,
+  );
+});
+
+test("loadBlock still resolves a 64-hex block_hash ref (#2314)", async () => {
+  const hash = `0x${"a".repeat(64)}`;
+  const calls = [];
+  const d1 = async (sql, params) => {
+    calls.push({ sql, params });
+    if (/WHERE block_hash = \?/.test(sql)) {
+      return [{ block_number: 9, block_hash: hash }];
+    }
+    return [];
+  };
+  const out = await loadBlock(d1, hash);
+  assert.equal(out.block.block_number, 9);
+  assert.equal(
+    calls.some(
+      (c) => /WHERE block_hash = \?/.test(c.sql) && c.params[0] === hash,
+    ),
+    true,
+  );
 });


### PR DESCRIPTION
## Summary

- The MCP `get_block` tool's shared loader (`loadBlock` in `src/blocks.mjs`) was the sibling missed by the REST block-ref hardening (#2063, merged in #2241): its non-hash branch still bound `Number(ref)`, so a malformed ref coerced into a wrong-but-valid `block_number` lookup instead of the schema-stable miss the REST route returns for the same input.
- This makes `loadBlock` mirror the REST `strictBlockNumber` guard so a non-hash ref must be a strict, safe-integer decimal — otherwise it is a clean miss (`block: null`), never a coerced wrong row.

Fixes #2314

## What Changed

- `src/blocks.mjs`: added a local `strictBlockNumber(ref)` helper (`^\d+$` + `Number.isSafeInteger`) and used it in `loadBlock`; a non-hash ref that fails the guard short-circuits to the schema-stable miss before any D1 query. Kept local (not imported from `workers/`) because `src/` is a leaf module and must not depend on the worker request handler. The hash branch and well-formed numeric refs are unchanged.
- `tests/blocks.test.mjs`: added regression tests asserting malformed non-hash refs (`0x1`, `1e3`, `" 5"`, `12-3`, `+7`, `0x1f`, oversized digits) miss without issuing the `block_number` lookup, and that a well-formed numeric ref and a 64-hex `block_hash` still resolve.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — behaviour-only fix to an existing loader; no schema/contract change.)

## Validation

- [x] `npm run check` (lint clean; format check passes on CI's LF checkout)
- [x] `npm run worker:test` (`tests/blocks.test.mjs`: 49 passed, incl. new regression tests)
- [x] `git diff --check`