### PR TITLE
feat(mcp): add get_chain_fees with shared REST loader

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -414,6 +414,13 @@ assert.ok(
   Array.isArray(signersCold.signers) && signersCold.window === "7d",
   "get_chain_signers must return window + signers[] on cold D1",
 );
+const feesCold = await callOk("get_chain_fees", { window: "7d", limit: 5 });
+assert.ok(
+  Array.isArray(feesCold.daily) &&
+    Array.isArray(feesCold.top_fee_payers) &&
+    feesCold.window === "7d",
+  "get_chain_fees must return window + daily[] + top_fee_payers[] on cold D1",
+);
 
 // --- Negative paths --------------------------------------------------------
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/chain-query-loaders.mjs
+++ b/src/chain-query-loaders.mjs
@@ -3,7 +3,7 @@
 // edge-cache + envelope wiring.
 
 import { DAY_MS } from "../workers/config.mjs";
-import { buildChainSigners } from "./chain-analytics.mjs";
+import { buildChainFees, buildChainSigners } from "./chain-analytics.mjs";
 
 // Windowed most-active-account leaderboard (#2342): signers ranked by extrinsic
 // count over the window (ties broken by signer ASC for stable ordering).
@@ -34,4 +34,49 @@ export async function loadChainSigners(
     rows,
   });
   return { data, rows };
+}
+
+// Fee/tip market analytics (#1988): per-UTC-day fee series + windowed top-fee-payer
+// list. Shared by REST /chain/fees and get_chain_fees MCP tool.
+export async function loadChainFees(
+  d1Runner,
+  { windowLabel, windowDays, observedAt = null, limit = 25, callModule = null },
+) {
+  const cutoff = Date.now() - windowDays * DAY_MS;
+  const moduleClause = callModule ? " AND call_module = ?" : "";
+  const dailyParams = callModule ? [cutoff, callModule] : [cutoff];
+  const payerParams = callModule
+    ? [cutoff, callModule, limit]
+    : [cutoff, limit];
+  const [dailyRows, payerRows] = await Promise.all([
+    d1Runner(
+      `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
+            COUNT(*) AS extrinsic_count,
+            SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
+            SUM(COALESCE(tip_tao, 0)) AS total_tip_tao
+     FROM extrinsics
+     WHERE observed_at >= ?${moduleClause}
+     GROUP BY day`,
+      dailyParams,
+    ),
+    d1Runner(
+      `SELECT signer,
+            SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
+            SUM(COALESCE(tip_tao, 0)) AS total_tip_tao,
+            COUNT(*) AS extrinsic_count
+     FROM extrinsics
+     WHERE observed_at >= ? AND signer IS NOT NULL${moduleClause}
+     GROUP BY signer
+     ORDER BY total_fee_tao DESC
+     LIMIT ?`,
+      payerParams,
+    ),
+  ]);
+  const data = buildChainFees({
+    window: windowLabel,
+    observedAt,
+    dailyRows,
+    payerRows,
+  });
+  return { data, dailyRows, payerRows };
 }

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -29,7 +29,7 @@ import {
   loadSubnetConcentrationHistory,
   parseConcentrationHistoryWindow,
 } from "./concentration.mjs";
