### PR TITLE
feat(mcp): add get_economics_trends with shared REST loader

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -305,6 +305,11 @@ assert.ok(
   econ.economics && Number.isInteger(econ.economics.netuid),
   "get_subnet_economics must return the per-subnet economics row",
 );
+const econTrends = await callOk("get_economics_trends", {});
+assert.ok(
+  Number.isInteger(econTrends.day_count) && Array.isArray(econTrends.days),
+  "get_economics_trends must return the schema-stable economics trends payload",
+);
 
 // The trajectory/metagraph/validators/neuron tiers are D1-backed; this cold env
 // has no neurons DB, so each tool must degrade to its schema-stable empty

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -179,9 +179,9 @@ export const MCP_INSTRUCTIONS =
   "callable subnets and how_do_i_call returns concrete call instructions " +
   "(base URL, auth, schema, health) for one subnet. For on-chain economics and " +
   "participation, get_subnet_economics returns a subnet's registration cost, " +
-  "open slots, stake, emission split and validator/miner counts, " +
-  "get_economics_trends the network-wide daily stake, price, and emission " +
-  "rollup across all subnets, get_subnet_trajectory its week-over-week trend, get_subnet_uptime its " +
+  "open slots, stake, emission split and validator/miner counts. " +
+  "get_economics_trends returns the network-wide daily stake, price, and emission " +
+  "rollup across all subnets. get_subnet_trajectory returns its week-over-week trend; get_subnet_uptime its " +
   "long-term surface uptime history, get_subnet_concentration stake and " +
   "emission decentralization metrics (Gini, HHI, Nakamoto), " +
   "get_subnet_concentration_history the decentralization trend over time, " +
@@ -1383,10 +1383,9 @@ export const MCP_TOOLS = [
       additionalProperties: false,
     },
     async handler(args, ctx) {
-      const { label, days } = requireHistoryWindow(args);
+      const { label } = requireHistoryWindow(args);
       const { data } = await loadEconomicsTrends(mcpD1Runner(ctx), {
-        windowLabel: label,
-        windowDays: days,
+        window: label,
       });
       return data;
     },
@@ -3380,6 +3379,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       schema_version: { type: "integer" },
       window: NULLABLE_STRING,
       day_count: { type: "integer" },
