### PR TITLE
feat(mcp): add get_subnet_health_trends with shared health-trends loader

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -314,6 +314,11 @@ assert.ok(
   Array.isArray(traj.points),
   "get_subnet_trajectory must return points[]",
 );
+const healthTrends = await callOk("get_subnet_health_trends", { netuid: 7 });
+assert.ok(
+  healthTrends.windows && typeof healthTrends.windows === "object",
+  "get_subnet_health_trends must return the per-window trends object",
+);
 const meta = await callOk("get_subnet_metagraph", { netuid: 7 });
 assert.ok(
   Array.isArray(meta.neurons),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -4,10 +4,15 @@
 // workers/request-handlers/analytics-routes.mjs (#1919); MCP tools call these
 // loaders so agents get REST parity without duplicating SQL paths.
 
-import { dailyLatencyColumns } from "./health-sql.mjs";
+import {
+  dailyLatencyColumns,
+  latencyStatColumns,
+  rankedChecksCte,
+} from "./health-sql.mjs";
 import {
   formatGlobalIncidents,
   formatLeaderboards,
+  formatTrends,
   formatUptime,
   INCIDENT_GAP_MS,
   MIN_INCIDENT_SAMPLES,
@@ -15,6 +20,7 @@ import {
 import {
   ANALYTICS_WINDOWS,
   DAY_MS,
+  HEALTH_TREND_WINDOWS,
   MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
   MAX_INCIDENT_ROWS,
   MAX_UPTIME_ROWS,
@@ -158,6 +164,44 @@ export async function loadSubnetUptime(
     rows,
     now: now || new Date().toISOString(),
   });
+}
+
+// Per-subnet rolling uptime + latency trend windows — shared by the REST route
+// (handleHealthTrends) and the get_subnet_health_trends MCP tool so both read
+// one D1 contract. Aggregates the ranked health-check history per surface for
+// every window in HEALTH_TREND_WINDOWS (7d/30d). The per-window reads are
+// independent, so they run in parallel (one D1 round-trip each) rather than
+// serialized. Returns {data, windows}: `data` is the formatTrends payload and
+// `windows` carries the raw rows so the REST caller can mark a D1 fallback.
+// Cold/absent D1 → every window degrades to empty surfaces (never throws).
+export async function loadHealthTrends(
+  d1,
+  netuid,
+  { observedAt = null, now = null } = {},
+) {
+  const nowMs = now ?? Date.now();
+  const windows = {};
+  const windowRows = await Promise.all(
+    Object.entries(HEALTH_TREND_WINDOWS).map(async ([label, days]) => {
+      const rows = await d1(
+        `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
+           SELECT MAX(surface_id) AS surface_id,
+                  surface_key,
+                  COUNT(*) AS total,
+                  SUM(ok) AS ok_count,
+                  ${latencyStatColumns({ includeMinMax: false })}
+           FROM ranked
+           GROUP BY surface_key`,
+        [netuid, nowMs - days * DAY_MS],
+      );
+      return [label, rows];
+    }),
+  );
+  for (const [label, rows] of windowRows) {
+    windows[label] = rows;
+  }
+  const data = formatTrends({ netuid, observedAt, windows });
+  return { data, windows };
 }
 
 export async function loadGlobalIncidents(

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -32,6 +32,7 @@ import {
 import {
   loadCompareSubnets,
   loadGlobalIncidents,
+  loadHealthTrends,
   loadRegistryLeaderboards,
   loadSubnetUptime,
   parseAnalyticsWindow,
@@ -124,7 +125,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.7.0";
+export const MCP_SERVER_VERSION = "1.8.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -180,7 +181,9 @@ export const MCP_INSTRUCTIONS =
   "participation, get_subnet_economics returns a subnet's registration cost, " +
   "open slots, stake, emission split and validator/miner counts, " +
   "get_subnet_trajectory its week-over-week trend, get_subnet_uptime its " +
-  "long-term surface uptime history, get_subnet_concentration stake and " +
+  "long-term surface uptime history, get_subnet_health_trends its rolling " +
+  "7d/30d uptime and latency trend windows per surface, " +
+  "get_subnet_concentration stake and " +
   "emission decentralization metrics (Gini, HHI, Nakamoto), " +
   "get_subnet_concentration_history the decentralization trend over time, " +
   "get_subnet_turnover validator-set and registration churn between two " +
@@ -1500,6 +1503,33 @@ export const MCP_TOOLS = [
         window: window || "90d",
         observedAt: await mcpObservedAt(ctx),
       });
+    },
+  },
+  {
+    name: "get_subnet_health_trends",
+    title: "Get subnet health trends",
+    description:
+      "Fetch one subnet's rolling 7d and 30d uptime + latency trend windows per " +
+      "operational surface, computed live from the D1 health-check history. Each " +
+      "window returns the aggregate uptime_ratio and latency sample count plus a " +
+      "per-surface breakdown (uptime_ratio, avg and p50/p95/p99 latency) for " +
+      "trend and regression analysis — the time-series companion to " +
+      "get_subnet_health's current status. Mirrors " +
+      "GET /api/v1/subnets/{netuid}/health/trends.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const { data } = await loadHealthTrends(mcpD1Runner(ctx), netuid, {
+        observedAt: await mcpObservedAt(ctx),
+      });
+      return data;
     },
   },
   {
@@ -3435,6 +3465,18 @@ const TOOL_OUTPUT_SCHEMAS = {
       observed_at: NULLABLE_STRING,
       surfaces: { type: "array", items: { type: "object" } },
       reliability: { type: ["object", "null"] },
+    },
+  },
+  get_subnet_health_trends: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "windows"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      observed_at: NULLABLE_STRING,
+      source: NULLABLE_STRING,
+      windows: { type: "object" },
     },
   },
   get_registry_leaderboards: {

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -7,6 +7,7 @@ import {
   growthRowsFromSamples,
   loadCompareSubnets,
   loadGlobalIncidents,
+  loadHealthTrends,
   loadRegistryLeaderboards,
   loadSubnetUptime,
   parseAnalyticsWindow,
@@ -171,6 +172,54 @@ describe("analytics-live loaders", () => {
     assert.equal(data.surfaces.length, 1);
     assert.equal(data.surfaces[0].samples, 50);
     assert.equal(data.surfaces[0].days[0].uptime_ratio, 0.9);
+  });
+
+  test("loadHealthTrends returns schema-stable empty windows on cold D1", async () => {
+    const { data, windows } = await loadHealthTrends(d1(), NETUID, {
+      observedAt: OBSERVED_AT,
+    });
+    assert.equal(data.netuid, NETUID);
+    assert.equal(data.observed_at, OBSERVED_AT);
+    // Both configured windows (7d/30d) degrade to an empty per-surface breakdown.
+    assert.deepEqual(Object.keys(data.windows), ["7d", "30d"]);
+    for (const window of Object.values(data.windows)) {
+      assert.deepEqual(window.surfaces, []);
+      assert.equal(window.uptime_ratio, null);
+    }
+    // Raw rows are surfaced so the REST caller can run its D1-fallback check.
+    assert.deepEqual(Object.keys(windows), ["7d", "30d"]);
+  });
+
+  test("loadHealthTrends aggregates ranked check rows per surface", async () => {
+    const { data } = await loadHealthTrends(
+      d1({
+        "FROM ranked": [
+          {
+            surface_id: "api-root",
+            surface_key: "api-root",
+            total: 100,
+            ok_count: 95,
+            latency_samples: 95,
+            avg_latency_ms: 120,
+            p50: 100,
+            p95: 180,
+            p99: 240,
+          },
+        ],
+      }),
+      NETUID,
+      { observedAt: OBSERVED_AT },
+    );
+    for (const window of Object.values(data.windows)) {
+      assert.equal(window.samples, 100);
+      assert.equal(window.uptime_ratio, 0.95);
+      assert.equal(window.surfaces.length, 1);
+      assert.equal(window.surfaces[0].surface_id, "api-root");
+      assert.equal(window.surfaces[0].samples, 100);
+      assert.equal(window.surfaces[0].uptime_ratio, 0.95);
+      assert.equal(window.surfaces[0].avg_latency_ms, 120);
+      assert.equal(window.surfaces[0].latency_ms.p95, 180);
+    }
   });
 
   test("loadRegistryLeaderboards returns all boards object", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3381,6 +3381,7 @@ describe("MCP economics + metagraph data tools", () => {
     surfaceStatus = [],
     uptimeRows = [],
     incidentRows = [],
+    trendRows = [],
     growthSamples = [],
     rpcRows = [],
     neuronDaily = [],
@@ -3420,6 +3421,11 @@ describe("MCP economics + metagraph data tools", () => {
                 }
                 if (sql.includes("FROM surface_uptime_daily")) {
                   return Promise.resolve({ results: uptimeRows });
+                }
+                // health-trends aggregates the ranked-checks CTE (which itself
+                // reads surface_checks), so match the outer `FROM ranked` first.
+                if (sql.includes("FROM ranked")) {
+                  return Promise.resolve({ results: trendRows });
                 }
                 if (sql.includes("FROM surface_checks")) {
                   return Promise.resolve({ results: incidentRows });
@@ -3771,6 +3777,56 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.netuid, 7);
     assert.equal(out.window, "90d");
     assert.deepEqual(out.surfaces, []);
+  });
+
+  test("get_subnet_health_trends returns schema-stable empty windows on cold D1", async () => {
+    const res = await callTool("get_subnet_health_trends", { netuid: 7 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.deepEqual(Object.keys(out.windows), ["7d", "30d"]);
+    for (const window of Object.values(out.windows)) {
+      assert.deepEqual(window.surfaces, []);
+      assert.equal(window.uptime_ratio, null);
+    }
+  });
+
+  test("get_subnet_health_trends aggregates ranked checks per surface", async () => {
+    const res = await callTool(
+      "get_subnet_health_trends",
+      { netuid: 7 },
+      {
+        env: {
+          METAGRAPH_HEALTH_DB: metagraphD1({
+            trendRows: [
+              {
+                surface_id: "api-root",
+                surface_key: "api-root",
+                total: 100,
+                ok_count: 95,
+                latency_samples: 95,
+                avg_latency_ms: 120,
+                p50: 100,
+                p95: 180,
+                p99: 240,
+              },
+            ],
+          }),
+        },
+      },
+    );
+    const out = res.body.result.structuredContent;
+    const window = out.windows["7d"];
+    assert.equal(window.samples, 100);
+    assert.equal(window.uptime_ratio, 0.95);
+    assert.equal(window.surfaces.length, 1);
+    assert.equal(window.surfaces[0].surface_id, "api-root");
+    assert.equal(window.surfaces[0].uptime_ratio, 0.95);
+    assert.equal(window.surfaces[0].latency_ms.p95, 180);
+  });
+
+  test("get_subnet_health_trends rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_health_trends", {});
+    assert.equal(res.body.result.isError, true);
   });
 
   test("get_registry_leaderboards returns boards from committed profiles", async () => {

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -53,10 +53,10 @@ import {
   formatGlobalIncidents,
   formatIncidents,
   formatPercentiles,
-  formatTrends,
   INCIDENT_GAP_MS,
   MIN_INCIDENT_SAMPLES,
 } from "../../src/health-serving.mjs";
+import { loadHealthTrends } from "../../src/analytics-live.mjs";
 import {
   buildChainActivity,
   buildChainCalls,
@@ -421,40 +421,17 @@ export async function handleHealthTrends(request, env, netuid, url, ctx = {}) {
   const validationError = validateQueryParams(url, []);
   if (validationError) return analyticsQueryError(validationError);
   return withEdgeCache(request, ctx, env, "trends", async () => {
-    const nowMs = Date.now();
-    const windows = {};
-    // The per-window aggregations are independent — run them in parallel (one D1
-    // round-trip each) like handleHealthPercentiles/handleLeaderboards, rather than
-    // serializing the two with an await-in-loop. Read through the shared d1All so a
-    // failure is logged + marked as a D1 fallback (the dark-serve log contract) —
-    // the inline bare catch this replaced swallowed errors silently, the exact
-    // failure mode the [d1All] logging exists to prevent.
-    const windowRows = await Promise.all(
-      Object.entries(HEALTH_TREND_WINDOWS).map(async ([label, days]) => {
-        const rows = await d1All(
-          env,
-          `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
-             SELECT MAX(surface_id) AS surface_id,
-                    surface_key,
-                    COUNT(*) AS total,
-                    SUM(ok) AS ok_count,
-                    ${latencyStatColumns({ includeMinMax: false })}
-             FROM ranked
-             GROUP BY surface_key`,
-          [netuid, nowMs - days * DAY_MS],
-        );
-        return [label, rows];
-      }),
-    );
-    for (const [label, rows] of windowRows) {
-      windows[label] = rows;
-    }
+    // Read through the shared loadHealthTrends loader (analytics-live.mjs) so the
+    // REST route and the get_subnet_health_trends MCP tool share one D1 read
+    // contract. The runner stays the analytics-local d1All so every per-window
+    // query is logged + marked as a D1 fallback (the dark-serve log contract),
+    // and `windows` carries the raw rows for the hasD1FallbackRows check below.
     const meta = await readHealthMetaKv(env);
-    const data = formatTrends({
+    const { data, windows } = await loadHealthTrends(
+      (sql, params) => d1All(env, sql, params),
       netuid,
-      observedAt: meta?.last_run_at || null,
-      windows,
-    });
+      { observedAt: meta?.last_run_at || null },
+    );
     const response = await envelopeResponse(
       request,
       {


### PR DESCRIPTION
## Summary

Adds the `get_subnet_health_trends` MCP tool, mirroring the existing REST route
`GET /api/v1/subnets/{netuid}/health/trends`. Agent workflows could read a
subnet's *current* status via `get_subnet_health` but had no MCP equivalent for
the rolling 7d/30d uptime + latency **trend** windows REST already exposes,
forcing a fall back to raw REST for trend/regression analysis.

Closes #2335.

## What Changed

- **Shared loader**: extracted the per-window ranked-checks aggregation out of
  `handleHealthTrends` into `loadHealthTrends(d1, netuid, {observedAt})` in
  `src/analytics-live.mjs` (next to `loadSubnetUptime`), so REST and MCP read one
  D1 contract. Returns `{data, windows}` — `data` is the `formatTrends` payload,
  `windows` carries raw rows for the caller's D1-fallback check.
- **REST behavior unchanged**: `handleHealthTrends` now calls the loader with the
  same analytics-local `d1All` runner, preserving the dark-serve D1-fallback
  marking and its `hasD1FallbackRows` check; the now-unused `formatTrends` import
  was dropped.
- **New MCP tool** `get_subnet_health_trends` (input `{netuid}`) returning the
  per-window `formatTrends` shape, plus its `TOOL_OUTPUT_SCHEMAS` entry and an
  `MCP_INSTRUCTIONS` mention.
- **Version**: bumped MCP server `1.7.0 → 1.8.0` (`server.json` +
  `MCP_SERVER_VERSION`) for the added tool.
- **Tests**: loader unit tests (cold-D1 empty windows, per-surface aggregation)
  in `tests/analytics-live.test.mjs`; MCP integration tests (cold / happy /
  missing-netuid) in `tests/mcp-server.test.mjs`; a `validate:mcp` smoke call.

No `/api/v1` route, schema, or contract change — the MCP server card is
worker-computed, so no generated artifacts are committed (same file set as the
sibling tool PR #2324).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (none —
      REST contract unchanged; this only adds an MCP tool).

## Validation

- [x] `npm run lint` (clean)
- [x] `npm run validate:mcp` (passed — 51 tools, lifecycle + all tools/call)
- [x] `npm run scan:public-safety` (clean)
- [x] `git diff --check` (clean)
- [x] `tests/analytics-live.test.mjs`, `tests/mcp-server.test.mjs`,
      `tests/analytics.test.mjs` green (after `npm run build`)
- [x] Prettier clean on all changed files
