### PR TITLE
feat(badge): add style=for-the-badge render style

### DIFF
--- a/src/badge.mjs
+++ b/src/badge.mjs
@@ -14,6 +14,8 @@
 //                      (subnet-api / openapi / sse / data-artifact); informational
 //                      blue, gray for 0; for a provider, the sum across its subnets
 //   style=flat-square  square corners, no gradient (default: flat)
+//   style=for-the-badge  the shields.io all-caps style: taller, bold, letter-
+//                      spaced, uppercase, square + matte
 //   label=…            override the left "metagraphed" segment text
 //
 // Worker-computed image/svg+xml, read-only, edge-cached, CORS-open. Unknown
@@ -37,7 +39,7 @@ const BADGE_METRICS = {
   apis: "apis",
 };
 // Allow-listed render styles; an unknown value falls back to "flat".
-const BADGE_STYLES = new Set(["flat", "flat-square"]);
+const BADGE_STYLES = new Set(["flat", "flat-square", "for-the-badge"]);
 // shields.io "informational" blue, used for plain-count metrics (e.g. apis).
 const INFO_COLOR = "#007ec6";
 // Surface kinds that are callable machine interfaces (mirrors the build's
@@ -120,36 +122,54 @@ export function gradeColor(grade) {
 }
 
 // Render a two-segment badge: gray label + colored message. `style` is "flat"
