### PR TITLE
feat(badge): add style=for-the-badge render style

### DIFF
--- a/src/badge.mjs
+++ b/src/badge.mjs
@@ -159,8 +159,10 @@ export function renderBadge(message, color, options = {}) {
     const displayMessage = String(message).toUpperCase();
     const eLabel = escapeXml(displayLabel);
     const eMsg = escapeXml(displayMessage);
-    const labelW = forTheBadgeTextWidth(displayLabel) + FOR_THE_BADGE_PAD;
-    const msgW = forTheBadgeTextWidth(displayMessage) + FOR_THE_BADGE_PAD;
+    const labelTextW = forTheBadgeTextWidth(displayLabel);
+    const msgTextW = forTheBadgeTextWidth(displayMessage);
+    const labelW = labelTextW + FOR_THE_BADGE_PAD;
+    const msgW = msgTextW + FOR_THE_BADGE_PAD;
     const total = labelW + msgW;
     const labelMid = labelW / 2;
     const msgMid = labelW + msgW / 2;
@@ -173,8 +175,8 @@ export function renderBadge(message, color, options = {}) {
       `<rect x="${labelW}" width="${msgW}" height="${FOR_THE_BADGE_HEIGHT}" fill="${color}"/>`,
       `</g>`,
       `<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="10" font-weight="bold">`,
-      `<text x="${labelMid}" y="20">${eLabel}</text>`,
-      `<text x="${msgMid}" y="20">${eMsg}</text>`,
+      `<text x="${labelMid}" y="20" textLength="${labelTextW}" lengthAdjust="spacing">${eLabel}</text>`,
+      `<text x="${msgMid}" y="20" textLength="${msgTextW}" lengthAdjust="spacing">${eMsg}</text>`,
       `</g>`,
       `</svg>`,
       ``,

--- a/src/badge.mjs
+++ b/src/badge.mjs
@@ -16,6 +16,7 @@
 //   metric=completeness  coverage completeness 0–100 from profiles.json
 //                        (alias: coverage); provider = mean across its subnets
 //   style=flat-square  square corners, no gradient (default: flat)
+//   style=for-the-badge  taller (28px), uppercase bold, letter-spaced, matte
 //   label=…            override the left "metagraphed" segment text
 //
 // Worker-computed image/svg+xml, read-only, edge-cached, CORS-open. Unknown
@@ -41,7 +42,10 @@ const BADGE_METRICS = {
   coverage: "completeness",
 };
 // Allow-listed render styles; an unknown value falls back to "flat".
-const BADGE_STYLES = new Set(["flat", "flat-square"]);
+const BADGE_STYLES = new Set(["flat", "flat-square", "for-the-badge"]);
+const FOR_THE_BADGE_HEIGHT = 28;
+const FOR_THE_BADGE_PAD = 12;
+const FOR_THE_BADGE_LETTER_SPACING = 1.25;
 // shields.io "informational" blue, used for plain-count metrics (e.g. apis).
 const INFO_COLOR = "#007ec6";
 // Surface kinds that are callable machine interfaces (mirrors the build's
@@ -110,6 +114,28 @@ function textWidth(text) {
   return Math.ceil(w);
 }
 
+// Width estimate for the shields `for-the-badge` style: uppercase bold 10px
+// Verdana plus synthetic letter-spacing. Safe overestimate so glyphs never clip.
+function forTheBadgeTextWidth(text) {
+  const upper = String(text).toUpperCase();
+  let w = 0;
+  for (const ch of upper) {
+    const cp = ch.codePointAt(0);
+    if (cp <= 0x7f) {
+      if (/[ilj.,:'!|]/.test(ch)) w += 4;
+      else if (/[MW%@]/.test(ch)) w += 11;
+      else if (/[A-Z0-9]/.test(ch)) w += 9;
+      else w += 7;
+    } else if (isWideCodePoint(cp)) {
+      w += 12;
+    } else {
+      w += 9;
+    }
+    w += FOR_THE_BADGE_LETTER_SPACING;
+  }
+  return Math.ceil(w);
+}
+
 // Readiness score (0–100) → color (green / amber / red; gray for unknown).
 export function scoreColor(score) {
   if (typeof score !== "number" || Number.isNaN(score)) return UNKNOWN_COLOR;
@@ -124,9 +150,37 @@ export function gradeColor(grade) {
 }
 
 // Render a two-segment badge: gray label + colored message. `style` is "flat"
-// (rounded + glossy gradient) or "flat-square" (square, matte).
+// (rounded + glossy gradient), "flat-square" (square, matte), or "for-the-badge"
+// (28px tall, uppercase bold, letter-spaced, matte).
 export function renderBadge(message, color, options = {}) {
   const { label = BADGE_LABEL, style = "flat" } = options;
+  if (style === "for-the-badge") {
+    const displayLabel = String(label).toUpperCase();
+    const displayMessage = String(message).toUpperCase();
+    const eLabel = escapeXml(displayLabel);
+    const eMsg = escapeXml(displayMessage);
+    const labelW = forTheBadgeTextWidth(displayLabel) + FOR_THE_BADGE_PAD;
+    const msgW = forTheBadgeTextWidth(displayMessage) + FOR_THE_BADGE_PAD;
+    const total = labelW + msgW;
+    const labelMid = labelW / 2;
+    const msgMid = labelW + msgW / 2;
+    return [
+      `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="${FOR_THE_BADGE_HEIGHT}" role="img" aria-label="${eLabel}: ${eMsg}">`,
+      `<title>${eLabel}: ${eMsg}</title>`,
+      `<clipPath id="r"><rect width="${total}" height="${FOR_THE_BADGE_HEIGHT}" rx="0" fill="#fff"/></clipPath>`,
+      `<g clip-path="url(#r)">`,
+      `<rect width="${labelW}" height="${FOR_THE_BADGE_HEIGHT}" fill="#555"/>`,
+      `<rect x="${labelW}" width="${msgW}" height="${FOR_THE_BADGE_HEIGHT}" fill="${color}"/>`,
+      `</g>`,
+      `<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="10" font-weight="bold">`,
+      `<text x="${labelMid}" y="20">${eLabel}</text>`,
+      `<text x="${msgMid}" y="20">${eMsg}</text>`,
+      `</g>`,
+      `</svg>`,
+      ``,
+    ].join("\n");
+  }
+
   const eLabel = escapeXml(label);
   const eMsg = escapeXml(message);
   const pad = 12;

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -180,6 +180,45 @@ describe("badge — rendering", () => {
     assert.match(svg, /aria-label="MY LABEL: OK"/);
   });
 
+  test("renderBadge for-the-badge width branches cover narrow, wide, CJK, and accented glyphs", () => {
+    const widthOf = (svg) => Number(svg.match(/width="(\d+)"/)[1]);
+    const narrow = widthOf(
+      renderBadge(".", "#000", { style: "for-the-badge", label: "." }),
+    );
+    const wide = widthOf(
+      renderBadge("@", "#000", { style: "for-the-badge", label: "@" }),
+    );
+    const punct = widthOf(
+      renderBadge("-", "#000", { style: "for-the-badge", label: "-" }),
+    );
+    const cjk = widthOf(
+      renderBadge("字", "#000", { style: "for-the-badge", label: "字" }),
+    );
+    const accent = widthOf(
+      renderBadge("é", "#000", { style: "for-the-badge", label: "é" }),
+    );
+    assert.ok(wide > narrow, "MW%@ glyphs should out-measure narrow ilj");
+    assert.ok(
+      punct > narrow,
+      "punctuation should use the lowercase-width branch",
+    );
+    assert.ok(cjk >= wide, "CJK should use the wide code-point branch");
+    assert.ok(
+      accent >= narrow,
+      "accented Latin should use the non-ASCII branch",
+    );
+  });
+
+  test("renderBadge for-the-badge escapes injected markup", () => {
+    const svg = renderBadge('"><x', "#000", {
+      style: "for-the-badge",
+      label: "a&b",
+    });
+    assert.ok(!svg.includes("<x>"));
+    assert.match(svg, /&lt;X/);
+    assert.match(svg, /A&amp;B/);
+  });
+
   test("scoreColor thresholds (green / amber / red / gray)", () => {
     assert.equal(scoreColor(92), "#2ea44f");
     assert.equal(scoreColor(80), "#2ea44f");

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -148,15 +148,43 @@ describe("badge — rendering", () => {
   });
 
   test("renderBadge flat + flat-square output is unchanged (regression)", () => {
-    const flat = renderBadge("92/100", "#2ea44f");
-    const square = renderBadge("92/100", "#2ea44f", { style: "flat-square" });
-    assert.equal(flat, renderBadge("92/100", "#2ea44f"));
+    const flatGolden =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="144" height="20" role="img" aria-label="metagraphed: 92/100">\n' +
+      "<title>metagraphed: 92/100</title>\n" +
+      '<linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>\n' +
+      '<clipPath id="r"><rect width="144" height="20" rx="3" fill="#fff"/></clipPath>\n' +
+      '<g clip-path="url(#r)">\n' +
+      '<rect width="85" height="20" fill="#555"/>\n' +
+      '<rect x="85" width="59" height="20" fill="#2ea44f"/>\n' +
+      '<rect width="144" height="20" fill="url(#s)"/>\n' +
+      "</g>\n" +
+      '<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">\n' +
+      '<text x="42.5" y="15" fill="#010101" fill-opacity=".3">metagraphed</text>\n' +
+      '<text x="42.5" y="14">metagraphed</text>\n' +
+      '<text x="114.5" y="15" fill="#010101" fill-opacity=".3">92/100</text>\n' +
+      '<text x="114.5" y="14">92/100</text>\n' +
+      "</g>\n" +
+      "</svg>\n";
+    const squareGolden =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="144" height="20" role="img" aria-label="metagraphed: 92/100">\n' +
+      "<title>metagraphed: 92/100</title>\n" +
+      '<clipPath id="r"><rect width="144" height="20" rx="0" fill="#fff"/></clipPath>\n' +
+      '<g clip-path="url(#r)">\n' +
+      '<rect width="85" height="20" fill="#555"/>\n' +
+      '<rect x="85" width="59" height="20" fill="#2ea44f"/>\n' +
+      "</g>\n" +
+      '<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">\n' +
+      '<text x="42.5" y="15" fill="#010101" fill-opacity=".3">metagraphed</text>\n' +
+      '<text x="42.5" y="14">metagraphed</text>\n' +
+      '<text x="114.5" y="15" fill="#010101" fill-opacity=".3">92/100</text>\n' +
+      '<text x="114.5" y="14">92/100</text>\n' +
+      "</g>\n" +
+      "</svg>\n";
+    assert.equal(renderBadge("92/100", "#2ea44f"), flatGolden);
     assert.equal(
-      square,
       renderBadge("92/100", "#2ea44f", { style: "flat-square" }),
+      squareGolden,
     );
-    assert.match(flat, /height="20"/);
-    assert.match(square, /height="20"/);
   });
 
   test("renderBadge style=for-the-badge is taller, uppercase, bold, and matte", () => {
@@ -169,6 +197,8 @@ describe("badge — rendering", () => {
     assert.match(svg, /aria-label="METAGRAPHED: 92\/100"/);
     assert.match(svg, />METAGRAPHED</);
     assert.match(svg, />92\/100</);
+    assert.match(svg, /textLength="\d+"/);
+    assert.match(svg, /lengthAdjust="spacing"/);
     assert.ok((svg.match(/<text /g) || []).length === 2);
   });
 

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -147,6 +147,39 @@ describe("badge — rendering", () => {
     assert.ok((square.match(/<text /g) || []).length === 4);
   });
 
+  test("renderBadge flat + flat-square output is unchanged (regression)", () => {
+    const flat = renderBadge("92/100", "#2ea44f");
+    const square = renderBadge("92/100", "#2ea44f", { style: "flat-square" });
+    assert.equal(flat, renderBadge("92/100", "#2ea44f"));
+    assert.equal(
+      square,
+      renderBadge("92/100", "#2ea44f", { style: "flat-square" }),
+    );
+    assert.match(flat, /height="20"/);
+    assert.match(square, /height="20"/);
+  });
+
+  test("renderBadge style=for-the-badge is taller, uppercase, bold, and matte", () => {
+    const svg = renderBadge("92/100", "#2ea44f", { style: "for-the-badge" });
+    assert.match(svg, /height="28"/);
+    assert.match(svg, /font-weight="bold"/);
+    assert.match(svg, /font-size="10"/);
+    assert.match(svg, /rx="0"/);
+    assert.ok(!svg.includes("linearGradient"));
+    assert.match(svg, /aria-label="METAGRAPHED: 92\/100"/);
+    assert.match(svg, />METAGRAPHED</);
+    assert.match(svg, />92\/100</);
+    assert.ok((svg.match(/<text /g) || []).length === 2);
+  });
+
+  test("renderBadge for-the-badge uppercases mixed-case labels", () => {
+    const svg = renderBadge("ok", "#2ea44f", {
+      style: "for-the-badge",
+      label: "My Label",
+    });
+    assert.match(svg, /aria-label="MY LABEL: OK"/);
+  });
+
   test("scoreColor thresholds (green / amber / red / gray)", () => {
     assert.equal(scoreColor(92), "#2ea44f");
     assert.equal(scoreColor(80), "#2ea44f");
@@ -193,6 +226,10 @@ describe("badge — rendering", () => {
       parseBadgeOptions(sp("style=flat-square")).style,
       "flat-square",
     );
+    assert.equal(
+      parseBadgeOptions(sp("style=for-the-badge")).style,
+      "for-the-badge",
+    );
     assert.equal(parseBadgeOptions(sp("style=plastic")).style, "flat");
     // label: default brand; override kept; control chars stripped; capped; blank→brand.
     assert.equal(parseBadgeOptions(sp("")).label, "metagraphed");
@@ -227,6 +264,16 @@ describe("badge — handleBadgeRequest", () => {
     assert.match(res.headers.get("cache-control"), /max-age=3600/);
     assert.match(text, /92\/100/);
     assert.match(text, /#2ea44f/); // green (>= 80)
+  });
+
+  test("style=for-the-badge renders through handleBadgeRequest", async () => {
+    const { res, text } = await badge(
+      "/api/v1/subnets/7/badge.svg?style=for-the-badge",
+    );
+    assert.equal(res.status, 200);
+    assert.match(text, /height="28"/);
+    assert.match(text, /92\/100/);
+    assert.match(text, /METAGRAPHED/);
   });
 
   test("a low score gets the red color", async () => {


### PR DESCRIPTION
## Summary

- Add `?style=for-the-badge` to embeddable subnet/provider badges — shields.io-style tall (28px), uppercase, bold, letter-spaced, matte rendering.
- Existing `flat` and `flat-square` output is unchanged; regression tests lock both styles.

Closes #2340

## Template Used

- Backend/code change

## What Changed

- `src/badge.mjs`: allow-list `for-the-badge`, add width estimator + render branch in `renderBadge`.
- `tests/badge.test.mjs`: style parsing, render contract, handler integration, flat/flat-square regression.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run lint`
- [x] `npx prettier --check src/badge.mjs tests/badge.test.mjs`
- [x] `npm test -- tests/badge.test.mjs`