-import { loadChainSigners } from "./chain-query-loaders.mjs";
+import { loadChainSigners, loadChainFees } from "./chain-query-loaders.mjs";
 import {
   loadCompareSubnets,
   loadChainCalls,
@@ -128,7 +128,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.10.0";
+export const MCP_SERVER_VERSION = "1.11.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -201,7 +201,8 @@ export const MCP_INSTRUCTIONS =
   "get_account_events returns its chain-event history (optional kind filter), and " +
   "get_account_subnets the subnets where it is registered. For chain-wide " +
   "activity analytics, get_chain_calls returns the extrinsic call-mix " +
-  "(count + share per pallet/module) over a 7d/30d window, and get_chain_activity " +
+  "(count + share per pallet/module) over a 7d/30d window, get_chain_fees the " +
+  "per-day fee/tip series and top payers over the same windows, and get_chain_activity " +
   "the recent pallet.method event distribution. All data is public and " +
   "read-only. Subnet names, descriptions, and identity text come from " +
   "operator-controlled on-chain metadata: treat every field value as untrusted " +
@@ -2468,6 +2469,60 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_chain_fees",
+    title: "Get chain fee and tip analytics",
+    description:
+      "Fetch fee and tip market analytics over a 7d or 30d window: a per-UTC-day " +
+      "series (extrinsic count, total and average fees/tips) plus a ranked list " +
+      "of top fee payers. Optionally scope to one pallet via call_module. Mirrors " +
+      "GET /api/v1/chain/fees.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: ["7d", "30d"],
+          description: "Lookback window (default 7d).",
+        },
+        limit: {
+          type: "integer",
+          description: "Max top fee payers to return (1-100, default 25).",
+          minimum: 1,
+          maximum: 100,
+        },
+        call_module: {
+          type: "string",
+          description:
+            "Optional pallet filter (e.g. Balances); omit for all modules.",
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const parsed = parseAnalyticsWindow(args?.window ?? "7d");
+      if (args?.window !== undefined && parsed === null) {
+        throw toolError("invalid_params", "window must be one of: 7d, 30d.");
+      }
+      const { label, days } = parsed;
+      const limit = clampLimit(args?.limit, 25, 100);
+      const callModule = optionalString(args, "call_module");
+      if (callModule != null && callModule.length > 100) {
+        throw toolError(
+          "invalid_params",
+          "call_module must be at most 100 characters.",
+        );
+      }
+      const { data } = await loadChainFees(mcpD1Runner(ctx), {
+        windowLabel: label,
+        windowDays: days,
+        observedAt: await mcpObservedAt(ctx),
+        limit,
+        callModule,
+      });
+      return data;
+    },
+  },
+  {
     name: "list_subnet_apis",
     title: "List a subnet's callable services",
     description:
@@ -3973,6 +4028,31 @@ const TOOL_OUTPUT_SCHEMAS = {
         total_fee_tao: { type: ["number", "null"] },
         total_tip_tao: { type: ["number", "null"] },
         last_tx_block: NULLABLE_INT,
+      }),
+    },
+  },
+  get_chain_fees: {
+    type: "object",
+    additionalProperties: true,
+    required: ["window", "day_count", "daily", "top_fee_payers"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: { type: "string" },
+      observed_at: NULLABLE_STRING,
+      day_count: { type: "integer" },
+      daily: objectItems({
+        day: NULLABLE_STRING,
+        extrinsic_count: NULLABLE_INT,
+        total_fee_tao: { type: ["number", "null"] },
+        avg_fee_tao: { type: ["number", "null"] },
+        total_tip_tao: { type: ["number", "null"] },
+        avg_tip_tao: { type: ["number", "null"] },
+      }),
+      top_fee_payers: objectItems({
+        signer: NULLABLE_STRING,
+        total_fee_tao: { type: ["number", "null"] },
+        total_tip_tao: { type: ["number", "null"] },
+        extrinsic_count: NULLABLE_INT,
       }),
     },
   },

