### PR TITLE
fix(feeds): render renamed-subnet before/after in registry feed items

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -100,10 +100,14 @@ function toRfc822(iso) {
 // (the diffSubnets shape), so render the actual name change instead of dropping
 // it; added/removed entries carry `name`. Falls back to the bare verb when no
 // names are present (e.g. a legacy/bare `{ netuid }` entry).
+function subnetRenameSide(value) {
+  return value == null ? "?" : clamp(String(value).trim(), 60) || "?";
+}
+
 function subnetChangeText(n, change, entry) {
   if (change === "renamed" && (entry?.before != null || entry?.after != null)) {
-    const before = entry.before != null ? clamp(String(entry.before), 60) : "?";
-    const after = entry.after != null ? clamp(String(entry.after), 60) : "?";
+    const before = subnetRenameSide(entry.before);
+    const after = subnetRenameSide(entry.after);
     return {
       title: `Subnet ${n} renamed — ${before} → ${after}`,
       summary: `Subnet ${n} renamed from ${before} to ${after} in the registry.`,

--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -96,26 +96,48 @@ function toRfc822(iso) {
 
 // ── item builders (from existing served artifacts) ──────────────────────────
 
+// Title + summary for one subnet change. A renamed entry carries before/after
+// (the diffSubnets shape), so render the actual name change instead of dropping
+// it; added/removed entries carry `name`. Falls back to the bare verb when no
+// names are present (e.g. a legacy/bare `{ netuid }` entry).
+function subnetChangeText(n, change, entry) {
+  if (change === "renamed" && (entry?.before != null || entry?.after != null)) {
+    const before = entry.before != null ? clamp(String(entry.before), 60) : "?";
+    const after = entry.after != null ? clamp(String(entry.after), 60) : "?";
+    return {
+      title: `Subnet ${n} renamed — ${before} → ${after}`,
+      summary: `Subnet ${n} renamed from ${before} to ${after} in the registry.`,
+    };
+  }
+  const name = typeof entry?.name === "string" ? entry.name : null;
+  return {
+    title: `Subnet ${n} ${change}${name ? ` — ${clamp(name, 80)}` : ""}`,
+    summary: `Subnet ${n} ${change} in the registry.`,
+  };
+}
+
 // Registry feed: the latest changelog window's subnet + artifact + coverage
 // changes. `netuid` (optional) filters to one subnet.
 function registryItems(changelog, netuid) {
   const at = toIso(changelog?.generated_at) || new Date().toISOString();
   const items = [];
 
-  // changelog.subnets is { added: [...], removed: [...], renamed: [...] }, each
-  // entry a netuid or { netuid, name }.
+  // changelog.subnets is { added: [...], removed: [...], renamed: [...] }.
+  // added/removed entries are { netuid, name, slug }; renamed entries are
+  // { netuid, before, after } (see scripts/changelog.mjs diffSubnets).
   const subnets = changelog?.subnets || {};
   for (const change of ["added", "removed", "renamed"]) {
     for (const entry of subnets[change] || []) {
       const n = typeof entry === "number" ? entry : entry?.netuid;
       if (typeof n !== "number") continue;
       if (netuid != null && n !== netuid) continue;
-      const name = typeof entry === "object" ? entry?.name : null;
+      const entryObj = typeof entry === "object" && entry ? entry : null;
+      const { title, summary } = subnetChangeText(n, change, entryObj);
       items.push({
         id: `registry:subnet:${n}:${change}:${at}`,
         url: `${SITE_URL}/subnets/${n}`,
-        title: `Subnet ${n} ${change}${name ? ` — ${clamp(name, 80)}` : ""}`,
-        summary: clamp(`Subnet ${n} ${change} in the registry.`),
+        title,
+        summary: clamp(summary),
         timestamp: at,
         tags: ["registry", "subnet", change],
       });

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -214,12 +214,20 @@ describe("feeds — item builders", () => {
     });
     assert.equal(afterOnly.length, 1);
     assert.equal(afterOnly[0].title, "Subnet 5 renamed — ? → Fresh");
+    assert.equal(
+      afterOnly[0].summary,
+      "Subnet 5 renamed from ? to Fresh in the registry.",
+    );
 
     const beforeOnly = registryItems({
       subnets: { renamed: [{ netuid: 6, before: "Stale" }] },
     });
     assert.equal(beforeOnly.length, 1);
     assert.equal(beforeOnly[0].title, "Subnet 6 renamed — Stale → ?");
+    assert.equal(
+      beforeOnly[0].summary,
+      "Subnet 6 renamed from Stale to ? in the registry.",
+    );
   });
 
   test("registryItems filtered by netuid omits artifacts + coverage", () => {

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -228,6 +228,16 @@ describe("feeds — item builders", () => {
       beforeOnly[0].summary,
       "Subnet 6 renamed from Stale to ? in the registry.",
     );
+
+    const blankSides = registryItems({
+      subnets: { renamed: [{ netuid: 8, before: "", after: "   " }] },
+    });
+    assert.equal(blankSides.length, 1);
+    assert.equal(blankSides[0].title, "Subnet 8 renamed — ? → ?");
+    assert.equal(
+      blankSides[0].summary,
+      "Subnet 8 renamed from ? to ? in the registry.",
+    );
   });
 
   test("registryItems filtered by netuid omits artifacts + coverage", () => {

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -192,6 +192,30 @@ describe("feeds — item builders", () => {
     }
   });
 
+  test("registryItems renders a renamed subnet's before/after (issue #2379)", () => {
+    // diffSubnets emits renames as { netuid, before, after } (no `name`).
+    const items = registryItems({
+      generated_at: "2026-06-15T00:00:00.000Z",
+      subnets: {
+        renamed: [{ netuid: 12, before: "OldName", after: "NewName" }],
+      },
+    });
+    assert.equal(items.length, 1);
+    assert.equal(items[0].title, "Subnet 12 renamed — OldName → NewName");
+    assert.equal(
+      items[0].summary,
+      "Subnet 12 renamed from OldName to NewName in the registry.",
+    );
+  });
+
+  test("registryItems renamed entry with a missing side renders a placeholder", () => {
+    const items = registryItems({
+      subnets: { renamed: [{ netuid: 5, after: "Fresh" }] },
+    });
+    assert.equal(items.length, 1);
+    assert.equal(items[0].title, "Subnet 5 renamed — ? → Fresh");
+  });
+
   test("registryItems filtered by netuid omits artifacts + coverage", () => {
     const items = registryItems(CHANGELOG, 7);
     assert.equal(items.length, 1);

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -209,11 +209,17 @@ describe("feeds — item builders", () => {
   });
 
   test("registryItems renamed entry with a missing side renders a placeholder", () => {
-    const items = registryItems({
+    const afterOnly = registryItems({
       subnets: { renamed: [{ netuid: 5, after: "Fresh" }] },
     });
-    assert.equal(items.length, 1);
-    assert.equal(items[0].title, "Subnet 5 renamed — ? → Fresh");
+    assert.equal(afterOnly.length, 1);
+    assert.equal(afterOnly[0].title, "Subnet 5 renamed — ? → Fresh");
+
+    const beforeOnly = registryItems({
+      subnets: { renamed: [{ netuid: 6, before: "Stale" }] },
+    });
+    assert.equal(beforeOnly.length, 1);
+    assert.equal(beforeOnly[0].title, "Subnet 6 renamed — Stale → ?");
   });
 
   test("registryItems filtered by netuid omits artifacts + coverage", () => {


### PR DESCRIPTION
## Summary

Renamed-subnet items in the registry feed (`registryItems`, `src/feeds.mjs`) silently dropped the rename. The builder reads `entry.name`, but `scripts/changelog.mjs` `diffSubnets` emits a renamed entry as `{ netuid, before, after }` (no `name`), so every renamed item rendered the bare title `"Subnet N renamed"` and a generic summary, discarding the one fact the item exists to convey.

Fixes #2379

## What Changed

- Added a small `subnetChangeText(n, change, entry)` helper that renders a rename's `before → after` in both the title and summary (with a `?` placeholder if one side is missing), while leaving `added`/`removed` entries (which carry `name`) and bare `{ netuid }` entries unchanged.
- Rewired the `registryItems` subnet loop through the helper and corrected the stale comment that claimed every entry is `{ netuid, name }`.
- Added regression tests in `tests/feeds.test.mjs` for the realistic `{ netuid, before, after }` shape and the missing-side placeholder; the existing bare-`{ netuid }` fallback assertion still holds.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes (pure feed-rendering fix; contract untouched).

## Validation

- [x] `npx vitest run tests/feeds.test.mjs` (66 passed)
- [x] `npm run lint`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
