### PR TITLE
Add covering index for neuron_daily subnet history

### DIFF
--- a/migrations/0028_neuron_daily_covering_index.sql
+++ b/migrations/0028_neuron_daily_covering_index.sql
@@ -1,0 +1,6 @@
+-- Cover the per-subnet history rollup so the aggregate query can seek the
+-- (netuid, snapshot_date) range and read the SUM columns from the index leaf
+-- without per-row heap lookups on the hot path.
+
+CREATE INDEX IF NOT EXISTS idx_neuron_daily_netuid_date_agg
+  ON neuron_daily (netuid, snapshot_date, validator_permit, stake_tao, emission_tao);

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -4,6 +4,7 @@
 // through workers/api.mjs.
 
 import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
 import { describe, test } from "vitest";
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
@@ -766,6 +767,55 @@ describe("handleSubnetHistory", () => {
     assert.equal(body.data.points[0].neuron_count, 2);
     assert.equal(body.data.points[0].validator_count, 1);
     assert.equal(body.data.points[0].total_stake_tao, 900);
+  });
+
+  test("uses the covering index for the aggregate history query plan", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`
+      CREATE TABLE neuron_daily (
+        netuid INTEGER NOT NULL,
+        uid INTEGER NOT NULL,
+        snapshot_date TEXT NOT NULL,
+        hotkey TEXT,
+        coldkey TEXT,
+        active INTEGER,
+        validator_permit INTEGER,
+        rank REAL,
+        trust REAL,
+        validator_trust REAL,
+        consensus REAL,
+        incentive REAL,
+        dividends REAL,
+        emission_tao REAL,
+        stake_tao REAL,
+        registered_at_block INTEGER,
+        is_immunity_period INTEGER,
+        axon TEXT,
+        block_number INTEGER,
+        captured_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (netuid, uid, snapshot_date)
+      );
+      CREATE INDEX idx_neuron_daily_netuid_date_agg
+        ON neuron_daily (netuid, snapshot_date, validator_permit, stake_tao, emission_tao);
+    `);
+
+    const sql =
+      "SELECT snapshot_date, COUNT(*) AS neuron_count, " +
+      "SUM(validator_permit) AS validator_count, " +
+      "SUM(stake_tao) AS total_stake_tao, SUM(emission_tao) AS total_emission_tao " +
+      "FROM neuron_daily WHERE netuid = ? GROUP BY snapshot_date ORDER BY snapshot_date DESC LIMIT ?";
+    const plan = db.prepare("EXPLAIN QUERY PLAN " + sql).all(NETUID, 400);
+
+    assert.equal(plan.length, 1);
+    assert.equal(
+      plan[0].detail,
+      "SEARCH neuron_daily USING COVERING INDEX idx_neuron_daily_netuid_date_agg (netuid=?)",
+    );
+    assert.equal(
+      plan.some(({ detail }) => /TEMP B-TREE/.test(detail)),
+      false,
+    );
   });
 
   test("invalid window returns 400", async () => {


### PR DESCRIPTION
## Summary
- Adds migration 0028_neuron_daily_covering_index.sql with a covering index: idx_neuron_daily_netuid_date_agg on neuron_daily (netuid, snapshot_date, validator_permit, stake_tao, emission_tao).
- Adds a regression test for handleSubnetHistory query-plan behavior to ensure the optimizer uses the covering index for subnet daily history aggregation.

## Testing
- npx vitest run tests/request-handlers-entities.test.mjs

Closes #2083
