### PR TITLE
feat(mcp): add get_chain_fees tool (REST parity)

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -404,6 +404,16 @@ assert.ok(
   Array.isArray(signersCold.signers) && signersCold.window === "7d",
   "get_chain_signers must return window + signers[] on cold D1",
 );
+const feesCold = await callOk("get_chain_fees", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  Array.isArray(feesCold.daily) &&
+    Array.isArray(feesCold.top_fee_payers) &&
+    feesCold.window === "7d",
+  "get_chain_fees must return window + daily[] + top_fee_payers[] on cold D1",
+);
 
 // --- Negative paths --------------------------------------------------------
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/chain-query-loaders.mjs
+++ b/src/chain-query-loaders.mjs
@@ -1,9 +1,9 @@
-// Shared chain-signers D1 loader for REST + MCP parity (#2342). Pure
-// orchestration over extrinsics-tier rows + buildChainSigners; REST handlers keep
-// edge-cache + envelope wiring.
+// Shared chain analytics D1 loaders for REST + MCP parity (#2342 signers,
+// #2381 fees). Pure orchestration over extrinsics-tier rows + chain-analytics
+// builders; REST handlers keep edge-cache + envelope wiring.
 
 import { DAY_MS } from "../workers/config.mjs";
-import { buildChainSigners } from "./chain-analytics.mjs";
+import { buildChainFees, buildChainSigners } from "./chain-analytics.mjs";
 
 // Windowed most-active-account leaderboard (#2342): signers ranked by extrinsic
 // count over the window (ties broken by signer ASC for stable ordering).
@@ -34,4 +34,49 @@ export async function loadChainSigners(
     rows,
   });
   return { data, rows };
+}
+
+// Fee/tip market analytics (#1988): per-UTC-day fee series plus a windowed
+// top-fee-payer list. Optional call_module scopes both queries to one pallet.
+export async function loadChainFees(
+  d1Runner,
+  { windowLabel, windowDays, observedAt = null, limit = 25, callModule = null },
+) {
+  const cutoff = Date.now() - windowDays * DAY_MS;
+  const moduleClause = callModule ? " AND call_module = ?" : "";
+  const dailyParams = callModule ? [cutoff, callModule] : [cutoff];
+  const payerParams = callModule
+    ? [cutoff, callModule, limit]
+    : [cutoff, limit];
+  const [dailyRows, payerRows] = await Promise.all([
+    d1Runner(
+      `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
+              COUNT(*) AS extrinsic_count,
+              SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
+              SUM(COALESCE(tip_tao, 0)) AS total_tip_tao
+       FROM extrinsics
+       WHERE observed_at >= ?${moduleClause}
+       GROUP BY day`,
+      dailyParams,
+    ),
+    d1Runner(
+      `SELECT signer,
+              SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
+              SUM(COALESCE(tip_tao, 0)) AS total_tip_tao,
+              COUNT(*) AS extrinsic_count
+       FROM extrinsics
+       WHERE observed_at >= ? AND signer IS NOT NULL${moduleClause}
+       GROUP BY signer
+       ORDER BY total_fee_tao DESC
+       LIMIT ?`,
+      payerParams,
+    ),
+  ]);
+  const data = buildChainFees({
+    window: windowLabel,
+    observedAt,
+    dailyRows,
+    payerRows,
+  });
+  return { data, dailyRows, payerRows };
 }

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -29,7 +29,7 @@ import {
   loadSubnetConcentrationHistory,
   parseConcentrationHistoryWindow,
 } from "./concentration.mjs";
