### PR TITLE
fix(api): round subnet-history total_stake_tao/total_emission_tao sums

### DIFF
--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -408,6 +408,13 @@ function toFiniteOrNull(v) {
 function roundTao(v) {
   return Math.round(v * 1e6) / 1e6;
 }
+// Round a TAO sum, preserving null — so an unrounded D1 SUM(stake_tao)/SUM(
+// emission_tao) never leaks accumulated float noise, while a null SUM (cold/
+// sparse day) stays null rather than collapsing to 0.
+function roundTaoOrNull(v) {
+  const n = toFiniteOrNull(v);
+  return n == null ? null : roundTao(n);
+}
 function roundPrice(v) {
   return Math.round(v * 1e9) / 1e9;
 }
@@ -437,8 +444,10 @@ export function buildSubnetHistory(rows, netuid, { window } = {}) {
       snapshot_date: r.snapshot_date,
       neuron_count: r.neuron_count ?? null,
       validator_count: r.validator_count ?? null,
-      total_stake_tao: r.total_stake_tao ?? null,
-      total_emission_tao: r.total_emission_tao ?? null,
+      // Round the per-day SUM(stake_tao)/SUM(emission_tao) to stop accumulated
+      // float noise from leaking, matching buildEconomicsTrends above.
+      total_stake_tao: roundTaoOrNull(r.total_stake_tao),
+      total_emission_tao: roundTaoOrNull(r.total_emission_tao),
     }));
   return {
     schema_version: 1,

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -187,6 +187,36 @@ describe("history builders", () => {
     assert.equal(out.points[0].validator_count, 64);
   });
 
+  test("buildSubnetHistory rounds the per-day TAO sums to drop float noise (#2354)", () => {
+    // A per-day SUM(stake_tao)/SUM(emission_tao) over many REAL UID cells
+    // accumulates float noise; the builder must round it like buildEconomicsTrends
+    // instead of leaking the long fractional tail. A null SUM stays null.
+    const out = buildSubnetHistory(
+      [
+        {
+          snapshot_date: "2026-06-20",
+          neuron_count: 3,
+          validator_count: 1,
+          total_stake_tao: 0.1 + 0.2, // 0.30000000000000004
+          total_emission_tao: 1.005 + 2.005, // 3.0100000000000002
+        },
+        {
+          snapshot_date: "2026-06-19",
+          neuron_count: 0,
+          validator_count: 0,
+          total_stake_tao: null,
+          total_emission_tao: null,
+        },
+      ],
+      7,
+    );
+    assert.equal(out.points[0].total_stake_tao, 0.3);
+    assert.equal(out.points[0].total_emission_tao, 3.01);
+    // A null SUM (cold/sparse day) stays null, never coerced to 0.
+    assert.equal(out.points[1].total_stake_tao, null);
+    assert.equal(out.points[1].total_emission_tao, null);
+  });
+
   test("buildNeuronHistory defaults window + per-point captured_at/block_number to null", () => {
     // A point row with no captured_at/block_number (sparse / pre-block-tag rows)
     // must still produce a schema-stable point — null, never undefined — and an


### PR DESCRIPTION
## Summary

- `GET /api/v1/subnets/{netuid}/history` aggregates per-UID `neuron_daily` rows with `SUM(stake_tao)`/`SUM(emission_tao)` `GROUP BY snapshot_date`, but `buildSubnetHistory` in `src/neuron-history.mjs` passed the two TAO sums through unrounded. Summing up to ~256 fractional `REAL` cells per day accumulates IEEE-754 float error, so the payload leaked a long fractional tail (e.g. `12345.678000000001`).
- `buildEconomicsTrends` **in the same module** already rounds the equivalent stake sum via `roundTao` for exactly this reason, so the two history endpoints disagreed on precision.

Fixes #2354

## What Changed

- `src/neuron-history.mjs`: added a null-preserving `roundTaoOrNull` helper (reuses the existing `toFiniteOrNull` + `roundTao`) and applied it to `total_stake_tao` and `total_emission_tao` in `buildSubnetHistory`. A null SUM (cold/sparse day) stays `null` rather than collapsing to `0`. Integer counts (`neuron_count`, `validator_count`) are unchanged. No schema/contract change — same fields, same types, just without the float tail.
- `tests/neuron-history.test.mjs`: added a regression test asserting noisy per-day sums (`0.1 + 0.2`, `1.005 + 2.005`) round to `0.3` / `3.01`, and a null SUM stays `null`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — behaviour-only fix; field types unchanged.)

## Validation

- [x] `npm run check` (lint clean; format check passes on CI's LF checkout)
- [x] `npm run worker:test` (`tests/neuron-history.test.mjs`: 45 passed, incl. new regression test)
- [x] `git diff --check`