### PR TITLE
fix(balance): bound finney RPC fetch with AbortSignal.timeout

### DIFF
--- a/src/account-balance.mjs
+++ b/src/account-balance.mjs
@@ -92,13 +92,11 @@ export async function loadAccountBalance(env, ss58) {
   let balanceTao = null;
   let rpcOk = false;
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), BALANCE_RPC_TIMEOUT_MS);
   try {
     const rpcResp = await fetch(FINNEY_RPC_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      signal: controller.signal,
+      signal: AbortSignal.timeout(BALANCE_RPC_TIMEOUT_MS),
       body: JSON.stringify({
         jsonrpc: "2.0",
         id: 1,
@@ -125,8 +123,6 @@ export async function loadAccountBalance(env, ss58) {
     }
   } catch {
     // RPC fetch failed — balance_tao stays null.
-  } finally {
-    clearTimeout(timeout);
   }
 
   const payload = {

--- a/tests/account-balance-loader.test.mjs
+++ b/tests/account-balance-loader.test.mjs
@@ -130,7 +130,9 @@ describe("loadAccountBalance", () => {
     const orig = globalThis.fetch;
     globalThis.fetch = async (_url, init) => {
       assert.ok(init?.signal, "finney fetch must pass AbortSignal.timeout");
-      throw new DOMException("The operation timed out.", "TimeoutError");
+      const err = new Error("The operation timed out.");
+      err.name = "TimeoutError";
+      throw err;
     };
     try {
       const data = await loadAccountBalance({}, SS58);

--- a/tests/account-balance-loader.test.mjs
+++ b/tests/account-balance-loader.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   BALANCE_NEGATIVE_KV_TTL,
+  BALANCE_RPC_TIMEOUT_MS,
   isFinneySs58Address,
   loadAccountBalance,
 } from "../src/account-balance.mjs";
@@ -120,6 +121,46 @@ describe("loadAccountBalance", () => {
       assert.equal(putKey, `balance:${SS58}`);
       assert.equal(putValue.balance_tao, null);
       assert.equal(putOptions.expirationTtl, BALANCE_NEGATIVE_KV_TTL);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  test("returns balance_tao:null when finney RPC times out (#2075)", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = async (_url, init) => {
+      assert.ok(init?.signal, "finney fetch must pass AbortSignal.timeout");
+      throw new DOMException("The operation timed out.", "TimeoutError");
+    };
+    try {
+      const data = await loadAccountBalance({}, SS58);
+      assert.equal(data.ss58, SS58);
+      assert.equal(data.balance_tao, null);
+      assert.ok(data.queried_at);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  test("passes AbortSignal.timeout to the finney fetch", async () => {
+    let seenSignal;
+    const orig = globalThis.fetch;
+    globalThis.fetch = async (_url, init) => {
+      seenSignal = init?.signal;
+      return {
+        ok: true,
+        json: async () => ({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { data: { free: 1_000_000_000, reserved: 0 } },
+        }),
+      };
+    };
+    try {
+      await loadAccountBalance({}, SS58);
+      assert.ok(seenSignal);
+      assert.equal(typeof seenSignal.aborted, "boolean");
+      assert.equal(BALANCE_RPC_TIMEOUT_MS, 5000);
     } finally {
       globalThis.fetch = orig;
     }

--- a/tests/account-balance.test.mjs
+++ b/tests/account-balance.test.mjs
@@ -126,6 +126,29 @@ test("GET /accounts/{ss58}/balance returns 200 with balance_tao:null on RPC fail
   assert.ok(body.data.queried_at);
 });
 
+test("GET /accounts/{ss58}/balance returns 200 with balance_tao:null on RPC timeout (#2075)", async () => {
+  await withFetchStub(
+    async (_url, init) => {
+      assert.ok(init?.signal, "finney fetch must pass AbortSignal.timeout");
+      throw new DOMException("The operation timed out.", "TimeoutError");
+    },
+    async () => {
+      const res = await handleRequest(
+        req(`/api/v1/accounts/${SS58}/balance`),
+        {},
+        {},
+      );
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.ok, true);
+      assert.equal(body.data.schema_version, 1);
+      assert.equal(body.data.ss58, SS58);
+      assert.equal(body.data.balance_tao, null);
+      assert.ok(body.data.queried_at);
+    },
+  );
+});
+
 test("GET /accounts/{ss58}/balance serves from KV cache when available", async () => {
   const cached = {
     schema_version: 1,

--- a/tests/account-balance.test.mjs
+++ b/tests/account-balance.test.mjs
@@ -130,7 +130,9 @@ test("GET /accounts/{ss58}/balance returns 200 with balance_tao:null on RPC time
   await withFetchStub(
     async (_url, init) => {
       assert.ok(init?.signal, "finney fetch must pass AbortSignal.timeout");
-      throw new DOMException("The operation timed out.", "TimeoutError");
+      const err = new Error("The operation timed out.");
+      err.name = "TimeoutError";
+      throw err;
     },
     async () => {
       const res = await handleRequest(


### PR DESCRIPTION
## Summary

Closes #2075 — bounds the outbound finney `system_account` JSON-RPC fetch with `AbortSignal.timeout(BALANCE_RPC_TIMEOUT_MS)` so a slow/hung connection falls into the existing `balance_tao: null` path instead of holding the Worker open indefinitely.

The route logic now lives in `src/account-balance.mjs` (shared by REST + MCP `get_account_balance`); this PR aligns it with the bounded-fetch pattern used in `rpc-proxy.mjs`, `health-prober.mjs`, and `webhooks.mjs`.

## What changed

| file | change |
| --- | --- |
| `src/account-balance.mjs` | replace manual `AbortController` timer with `AbortSignal.timeout(5000)` |
| `tests/account-balance-loader.test.mjs` | timeout + signal wiring tests |
| `tests/account-balance.test.mjs` | REST-level `TimeoutError` → `200` + `balance_tao: null` |

## Registry Safety

- [x] No secrets, PATs, wallet data, or private URLs
- [x] No registry / generated artifact changes
- [x] Read-only balance route behavior unchanged on success

## Validation

- [x] `npx vitest run tests/account-balance-loader.test.mjs tests/account-balance.test.mjs` — 27/27 pass
- [x] All pre-existing balance tests still pass (success, 400 invalid ss58, KV cache, negative cache, rate limit)

## Test plan

- [x] `TimeoutError` from finney fetch → `balance_tao: null` (loader + REST)
- [x] Fetch receives `AbortSignal.timeout` signal
- [x] No change to success response, KV TTL semantics, or invalid-ss58 400s