-import { loadChainSigners } from "./chain-query-loaders.mjs";
+import { loadChainSigners, loadChainFees } from "./chain-query-loaders.mjs";
 import {
   loadCompareSubnets,
   loadGlobalIncidents,
@@ -126,7 +126,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.9.0";
+export const MCP_SERVER_VERSION = "1.10.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -190,7 +190,8 @@ export const MCP_INSTRUCTIONS =
   "cross-subnet health/economics boards, compare_subnets a side-by-side view " +
   "across structure/economics/health, get_global_incidents recent cross-subnet " +
   "probe failures, get_chain_signers the windowed most-active-account " +
-  "leaderboard (extrinsic counts + fees), get_subnet_metagraph the " +
+  "leaderboard (extrinsic counts + fees), get_chain_fees the fee/tip " +
+  "market series + top payers, get_subnet_metagraph the " +
   "per-UID neuron snapshot (validator_permit filters to validators), " +
   "list_subnet_validators its validators ranked by stake, and get_neuron one " +
   "UID — use these to decide where to mine or validate. For wallet lookup, " +
@@ -2366,6 +2367,60 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_chain_fees",
+    title: "Get chain fee and tip market analytics",
+    description:
+      "Fetch fee/tip market analytics over the requested window (7d or 30d): a " +
+      "per-UTC-day fee series (totals + averages) plus a top-fee-payer list. " +
+      "Optionally scope to one pallet via call_module. Mirrors " +
+      "GET /api/v1/chain/fees.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: ["7d", "30d"],
+          description: "Lookback window (default 7d).",
+        },
+        limit: {
+          type: "integer",
+          description: "Max top fee payers to return (1-100, default 25).",
+          minimum: 1,
+          maximum: 100,
+        },
+        call_module: {
+          type: "string",
+          description:
+            "Optional pallet filter (e.g. Balances); omit for all modules.",
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const parsed = parseAnalyticsWindow(args?.window ?? "7d");
+      if (args?.window !== undefined && parsed === null) {
+        throw toolError("invalid_params", "window must be one of: 7d, 30d.");
+      }
+      const { label, days } = parsed;
+      const limit = clampLimit(args?.limit, 25, 100);
+      const callModule = optionalString(args, "call_module");
+      if (callModule != null && callModule.length > 100) {
+        throw toolError(
+          "invalid_params",
+          "call_module must be at most 100 characters.",
+        );
+      }
+      const { data } = await loadChainFees(mcpD1Runner(ctx), {
+        windowLabel: label,
+        windowDays: days,
+        observedAt: await mcpObservedAt(ctx),
+        limit,
+        callModule,
+      });
+      return data;
+    },
+  },
+  {
     name: "list_subnet_apis",
     title: "List a subnet's callable services",
     description:
@@ -3834,6 +3889,31 @@ const TOOL_OUTPUT_SCHEMAS = {
         total_fee_tao: { type: ["number", "null"] },
         total_tip_tao: { type: ["number", "null"] },
         last_tx_block: NULLABLE_INT,
+      }),
+    },
+  },
+  get_chain_fees: {
+    type: "object",
+    additionalProperties: true,
+    required: ["window", "day_count", "daily", "top_fee_payers"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: { type: "string" },
+      observed_at: NULLABLE_STRING,
+      day_count: { type: "integer" },
+      daily: objectItems({
+        day: NULLABLE_STRING,
+        extrinsic_count: NULLABLE_INT,
+        total_fee_tao: { type: ["number", "null"] },
+        avg_fee_tao: { type: ["number", "null"] },
+        total_tip_tao: { type: ["number", "null"] },
+        avg_tip_tao: { type: ["number", "null"] },
+      }),
+      top_fee_payers: objectItems({
+        signer: NULLABLE_STRING,
+        total_fee_tao: { type: ["number", "null"] },
+        total_tip_tao: { type: ["number", "null"] },
+        extrinsic_count: NULLABLE_INT,
       }),
     },
   },

