### PR TITLE
fix(extrinsics): strict-validate composite ref in loadExtrinsic for MCP get_extrinsic

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -253,6 +253,14 @@ export async function loadExtrinsics(
   return buildExtrinsicFeed(rows, { limit: lim, offset: off, nextCursor });
 }
 
+// A canonical composite ref is EXACTLY two strict decimal halves — so a loose
+// split("-") + Number() can't coerce a malformed ref (hex, sci-notation, an
+// extra/empty segment, leading space, oversized digits) into a wrong-but-valid
+// lookup. Mirrors the REST route's COMPOSITE_REF_RE + isSafeInteger guard
+// (#2063/#2241); this shared MCP get_extrinsic loader was the missed sibling.
+// Kept local because src/ is a leaf and must not import the worker request handler.
+const COMPOSITE_REF_RE = /^(\d+)-(\d+)$/;
+
 // Per-extrinsic detail by 0x hash or composite "block_number-extrinsic_index"
 // ref. Returns extrinsic:null when the ref is unknown or the store is cold —
 // never throws (schema-stable zero, mirrors the REST route). Events emitted by
@@ -266,11 +274,13 @@ export async function loadExtrinsic(d1, ref) {
       [String(ref)],
     );
   } else {
-    const [b, i] = String(ref).split("-");
-    const blockNumber = Number(b);
-    const extrinsicIndex = Number(i);
+    const composite = COMPOSITE_REF_RE.exec(String(ref));
+    const blockNumber = composite ? Number(composite[1]) : NaN;
+    const extrinsicIndex = composite ? Number(composite[2]) : NaN;
     rows =
-      Number.isInteger(blockNumber) && Number.isInteger(extrinsicIndex)
+      composite &&
+      Number.isSafeInteger(blockNumber) &&
+      Number.isSafeInteger(extrinsicIndex)
         ? await d1(
             `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE block_number = ? AND extrinsic_index = ? LIMIT 1`,
             [blockNumber, extrinsicIndex],

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -10,6 +10,7 @@ import {
   buildExtrinsicFeed,
   extrinsicInsertStatements,
   formatExtrinsic,
+  loadExtrinsic,
   pruneExtrinsics,
   validExtrinsicRows,
 } from "../src/extrinsics.mjs";
@@ -713,4 +714,97 @@ test("GET /extrinsics is schema-stable when D1 is cold (never 404)", async () =>
   const body = await res.json();
   assert.equal(body.data.extrinsic_count, 0);
   assert.equal(Array.isArray(body.data.extrinsics), true);
+});
+
+// ---- loadExtrinsic strict ref (MCP get_extrinsic) --------------------------
+// The shared loader behind the MCP get_extrinsic tool must mirror the REST
+// route's COMPOSITE_REF_RE guard: a non-hash ref must be exactly two strict,
+// safe-integer decimal halves — a malformed composite is a clean miss, never a
+// Number()-coerced wrong-but-valid lookup.
+
+// A d1 runner that records every query and answers the composite SELECT with the
+// row whose (block, index) is bound — so a coercion bug surfaces as a
+// wrong-but-valid hit instead of the expected miss.
+function recordingExtrinsicDb(known = new Set()) {
+  const calls = [];
+  const d1 = async (sql, params) => {
+    calls.push({ sql, params });
+    if (/block_number = \? AND extrinsic_index = \?/.test(sql)) {
+      const key = `${params[0]}-${params[1]}`;
+      return known.has(key)
+        ? [{ block_number: params[0], extrinsic_index: params[1] }]
+        : [];
+    }
+    return [];
+  };
+  return { d1, calls };
+}
+
+test("loadExtrinsic treats a malformed composite ref as a clean miss (#2316)", async () => {
+  // Each would coerce to a stored (block, index) under the old loose split path
+  // (1e3-0 -> 1000,0; 0x10-0 -> 16,0; 5-0-0 -> 5,0; 5.0-0 -> 5,0); the strict
+  // COMPOSITE_REF_RE guard must reject them.
+  const bad = [
+    "1e3-0",
+    "0x10-0",
+    " 5-0",
+    "5-0-0",
+    "5.0-0",
+    "5-",
+    "-3",
+    "5",
+    "99999999999999999999-0",
+  ];
+  for (const ref of bad) {
+    const { d1, calls } = recordingExtrinsicDb(
+      new Set(["1000-0", "16-0", "5-0", "1234-3"]),
+    );
+    const out = await loadExtrinsic(d1, ref);
+    assert.equal(out.extrinsic, null, `ref ${ref} must miss`);
+    assert.equal(out.ref, ref);
+    assert.equal(
+      calls.some((c) =>
+        /block_number = \? AND extrinsic_index = \?/.test(c.sql),
+      ),
+      false,
+      `ref ${ref} must skip the composite lookup`,
+    );
+  }
+});
+
+test("loadExtrinsic still resolves a canonical composite ref (#2316)", async () => {
+  const { d1, calls } = recordingExtrinsicDb(new Set(["1234-3"]));
+  const out = await loadExtrinsic(d1, "1234-3");
+  assert.equal(out.extrinsic.block_number, 1234);
+  assert.equal(out.extrinsic.extrinsic_index, 3);
+  assert.equal(
+    calls.some(
+      (c) =>
+        /block_number = \? AND extrinsic_index = \?/.test(c.sql) &&
+        c.params[0] === 1234 &&
+        c.params[1] === 3,
+    ),
+    true,
+  );
+});
+
+test("loadExtrinsic still resolves a 64-hex extrinsic_hash ref (#2316)", async () => {
+  const hash = `0x${"b".repeat(64)}`;
+  const calls = [];
+  const d1 = async (sql, params) => {
+    calls.push({ sql, params });
+    if (/WHERE extrinsic_hash = \?/.test(sql)) {
+      return [{ block_number: 7, extrinsic_index: 2, extrinsic_hash: hash }];
+    }
+    return [];
+  };
+  const out = await loadExtrinsic(d1, hash);
+  assert.equal(out.extrinsic.block_number, 7);
+  assert.equal(out.extrinsic.extrinsic_index, 2);
+  assert.equal(
+    calls.some(
+      (c) => /WHERE extrinsic_hash = \?/.test(c.sql) && c.params[0] === hash,
+    ),
+    true,
+  );
 });


### PR DESCRIPTION
## Summary

- The MCP `get_extrinsic` tool's shared loader (`loadExtrinsic` in `src/extrinsics.mjs`) was the sibling missed by the REST extrinsic-ref hardening (#2063, merged in #2241): its non-hash branch still did a loose `split("-")` + `Number()` with only `Number.isInteger`, so a malformed composite ref coerced into a wrong-but-valid `(block_number, extrinsic_index)` lookup instead of the schema-stable miss the REST route returns for the same input.
- This makes `loadExtrinsic` mirror the REST `COMPOSITE_REF_RE` + `Number.isSafeInteger` guard so a non-hash ref must be exactly two strict, safe-integer decimal halves — otherwise it is a clean miss (`extrinsic: null`).

Fixes #2316

## What Changed

- `src/extrinsics.mjs`: added a local `COMPOSITE_REF_RE = /^(\d+)-(\d+)$/` and used it in `loadExtrinsic`; a non-hash ref that fails the regex or whose halves aren't `Number.isSafeInteger` skips the D1 query and returns the schema-stable miss. Kept local (not imported from `workers/`) because `src/` is a leaf module and must not depend on the worker request handler. The hash branch and canonical `<block>-<index>` refs are unchanged.
- `tests/extrinsics.test.mjs`: added regression tests asserting malformed composite refs (`1e3-0`, `0x10-0`, `" 5-0"`, `5-0-0`, `5.0-0`, `5-`, `-3`, `5`, oversized digits) miss without issuing the composite lookup, and that a canonical `1234-3` ref and a 64-hex `extrinsic_hash` still resolve.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — behaviour-only fix to an existing loader; no schema/contract change.)

## Validation

- [x] `npm run check` (lint clean; format check passes on CI's LF checkout)
- [x] `npm run worker:test` (`tests/extrinsics.test.mjs`: 37 passed, incl. new regression tests)
- [x] `git diff --check`