### PR TITLE
feat(api): add subnet turnover change drilldown

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1541,7 +1541,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + retention, UID deregistrations, and a 0-100 stability score (computed live from the neuron_daily D1 rollup). */
+        /** Fetch validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + retention, UID deregistrations, and a 0-100 stability score. Add ?changes=true to include the entered/exited validator hotkeys and UID reassignment detail (computed live from the neuron_daily D1 rollup). */
         get: operations["subnetTurnover"];
         put?: never;
         post?: never;
@@ -4850,6 +4850,25 @@ export interface components {
         };
         /** @description Validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots, computed live from the neuron_daily D1 rollup. */
         SubnetTurnoverArtifact: {
+            /** @description Optional drilldown included only when the live turnover route is requested with changes=true. */
+            changes?: {
+                uid_reassignment_count?: number;
+                uid_reassignments: {
+                    from_hotkey: string;
+                    to_hotkey: string;
+                    uid: number;
+                }[];
+                validators_entered: {
+                    hotkey: string;
+                    uid: number | null;
+                }[];
+                validators_entered_count?: number;
+                validators_exited: {
+                    hotkey: string;
+                    uid: number | null;
+                }[];
+                validators_exited_count?: number;
+            } | null;
             comparable: boolean;
             end_date?: string | null;
             netuid: number;
@@ -17721,6 +17740,7 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d" | "1y" | "all";
+                changes?: "true";
             };
             header?: never;
             path: {
@@ -17742,6 +17762,30 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "changes": {
+                     *           "uid_reassignment_count": 1,
+                     *           "uid_reassignments": [
+                     *             {
+                     *               "from_hotkey": "example",
+                     *               "to_hotkey": "example",
+                     *               "uid": 1
+                     *             }
+                     *           ],
+                     *           "validators_entered": [
+                     *             {
+                     *               "hotkey": "example",
+                     *               "uid": 1
+                     *             }
+                     *           ],
+                     *           "validators_entered_count": 1,
+                     *           "validators_exited": [
+                     *             {
+                     *               "hotkey": "example",
+                     *               "uid": 1
+                     *             }
+                     *           ],
+                     *           "validators_exited_count": 1
+                     *         },
                      *         "comparable": false,
                      *         "end_date": "example",
                      *         "netuid": 7,

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1,763 +1,763 @@
 {
   "artifact_contracts": [
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "contracts",
       "path": "/metagraph/contracts.json",
       "schema_ref": "#/components/schemas/ContractsArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "providers",
       "path": "/metagraph/providers.json",
       "schema_ref": "#/components/schemas/ProvidersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "provider-detail",
       "path": "/metagraph/providers/{slug}.json",
       "schema_ref": "#/components/schemas/ProviderArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",
       "schema_ref": "#/components/schemas/ProviderEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "api-index",
       "path": "/metagraph/api-index.json",
       "schema_ref": "#/components/schemas/ApiIndexArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "openapi",
       "path": "/metagraph/openapi.json",
       "schema_ref": "#/components/schemas/OpenApiArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "type-definitions",
       "path": "/metagraph/types.d.ts",
       "schema_ref": null,
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "changelog",
       "path": "/metagraph/changelog.json",
       "schema_ref": "#/components/schemas/ChangelogArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnets",
       "path": "/metagraph/subnets.json",
       "schema_ref": "#/components/schemas/SubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "metagraph-latest",
       "path": "/metagraph/metagraph/latest.json",
       "schema_ref": "#/components/schemas/SubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-detail",
       "path": "/metagraph/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-overview",
       "path": "/metagraph/overview/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetOverviewArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "profiles",
       "path": "/metagraph/profiles.json",
       "schema_ref": "#/components/schemas/SubnetProfilesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "profile-detail",
       "path": "/metagraph/profiles/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetProfileArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "surfaces",
       "path": "/metagraph/surfaces.json",
       "schema_ref": "#/components/schemas/SurfacesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "surface-aliases",
       "path": "/metagraph/surface-aliases.json",
       "schema_ref": "#/components/schemas/SurfaceAliasesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "surfaces-subnet",
       "path": "/metagraph/surfaces/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetSurfacesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "endpoints",
       "path": "/metagraph/endpoints.json",
       "schema_ref": "#/components/schemas/EndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "endpoints-subnet",
       "path": "/metagraph/endpoints/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "candidates",
       "path": "/metagraph/candidates.json",
       "schema_ref": "#/components/schemas/CandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "candidates-subnet",
       "path": "/metagraph/candidates/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetCandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "review-queue",
       "path": "/metagraph/review-queue.json",
       "schema_ref": "#/components/schemas/ReviewQueueArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "search",
       "path": "/metagraph/search.json",
       "schema_ref": "#/components/schemas/SearchArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "search-index",
       "path": "/metagraph/search-index.json",
       "schema_ref": "#/components/schemas/SearchIndexArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "coverage",
       "path": "/metagraph/coverage.json",
       "schema_ref": "#/components/schemas/CoverageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "coverage-depth",
       "path": "/metagraph/coverage-depth.json",
       "schema_ref": "#/components/schemas/CoverageDepthArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "economics",
       "path": "/metagraph/economics.json",
       "schema_ref": "#/components/schemas/EconomicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "economics-trends",
       "path": "/metagraph/economics/trends.json",
       "schema_ref": "#/components/schemas/EconomicsTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "registry-summary",
       "path": "/metagraph/registry-summary.json",
       "schema_ref": "#/components/schemas/RegistrySummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "lineage",
       "path": "/metagraph/lineage.json",
       "schema_ref": "#/components/schemas/LineageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "fixtures-index",
       "path": "/metagraph/fixtures.json",
       "schema_ref": "#/components/schemas/FixturesIndexArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "agent-resources",
       "path": "/metagraph/agent-resources.json",
       "schema_ref": "#/components/schemas/AgentResourcesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "fixture-detail",
       "path": "/metagraph/fixtures/{surface_id}.json",
       "schema_ref": "#/components/schemas/JsonObject",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "curation",
       "path": "/metagraph/curation.json",
       "schema_ref": "#/components/schemas/CurationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "gaps",
       "path": "/metagraph/gaps.json",
       "schema_ref": "#/components/schemas/GapsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "verification",
       "path": "/metagraph/verification/latest.json",
       "schema_ref": "#/components/schemas/VerificationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "verification-subnet",
       "path": "/metagraph/verification/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetVerificationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "freshness",
       "path": "/metagraph/freshness.json",
       "schema_ref": "#/components/schemas/FreshnessArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "source-health",
       "path": "/metagraph/source-health.json",
       "schema_ref": "#/components/schemas/SourceHealthArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "source-snapshots",
       "path": "/metagraph/source-snapshots.json",
       "schema_ref": "#/components/schemas/SourceSnapshotsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "evidence-ledger",
       "path": "/metagraph/evidence-ledger.json",
       "schema_ref": "#/components/schemas/EvidenceLedgerArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "evidence-subnet",
       "path": "/metagraph/evidence/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetEvidenceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "health-latest",
       "path": "/metagraph/health/latest.json",
       "schema_ref": "#/components/schemas/HealthLatestArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "health-summary",
       "path": "/metagraph/health/summary.json",
       "schema_ref": "#/components/schemas/HealthSummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "health-history",
       "path": "/metagraph/health/history/{date}.json",
       "schema_ref": "#/components/schemas/HealthHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "health-subnet",
       "path": "/metagraph/health/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthSubnetArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "health-badge",
       "path": "/metagraph/health/badges/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthBadgeArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "health-trends",
       "path": "/metagraph/health/trends/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "health-trends-bulk",
       "path": "/metagraph/health/trends.json",
       "schema_ref": "#/components/schemas/BulkHealthTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "health-percentiles",
       "path": "/metagraph/health/percentiles/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthPercentilesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "health-incidents",
       "path": "/metagraph/health/incidents/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-trajectory",
       "path": "/metagraph/subnets/{netuid}/trajectory.json",
       "schema_ref": "#/components/schemas/SubnetTrajectoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-concentration",
       "path": "/metagraph/subnets/{netuid}/concentration.json",
       "schema_ref": "#/components/schemas/SubnetConcentrationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-concentration-history",
       "path": "/metagraph/subnets/{netuid}/concentration/history.json",
       "schema_ref": "#/components/schemas/SubnetConcentrationHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-turnover",
       "path": "/metagraph/subnets/{netuid}/turnover.json",
       "schema_ref": "#/components/schemas/SubnetTurnoverArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-metagraph",
       "path": "/metagraph/subnets/{netuid}/metagraph.json",
       "schema_ref": "#/components/schemas/SubnetMetagraphArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-neuron",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}.json",
       "schema_ref": "#/components/schemas/NeuronDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-validators",
       "path": "/metagraph/subnets/{netuid}/validators.json",
       "schema_ref": "#/components/schemas/SubnetValidatorsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-events",
       "path": "/metagraph/subnets/{netuid}/events.json",
       "schema_ref": "#/components/schemas/SubnetEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-neuron-history",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}/history.json",
       "schema_ref": "#/components/schemas/NeuronHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-history",
       "path": "/metagraph/subnets/{netuid}/history.json",
       "schema_ref": "#/components/schemas/SubnetHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "account-summary",
       "path": "/metagraph/accounts/{ss58}.json",
       "schema_ref": "#/components/schemas/AccountSummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "account-events",
       "path": "/metagraph/accounts/{ss58}/events.json",
       "schema_ref": "#/components/schemas/AccountEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "account-history",
       "path": "/metagraph/accounts/{ss58}/history.json",
       "schema_ref": "#/components/schemas/AccountHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "account-extrinsics",
       "path": "/metagraph/accounts/{ss58}/extrinsics.json",
       "schema_ref": "#/components/schemas/AccountExtrinsicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "account-transfers",
       "path": "/metagraph/accounts/{ss58}/transfers.json",
       "schema_ref": "#/components/schemas/AccountTransfersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "account-counterparties",
       "path": "/metagraph/accounts/{ss58}/counterparties.json",
       "schema_ref": "#/components/schemas/AccountCounterpartiesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "account-subnets",
       "path": "/metagraph/accounts/{ss58}/subnets.json",
       "schema_ref": "#/components/schemas/AccountSubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "account-balance",
       "path": "/metagraph/accounts/{ss58}/balance.json",
       "schema_ref": "#/components/schemas/AccountBalanceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "blocks-feed",
       "path": "/metagraph/blocks.json",
       "schema_ref": "#/components/schemas/BlocksFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "block-detail",
       "path": "/metagraph/blocks/{ref}.json",
       "schema_ref": "#/components/schemas/BlockDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "block-extrinsics",
       "path": "/metagraph/blocks/{ref}/extrinsics.json",
       "schema_ref": "#/components/schemas/BlockExtrinsicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "block-events",
       "path": "/metagraph/blocks/{ref}/events.json",
       "schema_ref": "#/components/schemas/BlockEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "chain-events-feed",
       "path": "/metagraph/chain-events.json",
       "schema_ref": "#/components/schemas/ChainEventsFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "block-chain-events",
       "path": "/metagraph/blocks/{ref}/chain-events.json",
       "schema_ref": "#/components/schemas/BlockChainEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "chain-events-stats",
       "path": "/metagraph/chain-events/stats.json",
       "schema_ref": "#/components/schemas/ChainEventsStatsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "extrinsics-feed",
       "path": "/metagraph/extrinsics.json",
       "schema_ref": "#/components/schemas/ExtrinsicsFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "extrinsic-detail",
       "path": "/metagraph/extrinsics/{hash}.json",
       "schema_ref": "#/components/schemas/ExtrinsicDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "chain-activity",
       "path": "/metagraph/chain/activity.json",
       "schema_ref": "#/components/schemas/ChainActivityArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "chain-calls",
       "path": "/metagraph/chain/calls.json",
       "schema_ref": "#/components/schemas/ChainCallsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "chain-signers",
       "path": "/metagraph/chain/signers.json",
       "schema_ref": "#/components/schemas/ChainSignersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "chain-fees",
       "path": "/metagraph/chain/fees.json",
       "schema_ref": "#/components/schemas/ChainFeesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-uptime",
       "path": "/metagraph/subnets/{netuid}/uptime.json",
       "schema_ref": "#/components/schemas/UptimeArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "global-incidents",
       "path": "/metagraph/incidents.json",
       "schema_ref": "#/components/schemas/GlobalIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",
       "schema_ref": "#/components/schemas/RegistryLeaderboardsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "compare",
       "path": "/metagraph/compare.json",
       "schema_ref": "#/components/schemas/CompareArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "rpc-usage",
       "path": "/metagraph/rpc/usage.json",
       "schema_ref": "#/components/schemas/RpcUsageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
       "schema_ref": "#/components/schemas/RpcEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "rpc-pools",
       "path": "/metagraph/rpc/pools.json",
       "schema_ref": "#/components/schemas/RpcPoolsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "endpoint-pools",
       "path": "/metagraph/endpoint-pools.json",
       "schema_ref": "#/components/schemas/EndpointPoolsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "endpoint-incidents",
       "path": "/metagraph/endpoint-incidents.json",
       "schema_ref": "#/components/schemas/EndpointIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "operational-surfaces",
       "path": "/metagraph/operational-surfaces.json",
       "schema_ref": "#/components/schemas/OperationalSurfacesArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "agent-catalog",
       "path": "/metagraph/agent-catalog.json",
       "schema_ref": "#/components/schemas/AgentCatalogArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "agent-catalog-subnet",
       "path": "/metagraph/agent-catalog/{netuid}.json",
       "schema_ref": "#/components/schemas/AgentCatalogSubnetArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",
       "schema_ref": "#/components/schemas/SchemaDriftArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "schema-index",
       "path": "/metagraph/schemas/index.json",
       "schema_ref": "#/components/schemas/SchemaIndexArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "schema-snapshot",
       "path": "/metagraph/schemas/{surface_id}.json",
       "schema_ref": "#/components/schemas/JsonObject",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",
       "schema_ref": "#/components/schemas/AdapterArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "r2-manifest",
       "path": "/metagraph/r2-manifest.json",
       "schema_ref": "#/components/schemas/R2ManifestArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "review-curation",
       "path": "/metagraph/review/curation.json",
       "schema_ref": "#/components/schemas/ReviewCurationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "review-gap-priorities",
       "path": "/metagraph/review/gap-priorities.json",
       "schema_ref": "#/components/schemas/ReviewGapPrioritiesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "subnet-gaps",
       "path": "/metagraph/review/gaps/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetGapsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "review-profile-completeness",
       "path": "/metagraph/review/profile-completeness.json",
       "schema_ref": "#/components/schemas/ReviewProfileCompletenessArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "review-adapter-candidates",
       "path": "/metagraph/review/adapter-candidates.json",
       "schema_ref": "#/components/schemas/ReviewAdapterCandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "review-enrichment-queue",
       "path": "/metagraph/review/enrichment-queue.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentQueueArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "review-enrichment-evidence",
       "path": "/metagraph/review/enrichment-evidence.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentEvidenceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "review-enrichment-targets",
       "path": "/metagraph/review/enrichment-targets.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentTargetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
       "schema_ref": "#/components/schemas/ReviewDecisionsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "id": "build-summary",
       "path": "/metagraph/build-summary.json",
       "schema_ref": "#/components/schemas/BuildSummaryArtifact",
@@ -765,7 +765,7 @@
     }
   ],
   "base_path": "/api/v1",
