### PR TITLE
fix(extrinsics): limit forced module index to module-only feeds

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2645,6 +2645,29 @@ describe("handleExtrinsics", () => {
     );
   });
 
+  test("does not force module-index for compound module filters", async () => {
+    const recentMs = Date.now() - 60_000;
+    for (const query of [
+      "call_module=Balances&call_function=__never__",
+      "call_module=Balances&success=true",
+      `call_module=Balances&from=${recentMs}`,
+      `call_module=Balances&to=${recentMs}`,
+    ]) {
+      const { env, captures } = dbWith({ extrinsics: [] });
+      await handleExtrinsics(
+        req("/api/v1/extrinsics"),
+        env,
+        url(`/api/v1/extrinsics?${query}&limit=10`),
+      );
+      const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
+      assert.ok(sql);
+      assert.ok(
+        !/INDEXED BY idx_extrinsics_module_block/.test(sql),
+        `compound module filter must stay planner-selected for ${query}, got: ${sql}`,
+      );
+    }
+  });
+
   test("uses idx_extrinsics_module_block for module feed query plan", () => {
     const db = new DatabaseSync(":memory:");
     db.exec(`

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1501,14 +1501,19 @@ export async function handleExtrinsics(request, env, url) {
     !hasSuccessFilter &&
     !hasBlockRangeFilter &&
     !useCursor;
-  // For module-scoped feed scans, force the composite module index so SQLite/D1
-  // seeks on the equality predicate instead of a PK-desc walk.
+  // For module-only feed scans, force the composite module index so SQLite/D1
+  // seeks on the equality predicate instead of a PK-desc walk. Let the planner
+  // choose when additional selective filters are present.
   const forceModuleIndex =
     hasCallModuleFilter &&
     !forceObservedOrderIndex &&
     !hasBlockFilter &&
     !hasBlockRangeFilter &&
     !hasSignerFilter &&
+    !hasCallFunctionFilter &&
+    !hasSuccessFilter &&
+    fromMs == null &&
+    toMs == null &&
     !useCursor;
   let sql = `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics`;
   if (forceObservedOrderIndex)


### PR DESCRIPTION
### Motivation
- A recent change forced `idx_extrinsics_module_block` whenever `call_module` was present but did not exclude other selective filters, allowing crafted compound queries to amplify D1 CPU/time by scanning a large module subset instead of using more selective indexes. 
- The intent is to keep module-only feed queries optimized while letting the SQLite/D1 planner choose more selective indexes for compound filters. 

### Description
- Tighten the `forceModuleIndex` predicate in `workers/request-handlers/entities.mjs` so the module index is only forced for true module-only feeds by requiring the absence of `call_function`, `success`, `from`, and `to` filters. 
- Update the explanatory comment to clarify this is a module-only hint and that the planner should be allowed to choose when additional selective filters exist. 
- Add a regression test `does not force module-index for compound module filters` to `tests/request-handlers-entities.test.mjs` that exercises `call_function`, `success`, and `from`/`to` compound queries and asserts the module index is not forced. 

### Testing
- Ran the modified extrinsics handler test file with `npx vitest run tests/request-handlers-entities.test.mjs`, and all tests passed (`184 passed`). 
- Ran formatting check with `npm run format:check -- workers/request-handlers/entities.mjs tests/request-handlers-entities.test.mjs`, and Prettier reported no issues. 
- Ran `git diff --check` to ensure no whitespace or diff issues were introduced and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a433206b480832cb6200fa5eae110ac)