### PR TITLE
feat(registry): add SN94 Bitsota openapi surface

### DIFF
--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -25,6 +25,23 @@
       },
       "source_urls": ["https://bitsota.ai/docs/autoresearch-backend-routes"],
       "url": "https://autoresearch.bitsota.com/api/v1/tasks"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-alveus-labs-openapi",
+      "kind": "openapi",
+      "name": "Bitsota autoresearch-bittensor coordinator",
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jeffrey701"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://autoresearch.bitsota.com/openapi.json",
+      "source_urls": ["https://bitsota.com/"],
+      "url": "https://autoresearch.bitsota.com/openapi.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add the machine-readable **OpenAPI 3.1 spec** served by the **SN94 Bitsota** autoresearch coordinator API (`https://autoresearch.bitsota.com/openapi.json`) as a community `openapi` surface. Bitsota already registers a subnet-api on this host but its OpenAPI spec was not yet captured.

## Proof

- **url:** https://autoresearch.bitsota.com/openapi.json — live OpenAPI 3.1.0 document (`autoresearch-bittensor coordinator`, 37 paths)
- **source_url:** https://bitsota.com/ — the official Bitsota site; `autoresearch.bitsota.com` is the same registrable domain, and the registry already lists the subnet-api `https://autoresearch.bitsota.com/api/v1/tasks` on this host (owner-matched)

## Changes

Edits exactly one file — `registry/subnets/bitsota.json` — appending one community surface (`authority: community`, `review.state: community-submitted`). No health/verification set by hand.

## Validation

- `npm run validate:surface -- registry/subnets/bitsota.json` — passed
- `npm run scan:public-safety` — passed
- `surface:add` probe — reachable + public-safe