-  "contract_version": "2026-06-29.1",
+  "contract_version": "2026-06-29.2",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "openapi_url": "/api/v1/openapi.json",
   "primary_domain": "api.metagraph.sh",
@@ -4278,7 +4278,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/turnover.json",
       "cache": "short",
-      "description": "Fetch validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + retention, UID deregistrations, and a 0-100 stability score (computed live from the neuron_daily D1 rollup).",
+      "description": "Fetch validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + retention, UID deregistrations, and a 0-100 stability score. Add ?changes=true to include the entered/exited validator hotkeys and UID reassignment detail (computed live from the neuron_daily D1 rollup).",
       "id": "subnet-turnover",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/turnover",
@@ -4295,6 +4295,15 @@
               "90d",
               "1y",
               "all"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "changes",
+          "schema": {
+            "enum": [
+              "true"
             ],
             "type": "string"
           }

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -2,7 +2,7 @@
   "artifacts": [
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Public artifact contract metadata for metagraph.sh consumers.",
       "id": "contracts",
       "path": "/metagraph/contracts.json",
@@ -11,7 +11,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Provider/source registry.",
       "id": "providers",
       "path": "/metagraph/providers.json",
@@ -20,7 +20,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Per-provider detail payload.",
       "id": "provider-detail",
       "path": "/metagraph/providers/{slug}.json",
@@ -29,7 +29,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Endpoint resources for one provider or operator.",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",
@@ -38,7 +38,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Clean API route index for metagraph.sh consumers.",
       "id": "api-index",
       "path": "/metagraph/api-index.json",
@@ -47,7 +47,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "OpenAPI 3.1 contract for the metagraph.sh backend API.",
       "id": "openapi",
       "path": "/metagraph/openapi.json",
@@ -56,7 +56,7 @@
     },
     {
       "content_type": "text/plain; charset=utf-8",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Generated TypeScript definitions for metagraph.sh backend consumers.",
       "id": "type-definitions",
       "path": "/metagraph/types.d.ts",
@@ -65,7 +65,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Reviewable generated artifact and subnet-change summary.",
       "id": "changelog",
       "path": "/metagraph/changelog.json",
@@ -74,7 +74,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "All active Finney subnets with compact registry metadata.",
       "id": "subnets",
       "path": "/metagraph/subnets.json",
@@ -83,7 +83,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Latest normalized all-subnet metagraph index with chain-native state and registry coverage metadata.",
       "id": "metagraph-latest",
       "path": "/metagraph/metagraph/latest.json",
@@ -92,7 +92,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Per-subnet detail payload.",
       "id": "subnet-detail",
       "path": "/metagraph/subnets/{netuid}.json",
@@ -101,7 +101,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Composed per-subnet overview: profile + health + curation + gaps + counts.",
       "id": "subnet-overview",
       "path": "/metagraph/overview/{netuid}.json",
@@ -110,7 +110,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Public-safe subnet identity and completeness profiles.",
       "id": "profiles",
       "path": "/metagraph/profiles.json",
@@ -119,7 +119,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Per-subnet public-safe profile detail.",
       "id": "profile-detail",
       "path": "/metagraph/profiles/{netuid}.json",
@@ -128,7 +128,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Curated public interface surfaces only.",
       "id": "surfaces",
       "path": "/metagraph/surfaces.json",
@@ -137,7 +137,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Deprecated surface display-id aliases mapped to stable surface keys for renamed surfaces.",
       "id": "surface-aliases",
       "path": "/metagraph/surface-aliases.json",
@@ -146,7 +146,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Curated public interface surfaces for one subnet.",
       "id": "surfaces-subnet",
       "path": "/metagraph/surfaces/{netuid}.json",
@@ -155,7 +155,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Generalized endpoint/resource registry derived from curated surfaces and probe observations.",
       "id": "endpoints",
       "path": "/metagraph/endpoints.json",
@@ -164,7 +164,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Generalized endpoint/resource registry for one subnet.",
       "id": "endpoints-subnet",
       "path": "/metagraph/endpoints/{netuid}.json",
@@ -173,7 +173,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Unpromoted candidate surfaces from public discovery.",
       "id": "candidates",
       "path": "/metagraph/candidates.json",
@@ -182,7 +182,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Unpromoted candidate surfaces for one subnet.",
       "id": "candidates-subnet",
       "path": "/metagraph/candidates/{netuid}.json",
@@ -191,7 +191,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Candidate surfaces queued for maintainer review.",
       "id": "review-queue",
       "path": "/metagraph/review-queue.json",
@@ -200,7 +200,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Compact search index for subnets, surfaces, and providers.",
       "id": "search",
       "path": "/metagraph/search.json",
@@ -209,7 +209,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Slim search index (the same documents as search.json without the per-document token blobs) for fast browser typeahead and listing.",
       "id": "search-index",
       "path": "/metagraph/search-index.json",
@@ -218,7 +218,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Registry coverage counts and source precedence.",
       "id": "coverage",
       "path": "/metagraph/coverage.json",
@@ -227,7 +227,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Machine-usable coverage depth scorecard with per-subnet readiness dimensions and a ranked enrichment queue.",
       "id": "coverage-depth",
       "path": "/metagraph/coverage-depth.json",
@@ -236,7 +236,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Per-subnet validator and economic metrics from the chain: validator/miner counts, total + max stake, registration cost, alpha price, and derived price-weighted emission share.",
       "id": "economics",
       "path": "/metagraph/economics.json",
@@ -245,7 +245,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Network-wide economics time series (#1307) aggregated per UTC day across all subnets from the daily subnet_snapshots D1 rollup (the same source the per-subnet trajectory reads), served live at /api/v1/economics/trends (no static file).",
       "id": "economics-trends",
       "path": "/metagraph/economics/trends.json",
@@ -254,7 +254,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Registry-wide summary: completeness rollup, top subnets, level counts, latest changes.",
       "id": "registry-summary",
       "path": "/metagraph/registry-summary.json",
@@ -263,7 +263,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Cross-network subnet lineage: maintainer-approved mainnet ↔ testnet pairs with reviewed match evidence.",
       "id": "lineage",
       "path": "/metagraph/lineage.json",
@@ -272,7 +272,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Index of captured live request/response fixtures (which surfaces carry a sanitized sample).",
       "id": "fixtures-index",
       "path": "/metagraph/fixtures.json",
@@ -281,7 +281,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Machine index of every AI resource: the copyable agent, the MCP server + tools, the skill, llms.txt, OpenAPI, and the agent-facing APIs.",
       "id": "agent-resources",
       "path": "/metagraph/agent-resources.json",
@@ -290,7 +290,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "A captured, sanitized live request/response sample for one surface.",
       "id": "fixture-detail",
       "path": "/metagraph/fixtures/{surface_id}.json",
@@ -299,7 +299,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Curation state and gaps for every active subnet.",
       "id": "curation",
       "path": "/metagraph/curation.json",
@@ -308,7 +308,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Missing public interface facets by subnet.",
       "id": "gaps",
       "path": "/metagraph/gaps.json",
@@ -317,7 +317,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Latest candidate verification snapshot.",
       "id": "verification",
       "path": "/metagraph/verification/latest.json",
@@ -326,7 +326,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Latest candidate verification snapshot for one subnet.",
       "id": "verification-subnet",
       "path": "/metagraph/verification/subnets/{netuid}.json",
@@ -335,7 +335,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Freshness and staleness summary for generated backend data.",
       "id": "freshness",
       "path": "/metagraph/freshness.json",
@@ -344,7 +344,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Upstream source and provider health summary.",
       "id": "source-health",
       "path": "/metagraph/source-health.json",
@@ -353,7 +353,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Compact hashes and counts for canonical source inputs.",
       "id": "source-snapshots",
       "path": "/metagraph/source-snapshots.json",
@@ -362,7 +362,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Public evidence ledger for subnet and surface claims.",
       "id": "evidence-ledger",
       "path": "/metagraph/evidence-ledger.json",
@@ -371,7 +371,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Public evidence ledger claims for one subnet.",
       "id": "evidence-subnet",
       "path": "/metagraph/evidence/{netuid}.json",
@@ -380,7 +380,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Latest surface health snapshot.",
       "id": "health-latest",
       "path": "/metagraph/health/latest.json",
@@ -389,7 +389,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Global and per-subnet health rollup.",
       "id": "health-summary",
       "path": "/metagraph/health/summary.json",
@@ -398,7 +398,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Compact daily health-history snapshot.",
       "id": "health-history",
       "path": "/metagraph/health/history/{date}.json",
@@ -407,7 +407,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Per-subnet health payload for metagraph.sh consumers.",
       "id": "health-subnet",
       "path": "/metagraph/health/subnets/{netuid}.json",
@@ -416,7 +416,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Badge data contract for status rendering.",
       "id": "health-badge",
       "path": "/metagraph/health/badges/{netuid}.json",
@@ -425,7 +425,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Computed 7d/30d uptime + success-only latency trends (mean, p50/p95/p99 tail, and healthy-sample count) for one subnet's operational surfaces. Served live from D1 at /api/v1/subnets/{netuid}/health/trends (no static file).",
       "id": "health-trends",
       "path": "/metagraph/health/trends/{netuid}.json",
@@ -434,7 +434,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Compact all-subnet 7d/30d daily uptime + success-only latency trend matrix (mean + healthy-sample count). Served live from D1 at /api/v1/health/trends (no static file).",
       "id": "health-trends-bulk",
       "path": "/metagraph/health/trends.json",
@@ -443,7 +443,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Latency percentiles (p50/p95/p99 + avg/min/max) per operational surface for one subnet, computed live from D1 at /api/v1/subnets/{netuid}/health/percentiles (no static file).",
       "id": "health-percentiles",
       "path": "/metagraph/health/percentiles/{netuid}.json",
@@ -452,7 +452,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "SLA (uptime ratio) and reconstructed downtime incidents per operational surface for one subnet, computed live from D1 at /api/v1/subnets/{netuid}/health/incidents (no static file).",
       "id": "health-incidents",
       "path": "/metagraph/health/incidents/{netuid}.json",
@@ -461,7 +461,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Week-over-week structural trajectory (completeness + surface/endpoint counts) for one subnet from daily snapshots, served live from D1 at /api/v1/subnets/{netuid}/trajectory (no static file).",
       "id": "subnet-trajectory",
       "path": "/metagraph/subnets/{netuid}/trajectory.json",
@@ -470,7 +470,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Stake & emission concentration metrics (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) for one subnet across three lenses — per-UID, per-entity (coldkeys collapsed to the true control distribution), and validator-only consensus power — served live from the neurons D1 tier at /api/v1/subnets/{netuid}/concentration (no static file).",
       "id": "subnet-concentration",
       "path": "/metagraph/subnets/{netuid}/concentration.json",
@@ -479,7 +479,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/concentration/history (no static file).",
       "id": "subnet-concentration-history",
       "path": "/metagraph/subnets/{netuid}/concentration/history.json",
@@ -488,7 +488,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + Jaccard retention, UID deregistrations, and a 0-100 stability score — served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/turnover (no static file).",
       "id": "subnet-turnover",
       "path": "/metagraph/subnets/{netuid}/turnover.json",
@@ -497,7 +497,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Per-UID metagraph (stake, trust, consensus, incentive, dividends, emission, validator_permit, rank, axon) for one subnet, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/metagraph (no static file).",
       "id": "subnet-metagraph",
       "path": "/metagraph/subnets/{netuid}/metagraph.json",
@@ -506,7 +506,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "A single neuron's metagraph state by UID, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/neurons/{uid} (no static file).",
       "id": "subnet-neuron",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}.json",
@@ -515,7 +515,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Validators (validator_permit) of one subnet ranked by stake, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/validators (no static file).",
       "id": "subnet-validators",
       "path": "/metagraph/subnets/{netuid}/validators.json",
@@ -524,7 +524,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "First-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, served live from the account_events D1 tier filtered by netuid at /api/v1/subnets/{netuid}/events (no static file).",
       "id": "subnet-events",
       "path": "/metagraph/subnets/{netuid}/events.json",
@@ -533,7 +533,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Per-UID daily metagraph history (stake/trust/emission/rank over time) for one UID, served live from the neuron_daily D1 rollup tier at /api/v1/subnets/{netuid}/neurons/{uid}/history (no static file).",
       "id": "subnet-neuron-history",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}/history.json",