+      rows_capped: { type: "boolean" },
       days: objectItems({
         snapshot_date: NULLABLE_STRING,
         subnet_count: NULLABLE_INT,

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -85,6 +85,7 @@ import {
 import {
   buildNeuronHistory,
   buildSubnetHistory,
+  loadEconomicsTrends,
   MAX_HISTORY_POINTS,
   NEURON_DAILY_READ_COLUMNS,
   parseHistoryWindow,
@@ -124,7 +125,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.7.0";
+export const MCP_SERVER_VERSION = "1.8.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -179,7 +180,8 @@ export const MCP_INSTRUCTIONS =
   "(base URL, auth, schema, health) for one subnet. For on-chain economics and " +
   "participation, get_subnet_economics returns a subnet's registration cost, " +
   "open slots, stake, emission split and validator/miner counts, " +
-  "get_subnet_trajectory its week-over-week trend, get_subnet_uptime its " +
+  "get_economics_trends the network-wide daily stake, price, and emission " +
+  "rollup across all subnets, get_subnet_trajectory its week-over-week trend, get_subnet_uptime its " +
   "long-term surface uptime history, get_subnet_concentration stake and " +
   "emission decentralization metrics (Gini, HHI, Nakamoto), " +
   "get_subnet_concentration_history the decentralization trend over time, " +
@@ -1357,6 +1359,36 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
       return loadSubnetEconomics(ctx, netuid);
+    },
+  },
+  {
+    name: "get_economics_trends",
+    title: "Get network-wide economics trends",
+    description:
+      "Fetch the network-wide daily economics time series aggregated across all " +
+      "subnets from the subnet_snapshots rollup: total stake, stake-weighted and " +
+      "median alpha price, total validator and miner counts, and mean emission " +
+      "share per UTC day, newest first. Choose the window (7d, 30d, 90d, 1y, " +
+      "all; default 30d). Use it to chart how the whole network's economics are " +
+      "moving over time. Mirrors GET /api/v1/economics/trends.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: ["7d", "30d", "90d", "1y", "all"],
+          description: "History window (default 30d).",
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const { label, days } = requireHistoryWindow(args);
+      const { data } = await loadEconomicsTrends(mcpD1Runner(ctx), {
+        windowLabel: label,
+        windowDays: days,
+      });
+      return data;
     },
   },
   {
@@ -3338,6 +3370,26 @@ const TOOL_OUTPUT_SCHEMAS = {
       captured_at: NULLABLE_STRING,
       summary: { type: ["object", "null"] },
       economics: { type: ["object", "null"] },
+    },
+  },
+  get_economics_trends: {
+    type: "object",
+    additionalProperties: true,
+    required: ["day_count", "days"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      day_count: { type: "integer" },
+      days: objectItems({
+        snapshot_date: NULLABLE_STRING,
+        subnet_count: NULLABLE_INT,
+        total_stake_tao: ANY,
+        alpha_price_tao_weighted: ANY,
+        alpha_price_tao_median: ANY,
+        validator_count: NULLABLE_INT,
+        miner_count: NULLABLE_INT,
+        mean_emission_share: ANY,
+      }),
     },
   },
   get_subnet_trajectory: {

--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -411,12 +411,18 @@ export function buildEconomicsTrends(rows, { window } = {}) {
 // Network-wide economics time series — shared by the REST route and MCP tool:
 // read raw per-subnet subnet_snapshots rows (newest first, bounded), roll up
 // with buildEconomicsTrends. Returns {data, rows} so REST can pass rows into
-// the D1-fallback WeakSet contract. Cold D1 → day_count:0.
-export async function loadEconomicsTrends(d1, { windowLabel, windowDays }) {
+// the D1-fallback WeakSet contract. Cold D1 → day_count:0. The `all` window
+// is bounded by ECONOMICS_TRENDS_ROW_CAP (~129 subnets × 365 days ≈ 47k rows
+// today); when the cap is hit, data.rows_capped is true.
+export async function loadEconomicsTrends(
+  d1,
+  { window = DEFAULT_HISTORY_WINDOW } = {},
+) {
+  const { label, days } = parseHistoryWindow(window);
   const params = [];
   let sql = `SELECT ${ECONOMICS_TRENDS_READ_COLUMNS} FROM subnet_snapshots WHERE TRUE`;
-  if (windowDays != null) {
-    const cutoff = new Date(Date.now() - windowDays * DAY_MS)
+  if (days != null) {
+    const cutoff = new Date(Date.now() - days * DAY_MS)
       .toISOString()
       .slice(0, 10);
     sql += " AND snapshot_date >= ?";
@@ -425,7 +431,10 @@ export async function loadEconomicsTrends(d1, { windowLabel, windowDays }) {
   sql += " ORDER BY snapshot_date DESC LIMIT ?";
   params.push(ECONOMICS_TRENDS_ROW_CAP);
   const rows = await d1(sql, params);
-  const data = buildEconomicsTrends(rows, { window: windowLabel });
+  const data = buildEconomicsTrends(rows, { window: label });
+  if (rows.length >= ECONOMICS_TRENDS_ROW_CAP) {
+    data.rows_capped = true;
+  }
   return { data, rows };
 }
 

--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -27,6 +27,15 @@ export const DEFAULT_HISTORY_WINDOW = "30d";
 // Bounds any single time-series response (1y = 365 daily points < this cap).
 export const MAX_HISTORY_POINTS = 400;
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// subnet_snapshots columns the network-wide economics trends handler reads.
+export const ECONOMICS_TRENDS_READ_COLUMNS =
+  "snapshot_date, total_stake_tao, alpha_price_tao, validator_count, miner_count, emission_share";
+
+// ~129 subnets × 365 days ≈ 47k rows for `all`; generous but finite.
+export const ECONOMICS_TRENDS_ROW_CAP = 60000;
+
 export function parseHistoryWindow(value) {
   const v = typeof value === "string" && value ? value : DEFAULT_HISTORY_WINDOW;
   if (!Object.prototype.hasOwnProperty.call(HISTORY_WINDOWS, v)) {
@@ -397,6 +406,27 @@ export function buildEconomicsTrends(rows, { window } = {}) {
     day_count: days.length,
     days,
   };
+}
+
+// Network-wide economics time series — shared by the REST route and MCP tool:
+// read raw per-subnet subnet_snapshots rows (newest first, bounded), roll up
+// with buildEconomicsTrends. Returns {data, rows} so REST can pass rows into
+// the D1-fallback WeakSet contract. Cold D1 → day_count:0.
+export async function loadEconomicsTrends(d1, { windowLabel, windowDays }) {
+  const params = [];
+  let sql = `SELECT ${ECONOMICS_TRENDS_READ_COLUMNS} FROM subnet_snapshots WHERE TRUE`;
+  if (windowDays != null) {
+    const cutoff = new Date(Date.now() - windowDays * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
+    sql += " AND snapshot_date >= ?";
+    params.push(cutoff);
+  }
+  sql += " ORDER BY snapshot_date DESC LIMIT ?";
+  params.push(ECONOMICS_TRENDS_ROW_CAP);
+  const rows = await d1(sql, params);
+  const data = buildEconomicsTrends(rows, { window: windowLabel });
+  return { data, rows };
 }
 
 function toFiniteOrNull(v) {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3554,6 +3554,84 @@ describe("MCP economics + metagraph data tools", () => {
     assert.match(res.body.result.content[0].text, /uid/);
   });
 
+  test("get_economics_trends returns schema-stable empty on cold D1", async () => {
+    const res = await callTool("get_economics_trends", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.day_count, 0);
+    assert.deepEqual(out.days, []);
+  });
+
+  test("get_economics_trends aggregates subnet_snapshots rows", async () => {
+    const res = await callTool(
+      "get_economics_trends",
+      { window: "7d" },
+      {
+        env: {
+          METAGRAPH_HEALTH_DB: metagraphD1({
+            growthSamples: [
+              {
+                snapshot_date: "2026-06-02",
+                total_stake_tao: 300,
+                alpha_price_tao: 0.02,
+                validator_count: 8,
+                miner_count: 50,
+                emission_share: 0.04,
+              },
+              {
+                snapshot_date: "2026-06-02",
+                total_stake_tao: 100,
+                alpha_price_tao: 0.06,
+                validator_count: 2,
+                miner_count: 10,
+                emission_share: 0.02,
+              },
+            ],
+          }),
+        },
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.day_count, 1);
+    assert.equal(out.days[0].subnet_count, 2);
+    assert.equal(out.days[0].total_stake_tao, 400);
+    assert.equal(out.days[0].alpha_price_tao_weighted, 0.03);
+  });
+
+  test("get_economics_trends rejects an invalid window", async () => {
+    const res = await callTool("get_economics_trends", { window: "400d" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("get_economics_trends accepts the all window without a date cutoff", async () => {
+    const res = await callTool(
+      "get_economics_trends",
+      { window: "all" },
+      {
+        env: {
+          METAGRAPH_HEALTH_DB: metagraphD1({
+            snapshots: [
+              {
+                snapshot_date: "2026-06-01",
+                total_stake_tao: 100,
+                alpha_price_tao: 0.01,
+                validator_count: 4,
+                miner_count: 20,
+                emission_share: 0.03,
+              },
+            ],
+          }),
+        },
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "all");
+    assert.equal(out.day_count, 1);
+    assert.equal(out.days[0].total_stake_tao, 100);
+  });
+
   test("get_subnet_trajectory computes the time series + deltas (sorted ascending)", async () => {
     const res = await callTool(
       "get_subnet_trajectory",

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -341,14 +341,12 @@ describe("economics trends loaders", () => {
   }
 
   test("loadEconomicsTrends returns schema-stable empty on cold D1", async () => {
-    const { data, rows } = await loadEconomicsTrends(d1(), {
-      windowLabel: "30d",
-      windowDays: 30,
-    });
+    const { data, rows } = await loadEconomicsTrends(d1(), { window: "30d" });
     assert.deepEqual(rows, []);
     assert.equal(data.window, "30d");
     assert.equal(data.day_count, 0);
     assert.deepEqual(data.days, []);
+    assert.equal(data.rows_capped, undefined);
   });
 
   test("loadEconomicsTrends aggregates subnet_snapshots rows", async () => {
@@ -373,7 +371,7 @@ describe("economics trends loaders", () => {
           },
         ],
       }),
-      { windowLabel: "7d", windowDays: 7 },
+      { window: "7d" },
     );
     assert.equal(data.day_count, 1);
     assert.equal(data.days[0].subnet_count, 2);
@@ -384,12 +382,27 @@ describe("economics trends loaders", () => {
   test("loadEconomicsTrends omits the date cutoff for the all window", async () => {
     const captures = { sql: [], params: [] };
     await loadEconomicsTrends(d1({ "FROM subnet_snapshots": [] }, captures), {
-      windowLabel: "all",
-      windowDays: null,
+      window: "all",
     });
     assert.match(captures.sql[0], /FROM subnet_snapshots/);
     assert.deepEqual(captures.params[0], [60000]);
     assert.doesNotMatch(captures.sql[0], /snapshot_date >=/);
+  });
+
+  test("loadEconomicsTrends sets rows_capped when the row cap is hit", async () => {
+    const rows = Array.from({ length: 60000 }, (_, i) => ({
+      snapshot_date: "2026-01-01",
+      total_stake_tao: i,
+      alpha_price_tao: 0.01,
+      validator_count: 1,
+      miner_count: 1,
+      emission_share: 0.01,
+    }));
+    const { data } = await loadEconomicsTrends(
+      d1({ "FROM subnet_snapshots": rows }),
+      { window: "all" },
+    );
+    assert.equal(data.rows_capped, true);
   });
 
   test("loadEconomicsTrends binds the exact 30d cutoff date", async () => {
@@ -399,8 +412,7 @@ describe("economics trends loaders", () => {
       vi.useFakeTimers();
       vi.setSystemTime(fixedNow);
       await loadEconomicsTrends(d1({ "FROM subnet_snapshots": [] }, captures), {
-        windowLabel: "30d",
-        windowDays: 30,
+        window: "30d",
       });
     } finally {
       vi.useRealTimers();

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -383,10 +383,10 @@ describe("economics trends loaders", () => {
 
   test("loadEconomicsTrends omits the date cutoff for the all window", async () => {
     const captures = { sql: [], params: [] };
-    await loadEconomicsTrends(
-      d1({ "FROM subnet_snapshots": [] }, captures),
-      { windowLabel: "all", windowDays: null },
-    );
+    await loadEconomicsTrends(d1({ "FROM subnet_snapshots": [] }, captures), {
+      windowLabel: "all",
+      windowDays: null,
+    });
     assert.match(captures.sql[0], /FROM subnet_snapshots/);
     assert.deepEqual(captures.params[0], [60000]);
     assert.doesNotMatch(captures.sql[0], /snapshot_date >=/);
@@ -398,10 +398,10 @@ describe("economics trends loaders", () => {
     try {
       vi.useFakeTimers();
       vi.setSystemTime(fixedNow);
-      await loadEconomicsTrends(
-        d1({ "FROM subnet_snapshots": [] }, captures),
-        { windowLabel: "30d", windowDays: 30 },
-      );
+      await loadEconomicsTrends(d1({ "FROM subnet_snapshots": [] }, captures), {
+        windowLabel: "30d",
+        windowDays: 30,
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { describe, test, vi } from "vitest";
 import {
   parseHistoryWindow,
   rollupNeuronDaily,
@@ -14,6 +14,7 @@ import {
   buildNeuronHistory,
   buildSubnetHistory,
   buildEconomicsTrends,
+  loadEconomicsTrends,
   HISTORY_WINDOWS,
   MAX_HISTORY_POINTS,
 } from "../src/neuron-history.mjs";
@@ -324,6 +325,88 @@ describe("history builders", () => {
     assert.equal(out.point_count, 1);
     assert.equal(out.points[0].neuron_count, 256);
     assert.deepEqual(buildSubnetHistory(undefined, 7).points, []);
+  });
+});
+
+describe("economics trends loaders", () => {
+  function d1(rowsBySql = {}, captures = { sql: [], params: [] }) {
+    return async (sql, params) => {
+      captures.sql.push(sql);
+      captures.params.push(params);
+      for (const [pattern, rows] of Object.entries(rowsBySql)) {
+        if (new RegExp(pattern).test(sql)) return rows;
+      }
+      return [];
+    };
+  }
+
+  test("loadEconomicsTrends returns schema-stable empty on cold D1", async () => {
+    const { data, rows } = await loadEconomicsTrends(d1(), {
+      windowLabel: "30d",
+      windowDays: 30,
+    });
+    assert.deepEqual(rows, []);
+    assert.equal(data.window, "30d");
+    assert.equal(data.day_count, 0);
+    assert.deepEqual(data.days, []);
+  });
+
+  test("loadEconomicsTrends aggregates subnet_snapshots rows", async () => {
+    const { data } = await loadEconomicsTrends(
+      d1({
+        "FROM subnet_snapshots": [
+          {
+            snapshot_date: "2026-06-02",
+            total_stake_tao: 300,
+            alpha_price_tao: 0.02,
+            validator_count: 8,
+            miner_count: 50,
+            emission_share: 0.04,
+          },
+          {
+            snapshot_date: "2026-06-02",
+            total_stake_tao: 100,
+            alpha_price_tao: 0.06,
+            validator_count: 2,
+            miner_count: 10,
+            emission_share: 0.02,
+          },
+        ],
+      }),
+      { windowLabel: "7d", windowDays: 7 },
+    );
+    assert.equal(data.day_count, 1);
+    assert.equal(data.days[0].subnet_count, 2);
+    assert.equal(data.days[0].total_stake_tao, 400);
+    assert.equal(data.days[0].alpha_price_tao_weighted, 0.03);
+  });
+
+  test("loadEconomicsTrends omits the date cutoff for the all window", async () => {
+    const captures = { sql: [], params: [] };
+    await loadEconomicsTrends(
+      d1({ "FROM subnet_snapshots": [] }, captures),
+      { windowLabel: "all", windowDays: null },
+    );
+    assert.match(captures.sql[0], /FROM subnet_snapshots/);
+    assert.deepEqual(captures.params[0], [60000]);
+    assert.doesNotMatch(captures.sql[0], /snapshot_date >=/);
+  });
+
+  test("loadEconomicsTrends binds the exact 30d cutoff date", async () => {
+    const fixedNow = new Date("2026-06-30T12:00:00.000Z");
+    const captures = { sql: [], params: [] };
+    try {
+      vi.useFakeTimers();
+      vi.setSystemTime(fixedNow);
+      await loadEconomicsTrends(
+        d1({ "FROM subnet_snapshots": [] }, captures),
+        { windowLabel: "30d", windowDays: 30 },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+    assert.equal(captures.params[0][0], "2026-05-31");
+    assert.equal(captures.params[0][1], 60000);
   });
 });
 

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -99,13 +99,10 @@ export async function handleTrajectory(request, env, netuid, url) {
 export async function handleEconomicsTrends(request, env, url) {
   const validationError = validateQueryParams(url, ["window"]);
   if (validationError) return analyticsQueryError(validationError);
-  const { label, days, error } = parseHistoryWindow(
-    url.searchParams.get("window"),
-  );
+  const { label, error } = parseHistoryWindow(url.searchParams.get("window"));
   if (error) return analyticsQueryError(error);
   const { data, rows } = await loadEconomicsTrends(d1Runner(env), {
-    windowLabel: label,
-    windowDays: days,
+    window: label,
   });
   return envelopeWithD1Fallback(
     request,

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -16,13 +16,14 @@ import {
   analyticsMeta,
   analyticsQueryError,
   d1All,
+  d1Runner,
   hasD1FallbackRows,
   markD1FallbackResponse,
   validateQueryParams,
 } from "./analytics.mjs";
 import { dailyLatencyColumns } from "../../src/health-sql.mjs";
 import {
-  buildEconomicsTrends,
+  loadEconomicsTrends,
   parseHistoryWindow,
 } from "../../src/neuron-history.mjs";
 import {
@@ -94,10 +95,7 @@ export async function handleTrajectory(request, env, netuid, url) {
 // stake, stake-weighted + median alpha price, total validator/miner counts, mean
 // emission share). Same source as the per-subnet trajectory; raw rows (not a GROUP
 // BY) so the weighted/median price is computed in the pure builder. Schema-stable
-// (day_count:0, days:[]) on a cold rollup. Bounded by ECONOMICS_TRENDS_ROW_CAP:
-// ~129 subnets × 365 days ≈ 47k rows for `all`, so the cap is generous but finite.
-const ECONOMICS_TRENDS_ROW_CAP = 60000;
-
+// (day_count:0, days:[]) on a cold rollup. Bounded by ECONOMICS_TRENDS_ROW_CAP.
 export async function handleEconomicsTrends(request, env, url) {
   const validationError = validateQueryParams(url, ["window"]);
   if (validationError) return analyticsQueryError(validationError);
@@ -105,22 +103,10 @@ export async function handleEconomicsTrends(request, env, url) {
     url.searchParams.get("window"),
   );
   if (error) return analyticsQueryError(error);
-  const params = [];
-  let sql =
-    "SELECT snapshot_date, total_stake_tao, alpha_price_tao, " +
-    "validator_count, miner_count, emission_share " +
-    "FROM subnet_snapshots WHERE TRUE";
-  if (days != null) {
-    const cutoff = new Date(Date.now() - days * DAY_MS)
-      .toISOString()
-      .slice(0, 10);
-    sql += " AND snapshot_date >= ?";
-    params.push(cutoff);
-  }
-  sql += " ORDER BY snapshot_date DESC LIMIT ?";
-  params.push(ECONOMICS_TRENDS_ROW_CAP);
-  const rows = await d1All(env, sql, params);
-  const data = buildEconomicsTrends(rows, { window: label });
+  const { data, rows } = await loadEconomicsTrends(d1Runner(env), {
+    windowLabel: label,
+    windowDays: days,
+  });
   return envelopeWithD1Fallback(
     request,
     {


### PR DESCRIPTION
Closes #2332

## Summary

- Adds `get_economics_trends` MCP tool, mirroring `GET /api/v1/economics/trends` for the network-wide daily stake, alpha price, validator/miner counts, and mean emission share rollup across all subnets.
- Introduces `loadEconomicsTrends` in `src/neuron-history.mjs` and routes **both** the REST handler and MCP tool through it, so the D1 read contract lives in one place (same pattern as #2302).
- Bumps MCP server version to **1.8.0**.

## Gittensory review follow-ups

- Linked issue #2332 (was missing).
- `loadEconomicsTrends` now accepts a single `window` string and parses it internally via `parseHistoryWindow`.
- `rows_capped: true` is returned when the `all` window hits `ECONOMICS_TRENDS_ROW_CAP` (60k rows).
- Split the dense MCP instructions sentence for the economics tools.
- Added `get_economics_trends` smoke call to `scripts/validate-mcp.mjs`.

Note: this PR touches `src/mcp-server.mjs` (maintainer-blocked path) by design — required to register the new public MCP tool.

## Test plan

- [x] `npm test -- tests/neuron-history.test.mjs tests/mcp-server.test.mjs tests/request-handlers-analytics.test.mjs -t economics`
- [x] `npm run validate:mcp`
- [x] Loader unit tests: cold D1, happy-path aggregation, `all` window, exact 30d cutoff (fake timers), `rows_capped` signal
- [x] MCP `callTool` integration tests: cold D1, happy path, invalid window, `all` window
- [x] Existing `handleEconomicsTrends` REST tests still pass via shared loader