### PR TITLE
feat(badge): add metric=completeness embeddable coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ curl -X POST https://api.metagraph.sh/api/v1/graphql \
 
 ## For agents
 
-| Resource              | URL                                                                                                                                                                                                  |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Copyable agent prompt | [`/agent.md`](https://api.metagraph.sh/agent.md)                                                                                                                                                     |
-| Agent workflows       | [`/agent-workflows.md`](https://api.metagraph.sh/agent-workflows.md)                                                                                                                                 |
-| Machine index         | [`/llms.txt`](https://api.metagraph.sh/llms.txt)                                                                                                                                                     |
-| GraphQL               | [`/api/v1/graphql`](https://api.metagraph.sh/api/v1/graphql) — POST a shaped query (subnet + health + surfaces + endpoints + economics, provider + subnets, opportunity boards); GET returns the SDL |
-| Drop-in skill         | [`/skills/bittensor/SKILL.md`](https://api.metagraph.sh/skills/bittensor/SKILL.md)                                                                                                                   |
-| Resources index       | [`/metagraph/agent-resources.json`](https://api.metagraph.sh/metagraph/agent-resources.json)                                                                                                         |
-| Content feeds         | [`/api/v1/feeds/registry`](https://api.metagraph.sh/api/v1/feeds/registry) — registry changes + incidents, as RSS / Atom / JSON Feed (per-subnet at `/api/v1/feeds/subnets/{netuid}`)                |
-| Embeddable badge      | `![metagraphed](https://api.metagraph.sh/api/v1/subnets/{netuid}/badge.svg)` — SVG (also `/providers/{slug}/badge.svg`); `?metric=uptime` for reliability, plus `?style=flat-square` and `?label=…`  |
+| Resource              | URL                                                                                                                                                                                                                                            |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Copyable agent prompt | [`/agent.md`](https://api.metagraph.sh/agent.md)                                                                                                                                                                                               |
+| Agent workflows       | [`/agent-workflows.md`](https://api.metagraph.sh/agent-workflows.md)                                                                                                                                                                           |
+| Machine index         | [`/llms.txt`](https://api.metagraph.sh/llms.txt)                                                                                                                                                                                               |
+| GraphQL               | [`/api/v1/graphql`](https://api.metagraph.sh/api/v1/graphql) — POST a shaped query (subnet + health + surfaces + endpoints + economics, provider + subnets, opportunity boards); GET returns the SDL                                           |
+| Drop-in skill         | [`/skills/bittensor/SKILL.md`](https://api.metagraph.sh/skills/bittensor/SKILL.md)                                                                                                                                                             |
+| Resources index       | [`/metagraph/agent-resources.json`](https://api.metagraph.sh/metagraph/agent-resources.json)                                                                                                                                                   |
+| Content feeds         | [`/api/v1/feeds/registry`](https://api.metagraph.sh/api/v1/feeds/registry) — registry changes + incidents, as RSS / Atom / JSON Feed (per-subnet at `/api/v1/feeds/subnets/{netuid}`)                                                          |
+| Embeddable badge      | `![metagraphed](https://api.metagraph.sh/api/v1/subnets/{netuid}/badge.svg)` — SVG (also `/providers/{slug}/badge.svg`); `?metric=uptime` for reliability, `?metric=completeness` for coverage score, plus `?style=flat-square` and `?label=…` |
 
 ## This repo
 

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1795,7 +1795,7 @@ const llmsHeader = [
   `- [MCP server](${llmsApiBase}/mcp): Model Context Protocol endpoint — agents query the registry as tools. Install: \`claude mcp add --transport http metagraphed ${llmsApiBase}/mcp\``,
   `- [MCP server card](${llmsApiBase}/.well-known/mcp/server-card.json): machine-readable server descriptor (tools, transport, protocol versions)`,
   `- [Content feeds](${llmsApiBase}/api/v1/feeds/registry): RSS 2.0 / Atom 1.0 / JSON Feed 1.1 of registry changes + incidents (per-subnet at /api/v1/feeds/subnets/{netuid}). Content-negotiated via Accept, or append .rss/.atom/.json.`,
-  `- Embeddable readiness badges: \`${llmsApiBase}/api/v1/subnets/{netuid}/badge.svg\` and \`/api/v1/providers/{slug}/badge.svg\` — SVG integration-readiness badge for READMEs.`,
+  `- Embeddable badges: \`${llmsApiBase}/api/v1/subnets/{netuid}/badge.svg\` and \`/api/v1/providers/{slug}/badge.svg\` — SVG badges for READMEs (\`?metric=readiness\` default, \`?metric=completeness\` for coverage score, \`?metric=uptime\` for reliability).`,
   `- [Bittensor skill](${llmsApiBase}/skills/bittensor/SKILL.md): drop-in agent skill for "what subnet does X, is it up, how do I call it"`,
   `- [Semantic search](${llmsApiBase}/api/v1/search/semantic?q=): natural-language vector search over subnets/surfaces`,
   `- [Ask](${llmsApiBase}/api/v1/ask): POST { question } for a grounded, cited answer over the registry`,

--- a/src/badge.mjs
+++ b/src/badge.mjs
@@ -13,6 +13,8 @@
 //   metric=apis        count of callable API surfaces the subnet exposes
 //                      (subnet-api / openapi / sse / data-artifact); informational
 //                      blue, gray for 0; for a provider, the sum across its subnets
+//   metric=completeness  coverage completeness 0–100 from profiles.json
+//                        (alias: coverage); provider = mean across its subnets
 //   style=flat-square  square corners, no gradient (default: flat)
 //   label=…            override the left "metagraphed" segment text
 //
@@ -35,6 +37,8 @@ const BADGE_METRICS = {
   reliability: "reliability",
   grade: "grade",
   apis: "apis",
+  completeness: "completeness",
+  coverage: "completeness",
 };
 // Allow-listed render styles; an unknown value falls back to "flat".
 const BADGE_STYLES = new Set(["flat", "flat-square"]);
@@ -188,6 +192,22 @@ function averageReadiness(netuids, subnetsIndex) {
   return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
 }
 
+// Mean completeness_score across a provider's subnets, rounded; null when
+// none of them resolve to a numeric score.
+function averageCompleteness(netuids, profilesArtifact) {
+  const byNetuid = new Map(
+    (profilesArtifact?.profiles || []).map((p) => [
+      p.netuid,
+      p.completeness_score,
+    ]),
+  );
+  const scores = (netuids || [])
+    .map((n) => byNetuid.get(n))
+    .filter((v) => typeof v === "number");
+  if (!scores.length) return null;
+  return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
+}
+
 // uptime_ratio (0–1) → trimmed percent: 0.9983 → "99.83%", 1 → "100%".
 export function formatUptimePercent(ratio) {
   const value = Number(ratio) || 0;
@@ -238,6 +258,35 @@ export function parseBadgeOptions(searchParams) {
   const rawLabel = searchParams.get("label");
   const label = rawLabel == null ? BADGE_LABEL : sanitizeLabel(rawLabel);
   return { metric, style, label };
+}
+
+// Completeness: the subnet's coverage completeness_score, or a provider's mean.
+async function completenessContent({ target, readArtifact, env }) {
+  let score = null;
+  if (target.kind === "subnet") {
+    const profiles = await readData(
+      readArtifact,
+      env,
+      "/metagraph/profiles.json",
+    );
+    const row = (profiles?.profiles || []).find(
+      (p) => p.netuid === target.netuid,
+    );
+    if (row && typeof row.completeness_score === "number") {
+      score = row.completeness_score;
+    }
+  } else {
+    const [providers, profiles] = await Promise.all([
+      readData(readArtifact, env, "/metagraph/providers.json"),
+      readData(readArtifact, env, "/metagraph/profiles.json"),
+    ]);
+    const provider = findProvider(providers, target.slug);
+    if (provider) score = averageCompleteness(provider.netuids, profiles);
+  }
+  return {
+    message: typeof score === "number" ? `${score}/100` : NA_MESSAGE,
+    color: scoreColor(score),
+  };
 }
 
 // Readiness: the subnet's own integration_readiness, or a provider's mean.
@@ -369,6 +418,8 @@ export async function handleBadgeRequest(request, env, url, deps = {}) {
       content = await apisContent(ctx);
     } else if (metric === "reliability" || metric === "grade") {
       content = await reliabilityContent({ ...ctx, metric });
+    } else if (metric === "completeness") {
+      content = await completenessContent(ctx);
     } else {
       content = await readinessContent(ctx);
     }

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -26,6 +26,14 @@ const PROVIDERS = {
     { id: "byid", netuids: [9] }, // only a scoreless subnet → n/a
   ],
 };
+const PROFILES = {
+  profiles: [
+    { netuid: 7, completeness_score: 85 },
+    { netuid: 12, completeness_score: 55 },
+    { netuid: 3, completeness_score: 20 },
+    // netuid 9 omitted → n/a
+  ],
+};
 
 function makeReadArtifact(fixtures) {
   return (_env, path) =>
@@ -72,6 +80,7 @@ async function badge(pathname, { method = "GET", fixtures = {} } = {}) {
     readArtifact: makeReadArtifact({
       "/metagraph/subnets.json": SUBNETS,
       "/metagraph/providers.json": PROVIDERS,
+      "/metagraph/profiles.json": PROFILES,
       ...SURFACES,
       ...fixtures,
     }),
@@ -169,6 +178,14 @@ describe("badge — rendering", () => {
     );
     assert.equal(parseBadgeOptions(sp("metric=GRADE")).metric, "grade");
     assert.equal(parseBadgeOptions(sp("metric=APIS")).metric, "apis");
+    assert.equal(
+      parseBadgeOptions(sp("metric=COMPLETENESS")).metric,
+      "completeness",
+    );
+    assert.equal(
+      parseBadgeOptions(sp("metric=coverage")).metric,
+      "completeness",
+    );
     assert.equal(parseBadgeOptions(sp("metric=bogus")).metric, "readiness");
     // style: flat default; flat-square allowed; anything else → flat.
     assert.equal(parseBadgeOptions(sp("")).style, "flat");
@@ -425,6 +442,61 @@ describe("badge — apis metric", () => {
     });
     assert.equal(res.status, 200);
     assert.match(await res.text(), /n\/a/);
+  });
+});
+
+describe("badge — completeness metric", () => {
+  test("subnet completeness renders the profile score + score color", async () => {
+    const { text } = await badge(
+      "/api/v1/subnets/7/badge.svg?metric=completeness",
+    );
+    assert.match(text, /85\/100/);
+    assert.match(text, /#2ea44f/); // green (>= 80)
+    assert.ok(!text.includes("92/100")); // not the readiness rendering
+  });
+
+  test("metric=coverage is an alias for completeness", async () => {
+    const { text } = await badge("/api/v1/subnets/7/badge.svg?metric=coverage");
+    assert.match(text, /85\/100/);
+  });
+
+  test("a low completeness score gets the red color", async () => {
+    const { text } = await badge(
+      "/api/v1/subnets/3/badge.svg?metric=completeness",
+    );
+    assert.match(text, /20\/100/);
+    assert.match(text, /#e05d44/);
+  });
+
+  test("provider completeness is the mean across its subnets", async () => {
+    const { text } = await badge(
+      "/api/v1/providers/datura/badge.svg?metric=completeness",
+    );
+    assert.match(text, /70\/100/); // round(mean(85, 55))
+    assert.match(text, /#dfb317/); // amber (50..79)
+  });
+
+  test("unknown subnet completeness degrades to n/a (gray, still 200)", async () => {
+    const { res, text } = await badge(
+      "/api/v1/subnets/999/badge.svg?metric=completeness",
+    );
+    assert.equal(res.status, 200);
+    assert.match(text, /n\/a/);
+    assert.match(text, /#9f9f9f/);
+  });
+
+  test("a subnet with no profile row is n/a", async () => {
+    const { text } = await badge(
+      "/api/v1/subnets/9/badge.svg?metric=completeness",
+    );
+    assert.match(text, /n\/a/);
+  });
+
+  test("provider with only scoreless subnets is n/a", async () => {
+    const { text } = await badge(
+      "/api/v1/providers/byid/badge.svg?metric=completeness",
+    );
+    assert.match(text, /n\/a/);
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1041,7 +1041,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // Embeddable SVG badges at /api/v1/{subnets/{netuid}|providers/{slug}}/
   // badge.svg. Worker-computed image, caught before the generic entity routing so
   // `badge.svg` isn't resolved as an entity sub-resource. `?metric=uptime` reads
-  // the live reliability rollup, hence the health DB binding.
+  // the live reliability rollup (health DB); `?metric=completeness` reads profiles.
   if (
     /^\/api\/v1\/(?:subnets|providers)\/[^/]+\/badge\.svg$/.test(url.pathname)
   ) {


### PR DESCRIPTION
## Summary

Add `?metric=completeness` (alias `?metric=coverage`) to the embeddable subnet/provider badge SVG endpoint. The badge reads each subnet's `completeness_score` from `/metagraph/profiles.json` and renders it with the existing green/amber/red color bands. Provider badges show the rounded mean across the provider's subnets.

This closes the gap between the registry's headline trustworthy-coverage metric (already on `/api/v1/profiles` and in `coverage.json`) and what subnet operators can embed in READMEs today (`readiness`, `uptime`, `grade`, `apis` only).

## What Changed

- `src/badge.mjs` — new `completeness` metric, `averageCompleteness()`, `completenessContent()`
- `tests/badge.test.mjs` — completeness metric test block + `coverage` alias
- `README.md` — document `?metric=completeness`
- `workers/api.mjs` — badge route comment
- `scripts/build-artifacts.mjs` — llms catalog badge line

No OpenAPI/schema regen — badges are Worker-computed, outside the contract.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. _(N/A — query param on existing Worker route only.)_

## Validation

- [x] `npm test -- tests/badge.test.mjs`
- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`

## Test plan

- [x] `npm test -- tests/badge.test.mjs` — subnet score, provider mean, aliases, n/a fallbacks
- [ ] `GET /api/v1/subnets/7/badge.svg?metric=completeness` returns SVG with `NN/100` and score color
- [ ] `GET /api/v1/subnets/7/badge.svg?metric=coverage` matches completeness
- [ ] Unknown netuid still returns 200 with gray `n/a` badge