@@ -542,7 +542,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Per-subnet daily aggregate history (neuron/validator counts + stake/emission totals) for one subnet, served live from the neuron_daily D1 rollup tier at /api/v1/subnets/{netuid}/history (no static file).",
       "id": "subnet-history",
       "path": "/metagraph/subnets/{netuid}/history.json",
@@ -551,7 +551,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Cross-subnet activity summary for one account (hotkey or coldkey): chain-event aggregates joined to current registrations, served live from D1 at /api/v1/accounts/{ss58} (no static file).",
       "id": "account-summary",
       "path": "/metagraph/accounts/{ss58}.json",
@@ -560,7 +560,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events (no static file).",
       "id": "account-events",
       "path": "/metagraph/accounts/{ss58}/events.json",
@@ -569,7 +569,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Durable per-day activity series for one account (hotkey-keyed, newest day first), served live from the account_events_daily rollup at /api/v1/accounts/{ss58}/history (no static file).",
       "id": "account-history",
       "path": "/metagraph/accounts/{ss58}/history.json",
@@ -578,7 +578,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Paginated extrinsics this account signed (by signer), newest first, served live from the extrinsics D1 tier at /api/v1/accounts/{ss58}/extrinsics (no static file).",
       "id": "account-extrinsics",
       "path": "/metagraph/accounts/{ss58}/extrinsics.json",
