### PR TITLE
feat(api): add block_start/block_end range filter to the account transfers feed

### DIFF
--- a/tests/account-routes.test.mjs
+++ b/tests/account-routes.test.mjs
@@ -295,6 +295,101 @@ test("GET /accounts/{ss58}/transfers rejects an unsupported direction enum value
   assert.equal(body.meta.parameter, "direction");
 });
 
+// A capturing D1 mock that records every (sql, params), so a filter test can
+// assert the predicate + bind order — the naive dbWith stub ignores the WHERE
+// clause, so it cannot prove a range filter is wired correctly.
+function capturingDb(events = []) {
+  const calls = [];
+  return {
+    calls,
+    env: {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              calls.push({ sql, params });
+              return {
+                async all() {
+                  return {
+                    results: /FROM account_events/.test(sql) ? events : [],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    },
+  };
+}
+
+test("GET /accounts/{ss58}/transfers accepts a block_start/block_end range and binds it in each arm (parity with /events)", async () => {
+  const db = capturingDb([]);
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/transfers?block_start=100&block_end=200`),
+    db.env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  const read = db.calls.find((c) => /FROM account_events/.test(c.sql));
+  assert.ok(read, "account_events read happened");
+  assert.match(read.sql, /block_number >= \?/);
+  assert.match(read.sql, /block_number <= \?/);
+  // default direction = both → the [key, block_start, block_end] binds repeat per
+  // UNION arm (hotkey arm, then coldkey + hotkey<> arm), before limit/offset.
+  assert.deepEqual(read.params.slice(0, 7), [
+    SS58,
+    100,
+    200,
+    SS58,
+    SS58,
+    100,
+    200,
+  ]);
+});
+
+test("GET /accounts/{ss58}/transfers applies a single bound with direction=sent", async () => {
+  const db = capturingDb([]);
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/transfers?direction=sent&block_start=500`),
+    db.env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  const read = db.calls.find((c) => /FROM account_events/.test(c.sql));
+  assert.match(read.sql, /hotkey = \?/);
+  assert.match(read.sql, /block_number >= \?/);
+  assert.doesNotMatch(read.sql, /block_number <= \?/);
+  assert.deepEqual(read.params.slice(0, 2), [SS58, 500]);
+});
+
+test("GET /accounts/{ss58}/transfers applies a block_end bound with direction=received", async () => {
+  const db = capturingDb([]);
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/transfers?direction=received&block_end=900`),
+    db.env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  const read = db.calls.find((c) => /FROM account_events/.test(c.sql));
+  assert.match(read.sql, /coldkey = \?/);
+  assert.match(read.sql, /block_number <= \?/);
+  assert.doesNotMatch(read.sql, /block_number >= \?/);
+  assert.deepEqual(read.params.slice(0, 2), [SS58, 900]);
+});
+
+test("GET /accounts/{ss58}/transfers rejects a non-integer block_start", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/transfers?block_start=abc`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.error.code, "invalid_query");
+  assert.equal(body.meta.parameter, "block_start");
+});
+
 test("GET /accounts/{ss58}/transfers is schema-stable when D1 is cold (never 404)", async () => {
   const res = await handleRequest(
     req(`/api/v1/accounts/${SS58}/transfers`),

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -646,6 +646,8 @@ export async function handleAccountExtrinsics(request, env, ss58, url) {
 export async function handleAccountTransfers(request, env, ss58, url) {
   const validationError = validateQueryParams(url, [
     "direction",
+    "block_start",
+    "block_end",
     "limit",
     "offset",
     "cursor",
@@ -663,6 +665,23 @@ export async function handleAccountTransfers(request, env, ss58, url) {
       message: `"${direction}" is not a valid direction. Supported: all, sent, received.`,
     });
   }
+  // Optional block-height range filter, parity with the events feed
+  // (handleAccountEvents) and the extrinsics/chain-events feeds. Both
+  // idx_account_events_hotkey and idx_account_events_coldkey lead block_number
+  // after the key column, so a bounded range stays index-satisfiable on this
+  // ~60s-cached public route rather than scanning all of an account's transfers.
+  const blockStartParam = parseNonNegativeIntParam(
+    url.searchParams.get("block_start"),
+    "block_start",
+  );
+  if (blockStartParam.error) return analyticsQueryError(blockStartParam.error);
+  const blockEndParam = parseNonNegativeIntParam(
+    url.searchParams.get("block_end"),
+    "block_end",
+  );
+  if (blockEndParam.error) return analyticsQueryError(blockEndParam.error);
+  const blockStart = blockStartParam.value;
+  const blockEnd = blockEndParam.value;
   const { limit, offset, cursor } = parsePagination(url, FEED_PAGINATION);
   // sent => this account is the sender (hotkey=from); received => recipient
   // (coldkey=to); default/all => either side. Keep the default read as two
@@ -674,21 +693,33 @@ export async function handleAccountTransfers(request, env, ss58, url) {
   const cursorClause = useCursor
     ? " AND (block_number, event_index) < (?, ?)"
     : "";
+  // Block-range predicate appended to each side's WHERE BEFORE the keyset cursor,
+  // so every arm's bind order is [key, block-range, cursor]. armParams carries the
+  // range + cursor binds shared by each UNION arm.
+  let rangeClause = "";
+  const rangeParams = [];
+  if (blockStart != null) {
+    rangeClause += " AND block_number >= ?";
+    rangeParams.push(blockStart);
+  }
+  if (blockEnd != null) {
+    rangeClause += " AND block_number <= ?";
+    rangeParams.push(blockEnd);
+  }
+  const armClause = `${rangeClause}${cursorClause}`;
+  const armParams = [...rangeParams, ...(useCursor ? [cur[0], cur[1]] : [])];
   let params;
   let sql;
   if (direction === "sent") {
-    params = [ss58];
-    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ?${cursorClause}`;
+    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ?${armClause}`;
+    params = [ss58, ...armParams];
   } else if (direction === "received") {
-    params = [ss58];
-    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ?${cursorClause}`;
+    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ?${armClause}`;
+    params = [ss58, ...armParams];
   } else {
-    params = [ss58];
-    if (useCursor) params.push(cur[0], cur[1]);
-    params.push(ss58, ss58);
-    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM (SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ?${cursorClause} UNION ALL SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ? AND hotkey <> ?${cursorClause})`;
+    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM (SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ?${armClause} UNION ALL SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ? AND hotkey <> ?${armClause})`;
+    params = [ss58, ...armParams, ss58, ss58, ...armParams];
   }
-  if (useCursor) params.push(cur[0], cur[1]);
   sql += " ORDER BY block_number DESC, event_index DESC LIMIT ?";
   params.push(limit);
   if (!useCursor) {


### PR DESCRIPTION
## Summary

`GET /api/v1/accounts/{ss58}/transfers` accepts `direction`/`limit`/`offset`/`cursor` but has no block-height range filter, unlike the sibling `GET /api/v1/accounts/{ss58}/events` and the extrinsics / chain-events feeds (which gained `block_start`/`block_end` in #2328). This adds the same optional range to the transfers feed for parity.

## Implementation

- Adds `block_start` / `block_end` to the accepted params, parsed with the existing `parseNonNegativeIntParam` (rejects non-integer / negative with a 400, mirroring the events feed).
- Appends the range predicate to **each** side's WHERE **before** the keyset cursor clause, so every UNION arm binds in `[key, block_start?, block_end?, cursor?]` order (verified for sent / received / both).
- Both `idx_account_events_hotkey` and `idx_account_events_coldkey` lead `block_number` after the key column, so a bounded range stays index-satisfiable on this ~60s-cached public route.

## Validation

- `npx vitest run` — **137 files / 3390 tests pass** (added 4 tests: both-arm range bind order, single bound + direction=sent, block_end + direction=received, and a non-integer `block_start` rejection)
- `npm run validate` — clean · `eslint` + `prettier --check` — clean
