### PR TITLE
fix(api): avoid transfer account OR scans

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -601,18 +601,20 @@ export async function loadAccountTransfers(
 ) {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
-  let sideClause = "(hotkey = ? OR coldkey = ?)";
-  let sideParams = [ss58, ss58];
+  let sql;
+  let params;
   if (direction === "sent") {
-    sideClause = "hotkey = ?";
-    sideParams = [ss58];
+    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ?`;
+    params = [ss58];
   } else if (direction === "received") {
-    sideClause = "coldkey = ?";
-    sideParams = [ss58];
+    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ?`;
+    params = [ss58];
+  } else {
+    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM (SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ? UNION ALL SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ? AND hotkey <> ?)`;
+    params = [ss58, ss58, ss58];
   }
-  const rows = await d1(
-    `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE event_kind = 'Transfer' AND ${sideClause} ORDER BY block_number DESC, event_index DESC LIMIT ? OFFSET ?`,
-    [...sideParams, lim, off],
-  );
+  sql += " ORDER BY block_number DESC, event_index DESC LIMIT ? OFFSET ?";
+  params.push(lim, off);
+  const rows = await d1(sql, params);
   return buildAccountTransfers(rows, ss58, { limit: lim, offset: off });
 }

--- a/tests/account-events-branch-coverage.test.mjs
+++ b/tests/account-events-branch-coverage.test.mjs
@@ -166,6 +166,7 @@ describe("loadAccountTransfers direction clauses", () => {
     const d1 = makeD1([[]]);
     await loadAccountTransfers(d1, "5Hk", { direction: "sent" });
     const { sql, params } = d1.calls[0];
+    assert.ok(/INDEXED BY idx_account_events_hotkey/.test(sql));
     assert.ok(/hotkey = \?/.test(sql));
     assert.ok(!/coldkey = \?/.test(sql)); // only the sent (hotkey) side clause
     // sideParams=[ss58] then lim, off bound.
@@ -176,8 +177,12 @@ describe("loadAccountTransfers direction clauses", () => {
     const d1 = makeD1([[{ block_number: 1, hotkey: "5Hk", observed_at: 1 }]]);
     const out = await loadAccountTransfers(d1, "5Hk", {});
     const { sql, params } = d1.calls[0];
-    assert.ok(/\(hotkey = \? OR coldkey = \?\)/.test(sql));
-    assert.deepEqual(params, ["5Hk", "5Hk", 100, 0]);
+    assert.ok(/UNION ALL/.test(sql));
+    assert.ok(/INDEXED BY idx_account_events_hotkey/.test(sql));
+    assert.ok(/INDEXED BY idx_account_events_coldkey/.test(sql));
+    assert.ok(/coldkey = \? AND hotkey <> \?/.test(sql));
+    assert.equal(sql.includes(" OR "), false);
+    assert.deepEqual(params, ["5Hk", "5Hk", "5Hk", 100, 0]);
     assert.equal(out.transfer_count, 1);
   });
 });

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1537,9 +1537,21 @@ describe("handleAccountTransfers", () => {
         ),
       ),
     );
-    const sql = captures.sql.find((s) => /Transfer/.test(s));
+    const idx = captures.sql.findIndex((s) => /Transfer/.test(s));
+    assert.ok(idx !== -1);
+    const sql = captures.sql[idx];
     assert.ok(/\(block_number, event_index\) < \(\?, \?\)/.test(sql));
     assert.ok(!/OFFSET/.test(sql));
+    assert.deepEqual(captures.params[idx], [
+      SS58,
+      200,
+      1,
+      SS58,
+      SS58,
+      200,
+      1,
+      1,
+    ]);
     assert.equal(body.data.next_cursor, encodeCursor([150, 2]));
   });
 

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1476,7 +1476,7 @@ describe("handleAccountTransfers", () => {
   });
 
   test("happy path reshapes Transfer rows (all direction)", async () => {
-    const { env } = dbWith({ transfers: [transferEventRow()] });
+    const { env, captures } = dbWith({ transfers: [transferEventRow()] });
     const body = await json(
       await handleAccountTransfers(
         req(`/api/v1/accounts/${SS58}/transfers`),
@@ -1488,6 +1488,11 @@ describe("handleAccountTransfers", () => {
     assert.equal(body.data.transfer_count, 1);
     assert.equal(body.data.transfers[0].from, SS58);
     assert.equal(body.data.transfers[0].amount_tao, 4.2);
+    const sql = captures.sql.find((s) => /Transfer/.test(s));
+    assert.ok(/UNION ALL/.test(sql));
+    assert.ok(/hotkey = \?/.test(sql));
+    assert.ok(/coldkey = \? AND hotkey <> \?/.test(sql));
+    assert.equal(sql.includes(" OR "), false);
   });
 
   test("direction=sent binds hotkey-only clause", async () => {
@@ -1611,13 +1616,13 @@ describe("handleAccountCounterparties", () => {
     assert.equal(body.data.ss58, SS58);
     assert.equal(body.data.counterparty_count, 2); // A, B
     assert.equal(body.data.counterparties[0].address, "B"); // highest volume (200)
-    // Read is a Transfer scan bound to the account on both sides.
-    const idx = captures.sql.findIndex((s) =>
-      /event_kind = 'Transfer' AND \(hotkey = \? OR coldkey = \?\)/.test(s),
+    // Read is two Transfer side seeks bound to the account, not a hotkey/coldkey OR.
+    const idx = captures.sql.findIndex(
+      (s) => /UNION ALL/.test(s) && /coldkey = \? AND hotkey <> \?/.test(s),
     );
     assert.ok(idx !== -1);
-    assert.equal(captures.params[idx][0], SS58);
-    assert.equal(captures.params[idx][1], SS58);
+    assert.equal(captures.sql[idx].includes(" OR "), false);
+    assert.deepEqual(captures.params[idx].slice(0, 3), [SS58, SS58, SS58]);
   });
 });
 

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -652,27 +652,30 @@ export async function handleAccountTransfers(request, env, ss58, url) {
   }
   const { limit, offset, cursor } = parsePagination(url, FEED_PAGINATION);
   // sent => this account is the sender (hotkey=from); received => recipient
-  // (coldkey=to); default/all => either side.
-  let sideClause = "(hotkey = ? OR coldkey = ?)";
-  let sideParams = [ss58, ss58];
-  if (direction === "sent") {
-    sideClause = "hotkey = ?";
-    sideParams = [ss58];
-  } else if (direction === "received") {
-    sideClause = "coldkey = ?";
-    sideParams = [ss58];
-  }
-  // Keyset (cursor) pagination mirrors loadAccountEvents/handleExtrinsicsFeed: a
-  // (block_number, event_index) row-value seek, stable + O(limit) at depth on the
-  // large account_events tier. offset stays as a deprecated fallback; cursor wins.
+  // (coldkey=to); default/all => either side. Keep the default read as two
+  // side-specific seeks rather than an OR predicate so D1 cannot satisfy only
+  // event_kind='Transfer' from the pair index and then filter all Transfer rows.
+  // Self-transfers are returned once, matching the old OR semantics.
   const cur = decodeCursor(cursor, 2);
   const useCursor = Boolean(cur);
-  const params = [...sideParams];
-  let sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE event_kind = 'Transfer' AND ${sideClause}`;
-  if (useCursor) {
-    sql += " AND (block_number, event_index) < (?, ?)";
-    params.push(cur[0], cur[1]);
+  const cursorClause = useCursor
+    ? " AND (block_number, event_index) < (?, ?)"
+    : "";
+  let params;
+  let sql;
+  if (direction === "sent") {
+    params = [ss58];
+    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ?${cursorClause}`;
+  } else if (direction === "received") {
+    params = [ss58];
+    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ?${cursorClause}`;
+  } else {
+    params = [ss58];
+    if (useCursor) params.push(cur[0], cur[1]);
+    params.push(ss58, ss58);
+    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM (SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ?${cursorClause} UNION ALL SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ? AND hotkey <> ?${cursorClause})`;
   }
+  if (useCursor) params.push(cur[0], cur[1]);
   sql += " ORDER BY block_number DESC, event_index DESC LIMIT ?";
   params.push(limit);
   if (!useCursor) {
@@ -783,8 +786,8 @@ export async function handleAccountCounterparties(request, env, ss58, url) {
   }
   const rows = await d1All(
     env,
-    `SELECT ${COUNTERPARTIES_READ_COLUMNS} FROM account_events WHERE event_kind = 'Transfer' AND (hotkey = ? OR coldkey = ?) ORDER BY block_number DESC LIMIT ?`,
-    [ss58, ss58, COUNTERPARTIES_SCAN_CAP],
+    `SELECT ${COUNTERPARTIES_READ_COLUMNS} FROM (SELECT ${COUNTERPARTIES_READ_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ? UNION ALL SELECT ${COUNTERPARTIES_READ_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ? AND hotkey <> ?) ORDER BY block_number DESC LIMIT ?`,
+    [ss58, ss58, ss58, COUNTERPARTIES_SCAN_CAP],
   );
   const data = buildCounterparties(rows, ss58, { limit });
   return envelopeResponse(


### PR DESCRIPTION
### Motivation

- Public account Transfer reads used `hotkey = ? OR coldkey = ?`, which can let SQLite/D1 choose a low-selectivity plan and scan too many Transfer rows.
- The REST route, counterparty rollup, and MCP/shared account transfer loader should all force side-specific account indexes while preserving existing response semantics.

### Description

- Rewrite `handleAccountTransfers` to use hotkey/coldkey indexed side seeks for `sent`, `received`, and all-direction reads.
- Rewrite the all-direction transfer and counterparty rollup paths with `UNION ALL` plus `hotkey <> ?` on the coldkey branch so self-transfers are still returned once.
- Apply the same indexed-seek pattern to `loadAccountTransfers`, which backs the MCP `get_account_transfers` tool.
- Add tests for the SQL shape, self-transfer de-dup guard, and all-direction cursor bind order.

### Testing

- `npm test -- --run tests/request-handlers-entities.test.mjs`
- `npm test -- --run tests/account-events-branch-coverage.test.mjs tests/request-handlers-entities.test.mjs`
- `npm test -- --run tests/mcp-server.test.mjs -t get_account_transfers`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42a948a8d4832c837b2232df25f0ab)