### PR TITLE
feat(registry): add SN18 Zeus openapi surface

### DIFF
--- a/registry/subnets/sn-18.json
+++ b/registry/subnets/sn-18.json
@@ -28,6 +28,23 @@
       },
       "source_urls": ["https://api.zeussubnet.com/openapi.json"],
       "url": "https://api.zeussubnet.com/v1/meta"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-18-zeus-openapi",
+      "kind": "openapi",
+      "name": "Zeus BOREAS Edge API (public)",
+      "provider": "zeus",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jeffrey701"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.zeussubnet.com/openapi.json",
+      "source_urls": ["https://www.zeussubnet.com/"],
+      "url": "https://api.zeussubnet.com/openapi.json"
     }
   ],
   "website_url": "https://www.zeussubnet.com/"


### PR DESCRIPTION
## Summary

Add the machine-readable **OpenAPI spec** served by the **SN18 Zeus** subnet API (`https://api.zeussubnet.com/openapi.json`) as a community `openapi` surface. Zeus already registers a subnet-api on this host but its OpenAPI spec was not yet captured.

## Proof

- **url:** https://api.zeussubnet.com/openapi.json — live, machine-readable OpenAPI document
- **source_url:** https://www.zeussubnet.com/ — the official Zeus website; `api.zeussubnet.com` is the same registrable domain, and the registry already lists the subnet-api `https://api.zeussubnet.com/v1/meta` on this host (owner-matched)

## Changes

Edits exactly one file — `registry/subnets/sn-18.json` — appending one community surface (`authority: community`, `review.state: community-submitted`). No health/verification set by hand.

## Validation

- `npm run validate:surface -- registry/subnets/sn-18.json` — passed
- `npm run scan:public-safety` — passed
- `surface:add` probe — reachable + public-safe