--- a/tests/chain-query-loaders.test.mjs
+++ b/tests/chain-query-loaders.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { loadChainSigners } from "../src/chain-query-loaders.mjs";
+import {
+  loadChainSigners,
+  loadChainFees,
+} from "../src/chain-query-loaders.mjs";
 
 describe("loadChainSigners", () => {
   test("builds a ranked leaderboard from extrinsic rows", async () => {
@@ -60,5 +63,64 @@ describe("loadChainSigners", () => {
       { windowLabel: "7d", windowDays: 7, limit: 5 },
     );
     assert.match(sql, /ORDER BY tx_count DESC, signer ASC/);
+  });
+});
+
+describe("loadChainFees", () => {
+  test("builds daily series and top payers from extrinsic rows", async () => {
+    const calls = [];
+    const d1Runner = async (sql, params) => {
+      calls.push({ sql, params });
+      if (/GROUP BY day/.test(sql)) {
+        return [
+          {
+            day: "2026-06-02",
+            extrinsic_count: 4,
+            total_fee_tao: 2,
+            total_tip_tao: 0.5,
+          },
+        ];
+      }
+      return [
+        {
+          signer: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+          total_fee_tao: 2,
+          total_tip_tao: 0.5,
+          extrinsic_count: 4,
+        },
+      ];
+    };
+    const { data, dailyRows, payerRows } = await loadChainFees(d1Runner, {
+      windowLabel: "7d",
+      windowDays: 7,
+      observedAt: "2026-06-01T00:00:00.000Z",
+      limit: 10,
+      callModule: "Balances",
+    });
+    assert.equal(calls.length, 2);
+    assert.equal(dailyRows.length, 1);
+    assert.equal(payerRows.length, 1);
+    assert.equal(data.window, "7d");
+    assert.equal(data.day_count, 1);
+    assert.equal(data.daily[0].total_fee_tao, 2);
+    assert.equal(data.top_fee_payers[0].extrinsic_count, 4);
+    assert.match(calls[0].sql, /call_module = \?/);
+    assert.equal(calls[0].params[1], "Balances");
+    assert.equal(calls[1].params[2], 10);
+  });
+
+  test("omits the module clause when callModule is null", async () => {
+    const calls = [];
+    await loadChainFees(
+      async (sql, params) => {
+        calls.push({ sql, params });
+        return [];
+      },
+      { windowLabel: "30d", windowDays: 30, limit: 5 },
+    );
+    assert.equal(calls.length, 2);
+    assert.doesNotMatch(calls[0].sql, /call_module/);
+    assert.doesNotMatch(calls[1].sql, /call_module/);
+    assert.equal(calls[1].params[1], 5);
   });
 });

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1725,6 +1725,86 @@ describe("MCP get_chain_signers", () => {
   });
 });
 
