### PR TITLE
feat(mcp): add get_chain_fees tool for REST parity

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -414,6 +414,16 @@ assert.ok(
   Array.isArray(signersCold.signers) && signersCold.window === "7d",
   "get_chain_signers must return window + signers[] on cold D1",
 );
+const feesCold = await callOk("get_chain_fees", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  Array.isArray(feesCold.daily) &&
+    Array.isArray(feesCold.top_fee_payers) &&
+    feesCold.window === "7d",
+  "get_chain_fees must return window + daily[] + top_fee_payers[] on cold D1",
+);
 
 // --- Negative paths --------------------------------------------------------
 

--- a/src/chain-query-loaders.mjs
+++ b/src/chain-query-loaders.mjs
@@ -1,9 +1,9 @@
-// Shared chain-signers D1 loader for REST + MCP parity (#2342). Pure
-// orchestration over extrinsics-tier rows + buildChainSigners; REST handlers keep
-// edge-cache + envelope wiring.
+// Shared chain-signers / chain-fees D1 loaders for REST + MCP parity (#2342,
+// #2386). Pure orchestration over extrinsics-tier rows + build* helpers; REST
+// handlers keep edge-cache + envelope wiring.
 
 import { DAY_MS } from "../workers/config.mjs";
-import { buildChainSigners } from "./chain-analytics.mjs";
+import { buildChainFees, buildChainSigners } from "./chain-analytics.mjs";
 
 // Windowed most-active-account leaderboard (#2342): signers ranked by extrinsic
 // count over the window (ties broken by signer ASC for stable ordering).
@@ -34,4 +34,55 @@ export async function loadChainSigners(
     rows,
   });
   return { data, rows };
+}
+
+// Fee/tip market analytics (#1988, #2386): per-UTC-day fee series plus a
+// windowed top-fee-payer list. Optional call_module scopes both queries.
+export async function loadChainFees(
+  d1Runner,
+  {
+    windowLabel,
+    windowDays,
+    observedAt = null,
+    limit = 25,
+    callModule = null,
+  },
+) {
+  const cutoff = Date.now() - windowDays * DAY_MS;
+  const moduleClause = callModule ? " AND call_module = ?" : "";
+  const dailyParams = callModule ? [cutoff, callModule] : [cutoff];
+  const payerParams = callModule
+    ? [cutoff, callModule, limit]
+    : [cutoff, limit];
+  const [dailyRows, payerRows] = await Promise.all([
+    d1Runner(
+      `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
+              COUNT(*) AS extrinsic_count,
+              SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
+              SUM(COALESCE(tip_tao, 0)) AS total_tip_tao
+       FROM extrinsics
+       WHERE observed_at >= ?${moduleClause}
+       GROUP BY day`,
+      dailyParams,
+    ),
+    d1Runner(
+      `SELECT signer,
+              SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
+              SUM(COALESCE(tip_tao, 0)) AS total_tip_tao,
+              COUNT(*) AS extrinsic_count
+       FROM extrinsics
+       WHERE observed_at >= ? AND signer IS NOT NULL${moduleClause}
+       GROUP BY signer
+       ORDER BY total_fee_tao DESC
+       LIMIT ?`,
+      payerParams,
+    ),
+  ]);
+  const data = buildChainFees({
+    window: windowLabel,
+    observedAt,
+    dailyRows,
+    payerRows,
+  });
+  return { data, dailyRows, payerRows };
 }

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -29,7 +29,7 @@ import {
   loadSubnetConcentrationHistory,
   parseConcentrationHistoryWindow,
 } from "./concentration.mjs";
