### PR TITLE
fix(mcp): bound chain signers D1 fanout

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -23,6 +23,7 @@ import {
   clampOffset,
 } from "../workers/request-params.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
+import { d1TimeoutMs, withTimeout } from "../workers/storage.mjs";
 import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
 import {
   loadSubnetConcentration,
@@ -356,17 +357,21 @@ function mcpContractVersion(ctx) {
 }
 
 // A (sql, params) => Promise<rows[]> runner over the health DB for the metagraph
-// / trajectory loaders. Like the REST d1All, a cold DB or query error yields []
-// (schema-stable empty payload). No withTimeout — unavailable to this pure module.
+// / trajectory loaders. Like the REST d1All, a cold DB, timeout, or query error
+// yields [] (schema-stable empty payload). The timeout keeps public MCP tools
+// from monopolizing D1/Worker time with expensive aggregates.
 function mcpD1Runner(ctx) {
   return async (sql, params) => {
     const db = ctx.env?.METAGRAPH_HEALTH_DB;
     if (!db?.prepare) return [];
     try {
-      const result = await db
-        .prepare(sql)
-        .bind(...params)
-        .all();
+      const result = await withTimeout(
+        db
+          .prepare(sql)
+          .bind(...params)
+          .all(),
+        d1TimeoutMs(ctx.env),
+      );
       return result?.results || [];
     } catch {
       return [];
@@ -522,6 +527,53 @@ async function loadChainEventsFeed(
     next_cursor: data?.next_cursor ?? null,
     events: Array.isArray(data?.events) ? data.events : [],
   };
+}
+
+async function requireDataTierRateLimit(ctx) {
+  if (!ctx.env?.DATA_RATE_LIMITER?.limit) return;
+  const { success } = await ctx.env.DATA_RATE_LIMITER.limit({
+    key: `data:${ctx.clientIp || "anonymous"}`,
+  });
+  if (!success) {
+    throw toolError(
+      "data_rate_limited",
+      "Too many data API requests from this client; slow down.",
+    );
+  }
+}
+
+function chainSignersCacheKey({ label, limit, callModule, sort }) {
+  return JSON.stringify([label, limit, callModule || "", sort || ""]);
+}
+
+async function loadMcpChainSigners(ctx, options) {
+  ctx.chainSignersCache ||= new Map();
+  const key = chainSignersCacheKey(options);
+  if (!ctx.chainSignersCache.has(key)) {
+    // The limiter charge lives inside the cache-miss promise (not ahead of the
+    // cache check) so a batch of identical calls shares one limiter charge
+    // alongside the one D1 aggregation, instead of paying the limiter once per
+    // duplicate request in the batch.
+    ctx.chainSignersCache.set(
+      key,
+      requireDataTierRateLimit(ctx)
+        .then(() =>
+          loadChainSigners(mcpD1Runner(ctx), {
+            windowLabel: options.label,
+            windowDays: options.days,
+            observedAt: options.observedAt,
+            limit: options.limit,
+            callModule: options.callModule,
+            sort: options.sort,
+          }),
+        )
+        .catch((error) => {
+          ctx.chainSignersCache.delete(key);
+          throw error;
+        }),
+    );
+  }
+  return ctx.chainSignersCache.get(key);
 }
 
 async function mcpObservedAt(ctx) {
@@ -3165,9 +3217,9 @@ export const MCP_TOOLS = [
           "call_module must be at most 100 characters.",
         );
       }
-      const { data } = await loadChainSigners(mcpD1Runner(ctx), {
-        windowLabel: label,
-        windowDays: days,
+      const { data } = await loadMcpChainSigners(ctx, {
+        label,
+        days,
         observedAt: await mcpObservedAt(ctx),
         limit,
         callModule,

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -532,7 +532,7 @@ async function loadChainEventsFeed(
 async function requireDataTierRateLimit(ctx) {
   if (!ctx.env?.DATA_RATE_LIMITER?.limit) return;
   const { success } = await ctx.env.DATA_RATE_LIMITER.limit({
-    key: `data:${ctx.clientIp || "anonymous"}`,
+    key: `data:${ctx.clientIp}`,
   });
   if (!success) {
     throw toolError(
@@ -543,7 +543,7 @@ async function requireDataTierRateLimit(ctx) {
 }
 
 function chainSignersCacheKey({ label, limit, callModule, sort }) {
-  return JSON.stringify([label, limit, callModule || "", sort || ""]);
+  return JSON.stringify([label, limit, callModule || "", sort]);
 }
 
 async function loadMcpChainSigners(ctx, options) {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1988,6 +1988,148 @@ describe("MCP get_chain_signers", () => {
     assert.equal(out.signer_count, 0);
     assert.deepEqual(out.signers, []);
   });
+
+  test("applies the data-tier limiter before the D1 signers aggregation", async () => {
+    let d1Calls = 0;
+    const limiterKeys = [];
+    const res = await callTool(
+      "get_chain_signers",
+      {},
+      {
+        env: {
+          DATA_RATE_LIMITER: {
+            async limit({ key }) {
+              limiterKeys.push(key);
+              return { success: false };
+            },
+          },
+          METAGRAPH_HEALTH_DB: {
+            prepare() {
+              d1Calls += 1;
+              return {
+                bind() {
+                  return {
+                    async all() {
+                      return { results: [] };
+                    },
+                  };
+                },
+              };
+            },
+          },
+        },
+      },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /Too many data API requests/);
+    assert.deepEqual(limiterKeys, ["data:anonymous"]);
+    assert.equal(d1Calls, 0);
+  });
+
+  test("coalesces identical batched signers calls into one D1 query", async () => {
+    let d1Calls = 0;
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          d1Calls += 1;
+          return {
+            bind() {
+              return {
+                async all() {
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const message = (id) => ({
+      jsonrpc: "2.0",
+      id,
+      method: "tools/call",
+      params: {
+        name: "get_chain_signers",
+        arguments: { window: "7d", limit: 50 },
+      },
+    });
+    const res = await rpc([message(1), message(2)], { env });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.length, 2);
+    assert.equal(d1Calls, 1);
+  });
+
+  test("returns an empty leaderboard when the signers D1 query times out", async () => {
+    const env = {
+      METAGRAPH_D1_TIMEOUT_MS: "1",
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  return new Promise(() => {});
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const res = await callTool("get_chain_signers", {}, { env });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.signer_count, 0);
+    assert.deepEqual(out.signers, []);
+  });
+
+  test("a batch of identical signers calls shares one limiter charge, not one per duplicate", async () => {
+    let d1Calls = 0;
+    let limiterCalls = 0;
+    const env = {
+      DATA_RATE_LIMITER: {
+        async limit() {
+          limiterCalls += 1;
+          return { success: false };
+        },
+      },
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          d1Calls += 1;
+          return {
+            bind() {
+              return {
+                async all() {
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const message = (id) => ({
+      jsonrpc: "2.0",
+      id,
+      method: "tools/call",
+      params: {
+        name: "get_chain_signers",
+        arguments: { window: "7d", limit: 50 },
+      },
+    });
+    const res = await rpc([message(1), message(2), message(3)], { env });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.length, 3);
+    for (const entry of res.body) {
+      assert.equal(entry.result.isError, true);
+      assert.match(entry.result.content[0].text, /Too many data API requests/);
+    }
+    assert.equal(
+      limiterCalls,
+      1,
+      "identical batched calls must share a single limiter charge",
+    );
+    assert.equal(d1Calls, 0);
+  });
 });
 
 describe("MCP get_chain_fees", () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -2026,6 +2026,42 @@ describe("MCP get_chain_signers", () => {
     assert.equal(d1Calls, 0);
   });
 
+  test("proceeds to the D1 signers aggregation when the data-tier limiter allows the request", async () => {
+    let d1Calls = 0;
+    const limiterKeys = [];
+    const res = await callTool(
+      "get_chain_signers",
+      {},
+      {
+        env: {
+          DATA_RATE_LIMITER: {
+            async limit({ key }) {
+              limiterKeys.push(key);
+              return { success: true };
+            },
+          },
+          METAGRAPH_HEALTH_DB: {
+            prepare() {
+              d1Calls += 1;
+              return {
+                bind() {
+                  return {
+                    async all() {
+                      return { results: [] };
+                    },
+                  };
+                },
+              };
+            },
+          },
+        },
+      },
+    );
+    assert.equal(res.body.result.isError, false);
+    assert.deepEqual(limiterKeys, ["data:anonymous"]);
+    assert.equal(d1Calls, 1);
+  });
+
   test("coalesces identical batched signers calls into one D1 query", async () => {
     let d1Calls = 0;
     const env = {


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated MCP `get_chain_signers` calls from triggering expensive, uncapped D1 GROUP BY scans that can be amplified by JSON-RPC batching and cause availability / cost abuse. 
- Match the REST route's protections (timeout + amortization) so MCP tooling does not monopolize D1/Worker time or bypass existing data-tier limits.

### Description
- Wrap MCP D1 reads in the existing timeout guard by importing and using `withTimeout` + `d1TimeoutMs` inside `mcpD1Runner` so slow queries degrade to schema-stable empty results. 
- Add a `requireDataTierRateLimit` check that charges the `DATA_RATE_LIMITER` before running expensive aggregations. 
- Add per-request promise coalescing via `loadMcpChainSigners` (in-memory per-request Map keyed by query args) so identical batched `get_chain_signers` calls share a single D1 aggregation instead of fanning out. 
- Route the `get_chain_signers` tool handler through the new `loadMcpChainSigners` path and add unit tests covering limiter short-circuiting, batched-call coalescing, and D1 timeout fallback.

### Testing
- Ran `npm run build` and the build completed successfully. 
- Ran MCP validation with `node scripts/validate-mcp.mjs` and `npm run validate:mcp`, which passed. 
- Ran unit tests for the MCP surface with `npm test -- --run tests/mcp-server.test.mjs` and the tests (including the new signers tests) passed. 
- Ran lint/format checks with `npm run lint` and `npm run format:check`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a433437a510832c965a61a119088770)