### PR TITLE
fix: force module index on extrinsics feed

### DIFF
--- a/migrations/0029_extrinsics_module_block_index.sql
+++ b/migrations/0029_extrinsics_module_block_index.sql
@@ -1,0 +1,7 @@
+-- Track a feed-oriented module index by the stable naming used by issue #2082.
+-- Keep the leading columns aligned to the hottest filter + newest-first ordering.
+
+DROP INDEX IF EXISTS idx_extrinsics_call_module_order;
+
+CREATE INDEX IF NOT EXISTS idx_extrinsics_module_block
+  ON extrinsics (call_module, block_number DESC, extrinsic_index DESC);

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2568,10 +2568,12 @@ describe("handleExtrinsics", () => {
       CREATE INDEX IF NOT EXISTS idx_extrinsics_module_block
         ON extrinsics (call_module, block_number DESC, extrinsic_index DESC);
     `);
-    const plan = db.prepare(
-      "EXPLAIN QUERY PLAN " +
-        "SELECT * FROM extrinsics WHERE call_module = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT ?",
-    ).all("Balances", 10);
+    const plan = db
+      .prepare(
+        "EXPLAIN QUERY PLAN " +
+          "SELECT * FROM extrinsics WHERE call_module = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT ?",
+      )
+      .all("Balances", 10);
 
     assert.equal(plan.length, 1);
     assert.equal(

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2534,6 +2534,52 @@ describe("handleExtrinsics", () => {
     assert.ok(captures.params.flat().includes(0));
   });
 
+  test("forces module-index for a module-only feed path (#2082)", async () => {
+    const { env, captures } = dbWith({ extrinsics: [] });
+    await handleExtrinsics(
+      req("/api/v1/extrinsics"),
+      env,
+      url("/api/v1/extrinsics?call_module=Balances&limit=10"),
+    );
+    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
+    assert.ok(sql);
+    assert.ok(
+      /INDEXED BY idx_extrinsics_module_block/.test(sql),
+      `expected module-filter call to use idx_extrinsics_module_block, got: ${sql}`,
+    );
+  });
+
+  test("uses idx_extrinsics_module_block for module feed query plan", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`
+      CREATE TABLE extrinsics (
+        block_number INTEGER NOT NULL,
+        extrinsic_index INTEGER NOT NULL,
+        extrinsic_hash TEXT NOT NULL,
+        signer TEXT,
+        call_module TEXT,
+        call_function TEXT,
+        call_args TEXT,
+        fee_tao REAL,
+        success INTEGER,
+        observed_at INTEGER,
+        PRIMARY KEY (block_number, extrinsic_index)
+      );
+      CREATE INDEX IF NOT EXISTS idx_extrinsics_module_block
+        ON extrinsics (call_module, block_number DESC, extrinsic_index DESC);
+    `);
+    const plan = db.prepare(
+      "EXPLAIN QUERY PLAN " +
+        "SELECT * FROM extrinsics WHERE call_module = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT ?",
+    ).all("Balances", 10);
+
+    assert.equal(plan.length, 1);
+    assert.equal(
+      plan[0].detail,
+      "SEARCH extrinsics USING INDEX idx_extrinsics_module_block (call_module=?)",
+    );
+  });
+
   test("keeps broad standalone time filters planner-selected", async () => {
     const { env, captures } = dbWith({ extrinsics: [] });
     await handleExtrinsics(

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -894,7 +894,7 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
     maxLimit: 100,
   });
   if (limitError) return analyticsQueryError(limitError);
-  // Optional pallet scope, backed by idx_extrinsics_call_module_order.
+  // Optional pallet scope, backed by idx_extrinsics_module_block.
   const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
@@ -958,7 +958,7 @@ export async function handleChainFees(request, env, url, ctx = {}) {
   });
   if (limitError) return analyticsQueryError(limitError);
   // Optional pallet scope (applies to both the daily series and the payer list),
-  // backed by idx_extrinsics_call_module_order.
+  // backed by idx_extrinsics_module_block.
   const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1408,12 +1408,15 @@ export async function handleExtrinsics(request, env, url) {
     params.push(val);
   };
   const hasBlockFilter = numericFilters.block != null;
+  const hasSignerFilter = Boolean(sp.get("signer"));
+  const hasCallModuleFilter = Boolean(sp.get("call_module"));
+  const hasCallFunctionFilter = Boolean(sp.get("call_function"));
   const hasEqualityFilter =
-    sp.get("signer") || sp.get("call_module") || sp.get("call_function");
+    hasSignerFilter || hasCallModuleFilter || hasCallFunctionFilter;
   if (hasBlockFilter) eq("block_number", numericFilters.block);
-  if (sp.get("signer")) eq("signer", sp.get("signer"));
-  if (sp.get("call_module")) eq("call_module", sp.get("call_module"));
-  if (sp.get("call_function")) eq("call_function", sp.get("call_function"));
+  if (hasSignerFilter) eq("signer", sp.get("signer"));
+  if (hasCallModuleFilter) eq("call_module", sp.get("call_module"));
+  if (hasCallFunctionFilter) eq("call_function", sp.get("call_function"));
   // success is stored 1/0/NULL; bind the literal so success=false never leaks
   // NULL (undeterminable) rows. Any non-true/false value is ignored.
   const successRaw = sp.get("success");
@@ -1464,9 +1467,19 @@ export async function handleExtrinsics(request, env, url) {
     !hasSuccessFilter &&
     !hasBlockRangeFilter &&
     !useCursor;
+  // For module-scoped feed scans, force the composite module index so SQLite/D1
+  // seeks on the equality predicate instead of a PK-desc walk.
+  const forceModuleIndex =
+    hasCallModuleFilter &&
+    !forceObservedOrderIndex &&
+    !hasBlockFilter &&
+    !hasBlockRangeFilter &&
+    !hasSignerFilter &&
+    !useCursor;
   let sql = `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics`;
   if (forceObservedOrderIndex)
     sql += " INDEXED BY idx_extrinsics_observed_order";
+  else if (forceModuleIndex) sql += " INDEXED BY idx_extrinsics_module_block";
   if (conds.length) sql += ` WHERE ${conds.join(" AND ")}`;
   sql += " ORDER BY block_number DESC, extrinsic_index DESC LIMIT ?";
   params.push(limit);


### PR DESCRIPTION
## Summary
- Force handleExtrinsics to use the composite module index for `?call_module=` feed queries so module-only requests avoid PK-desc scans and use indexed equality seek.
- Added migration `0029_extrinsics_module_block_index.sql` to provide `idx_extrinsics_module_block` and keep migration idempotence.
- Added regression coverage for module-filter query shape and planner behavior.

Closes #2082.