### PR TITLE
fix(api): canonicalize global-incidents edge-cache key on the window parameter

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -287,6 +287,41 @@ describe("analytics edge cache", () => {
     assert.equal(cache.store.size, 1);
   });
 
+  test("global-incidents canonicalizes omitted and explicit default window to the same cache key", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+
+    // No ?window — resolves to the 7d default and caches at ?window=7d.
+    const first = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/incidents"),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(first.status, 200);
+    const queriesAfterMiss = queries.length;
+
+    // Explicit ?window=7d is the canonical form — must be a cache HIT (no new D1).
+    const hit = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/incidents?window=7d"),
+      env,
+      ctx,
+    );
+    assert.equal(hit.status, 200);
+    assert.equal(
+      queries.length,
+      queriesAfterMiss,
+      "explicit ?window=7d must be a cache HIT (no D1 queries)",
+    );
+    assert.deepEqual(cache.putKeys, [
+      expectedKey("global-incidents", "/api/v1/incidents", "?window=7d"),
+    ]);
+    assert.equal(cache.store.size, 1);
+  });
+
   test("turnover: explicit ?window=30d populates cache; omitted window is a HIT", async () => {
     originalCaches = globalThis.caches;
     const cache = mockCaches();

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -38,6 +38,7 @@ import {
   handleBadgeSvgRequest,
 } from "./request-handlers/discovery.mjs";
 import {
+  canonicalHealthWindowCachePath,
   configureAnalytics,
   d1All,
   handleBulkHealthTrends,
@@ -1508,8 +1509,16 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       return handleExtrinsics(request, env, resolved.url);
     }
     if (resolved.url.pathname === "/api/v1/incidents") {
-      return withEdgeCache(request, ctx, env, "global-incidents", () =>
-        handleGlobalIncidents(request, env, resolved.url),
+      return withEdgeCache(
+        request,
+        ctx,
+        env,
+        "global-incidents",
+        () => handleGlobalIncidents(request, env, resolved.url),
+        // Canonicalize on the resolved window so the bare path and an explicit
+        // ?window=<default> share one entry instead of fragmenting the cache
+        // (mirrors the per-subnet health-incidents route).
+        canonicalHealthWindowCachePath(resolved.url),
       );
     }
     if (resolved.url.pathname === "/api/v1/chain/activity") {


### PR DESCRIPTION
## Summary

- The `/api/v1/incidents` (global incidents) route wrapped `handleGlobalIncidents` in `withEdgeCache` with **no** canonical cache key, so it keyed on the raw `pathname + search`. The bare path (default window), an explicit `?window=7d`, and reordered variants each minted a **separate** edge-cache entry for an identical response. The per-subnet health-incidents route already canonicalizes its key via `canonicalHealthWindowCachePath`.

## What Changed

- `workers/api.mjs`: pass `canonicalHealthWindowCachePath(resolved.url)` as the cache key for the global-incidents route (it resolves `?window` to the canonical default, matching the sibling health-incidents route). Behavior-preserving — distinct windows still key separately; the served body is unchanged.
- `tests/analytics-edge-cache.test.mjs`: assert the bare path and explicit default `?window=7d` resolve to one cache entry (HIT, no extra D1).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change — edge-cache keying only.)

## Validation

- [x] `npx vitest run tests/analytics-edge-cache.test.mjs` — 26 passed
- [x] `npx vitest run tests/analytics.test.mjs tests/request-handlers-analytics.test.mjs tests/api-coverage.test.mjs` — 296 passed
- [x] prettier `--check` + eslint clean
- [x] `git diff --check`
