### PR TITLE
fix(api): round account-summary activity.total_fee_tao to rao precision

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -83,6 +83,17 @@ function toBlockNumber(value) {
   return Number.isInteger(n) && n >= 0 ? n : null;
 }
 
+// Round a TAO sum to rao precision (9 dp), preserving null — so a D1 SUM(fee_tao)
+// never leaks accumulated IEEE-754 float noise into the payload. Mirrors `toTao`
+// in src/chain-analytics.mjs (which rounds the SAME signer-total-fee value for
+// /chain/signers + /chain/fees); kept null-preserving here because the activity
+// aggregate is null on a cold store, not 0.
+function toTaoOrNull(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.round(n * 1e9) / 1e9 : null;
+}
+
 // One D1 account_events row → a clean API event object (#1347 consumes this).
 export function formatAccountEvent(row) {
   if (!row || typeof row !== "object") return null;
@@ -253,7 +264,7 @@ export function formatAccountActivity(agg, modules) {
     tx_count: a.tx_count ?? 0,
     last_tx_block: toBlockNumber(a.last_tx_block),
     last_tx_at: toIso(a.last_tx_at),
-    total_fee_tao: a.total_fee_tao ?? null,
+    total_fee_tao: toTaoOrNull(a.total_fee_tao),
     modules_called: (modules || [])
       .filter((m) => m && m.call_module)
       .map((m) => ({ call_module: m.call_module, count: m.count ?? 0 })),

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -307,6 +307,29 @@ test("buildAccountSummary threads the signing activity sub-object (#1847)", () =
   assert.equal(out.activity.modules_called[0].call_module, "SubtensorModule");
 });
 
+test("buildAccountSummary rounds activity.total_fee_tao to rao precision (#2351)", () => {
+  // A D1 SUM(fee_tao) over many REAL cells accumulates float noise; the activity
+  // shaper must round it to 9 dp (rao) like toTao does for /chain/signers +
+  // /chain/fees, instead of leaking the long fractional tail.
+  const noisy = 0.1 + 0.2; // 0.30000000000000004
+  const out = buildAccountSummary("5Hk", {
+    activity: { tx_count: 2, total_fee_tao: noisy },
+  });
+  assert.equal(out.activity.total_fee_tao, 0.3);
+
+  // A sub-rao tail is rounded away, not preserved verbatim.
+  const out2 = buildAccountSummary("5Hk", {
+    activity: { tx_count: 1, total_fee_tao: 0.0123456789012 },
+  });
+  assert.equal(out2.activity.total_fee_tao, 0.012345679);
+
+  // Absent aggregate stays null (cold store), never coerced to 0.
+  const cold = buildAccountSummary("5Hk", {
+    activity: { tx_count: 0, total_fee_tao: null },
+  });
+  assert.equal(cold.activity.total_fee_tao, null);
+});
+
 test("account builders null invalid block heights and indices", () => {
   const event = formatAccountEvent({
     block_number: -1,

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -328,6 +328,12 @@ test("buildAccountSummary rounds activity.total_fee_tao to rao precision (#2351)
     activity: { tx_count: 0, total_fee_tao: null },
   });
   assert.equal(cold.activity.total_fee_tao, null);
+
+  // A non-finite aggregate (e.g. a non-numeric cell) is nulled, not NaN.
+  const bad = buildAccountSummary("5Hk", {
+    activity: { tx_count: 1, total_fee_tao: "not-a-number" },
+  });
+  assert.equal(bad.activity.total_fee_tao, null);
 });
 
 test("account builders null invalid block heights and indices", () => {


### PR DESCRIPTION
## Summary

- `GET /api/v1/accounts/{ss58}` and the MCP `get_account` tool (both share `loadAccountSummary` in `src/account-events.mjs`) reported `activity.total_fee_tao` straight from a D1 `SUM(fee_tao)` aggregate, unrounded — so summing many `REAL` fee cells leaked accumulated IEEE-754 float noise (e.g. `0.30000000000000004`).
- Every other TAO sum in the codebase rounds to rao precision (9 dp) to prevent exactly this. The **same** signer-total-fee value is already rounded via `toTao` in `buildChainSigners` (`/chain/signers`) and `buildChainFees` (`/chain/fees`); the account-summary path was the one that was missed, so the endpoints disagreed on the precision of the same number.

Fixes #2351

## What Changed

- `src/account-events.mjs`: added a null-preserving `toTaoOrNull` helper (rounds to 9 dp, keeps `null` for the cold-store aggregate) and used it for `activity.total_fee_tao` in `formatAccountActivity`. Mirrors `toTao` in `src/chain-analytics.mjs`; null-preserving because the activity aggregate is `null` (not `0`) on a cold store. No schema/contract change — same field, same type, just without the float tail.
- `tests/account-events.test.mjs`: added a regression test asserting a noisy sum (`0.1 + 0.2`) rounds to `0.3`, a sub-rao tail is rounded to 9 dp, and an absent aggregate stays `null`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — behaviour-only fix; the field type is unchanged.)

## Validation

- [x] `npm run check` (lint clean; format check passes on CI's LF checkout)
- [x] `npm run worker:test` (`tests/account-events.test.mjs`: 45 passed, incl. new regression test)
- [x] `git diff --check`