### PR TITLE
fix(api): canonicalize chain-activity edge-cache key on the window parameter

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -287,6 +287,63 @@ describe("analytics edge cache", () => {
     assert.equal(cache.store.size, 1);
   });
 
+  test("chain-activity canonicalizes omitted and explicit default window to the same cache key", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+
+    // No ?window — resolves to the 7d default and caches at ?window=7d.
+    const first = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/chain/activity"),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(first.status, 200);
+    const queriesAfterMiss = queries.length;
+
+    // Explicit ?window=7d is the canonical form — must be a cache HIT (no new D1).
+    const hit = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/chain/activity?window=7d"),
+      env,
+      ctx,
+    );
+    assert.equal(hit.status, 200);
+    assert.equal(
+      queries.length,
+      queriesAfterMiss,
+      "explicit ?window=7d must be a cache HIT (no D1 queries)",
+    );
+    assert.deepEqual(cache.putKeys, [
+      expectedKey("chain-activity", "/api/v1/chain/activity", "?window=7d"),
+    ]);
+    assert.equal(cache.store.size, 1);
+  });
+
+  test("chain-activity keys distinct windows separately (7d vs 30d)", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+
+    for (const url of [
+      "https://api.metagraph.sh/api/v1/chain/activity?window=7d",
+      "https://api.metagraph.sh/api/v1/chain/activity?window=30d",
+    ]) {
+      await handleRequest(new Request(url), env, ctx);
+      await Promise.resolve();
+    }
+    // Distinct windows remain distinct entries (canonical key preserves window).
+    assert.equal(cache.store.size, 2);
+    assert.deepEqual(cache.putKeys, [
+      expectedKey("chain-activity", "/api/v1/chain/activity", "?window=7d"),
+      expectedKey("chain-activity", "/api/v1/chain/activity", "?window=30d"),
+    ]);
+  });
+
   test("turnover: explicit ?window=30d populates cache; omitted window is a HIT", async () => {
     originalCaches = globalThis.caches;
     const cache = mockCaches();

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -761,56 +761,67 @@ export async function handleGlobalIncidents(request, env, url) {
 export async function handleChainActivity(request, env, url, ctx = {}) {
   const { label, days, error } = analyticsWindow(url);
   if (error) return analyticsQueryError(error);
-  return withEdgeCache(request, ctx, env, "chain-activity", async () => {
-    const cutoff = Date.now() - days * DAY_MS;
-    // observed_at is epoch-ms; `/ 1000` (SQLite integer division) → unix seconds
-    // for strftime's 'unixepoch' UTC bucketer. Values are always bound.
-    const [extrinsicRows, blockRows] = await Promise.all([
-      d1All(
-        env,
-        `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
+  return withEdgeCache(
+    request,
+    ctx,
+    env,
+    "chain-activity",
+    async () => {
+      const cutoff = Date.now() - days * DAY_MS;
+      // observed_at is epoch-ms; `/ 1000` (SQLite integer division) → unix seconds
+      // for strftime's 'unixepoch' UTC bucketer. Values are always bound.
+      const [extrinsicRows, blockRows] = await Promise.all([
+        d1All(
+          env,
+          `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
                 COUNT(*) AS extrinsic_count,
                 SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) AS successful_extrinsics,
                 COUNT(DISTINCT signer) AS unique_signers
          FROM extrinsics
          WHERE observed_at >= ?
          GROUP BY day`,
-        [cutoff],
-      ),
-      d1All(
-        env,
-        `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
+          [cutoff],
+        ),
+        d1All(
+          env,
+          `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
                 COUNT(*) AS block_count,
                 SUM(event_count) AS event_count
          FROM blocks
          WHERE observed_at >= ?
          GROUP BY day`,
-        [cutoff],
-      ),
-    ]);
-    const meta = await readHealthMetaKv(env);
-    const data = buildChainActivity({
-      window: label,
-      observedAt: meta?.last_run_at || null,
-      extrinsicRows,
-      blockRows,
-    });
-    const response = await envelopeResponse(
-      request,
-      {
-        data,
-        meta: await analyticsMeta(
-          env,
-          "/metagraph/chain/activity.json",
-          data.observed_at,
+          [cutoff],
         ),
-      },
-      "short",
-    );
-    return hasD1FallbackRows(extrinsicRows, blockRows)
-      ? markD1FallbackResponse(response)
-      : response;
-  });
+      ]);
+      const meta = await readHealthMetaKv(env);
+      const data = buildChainActivity({
+        window: label,
+        observedAt: meta?.last_run_at || null,
+        extrinsicRows,
+        blockRows,
+      });
+      const response = await envelopeResponse(
+        request,
+        {
+          data,
+          meta: await analyticsMeta(
+            env,
+            "/metagraph/chain/activity.json",
+            data.observed_at,
+          ),
+        },
+        "short",
+      );
+      return hasD1FallbackRows(extrinsicRows, blockRows)
+        ? markD1FallbackResponse(response)
+        : response;
+    },
+    // Canonicalize the cache key on the RESOLVED window so the bare path, an
+    // explicit ?window=<default>, and reordered/duplicate variants all share one
+    // entry instead of fragmenting the cache (mirrors the percentiles/incidents/
+    // economics-trends windowed routes). `label` is the validated window.
+    `${url.pathname}?window=${encodeURIComponent(label)}`,
+  );
 }
 
 // Extrinsic call-mix breakdown (#1989): counts + share per call_module (or


### PR DESCRIPTION
## Summary

- `handleChainActivity` passed **no** canonical cache key to `withEdgeCache`, so it keyed on the raw `pathname + search`. The bare path (default window), an explicit `?window=7d`, and reordered/duplicate query variants each minted a **separate** edge-cache entry for an identical response — re-running the full-window D1 aggregation on every variant. Every sibling windowed analytics route (percentiles, incidents, economics-trends, subnet-history) already canonicalizes its key.

## What Changed

- `workers/request-handlers/analytics.mjs`: pass the resolved-window canonical path (`${url.pathname}?window=${label}`) as the cache key so equivalent requests share one entry. `label` is the already-validated window from `analyticsWindow`. Behavior-preserving — distinct windows still key separately, and the served body is unchanged.
- `tests/analytics-edge-cache.test.mjs`: assert the bare path and explicit default `?window=7d` resolve to one cache entry (HIT, no extra D1), and that 7d/30d stay distinct.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change — edge-cache keying only; responses unchanged.)

## Validation

- [x] `npx vitest run tests/analytics-edge-cache.test.mjs` — 27 passed
- [x] `npx vitest run tests/analytics.test.mjs tests/request-handlers-analytics.test.mjs` — 155 passed
- [x] prettier `--check` + eslint clean
- [x] `git diff --check`
