### PR TITLE
fix(chain): label account transfers by the requested side

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -404,13 +404,15 @@ export function buildAccountSubnets(rows, ss58) {
 // Balances.Transfer feed only, NOT a full balance ledger (stake flows are separate
 // event kinds). Null-safe on a cold store.
 //
-// `direction` (the option) is the side the CALLER filtered on. When it is an
-// explicit `sent`/`received`, every returned row is on that side by construction,
-// so the row is labeled with the requested side — otherwise a self-transfer
-// (from === to === ss58, i.e. hotkey === coldkey === ss58) returned by the
-// received-side query would be mislabeled `sent` by the hotkey-first per-row
-// derivation, contradicting the requested filter (#2362). With no side filter
-// (`all`/omitted) the per-row hotkey-first derivation is kept unchanged.
+// `direction` (the option) is an INTERNAL post-filter hint: the side the loader
+// already filtered the SQL on (see loadAccountTransfers / handleAccountTransfers),
+// NOT a free-form caller input. ONLY the exact strings `sent`/`received` force the
+// label; every other value (`all`, omitted, junk) falls back to the per-row
+// hotkey-first derivation. It must only be passed when the rows are guaranteed to
+// be on that side — when set, every row is labeled with it. This fixes a
+// self-transfer (from === to === ss58, i.e. hotkey === coldkey === ss58) returned
+// by the received-side query, which the hotkey-first per-row derivation would
+// otherwise mislabel `sent`, contradicting the requested filter (#2362).
 export function buildAccountTransfers(
   rows,
   ss58,

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -403,11 +403,21 @@ export function buildAccountSubnets(rows, ss58) {
 // ss58: it sent (== from) or received (== to). This is the native-TAO
 // Balances.Transfer feed only, NOT a full balance ledger (stake flows are separate
 // event kinds). Null-safe on a cold store.
+//
+// `direction` (the option) is the side the CALLER filtered on. When it is an
+// explicit `sent`/`received`, every returned row is on that side by construction,
+// so the row is labeled with the requested side — otherwise a self-transfer
+// (from === to === ss58, i.e. hotkey === coldkey === ss58) returned by the
+// received-side query would be mislabeled `sent` by the hotkey-first per-row
+// derivation, contradicting the requested filter (#2362). With no side filter
+// (`all`/omitted) the per-row hotkey-first derivation is kept unchanged.
 export function buildAccountTransfers(
   rows,
   ss58,
-  { limit, offset, nextCursor } = {},
+  { limit, offset, nextCursor, direction } = {},
 ) {
+  const fixedDirection =
+    direction === "sent" || direction === "received" ? direction : null;
   const transfers = (rows || [])
     .filter((r) => r && typeof r === "object")
     .map((r) => ({
@@ -417,7 +427,8 @@ export function buildAccountTransfers(
       to: r.coldkey ?? null,
       amount_tao: r.amount_tao ?? null,
       direction:
-        r.hotkey === ss58 ? "sent" : r.coldkey === ss58 ? "received" : null,
+        fixedDirection ??
+        (r.hotkey === ss58 ? "sent" : r.coldkey === ss58 ? "received" : null),
       observed_at: toIso(r.observed_at),
     }));
   return {
@@ -627,5 +638,9 @@ export async function loadAccountTransfers(
   sql += " ORDER BY block_number DESC, event_index DESC LIMIT ? OFFSET ?";
   params.push(lim, off);
   const rows = await d1(sql, params);
-  return buildAccountTransfers(rows, ss58, { limit: lim, offset: off });
+  return buildAccountTransfers(rows, ss58, {
+    limit: lim,
+    offset: off,
+    direction,
+  });
 }

--- a/tests/account-events-branch-coverage.test.mjs
+++ b/tests/account-events-branch-coverage.test.mjs
@@ -185,4 +185,25 @@ describe("loadAccountTransfers direction clauses", () => {
     assert.deepEqual(params, ["5Hk", "5Hk", "5Hk", 100, 0]);
     assert.equal(out.transfer_count, 1);
   });
+
+  test("loadAccountTransfers received-side query labels a self-transfer 'received' (#2362)", async () => {
+    // Tie the requested-side labeling to the REAL query shape: the received-side
+    // read selects on coldkey only (no hotkey union), so a self-transfer
+    // (hotkey === coldkey === ss58) IS returned by it — and must be labeled
+    // 'received' to match the requested filter, not 'sent' from the hotkey-first
+    // per-row derivation.
+    const d1 = makeD1([
+      [{ block_number: 5, event_index: 0, hotkey: "5Self", coldkey: "5Self" }],
+    ]);
+    const out = await loadAccountTransfers(d1, "5Self", {
+      direction: "received",
+    });
+    const { sql, params } = d1.calls[0];
+    assert.ok(/INDEXED BY idx_account_events_coldkey/.test(sql));
+    assert.ok(/coldkey = \?/.test(sql));
+    assert.ok(!/hotkey = \?/.test(sql)); // only the received (coldkey) side clause
+    assert.ok(!/UNION ALL/.test(sql));
+    assert.deepEqual(params, ["5Self", 100, 0]);
+    assert.equal(out.transfers[0].direction, "received");
+  });
 });

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -419,8 +419,12 @@ test("buildAccountTransfers labels a self-transfer by the requested side (#2362)
   // No side filter (both/all/omitted) keeps the per-row hotkey-first derivation.
   const both = buildAccountTransfers([selfRow], "5SELF");
   assert.equal(both.transfers[0].direction, "sent");
-  const all = buildAccountTransfers([selfRow], "5SELF", { direction: "all" });
-  assert.equal(all.transfers[0].direction, "sent");
+  // Only the exact strings "sent"/"received" force a label; every other value
+  // ("all", "both", junk) falls back to the per-row hotkey-first derivation.
+  for (const value of ["all", "both", "BOTH", "", "weird"]) {
+    const out = buildAccountTransfers([selfRow], "5SELF", { direction: value });
+    assert.equal(out.transfers[0].direction, "sent");
+  }
 });
 
 test("buildAccountTransfers explicit side never flips a normal row (#2362)", () => {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -22,6 +22,7 @@ import {
   pruneAccountEvents,
   validEventRows,
   buildAccountTransfers,
+  loadAccountTransfers,
 } from "../src/account-events.mjs";
 import { encodeCursor } from "../src/cursor.mjs";
 
@@ -388,6 +389,82 @@ test("account builders null invalid block heights and indices", () => {
   );
   assert.equal(fracTransfers.transfers[0].block_number, null);
   assert.equal(fracTransfers.transfers[0].event_index, null);
+});
+
+test("buildAccountTransfers labels a self-transfer by the requested side (#2362)", () => {
+  // A self-transfer (from === to === ss58, i.e. hotkey === coldkey === ss58) is
+  // returned by BOTH the sent-side and received-side queries. Without the
+  // requested direction the hotkey-first per-row derivation always labels it
+  // "sent" — so a ?direction=received page would contain a row whose direction
+  // contradicts the filter. The requested side must win.
+  const selfRow = {
+    block_number: 5,
+    event_index: 0,
+    hotkey: "5SELF",
+    coldkey: "5SELF",
+    amount_tao: 1,
+    observed_at: null,
+  };
+
+  // received-side query → labeled "received" (was "sent" before the fix).
+  const received = buildAccountTransfers([selfRow], "5SELF", {
+    direction: "received",
+  });
+  assert.equal(received.transfers[0].direction, "received");
+
+  // sent-side query → labeled "sent".
+  const sent = buildAccountTransfers([selfRow], "5SELF", { direction: "sent" });
+  assert.equal(sent.transfers[0].direction, "sent");
+
+  // No side filter (both/all/omitted) keeps the per-row hotkey-first derivation.
+  const both = buildAccountTransfers([selfRow], "5SELF");
+  assert.equal(both.transfers[0].direction, "sent");
+  const all = buildAccountTransfers([selfRow], "5SELF", { direction: "all" });
+  assert.equal(all.transfers[0].direction, "sent");
+});
+
+test("buildAccountTransfers explicit side never flips a normal row (#2362)", () => {
+  // For a non-self transfer the requested side already matches the per-row
+  // derivation, so forcing the label is a no-op — the fix only changes the
+  // self-transfer edge, never a genuine counterparty row.
+  const out = buildAccountTransfers(
+    [
+      {
+        block_number: 9,
+        event_index: 1,
+        hotkey: "5SENDER",
+        coldkey: "5ME",
+        amount_tao: 2,
+        observed_at: null,
+      },
+    ],
+    "5ME",
+    { direction: "received" },
+  );
+  assert.equal(out.transfers[0].direction, "received");
+  assert.equal(out.transfers[0].from, "5SENDER");
+  assert.equal(out.transfers[0].to, "5ME");
+});
+
+test("loadAccountTransfers threads the requested direction into the label (#2362)", async () => {
+  // End-to-end through the shared MCP/REST loader: the received-side query yields
+  // the self-transfer row, and the loader must hand the requested direction to
+  // buildAccountTransfers so the row is labeled "received", not "sent".
+  const selfRow = {
+    block_number: 5,
+    event_index: 0,
+    hotkey: "5SELF",
+    coldkey: "5SELF",
+    amount_tao: 1,
+    observed_at: null,
+  };
+  const d1 = async (sql) =>
+    /coldkey = \?/.test(sql) && !/hotkey <>/.test(sql) ? [selfRow] : [];
+  const out = await loadAccountTransfers(d1, "5SELF", {
+    direction: "received",
+  });
+  assert.equal(out.transfers.length, 1);
+  assert.equal(out.transfers[0].direction, "received");
 });
 
 test("formatRegistration defaults every sparse field to null/false (null-safe)", () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -700,7 +700,12 @@ export async function handleAccountTransfers(request, env, ss58, url) {
   const nextCursor = last
     ? encodeCursor([last.block_number, last.event_index])
     : null;
-  const data = buildAccountTransfers(rows, ss58, { limit, offset, nextCursor });
+  const data = buildAccountTransfers(rows, ss58, {
+    limit,
+    offset,
+    nextCursor,
+    direction,
+  });
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

- The native-TAO transfer feed (`GET /api/v1/accounts/{ss58}/transfers` and the MCP `get_account_transfers` tool) could return a row whose `direction` contradicts the `direction` filter the caller applied.
- `buildAccountTransfers` derives `direction` per-row, hotkey-first, and was never told which side the caller filtered on. A self-transfer (`from === to === ss58`, i.e. the poller writes `hotkey === coldkey === ss58`) matches the received-side query but was labeled `sent`.
- Thread the already-known requested direction into the shared builder so an explicit `sent`/`received` query labels every returned row with that side; the no-filter (`all`/omitted) path is unchanged.

## What Changed

- `src/account-events.mjs` — `buildAccountTransfers` accepts a `direction` option; when it is `sent`/`received` the row is labeled with the requested side, otherwise the existing per-row hotkey-first derivation is used. `loadAccountTransfers` (shared MCP/REST loader) passes its `direction` through.
- `workers/request-handlers/entities.mjs` — `handleAccountTransfers` passes the validated `direction` query param into the builder.
- `tests/account-events.test.mjs` — regression coverage: a self-transfer is labeled by the requested side (`received`/`sent`), a no-filter/`all` page keeps the per-row derivation, a normal counterparty row is never flipped, and the end-to-end `loadAccountTransfers` received-side path labels `received`.
- No schema/contract change: the `direction` field already exists; only its value for the self-transfer edge changes.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none - behavior-only fix)

## Validation

- [x] prettier --check on the changed files
- [x] vitest run tests/account-events.test.mjs (47 passed)
- [x] git diff --check

Fixes #2362
