### PR TITLE
fix(api): reject non-safe-integer netuid on the account history feed

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1492,7 +1492,9 @@ describe("handleAccountHistory", () => {
   });
 
   test("rejects malformed netuid filters with 400", async () => {
-    for (const netuid of ["abc", "-1", "7.5", ""]) {
+    // 9007199254740993 = Number.MAX_SAFE_INTEGER + 2: passes /^\d+$/ but loses
+    // precision under Number(), so the safe-integer guard rejects it.
+    for (const netuid of ["abc", "-1", "7.5", "", "9007199254740993"]) {
       const res = await handleAccountHistory(
         req(`/api/v1/accounts/${SS58}/history`),
         emptyEnv(),

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -556,7 +556,10 @@ export async function handleAccountHistory(request, env, ss58, url) {
   const { from, to } = range;
   const { limit, offset, cursor } = parsePagination(url, FEED_PAGINATION);
   const netuid = url.searchParams.get("netuid");
-  if (netuid != null && !/^\d+$/.test(netuid)) {
+  if (
+    netuid != null &&
+    (!/^\d+$/.test(netuid) || !Number.isSafeInteger(Number(netuid)))
+  ) {
     return errorResponse(
       "invalid_param",
       "netuid must be a non-negative integer.",


### PR DESCRIPTION
## Summary

`handleAccountHistory` (`GET /api/v1/accounts/{ss58}/history`) validated the `?netuid` filter with a bare `/^\d+$/` regex, which accepts digit-strings above `Number.MAX_SAFE_INTEGER`. Such values pass the regex but silently lose precision under `Number()` before being bound to D1, so a request like `?netuid=9007199254740993` was treated as a valid (but wrong) netuid instead of being rejected.

This adds a `Number.isSafeInteger` guard to the existing check â€” the same class of hardening already applied to the extrinsics feed (#2274), the blocks feed (#2311), and the keyset cursor codec (#2301).

## What changed

- **`workers/request-handlers/entities.mjs`** â€” extended the existing `netuid` guard at `handleAccountHistory` to also reject values that exceed `Number.MAX_SAFE_INTEGER`. No behaviour change for any currently valid or currently rejected input; only previously-silently-accepted unsafe integers are now rejected with the same `400 invalid_param`.

- **`tests/request-handlers-entities.test.mjs`** â€” added `9007199254740993` (`MAX_SAFE_INTEGER + 2`) to the existing malformed-netuid rejection loop.

## Validation run

```
npx vitest run tests/request-handlers-entities.test.mjs tests/account-history.test.mjs
# Test Files  2 passed (2)
# Tests       190 passed (190)

npx eslint workers/request-handlers/entities.mjs tests/request-handlers-entities.test.mjs
# clean

npx prettier --check workers/request-handlers/entities.mjs tests/request-handlers-entities.test.mjs
# All matched files use Prettier code style

npm run validate
# Validated 129 native subnet(s), 129 curated overlay(s), 1213 surface(s), 125 provider(s), and 2037 candidate(s).
```

No schema/contract change â€” no `npm run build` or artifact regeneration needed. No linked issue (the gap was found by auditing feeds lacking the safe-integer guard already applied to siblings).
