### PR TITLE
fix(api): null counterparty first_block when scan is capped

### DIFF
--- a/src/counterparties.mjs
+++ b/src/counterparties.mjs
@@ -202,19 +202,21 @@ export function buildCounterpartyRelationship(
   }
 
   const cap = Math.max(1, Math.min(limit, 100));
+  const scanCapped = list.length >= COUNTERPARTY_RELATIONSHIP_SCAN_CAP;
   return {
     schema_version: 1,
     ss58,
     counterparty,
     transfer_count: transfers.length,
     transfers_scanned: list.length,
-    scan_capped: list.length >= COUNTERPARTY_RELATIONSHIP_SCAN_CAP,
+    scan_capped: scanCapped,
     total_sent_tao: round(totalSent),
     total_received_tao: round(totalReceived),
     net_tao: round(totalReceived - totalSent),
-    first_block: firstBlock,
+    // Oldest block/timestamp are unknowable when the newest-first scan was truncated.
+    first_block: scanCapped ? null : firstBlock,
     last_block: lastBlock,
-    first_seen_at: toIso(firstObserved),
+    first_seen_at: scanCapped ? null : toIso(firstObserved),
     last_seen_at: toIso(lastObserved),
     limit: cap,
     transfers: transfers.slice(0, cap),

--- a/tests/counterparties.test.mjs
+++ b/tests/counterparties.test.mjs
@@ -304,6 +304,8 @@ describe("buildCounterpartyRelationship", () => {
     const data = buildCounterpartyRelationship(rows, ME, "A", { limit: 2 });
     assert.equal(data.transfer_count, COUNTERPARTY_RELATIONSHIP_SCAN_CAP);
     assert.equal(data.scan_capped, true);
+    assert.equal(data.first_block, null);
+    assert.equal(data.first_seen_at, null);
     assert.equal(data.total_sent_tao, COUNTERPARTY_RELATIONSHIP_SCAN_CAP);
     assert.equal(data.transfers.length, 2);
   });


### PR DESCRIPTION
## Summary

When a counterparty relationship scan hits `COUNTERPARTY_RELATIONSHIP_SCAN_CAP`, `first_block` and `first_seen_at` now return `null` instead of the minimum block/timestamp from the truncated scan.

Fixes #2356

## What Changed

- `buildCounterpartyRelationship` nulls `first_block` / `first_seen_at` when `scan_capped` is true
- Regression test asserts the capped-scan contract

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npx vitest run tests/counterparties.test.mjs`