### PR TITLE
feat(api): negation filters (not_) on the subnets list endpoint

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -14415,6 +14415,13 @@ export interface operations {
                 max_surface_count?: number;
                 min_tempo?: number;
                 max_tempo?: number;
+                not_netuid?: number;
+                not_netuids?: string;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_domain?: "agents" | "compute" | "data" | "finance" | "inference" | "media" | "prediction" | "privacy" | "robotics" | "science" | "search" | "security" | "storage" | "training";
+                not_status?: "active" | "inactive";
+                not_subnet_type?: "root" | "application";
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -998,6 +998,88 @@
           }
         },
         {
+          "name": "not_netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "not_netuids",
+          "schema": {
+            "maxLength": 767,
+            "pattern": "^\\d{1,5}(,\\d{1,5}){0,127}$",
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_coverage_level",
+          "schema": {
+            "enum": [
+              "native-only",
+              "manifested",
+              "probed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "community-seeded",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_domain",
+          "schema": {
+            "enum": [
+              "agents",
+              "compute",
+              "data",
+              "finance",
+              "inference",
+              "media",
+              "prediction",
+              "privacy",
+              "robotics",
+              "science",
+              "search",
+              "security",
+              "storage",
+              "training"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_status",
+          "schema": {
+            "enum": [
+              "active",
+              "inactive"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "not_subnet_type",
+          "schema": {
+            "enum": [
+              "root",
+              "application"
+            ],
+            "type": "string"
+          }
+        },
+        {
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -28430,6 +28430,102 @@
           },
           {
             "in": "query",
+            "name": "not_netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_netuids",
+            "required": false,
+            "schema": {
+              "maxLength": 767,
+              "pattern": "^\\d{1,5}(,\\d{1,5}){0,127}$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_coverage_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native-only",
+                "manifested",
+                "probed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "community-seeded",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_domain",
+            "required": false,
+            "schema": {
+              "enum": [
+                "agents",
+                "compute",
+                "data",
+                "finance",
+                "inference",
+                "media",
+                "prediction",
+                "privacy",
+                "robotics",
+                "science",
+                "search",
+                "security",
+                "storage",
+                "training"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "active",
+                "inactive"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "not_subnet_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "root",
+                "application"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -14415,6 +14415,13 @@ export interface operations {
                 max_surface_count?: number;
                 min_tempo?: number;
                 max_tempo?: number;
+                not_netuid?: number;
+                not_netuids?: string;
+                not_coverage_level?: "native-only" | "manifested" | "probed";
+                not_curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                not_domain?: "agents" | "compute" | "data" | "finance" | "inference" | "media" | "prediction" | "privacy" | "robotics" | "science" | "search" | "security" | "storage" | "training";
+                not_status?: "active" | "inactive";
+                not_subnet_type?: "root" | "application";
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -606,6 +606,17 @@ export const API_QUERY_COLLECTIONS = {
       "surface_count",
       "tempo",
     ],
+    // Exclusion filters: `?not_status=active`, `?not_domain=inference`,
+    // `?not_netuids=1,7` — the complement of the matching equality filter.
+    negationFilters: [
+      "netuid",
+      "netuids",
+      "coverage_level",
+      "curation_level",
+      "domain",
+      "status",
+      "subnet_type",
+    ],
   }),
 };
 
@@ -2721,6 +2732,10 @@ function queryCollection(dataKey, options = {}) {
     // params (inclusive bounds on the numeric row[F]). Generalizes the one-off
     // hand-rolled min_readiness the MCP list_subnets tool did.
     range_filters: options.rangeFilters || [],
+    // Exclusion filters: each equality-filter field F listed here also accepts a
+    // `not_F` query param returning the complement of `?F=v` (same schema).
+    // Opt-in per collection so the contract surface grows deliberately.
+    negation_filters: options.negationFilters || [],
     search_keys: options.search || [],
     sort_fields: options.sort || [],
   };
@@ -2748,6 +2763,11 @@ function listQuery(collection, options = {}) {
     { name: `min_${field}`, schema: { type: "number" } },
     { name: `max_${field}`, schema: { type: "number" } },
   ]);
+  // Each opt-in negation field F → a `not_F` exclusion parameter accepting the
+  // same values as `F` (the complement of `?F=v`).
+  const negationParameters = config.negation_filters
+    .filter((field) => config.filters[field] && !excluded.has(field))
+    .map((field) => ({ name: `not_${field}`, schema: config.filters[field] }));
   return {
     collection,
     filterNames: filterParameters.map((parameter) => parameter.name),
@@ -2755,6 +2775,7 @@ function listQuery(collection, options = {}) {
       ...filterParameters,
       ...searchParameters,
       ...rangeParameters,
+      ...negationParameters,
       {
         name: "fields",
         schema: fieldListSchema,

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -255,6 +255,185 @@ describe("list-query sort tie-break", () => {
   });
 });
 
+describe("list-query negation (exclusion) filters", () => {
+  const data = {
+    subnets: [
+      {
+        netuid: 1,
+        status: "active",
+        subnet_type: "application",
+        categories: ["agents"],
+      },
+      {
+        netuid: 2,
+        status: "inactive",
+        subnet_type: "application",
+        derived_categories: ["compute"],
+      },
+      {
+        netuid: 3,
+        status: "active",
+        subnet_type: "root",
+        categories: ["data", "agents"],
+      },
+      { netuid: 4 }, // none of the negation fields present
+    ],
+  };
+  const netuids = (result) => result.data.subnets.map((r) => r.netuid);
+
+  test("not_<scalar> drops rows matching the value (complement of equality)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_status=active"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [2, 4]);
+  });
+
+  test("a row missing the field is never excluded", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_subnet_type=application"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [3, 4]);
+  });
+
+  test("F and its own not_F AND together to empty (contradictory filters)", () => {
+    // status=active keeps {1,3}; not_status=active drops them — the two compose
+    // with AND semantics, so the contradiction yields no rows.
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?status=active&not_status=active"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), []);
+  });
+
+  test("not_F and F partition the rows (exact complement)", () => {
+    const included = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?status=active"),
+      "subnets",
+    );
+    const excluded = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_status=active"),
+      "subnets",
+    );
+    assert.deepEqual(
+      [...netuids(included), ...netuids(excluded)].sort(),
+      [1, 2, 3, 4],
+    );
+  });
+
+  test("not_<csv-membership> drops rows whose mapped field is in the set", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_netuids=1,3"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [2, 4]);
+  });
+
+  test("inclusion netuids csv filter keeps the listed rows (shared matcher)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?netuids=1,3"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [1, 3]);
+  });
+
+  test("not_<array-membership> drops rows whose array union contains the value", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_domain=agents"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [2, 4]);
+  });
+
+  test("multiple not_ params AND together and compose with sort", () => {
+    const result = applyQueryFilters(
+      data,
+      query(
+        "/api/v1/subnets?not_status=active&not_subnet_type=application&sort=netuid&order=desc",
+      ),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [4]);
+  });
+
+  test("no not_ param is a no-op (every row passes)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?sort=netuid"),
+      "subnets",
+    );
+    assert.deepEqual(netuids(result), [1, 2, 3, 4]);
+  });
+
+  test("an invalid not_<enum> value is a query error naming the not_ param", () => {
+    const bad = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_status=bogus"),
+      "subnets",
+    );
+    assert.equal(bad.error.parameter, "not_status");
+    assert.match(bad.error.message, /not supported for this route/);
+  });
+
+  test("an invalid not_<integer> value is a query error", () => {
+    const bad = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_netuid=-1"),
+      "subnets",
+    );
+    assert.equal(bad.error.parameter, "not_netuid");
+    assert.match(bad.error.message, /must be a non-negative integer/);
+  });
+
+  test("a malformed not_<pattern> value is a query error", () => {
+    const bad = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?not_netuids=abc"),
+      "subnets",
+    );
+    assert.equal(bad.error.parameter, "not_netuids");
+    assert.match(bad.error.message, /not in the expected format/);
+  });
+
+  test("an over-length not_<maxLength> value is a query error", () => {
+    const tooLong = `1${",1".repeat(400)}`; // exceeds the netuids 767 cap
+    const bad = applyQueryFilters(
+      data,
+      query(`/api/v1/subnets?not_netuids=${tooLong}`),
+      "subnets",
+    );
+    assert.equal(bad.error.parameter, "not_netuids");
+    assert.match(bad.error.message, /too long/);
+  });
+
+  test("an array-valued field excludes when the value is a member of the array", () => {
+    const arrayData = {
+      subnets: [
+        { netuid: 1, subnet_type: ["application", "root"] },
+        { netuid: 2, subnet_type: "application" },
+      ],
+    };
+    const result = applyQueryFilters(
+      arrayData,
+      query("/api/v1/subnets?not_subnet_type=root"),
+      "subnets",
+    );
+    assert.deepEqual(
+      result.data.subnets.map((r) => r.netuid),
+      [2],
+    );
+  });
+});
+
 describe("list-query numeric range filters", () => {
   const data = {
     subnets: [
@@ -595,8 +774,9 @@ describe("list-query canonicalListSearch (cache-key safety)", () => {
       "/api/v1/subnets?q=chutes&fields=netuid&sort=netuid&order=desc" +
         "&limit=5&cursor=10&curation_level=native" + // a plain filter
         "&netuids=1,2" + // a csv filter
-        "&domain=ai" + // an array filter
+        "&domain=data" + // an array filter (a valid domain enum value)
         "&min_block=100&max_block=200" + // a range filter pair
+        "&not_status=inactive&not_netuids=9&not_domain=data" + // negation filters
         "&utm_campaign=evil&token=SECRET123&__proto__=x", // ignored extras
     );
     const p = params(canonicalListSearch(url, "subnets"));
@@ -609,9 +789,13 @@ describe("list-query canonicalListSearch (cache-key safety)", () => {
     assert.equal(p.get("cursor"), "10");
     assert.equal(p.get("curation_level"), "native");
     assert.equal(p.get("netuids"), "1,2");
-    assert.equal(p.get("domain"), "ai");
+    assert.equal(p.get("domain"), "data");
     assert.equal(p.get("min_block"), "100");
     assert.equal(p.get("max_block"), "200");
+    // The exclusion (negation) params are cache-key-significant too.
+    assert.equal(p.get("not_status"), "inactive");
+    assert.equal(p.get("not_netuids"), "9");
+    assert.equal(p.get("not_domain"), "data");
     // Dropped: anything the edge cache key ignores.
     assert.equal(p.has("utm_campaign"), false);
     assert.equal(p.has("token"), false);

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -53,6 +53,10 @@ function listQueryParamNames(queryCollection, queryFilterNames = []) {
   ]);
   const csvNames = Object.keys(config.csv_filters || {});
   const arrayNames = Object.keys(config.array_filters || {});
+  // Opt-in exclusion params (`not_F`) must be distinguished in the cache key.
+  const negationNames = (config.negation_filters || []).map(
+    (field) => `not_${field}`,
+  );
   return [
     "q",
     "fields",
@@ -64,6 +68,7 @@ function listQueryParamNames(queryCollection, queryFilterNames = []) {
     ...csvNames,
     ...arrayNames,
     ...rangeNames,
+    ...negationNames,
   ];
 }
 
@@ -116,40 +121,91 @@ export function paginationLinkHeader(url, pagination, options = {}) {
   return links.length > 0 ? linkHeader(links) : null;
 }
 
+// Does `row` satisfy filter `key` = `expected`? The single per-field matcher
+// shared by inclusion (filterRows) and exclusion (excludeFilterRows), so `?F=v`
+// and `?not_F=v` stay exact complements. Three modes: CSV membership (against
+// `csvWanted`, the precomputed value Set), array-membership over the union of
+// arrayFilters[key], else scalar/array equality on row[key].
+function rowMatchesFilter(
+  row,
+  key,
+  expected,
+  csvFilters,
+  arrayFilters,
+  csvWanted,
+) {
+  const csvField = csvFilters[key];
+  if (csvField) {
+    return csvWanted?.has(String(row[csvField])) ?? false;
+  }
+  const arrayFields = arrayFilters[key];
+  if (arrayFields) {
+    return arrayFields.some(
+      (field) =>
+        Array.isArray(row[field]) && row[field].map(String).includes(expected),
+    );
+  }
+  const value = row[key];
+  if (Array.isArray(value)) {
+    return value.map(String).includes(expected);
+  }
+  return String(value) === expected;
+}
+
 function filterRows(rows, params, keys, csvFilters = {}, arrayFilters = {}) {
   const csvWantedByKey = new Map(
-    Object.keys(csvFilters)
-      .filter((key) => params.has(key))
+    keys
+      .filter((key) => csvFilters[key] && params.has(key))
       .map((key) => [key, new Set(params.get(key).split(","))]),
   );
-
   return rows.filter((row) =>
-    keys.every((key) => {
-      if (!params.has(key)) {
-        return true;
-      }
-      const expected = params.get(key);
-      // CSV membership filter (e.g. ?netuids=1,7,74 -> match row.netuid).
-      const csvField = csvFilters[key];
-      if (csvField) {
-        return csvWantedByKey.get(key)?.has(String(row[csvField])) ?? false;
-      }
-      // Array-membership filter over the UNION of one or more array fields
-      // (e.g. ?domain=inference -> match row.categories or row.derived_categories).
-      const arrayFields = arrayFilters[key];
-      if (arrayFields) {
-        return arrayFields.some(
-          (field) =>
-            Array.isArray(row[field]) &&
-            row[field].map(String).includes(expected),
-        );
-      }
-      const value = row[key];
-      if (Array.isArray(value)) {
-        return value.map(String).includes(expected);
-      }
-      return String(value) === expected;
-    }),
+    keys.every(
+      (key) =>
+        !params.has(key) ||
+        rowMatchesFilter(
+          row,
+          key,
+          params.get(key),
+          csvFilters,
+          arrayFilters,
+          csvWantedByKey.get(key),
+        ),
+    ),
+  );
+}
+
+// Exclusion (negation) filter: `?not_F=v` keeps exactly the rows that `?F=v`
+// would drop — the complement, via the same rowMatchesFilter used for inclusion.
+// Scoped to the collection's opt-in negation fields; validation has confirmed
+// each present not_F value satisfies F's schema.
+function excludeFilterRows(
+  rows,
+  params,
+  negationFields,
+  csvFilters = {},
+  arrayFilters = {},
+) {
+  const present = negationFields.filter((key) => params.has(`not_${key}`));
+  if (present.length === 0) {
+    return rows;
+  }
+  const csvUnwantedByKey = new Map(
+    present
+      .filter((key) => csvFilters[key])
+      .map((key) => [key, new Set(params.get(`not_${key}`).split(","))]),
+  );
+  return rows.filter((row) =>
+    present.every(
+      (key) =>
+        !rowMatchesFilter(
+          row,
+          key,
+          params.get(`not_${key}`),
+          csvFilters,
+          arrayFilters,
+          csvUnwantedByKey.get(key),
+        ),
+    ),
   );
 }
 
@@ -191,16 +247,22 @@ function applyListTransform(data, params, config) {
     return { error: projection.error };
   }
   const filterKeys = Object.keys(config.filters);
-  const filtered = rangeFilterRows(
-    filterRows(
-      searchRows(data[key], params, config.search_keys),
+  const filtered = excludeFilterRows(
+    rangeFilterRows(
+      filterRows(
+        searchRows(data[key], params, config.search_keys),
+        params,
+        filterKeys,
+        config.csv_filters,
+        config.array_filters,
+      ),
       params,
-      filterKeys,
-      config.csv_filters,
-      config.array_filters,
+      config.range_filters,
     ),
     params,
-    config.range_filters,
+    config.negation_filters || [],
+    config.csv_filters,
+    config.array_filters,
   );
   const sorted = sortRows(filtered, params);
   const paginated = paginateRows(sorted, params);
@@ -313,6 +375,34 @@ function paginateRows(rows, params) {
   };
 }
 
+// Validate one equality-filter value against its field schema. `parameter` is
+// the query-param name actually sent (`F` or its negation `not_F`) so the error
+// names it. Returns an error object or null.
+function validateFilterValue(parameter, value, schema) {
+  if (schema.type === "integer" && integerParam(value) === null) {
+    return {
+      parameter,
+      message: `${parameter} must be a non-negative integer.`,
+    };
+  }
+  if (schema.enum && !schema.enum.includes(value)) {
+    return {
+      parameter,
+      message: `${parameter} is not supported for this route.`,
+    };
+  }
+  if (schema.maxLength && value.length > schema.maxLength) {
+    return { parameter, message: `${parameter} is too long.` };
+  }
+  if (schema.pattern && !new RegExp(schema.pattern).test(value)) {
+    return {
+      parameter,
+      message: `${parameter} is not in the expected format.`,
+    };
+  }
+  return null;
+}
+
 function validateListQuery(params, config) {
   const limit = params.get("limit");
   if (
@@ -355,34 +445,23 @@ function validateListQuery(params, config) {
     };
   }
 
+  const negationFields = new Set(config.negation_filters || []);
   for (const [key, schema] of Object.entries(config.filters)) {
-    if (!params.has(key)) {
-      continue;
-    }
-    const value = params.get(key);
-    if (schema.type === "integer" && integerParam(value) === null) {
-      return {
-        parameter: key,
-        message: `${key} must be a non-negative integer.`,
-      };
-    }
-    if (schema.enum && !schema.enum.includes(value)) {
-      return {
-        parameter: key,
-        message: `${key} is not supported for this route.`,
-      };
-    }
-    if (schema.maxLength && value.length > schema.maxLength) {
-      return {
-        parameter: key,
-        message: `${key} is too long.`,
-      };
-    }
-    if (schema.pattern && !new RegExp(schema.pattern).test(value)) {
-      return {
-        parameter: key,
-        message: `${key} is not in the expected format.`,
-      };
+    // Each filter validates its inclusion param (`F`) and, where the collection
+    // opts in, its exclusion param (`not_F`) against the same schema.
+    const paramsToCheck = negationFields.has(key) ? [key, `not_${key}`] : [key];
+    for (const parameter of paramsToCheck) {
+      if (!params.has(parameter)) {
+        continue;
+      }
+      const error = validateFilterValue(
+        parameter,
+        params.get(parameter),
+        schema,
+      );
+      if (error) {
+        return error;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Resubmits the list-endpoint negation filter, **scoped down per the #2277 review** — that PR was closed as too large (4400+ LOC) with a request to break it into ≤1000-LOC chunks and address the review nits. This is the first chunk: **~590 LOC, subnets collection only.**

`?not_F=v` returns the exact complement of `?F=v`, reusing each field's existing filter schema for validation. Negation is now **opt-in per collection** (a `negationFilters` list, mirroring `rangeFilters`), so the contract surface grows deliberately — other collections can opt in in follow-up PRs.

## Addresses the #2277 review nits
- **Shared matcher (nits 2 & 5):** inclusion (`filterRows`) and exclusion (`excludeFilterRows`) now both go through one `rowMatchesFilter` helper, so `F=v` and `not_F=v` are guaranteed exact complements and future filter-mode changes apply to both sides.
- **Canonical cache-key coverage (nits 1 & 4):** the `canonicalListSearch` test now asserts `not_status`, `not_netuids`, and `not_domain` survive canonicalization (they're cache-key-significant).
- **Size:** opt-in scoping keeps the generated `openapi.json` under 1 MiB, so no artifact-verifier change is needed (the #2277 `gitShow` maxBuffer workaround is dropped).
- No self-authored issue is linked.

## Changes
- `src/contracts.mjs`: `negation_filters` opt-in on `queryCollection`; `listQuery` emits `not_F` params from it; enabled on the `subnets` collection (7 fields).
- `workers/list-query.mjs`: extracted `rowMatchesFilter`; `excludeFilterRows` as its negation; `not_F` registered in `listQueryParamNames`; `validateFilterValue` validates `F` and `not_F`.
- Regenerated `openapi.json` / `api-index.json` / type declarations.
- `tests/list-query.test.mjs`: negation behaviour, exact-complement partition, validation branches, and the canonical cache-key assertions.

## Validation
- `npm run lint`, `npm run format:check`, `npm run validate:contract-drift`, `npm run validate:openapi` (94 routes), full `npm test` — green
- `npx vitest run tests/list-query.test.mjs` — 59 passed; new lines fully covered