### PR TITLE
feat(mcp): add get_account_balance with full SS58 checksum validation (#2338)

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -357,6 +357,11 @@ assert.ok(
   Array.isArray(accountSubnets.subnets),
   "get_account_subnets must return subnets[]",
 );
+const accountBalance = await callOk("get_account_balance", { ss58: SS58 });
+assert.ok(
+  "balance_tao" in accountBalance && accountBalance.ss58 === SS58,
+  "get_account_balance must return ss58 + balance_tao (null on cold RPC)",
+);
 
 // Derive a real surface_id with a captured schema so get_api_schema resolves.
 const schemaService = apis.services.find((service) => service.schema_artifact);

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/account-balance.mjs
+++ b/src/account-balance.mjs
@@ -90,6 +90,8 @@ export async function loadAccountBalance(env, ss58) {
       const rpcBody = await rpcResp.json();
       const data = rpcBody?.result?.data;
       if (data && typeof data.free !== "undefined") {
+        // Sum in BigInt rao space, then divide once — avoids float precision loss
+        // on large on-chain balances before converting the remainder to TAO.
         const toRao = (v) =>
           typeof v === "string"
             ? BigInt(v)

--- a/src/account-balance.mjs
+++ b/src/account-balance.mjs
@@ -1,6 +1,8 @@
 // Live finney account TAO balance (free + reserved) via RPC (#1818).
 // Shared by GET /api/v1/accounts/{ss58}/balance and MCP get_account_balance.
 
+import { createHash } from "node:crypto";
+
 const SS58_BASE58_ALPHABET =
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 const SS58_BASE58_INDEX = new Map(
@@ -10,6 +12,8 @@ const FINNEY_SS58_PREFIX = 42;
 const FINNEY_SS58_MIN_LENGTH = 47;
 const FINNEY_SS58_MAX_LENGTH = 48;
 const FINNEY_SS58_DECODED_LENGTH = 35;
+const FINNEY_SS58_CHECKSUM_LENGTH = 2; // prefix < 64 → 2-byte SS58 checksum
+const SS58_PREIMAGE = new TextEncoder().encode("SS58PRE");
 export const BALANCE_KV_TTL = 60; // seconds
 export const BALANCE_NEGATIVE_KV_TTL = 10; // seconds
 export const BALANCE_RPC_TIMEOUT_MS = 5000;
@@ -38,6 +42,21 @@ function decodeBase58(value) {
   return Uint8Array.from(bytes.reverse());
 }
 
+function verifyFinneySs58Checksum(decoded) {
+  if (decoded.length !== FINNEY_SS58_DECODED_LENGTH) return false;
+  const body = decoded.subarray(
+    0,
+    decoded.length - FINNEY_SS58_CHECKSUM_LENGTH,
+  );
+  const checksum = decoded.subarray(
+    decoded.length - FINNEY_SS58_CHECKSUM_LENGTH,
+  );
+  const hash = createHash("blake2b512")
+    .update(Buffer.concat([Buffer.from(SS58_PREIMAGE), Buffer.from(body)]))
+    .digest();
+  return hash[0] === checksum[0] && hash[1] === checksum[1];
+}
+
 export function isFinneySs58Address(value) {
   if (
     value.length < FINNEY_SS58_MIN_LENGTH ||
@@ -49,7 +68,8 @@ export function isFinneySs58Address(value) {
   const decoded = decodeBase58(value);
   return (
     decoded?.length === FINNEY_SS58_DECODED_LENGTH &&
-    decoded[0] === FINNEY_SS58_PREFIX
+    decoded[0] === FINNEY_SS58_PREFIX &&
+    verifyFinneySs58Checksum(decoded)
   );
 }
 

--- a/src/account-balance.mjs
+++ b/src/account-balance.mjs
@@ -1,0 +1,128 @@
+// Live finney account TAO balance (free + reserved) via RPC (#1818).
+// Shared by GET /api/v1/accounts/{ss58}/balance and MCP get_account_balance.
+
+const SS58_BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const SS58_BASE58_INDEX = new Map(
+  [...SS58_BASE58_ALPHABET].map((char, index) => [char, index]),
+);
+const FINNEY_SS58_PREFIX = 42;
+const FINNEY_SS58_MIN_LENGTH = 47;
+const FINNEY_SS58_MAX_LENGTH = 48;
+const FINNEY_SS58_DECODED_LENGTH = 35;
+export const BALANCE_KV_TTL = 60; // seconds
+export const BALANCE_NEGATIVE_KV_TTL = 10; // seconds
+export const BALANCE_RPC_TIMEOUT_MS = 5000;
+const FINNEY_RPC_URL = "https://entrypoint-finney.opentensor.ai:443";
+
+function decodeBase58(value) {
+  const bytes = [0];
+  for (const char of value) {
+    const carryStart = SS58_BASE58_INDEX.get(char);
+    if (carryStart == null) return null;
+    let carry = carryStart;
+    for (let index = 0; index < bytes.length; index += 1) {
+      carry += bytes[index] * 58;
+      bytes[index] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  for (const char of value) {
+    if (char !== "1") break;
+    bytes.push(0);
+  }
+  return Uint8Array.from(bytes.reverse());
+}
+
+export function isFinneySs58Address(value) {
+  if (
+    value.length < FINNEY_SS58_MIN_LENGTH ||
+    value.length > FINNEY_SS58_MAX_LENGTH
+  ) {
+    return false;
+  }
+
+  const decoded = decodeBase58(value);
+  return (
+    decoded?.length === FINNEY_SS58_DECODED_LENGTH &&
+    decoded[0] === FINNEY_SS58_PREFIX
+  );
+}
+
+// Query live balance for one finney ss58. Uses METAGRAPH_CONTROL KV (60s TTL) when
+// present; balance_tao is null on RPC failure (schema-stable, never throws).
+export async function loadAccountBalance(env, ss58) {
+  const cacheKey = `balance:${ss58}`;
+  const kv = env?.METAGRAPH_CONTROL;
+
+  if (kv?.get) {
+    try {
+      const cached = await kv.get(cacheKey, { type: "json" });
+      if (cached) return cached;
+    } catch {
+      // KV read failure is non-fatal — fall through to the live RPC.
+    }
+  }
+
+  const queriedAt = new Date().toISOString();
+  let balanceTao = null;
+  let rpcOk = false;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), BALANCE_RPC_TIMEOUT_MS);
+  try {
+    const rpcResp = await fetch(FINNEY_RPC_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: controller.signal,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "system_account",
+        params: [ss58],
+      }),
+    });
+    if (rpcResp.ok) {
+      const rpcBody = await rpcResp.json();
+      const data = rpcBody?.result?.data;
+      if (data && typeof data.free !== "undefined") {
+        const toRao = (v) =>
+          typeof v === "string"
+            ? BigInt(v)
+            : BigInt(Math.trunc(Number(v ?? 0)));
+        const totalRao = toRao(data.free) + toRao(data.reserved);
+        balanceTao =
+          Number(totalRao / 1_000_000_000n) +
+          Number(totalRao % 1_000_000_000n) / 1e9;
+        rpcOk = true;
+      }
+    }
+  } catch {
+    // RPC fetch failed — balance_tao stays null.
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const payload = {
+    schema_version: 1,
+    ss58,
+    balance_tao: balanceTao,
+    queried_at: queriedAt,
+  };
+
+  if (kv?.put) {
+    try {
+      await kv.put(cacheKey, JSON.stringify(payload), {
+        expirationTtl: rpcOk ? BALANCE_KV_TTL : BALANCE_NEGATIVE_KV_TTL,
+      });
+    } catch {
+      // KV write failure is non-fatal.
+    }
+  }
+
+  return payload;
+}

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -92,6 +92,7 @@ import {
   parseHistoryWindow,
 } from "./neuron-history.mjs";
 import { loadSubnetTurnover } from "./turnover.mjs";
+import { isFinneySs58Address, loadAccountBalance } from "./account-balance.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import { loadBlocks, loadBlock } from "./blocks.mjs";
 import { loadExtrinsics, loadExtrinsic } from "./extrinsics.mjs";
@@ -195,6 +196,7 @@ export const MCP_INSTRUCTIONS =
   "list_subnet_validators its validators ranked by stake, and get_neuron one " +
   "UID — use these to decide where to mine or validate. For wallet lookup, " +
   "get_account summarizes what one hotkey or coldkey does across the network, " +
+  "get_account_balance its live native-TAO balance (free+reserved) from finney RPC, " +
   "get_account_events returns its chain-event history (optional kind filter), and " +
   "get_account_subnets the subnets where it is registered. All data is public and " +
   "read-only. Subnet names, descriptions, and identity text come from " +
@@ -1878,6 +1880,50 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const ss58 = requireSs58(args);
       return loadAccountSummary(mcpD1Runner(ctx), ss58);
+    },
+  },
+  {
+    name: "get_account_balance",
+    title: "Get an account's live TAO balance",
+    description:
+      "Fetch the live native-TAO balance (free + reserved, in TAO) for one account " +
+      "by its SS58 address, queried from the finney RPC at request time with a 60s KV " +
+      "cache. balance_tao is null on RPC failure (schema-stable, not an error). Use " +
+      "it alongside get_account when an agent needs the wallet's current holdings. " +
+      "Mirrors GET /api/v1/accounts/{ss58}/balance.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ss58: {
+          type: "string",
+          description:
+            "The account's SS58 address (finney network), base58, 47-48 chars.",
+          pattern: SS58_PATTERN_SOURCE,
+        },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const ss58 = requireSs58(args);
+      if (!isFinneySs58Address(ss58)) {
+        throw toolError(
+          "invalid_params",
+          "Argument `ss58` must be a valid finney SS58 account address.",
+        );
+      }
+      if (ctx.env.RPC_RATE_LIMITER?.limit) {
+        const { success } = await ctx.env.RPC_RATE_LIMITER.limit({
+          key: `balance:mcp:${ctx.clientIp}`,
+        });
+        if (!success) {
+          throw toolError(
+            "rate_limited",
+            "Too many live balance requests from this client; slow down.",
+          );
+        }
+      }
+      return loadAccountBalance(ctx.env, ss58);
     },
   },
   {
@@ -3676,6 +3722,17 @@ const TOOL_OUTPUT_SCHEMAS = {
       registrations: objectItems(ACCOUNT_REGISTRATION_ITEM),
       recent_events: objectItems(ACCOUNT_EVENT_ITEM),
       activity: { type: "object", additionalProperties: true },
+    },
+  },
+  get_account_balance: {
+    type: "object",
+    additionalProperties: true,
+    required: ["ss58", "balance_tao", "queried_at"],
+    properties: {
+      schema_version: { type: "integer" },
+      ss58: { type: "string" },
+      balance_tao: { type: ["number", "null"] },
+      queried_at: NULLABLE_STRING,
     },
   },
   get_account_events: {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -127,7 +127,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.9.0";
+export const MCP_SERVER_VERSION = "1.10.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",

--- a/tests/account-balance-loader.test.mjs
+++ b/tests/account-balance-loader.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  isFinneySs58Address,
+  loadAccountBalance,
+} from "../src/account-balance.mjs";
+
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+describe("isFinneySs58Address", () => {
+  test("accepts a valid finney address", () => {
+    assert.equal(isFinneySs58Address(SS58), true);
+  });
+
+  test("rejects malformed captures", () => {
+    assert.equal(isFinneySs58Address("notanss58address"), false);
+    assert.equal(
+      isFinneySs58Address("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXc6TYeyZ1km1"),
+      false,
+    );
+  });
+});
+
+describe("loadAccountBalance", () => {
+  test("decodes hex-encoded rao balances from finney RPC", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { data: { free: "0x77359400", reserved: "0x1dcd6500" } },
+      }),
+    });
+    try {
+      const data = await loadAccountBalance({}, SS58);
+      assert.equal(data.ss58, SS58);
+      assert.equal(data.balance_tao, 2.5);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  test("serves from KV cache when present", async () => {
+    const cached = {
+      schema_version: 1,
+      ss58: SS58,
+      balance_tao: 9.99,
+      queried_at: "2026-01-01T00:00:00.000Z",
+    };
+    const env = {
+      METAGRAPH_CONTROL: {
+        async get() {
+          return cached;
+        },
+      },
+    };
+    let fetchCalled = false;
+    const orig = globalThis.fetch;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return { ok: false };
+    };
+    try {
+      const data = await loadAccountBalance(env, SS58);
+      assert.deepEqual(data, cached);
+      assert.equal(fetchCalled, false);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+});

--- a/tests/account-balance-loader.test.mjs
+++ b/tests/account-balance-loader.test.mjs
@@ -20,6 +20,13 @@ describe("isFinneySs58Address", () => {
       false,
     );
   });