@@ -587,7 +587,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers (no static file).",
       "id": "account-transfers",
       "path": "/metagraph/accounts/{ss58}/transfers.json",
@@ -596,7 +596,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Per-counterparty fund-flow rollup for one account, with optional ?counterparty=<ss58> relationship evidence — native-TAO transfers from the account_events D1 tier at /api/v1/accounts/{ss58}/counterparties (no static file).",
       "id": "account-counterparties",
       "path": "/metagraph/accounts/{ss58}/counterparties.json",
@@ -605,7 +605,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "The subnets where an account's hotkey is currently registered, served live from the neurons D1 tier at /api/v1/accounts/{ss58}/subnets (no static file).",
       "id": "account-subnets",
       "path": "/metagraph/accounts/{ss58}/subnets.json",
@@ -614,7 +614,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Live TAO balance (free+reserved, in TAO) for a finney account, queried from the RPC at request time with 60s KV cache. balance_tao is null on RPC failure. (#1818)",
       "id": "account-balance",
       "path": "/metagraph/accounts/{ss58}/balance.json",
@@ -623,7 +623,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "The recent-block feed (newest first) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks (no static file).",
       "id": "blocks-feed",
       "path": "/metagraph/blocks.json",
@@ -632,7 +632,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks/{ref} (no static file).",
       "id": "block-detail",
       "path": "/metagraph/blocks/{ref}.json",
@@ -641,7 +641,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "The extrinsics in one block (by numeric block_number or 0x block_hash), in natural order, served live from the first-party extrinsics D1 tier at /api/v1/blocks/{ref}/extrinsics (no static file).",
       "id": "block-extrinsics",
       "path": "/metagraph/blocks/{ref}/extrinsics.json",
@@ -650,7 +650,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "The decoded chain events in one block (by numeric block_number or 0x block_hash), in natural order, served live from the first-party account_events D1 tier filtered by block_number at /api/v1/blocks/{ref}/events (no static file).",
       "id": "block-events",
       "path": "/metagraph/blocks/{ref}/events.json",
@@ -659,7 +659,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events (no static file). Distinct from the curated account-attributed event stream; empty before the all-events backfill runs.",
       "id": "chain-events-feed",
       "path": "/metagraph/chain-events.json",
@@ -668,7 +668,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Every raw pallet-level event in one block (event_index ascending) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/blocks/{ref}/chain-events (no static file). Distinct from /blocks/{ref}/events (the curated account-attributed D1 stream).",
       "id": "block-chain-events",
       "path": "/metagraph/blocks/{ref}/chain-events.json",
@@ -677,7 +677,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Chain-activity aggregate (pallet.method event distribution over the most recent N blocks) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events/stats (no static file) and consumed by the get_chain_activity MCP tool.",
       "id": "chain-events-stats",
       "path": "/metagraph/chain-events/stats.json",
@@ -686,7 +686,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "The recent-extrinsic feed (newest first) for the block explorer (#1345), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics (no static file).",
       "id": "extrinsics-feed",
       "path": "/metagraph/extrinsics.json",
@@ -695,7 +695,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics/{hash} (no static file).",
       "id": "extrinsic-detail",
       "path": "/metagraph/extrinsics/{hash}.json",
@@ -704,7 +704,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Daily network-activity aggregates (extrinsic/event/block counts, success rate, unique signers) over a 7d or 30d window for the block explorer (#1987), computed live from the first-party chain D1 tiers at /api/v1/chain/activity (no static file).",
       "id": "chain-activity",
       "path": "/metagraph/chain/activity.json",
@@ -713,7 +713,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Extrinsic call-mix breakdown (count + share per call_module / call_function) over a 7d or 30d window for the block explorer (#1989), computed live from the first-party extrinsics D1 tier at /api/v1/chain/calls (no static file).",
       "id": "chain-calls",
       "path": "/metagraph/chain/calls.json",
@@ -722,7 +722,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Windowed most-active-account leaderboard (signers ranked by extrinsic count, with fees/tips + newest block) over a 7d or 30d window for the block explorer (#1990), computed live from the first-party extrinsics D1 tier at /api/v1/chain/signers (no static file).",
       "id": "chain-signers",
       "path": "/metagraph/chain/signers.json",
@@ -731,7 +731,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Fee/tip market analytics (daily totals + averages and a top-fee-payer list) over a 7d or 30d window for the block explorer (#1988), computed live from the first-party extrinsics D1 tier at /api/v1/chain/fees (no static file).",
       "id": "chain-fees",
       "path": "/metagraph/chain/fees.json",
@@ -740,7 +740,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Long-term daily uptime history per operational surface for one subnet (90d/1y window), served live from the surface_uptime_daily D1 rollup (no static file).",
       "id": "subnet-uptime",
       "path": "/metagraph/subnets/{netuid}/uptime.json",
@@ -749,7 +749,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window, served live from D1 at /api/v1/incidents (no static file).",
       "id": "global-incidents",
       "path": "/metagraph/incidents.json",
@@ -758,7 +758,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Registry leaderboards — operational (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable) and economic opportunity (open-slots, cheapest-registration, highest-emission, validator-headroom) — computed live from D1 + registry projections + the economics tier at /api/v1/registry/leaderboards (no static file).",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",
@@ -767,7 +767,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Cross-subnet comparison — registry structure (completeness + surface counts), the live economics tier, and the live per-subnet health rollup placed side by side for the requested netuids in requested order — computed live from registry projections + the economics tier + D1 at /api/v1/compare (no static file).",
       "id": "compare",
       "path": "/metagraph/compare.json",
@@ -776,7 +776,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets) over a 7d/30d window, computed live from the rpc_proxy_events telemetry at /api/v1/rpc/usage (no static file).",
       "id": "rpc-usage",
       "path": "/metagraph/rpc/usage.json",
@@ -785,7 +785,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Bittensor base-layer RPC endpoint registry and probe status.",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
@@ -794,7 +794,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Endpoint pool scoring for future read-only RPC routing.",
       "id": "rpc-pools",
       "path": "/metagraph/rpc/pools.json",
@@ -803,7 +803,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Generalized endpoint pool scoring for future read-only routing.",
       "id": "endpoint-pools",
       "path": "/metagraph/endpoint-pools.json",
@@ -812,7 +812,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Probe-derived endpoint incident summary and active endpoint failures.",
       "id": "endpoint-incidents",
       "path": "/metagraph/endpoint-incidents.json",
@@ -821,7 +821,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Operational surfaces (RPC/WSS/subnet-api/SSE/data-artifact) probed live by the cron health prober; input list for the 15-minute scheduled prober.",
       "id": "operational-surfaces",
       "path": "/metagraph/operational-surfaces.json",
@@ -830,7 +830,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Compact index of subnets exposing callable services (subnet-api/openapi/sse/data-artifact) — the machine-readable 'which subnet does X + how to call it' index for AI agents.",
       "id": "agent-catalog",
       "path": "/metagraph/agent-catalog.json",
@@ -839,7 +839,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Per-subnet agent capability catalog: each callable service with its base URL, auth, machine-readable schema, and live-build health/eligibility.",
       "id": "agent-catalog-subnet",
       "path": "/metagraph/agent-catalog/{netuid}.json",
@@ -848,7 +848,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "OpenAPI schema snapshot/drift status.",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",
@@ -857,7 +857,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Index of captured machine-readable schemas.",
       "id": "schema-index",
       "path": "/metagraph/schemas/index.json",
@@ -866,7 +866,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Captured machine-readable OpenAPI/Swagger schema snapshot detail.",
       "id": "schema-snapshot",
       "path": "/metagraph/schemas/{surface_id}.json",
@@ -875,7 +875,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Adapter-backed public metrics by subnet slug.",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",
@@ -884,7 +884,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "R2 upload manifest for generated artifact history.",
       "id": "r2-manifest",
       "path": "/metagraph/r2-manifest.json",
@@ -893,7 +893,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Maintainer curation and adapter candidate report.",
       "id": "review-curation",
       "path": "/metagraph/review/curation.json",
@@ -902,7 +902,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Subnet interface gap priorities.",
       "id": "review-gap-priorities",
       "path": "/metagraph/review/gap-priorities.json",
@@ -911,7 +911,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Interface gap priorities and enrichment queue for one subnet.",
       "id": "subnet-gaps",
       "path": "/metagraph/review/gaps/{netuid}.json",
@@ -920,7 +920,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Profile completeness and contributor targeting report.",
       "id": "review-profile-completeness",
       "path": "/metagraph/review/profile-completeness.json",
@@ -929,7 +929,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Subnets worth deeper adapter work.",
       "id": "review-adapter-candidates",
       "path": "/metagraph/review/adapter-candidates.json",
@@ -938,7 +938,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Prioritized all-subnet enrichment work queue for contributor-safe registry improvements.",
       "id": "review-enrichment-queue",
       "path": "/metagraph/review/enrichment-queue.json",
@@ -947,7 +947,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Detailed candidate evidence by missing or contributor-target surface kind for enrichment work.",
       "id": "review-enrichment-evidence",
       "path": "/metagraph/review/enrichment-evidence.json",
@@ -956,7 +956,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Contributor-oriented enrichment target pack grouped by submission kind, review route, and evidence action.",
       "id": "review-enrichment-targets",
       "path": "/metagraph/review/enrichment-targets.json",
@@ -965,7 +965,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Public-safe maintainer review decision ledger.",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
@@ -974,7 +974,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-29.1",
+      "contract_version": "2026-06-29.2",
       "description": "Generated build summary.",
       "id": "build-summary",
       "path": "/metagraph/build-summary.json",
@@ -983,7 +983,7 @@
     }
   ],
   "base_path": "/metagraph",
-  "contract_version": "2026-06-29.1",
+  "contract_version": "2026-06-29.2",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "name": "Metagraphed public backend artifact contract",
   "notes": [

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -13220,6 +13220,101 @@
         "additionalProperties": true,
         "description": "Validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots, computed live from the neuron_daily D1 rollup.",
         "properties": {
+          "changes": {
+            "additionalProperties": false,
+            "description": "Optional drilldown included only when the live turnover route is requested with changes=true.",
+            "properties": {
+              "uid_reassignment_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "uid_reassignments": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "from_hotkey": {
+                      "type": "string"
+                    },
+                    "to_hotkey": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "uid",
+                    "from_hotkey",
+                    "to_hotkey"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "validators_entered": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "hotkey": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "hotkey",
+                    "uid"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "validators_entered_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "validators_exited": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "hotkey": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "hotkey",
+                    "uid"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "validators_exited_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "validators_entered",
+              "validators_exited",
+              "uid_reassignments"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "comparable": {
             "type": "boolean"
           },
@@ -14292,7 +14387,7 @@
   "info": {
     "description": "Public, read-only API over canonical Metagraphed registry artifacts for Bittensor subnet interfaces. **No authentication** — every operation is an unauthenticated GET. Responses use a stable JSON envelope `{ ok, schema_version, data, meta }` (errors: `{ ok: false, error }`) and carry `ETag` + `Cache-Control` for conditional caching. Rate-limited per client. Multi-network: insert a `/{network}/` segment after `/api/v1/` (mainnet is the default — omit it) to read testnet data, e.g. `/api/v1/testnet/subnets`. Testnet exposes the subset of routes that have data; `/api/v1/lineage` tracks which testnet subnets have graduated.",
     "title": "Metagraphed API",
-    "version": "2026-06-29.1"
+    "version": "2026-06-29.2"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -33048,6 +33143,17 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "changes",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -33056,6 +33162,30 @@
               "application/json": {
                 "example": {
                   "data": {
+                    "changes": {
+                      "uid_reassignment_count": 1,
+                      "uid_reassignments": [
+                        {
+                          "from_hotkey": "example",
+                          "to_hotkey": "example",
+                          "uid": 1
+                        }
+                      ],
+                      "validators_entered": [
+                        {
+                          "hotkey": "example",
+                          "uid": 1
+                        }
+                      ],
+                      "validators_entered_count": 1,
+                      "validators_exited": [
+                        {
+                          "hotkey": "example",
+                          "uid": 1
+                        }
+                      ],
+                      "validators_exited_count": 1
+                    },
                     "comparable": false,
                     "end_date": "example",
                     "netuid": 7,
@@ -33172,7 +33302,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + retention, UID deregistrations, and a 0-100 stability score (computed live from the neuron_daily D1 rollup).",
+        "summary": "Fetch validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + retention, UID deregistrations, and a 0-100 stability score. Add ?changes=true to include the entered/exited validator hotkeys and UID reassignment detail (computed live from the neuron_daily D1 rollup).",
         "tags": [
           "subnets",
           "analytics"
@@ -33732,7 +33862,7 @@
   ],
   "x-metagraphed": {
     "canonical_artifact_base_path": "/metagraph",
-    "contract_version": "2026-06-29.1",
+    "contract_version": "2026-06-29.2",
     "generated_at": "1970-01-01T00:00:00.000Z",
     "notes": "OpenAPI describes Worker response envelopes and canonical artifact payloads. Raw /metagraph JSON remains the reviewed source contract.",
     "schema_version": 1

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1541,7 +1541,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + retention, UID deregistrations, and a 0-100 stability score (computed live from the neuron_daily D1 rollup). */
+        /** Fetch validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + retention, UID deregistrations, and a 0-100 stability score. Add ?changes=true to include the entered/exited validator hotkeys and UID reassignment detail (computed live from the neuron_daily D1 rollup). */
         get: operations["subnetTurnover"];
         put?: never;
         post?: never;
@@ -4850,6 +4850,25 @@ export interface components {
         };
         /** @description Validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots, computed live from the neuron_daily D1 rollup. */
         SubnetTurnoverArtifact: {
+            /** @description Optional drilldown included only when the live turnover route is requested with changes=true. */
+            changes?: {
+                uid_reassignment_count?: number;
+                uid_reassignments: {
+                    from_hotkey: string;
+                    to_hotkey: string;
+                    uid: number;
+                }[];
+                validators_entered: {
+                    hotkey: string;
+                    uid: number | null;
+                }[];
+                validators_entered_count?: number;
+                validators_exited: {
+                    hotkey: string;
+                    uid: number | null;
+                }[];
+                validators_exited_count?: number;
+            } | null;
             comparable: boolean;
             end_date?: string | null;
             netuid: number;
@@ -17721,6 +17740,7 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d" | "1y" | "all";
+                changes?: "true";
             };
             header?: never;
             path: {
@@ -17742,6 +17762,30 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "changes": {
+                     *           "uid_reassignment_count": 1,
+                     *           "uid_reassignments": [
+                     *             {
+                     *               "from_hotkey": "example",
+                     *               "to_hotkey": "example",
+                     *               "uid": 1
+                     *             }
+                     *           ],
+                     *           "validators_entered": [
+                     *             {
+                     *               "hotkey": "example",
+                     *               "uid": 1
+                     *             }
+                     *           ],
+                     *           "validators_entered_count": 1,
+                     *           "validators_exited": [
+                     *             {
+                     *               "hotkey": "example",
+                     *               "uid": 1
+                     *             }
+                     *           ],
+                     *           "validators_exited_count": 1
+                     *         },
                      *         "comparable": false,
                      *         "end_date": "example",
                      *         "netuid": 7,

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -13198,6 +13198,101 @@
         "additionalProperties": true,
         "description": "Validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots, computed live from the neuron_daily D1 rollup.",
         "properties": {
+          "changes": {
+            "additionalProperties": false,
+            "description": "Optional drilldown included only when the live turnover route is requested with changes=true.",
+            "properties": {
+              "uid_reassignment_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "uid_reassignments": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "from_hotkey": {
+                      "type": "string"
+                    },
+                    "to_hotkey": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "uid",
+                    "from_hotkey",
+                    "to_hotkey"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "validators_entered": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "hotkey": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "hotkey",
+                    "uid"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "validators_entered_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "validators_exited": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "hotkey": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "hotkey",
+                    "uid"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "validators_exited_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "validators_entered",
+              "validators_exited",
+              "uid_reassignments"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "comparable": {
             "type": "boolean"
           },

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -858,7 +858,59 @@
           "neurons_end": { "type": "integer", "minimum": 0 },
           "uids_deregistered": { "type": "integer", "minimum": 0 },
           "neuron_retention": { "type": ["number", "null"] },
-          "stability_score": { "type": ["integer", "null"] }
+          "stability_score": { "type": ["integer", "null"] },
+          "changes": {
+            "type": ["object", "null"],
+            "description": "Optional drilldown included only when the live turnover route is requested with changes=true.",
+            "required": [
+              "validators_entered",
+              "validators_exited",
+              "uid_reassignments"
+            ],
+            "properties": {
+              "validators_entered_count": { "type": "integer", "minimum": 0 },
+              "validators_exited_count": { "type": "integer", "minimum": 0 },
+              "uid_reassignment_count": { "type": "integer", "minimum": 0 },
+              "validators_entered": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["hotkey", "uid"],
+                  "properties": {
+                    "hotkey": { "type": "string" },
+                    "uid": { "type": ["integer", "null"] }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "validators_exited": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["hotkey", "uid"],
+                  "properties": {
+                    "hotkey": { "type": "string" },
+                    "uid": { "type": ["integer", "null"] }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "uid_reassignments": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["uid", "from_hotkey", "to_hotkey"],
+                  "properties": {
+                    "uid": { "type": "integer", "minimum": 0 },
+                    "from_hotkey": { "type": "string" },
+                    "to_hotkey": { "type": "string" }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          }
         },
         "additionalProperties": true
       },

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2,7 +2,7 @@ import { artifactStorageTierForPath } from "./artifact-storage.mjs";
 import { DOMAIN_TAGS } from "./domain-tags.mjs";
 import { sampleFromSchema } from "./openapi-sample.mjs";
 
-export const CONTRACT_VERSION = "2026-06-29.1";
+export const CONTRACT_VERSION = "2026-06-29.2";
 export const SCHEMA_VERSION = 1;
 // The API + artifacts are served from the api subdomain; the bare apex
 // (metagraph.sh) is the metagraphed-ui UI. PRIMARY_DOMAIN drives the OpenAPI
@@ -1738,7 +1738,7 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/turnover",
     "/metagraph/subnets/{netuid}/turnover.json",
-    "Fetch validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + retention, UID deregistrations, and a 0-100 stability score (computed live from the neuron_daily D1 rollup).",
+    "Fetch validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + retention, UID deregistrations, and a 0-100 stability score. Add ?changes=true to include the entered/exited validator hotkeys and UID reassignment detail (computed live from the neuron_daily D1 rollup).",
     "short",
     ["subnets", "analytics"],
     [
@@ -1746,6 +1746,7 @@ export const API_ROUTES = [
         name: "window",
         schema: { type: "string", enum: ["7d", "30d", "90d", "1y", "all"] },
       },
+      { name: "changes", schema: { type: "string", enum: ["true"] } },
     ],
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),

--- a/src/turnover.mjs
+++ b/src/turnover.mjs
@@ -52,17 +52,43 @@ function validatorHotkeys(rows) {
   return set;
 }
 
+function normalizedUid(value) {
+  if (value == null) return null;
+  const uid = Number(value);
+  return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
+}
+
 // UID → hotkey map for one snapshot (rows with a real hotkey). A UID whose hotkey
 // changes between snapshots was deregistered + re-registered to a new owner.
 function uidHotkeyMap(rows) {
   const map = new Map();
   for (const row of rows) {
+    const uid = normalizedUid(row?.uid);
     const hotkey = row?.hotkey;
-    if (row?.uid != null && typeof hotkey === "string" && hotkey.length > 0) {
-      map.set(row.uid, hotkey);
+    if (uid != null && typeof hotkey === "string" && hotkey.length > 0) {
+      map.set(uid, hotkey);
     }
   }
   return map;
+}
+
+function validatorHotkeyMap(rows) {
+  const map = new Map();
+  for (const row of rows) {
+    const hotkey = row?.hotkey;
+    if (
+      Number(row?.validator_permit) === 1 &&
+      typeof hotkey === "string" &&
+      hotkey.length > 0
+    ) {
+      map.set(hotkey, { hotkey, uid: normalizedUid(row.uid) });
+    }
+  }
+  return map;
+}
+
+function sortValidatorDetails(rows) {
+  return rows.sort((a, b) => a.hotkey.localeCompare(b.hotkey));
 }
 
 const EMPTY_TURNOVER = {
@@ -77,6 +103,20 @@ const EMPTY_TURNOVER = {
   uids_deregistered: 0,
   neuron_retention: null,
   stability_score: null,
+};
+
+const EMPTY_TURNOVER_CHANGES = {
+  comparable: false,
+  validators_start: 0,
+  validators_end: 0,
+  validators_entered_count: 0,
+  validators_exited_count: 0,
+  neurons_start: 0,
+  neurons_end: 0,
+  uid_reassignment_count: 0,
+  validators_entered: [],
+  validators_exited: [],
+  uid_reassignments: [],
 };
 
 // Compare a subnet's start-of-window vs end-of-window neuron_daily snapshots into a
@@ -156,14 +196,81 @@ export function buildTurnover(
   };
 }
 
-// One subnet's validator-set & registration churn — shared by the REST route and
-// MCP tool: MIN/MAX the window's boundary snapshot_dates on neuron_daily, read
-// exactly those two days' rows, shape with buildTurnover. Cold D1 → comparable:false.
-export async function loadSubnetTurnover(
-  d1,
+// Detail view for the turnover scorecard: which validator hotkeys entered/exited
+// and which UID slots were reassigned to a different hotkey between the boundary
+// snapshots.
+export function buildTurnoverChanges(
+  rows,
   netuid,
-  { windowLabel, windowDays },
+  { window, startDate, endDate } = {},
 ) {
+  const list = Array.isArray(rows) ? rows : [];
+  const base = {
+    schema_version: 1,
+    netuid,
+    window: window ?? null,
+    start_date: startDate ?? null,
+    end_date: endDate ?? null,
+  };
+  if (startDate == null || endDate == null || list.length === 0) {
+    return { ...base, ...EMPTY_TURNOVER_CHANGES };
+  }
+
+  const startRows = list.filter((row) => row?.snapshot_date === startDate);
+  const endRows = list.filter((row) => row?.snapshot_date === endDate);
+  const startValidators = validatorHotkeyMap(startRows);
+  const endValidators = validatorHotkeyMap(endRows);
+
+  const entered = sortValidatorDetails(
+    [...endValidators]
+      .filter(([hotkey]) => !startValidators.has(hotkey))
+      .map(([, value]) => value),
+  );
+  const exited = sortValidatorDetails(
+    [...startValidators]
+      .filter(([hotkey]) => !endValidators.has(hotkey))
+      .map(([, value]) => value),
+  );
+
+  const startMap = uidHotkeyMap(startRows);
+  const endMap = uidHotkeyMap(endRows);
+  const reassignments = [];
+  for (const [uid, fromHotkey] of startMap) {
+    const toHotkey = endMap.get(uid);
+    if (toHotkey != null && toHotkey !== fromHotkey) {
+      reassignments.push({ uid, from_hotkey: fromHotkey, to_hotkey: toHotkey });
+    }
+  }
+  reassignments.sort((a, b) => a.uid - b.uid);
+
+  return {
+    ...base,
+    comparable: startDate !== endDate,
+    validators_start: startValidators.size,
+    validators_end: endValidators.size,
+    validators_entered_count: entered.length,
+    validators_exited_count: exited.length,
+    neurons_start: startMap.size,
+    neurons_end: endMap.size,
+    uid_reassignment_count: reassignments.length,
+    validators_entered: entered,
+    validators_exited: exited,
+    uid_reassignments: reassignments,
+  };
+}
+
+function turnoverChangeDetail(changes) {
+  return {
+    validators_entered_count: changes.validators_entered_count,
+    validators_exited_count: changes.validators_exited_count,
+    uid_reassignment_count: changes.uid_reassignment_count,
+    validators_entered: changes.validators_entered,
+    validators_exited: changes.validators_exited,
+    uid_reassignments: changes.uid_reassignments,
+  };
+}
+
+async function loadTurnoverBoundaryRows(d1, netuid, { windowDays }) {
   let boundsSql =
     "SELECT MIN(snapshot_date) AS start_date, MAX(snapshot_date) AS end_date FROM neuron_daily WHERE netuid = ?";
   const boundsParams = [netuid];
@@ -184,9 +291,33 @@ export async function loadSubnetTurnover(
           `SELECT ${TURNOVER_READ_COLUMNS} FROM neuron_daily WHERE netuid = ? AND snapshot_date IN (?, ?) ORDER BY snapshot_date ASC, uid ASC`,
           [netuid, startDate, endDate],
         );
-  return buildTurnover(rows, netuid, {
+  return { startDate, endDate, rows };
+}
+
+// One subnet's validator-set & registration churn — shared by the REST route and
+// MCP tool: MIN/MAX the window's boundary snapshot_dates on neuron_daily, read
+// exactly those two days' rows, shape with buildTurnover. Cold D1 → comparable:false.
+export async function loadSubnetTurnover(
+  d1,
+  netuid,
+  { windowLabel, windowDays, includeChanges = false },
+) {
+  const { startDate, endDate, rows } = await loadTurnoverBoundaryRows(
+    d1,
+    netuid,
+    {
+      windowDays,
+    },
+  );
+  const options = {
     window: windowLabel,
     startDate,
     endDate,
-  });
+  };
+  const data = buildTurnover(rows, netuid, options);
+  if (!includeChanges) return data;
+  return {
+    ...data,
+    changes: turnoverChangeDetail(buildTurnoverChanges(rows, netuid, options)),
+  };
 }

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -19,7 +19,7 @@ import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
 
 describe("public contract registry", () => {
   test("keeps API routes and artifacts unique", () => {
-    assert.equal(CONTRACT_VERSION, "2026-06-29.1");
+    assert.equal(CONTRACT_VERSION, "2026-06-29.2");
     assert.equal(CACHE_SECONDS.short, 60);
     assert.equal(
       new Set(API_ROUTES.map((route) => route.id)).size,

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1159,6 +1159,71 @@ describe("handleSubnetTurnover", () => {
     assert.equal(captures.params[idx][0], NETUID);
   });
 
+  test("rejects an invalid changes flag with 400", async () => {
+    const res = await handleSubnetTurnover(
+      req(`/api/v1/subnets/${NETUID}/turnover`),
+      emptyEnv(),
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/turnover?changes=false`),
+    );
+    await errorJson(res);
+  });
+
+  test("changes=true returns schema-stable empty detail on cold D1", async () => {
+    const body = await assertColdSchema(
+      handleSubnetTurnover,
+      req(`/api/v1/subnets/${NETUID}/turnover`),
+      emptyEnv(),
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/turnover?changes=true`),
+    );
+    assert.equal(body.data.netuid, NETUID);
+    assert.equal(body.data.comparable, false);
+    assert.deepEqual(body.data.changes.validators_entered, []);
+    assert.equal(
+      body.meta.artifact_path,
+      `/metagraph/subnets/${NETUID}/turnover.json`,
+    );
+  });
+
+  test("changes=true returns entry, exit, and UID reassignment detail", async () => {
+    const { env } = dbWith({
+      turnoverBounds: [{ start_date: "2026-06-01", end_date: "2026-06-30" }],
+      turnoverRows: [
+        {
+          snapshot_date: "2026-06-01",
+          uid: 1,
+          hotkey: "V2",
+          validator_permit: 1,
+        },
+        {
+          snapshot_date: "2026-06-30",
+          uid: 1,
+          hotkey: "V3",
+          validator_permit: 1,
+        },
+      ],
+    });
+    const body = await json(
+      await handleSubnetTurnover(
+        req(`/api/v1/subnets/${NETUID}/turnover`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/turnover?window=30d&changes=true`),
+      ),
+    );
+    assert.equal(body.data.window, "30d");
+    assert.deepEqual(body.data.changes.validators_entered, [
+      { hotkey: "V3", uid: 1 },
+    ]);
+    assert.deepEqual(body.data.changes.validators_exited, [
+      { hotkey: "V2", uid: 1 },
+    ]);
+    assert.deepEqual(body.data.changes.uid_reassignments, [
+      { uid: 1, from_hotkey: "V2", to_hotkey: "V3" },
+    ]);
+  });
+
   describe("canonicalSubnetTurnoverCachePath", () => {
     test("omitted window and explicit ?window=30d produce the same cache key", () => {
       const noWindow = canonicalSubnetTurnoverCachePath(
@@ -1171,6 +1236,15 @@ describe("handleSubnetTurnover", () => {
       );
       assert.equal(noWindow, explicit30d);
       assert.equal(noWindow, "/api/v1/subnets/1/turnover?window=30d");
+      const withChanges = canonicalSubnetTurnoverCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/1/turnover?changes=true",
+        ),
+      );
+      assert.equal(
+        withChanges,
+        "/api/v1/subnets/1/turnover?window=30d&changes=true",
+      );
     });
 
     test("preserves a non-default valid window label", () => {

--- a/tests/turnover.test.mjs
+++ b/tests/turnover.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, test, vi } from "vitest";
-import { buildTurnover, loadSubnetTurnover } from "../src/turnover.mjs";
+import {
+  buildTurnover,
+  buildTurnoverChanges,
+  loadSubnetTurnover,
+} from "../src/turnover.mjs";
 
 describe("buildTurnover", () => {
   test("cold / empty / non-array / no-window inputs yield a schema-stable empty block", () => {
@@ -192,6 +196,95 @@ describe("buildTurnover", () => {
     assert.equal(data.validators_end, 1); // V1
     assert.equal(data.neurons_start, 0);
     assert.equal(data.neurons_end, 1);
+  });
+});
+
+describe("buildTurnoverChanges", () => {
+  test("cold / empty / non-array inputs yield schema-stable empty detail", () => {
+    for (const rows of [[], null, undefined]) {
+      const data = buildTurnoverChanges(rows, 7, { window: "30d" });
+      assert.equal(data.netuid, 7);
+      assert.equal(data.comparable, false);
+      assert.equal(data.validators_entered_count, 0);
+      assert.deepEqual(data.validators_entered, []);
+      assert.deepEqual(data.validators_exited, []);
+      assert.deepEqual(data.uid_reassignments, []);
+    }
+  });
+
+  test("lists validator entries, exits, and UID reassignments", () => {
+    const data = buildTurnoverChanges(
+      [
+        {
+          snapshot_date: "2026-06-01",
+          uid: "0",
+          hotkey: "V1",
+          validator_permit: 1,
+        },
+        {
+          snapshot_date: "2026-06-01",
+          uid: 1,
+          hotkey: "V2",
+          validator_permit: 1,
+        },
+        {
+          snapshot_date: "2026-06-01",
+          uid: 2,
+          hotkey: "M1",
+          validator_permit: 0,
+        },
+        {
+          snapshot_date: "2026-06-01",
+          uid: 3,
+          hotkey: "V4",
+          validator_permit: 1,
+        },
+        {
+          snapshot_date: "2026-06-30",
+          uid: "0",
+          hotkey: "V1",
+          validator_permit: 1,
+        },
+        {
+          snapshot_date: "2026-06-30",
+          uid: 1,
+          hotkey: "V3",
+          validator_permit: 1,
+        },
+        {
+          snapshot_date: "2026-06-30",
+          uid: 2,
+          hotkey: "M1",
+          validator_permit: 0,
+        },
+        {
+          snapshot_date: "2026-06-30",
+          uid: 4,
+          hotkey: "V0",
+          validator_permit: 1,
+        },
+      ],
+      9,
+      {
+        window: "30d",
+        startDate: "2026-06-01",
+        endDate: "2026-06-30",
+      },
+    );
+    assert.equal(data.comparable, true);
+    assert.equal(data.validators_entered_count, 2);
+    assert.equal(data.validators_exited_count, 2);
+    assert.deepEqual(data.validators_entered, [
+      { hotkey: "V0", uid: 4 },
+      { hotkey: "V3", uid: 1 },
+    ]);
+    assert.deepEqual(data.validators_exited, [
+      { hotkey: "V2", uid: 1 },
+      { hotkey: "V4", uid: 3 },
+    ]);
+    assert.deepEqual(data.uid_reassignments, [
+      { uid: 1, from_hotkey: "V2", to_hotkey: "V3" },
+    ]);
   });
 });
 

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -341,7 +341,16 @@ export function canonicalSubnetConcentrationHistoryCachePath(url) {
 // parseHistoryWindow). Distinct from canonicalSubnetConcentrationHistoryCachePath
 // which uses a different parse function (parseConcentrationHistoryWindow).
 export function canonicalSubnetTurnoverCachePath(url) {
-  return canonicalWindowedCachePath(url, parseHistoryWindow);
+  const validationError = validateQueryParams(url, ["window", "changes"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const { label, error } = parseHistoryWindow(url.searchParams.get("window"));
+  if (error) return `${url.pathname}${url.search}`;
+  const changes = url.searchParams.get("changes");
+  if (changes != null && changes !== "true") {
+    return `${url.pathname}${url.search}`;
+  }
+  const suffix = changes === "true" ? "&changes=true" : "";
+  return `${url.pathname}?window=${encodeURIComponent(label)}${suffix}`;
 }
 
 // Canonical edge-cache key for the subnet-metagraph route. Only
@@ -401,21 +410,28 @@ export async function handleSubnetConcentrationHistory(
 }
 
 // GET /api/v1/subnets/{netuid}/turnover?window=7d|30d|90d|1y|all: validator-set &
-// registration churn between the window's start and end neuron_daily snapshots —
-// validators entered/exited + Jaccard retention, UID deregistrations, and a 0–100
-// stability score. Reads only the two boundary snapshot_dates (a MIN/MAX bounds
-// query then their rows). Cold/absent store or a single snapshot → 200 with
-// comparable:false + zeroed metrics (schema-stable, never 404).
+// registration churn between the window's start and end neuron_daily snapshots.
+// Add ?changes=true for validator hotkeys entered/exited and UID slots reassigned
+// between the same boundary snapshots. Cold/absent store or a single snapshot →
+// 200 with comparable:false + zeroed metrics (schema-stable, never 404).
 export async function handleSubnetTurnover(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "changes"]);
   if (validationError) return analyticsQueryError(validationError);
   const { label, days, error } = parseHistoryWindow(
     url.searchParams.get("window"),
   );
   if (error) return analyticsQueryError(error);
+  const changes = url.searchParams.get("changes");
+  if (changes != null && changes !== "true") {
+    return analyticsQueryError({
+      parameter: "changes",
+      message: `"${changes}" is not a valid changes flag. Supported: true.`,
+    });
+  }
   const data = await loadSubnetTurnover(d1Runner(env), netuid, {
     windowLabel: label,
     windowDays: days,
+    includeChanges: changes === "true",
   });
   return envelopeResponse(
     request,


### PR DESCRIPTION
## Summary
Add an optional subnet turnover drilldown for explorer/API consumers.

Closes #2347

## What changed
- Extended `GET /api/v1/subnets/{netuid}/turnover` with `changes=true` to include entered/exited validator hotkeys and UID reassignment detail.
- Kept the default turnover response unchanged when `changes` is omitted.
- Added bounded, schema-stable builder and handler coverage for cold D1, invalid query flags, sorting, and reassignment detail.
- Regenerated OpenAPI, generated TypeScript definitions, API index, and contracts with `CONTRACT_VERSION` bumped to `2026-06-29.2`.

## Why
The aggregate turnover scorecard is useful for ranking stability, but explorer users also need the concrete validator and UID-slot evidence behind a churn score.

## Validation
- `npm run build`
- `npm exec vitest -- run tests/turnover.test.mjs tests/request-handlers-entities.test.mjs tests/contracts.test.mjs`
- `npm run format:check`
- `npm run lint`
- `git diff --check`
- `npm run validate:contract-drift`
- `npm run validate:schemas`
- `npm run validate:api`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:openapi-examples`
- `npm run validate:generated-client`
- `npm run validate`
- `npm run validate:schema-enums`
- `npm run validate:committed-seed`
- `npm run validate:mcp`
- `npm run validate:ai`
- `npm run validate:artifact-budgets`
- `npm run validate:docs`
- `npm run validate:intake`
- `npm run validate:workflows`
- `npm run validate:migrations`
- `npm run scan:public-safety`
- `npm run validate:private-boundary`
- `npm run cloudflare:verify:dry-run`
- `npm run worker:deploy:dry-run`
- `npm run worker:bundle:budget`
- `npm run validate:client-sdk-sync`
- `npm run validate:adapters`
- `npm run worker:test`
- `npm run test:coverage` — 137 files, 3387 tests passed; statements 98.84%, branches 95.30%, functions 98.64%, lines 99.20%.
- `cd python && uv run --extra test python -m unittest discover -s tests` — 37 tests passed, 1 skipped.

## Notes
- Worker bundle budget passed with an existing near-budget warning.
- Cloudflare dry-run passed with local environment warnings for unset live account bindings.
