### PR TITLE
fix(health): scope IPv6 unique-local SSRF patterns to literal hosts

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -51,6 +51,8 @@ export const OPERATIONAL_SURFACE_KINDS = [
 // build injects the stronger DNS-aware `isUnsafeResolvedUrl` from scripts/lib.mjs.
 // Operational surfaces are already curated `public_safe`, so this is defense in
 // depth, not the primary control.
+// IPv4 / registrable-domain unsafe prefixes. Their leading characters can never
+// collide with a public hostname, so they are matched against EVERY host.
 const UNSAFE_HOST_PATTERNS = [
   /^localhost$/i,
   /\.localhost$/i,
@@ -60,17 +62,39 @@ const UNSAFE_HOST_PATTERNS = [
   /^192\.168\./,
   /^169\.254\./,
   /^0\./,
+  // 172.16.0.0 - 172.31.255.255 (private range).
+  /^172\.(1[6-9]|2\d|3[01])\./,
   // 100.64.0.0/10 CGNAT — blocked by the webhook + build SSRF guards; the probe
   // literal guard must stay in parity (issue #2312).
   /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./,
+];
+
+// IPv6-LITERAL-only unsafe patterns. These are applied ONLY when the host is an
+// IPv6 literal (it contains a ':'), so a registrable domain that merely begins
+// with the same hex characters (e.g. fda.gov, fd.io, fdroid.org) is never
+// misread as a unique-local address. Covers loopback (::1), the unspecified
+// address (::), the fe80::/10 link-local + fec0::/10 deprecated site-local range
+// (the whole fe80::–feff: block, mirroring the webhook guard, issue #1538), and
+// the FULL fc00::/7 unique-local range (fc00:–fdff:, not just the fc00: hextet).
+const UNSAFE_IPV6_LITERAL_PATTERNS = [
   /^::1$/,
   /^::$/,
-  // fe80::/10 link-local + fec0::/10 deprecated site-local (RFC 3879) — the whole
-  // fe80::–feff: reserved range, mirroring the webhook guard (issue #1538).
   /^fe[89a-f][0-9a-f]:/i,
-  /^fc00:/i,
-  /^fd/i,
+  /^f[cd][0-9a-f]{2}:/i,
 ];
+
+// Classify a bare (bracket-stripped) host as an unsafe literal target. IPv6
+// literal rules only apply to colon-bearing hosts so a public `fd*`/`fc*` domain
+// is not mistaken for a unique-local IPv6 address.
+function isUnsafeLiteralHost(host) {
+  if (
+    host.includes(":") &&
+    UNSAFE_IPV6_LITERAL_PATTERNS.some((pattern) => pattern.test(host))
+  ) {
+    return true;
+  }
+  return UNSAFE_HOST_PATTERNS.some((pattern) => pattern.test(host));
+}
 
 export function isUnsafePublicUrl(value) {
   try {
@@ -86,25 +110,15 @@ export function isUnsafePublicUrl(value) {
     if (!host) {
       return true;
     }
-    // 172.16.0.0 – 172.31.255.255 (private range).
-    if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) {
-      return true;
-    }
     // IPv4 tunnelled inside an IPv6 literal (::ffff:a.b.c.d mapped, ::a.b.c.d
     // compatible, 2002::/16 6to4, 64:ff9b::/96 NAT64) hides a private/loopback
     // target — e.g. ::ffff:169.254.169.254 (cloud metadata) — from the prefix
     // patterns. Re-check the embedded v4 against the same ranges.
     const embedded = ipv6EmbeddedIpv4(host);
-    if (embedded) {
-      const dotted = embedded.join(".");
-      if (
-        /^172\.(1[6-9]|2\d|3[01])\./.test(dotted) ||
-        UNSAFE_HOST_PATTERNS.some((pattern) => pattern.test(dotted))
-      ) {
-        return true;
-      }
+    if (embedded && isUnsafeLiteralHost(embedded.join("."))) {
+      return true;
     }
-    return UNSAFE_HOST_PATTERNS.some((pattern) => pattern.test(host));
+    return isUnsafeLiteralHost(host);
   } catch {
     return true;
   }

--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -87,12 +87,16 @@ const UNSAFE_IPV6_LITERAL_PATTERNS = [
   /^f[cd][0-9a-f]{2}:/i,
 ];
 
-// Classify a bare (bracket-stripped) host as an unsafe literal target. IPv6
-// literal rules only apply to colon-bearing hosts so a public `fd*`/`fc*` domain
-// is not mistaken for a unique-local IPv6 address.
-function isUnsafeLiteralHost(host) {
+function isIpv6LiteralHost(host) {
+  return host.includes(":");
+}
+
+// Classify a bare (bracket-stripped) host as an unsafe target. IPv6 literal
+// rules only apply to colon-bearing hosts so a public `fd*`/`fc*` domain is not
+// mistaken for a unique-local IPv6 address.
+function isUnsafeHost(host) {
   if (
-    host.includes(":") &&
+    isIpv6LiteralHost(host) &&
     UNSAFE_IPV6_LITERAL_PATTERNS.some((pattern) => pattern.test(host))
   ) {
     return true;
@@ -119,10 +123,10 @@ export function isUnsafePublicUrl(value) {
     // target — e.g. ::ffff:169.254.169.254 (cloud metadata) — from the prefix
     // patterns. Re-check the embedded v4 against the same ranges.
     const embedded = ipv6EmbeddedIpv4(host);
-    if (embedded && isUnsafeLiteralHost(embedded.join("."))) {
+    if (embedded && isUnsafeHost(embedded.join("."))) {
       return true;
     }
-    return isUnsafeLiteralHost(host);
+    return isUnsafeHost(host);
   } catch {
     return true;
   }

--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -51,8 +51,12 @@ export const OPERATIONAL_SURFACE_KINDS = [
 // build injects the stronger DNS-aware `isUnsafeResolvedUrl` from scripts/lib.mjs.
 // Operational surfaces are already curated `public_safe`, so this is defense in
 // depth, not the primary control.
-// IPv4 / registrable-domain unsafe prefixes. Their leading characters can never
-// collide with a public hostname, so they are matched against EVERY host.
+// IPv4 private-range and reserved-name prefixes, matched against EVERY host.
+// These are intentionally conservative: a host that leads with a private IPv4
+// prefix or a reserved suffix (e.g. the numeric-label `172.16.example.com`) is
+// treated as unsafe even on the rare chance it is a registrable name, since the
+// Worker guard has no DNS to disambiguate it. The IPv6-literal ranges, by
+// contrast, are NOT applied to every host (see UNSAFE_IPV6_LITERAL_PATTERNS).
 const UNSAFE_HOST_PATTERNS = [
   /^localhost$/i,
   /\.localhost$/i,

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -146,6 +146,33 @@ describe("isUnsafePublicUrl", () => {
       assert.equal(isUnsafePublicUrl(url), false, url);
     }
   });
+
+  test("allows public domains that begin with fc/fd (issue #2375)", () => {
+    // The unique-local IPv6 patterns must only apply to IPv6 literals — a
+    // registrable hostname starting with the same hex chars is public.
+    for (const url of [
+      "https://fda.gov/api",
+      "https://fd.io/x",
+      "https://fdroid.org/x",
+      "https://fdic.gov/x",
+      "https://fc-bank.example/x",
+      "wss://fde.example.com:443",
+    ]) {
+      assert.equal(isUnsafePublicUrl(url), false, url);
+    }
+  });
+
+  test("blocks the full fc00::/7 unique-local range, not just fc00: (issue #2375)", () => {
+    for (const url of [
+      "http://[fc00::1]/x",
+      "http://[fc12::1]/x", // fc-hextet ULA the old /^fc00:/ missed
+      "https://[fcab:1:2::3]/x",
+      "http://[fd00::1]/x",
+      "http://[fdff::1]/x",
+    ]) {
+      assert.equal(isUnsafePublicUrl(url), true, url);
+    }
+  });
 });
 
 describe("classifyProbe", () => {

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -169,6 +169,7 @@ describe("isUnsafePublicUrl", () => {
       "https://[fcab:1:2::3]/x",
       "http://[fd00::1]/x",
       "http://[fdff::1]/x",
+      "http://[fdff:ffff::1]/x", // upper bound — only the first hextet decides ULA
     ]) {
       assert.equal(isUnsafePublicUrl(url), true, url);
     }

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -155,7 +155,9 @@ describe("isUnsafePublicUrl", () => {
       "https://fd.io/x",
       "https://fdroid.org/x",
       "https://fdic.gov/x",
+      "https://fc00.example.com/x",
       "https://fc-bank.example/x",
+      "https://fdff.example.com/x",
       "wss://fde.example.com:443",
     ]) {
       assert.equal(isUnsafePublicUrl(url), false, url);


### PR DESCRIPTION
## Summary

Fix a false-positive (and a paired false-negative) in the health prober's literal SSRF guard `isUnsafePublicUrl` (`src/health-probe-core.mjs`). The IPv6 unique-local / link-local patterns were matched against every host, so any public domain beginning with `fd` (`fda.gov`, `fd.io`, `fdroid.org`) was wrongly classified unsafe and silently never probed. At the same time `/^fc00:/i` only matched the single `fc00:` hextet, so other `fc00::/7` unique-local addresses (e.g. `fc12::1`) slipped through.

Fixes #2375

## What Changed

- Split the IPv6-literal patterns out of `UNSAFE_HOST_PATTERNS` into a new `UNSAFE_IPV6_LITERAL_PATTERNS` list and added a small `isUnsafeLiteralHost(host)` helper that only applies the IPv6 rules when the host is an IPv6 literal (contains `:`), mirroring the colon-gated webhook guard in `src/webhooks.mjs`.
- Widened unique-local detection from `/^fc00:/i` + `/^fd/i` to `/^f[cd][0-9a-f]{2}:/i`, covering the full `fc00::/7` range (`fc00:`-`fdff:`).
- Folded the `172.16.0.0/12` private-range check into `UNSAFE_HOST_PATTERNS` so the host and the IPv4-embedded-IPv6 path share one classifier.
- Extended the `isUnsafePublicUrl` regression suite in `tests/health-probe-core.test.mjs`: public `fc`/`fd` domains stay allowed, and the full `fc00::/7` literal range stays blocked. No regression on the prior SSRF parity fixes (#1538 / #1541 / #2312 / #1533).

## Scope and Risk

This is limited to local URL classification before probes are attempted. It does not change probe scheduling, persisted artifacts, schemas, OpenAPI output, or public API response shapes. The main risk is SSRF classifier drift, covered by regression tests for public `fc`/`fd` hostnames, IPv6 ULA literals, and existing private/tunnelled IP cases.
## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes (pure runtime guard fix; contract untouched).

## Validation

- [x] `npx vitest run tests/health-probe-core.test.mjs` (107 passed)
- [x] `npx vitest run tests/build-readiness.test.mjs tests/health-ok-latency.test.mjs` (the other importers of the guard, 79 passed)
- [x] `npm run lint`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