-// (rounded + glossy gradient) or "flat-square" (square, matte).
+// (rounded + glossy gradient), "flat-square" (square, matte), or "for-the-badge"
+// (shields.io's taller, bold, uppercase, letter-spaced style — square + matte).
 export function renderBadge(message, color, options = {}) {
   const { label = BADGE_LABEL, style = "flat" } = options;
-  const eLabel = escapeXml(label);
-  const eMsg = escapeXml(message);
-  const pad = 12;
-  const labelW = textWidth(label) + pad;
-  const msgW = textWidth(message) + pad;
+  const forTheBadge = style === "for-the-badge";
+  // for-the-badge uppercases the text; the other styles render it verbatim.
+  const labelText = forTheBadge ? String(label).toUpperCase() : String(label);
+  const msgText = forTheBadge ? String(message).toUpperCase() : String(message);
+  const eLabel = escapeXml(labelText);
+  const eMsg = escapeXml(msgText);
+  const height = forTheBadge ? 28 : 20;
+  const pad = forTheBadge ? 18 : 12;
+  const spacing = forTheBadge ? 1.25 : 0;
+  // Segment width: glyph estimate + letter-spacing (applied after every glyph) +
+  // padding — all safe overestimates, so the text never clips its segment. With
+  // spacing 0 + pad 12 this is exactly the original flat/flat-square geometry.
+  const segWidth = (t) => textWidth(t) + spacing * [...t].length + pad;
+  const labelW = segWidth(labelText);
+  const msgW = segWidth(msgText);
   const total = labelW + msgW;
   const labelMid = labelW / 2;
   const msgMid = labelW + msgW / 2;
-  const square = style === "flat-square";
+  const square = forTheBadge || style === "flat-square";
   const rx = square ? 0 : 3;
+  const mainY = forTheBadge ? 18 : 14;
+  const shadowY = mainY + 1;
+  const textAttrs = forTheBadge
+    ? ` font-size="10" font-weight="bold" letter-spacing="${spacing}"`
+    : ` font-size="11"`;
   return [
-    `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="20" role="img" aria-label="${eLabel}: ${eMsg}">`,
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="${height}" role="img" aria-label="${eLabel}: ${eMsg}">`,
     `<title>${eLabel}: ${eMsg}</title>`,
     square
       ? null
       : `<linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>`,
-    `<clipPath id="r"><rect width="${total}" height="20" rx="${rx}" fill="#fff"/></clipPath>`,
+    `<clipPath id="r"><rect width="${total}" height="${height}" rx="${rx}" fill="#fff"/></clipPath>`,
     `<g clip-path="url(#r)">`,
-    `<rect width="${labelW}" height="20" fill="#555"/>`,
-    `<rect x="${labelW}" width="${msgW}" height="20" fill="${color}"/>`,
-    square ? null : `<rect width="${total}" height="20" fill="url(#s)"/>`,
+    `<rect width="${labelW}" height="${height}" fill="#555"/>`,
+    `<rect x="${labelW}" width="${msgW}" height="${height}" fill="${color}"/>`,
+    square
+      ? null
+      : `<rect width="${total}" height="${height}" fill="url(#s)"/>`,
     `</g>`,
-    `<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">`,
-    `<text x="${labelMid}" y="15" fill="#010101" fill-opacity=".3">${eLabel}</text>`,
-    `<text x="${labelMid}" y="14">${eLabel}</text>`,
-    `<text x="${msgMid}" y="15" fill="#010101" fill-opacity=".3">${eMsg}</text>`,
-    `<text x="${msgMid}" y="14">${eMsg}</text>`,
+    `<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif"${textAttrs}>`,
+    `<text x="${labelMid}" y="${shadowY}" fill="#010101" fill-opacity=".3">${eLabel}</text>`,
+    `<text x="${labelMid}" y="${mainY}">${eLabel}</text>`,
+    `<text x="${msgMid}" y="${shadowY}" fill="#010101" fill-opacity=".3">${eMsg}</text>`,
+    `<text x="${msgMid}" y="${mainY}">${eMsg}</text>`,
     `</g>`,
     `</svg>`,
     ``,

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -138,6 +138,37 @@ describe("badge — rendering", () => {
     assert.ok((square.match(/<text /g) || []).length === 4);
   });
 
+  test("renderBadge style=for-the-badge: taller, uppercase, bold, square, matte", () => {
+    const svg = renderBadge("ok", "#2ea44f", {
+      label: "metagraphed",
+      style: "for-the-badge",
+    });
+    assert.match(svg, /height="28"/); // taller than the 20px default
+    assert.match(svg, /rx="0"/); // square corners
+    assert.ok(!svg.includes("linearGradient")); // matte, no gradient
+    assert.match(svg, /font-weight="bold"/);
+    assert.match(svg, /letter-spacing="1.25"/);
+    assert.match(svg, /font-size="10"/);
+    // Text is uppercased (both label and message).
+    assert.match(svg, /aria-label="METAGRAPHED: OK"/);
+    assert.ok(
+      svg.includes(">METAGRAPHED</text>") && svg.includes(">OK</text>"),
+    );
+    assert.ok((svg.match(/<text /g) || []).length === 4);
+  });
+
+  test("flat / flat-square output is unchanged by the for-the-badge refactor", () => {
+    const svg = renderBadge("92/100", "#2ea44f");
+    assert.match(svg, /height="20"/);
+    assert.match(svg, /rx="3"/);
+    assert.match(svg, /font-size="11"/);
+    assert.ok(!svg.includes("font-weight"));
+    assert.ok(!svg.includes("letter-spacing"));
+    assert.match(svg, /linearGradient/);
+    assert.match(svg, / y="14"/);
+    assert.match(svg, / y="15"/);
+  });
+
   test("scoreColor thresholds (green / amber / red / gray)", () => {
     assert.equal(scoreColor(92), "#2ea44f");
     assert.equal(scoreColor(80), "#2ea44f");
@@ -175,6 +206,10 @@ describe("badge — rendering", () => {
     assert.equal(
       parseBadgeOptions(sp("style=flat-square")).style,
       "flat-square",
+    );
+    assert.equal(
+      parseBadgeOptions(sp("style=for-the-badge")).style,
+      "for-the-badge",
     );
     assert.equal(parseBadgeOptions(sp("style=plastic")).style, "flat");
     // label: default brand; override kept; control chars stripped; capped; blank→brand.


### PR DESCRIPTION
## Summary

Adds `?style=for-the-badge` to the embeddable badge, alongside the existing `flat` (default) and `flat-square`. It renders the same two-segment badge — same `metric`/`label`/color logic — in shields.io's popular **for-the-badge** look.

Closes #2340

## Behavior

- Taller (28px), **uppercase** text, **bold**, letter-spaced, square corners, matte (no gradient).
- Works with every existing option: `?metric=…`, `?label=…`, subnet + provider badges.
- Unknown styles still fall back to `flat`.

## Scope

- Self-contained in `src/badge.mjs` — `renderBadge` is parametrized by style; no schema/contract/artifact change (badges aren't part of the typed OpenAPI envelope), so nothing to regenerate.
- **`flat` / `flat-square` output is byte-identical to before** (with spacing 0 + pad 12 the geometry is unchanged) — guarded by an explicit regression test.
- The per-segment width estimate stays a safe overestimate (glyph width + letter-spacing + padding), so the larger for-the-badge glyphs never clip.

## Tests (`tests/badge.test.mjs`)

- `for-the-badge` renders taller/uppercase/bold/square/matte with both text layers.
- A regression test asserting `flat`/`flat-square` output is unchanged by the refactor.
- The `style=for-the-badge` allow-list assertion.

```
✓ tests/badge.test.mjs (43 tests)
```

`eslint` and `prettier --check` clean on both files. Full local `vitest` run shows no new failures (only the pre-existing Windows-only env files, which pass on Linux CI).