### PR TITLE
fix(api): clamp sub-perfect concentration ratios below a perfect 1.0

### DIFF
--- a/src/concentration.mjs
+++ b/src/concentration.mjs
@@ -24,6 +24,18 @@ function round(value, dp = 6) {
   return Math.round(value * factor) / factor;
 }
 
+// Round a 0..1 concentration ratio (gini, hhi, normalized variants, top-K share)
+// WITHOUT letting a sub-perfect value round up to an exact 1 — a near-monopoly
+// that holds 99.99996% must not display as a perfect 1.0 ("total concentration"),
+// the same anti-overstatement guard the turnover/chain-activity ratios apply. A
+// genuine ratio of exactly 1 (e.g. a single holder's 100% share) keeps 1.0.
+function roundRatio(value, dp = 6) {
+  if (value == null || !Number.isFinite(value)) return null;
+  const factor = 10 ** dp;
+  const rounded = Math.round(value * factor) / factor;
+  return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
+}
+
 function captureStamp(value) {
   if (typeof value === "number" && Number.isFinite(value)) {
     return { ms: value, value: new Date(value).toISOString() };
@@ -105,7 +117,7 @@ function topShares(descending, total) {
   const out = {};
   for (const p of TOP_PERCENTILES) {
     const k = Math.max(1, Math.ceil((n * p) / 100));
-    out[`top_${p}pct_share`] = round(prefix[k - 1] / total);
+    out[`top_${p}pct_share`] = roundRatio(prefix[k - 1] / total);
   }
   return out;
 }
@@ -137,13 +149,13 @@ export function computeConcentration(values) {
   return {
     holders,
     total: round(total, 4),
-    gini: round(gini(ascending, total)),
-    hhi: round(h),
-    hhi_normalized: round(hhiNormalized(h, holders)),
+    gini: roundRatio(gini(ascending, total)),
+    hhi: roundRatio(h),
+    hhi_normalized: roundRatio(hhiNormalized(h, holders)),
     nakamoto_coefficient: nakamoto(descending, total),
     ...topShares(descending, total),
     entropy: round(bits),
-    entropy_normalized: round(normalized),
+    entropy_normalized: roundRatio(normalized),
   };
 }
 

--- a/tests/concentration.test.mjs
+++ b/tests/concentration.test.mjs
@@ -80,6 +80,26 @@ describe("computeConcentration", () => {
     assert.equal(c.nakamoto_coefficient, 1);
     assert.ok(c.entropy_normalized < 0.2);
   });
+
+  test("a sub-perfect top share does not round up to a perfect 1.0", () => {
+    // Two holders, one with 99.99999% — top_1pct_share is 0.9999999, which would
+    // round to a misleading 1.0 ("total concentration"). It must clamp just below
+    // 1 instead, like the turnover/chain-activity ratio guards.
+    const c = computeConcentration([9_999_999, 1]);
+    assert.ok(
+      c.top_1pct_share < 1,
+      `top_1pct_share must stay below 1, got ${c.top_1pct_share}`,
+    );
+    assert.equal(c.top_1pct_share, 0.999999);
+  });
+
+  test("a genuine 100% share (single holder) still reports exactly 1.0", () => {
+    // The clamp must only catch sub-perfect values — a true monopoly is 1.0.
+    const c = computeConcentration([500]);
+    assert.equal(c.top_1pct_share, 1);
+    assert.equal(c.hhi, 1);
+    assert.equal(c.hhi_normalized, 1);
+  });
 });
 
 describe("buildConcentration", () => {


### PR DESCRIPTION
## Summary

- `computeConcentration` rounded `gini`, `hhi`, `hhi_normalized`, `entropy_normalized`, and the top-K% shares with a plain `round()` that lets a near-perfect value (e.g. a 99.99999% top share) round **up** to an exact `1.0` — misreporting a near-monopoly as *total* concentration. The sibling turnover (#2299), chain-activity (#2020), and uptime (#2224) ratios already guard against this exact overstatement.

## What Changed

- `src/concentration.mjs`: add `roundRatio()` that clamps a sub-1 value which rounds to `>= 1` down to the largest sub-1 decimal, and apply it to the 0..1 ratio fields. Amounts (`total`) and the unbounded Shannon entropy (`bits`, can exceed 1) keep plain `round()`. A genuine `1.0` (a single holder's 100% share, where `value === 1`) is preserved — the guard only triggers when `value < 1`.
- `tests/concentration.test.mjs`: a sub-perfect top share clamps just below 1 (`0.999999`, not `1.0`); a true single-holder monopoly still reports exactly `1.0` for top share / hhi / hhi_normalized.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change — a value-accuracy fix to the existing number|null fields, matching the established ratio guards.)

## Validation

- [x] `npx vitest run tests/concentration.test.mjs` — 26 passed
- [x] `npx vitest run tests/request-handlers-entities.test.mjs tests/mcp-server.test.mjs tests/data-api.test.mjs` — green (464 total)
- [x] prettier `--check` + eslint clean
- [x] `git diff --check`