-import { loadChainSigners } from "./chain-query-loaders.mjs";
+import { loadChainFees, loadChainSigners } from "./chain-query-loaders.mjs";
 import {
   loadCompareSubnets,
   loadChainCalls,
@@ -192,7 +192,8 @@ export const MCP_INSTRUCTIONS =
   "cross-subnet health/economics boards, compare_subnets a side-by-side view " +
   "across structure/economics/health, get_global_incidents recent cross-subnet " +
   "probe failures, get_chain_signers the windowed most-active-account " +
-  "leaderboard (extrinsic counts + fees), get_subnet_metagraph the " +
+  "leaderboard (extrinsic counts + fees), get_chain_fees the fee/tip market " +
+  "analytics (per-day series + top payers), get_subnet_metagraph the " +
   "per-UID neuron snapshot (validator_permit filters to validators), " +
   "list_subnet_validators its validators ranked by stake, and get_neuron one " +
   "UID — use these to decide where to mine or validate. For wallet lookup, " +
@@ -2468,6 +2469,59 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_chain_fees",
+    title: "Get chain fee/tip market analytics",
+    description:
+      "Fetch fee/tip market analytics: a per-UTC-day fee series (totals + " +
+      "averages) plus a windowed top-fee-payer list. Optionally scope to one " +
+      "pallet via call_module. Mirrors GET /api/v1/chain/fees.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: ["7d", "30d"],
+          description: "Lookback window (default 7d).",
+        },
+        limit: {
+          type: "integer",
+          description: "Max top fee payers to return (1-100, default 25).",
+          minimum: 1,
+          maximum: 100,
+        },
+        call_module: {
+          type: "string",
+          description:
+            "Optional pallet filter (e.g. Balances); omit for all modules.",
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const parsed = parseAnalyticsWindow(args?.window ?? "7d");
+      if (args?.window !== undefined && parsed === null) {
+        throw toolError("invalid_params", "window must be one of: 7d, 30d.");
+      }
+      const { label, days } = parsed;
+      const limit = clampLimit(args?.limit, 25, 100);
+      const callModule = optionalString(args, "call_module");
+      if (callModule != null && callModule.length > 100) {
+        throw toolError(
+          "invalid_params",
+          "call_module must be at most 100 characters.",
+        );
+      }
+      const { data } = await loadChainFees(mcpD1Runner(ctx), {
+        windowLabel: label,
+        windowDays: days,
+        observedAt: await mcpObservedAt(ctx),
+        limit,
+        callModule,
+      });
+      return data;
+    },
+  },
+  {
     name: "list_subnet_apis",
     title: "List a subnet's callable services",
     description:
@@ -3973,6 +4027,31 @@ const TOOL_OUTPUT_SCHEMAS = {
         total_fee_tao: { type: ["number", "null"] },
         total_tip_tao: { type: ["number", "null"] },
         last_tx_block: NULLABLE_INT,
+      }),
+    },
+  },
+  get_chain_fees: {
+    type: "object",
+    additionalProperties: true,
+    required: ["window", "day_count", "daily", "top_fee_payers"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: { type: "string" },
+      observed_at: NULLABLE_STRING,
+      day_count: { type: "integer" },
+      daily: objectItems({
+        day: NULLABLE_STRING,
+        extrinsic_count: NULLABLE_INT,
+        total_fee_tao: { type: ["number", "null"] },
+        avg_fee_tao: { type: ["number", "null"] },
+        total_tip_tao: { type: ["number", "null"] },
+        avg_tip_tao: { type: ["number", "null"] },
+      }),
+      top_fee_payers: objectItems({
+        signer: NULLABLE_STRING,
+        total_fee_tao: { type: ["number", "null"] },
+        total_tip_tao: { type: ["number", "null"] },
+        extrinsic_count: NULLABLE_INT,
       }),
     },
   },

