### PR TITLE
feat(mcp): exclusion filters (not_) on list_subnets categorical args

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -878,6 +878,54 @@ function rangeFilterSubnets(rows, args) {
   );
 }
 
+// Categorical args list_subnets filters on, each available as inclusion (`arg`)
+// and exclusion (`not_arg`).
+const LIST_SUBNETS_CATEGORICAL = ["status", "subnet_type", "domain"];
+
+// Does `subnet` match categorical filter `field` = `value` (already lowercased)?
+// `domain` tests the union of curated + derived categories; the rest are scalar.
+// Shared by inclusion and exclusion so `status=` and `not_status=` stay exact
+// complements.
+function subnetCategoricalMatch(subnet, field, value) {
+  if (field === "domain") {
+    const tags = [
+      ...(Array.isArray(subnet.categories) ? subnet.categories : []),
+      ...(Array.isArray(subnet.derived_categories)
+        ? subnet.derived_categories
+        : []),
+    ].map((tag) => String(tag).toLowerCase());
+    return tags.includes(value);
+  }
+  return String(subnet[field] || "").toLowerCase() === value;
+}
+
+// Apply the categorical filters: keep rows matching every `field=v` and matching
+// none of the `not_field=v` exclusions (case-insensitive). A row missing the
+// field never matches, so it survives an exclusion but fails an inclusion.
+function categoricalFilterSubnets(rows, args) {
+  const includes = [];
+  const excludes = [];
+  for (const arg of LIST_SUBNETS_CATEGORICAL) {
+    const inc = typeof args?.[arg] === "string" ? args[arg].trim() : "";
+    if (inc) includes.push({ field: arg, value: inc.toLowerCase() });
+    const exc =
+      typeof args?.[`not_${arg}`] === "string" ? args[`not_${arg}`].trim() : "";
+    if (exc) excludes.push({ field: arg, value: exc.toLowerCase() });
+  }
+  if (includes.length === 0 && excludes.length === 0) {
+    return rows;
+  }
+  return rows.filter(
+    (subnet) =>
+      includes.every(({ field, value }) =>
+        subnetCategoricalMatch(subnet, field, value),
+      ) &&
+      excludes.every(
+        ({ field, value }) => !subnetCategoricalMatch(subnet, field, value),
+      ),
+  );
+}
+
 // A search.json document → keywordScore shape: title/slug are identity; subtitle
 // and tokens (which already fold in categories/service kinds) are recall-only.
 function scoreDocument(doc, terms) {
@@ -1067,6 +1115,18 @@ export const MCP_TOOLS = [
           description:
             "Filter to subnets tagged with this domain/category, e.g. 'inference'.",
         },
+        not_status: {
+          type: "string",
+          description: "Exclude subnets with this lifecycle status.",
+        },
+        not_subnet_type: {
+          type: "string",
+          description: "Exclude subnets of this type (e.g. 'root').",
+        },
+        not_domain: {
+          type: "string",
+          description: "Exclude subnets tagged with this domain/category.",
+        },
         min_readiness: {
           type: "integer",
           description:
@@ -1121,43 +1181,9 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const index = await loadArtifactData(ctx, "/metagraph/subnets.json");
       const all = Array.isArray(index.subnets) ? index.subnets : [];
-      const status =
-        typeof args?.status === "string"
-          ? args.status.trim().toLowerCase()
-          : null;
-      const subnetType =
-        typeof args?.subnet_type === "string"
-          ? args.subnet_type.trim().toLowerCase()
-          : null;
-      const domain =
-        typeof args?.domain === "string"
-          ? args.domain.trim().toLowerCase()
-          : null;
-      const categorical = all.filter((subnet) => {
-        if (status && String(subnet.status || "").toLowerCase() !== status) {
-          return false;
-        }
-        if (
-          subnetType &&
-          String(subnet.subnet_type || "").toLowerCase() !== subnetType
-        ) {
-          return false;
-        }
-        if (domain) {
-          const tags = [
-            ...(Array.isArray(subnet.categories) ? subnet.categories : []),
-            ...(Array.isArray(subnet.derived_categories)
-              ? subnet.derived_categories
-              : []),
-          ].map((tag) => String(tag).toLowerCase());
-          if (!tags.includes(domain)) {
-            return false;
-          }
-        }
-        return true;
-      });
-      // Apply the inclusive numeric range bounds (min_/max_) after the
-      // categorical filters, mirroring the REST list endpoint's filter order.
+      // Categorical inclusion (status/subnet_type/domain) and exclusion
+      // (not_status/not_subnet_type/not_domain), then the numeric range bounds.
+      const categorical = categoricalFilterSubnets(all, args);
       const filtered = rangeFilterSubnets(categorical, args);
       // Sort the filtered list before paging; unscored subnets sort last and
       // equal values tie-break by netuid for a stable page (sortSubnets).

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -2969,6 +2969,46 @@ describe("list_subnets", () => {
   const rangeNetuids = (out) =>
     out.subnets.map((s) => s.netuid).sort((a, b) => a - b);
 
+  // Fixture: 0=root/active, 7=application/active/inference, 8=application/deprecated/data.
+  test("not_status / not_subnet_type / not_domain exclude matching subnets", async () => {
+    const notActive = (
+      await callTool("list_subnets", { not_status: "active" }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(notActive), [8]); // only the deprecated one
+
+    const notApp = (
+      await callTool(
+        "list_subnets",
+        { not_subnet_type: "application" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(notApp), [0]); // only the root one
+
+    const notInference = (
+      await callTool("list_subnets", { not_domain: "inference" }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(notInference), [0, 8]); // 7 (inference) dropped
+  });
+
+  test("not_<categorical> is case-insensitive (matches the inclusion form)", async () => {
+    const out = (
+      await callTool("list_subnets", { not_status: "ACTIVE" }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(out), [8]);
+  });
+
+  test("inclusion and exclusion compose (status=active AND not_subnet_type=root)", async () => {
+    const out = (
+      await callTool(
+        "list_subnets",
+        { status: "active", not_subnet_type: "root" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(out), [7]); // active {0,7} minus root {0}
+  });
+
   test("max_readiness keeps rows <= the bound (complement of min_readiness)", async () => {
     const out = (
       await callTool("list_subnets", { max_readiness: 50 }, { deps })


### PR DESCRIPTION
## Summary

`list_subnets` supports categorical inclusion (`status`, `subnet_type`, `domain`) but no way to **exclude** a value. This adds `not_status`, `not_subnet_type`, and `not_domain` — the complement of the matching inclusion arg — extending the same parity work as the merged range filters (#2280).

Inclusion and exclusion now share one case-insensitive `subnetCategoricalMatch` helper, so `status=active` and `not_status=active` are exact complements; a row missing the field survives an exclusion but fails an inclusion. Composes with the existing `min_/max_` range filters, sort, and pagination.

## Changes
- `src/mcp-server.mjs`: `subnetCategoricalMatch` + `categoricalFilterSubnets` (inclusion + `not_` exclusion); the 3 `not_` args added to the `list_subnets` inputSchema. No server-card regen (worker-computed), no contract/openapi change.
- `tests/mcp-server.test.mjs`: exclusion per field, case-insensitivity, and inclusion+exclusion composition.

## Validation
- `npm run lint`, `npm run format:check`, `node scripts/validate-mcp.mjs` (52 tools) — green
- `npx vitest run tests/mcp-server.test.mjs` — 260 passed; new lines fully covered