### PR TITLE
feat(graphql): add compare query mirroring /api/v1/compare

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -15,6 +15,12 @@ import {
   resolveLiveHealth,
   subnetBadgeStatus,
 } from "./health-serving.mjs";
+import {
+  loadCompareSubnets,
+  parseCompareDimensionList,
+  parseCompareNetuidList,
+} from "./analytics-live.mjs";
+import { KV_HEALTH_META } from "./kv-keys.mjs";
 
 export const GRAPHQL_MAX_DEPTH = 7;
 export const GRAPHQL_MAX_COMPLEXITY = 50;
@@ -46,6 +52,8 @@ export const SDL = `
     health: GlobalHealth
     "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
     opportunity_boards(limit: Int): OpportunityBoards!
+    "Cross-subnet comparison: registry structure, live economics, and live health placed side by side for the requested netuids, in requested order. Mirrors GET /api/v1/compare."
+    compare(netuids: [Int!]!, dimensions: [String!]): Compare!
   }
 
   type SubnetList {
@@ -263,6 +271,49 @@ export const SDL = `
     validator_headroom: Int
     max_validators: Int
   }
+
+  type Compare {
+    schema_version: Int!
+    source: String
+    observed_at: String
+    dimensions: [String!]!
+    requested_netuids: [Int!]!
+    subnets: [CompareSubnet!]!
+  }
+
+  type CompareSubnet {
+    netuid: Int!
+    name: String
+    slug: String
+    found: Boolean!
+    structure: CompareStructure
+    economics: CompareEconomics
+    health: CompareHealth
+  }
+
+  type CompareStructure {
+    completeness_score: Float
+    surface_count: Int
+    operational_interface_count: Int
+  }
+
+  type CompareEconomics {
+    registration_cost_tao: Float
+    registration_allowed: Boolean
+    open_slots: Int
+    emission_share: Float
+    alpha_price_tao: Float
+    validator_count: Int
+    miner_count: Int
+    total_stake_tao: Float
+    miner_readiness: Int
+  }
+
+  type CompareHealth {
+    surface_count: Int
+    ok_count: Int
+    avg_latency_ms: Int
+  }
 `;
 
 const schema = buildSchema(SDL);
@@ -285,6 +336,7 @@ export const FIELD_COMPLEXITY = {
   endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
+  compare: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -491,6 +543,7 @@ const ARTIFACT = {
   economics: "/metagraph/economics.json",
   surfaces: "/metagraph/surfaces.json",
   endpoints: "/metagraph/endpoints.json",
+  profiles: "/metagraph/profiles.json",
 };
 const LIVE_HEALTH_KEY = "live:health";
 const LIVE_ECONOMICS_KEY = "live:economics";
@@ -550,6 +603,41 @@ function loadEconomics(context) {
     const res = await readArtifact(context.env, ARTIFACT.economics);
     return res.ok ? res.data : null;
   });
+}
+
+// A (sql, params) => Promise<rows[]> runner over the health DB, mirroring REST's
+// d1All and the MCP compare runner: a cold DB or query error yields [] so the
+// compare health dimension degrades to null rows instead of erroring.
+function graphqlD1(context) {
+  return async (sql, params) => {
+    const db = context.env?.METAGRAPH_HEALTH_DB;
+    if (!db?.prepare) return [];
+    try {
+      const result = await db
+        .prepare(sql)
+        .bind(...params)
+        .all();
+      return result?.results || [];
+    } catch {
+      return [];
+    }
+  };
+}
+
+// Cron snapshot freshness stamp (KV health:meta) — the same observed_at REST
+// compare stamps its envelope with. Null when the live store is cold.
+function loadObservedAt(context) {
+  return once(context, KV_HEALTH_META, async () => {
+    const meta = await readHealthKv(context.env, KV_HEALTH_META);
+    return meta?.last_run_at || null;
+  });
+}
+
+// Economics subnet rows for compare, reusing the live-preferring economics memo
+// (same source the `economics` root + opportunity boards serve).
+async function loadEconomicsRows(context) {
+  const data = await loadEconomics(context);
+  return Array.isArray(data?.subnets) ? data.subnets : [];
 }
 
 // --- Node builders (attach lazy relationship resolvers to artifact rows) ---
@@ -746,6 +834,39 @@ const rootValue = {
       highest_emission: boards["highest-emission"] || [],
       validator_headroom: boards["validator-headroom"] || [],
     };
+  },
+
+  async compare({ netuids, dimensions }, context) {
+    // Reuse the REST/MCP shared parsers so the GraphQL contract matches
+    // /api/v1/compare and the compare_subnets MCP tool exactly (distinctness +
+    // range + the dimension whitelist), then the shared loader composes the rows.
+    const parsedNetuids = parseCompareNetuidList(netuids);
+    if (!parsedNetuids) {
+      throw new GraphQLError(
+        "netuids must be a non-empty array of 1-128 distinct non-negative subnet ids.",
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const parsedDimensions = parseCompareDimensionList(dimensions);
+    if (dimensions != null && parsedDimensions === null) {
+      throw new GraphQLError(
+        "dimensions must be a non-empty subset of structure, economics, health.",
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const profilesData = await loadArtifact(context, ARTIFACT.profiles);
+    const profiles = Array.isArray(profilesData?.profiles)
+      ? profilesData.profiles
+      : [];
+    return loadCompareSubnets(graphqlD1(context), {
+      profiles,
+      economicsRows: parsedDimensions.includes("economics")
+        ? await loadEconomicsRows(context)
+        : [],
+      netuids: parsedNetuids,
+      dimensions: parsedDimensions,
+      observedAt: await loadObservedAt(context),
+    });
   },
 };
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -15,7 +15,11 @@ import {
 } from "../src/graphql.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { resolveClientIp } from "../workers/config.mjs";
-import { KV_ECONOMICS_CURRENT, KV_HEALTH_CURRENT } from "../src/kv-keys.mjs";
+import {
+  KV_ECONOMICS_CURRENT,
+  KV_HEALTH_CURRENT,
+  KV_HEALTH_META,
+} from "../src/kv-keys.mjs";
 
 // Minimal fake env — no R2 or ASSETS, so readArtifact always returns ok:false.
 const emptyEnv = {};
@@ -1455,5 +1459,201 @@ describe("graphql — resolver branch coverage", () => {
     const res = await handleGraphQLRequest(req, emptyEnv);
     assert.equal(res.status, 200);
     assert.deepEqual(await res.json(), { data: { __typename: "Query" } });
+  });
+});
+
+describe("graphql — compare (reuse the shared compare loader)", () => {
+  const profilesEnv = (extra = {}, opts = {}) =>
+    fixtureEnv(
+      {
+        "/metagraph/profiles.json": {
+          profiles: [
+            {
+              netuid: 1,
+              slug: "a",
+              name: "A",
+              completeness_score: 90,
+              surface_count: 4,
+              operational_interface_count: 2,
+            },
+            {
+              netuid: 2,
+              slug: "b",
+              name: "B",
+              completeness_score: 50,
+              surface_count: 1,
+              operational_interface_count: 0,
+            },
+          ],
+        },
+        ...extra,
+      },
+      opts,
+    );
+
+  test("default dimensions: structure + economics + health side by side", async () => {
+    const env = profilesEnv({
+      "/metagraph/economics.json": {
+        subnets: [{ netuid: 1, emission_share: 0.1, open_slots: 5 }],
+      },
+    });
+    const { status, body } = await gql(
+      `{ compare(netuids: [1, 99]) {
+          schema_version dimensions requested_netuids
+          subnets { netuid found
+            structure { completeness_score surface_count }
+            economics { emission_share open_slots }
+            health { ok_count }
+          }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const c = body.data.compare;
+    assert.equal(c.schema_version, 1);
+    assert.deepEqual(c.dimensions, ["structure", "economics", "health"]);
+    assert.deepEqual(c.requested_netuids, [1, 99]);
+    // Requested order is preserved.
+    assert.equal(c.subnets[0].netuid, 1);
+    assert.equal(c.subnets[0].found, true);
+    assert.equal(c.subnets[0].structure.completeness_score, 90);
+    assert.equal(c.subnets[0].economics.emission_share, 0.1);
+    // No D1 binding → health is null, not an error.
+    assert.equal(c.subnets[0].health, null);
+    // Unknown netuid → found:false, all dimension blocks null.
+    assert.equal(c.subnets[1].netuid, 99);
+    assert.equal(c.subnets[1].found, false);
+    assert.equal(c.subnets[1].structure, null);
+    assert.equal(c.subnets[1].economics, null);
+  });
+
+  test("explicit dimensions subset skips the economics read", async () => {
+    const reads = new Map();
+    const env = profilesEnv({}, { reads });
+    const { status, body } = await gql(
+      `{ compare(netuids: [1], dimensions: ["structure"]) {
+          dimensions subnets { structure { surface_count } economics { emission_share } }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.compare.dimensions, ["structure"]);
+    assert.equal(body.data.compare.subnets[0].structure.surface_count, 4);
+    assert.equal(body.data.compare.subnets[0].economics, null);
+    // economics dimension excluded → no economics artifact read.
+    assert.equal(reads.has("latest/economics.json"), false);
+  });
+
+  test("observed_at is stamped from the health:meta KV freshness", async () => {
+    const env = profilesEnv(
+      {},
+      { kv: { [KV_HEALTH_META]: { last_run_at: "2026-06-23T00:00:00.000Z" } } },
+    );
+    const { body } = await gql(
+      `{ compare(netuids: [1], dimensions: ["structure"]) { observed_at } }`,
+      env,
+    );
+    assert.equal(body.data.compare.observed_at, "2026-06-23T00:00:00.000Z");
+  });
+
+  test("the health dimension runs the D1 surface_status aggregate", async () => {
+    const env = profilesEnv();
+    env.METAGRAPH_HEALTH_DB = {
+      prepare() {
+        return {
+          bind() {
+            return {
+              async all() {
+                return {
+                  results: [
+                    {
+                      netuid: 1,
+                      surface_count: 3,
+                      ok_count: 3,
+                      avg_latency_ms: 42,
+                    },
+                  ],
+                };
+              },
+            };
+          },
+        };
+      },
+    };
+    const { status, body } = await gql(
+      `{ compare(netuids: [1], dimensions: ["health"]) {
+          subnets { netuid health { surface_count ok_count avg_latency_ms } }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.compare.subnets[0].health.ok_count, 3);
+    assert.equal(body.data.compare.subnets[0].health.avg_latency_ms, 42);
+  });
+
+  test("a D1 result with no rows yields null health (results || [] fallback)", async () => {
+    const env = profilesEnv();
+    env.METAGRAPH_HEALTH_DB = {
+      prepare: () => ({ bind: () => ({ all: async () => ({}) }) }),
+    };
+    const { status, body } = await gql(
+      `{ compare(netuids: [1], dimensions: ["health"]) { subnets { health { ok_count } } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.compare.subnets[0].health, null);
+  });
+
+  test("a D1 error degrades the health dimension to null (no throw)", async () => {
+    const env = profilesEnv();
+    env.METAGRAPH_HEALTH_DB = {
+      prepare() {
+        throw new Error("db unavailable");
+      },
+    };
+    const { status, body } = await gql(
+      `{ compare(netuids: [1], dimensions: ["health"]) { subnets { health { ok_count } } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.compare.subnets[0].health, null);
+  });
+
+  test("invalid netuids (empty / negative) returns BAD_USER_INPUT", async () => {
+    const empty = await gql("{ compare(netuids: []) { schema_version } }");
+    assert.equal(empty.status, 200);
+    assert.ok(
+      empty.body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
+    const neg = await gql("{ compare(netuids: [-1]) { schema_version } }");
+    assert.ok(
+      neg.body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+    );
+  });
+
+  test("an unknown dimension returns BAD_USER_INPUT", async () => {
+    const { body } = await gql(
+      '{ compare(netuids: [1], dimensions: ["bogus"]) { schema_version } }',
+    );
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+  });
+
+  test("cold store: no profiles/economics artifacts → found:false, empty rows", async () => {
+    // emptyEnv: readArtifact always ok:false, so profiles and economics both
+    // resolve to [] (the fallback arms), observed_at is null, and every
+    // requested netuid is reported found:false with null dimension blocks.
+    const { status, body } = await gql(
+      `{ compare(netuids: [1], dimensions: ["economics"]) {
+          observed_at subnets { netuid found economics { emission_share } }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.compare.observed_at, null);
+    assert.equal(body.data.compare.subnets[0].found, false);
+    assert.equal(body.data.compare.subnets[0].economics, null);
+  });
+
+  test("compare is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.compare, 5);
   });
 });


### PR DESCRIPTION
## Summary

The read-only GraphQL endpoint (`/api/v1/graphql`) exposes subnet/surface/provider/economics/health data but has no cross-subnet comparison query, so GraphQL consumers must fall back to REST for one of the most useful analytical views. This adds the `compare` query to close that parity gap with `GET /api/v1/compare` (and the `compare_subnets` MCP tool).

```graphql
query {
  compare(netuids: [1, 3, 7], dimensions: ["structure", "economics", "health"]) {
    schema_version observed_at dimensions requested_netuids
    subnets {
      netuid name slug found
      structure { completeness_score surface_count operational_interface_count }
      economics { emission_share registration_cost_tao open_slots validator_count miner_count total_stake_tao }
      health { surface_count ok_count avg_latency_ms }
    }
  }
}
```

## Implementation

- Reuses the **shared** `loadCompareSubnets` loader and the `parseCompareNetuidList` / `parseCompareDimensionList` parsers from `src/analytics-live.mjs` — the same code REST `handleCompare` and the `compare_subnets` MCP tool call — so the dimension whitelist, netuid validation (1–128 distinct, non-negative), requested-order preservation, and cold-store degradation match the existing contract exactly. No new data logic.
- Thin resolver: reads `/metagraph/profiles.json` (structure), the live-preferring economics memo (only when the `economics` dimension is requested), and the health `surface_status` aggregate via a cold-safe D1 runner (health dimension only). `observed_at` is stamped from the `health:meta` KV freshness, mirroring REST.
- `compare` weighted as a fan-out field in `FIELD_COMPLEXITY` (5), like the other read/fan-out roots.
- GraphQL is in `NON_CONTRACT_PATHS` and has no SDL snapshot, so no OpenAPI/contract regeneration is required.

## Validation

- `npx vitest run` — **137 files / 3396 tests pass** (added 10 compare tests: default + subset dimensions, cold store, D1 happy/empty/error paths, invalid netuids/dimension, observed_at, complexity weight; new `src/graphql.mjs` lines at 100% with branches covered)
- `npm run validate` — clean · `eslint` + `prettier --check` — clean

## Scope note

Issue #1807 also proposes a `surface_readiness` query, but there is **no** `/api/v1/surfaces/readiness` REST endpoint and the proposed `auth` / `rate_limit` fields do not exist at the readiness-scorecard grain (they live on individual surface rows). Rather than fabricate data or invent a divergent shape, this PR ships the faithful `compare` half and leaves `surface_readiness` for a follow-up once its shape is settled.

Refs #1807.
