### PR TITLE
fix(api): clamp a sub-perfect reliability score below a perfect 100

### DIFF
--- a/src/reliability.mjs
+++ b/src/reliability.mjs
@@ -60,7 +60,18 @@ export function scoreFromStats({
             (avgLatencyMs - LATENCY_FREE_MS) * LATENCY_PENALTY_PER_MS,
           ),
         );
-  const score = Math.max(0, Math.round(uptimeScore - latencyPenalty));
+  let score = Math.max(0, Math.round(uptimeScore - latencyPenalty));
+  // Apply the same anti-overstatement guard `displayUptimeRatio` enforces for the
+  // displayed ratio (#1799) and turnover's `stability_score` enforces for its 0–100
+  // composite (#2299): a sub-perfect uptime must never round the 0–100 score up to a
+  // flawless 100. okCount/samples = 24999/25000 = 0.99996 yields uptimeScore 99.996,
+  // and `Math.round` lifts that to 100 — reporting a perfect reliability score (and
+  // the top grade) for a surface that demonstrably failed a probe, while the very same
+  // call honestly reports `uptime_ratio: 0.9999`. Clamp the score to 99 whenever uptime
+  // is sub-perfect; only a genuine okCount === samples (uptimeRatio exactly 1) keeps the
+  // perfect 100. (Any latencyPenalty already pulls the score below 100, so this only
+  // fires when uptime alone rounded up to a 100.)
+  if (score >= 100 && uptimeRatio < 1) score = 99;
   return {
     score,
     grade: gradeFor(score),

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -2540,6 +2540,33 @@ describe("computeReliability (score from uptime history)", () => {
     );
   });
 
+  test("a sub-perfect uptime must not round the 0-100 score up to a perfect 100", () => {
+    // The same 24999/25000 = 0.99996 input whose displayed ratio clamps to 0.9999
+    // above: uptimeScore = 99.996, which a bare Math.round lifts to 100 — overstating
+    // a surface that demonstrably failed a probe as a flawless 100 (and grade A),
+    // contradicting the honest uptime_ratio on the very same object. It must clamp to 99.
+    const subPerfect = scoreFromStats({
+      samples: 25000,
+      okCount: 24999,
+      avgLatencyMs: null,
+    });
+    assert.equal(subPerfect.score, 99);
+    assert.equal(subPerfect.uptime_ratio, 0.9999);
+    // 99 still grades A (>=99), so the grade is unchanged — only the overstated 100 is.
+    assert.equal(subPerfect.grade, "A");
+    // a genuine perfect uptime (okCount === samples) still scores an honest 100.
+    assert.equal(
+      scoreFromStats({ samples: 25000, okCount: 25000, avgLatencyMs: null })
+        .score,
+      100,
+    );
+    // an already-sub-100 score is untouched by the clamp (90% uptime -> 90).
+    assert.equal(
+      scoreFromStats({ samples: 100, okCount: 90, avgLatencyMs: null }).score,
+      90,
+    );
+  });
+
   test("covers grade B, null latency, missing day, and nullish rows", () => {
     // grade B (95-98)
     assert.equal(


### PR DESCRIPTION
## Summary

`scoreFromStats` in `src/reliability.mjs` builds the 0–100 reliability `score` as `Math.round(uptimeScore - latencyPenalty)`, where `uptimeScore = uptime_ratio * 100`. A sub-perfect uptime such as `24999/25000 = 0.99996` produces `uptimeScore = 99.996`, which `Math.round` lifts to a flawless **100** (and grade **A**) for a surface that demonstrably failed a probe.

This contradicts the module's own anti-overstatement intent: `displayUptimeRatio` (#1799) already clamps the displayed `uptime_ratio` on the **same** result object to `0.9999`, so the response reports `uptime_ratio: 0.9999` next to a perfect `score: 100`.

## Fix

Apply the same guard `displayUptimeRatio` enforces for the ratio and `buildTurnover` enforces for `stability_score` (#2299): clamp the score to **99** when uptime is sub-perfect. Only a genuine `okCount === samples` (uptime ratio exactly 1) keeps the perfect 100. A `latencyPenalty` already pulls the score below 100, so this only fires when uptime alone rounded up.

`99` still grades **A** (`>= 99`), so grades are unchanged — only the overstated `100` becomes an honest `99`.

## Validation

- `npx vitest run tests/health-serving.test.mjs` — 132 passed (added a regression test covering the sub-perfect score, the genuine perfect 100, and an unaffected sub-100 score)
- `npx eslint src/reliability.mjs tests/health-serving.test.mjs` — clean
- `npx prettier --check` — clean
