### PR TITLE
test(chain-analytics): cover buildChainFees junk-row filtering + cold store

### DIFF
--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -615,6 +615,47 @@ test("buildChainFees computes per-day averages + null avg on a zero-extrinsic da
   assert.equal(out.top_fee_payers[0].signer, "5Pay");
 });
 
+test("buildChainFees drops junk daily rows and payer rows without a signer", () => {
+  const out = buildChainFees({
+    window: "30d",
+    dailyRows: [
+      null,
+      "not-an-object",
+      { extrinsic_count: 5 }, // no string `day` → dropped
+      { day: "2026-06-20", extrinsic_count: 10, total_fee_tao: 2.0 },
+    ],
+    payerRows: [
+      null,
+      { total_fee_tao: 1.0 }, // missing signer → dropped
+      { signer: "", total_fee_tao: 1.0 }, // empty signer → dropped
+      { signer: "5Keep", total_fee_tao: 0.4, extrinsic_count: 4 },
+    ],
+  });
+  // Only the one well-formed daily row + the one valid payer survive the filters.
+  assert.equal(out.day_count, 1);
+  assert.deepEqual(
+    out.daily.map((d) => d.day),
+    ["2026-06-20"],
+  );
+  assert.equal(out.daily[0].avg_fee_tao, 0.2); // 2.0 / 10
+  assert.deepEqual(
+    out.top_fee_payers.map((p) => p.signer),
+    ["5Keep"],
+  );
+});
+
+test("buildChainFees is schema-stable on empty input (cold store)", () => {
+  const out = buildChainFees({ window: "7d" });
+  assert.deepEqual(out, {
+    schema_version: 1,
+    window: "7d",
+    observed_at: null,
+    day_count: 0,
+    daily: [],
+    top_fee_payers: [],
+  });
+});
+
 test("GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL fees", async () => {
   const captured = [];
   const env = {


### PR DESCRIPTION
## Summary

- `buildChainFees` (`src/chain-analytics.mjs`) defensively filters malformed `dailyRows` (null / non-object / missing string `day`) and `payerRows` without a `signer`, and returns a schema-stable empty shape on cold input. The existing suite only ever fed well-formed rows, so those `.filter()` branches and the cold-store path were never exercised.

## What Changed

- `tests/chain-analytics.test.mjs`: add tests asserting (1) junk daily rows and signer-less payer rows are dropped while valid rows survive, and (2) `buildChainFees({ window })` returns the schema-stable empty payload (`day_count: 0`, empty arrays) on cold input.

Test-only change — no runtime code touched.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — tests only.)

## Validation

- [x] `npx vitest run tests/chain-analytics.test.mjs` — 31 passed
- [x] prettier `--check` + eslint clean
- [x] `git diff --check`
