### PR TITLE
feat(mcp): add get_chain_signers tool mirroring REST /chain/signers (#2342)

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -396,6 +396,14 @@ assert.equal(
   true,
   "get_chain_activity must isError without the DATA_API binding",
 );
+const signersCold = await callOk("get_chain_signers", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  Array.isArray(signersCold.signers) && signersCold.window === "7d",
+  "get_chain_signers must return window + signers[] on cold D1",
+);
 
 // --- Negative paths --------------------------------------------------------
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/chain-query-loaders.mjs
+++ b/src/chain-query-loaders.mjs
@@ -1,12 +1,13 @@
-// Shared chain-signers D1 loader for REST + MCP parity (#1990). Pure
+// Shared chain-signers D1 loader for REST + MCP parity (#2342). Pure
 // orchestration over extrinsics-tier rows + buildChainSigners; REST handlers keep
 // edge-cache + envelope wiring.
 
 import { DAY_MS } from "../workers/config.mjs";
 import { buildChainSigners } from "./chain-analytics.mjs";
 
-// Windowed most-active-account leaderboard (#1990): signers ranked by extrinsic
-// count over the window. Optional call_module scopes to one pallet.
+// Windowed most-active-account leaderboard (#2342): signers ranked by extrinsic
+// count over the window (ties broken by signer ASC for stable ordering).
+// Optional call_module scopes to one pallet.
 export async function loadChainSigners(
   d1Runner,
   { windowLabel, windowDays, observedAt = null, limit = 50, callModule = null },

--- a/src/chain-query-loaders.mjs
+++ b/src/chain-query-loaders.mjs
@@ -1,0 +1,36 @@
+// Shared chain D1 query loaders for REST + MCP parity (#1990 signers, #1989 calls,
+// #1988 fees). Pure orchestration over extrinsics-tier rows + chain-analytics
+// builders; REST handlers keep edge-cache + envelope wiring.
+
+import { DAY_MS } from "../workers/config.mjs";
+import { buildChainSigners } from "./chain-analytics.mjs";
+
+// Windowed most-active-account leaderboard (#1990): signers ranked by extrinsic
+// count over the window. Optional call_module scopes to one pallet.
+export async function loadChainSigners(
+  d1Runner,
+  { windowLabel, windowDays, observedAt = null, limit = 50, callModule = null },
+) {
+  const cutoff = Date.now() - windowDays * DAY_MS;
+  const moduleClause = callModule ? " AND call_module = ?" : "";
+  const params = callModule ? [cutoff, callModule, limit] : [cutoff, limit];
+  const rows = await d1Runner(
+    `SELECT signer,
+            COUNT(*) AS tx_count,
+            SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
+            SUM(COALESCE(tip_tao, 0)) AS total_tip_tao,
+            MAX(block_number) AS last_tx_block
+     FROM extrinsics
+     WHERE observed_at >= ? AND signer IS NOT NULL${moduleClause}
+     GROUP BY signer
+     ORDER BY tx_count DESC
+     LIMIT ?`,
+    params,
+  );
+  const data = buildChainSigners({
+    window: windowLabel,
+    observedAt,
+    rows,
+  });
+  return { data, rows };
+}

--- a/src/chain-query-loaders.mjs
+++ b/src/chain-query-loaders.mjs
@@ -1,6 +1,6 @@
-// Shared chain D1 query loaders for REST + MCP parity (#1990 signers, #1989 calls,
-// #1988 fees). Pure orchestration over extrinsics-tier rows + chain-analytics
-// builders; REST handlers keep edge-cache + envelope wiring.
+// Shared chain-signers D1 loader for REST + MCP parity (#1990). Pure
+// orchestration over extrinsics-tier rows + buildChainSigners; REST handlers keep
+// edge-cache + envelope wiring.
 
 import { DAY_MS } from "../workers/config.mjs";
 import { buildChainSigners } from "./chain-analytics.mjs";
@@ -23,7 +23,7 @@ export async function loadChainSigners(
      FROM extrinsics
      WHERE observed_at >= ? AND signer IS NOT NULL${moduleClause}
      GROUP BY signer
-     ORDER BY tx_count DESC
+     ORDER BY tx_count DESC, signer ASC
      LIMIT ?`,
     params,
   );

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -2342,13 +2342,11 @@ export const MCP_TOOLS = [
       additionalProperties: false,
     },
     async handler(args, ctx) {
-      if (
-        args?.window !== undefined &&
-        parseAnalyticsWindow(args.window) === null
-      ) {
+      const parsed = parseAnalyticsWindow(args?.window ?? "7d");
+      if (args?.window !== undefined && parsed === null) {
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
-      const { label, days } = parseAnalyticsWindow(args?.window ?? "7d");
+      const { label, days } = parsed;
       const limit = clampLimit(args?.limit, 50, 100);
       const callModule = optionalString(args, "call_module");
       if (callModule != null && callModule.length > 100) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -29,6 +29,7 @@ import {
   loadSubnetConcentrationHistory,
   parseConcentrationHistoryWindow,
 } from "./concentration.mjs";
+import { loadChainSigners } from "./chain-query-loaders.mjs";
 import {
   loadCompareSubnets,
   loadGlobalIncidents,
@@ -188,7 +189,8 @@ export const MCP_INSTRUCTIONS =
   "boundary snapshots, get_registry_leaderboards the live " +
   "cross-subnet health/economics boards, compare_subnets a side-by-side view " +
   "across structure/economics/health, get_global_incidents recent cross-subnet " +
-  "probe failures, get_subnet_metagraph the " +
+  "probe failures, get_chain_signers the windowed most-active-account " +
+  "leaderboard (extrinsic counts + fees), get_subnet_metagraph the " +
   "per-UID neuron snapshot (validator_permit filters to validators), " +
   "list_subnet_validators its validators ranked by stake, and get_neuron one " +
   "UID — use these to decide where to mine or validate. For wallet lookup, " +
@@ -2310,6 +2312,62 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_chain_signers",
+    title: "Get the most-active account signers",
+    description:
+      "Fetch the windowed most-active-account leaderboard: signers ranked by " +
+      "extrinsic count over the requested window (7d or 30d), with total fees, " +
+      "tips, and last signed block. Optionally scope to one pallet via " +
+      "call_module. Mirrors GET /api/v1/chain/signers.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: ["7d", "30d"],
+          description: "Lookback window (default 7d).",
+        },
+        limit: {
+          type: "integer",
+          description: "Max signers to return (1-100, default 50).",
+          minimum: 1,
+          maximum: 100,
+        },
+        call_module: {
+          type: "string",
+          description:
+            "Optional pallet filter (e.g. Balances); omit for all modules.",
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      if (
+        args?.window !== undefined &&
+        parseAnalyticsWindow(args.window) === null
+      ) {
+        throw toolError("invalid_params", "window must be one of: 7d, 30d.");
+      }
+      const { label, days } = parseAnalyticsWindow(args?.window ?? "7d");
+      const limit = clampLimit(args?.limit, 50, 100);
+      const callModule = optionalString(args, "call_module");
+      if (callModule != null && callModule.length > 100) {
+        throw toolError(
+          "invalid_params",
+          "call_module must be at most 100 characters.",
+        );
+      }
+      const { data } = await loadChainSigners(mcpD1Runner(ctx), {
+        windowLabel: label,
+        windowDays: days,
+        observedAt: await mcpObservedAt(ctx),
+        limit,
+        callModule,
+      });
+      return data;
+    },
+  },
+  {
     name: "list_subnet_apis",
     title: "List a subnet's callable services",
     description:
@@ -3760,6 +3818,24 @@ const TOOL_OUTPUT_SCHEMAS = {
         pallet: NULLABLE_STRING,
         method: NULLABLE_STRING,
         count: NULLABLE_INT,
+      }),
+    },
+  },
+  get_chain_signers: {
+    type: "object",
+    additionalProperties: true,
+    required: ["window", "signer_count", "signers"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: { type: "string" },
+      observed_at: NULLABLE_STRING,
+      signer_count: { type: "integer" },
+      signers: objectItems({
+        signer: NULLABLE_STRING,
+        tx_count: NULLABLE_INT,
+        total_fee_tao: { type: ["number", "null"] },
+        total_tip_tao: { type: ["number", "null"] },
+        last_tx_block: NULLABLE_INT,
       }),
     },
   },

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -126,7 +126,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.8.0";
+export const MCP_SERVER_VERSION = "1.9.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",

--- a/tests/chain-query-loaders.test.mjs
+++ b/tests/chain-query-loaders.test.mjs
@@ -35,6 +35,23 @@ describe("loadChainSigners", () => {
 
   test("omits the module clause when callModule is null", async () => {
     let sql = "";
+    let params;
+    await loadChainSigners(
+      async (query, bound) => {
+        sql = query;
+        params = bound;
+        return [];
+      },
+      { windowLabel: "7d", windowDays: 7, limit: 5 },
+    );
+    assert.doesNotMatch(sql, /call_module/);
+    assert.equal(params.length, 2);
+    assert.equal(params[1], 5);
+    assert.equal(typeof params[0], "number");
+  });
+
+  test("orders equal tx_count rows by signer ASC in SQL", async () => {
+    let sql = "";
     await loadChainSigners(
       async (query) => {
         sql = query;
@@ -42,6 +59,6 @@ describe("loadChainSigners", () => {
       },
       { windowLabel: "7d", windowDays: 7, limit: 5 },
     );
-    assert.doesNotMatch(sql, /call_module/);
+    assert.match(sql, /ORDER BY tx_count DESC, signer ASC/);
   });
 });

--- a/tests/chain-query-loaders.test.mjs
+++ b/tests/chain-query-loaders.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadChainSigners } from "../src/chain-query-loaders.mjs";
+
+describe("loadChainSigners", () => {
+  test("builds a ranked leaderboard from extrinsic rows", async () => {
+    const calls = [];
+    const d1Runner = async (sql, params) => {
+      calls.push({ sql, params });
+      return [
+        {
+          signer: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+          tx_count: 8,
+          total_fee_tao: 2,
+          total_tip_tao: 0.5,
+          last_tx_block: 100,
+        },
+      ];
+    };
+    const { data, rows } = await loadChainSigners(d1Runner, {
+      windowLabel: "30d",
+      windowDays: 30,
+      observedAt: "2026-06-01T00:00:00.000Z",
+      limit: 10,
+      callModule: "Balances",
+    });
+    assert.equal(rows.length, 1);
+    assert.equal(data.window, "30d");
+    assert.equal(data.signer_count, 1);
+    assert.equal(data.signers[0].tx_count, 8);
+    assert.match(calls[0].sql, /call_module = \?/);
+    assert.equal(calls[0].params[1], "Balances");
+    assert.equal(calls[0].params[2], 10);
+  });
+
+  test("omits the module clause when callModule is null", async () => {
+    let sql = "";
+    await loadChainSigners(
+      async (query) => {
+        sql = query;
+        return [];
+      },
+      { windowLabel: "7d", windowDays: 7, limit: 5 },
+    );
+    assert.doesNotMatch(sql, /call_module/);
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1630,6 +1630,62 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
   });
 });
 
+describe("MCP get_chain_signers", () => {
+  test("returns signers ranked by tx_count from D1", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              return {
+                async all() {
+                  assert.match(sql, /FROM extrinsics/);
+                  assert.ok(params.includes(50));
+                  return {
+                    results: [
+                      {
+                        signer:
+                          "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                        tx_count: 12,
+                        total_fee_tao: 1.5,
+                        total_tip_tao: 0.25,
+                        last_tx_block: 4200000,
+                      },
+                    ],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const res = await callTool(
+      "get_chain_signers",
+      { window: "7d", limit: 50 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.signer_count, 1);
+    assert.equal(out.signers[0].tx_count, 12);
+    assert.equal(out.signers[0].total_fee_tao, 1.5);
+  });
+
+  test("rejects an invalid window", async () => {
+    const res = await callTool("get_chain_signers", { window: "99d" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/i);
+  });
+
+  test("returns an empty leaderboard on a cold D1 store", async () => {
+    const res = await callTool("get_chain_signers", {}, {});
+    const out = res.body.result.structuredContent;
+    assert.equal(out.signer_count, 0);
+    assert.deepEqual(out.signers, []);
+  });
+});
+
 // keyword-search.test.mjs covers the scoring matrix; here we only prove both
 // tools are wired to it — substring noise is gone and the precise target wins.
 describe("MCP keyword discovery relevance", () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1678,6 +1678,45 @@ describe("MCP get_chain_signers", () => {
     assert.match(res.body.result.content[0].text, /window/i);
   });
 
+  test("rejects an over-long call_module", async () => {
+    const res = await callTool(
+      "get_chain_signers",
+      { call_module: "x".repeat(101) },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /call_module/i);
+  });
+
+  test("scopes the leaderboard by call_module", async () => {
+    let boundModule;
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              boundModule = params[1];
+              return {
+                async all() {
+                  assert.match(sql, /call_module = \?/);
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const res = await callTool(
+      "get_chain_signers",
+      { window: "30d", call_module: "Balances", limit: 10 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(boundModule, "Balances");
+  });
+
   test("returns an empty leaderboard on a cold D1 store", async () => {
     const res = await callTool("get_chain_signers", {}, {});
     const out = res.body.result.structuredContent;

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -61,8 +61,8 @@ import {
   buildChainActivity,
   buildChainCalls,
   buildChainFees,
-  buildChainSigners,
 } from "../../src/chain-analytics.mjs";
+import { loadChainSigners } from "../../src/chain-query-loaders.mjs";
 
 // Injected once from api.mjs (see configureAnalytics). The in-isolate memoized
 // snapshot-meta read lives in api.mjs because the deferred handler clusters and a
@@ -890,33 +890,19 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
   const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
-  const moduleClause = callModule ? " AND call_module = ?" : "";
   return withEdgeCache(
     request,
     ctx,
     env,
     "chain-signers",
     async () => {
-      const cutoff = Date.now() - days * DAY_MS;
-      const rows = await d1All(
-        env,
-        `SELECT signer,
-              COUNT(*) AS tx_count,
-              SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
-              SUM(COALESCE(tip_tao, 0)) AS total_tip_tao,
-              MAX(block_number) AS last_tx_block
-       FROM extrinsics
-       WHERE observed_at >= ? AND signer IS NOT NULL${moduleClause}
-       GROUP BY signer
-       ORDER BY tx_count DESC
-       LIMIT ?`,
-        callModule ? [cutoff, callModule, limit] : [cutoff, limit],
-      );
       const meta = await readHealthMetaKv(env);
-      const data = buildChainSigners({
-        window: label,
+      const { data, rows } = await loadChainSigners(d1Runner(env), {
+        windowLabel: label,
+        windowDays: days,
         observedAt: meta?.last_run_at || null,
-        rows,
+        limit,
+        callModule,
       });
       const response = await envelopeResponse(
         request,


### PR DESCRIPTION
## Summary

REST exposes `GET /api/v1/chain/signers` for the windowed most-active-account leaderboard, but MCP clients had no equivalent. This PR extracts a shared D1 loader and adds `get_chain_signers` so agents can query signer activity without falling back to HTTP.

Closes #2342

## Scope summary

| Area | Change |
|------|--------|
| **Files touched** | 6 — `src/chain-query-loaders.mjs` (new), `workers/request-handlers/analytics.mjs`, `src/mcp-server.mjs`, `tests/chain-query-loaders.test.mjs`, `tests/mcp-server.test.mjs`, `scripts/validate-mcp.mjs` |
| **Behavior** | MCP `get_chain_signers` mirrors REST: 7d/30d window, limit 1–100, optional `call_module` filter |
| **Schema / contract** | New MCP tool + output schema; REST response unchanged |
| **Generated artifacts** | None committed |

## Conflict avoidance

This PR intentionally avoids files touched by open PRs:
- No `entities.mjs` (#2328, #2319, #2339)
- No `analytics-routes.mjs` / `neuron-history.mjs` (#2324 economics trends)
- No `analytics-live.mjs` (#2337 health trends)
- Loader lives in a new module (`chain-query-loaders.mjs`) instead of `analytics-live.mjs`

## What changed

- Extract `loadChainSigners` into `src/chain-query-loaders.mjs` (D1 query + `buildChainSigners`)
- Wire REST `handleChainSigners` through the shared loader (preserves D1-fallback marking)
- Add MCP tool `get_chain_signers` after `get_chain_activity` with instructions + output schema
- Unit tests for loader + MCP integration tests (success, invalid window, cold D1)
- `validate-mcp.mjs` smoke call

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts committed.
- [x] No breaking public API changes; REST chain/signers behavior preserved.

## Validation

- [x] `npx vitest run tests/chain-query-loaders.test.mjs` — 2 passed
- [x] `npx vitest run tests/mcp-server.test.mjs -t get_chain_signers` — 3 passed
- [x] `npx vitest run tests/chain-analytics.test.mjs -t chain/signers` — 3 passed
- [x] `npm run format:check` — clean

## Test plan

- [x] Loader applies call_module filter and builds ranked signers
- [x] MCP tool returns signers from stubbed D1
- [x] MCP tool rejects invalid window
- [x] MCP tool returns empty signers[] on cold D1
- [ ] CI `validate-mcp` + full test suite green