### PR TITLE
fix(probe): recheck subtensor RPC URL safety

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -461,6 +461,14 @@ export async function probeSubtensorHttp(url, timeoutMs, options = {}) {
 
 async function jsonRpcHttp(url, method, params, id, timeoutMs, options = {}) {
   const { isUnsafeUrl = isUnsafePublicUrl, fetchImpl = fetch } = options;
+  if (await isUnsafeUrl(url)) {
+    return {
+      transport_error: true,
+      unsafe_url: true,
+      error: "unsafe URL",
+    };
+  }
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -610,6 +610,33 @@ describe("probeSubtensorHttp / jsonRpcHttp (HTTP RPC)", () => {
     assert.equal(probe.archive_support, undefined);
   });
 
+  test("rechecks URL safety before each sequential RPC fetch", async () => {
+    let fetchCount = 0;
+    let safetyChecks = 0;
+    const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
+      isUnsafeUrl: async () => {
+        safetyChecks += 1;
+        return fetchCount > 0;
+      },
+      fetchImpl: async (_url, init) => {
+        fetchCount += 1;
+        const req = JSON.parse(init.body);
+        return fakeResponse({
+          status: 200,
+          body: rpcBody(req.id, { number: "0x1" }),
+        });
+      },
+    });
+
+    assert.equal(fetchCount, 1);
+    assert.equal(safetyChecks, 3);
+    assert.equal(probe.transport_error, true);
+    assert.equal(probe.unsafe_url, true);
+    assert.equal(probe.error, "unsafe URL");
+    assert.equal(probe.method_results.chain_getHeader.ok, true);
+    assert.equal(probe.method_results.system_health.ok, false);
+  });
+
   test("non-JSON response is a transport error (response was not JSON)", async () => {
     const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
       isUnsafeUrl: async () => false,


### PR DESCRIPTION
### Motivation
- Prevent a DNS-rebinding TOCTOU that introduced an SSRF window by ensuring each sequential JSON-RPC POST re-validates the target URL immediately before the fetch.

### Description
- Add an immediate `isUnsafeUrl(url)` check in `jsonRpcHttp` so each RPC call fails closed when the resolved address becomes unsafe; changes in `src/health-probe-core.mjs`.
- Add a regression test `rechecks URL safety before each sequential RPC fetch` in `tests/health-probe-core.test.mjs` that simulates the endpoint becoming unsafe after the first call and verifies later calls are blocked.

### Testing
- Ran unit tests with `npm test -- tests/health-probe-core.test.mjs` and all tests passed (105 tests).
- Ran linters and format checks with `npm run lint` and `npm run format:check`, both succeeded.
- Built the generated artifacts with `npm run build`, which completed successfully.
- Ran the full validators with `npm run validate`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a425bbce570832c8e7be0fb24084ad4)