### PR TITLE
fix(api): signal uptime row-cap truncation for 1y window

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -5072,6 +5072,8 @@ export interface components {
             [key: string]: unknown;
         });
         UptimeArtifact: {
+            /** @description Present and true only when the underlying uptime read hit MAX_UPTIME_ROWS and the oldest (possibly partial) day was dropped before aggregation. Absent when the result was not truncated. */
+            capped?: boolean;
             netuid: number;
             reliability?: components["schemas"]["ReliabilityScore"] | null;
             schema_version: number;
@@ -17904,6 +17906,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "capped": false,
                      *         "netuid": 7,
                      *         "reliability": {
                      *           "avg_latency_ms": 120,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -14022,6 +14022,10 @@
       "UptimeArtifact": {
         "additionalProperties": true,
         "properties": {
+          "capped": {
+            "description": "Present and true only when the underlying uptime read hit MAX_UPTIME_ROWS and the oldest (possibly partial) day was dropped before aggregation. Absent when the result was not truncated.",
+            "type": "boolean"
+          },
           "netuid": {
             "minimum": 0,
             "type": "integer"
@@ -33341,6 +33345,7 @@
               "application/json": {
                 "example": {
                   "data": {
+                    "capped": false,
                     "netuid": 7,
                     "reliability": {
                       "avg_latency_ms": 120,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5072,6 +5072,8 @@ export interface components {
             [key: string]: unknown;
         });
         UptimeArtifact: {
+            /** @description Present and true only when the underlying uptime read hit MAX_UPTIME_ROWS and the oldest (possibly partial) day was dropped before aggregation. Absent when the result was not truncated. */
+            capped?: boolean;
             netuid: number;
             reliability?: components["schemas"]["ReliabilityScore"] | null;
             schema_version: number;
@@ -17904,6 +17906,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "capped": false,
                      *         "netuid": 7,
                      *         "reliability": {
                      *           "avg_latency_ms": 120,

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -14000,6 +14000,10 @@
       "UptimeArtifact": {
         "additionalProperties": true,
         "properties": {
+          "capped": {
+            "description": "Present and true only when the underlying uptime read hit MAX_UPTIME_ROWS and the oldest (possibly partial) day was dropped before aggregation. Absent when the result was not truncated.",
+            "type": "boolean"
+          },
           "netuid": {
             "minimum": 0,
             "type": "integer"

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -1089,6 +1089,10 @@
           "netuid": { "type": "integer", "minimum": 0 },
           "window": { "type": ["string", "null"] },
           "source": { "type": "string" },
+          "capped": {
+            "type": "boolean",
+            "description": "Present and true only when the underlying uptime read hit MAX_UPTIME_ROWS and the oldest (possibly partial) day was dropped before aggregation. Absent when the result was not truncated."
+          },
           "reliability": {
             "oneOf": [
               { "$ref": "#/components/schemas/ReliabilityScore" },

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1085,13 +1085,28 @@ export function formatUptime({
   netuid,
   window,
   observedAt = null,
-  rows,
+  rows: rawRows,
   now = null,
+  capped = false,
 }) {
+  // When the D1 read hit MAX_UPTIME_ROWS the oldest day in the result may be a
+  // partial surface×day slice — drop it (mirrors buildConcentrationHistory).
+  let rows = rawRows || [];
+  if (capped && rows.length > 0) {
+    const days = [
+      ...new Set(
+        rows.map((row) => row?.day).filter((day) => typeof day === "string"),
+      ),
+    ].sort();
+    if (days.length > 1) {
+      const oldest = days[0];
+      rows = rows.filter((row) => row?.day !== oldest);
+    }
+  }
   // computeReliability keys per-surface aggregation on the stable surface_key
   // itself (falling back to surface_id), so renamed rows already collapse into
   // one bucket — no need to pre-rewrite surface_id here.
-  const reliability = computeReliability(rows || [], {
+  const reliability = computeReliability(rows, {
     window: window || null,
     now,
   });
@@ -1156,6 +1171,7 @@ export function formatUptime({
     source: "live-cron-prober",
     reliability: reliability.subnet,
     surfaces,
+    ...(capped ? { capped: true } : {}),
   };
 }
 

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -2253,6 +2253,34 @@ describe("formatUptime (daily uptime history)", () => {
     assert.equal(out.reliability.surface_count, 1);
   });
 
+  test("drops the oldest day and sets capped when the D1 read hit the row cap", () => {
+    const out = formatUptime({
+      netuid: 7,
+      window: "1y",
+      capped: true,
+      rows: [
+        {
+          surface_id: "a",
+          day: "2026-06-02",
+          samples: 10,
+          ok_count: 10,
+          status: "ok",
+        },
+        {
+          surface_id: "a",
+          day: "2026-06-01",
+          samples: 10,
+          ok_count: 5,
+          status: "degraded",
+        },
+      ],
+    });
+    assert.equal(out.capped, true);
+    assert.equal(out.surfaces.length, 1);
+    assert.equal(out.surfaces[0].day_count, 1);
+    assert.equal(out.surfaces[0].days[0].day, "2026-06-02");
+  });
+
   test("returns an empty series + null reliability for no rows", () => {
     const out = formatUptime({ netuid: 7, window: "1y", rows: [] });
     assert.deepEqual(out.surfaces, []);

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -18,6 +18,7 @@ import {
   handleTrajectory,
   handleUptime,
 } from "../workers/request-handlers/analytics-routes.mjs";
+import { MAX_UPTIME_ROWS } from "../workers/config.mjs";
 
 const NETUID = 7;
 const OBSERVED_AT = "2026-06-24T12:00:00.000Z";
@@ -231,6 +232,28 @@ describe("handleEconomicsTrends", () => {
 });
 
 describe("handleUptime", () => {
+  function uptimeRows(count) {
+    const rows = Array.from({ length: count - 1 }, (_, i) => ({
+      surface_id: `sn-7-surface-${i}`,
+      surface_key: `surface-${i}`,
+      day: "2026-06-02",
+      samples: 1,
+      ok_count: 1,
+      uptime_ratio: 1,
+      status: "ok",
+    }));
+    rows.push({
+      surface_id: "sn-7-oldest",
+      surface_key: "oldest",
+      day: "2026-06-01",
+      samples: 1,
+      ok_count: 0,
+      uptime_ratio: 0,
+      status: "failed",
+    });
+    return rows;
+  }
+
   test("defaults window to 90d and returns empty surfaces on cold D1", async () => {
     const body = await json(
       await handleUptime(
@@ -288,6 +311,34 @@ describe("handleUptime", () => {
     assert.equal(body.data.surfaces.length, 1);
     assert.equal(body.data.surfaces[0].surface_id, "sn-7-acme-subnet-api");
     assert.equal(body.data.surfaces[0].days[0].uptime_ratio, 0.9);
+  });
+
+  test("does not set capped when the D1 read exactly reaches MAX_UPTIME_ROWS", async () => {
+    const rows = uptimeRows(MAX_UPTIME_ROWS);
+    const env = d1Env({ "FROM surface_uptime_daily": rows });
+    const body = await json(
+      await handleUptime(req("/"), env, NETUID, url("/?window=1y")),
+    );
+    assert.equal(body.data.capped, undefined);
+    assert.equal(body.data.window, "1y");
+    const days = body.data.surfaces.flatMap((surface) =>
+      surface.days.map((day) => day.day),
+    );
+    assert.ok(days.includes("2026-06-01"));
+  });
+
+  test("sets capped when the D1 read returns a sentinel row and drops the oldest day", async () => {
+    const rows = uptimeRows(MAX_UPTIME_ROWS + 1);
+    const env = d1Env({ "FROM surface_uptime_daily": rows });
+    const body = await json(
+      await handleUptime(req("/"), env, NETUID, url("/?window=1y")),
+    );
+    assert.equal(body.data.capped, true);
+    assert.equal(body.data.window, "1y");
+    const days = body.data.surfaces.flatMap((surface) =>
+      surface.days.map((day) => day.day),
+    );
+    assert.ok(!days.includes("2026-06-01"));
   });
 });
 

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -175,15 +175,18 @@ export async function handleUptime(request, env, netuid, url) {
      GROUP BY COALESCE(surface_key, surface_id), day
      ORDER BY day DESC
      LIMIT ?`,
-    [netuid, cutoff, MAX_UPTIME_ROWS],
+    [netuid, cutoff, MAX_UPTIME_ROWS + 1],
   );
+  const capped = rows.length > MAX_UPTIME_ROWS;
+  const visibleRows = capped ? rows.slice(0, MAX_UPTIME_ROWS) : rows;
   const healthMeta = await readHealthMetaKv(env);
   const data = formatUptime({
     netuid,
     window: windowParam,
     observedAt: healthMeta?.last_run_at || null,
-    rows,
+    rows: visibleRows,
     now: new Date().toISOString(),
+    capped,
   });
   return envelopeWithD1Fallback(
     request,
@@ -196,7 +199,7 @@ export async function handleUptime(request, env, netuid, url) {
       ),
     },
     "short",
-    [rows],
+    [visibleRows],
   );
 }
 


### PR DESCRIPTION
## Summary

When `handleUptime` proves the D1 uptime query was row-cap truncated, the response now sets `capped: true` and drops the oldest (possibly partial) day before computing reliability — mirroring concentration history without falsely capping exact-size result sets.

Fixes #2355

## What Changed

- `handleUptime` fetches one sentinel row (`MAX_UPTIME_ROWS + 1`) so it can distinguish exact-size results from truncated results
- `handleUptime` trims the sentinel before calling `formatUptime` and only passes `capped: true` when truncation is proven
- `formatUptime` drops the oldest visible day when capped and exposes `capped: true`
- Regression tests cover both `MAX_UPTIME_ROWS` (not capped) and `MAX_UPTIME_ROWS + 1` (capped) boundary behavior

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `git diff --check`
- [x] `npx vitest run tests/health-serving.test.mjs tests/request-handlers-analytics-routes.test.mjs`