--- a/tests/chain-query-loaders.test.mjs
+++ b/tests/chain-query-loaders.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { loadChainSigners } from "../src/chain-query-loaders.mjs";
+import {
+  loadChainSigners,
+  loadChainFees,
+} from "../src/chain-query-loaders.mjs";
 
 describe("loadChainSigners", () => {
   test("builds a ranked leaderboard from extrinsic rows", async () => {
@@ -60,5 +63,65 @@ describe("loadChainSigners", () => {
       { windowLabel: "7d", windowDays: 7, limit: 5 },
     );
     assert.match(sql, /ORDER BY tx_count DESC, signer ASC/);
+  });
+});
+
+describe("loadChainFees", () => {
+  test("builds daily series and top payers from extrinsic rows", async () => {
+    const calls = [];
+    const d1Runner = async (sql, params) => {
+      calls.push({ sql, params });
+      if (sql.includes("strftime")) {
+        return [
+          {
+            day: "2026-06-01",
+            extrinsic_count: 10,
+            total_fee_tao: 5,
+            total_tip_tao: 1,
+          },
+        ];
+      }
+      return [
+        {
+          signer: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+          total_fee_tao: 3,
+          total_tip_tao: 0.5,
+          extrinsic_count: 4,
+        },
+      ];
+    };
+    const { data, dailyRows, payerRows } = await loadChainFees(d1Runner, {
+      windowLabel: "7d",
+      windowDays: 7,
+      observedAt: "2026-06-01T00:00:00.000Z",
+      limit: 10,
+      callModule: "SubtensorModule",
+    });
+    assert.equal(calls.length, 2);
+    assert.equal(dailyRows.length, 1);
+    assert.equal(payerRows.length, 1);
+    assert.equal(data.window, "7d");
+    assert.equal(data.day_count, 1);
+    assert.equal(data.daily[0].extrinsic_count, 10);
+    assert.equal(data.top_fee_payers[0].total_fee_tao, 3);
+    assert.match(calls[0].sql, /call_module = \?/);
+    assert.match(calls[1].sql, /ORDER BY total_fee_tao DESC/);
+    assert.equal(calls[1].params[1], "SubtensorModule");
+    assert.equal(calls[1].params[2], 10);
+  });
+
+  test("omits the module clause when callModule is null", async () => {
+    const sqls = [];
+    await loadChainFees(
+      async (query) => {
+        sqls.push(query);
+        return [];
+      },
+      { windowLabel: "30d", windowDays: 30, limit: 5 },
+    );
+    assert.equal(sqls.length, 2);
+    for (const sql of sqls) {
+      assert.doesNotMatch(sql, /call_module/);
+    }
   });
 });

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1725,6 +1725,116 @@ describe("MCP get_chain_signers", () => {
   });
 });
 
