### PR TITLE
test(counterparties): cover the equal-volume sort tie-breaks

### DIFF
--- a/tests/counterparties.test.mjs
+++ b/tests/counterparties.test.mjs
@@ -51,6 +51,24 @@ describe("buildCounterparties", () => {
     assert.equal(data.counterparties[2].address, "B");
   });
 
+  test("breaks equal-volume ties by newest last_block, then by ascending address", () => {
+    // Three counterparties with the SAME total volume (100 each), so the
+    // comparator falls through to its last_block then address tie-breaks — the
+    // branches the volume-ranked test above never exercises.
+    const rows = [
+      { hotkey: "ME", coldkey: "P", amount_tao: 100, block_number: 20 },
+      { hotkey: "ME", coldkey: "Q", amount_tao: 100, block_number: 20 },
+      { hotkey: "ME", coldkey: "R", amount_tao: 100, block_number: 10 },
+    ];
+    const data = buildCounterparties(rows, ME, { limit: 20 });
+    // Equal volume → newer last_block first (P/Q at 20 before R at 10); P and Q
+    // tie on volume AND block → ascending address ("P" < "Q").
+    assert.deepEqual(
+      data.counterparties.map((c) => c.address),
+      ["P", "Q", "R"],
+    );
+  });
+
   test("skips self-transfers (account on both sides)", () => {
     const data = buildCounterparties(
       [


### PR DESCRIPTION
## Summary

- `buildCounterparties` (`src/counterparties.mjs`) ranks counterparties by total volume, then by newest `last_block`, then by ascending `address`. The existing suite only fed **distinct-volume** rows, so the comparator's `last_block` and `address` tie-break branches were never exercised.

## What Changed

- `tests/counterparties.test.mjs`: add a test with three **equal-volume** counterparties asserting the newest-block-first then ascending-address ordering, covering the previously-untested comparator branches (mirrors the list-query sort-tiebreak coverage).

Test-only change — no runtime code touched.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — tests only.)

## Validation

- [x] `npx vitest run tests/counterparties.test.mjs` — 23 passed
- [x] prettier `--check` + eslint clean
- [x] `git diff --check`