--- a/tests/chain-query-loaders.test.mjs
+++ b/tests/chain-query-loaders.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { loadChainSigners } from "../src/chain-query-loaders.mjs";
+import { loadChainFees, loadChainSigners } from "../src/chain-query-loaders.mjs";
 
 describe("loadChainSigners", () => {
   test("builds a ranked leaderboard from extrinsic rows", async () => {
@@ -60,5 +60,65 @@ describe("loadChainSigners", () => {
       { windowLabel: "7d", windowDays: 7, limit: 5 },
     );
     assert.match(sql, /ORDER BY tx_count DESC, signer ASC/);
+  });
+});
+
+describe("loadChainFees", () => {
+  test("builds daily series + top payers from extrinsic rows", async () => {
+    const calls = [];
+    const d1Runner = async (sql, params) => {
+      calls.push({ sql, params });
+      if (sql.includes("GROUP BY day")) {
+        return [
+          {
+            day: "2026-06-01",
+            extrinsic_count: 4,
+            total_fee_tao: 2,
+            total_tip_tao: 0.5,
+          },
+        ];
+      }
+      return [
+        {
+          signer: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+          total_fee_tao: 1.5,
+          total_tip_tao: 0.25,
+          extrinsic_count: 3,
+        },
+      ];
+    };
+    const { data, dailyRows, payerRows } = await loadChainFees(d1Runner, {
+      windowLabel: "7d",
+      windowDays: 7,
+      observedAt: "2026-06-01T00:00:00.000Z",
+      limit: 10,
+      callModule: "Balances",
+    });
+    assert.equal(calls.length, 2);
+    assert.equal(dailyRows.length, 1);
+    assert.equal(payerRows.length, 1);
+    assert.equal(data.window, "7d");
+    assert.equal(data.day_count, 1);
+    assert.equal(data.daily[0].extrinsic_count, 4);
+    assert.equal(data.top_fee_payers[0].extrinsic_count, 3);
+    assert.match(calls[0].sql, /call_module = \?/);
+    assert.equal(calls[0].params[1], "Balances");
+    assert.match(calls[1].sql, /ORDER BY total_fee_tao DESC/);
+    assert.equal(calls[1].params[2], 10);
+  });
+
+  test("omits the module clause when callModule is null", async () => {
+    const sqls = [];
+    await loadChainFees(
+      async (sql) => {
+        sqls.push(sql);
+        return [];
+      },
+      { windowLabel: "30d", windowDays: 30, limit: 5 },
+    );
+    assert.equal(sqls.length, 2);
+    for (const sql of sqls) {
+      assert.doesNotMatch(sql, /call_module/);
+    }
   });
 });

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1725,6 +1725,114 @@ describe("MCP get_chain_signers", () => {
   });
 });
 