+describe("MCP get_chain_fees", () => {
+  test("returns daily series and top payers from D1", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              return {
+                async all() {
+                  if (sql.includes("strftime")) {
+                    assert.ok(params.length >= 1);
+                    return {
+                      results: [
+                        {
+                          day: "2026-06-01",
+                          extrinsic_count: 20,
+                          total_fee_tao: 8,
+                          total_tip_tao: 2,
+                        },
+                      ],
+                    };
+                  }
+                  assert.match(sql, /ORDER BY total_fee_tao DESC/);
+                  assert.ok(params.includes(25));
+                  return {
+                    results: [
+                      {
+                        signer:
+                          "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                        total_fee_tao: 4,
+                        total_tip_tao: 1,
+                        extrinsic_count: 6,
+                      },
+                    ],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const res = await callTool(
+      "get_chain_fees",
+      { window: "7d", limit: 25 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.day_count, 1);
+    assert.equal(out.daily[0].extrinsic_count, 20);
+    assert.equal(out.top_fee_payers[0].total_fee_tao, 4);
+  });
+
+  test("rejects an invalid window", async () => {
+    const res = await callTool("get_chain_fees", { window: "99d" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/i);
+  });
+
+  test("rejects an over-long call_module", async () => {
+    const res = await callTool(
+      "get_chain_fees",
+      { call_module: "x".repeat(101) },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /call_module/i);
+  });
+
+  test("scopes both queries by call_module", async () => {
+    const boundModules = [];
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              if (sql.includes("call_module = ?")) {
+                boundModules.push(params[1]);
+              }
+              return {
+                async all() {
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const res = await callTool(
+      "get_chain_fees",
+      { window: "30d", call_module: "Balances", limit: 10 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(boundModules.length, 2);
+    assert.ok(boundModules.every((m) => m === "Balances"));
+  });
+
+  test("returns empty series on a cold D1 store", async () => {
+    const res = await callTool("get_chain_fees", {}, {});
+    const out = res.body.result.structuredContent;
+    assert.equal(out.day_count, 0);
+    assert.deepEqual(out.daily, []);
+    assert.deepEqual(out.top_fee_payers, []);
+  });
+});
+
 // keyword-search.test.mjs covers the scoring matrix; here we only prove both
 // tools are wired to it — substring noise is gone and the precise target wins.
 describe("MCP keyword discovery relevance", () => {

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -60,9 +60,11 @@ import { loadSubnetHealthTrends } from "../../src/analytics-live.mjs";
 import {
   buildChainActivity,
   buildChainCalls,
-  buildChainFees,
 } from "../../src/chain-analytics.mjs";
-import { loadChainSigners } from "../../src/chain-query-loaders.mjs";
+import {
+  loadChainFees,
+  loadChainSigners,
+} from "../../src/chain-query-loaders.mjs";
 
 // Injected once from api.mjs (see configureAnalytics). The in-isolate memoized
 // snapshot-meta read lives in api.mjs because the deferred handler clusters and a
@@ -940,47 +942,23 @@ export async function handleChainFees(request, env, url, ctx = {}) {
   const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
-  const moduleClause = callModule ? " AND call_module = ?" : "";
   return withEdgeCache(
     request,
     ctx,
     env,
     "chain-fees",
     async () => {
-      const cutoff = Date.now() - days * DAY_MS;
-      const [dailyRows, payerRows] = await Promise.all([
-        d1All(
-          env,
-          `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
-                COUNT(*) AS extrinsic_count,
-                SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
-                SUM(COALESCE(tip_tao, 0)) AS total_tip_tao
-         FROM extrinsics
-         WHERE observed_at >= ?${moduleClause}
-         GROUP BY day`,
-          callModule ? [cutoff, callModule] : [cutoff],
-        ),
-        d1All(
-          env,
-          `SELECT signer,
-                SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
-                SUM(COALESCE(tip_tao, 0)) AS total_tip_tao,
-                COUNT(*) AS extrinsic_count
-         FROM extrinsics
-         WHERE observed_at >= ? AND signer IS NOT NULL${moduleClause}
-         GROUP BY signer
-         ORDER BY total_fee_tao DESC
-         LIMIT ?`,
-          callModule ? [cutoff, callModule, limit] : [cutoff, limit],
-        ),
-      ]);
       const meta = await readHealthMetaKv(env);
-      const data = buildChainFees({
-        window: label,
-        observedAt: meta?.last_run_at || null,
-        dailyRows,
-        payerRows,
-      });
+      const { data, dailyRows, payerRows } = await loadChainFees(
+        d1Runner(env),
+        {
+          windowLabel: label,
+          windowDays: days,
+          observedAt: meta?.last_run_at || null,
+          limit,
+          callModule,
+        },
+      );
       const response = await envelopeResponse(
         request,
         {


### PR DESCRIPTION
## Summary

Adds **`get_chain_fees`** MCP tool — parity with `GET /api/v1/chain/fees` — so agents can query fee/tip market analytics (per-UTC-day series + top fee payers) over `7d`/`30d` windows with optional `call_module` scoping.

Closes #2381

## Scope

| area | change |
| --- | --- |
| `src/chain-query-loaders.mjs` | new `loadChainFees` loader (shared REST + MCP D1 path) |
| `workers/request-handlers/analytics.mjs` | thin refactor `handleChainFees` → loader |
| `src/mcp-server.mjs` | register tool + output schema; bump **1.9.0 → 1.10.0** |
| `server.json` | registry version **1.10.0** |
| tests | loader unit tests, MCP handler tests, `validate-mcp.mjs` cold smoke |

## REST ↔ MCP parity

| REST | MCP | params |
| --- | --- | --- |
| `GET /api/v1/chain/fees` | `get_chain_fees` | `window` (7d/30d), `limit` (default 25), `call_module` (optional) |

Response: `buildChainFees` shape — `window`, `observed_at`, `day_count`, `daily[]`, `top_fee_payers[]`.

## Registry Safety checklist

- [x] Read-only tool — no registry mutation
- [x] No new secrets or auth surfaces
- [x] Output schema registered in `TOOL_OUTPUT_SCHEMAS`
- [x] MCP SemVer minor bump (new tool per #393 policy)

## Validation checklist

- [x] `npx vitest run tests/chain-query-loaders.test.mjs tests/mcp-server.test.mjs tests/chain-analytics.test.mjs` — pass
- [x] `node scripts/validate-mcp.mjs` — pass (53 tools)
- [x] Existing `GET /api/v1/chain/fees` tests unchanged (handler delegates to same queries via loader)

## Test plan

- [x] `loadChainFees` builds daily + payer rows; module filter applied to both queries
- [x] MCP `get_chain_fees` happy path, invalid window, over-long `call_module`, module scoping, cold D1
- [x] `validate-mcp.mjs` cold-path smoke for `get_chain_fees`

