### PR TITLE
fix(chain): lowercase 0x hashes in MCP get_block/get_extrinsic loaders

### DIFF
--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -199,7 +199,11 @@ export async function loadBlock(d1, ref) {
   const sql = isHash
     ? `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_hash = ? LIMIT 1`
     : `SELECT ${BLOCK_READ_COLUMNS} FROM blocks WHERE block_number = ? LIMIT 1`;
-  const param = isHash ? String(ref) : blockNumber;
+  // The poller stores hashes lowercase and D1 TEXT columns are BINARY-collated,
+  // so a mixed/upper-case 0x ref would miss. Lowercase the hash before binding —
+  // parity with the REST handleBlock route (#1955); this shared MCP get_block
+  // loader was the missed sibling (the strict-ref guard #2314 left it case-naive).
+  const param = isHash ? String(ref).toLowerCase() : blockNumber;
   const rows = await d1(sql, [param]);
   let prev = null;
   let next = null;

--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -269,9 +269,14 @@ export async function loadExtrinsic(d1, ref) {
   const isHash = /^0x[0-9a-fA-F]{64}$/.test(String(ref));
   let rows;
   if (isHash) {
+    // The poller stores hashes lowercase and D1 TEXT columns are BINARY-collated,
+    // so a mixed/upper-case 0x ref would miss. Lowercase the hash before binding —
+    // parity with the REST handleExtrinsic route (#1955); this shared MCP
+    // get_extrinsic loader was the missed sibling (the composite-ref guard #2316
+    // left it case-naive).
     rows = await d1(
       `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE extrinsic_hash = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT 1`,
-      [String(ref)],
+      [String(ref).toLowerCase()],
     );
   } else {
     const composite = COMPOSITE_REF_RE.exec(String(ref));

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -701,3 +701,28 @@ test("loadBlock still resolves a 64-hex block_hash ref (#2314)", async () => {
     true,
   );
 });
+
+test("loadBlock lowercases a mixed-case 0x block_hash before binding (#2349)", async () => {
+  // The poller stores hashes lowercase + D1 is BINARY-collated, so an upper-case
+  // ref must be lowercased before binding or the MCP get_block tool misses a
+  // block the REST route resolves. Mirrors the REST handleBlock guard (#1955).
+  const lower = `0x${"a".repeat(64)}`;
+  const mixed = `0x${"A".repeat(64)}`;
+  const calls = [];
+  const d1 = async (sql, params) => {
+    calls.push({ sql, params });
+    if (/WHERE block_hash = \?/.test(sql)) {
+      return params[0] === lower ? [{ block_number: 9, block_hash: lower }] : [];
+    }
+    return [];
+  };
+  const out = await loadBlock(d1, mixed);
+  assert.equal(out.block.block_number, 9);
+  assert.equal(
+    calls.some(
+      (c) => /WHERE block_hash = \?/.test(c.sql) && c.params[0] === lower,
+    ),
+    true,
+    "the hash bind parameter must be lowercased",
+  );
+});

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -712,7 +712,9 @@ test("loadBlock lowercases a mixed-case 0x block_hash before binding (#2349)", a
   const d1 = async (sql, params) => {
     calls.push({ sql, params });
     if (/WHERE block_hash = \?/.test(sql)) {
-      return params[0] === lower ? [{ block_number: 9, block_hash: lower }] : [];
+      return params[0] === lower
+        ? [{ block_number: 9, block_hash: lower }]
+        : [];
     }
     return [];
   };

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -808,3 +808,31 @@ test("loadExtrinsic still resolves a 64-hex extrinsic_hash ref (#2316)", async (
     true,
   );
 });
+
+test("loadExtrinsic lowercases a mixed-case 0x extrinsic_hash before binding (#2349)", async () => {
+  // The poller stores hashes lowercase + D1 is BINARY-collated, so an upper-case
+  // ref must be lowercased before binding or the MCP get_extrinsic tool misses an
+  // extrinsic the REST route resolves. Mirrors the REST handleExtrinsic guard (#1955).
+  const lower = `0x${"b".repeat(64)}`;
+  const mixed = `0x${"B".repeat(64)}`;
+  const calls = [];
+  const d1 = async (sql, params) => {
+    calls.push({ sql, params });
+    if (/WHERE extrinsic_hash = \?/.test(sql)) {
+      return params[0] === lower
+        ? [{ block_number: 7, extrinsic_index: 2, extrinsic_hash: lower }]
+        : [];
+    }
+    return [];
+  };
+  const out = await loadExtrinsic(d1, mixed);
+  assert.equal(out.extrinsic.block_number, 7);
+  assert.equal(out.extrinsic.extrinsic_index, 2);
+  assert.equal(
+    calls.some(
+      (c) => /WHERE extrinsic_hash = \?/.test(c.sql) && c.params[0] === lower,
+    ),
+    true,
+    "the hash bind parameter must be lowercased",
+  );
+});


### PR DESCRIPTION
## Summary

- `loadBlock` (`src/blocks.mjs`) and `loadExtrinsic` (`src/extrinsics.mjs`) - the shared loaders behind the MCP `get_block` / `get_extrinsic` tools - bound the raw `0x` hash with `String(ref)`, so a mixed/upper-case hash missed under D1's BINARY collation (the poller stores hashes lowercase) while the equivalent REST routes resolve it.
- Lowercase the hash before binding, matching `handleBlock` / `handleExtrinsic` in `workers/request-handlers/entities.mjs`. This is the hash-case sibling of the already-fixed numeric (#2314) and composite (#2316) MCP-loader parity gaps.

Fixes #2349

## Template Used

- Backend/code change

## What Changed

- `src/blocks.mjs`: `loadBlock` hash branch binds `String(ref).toLowerCase()`.
- `src/extrinsics.mjs`: `loadExtrinsic` hash branch binds `String(ref).toLowerCase()`.
- `tests/blocks.test.mjs` / `tests/extrinsics.test.mjs`: regression tests asserting a mixed-case `0x` hash is lowercased before binding (fail on current `main`, pass after the fix). Numeric/composite and cold-store paths unchanged.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No schema/contract change.)

## Validation

- [x] `npm test -- tests/blocks.test.mjs tests/extrinsics.test.mjs` (89 passed)
- [x] `git diff --check`