+describe("MCP get_chain_fees", () => {
+  test("returns daily series + top payers from D1", async () => {
+    let dailySql;
+    let payerSql;
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              return {
+                async all() {
+                  if (sql.includes("GROUP BY day")) {
+                    dailySql = sql;
+                    return {
+                      results: [
+                        {
+                          day: "2026-06-01",
+                          extrinsic_count: 5,
+                          total_fee_tao: 3,
+                          total_tip_tao: 1,
+                        },
+                      ],
+                    };
+                  }
+                  payerSql = sql;
+                  return {
+                    results: [
+                      {
+                        signer:
+                          "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                        total_fee_tao: 2,
+                        total_tip_tao: 0.5,
+                        extrinsic_count: 4,
+                      },
+                    ],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const res = await callTool(
+      "get_chain_fees",
+      { window: "7d", limit: 25 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.day_count, 1);
+    assert.equal(out.daily[0].extrinsic_count, 5);
+    assert.equal(out.top_fee_payers[0].total_fee_tao, 2);
+    assert.match(dailySql, /FROM extrinsics/);
+    assert.match(payerSql, /ORDER BY total_fee_tao DESC/);
+  });
+
+  test("rejects an invalid window", async () => {
+    const res = await callTool("get_chain_fees", { window: "99d" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/i);
+  });
+
+  test("rejects an over-long call_module", async () => {
+    const res = await callTool(
+      "get_chain_fees",
+      { call_module: "x".repeat(101) },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /call_module/i);
+  });
+
+  test("scopes both queries by call_module", async () => {
+    let boundModule;
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              if (sql.includes("call_module = ?")) {
+                boundModule = params[1];
+              }
+              return { async all() { return { results: [] }; } };
+            },
+          };
+        },
+      },
+    };
+    const res = await callTool(
+      "get_chain_fees",
+      { window: "30d", call_module: "Balances", limit: 10 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(boundModule, "Balances");
+  });
+
+  test("returns empty series on a cold D1 store", async () => {
+    const res = await callTool("get_chain_fees", {}, {});
+    const out = res.body.result.structuredContent;
+    assert.equal(out.day_count, 0);
+    assert.deepEqual(out.daily, []);
+    assert.deepEqual(out.top_fee_payers, []);
+  });
+});
+
 // keyword-search.test.mjs covers the scoring matrix; here we only prove both
 // tools are wired to it — substring noise is gone and the precise target wins.
 describe("MCP keyword discovery relevance", () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1733,7 +1733,7 @@ describe("MCP get_chain_fees", () => {
       METAGRAPH_HEALTH_DB: {
         prepare(sql) {
           return {
-            bind(...params) {
+            bind() {
               return {
                 async all() {
                   if (sql.includes("GROUP BY day")) {

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -62,9 +62,8 @@ import {
 } from "../../src/analytics-live.mjs";
 import {
   buildChainActivity,
-  buildChainFees,
 } from "../../src/chain-analytics.mjs";
-import { loadChainSigners } from "../../src/chain-query-loaders.mjs";
+import { loadChainFees, loadChainSigners } from "../../src/chain-query-loaders.mjs";
 
 // Injected once from api.mjs (see configureAnalytics). The in-isolate memoized
 // snapshot-meta read lives in api.mjs because the deferred handler clusters and a
@@ -919,46 +918,19 @@ export async function handleChainFees(request, env, url, ctx = {}) {
   const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
-  const moduleClause = callModule ? " AND call_module = ?" : "";
   return withEdgeCache(
     request,
     ctx,
     env,
     "chain-fees",
     async () => {
-      const cutoff = Date.now() - days * DAY_MS;
-      const [dailyRows, payerRows] = await Promise.all([
-        d1All(
-          env,
-          `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
-                COUNT(*) AS extrinsic_count,
-                SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
-                SUM(COALESCE(tip_tao, 0)) AS total_tip_tao
-         FROM extrinsics
-         WHERE observed_at >= ?${moduleClause}
-         GROUP BY day`,
-          callModule ? [cutoff, callModule] : [cutoff],
-        ),
-        d1All(
-          env,
-          `SELECT signer,
-                SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
-                SUM(COALESCE(tip_tao, 0)) AS total_tip_tao,
-                COUNT(*) AS extrinsic_count
-         FROM extrinsics
-         WHERE observed_at >= ? AND signer IS NOT NULL${moduleClause}
-         GROUP BY signer
-         ORDER BY total_fee_tao DESC
-         LIMIT ?`,
-          callModule ? [cutoff, callModule, limit] : [cutoff, limit],
-        ),
-      ]);
       const meta = await readHealthMetaKv(env);
-      const data = buildChainFees({
-        window: label,
+      const { data, dailyRows, payerRows } = await loadChainFees(d1Runner(env), {
+        windowLabel: label,
+        windowDays: days,
         observedAt: meta?.last_run_at || null,
-        dailyRows,
-        payerRows,
+        limit,
+        callModule,
       });
       const response = await envelopeResponse(
         request,


### PR DESCRIPTION
## Summary

- Add `get_chain_fees` MCP tool mirroring `GET /api/v1/chain/fees` so agents can query fee/tip market analytics (per-day series + top payers) without raw REST.
- Extract shared `loadChainFees` D1 loader in `src/chain-query-loaders.mjs`; refactor `handleChainFees` to use it (same pattern as `loadChainSigners` / `get_chain_signers`).

Closes #2386

## Template Used

- Backend/code change

## What Changed

- `src/chain-query-loaders.mjs`: new `loadChainFees` loader (daily fee series + top-fee-payer queries).
- `workers/request-handlers/analytics.mjs`: `handleChainFees` delegates to the shared loader.
- `src/mcp-server.mjs`: register `get_chain_fees` with input/output schema and server instructions.
- Tests: loader unit tests, MCP handler tests, `validate-mcp` cold-path smoke.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/chain-query-loaders.test.mjs tests/mcp-server.test.mjs tests/chain-analytics.test.mjs`
- [x] `npm run validate:mcp`