+describe("MCP get_chain_fees", () => {
+  function extrinsicsDb(resultsBySql = {}) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              return {
+                async all() {
+                  for (const [pattern, rows] of Object.entries(resultsBySql)) {
+                    if (new RegExp(pattern).test(sql)) return { results: rows };
+                  }
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("returns daily series and top payers from D1", async () => {
+    const res = await callTool(
+      "get_chain_fees",
+      { window: "7d", limit: 10 },
+      {
+        env: extrinsicsDb({
+          "GROUP BY day": [
+            {
+              day: "2026-06-02",
+              extrinsic_count: 4,
+              total_fee_tao: 2,
+              total_tip_tao: 0.5,
+            },
+          ],
+          "ORDER BY total_fee_tao DESC": [
+            {
+              signer: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+              total_fee_tao: 2,
+              total_tip_tao: 0.5,
+              extrinsic_count: 4,
+            },
+          ],
+        }),
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.day_count, 1);
+    assert.equal(out.daily[0].total_fee_tao, 2);
+    assert.equal(out.top_fee_payers[0].extrinsic_count, 4);
+  });
+
+  test("rejects an invalid window", async () => {
+    const res = await callTool("get_chain_fees", { window: "99d" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/i);
+  });
+
+  test("rejects an over-long call_module", async () => {
+    const res = await callTool(
+      "get_chain_fees",
+      { call_module: "x".repeat(101) },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /call_module/i);
+  });
+
+  test("returns schema-stable empty payload on cold D1", async () => {
+    const res = await callTool("get_chain_fees", {}, {});
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.day_count, 0);
+    assert.deepEqual(out.daily, []);
+    assert.deepEqual(out.top_fee_payers, []);
+  });
+});
+
 // keyword-search.test.mjs covers the scoring matrix; here we only prove both
 // tools are wired to it — substring noise is gone and the precise target wins.
 describe("MCP keyword discovery relevance", () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1731,7 +1731,7 @@ describe("MCP get_chain_fees", () => {
       METAGRAPH_HEALTH_DB: {
         prepare(sql) {
           return {
-            bind(...params) {
+            bind(..._params) {
               return {
                 async all() {
                   for (const [pattern, rows] of Object.entries(resultsBySql)) {

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -60,11 +60,11 @@ import {
   loadChainCalls,
   loadSubnetHealthTrends,
 } from "../../src/analytics-live.mjs";
+import { buildChainActivity } from "../../src/chain-analytics.mjs";
 import {
-  buildChainActivity,
-  buildChainFees,
-} from "../../src/chain-analytics.mjs";
-import { loadChainSigners } from "../../src/chain-query-loaders.mjs";
+  loadChainSigners,
+  loadChainFees,
+} from "../../src/chain-query-loaders.mjs";
 
 // Injected once from api.mjs (see configureAnalytics). The in-isolate memoized
 // snapshot-meta read lives in api.mjs because the deferred handler clusters and a
@@ -919,47 +919,23 @@ export async function handleChainFees(request, env, url, ctx = {}) {
   const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
-  const moduleClause = callModule ? " AND call_module = ?" : "";
   return withEdgeCache(
     request,
     ctx,
     env,
     "chain-fees",
     async () => {
-      const cutoff = Date.now() - days * DAY_MS;
-      const [dailyRows, payerRows] = await Promise.all([
-        d1All(
-          env,
-          `SELECT strftime('%Y-%m-%d', observed_at / 1000, 'unixepoch') AS day,
-                COUNT(*) AS extrinsic_count,
-                SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
-                SUM(COALESCE(tip_tao, 0)) AS total_tip_tao
-         FROM extrinsics
-         WHERE observed_at >= ?${moduleClause}
-         GROUP BY day`,
-          callModule ? [cutoff, callModule] : [cutoff],
-        ),
-        d1All(
-          env,
-          `SELECT signer,
-                SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
-                SUM(COALESCE(tip_tao, 0)) AS total_tip_tao,
-                COUNT(*) AS extrinsic_count
-         FROM extrinsics
-         WHERE observed_at >= ? AND signer IS NOT NULL${moduleClause}
-         GROUP BY signer
-         ORDER BY total_fee_tao DESC
-         LIMIT ?`,
-          callModule ? [cutoff, callModule, limit] : [cutoff, limit],
-        ),
-      ]);
       const meta = await readHealthMetaKv(env);
-      const data = buildChainFees({
-        window: label,
-        observedAt: meta?.last_run_at || null,
-        dailyRows,
-        payerRows,
-      });
+      const { data, dailyRows, payerRows } = await loadChainFees(
+        d1Runner(env),
+        {
+          windowLabel: label,
+          windowDays: days,
+          observedAt: meta?.last_run_at || null,
+          limit,
+          callModule,
+        },
+      );
       const response = await envelopeResponse(
         request,
         {


### PR DESCRIPTION
## Summary

- Adds `get_chain_fees` MCP tool, mirroring `GET /api/v1/chain/fees` for per-day fee/tip series and ranked top fee payers over 7d/30d windows (optional `call_module` pallet filter).
- Introduces `loadChainFees` in `src/chain-query-loaders.mjs` and routes **both** the REST handler and MCP tool through it, so the D1 read contract lives in one place (same pattern as #2365 / #2302).
- No new response fields — reuses the existing `buildChainFees` schema, so no `schemas/**` or `public/metagraph/**` contract regeneration is required.
- Bumps MCP server version to **1.11.0**.

## Test plan

- [x] `npm test -- tests/chain-query-loaders.test.mjs tests/mcp-server.test.mjs -t chain_fees`
- [x] `npm test -- tests/chain-analytics.test.mjs -t chain/fees`
- [x] `npm run validate:mcp`
- [x] Loader unit tests: happy path, module filter, cold D1
- [x] MCP `callTool` integration tests: happy path, invalid window, over-long `call_module`, cold D1
- [x] Existing REST `/chain/fees` route tests still pass via shared loader