+
+  test("rejects a finney-shaped address with a bad SS58 checksum", () => {
+    // Same prefix/length as SS58 but last base58 digit flipped → checksum mismatch.
+    const badChecksum = `${SS58.slice(0, -1)}4`;
+    assert.notEqual(badChecksum, SS58);
+    assert.equal(isFinneySs58Address(badChecksum), false);
+  });
 });
 
 describe("loadAccountBalance", () => {

--- a/tests/account-balance-loader.test.mjs
+++ b/tests/account-balance-loader.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  BALANCE_NEGATIVE_KV_TTL,
   isFinneySs58Address,
   loadAccountBalance,
 } from "../src/account-balance.mjs";
@@ -41,6 +42,24 @@ describe("loadAccountBalance", () => {
     }
   });
 
+  test("decodes numeric rao balances from finney RPC", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { data: { free: 2_000_000_000, reserved: 500_000_000 } },
+      }),
+    });
+    try {
+      const data = await loadAccountBalance({}, SS58);
+      assert.equal(data.balance_tao, 2.5);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
   test("serves from KV cache when present", async () => {
     const cached = {
       schema_version: 1,
@@ -65,6 +84,35 @@ describe("loadAccountBalance", () => {
       const data = await loadAccountBalance(env, SS58);
       assert.deepEqual(data, cached);
       assert.equal(fetchCalled, false);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  test("negative-caches RPC failures with the short TTL", async () => {
+    let putKey;
+    let putValue;
+    let putOptions;
+    const env = {
+      METAGRAPH_CONTROL: {
+        async get() {
+          return null;
+        },
+        async put(key, value, options) {
+          putKey = key;
+          putValue = JSON.parse(value);
+          putOptions = options;
+        },
+      },
+    };
+    const orig = globalThis.fetch;
+    globalThis.fetch = async () => ({ ok: false });
+    try {
+      const data = await loadAccountBalance(env, SS58);
+      assert.equal(data.balance_tao, null);
+      assert.equal(putKey, `balance:${SS58}`);
+      assert.equal(putValue.balance_tao, null);
+      assert.equal(putOptions.expirationTtl, BALANCE_NEGATIVE_KV_TTL);
     } finally {
       globalThis.fetch = orig;
     }

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4199,6 +4199,51 @@ describe("MCP account tools (get_account + events + subnets)", () => {
     assert.equal(out.recent_events[0].event_kind, "StakeAdded");
   });
 
+  test("get_account_balance returns balance_tao from finney RPC", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { data: { free: 2_000_000_000, reserved: 500_000_000 } },
+      }),
+    });
+    try {
+      const res = await callTool("get_account_balance", { ss58: SS58 }, {});
+      const out = res.body.result.structuredContent;
+      assert.equal(out.ss58, SS58);
+      assert.equal(out.balance_tao, 2.5);
+      assert.ok(out.queried_at);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  test("get_account_balance rejects a non-finney ss58 prefix", async () => {
+    const res = await callTool(
+      "get_account_balance",
+      { ss58: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXc6TYeyZ1km1" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /finney/i);
+  });
+
+  test("get_account_balance returns balance_tao:null on RPC failure", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw new Error("rpc down");
+    };
+    try {
+      const res = await callTool("get_account_balance", { ss58: SS58 }, {});
+      const out = res.body.result.structuredContent;
+      assert.equal(out.balance_tao, null);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
   test("get_account_events filters by kind and echoes the limit", async () => {
     const capture = [];
     const env = accountD1(

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4244,6 +4244,42 @@ describe("MCP account tools (get_account + events + subnets)", () => {
     }
   });
 
+  test("get_account_balance applies the RPC rate limiter before finney fetch", async () => {
+    let limiterKey;
+    let fetchCalled = false;
+    const orig = globalThis.fetch;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      throw new Error("should not fetch");
+    };
+    const env = {
+      MCP_RATE_LIMITER: {
+        async limit() {
+          return { success: true };
+        },
+      },
+      RPC_RATE_LIMITER: {
+        async limit({ key }) {
+          limiterKey = key;
+          return { success: false };
+        },
+      },
+    };
+    try {
+      const res = await callTool(
+        "get_account_balance",
+        { ss58: SS58 },
+        { env },
+      );
+      assert.equal(res.body.result.isError, true);
+      assert.match(res.body.result.content[0].text, /rate_limited/);
+      assert.equal(limiterKey, "balance:mcp:anonymous");
+      assert.equal(fetchCalled, false);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
   test("get_account_events filters by kind and echoes the limit", async () => {
     const capture = [];
     const env = accountD1(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -63,6 +63,10 @@ import {
   loadAccountEvents,
   loadAccountSubnets,
 } from "../../src/account-events.mjs";
+import {
+  isFinneySs58Address,
+  loadAccountBalance,
+} from "../../src/account-balance.mjs";
 import { decodeCursor, encodeCursor } from "../../src/cursor.mjs";
 import {
   BLOCK_READ_COLUMNS,
@@ -916,63 +920,7 @@ export async function handleSubnetEvents(request, env, netuid, url) {
   );
 }
 
-// Bittensor/finney account addresses are SS58-encoded values with network
-// prefix 42, a 32-byte account id, and a checksum suffix. The balance route is
-// a live RPC fan-out, so reject malformed path captures before any cache/limit
-// work. This decoder enforces the base58 alphabet and fixed finney payload
-// shape; the RPC limiter below remains the upstream abuse boundary.
-const SS58_BASE58_ALPHABET =
-  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-const SS58_BASE58_INDEX = new Map(
-  [...SS58_BASE58_ALPHABET].map((char, index) => [char, index]),
-);
-const FINNEY_SS58_PREFIX = 42;
-const FINNEY_SS58_MIN_LENGTH = 47;
-const FINNEY_SS58_MAX_LENGTH = 48;
-const FINNEY_SS58_DECODED_LENGTH = 35;
-const BALANCE_KV_TTL = 60; // seconds
-const BALANCE_NEGATIVE_KV_TTL = 10; // seconds
-const BALANCE_RPC_TIMEOUT_MS = 5000;
-const BALANCE_RATE_LIMIT = { limit: 100, windowSeconds: 60 };
-const FINNEY_RPC_URL = "https://entrypoint-finney.opentensor.ai:443";
-
-function decodeBase58(value) {
-  const bytes = [0];
-  for (const char of value) {
-    const carryStart = SS58_BASE58_INDEX.get(char);
-    if (carryStart == null) return null;
-    let carry = carryStart;
-    for (let index = 0; index < bytes.length; index += 1) {
-      carry += bytes[index] * 58;
-      bytes[index] = carry & 0xff;
-      carry >>= 8;
-    }
-    while (carry > 0) {
-      bytes.push(carry & 0xff);
-      carry >>= 8;
-    }
-  }
-  for (const char of value) {
-    if (char !== "1") break;
-    bytes.push(0);
-  }
-  return Uint8Array.from(bytes.reverse());
-}
-
-function isFinneySs58Address(value) {
-  if (
-    value.length < FINNEY_SS58_MIN_LENGTH ||
-    value.length > FINNEY_SS58_MAX_LENGTH
-  ) {
-    return false;
-  }
-
-  const decoded = decodeBase58(value);
-  return (
-    decoded?.length === FINNEY_SS58_DECODED_LENGTH &&
-    decoded[0] === FINNEY_SS58_PREFIX
-  );
-}
+export const BALANCE_RATE_LIMIT = { limit: 100, windowSeconds: 60 };
 
 // GET /api/v1/accounts/{ss58}/balance (#1818): live TAO balance (free+reserved)
 // for one account, queried from the finney RPC at request time. 60s KV cache via
@@ -1010,90 +958,12 @@ export async function handleAccountBalance(request, env, ss58) {
     }
   }
 
-  const cacheKey = `balance:${ss58}`;
-  const kv = env.METAGRAPH_CONTROL;
-
-  const respond = (data) =>
-    envelopeResponse(
-      request,
-      { data, meta: { contract_version: contractVersion(env) } },
-      "short",
-    );
-
-  // KV cache hit — return immediately without touching the RPC.
-  if (kv?.get) {
-    try {
-      const cached = await kv.get(cacheKey, { type: "json" });
-      if (cached) return respond(cached);
-    } catch {
-      // KV read failure is non-fatal — fall through to the live RPC.
-    }
-  }
-
-  const queriedAt = new Date().toISOString();
-  let balanceTao = null;
-  let rpcOk = false;
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), BALANCE_RPC_TIMEOUT_MS);
-  try {
-    const rpcResp = await fetch(FINNEY_RPC_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      signal: controller.signal,
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "system_account",
-        params: [ss58],
-      }),
-    });
-    if (rpcResp.ok) {
-      const rpcBody = await rpcResp.json();
-      const data = rpcBody?.result?.data;
-      if (data && typeof data.free !== "undefined") {
-        // free + reserved are hex-encoded u128 rao values (1 TAO = 1e9 rao).
-        // Sum in BigInt space and split the whole / fractional TAO only at the
-        // end, so a balance above Number.MAX_SAFE_INTEGER rao (~9.007M TAO) keeps
-        // its low-order rao digits — a direct Number(BigInt(...)) cast would
-        // collapse them to the nearest double *before* the 1e9 scale. A malformed
-        // hex `free` still throws here (BigInt parse) and is caught below →
-        // balance_tao:null, 200 (unchanged error path).
-        const toRao = (v) =>
-          typeof v === "string"
-            ? BigInt(v)
-            : BigInt(Math.trunc(Number(v ?? 0)));
-        const totalRao = toRao(data.free) + toRao(data.reserved);
-        balanceTao =
-          Number(totalRao / 1_000_000_000n) +
-          Number(totalRao % 1_000_000_000n) / 1e9;
-        rpcOk = true;
-      }
-    }
-  } catch {
-    // RPC fetch failed — balance_tao stays null, return 200 below.
-  } finally {
-    clearTimeout(timeout);
-  }
-
-  const data = {
-    schema_version: 1,
-    ss58,
-    balance_tao: balanceTao,
-    queried_at: queriedAt,
-  };
-
-  if (kv?.put) {
-    try {
-      await kv.put(cacheKey, JSON.stringify(data), {
-        expirationTtl: rpcOk ? BALANCE_KV_TTL : BALANCE_NEGATIVE_KV_TTL,
-      });
-    } catch {
-      // KV write failure is non-fatal.
-    }
-  }
-
-  return respond(data);
+  const data = await loadAccountBalance(env, ss58);
+  return envelopeResponse(
+    request,
+    { data, meta: { contract_version: contractVersion(env) } },
+    "short",
+  );
 }
 // GET /api/v1/blocks: the recent-block feed (newest first), served live from the
 // `blocks` D1 tier (#1345 block explorer). ?limit clamp <=100, ?offset. Cold/


### PR DESCRIPTION
## Summary

Resubmission of [#2339](https://github.com/JSONbored/metagraphed/pull/2339) (closed per [maintainer review](https://github.com/JSONbored/metagraphed/pull/2339#pullrequestreview-4594992647)). Extracts shared `loadAccountBalance` / `isFinneySs58Address` and adds MCP `get_account_balance` mirroring `GET /api/v1/accounts/{ss58}/balance`.

**Review fix:** `isFinneySs58Address` now validates the SS58 blake2b-512 `SS58PRE` checksum (2-byte suffix for finney prefix 42), not only base58 shape, decoded length, and network prefix.

Closes #2338

## Scope summary

| Area | Change |
|------|--------|
| **Files touched** | 7 — `src/account-balance.mjs`, `workers/request-handlers/entities.mjs`, `src/mcp-server.mjs`, `server.json`, tests, `scripts/validate-mcp.mjs` |
| **Behavior** | REST + MCP balance routes reject checksum-invalid finney addresses before RPC; MCP `get_account_balance` added |
| **MCP version** | **1.9.0** (minor bump for new tool; main is 1.8.0) |
| **Generated artifacts** | None committed |

## What changed vs #2339

- SS58 checksum verification via `blake2b512("SS58PRE" + prefix‖pubkey)`
- Unit test: finney-shaped address with flipped checksum digit → rejected
- MCP server + registry version bumped to `1.9.0`

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts committed.
- [x] No breaking public API changes; REST balance route behavior preserved (stricter ss58 validation only).

## Validation

- [x] `npx vitest run tests/account-balance-loader.test.mjs` — 7 passed
- [x] `npx vitest run tests/account-balance.test.mjs` — 17 passed
- [x] `npx vitest run tests/mcp-server.test.mjs -t get_account_balance` — 4 passed
- [x] `npm run format:check` — clean

## Test plan

- [x] Valid finney SS58 passes checksum + returns balance
- [x] Wrong network prefix rejected
- [x] Bad checksum rejected (no RPC)
- [x] MCP rate limit + negative KV cache covered
- [ ] CI green
