### PR TITLE
feat(mcp): add get_rpc_usage with shared REST loader

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -414,6 +414,13 @@ assert.ok(
   Array.isArray(signersCold.signers) && signersCold.window === "7d",
   "get_chain_signers must return window + signers[] on cold D1",
 );
+const rpcUsageCold = await callOk("get_rpc_usage", { window: "7d" });
+assert.ok(
+  rpcUsageCold.window === "7d" &&
+    Array.isArray(rpcUsageCold.endpoints) &&
+    Array.isArray(rpcUsageCold.buckets),
+  "get_rpc_usage must return window + endpoints[] + buckets[] on cold D1",
+);
 
 // --- Negative paths --------------------------------------------------------
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -30,6 +30,7 @@ import {
   parseConcentrationHistoryWindow,
 } from "./concentration.mjs";
 import { loadChainSigners } from "./chain-query-loaders.mjs";
+import { loadRpcUsage } from "./rpc-usage-loader.mjs";
 import {
   loadCounterparties,
   loadCounterpartyRelationship,
@@ -132,7 +133,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.10.0";
+export const MCP_SERVER_VERSION = "1.11.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -196,7 +197,9 @@ export const MCP_INSTRUCTIONS =
   "cross-subnet health/economics boards, compare_subnets a side-by-side view " +
   "across structure/economics/health, get_global_incidents recent cross-subnet " +
   "probe failures, get_chain_signers the windowed most-active-account " +
-  "leaderboard (extrinsic counts + fees), get_subnet_metagraph the " +
+  "leaderboard (extrinsic counts + fees), get_rpc_usage the RPC reverse-proxy " +
+  "usage analytics (request volume, latency, failover, cache hits, per-endpoint " +
+  "distribution) over a 7d/30d window, get_subnet_metagraph the " +
   "per-UID neuron snapshot (validator_permit filters to validators), " +
   "list_subnet_validators its validators ranked by stake, and get_neuron one " +
   "UID — use these to decide where to mine or validate. For wallet lookup, " +
@@ -2813,6 +2816,41 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_rpc_usage",
+    title: "Get RPC reverse-proxy usage analytics",
+    description:
+      "Fetch RPC reverse-proxy usage analytics over a 7d or 30d window: total " +
+      "request volume, error and failover rates, cache-hit rate, latency p50/p95 " +
+      "and average, per-endpoint request distribution, per-network breakdown, " +
+      "and bounded time buckets (1h for 7d, 6h for 30d). Computed live from the " +
+      "rpc_proxy_events D1 telemetry. Use alongside get_best_rpc_endpoint to see " +
+      "which endpoints are actually carrying traffic. Mirrors " +
+      "GET /api/v1/rpc/usage.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: ["7d", "30d"],
+          description: "Aggregation window (default 7d).",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const parsed = parseAnalyticsWindow(args?.window ?? "7d");
+      if (args?.window !== undefined && parsed === null) {
+        throw toolError("invalid_params", "window must be one of: 7d, 30d.");
+      }
+      const { label } = parsed;
+      return loadRpcUsage(mcpD1Runner(ctx), {
+        window: label,
+        observedAt: await mcpObservedAt(ctx),
+      });
+    },
+  },
+  {
     name: "get_best_rpc_endpoint",
     title: "Get the best Bittensor RPC endpoint",
     description:
@@ -4069,6 +4107,22 @@ const TOOL_OUTPUT_SCHEMAS = {
         total_tip_tao: { type: ["number", "null"] },
         last_tx_block: NULLABLE_INT,
       }),
+    },
+  },
+  get_rpc_usage: {
+    type: "object",
+    additionalProperties: true,
+    required: ["window", "summary", "endpoints", "networks", "buckets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: { type: "string" },
+      bucket_granularity: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      source: NULLABLE_STRING,
+      summary: { type: "object" },
+      endpoints: { type: "array" },
+      networks: { type: "array" },
+      buckets: { type: "array" },
     },
   },
   list_subnet_apis: {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -3493,6 +3493,79 @@ const EXTRINSIC_ITEM = {
   tip_tao: ANY,
   observed_at: NULLABLE_STRING,
 };
+// RpcUsageArtifact item shapes — shared by get_rpc_usage outputSchema (mirrors
+// schemas/api-components.schema.json#/components/schemas/RpcUsageArtifact).
+const RPC_USAGE_LATENCY_MS = {
+  type: "object",
+  additionalProperties: true,
+  required: ["p50", "p95", "avg"],
+  properties: {
+    p50: NULLABLE_INT,
+    p95: NULLABLE_INT,
+    avg: NULLABLE_INT,
+  },
+};
+const RPC_USAGE_SUMMARY = {
+  type: "object",
+  additionalProperties: true,
+  required: ["total_requests", "ok_requests", "error_requests", "latency_ms"],
+  properties: {
+    total_requests: { type: "integer", minimum: 0 },
+    ok_requests: { type: "integer", minimum: 0 },
+    error_requests: { type: "integer", minimum: 0 },
+    error_rate: { type: ["number", "null"] },
+    failover_requests: { type: "integer", minimum: 0 },
+    failover_rate: { type: ["number", "null"] },
+    cache_hits: { type: "integer", minimum: 0 },
+    cache_hit_rate: { type: ["number", "null"] },
+    latency_ms: RPC_USAGE_LATENCY_MS,
+  },
+};
+const RPC_USAGE_ENDPOINTS = {
+  type: "array",
+  items: {
+    type: "object",
+    additionalProperties: true,
+    required: ["endpoint_id", "requests", "ok_requests"],
+    properties: {
+      rank: { type: "integer", minimum: 1 },
+      endpoint_id: NULLABLE_STRING,
+      provider: NULLABLE_STRING,
+      requests: { type: "integer", minimum: 0 },
+      ok_requests: { type: "integer", minimum: 0 },
+      error_rate: { type: ["number", "null"] },
+      avg_latency_ms: NULLABLE_INT,
+    },
+  },
+};
+const RPC_USAGE_NETWORKS = {
+  type: "array",
+  items: {
+    type: "object",
+    additionalProperties: true,
+    required: ["network", "requests", "ok_requests"],
+    properties: {
+      network: { type: "string" },
+      requests: { type: "integer", minimum: 0 },
+      ok_requests: { type: "integer", minimum: 0 },
+      error_rate: { type: ["number", "null"] },
+    },
+  },
+};
+const RPC_USAGE_BUCKETS = {
+  type: "array",
+  items: {
+    type: "object",
+    additionalProperties: true,
+    required: ["ts", "requests", "errors", "avg_latency_ms"],
+    properties: {
+      ts: { type: "integer", minimum: 0 },
+      requests: { type: "integer", minimum: 0 },
+      errors: { type: "integer", minimum: 0 },
+      avg_latency_ms: NULLABLE_INT,
+    },
+  },
+};
 const TOOL_OUTPUT_SCHEMAS = {
   search_subnets: {
     type: "object",
@@ -4112,17 +4185,24 @@ const TOOL_OUTPUT_SCHEMAS = {
   get_rpc_usage: {
     type: "object",
     additionalProperties: true,
-    required: ["window", "summary", "endpoints", "networks", "buckets"],
+    required: [
+      "schema_version",
+      "source",
+      "summary",
+      "endpoints",
+      "networks",
+      "buckets",
+    ],
     properties: {
       schema_version: { type: "integer" },
-      window: { type: "string" },
+      window: NULLABLE_STRING,
       bucket_granularity: NULLABLE_STRING,
       observed_at: NULLABLE_STRING,
-      source: NULLABLE_STRING,
-      summary: { type: "object" },
-      endpoints: { type: "array" },
-      networks: { type: "array" },
-      buckets: { type: "array" },
+      source: { type: "string" },
+      summary: RPC_USAGE_SUMMARY,
+      endpoints: RPC_USAGE_ENDPOINTS,
+      networks: RPC_USAGE_NETWORKS,
+      buckets: RPC_USAGE_BUCKETS,
     },
   },
   list_subnet_apis: {

--- a/src/rpc-usage-loader.mjs
+++ b/src/rpc-usage-loader.mjs
@@ -1,0 +1,102 @@
+// Shared RPC reverse-proxy usage analytics D1 loader for REST + MCP parity.
+// Pure orchestration over rpc_proxy_events rows + formatRpcUsage; REST handlers
+// keep edge-cache + envelope wiring.
+
+import {
+  ANALYTICS_WINDOWS,
+  DAY_MS,
+  RPC_USAGE_BUCKETS,
+} from "../workers/config.mjs";
+import { formatRpcUsage } from "./health-serving.mjs";
+
+// RPC reverse-proxy usage analytics (B3): request volume, latency p50/p95,
+// failover + error rate, cache-hit rate, per-endpoint distribution, and bounded
+// time buckets. `d1` is a (sql, params) => rows runner — d1Runner(env) in the
+// Worker, mcpD1Runner(ctx) in the MCP server.
+export async function loadRpcUsage(
+  d1,
+  { window = "7d", observedAt = null, now = Date.now() } = {},
+) {
+  const windowLabel = Object.hasOwn(ANALYTICS_WINDOWS, window) ? window : "7d";
+  const days = ANALYTICS_WINDOWS[windowLabel];
+  const since = now - days * DAY_MS;
+  const bucketConfig = RPC_USAGE_BUCKETS[windowLabel];
+  const [totalsRows, latencyRows, endpointRows, networkRows, bucketRows] =
+    await Promise.all([
+      d1(
+        `SELECT COUNT(*) AS total,
+                SUM(CASE WHEN ok = 1 THEN 1 ELSE 0 END) AS ok_count,
+                SUM(CASE WHEN attempts > 1 THEN 1 ELSE 0 END) AS failover_count,
+                SUM(CASE WHEN cache = 'hit' THEN 1 ELSE 0 END) AS cache_hits,
+                AVG(latency_ms) AS avg_latency_ms
+         FROM rpc_proxy_events
+         WHERE observed_at >= ?`,
+        [since],
+      ),
+      d1(
+        `WITH ranked AS (
+           SELECT latency_ms,
+                  ROW_NUMBER() OVER (ORDER BY latency_ms) AS rn,
+                  COUNT(*) OVER () AS cnt
+           FROM rpc_proxy_events
+           WHERE observed_at >= ? AND latency_ms IS NOT NULL
+         )
+         SELECT MAX(CASE WHEN rn = CAST(0.50 * cnt AS INTEGER) + (0.50 * cnt > CAST(0.50 * cnt AS INTEGER)) THEN latency_ms END) AS p50,
+                MAX(CASE WHEN rn = CAST(0.95 * cnt AS INTEGER) + (0.95 * cnt > CAST(0.95 * cnt AS INTEGER)) THEN latency_ms END) AS p95
+         FROM ranked`,
+        [since],
+      ),
+      d1(
+        `SELECT endpoint_id, provider,
+                COUNT(*) AS requests,
+                SUM(CASE WHEN ok = 1 THEN 1 ELSE 0 END) AS ok_count,
+                AVG(latency_ms) AS avg_latency_ms
+         FROM rpc_proxy_events
+         WHERE observed_at >= ? AND endpoint_id IS NOT NULL
+         GROUP BY endpoint_id, provider
+         ORDER BY requests DESC
+         LIMIT 50`,
+        [since],
+      ),
+      d1(
+        `SELECT network,
+                COUNT(*) AS requests,
+                SUM(CASE WHEN ok = 1 THEN 1 ELSE 0 END) AS ok_count
+         FROM rpc_proxy_events
+         WHERE observed_at >= ?
+         GROUP BY network
+         ORDER BY requests DESC`,
+        [since],
+      ),
+      d1(
+        `SELECT ts, requests, errors, avg_latency_ms FROM (
+           SELECT CAST(observed_at / ? AS INTEGER) * ? AS ts,
+                  COUNT(*) AS requests,
+                  SUM(CASE WHEN ok = 1 THEN 0 ELSE 1 END) AS errors,
+                  AVG(latency_ms) AS avg_latency_ms
+           FROM rpc_proxy_events
+           WHERE observed_at >= ?
+           GROUP BY ts
+           ORDER BY ts DESC
+           LIMIT ?
+         )
+         ORDER BY ts ASC`,
+        [
+          bucketConfig.bucketMs,
+          bucketConfig.bucketMs,
+          since,
+          bucketConfig.maxBuckets,
+        ],
+      ),
+    ]);
+  return formatRpcUsage({
+    window: windowLabel,
+    observedAt,
+    totals: totalsRows[0],
+    latency: latencyRows[0],
+    endpointRows,
+    networkRows,
+    bucketRows,
+    bucketGranularity: bucketConfig.granularity,
+  });
+}

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -147,6 +147,20 @@ describe("MCP tool registry", () => {
     assert.ok(pointProperties?.emission_top_10pct_share);
   });
 
+  test("get_rpc_usage advertises a typed RpcUsageArtifact-shaped outputSchema", () => {
+    const def = listToolDefinitions().find((t) => t.name === "get_rpc_usage");
+    assert.ok(def);
+    const summary = def.outputSchema?.properties?.summary?.properties;
+    assert.ok(summary?.total_requests);
+    assert.ok(summary?.latency_ms?.properties?.p50);
+    const endpoint = def.outputSchema?.properties?.endpoints?.items?.properties;
+    assert.ok(endpoint?.endpoint_id);
+    assert.ok(endpoint?.error_rate);
+    const bucket = def.outputSchema?.properties?.buckets?.items?.properties;
+    assert.ok(bucket?.ts);
+    assert.ok(bucket?.avg_latency_ms);
+  });
+
   test("every advertised tool description carries the untrusted-data note", () => {
     for (const def of listToolDefinitions()) {
       assert.match(
@@ -1726,8 +1740,8 @@ describe("MCP get_chain_signers", () => {
 });
 
 describe("MCP get_rpc_usage", () => {
-  test("returns usage analytics from rpc_proxy_events", async () => {
-    const env = {
+  function rpcUsageDb() {
+    return {
       METAGRAPH_HEALTH_DB: {
         prepare(sql) {
           return {
@@ -1790,7 +1804,14 @@ describe("MCP get_rpc_usage", () => {
         },
       },
     };
-    const res = await callTool("get_rpc_usage", { window: "7d" }, { env });
+  }
+
+  test("returns usage analytics from rpc_proxy_events", async () => {
+    const res = await callTool(
+      "get_rpc_usage",
+      { window: "7d" },
+      { env: rpcUsageDb() },
+    );
     const out = res.body.result.structuredContent;
     assert.equal(out.window, "7d");
     assert.equal(out.summary.total_requests, 50);
@@ -1812,6 +1833,24 @@ describe("MCP get_rpc_usage", () => {
     assert.equal(out.summary.total_requests, 0);
     assert.deepEqual(out.endpoints, []);
     assert.deepEqual(out.buckets, []);
+  });
+
+  test("cold and populated payloads validate against the declared outputSchema", async () => {
+    const ajv = new Ajv2020({ strict: false });
+    const validate = ajv.compile(
+      listToolDefinitions().find((t) => t.name === "get_rpc_usage")
+        .outputSchema,
+    );
+    for (const [label, env] of [
+      ["cold", {}],
+      ["populated", rpcUsageDb()],
+    ]) {
+      const res = await callTool("get_rpc_usage", { window: "7d" }, { env });
+      assert.ok(
+        validate(res.body.result.structuredContent),
+        `${label}: ${JSON.stringify(validate.errors)}`,
+      );
+    }
   });
 });
 

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1725,6 +1725,96 @@ describe("MCP get_chain_signers", () => {
   });
 });
 
+describe("MCP get_rpc_usage", () => {
+  test("returns usage analytics from rpc_proxy_events", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(..._params) {
+              return {
+                async all() {
+                  if (/COUNT\(\*\) AS total/.test(sql)) {
+                    return {
+                      results: [
+                        {
+                          total: 50,
+                          ok_count: 48,
+                          failover_count: 2,
+                          cache_hits: 10,
+                          avg_latency_ms: 80,
+                        },
+                      ],
+                    };
+                  }
+                  if (/ROW_NUMBER\(\) OVER/.test(sql)) {
+                    return { results: [{ p50: 70, p95: 200 }] };
+                  }
+                  if (/GROUP BY endpoint_id/.test(sql)) {
+                    return {
+                      results: [
+                        {
+                          endpoint_id: "a",
+                          provider: "p",
+                          requests: 50,
+                          ok_count: 48,
+                          avg_latency_ms: 80,
+                        },
+                      ],
+                    };
+                  }
+                  if (/GROUP BY network/.test(sql)) {
+                    return {
+                      results: [
+                        { network: "finney", requests: 50, ok_count: 48 },
+                      ],
+                    };
+                  }
+                  if (/GROUP BY ts/.test(sql)) {
+                    return {
+                      results: [
+                        {
+                          ts: 1_700_000_000_000,
+                          requests: 5,
+                          errors: 0,
+                          avg_latency_ms: 75,
+                        },
+                      ],
+                    };
+                  }
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const res = await callTool("get_rpc_usage", { window: "7d" }, { env });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.summary.total_requests, 50);
+    assert.equal(out.endpoints[0].endpoint_id, "a");
+    assert.equal(out.networks[0].network, "finney");
+    assert.equal(out.buckets.length, 1);
+  });
+
+  test("rejects an invalid window", async () => {
+    const res = await callTool("get_rpc_usage", { window: "99d" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/i);
+  });
+
+  test("returns a cold-stable zeroed payload on empty D1", async () => {
+    const res = await callTool("get_rpc_usage", {}, {});
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.summary.total_requests, 0);
+    assert.deepEqual(out.endpoints, []);
+    assert.deepEqual(out.buckets, []);
+  });
+});
+
 describe("MCP get_account_counterparties", () => {
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
   const CP = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy";

--- a/tests/rpc-usage-loader.test.mjs
+++ b/tests/rpc-usage-loader.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadRpcUsage } from "../src/rpc-usage-loader.mjs";
+
+describe("loadRpcUsage", () => {
+  test("aggregates rpc_proxy_events rows into the usage payload", async () => {
+    const now = 1_700_000_000_000;
+    const d1 = async (sql) => {
+      if (/COUNT\(\*\) AS total/.test(sql)) {
+        return [
+          {
+            total: 100,
+            ok_count: 90,
+            failover_count: 5,
+            cache_hits: 20,
+            avg_latency_ms: 150,
+          },
+        ];
+      }
+      if (/ROW_NUMBER\(\) OVER/.test(sql)) {
+        return [{ p50: 120, p95: 400 }];
+      }
+      if (/GROUP BY endpoint_id/.test(sql)) {
+        return [
+          {
+            endpoint_id: "fx",
+            provider: "onfinality",
+            requests: 60,
+            ok_count: 55,
+            avg_latency_ms: 140,
+          },
+        ];
+      }
+      if (/GROUP BY network/.test(sql)) {
+        return [{ network: "finney", requests: 100, ok_count: 90 }];
+      }
+      if (/GROUP BY ts/.test(sql)) {
+        return [
+          { ts: now - 3_600_000, requests: 10, errors: 1, avg_latency_ms: 100 },
+        ];
+      }
+      return [];
+    };
+    const data = await loadRpcUsage(d1, {
+      window: "7d",
+      observedAt: "2026-06-30T00:00:00Z",
+      now,
+    });
+    assert.equal(data.window, "7d");
+    assert.equal(data.observed_at, "2026-06-30T00:00:00Z");
+    assert.equal(data.summary.total_requests, 100);
+    assert.equal(data.summary.ok_requests, 90);
+    assert.equal(data.endpoints[0].endpoint_id, "fx");
+    assert.equal(data.networks[0].network, "finney");
+    assert.equal(data.buckets.length, 1);
+    assert.equal(data.bucket_granularity, "1h");
+  });
+
+  test("returns a cold-stable zeroed payload when D1 has no rows", async () => {
+    const d1 = async () => [];
+    const data = await loadRpcUsage(d1, { window: "30d" });
+    assert.equal(data.window, "30d");
+    assert.equal(data.summary.total_requests, 0);
+    assert.deepEqual(data.endpoints, []);
+    assert.deepEqual(data.networks, []);
+    assert.deepEqual(data.buckets, []);
+    assert.equal(data.bucket_granularity, "6h");
+  });
+
+  test("falls back to 7d for an unknown window label", async () => {
+    const d1 = async () => [];
+    const data = await loadRpcUsage(d1, { window: "bogus" });
+    assert.equal(data.window, "7d");
+    assert.equal(data.bucket_granularity, "1h");
+  });
+});

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -37,7 +37,7 @@ import {
   analyticsMeta,
   analyticsQueryError,
   analyticsWindow,
-  d1All,
+  d1Runner,
 } from "./analytics.mjs";
 import {
   findSurface,
@@ -49,17 +49,13 @@ import {
   workerResolvedUrlSafetyGuard,
   workerWebSocketConnector,
 } from "../../src/health-prober.mjs";
+import { overlayRpcPoolEligibility } from "../../src/health-serving.mjs";
+import { loadRpcUsage } from "../../src/rpc-usage-loader.mjs";
 import {
-  formatRpcUsage,
-  overlayRpcPoolEligibility,
-} from "../../src/health-serving.mjs";
-import {
-  DAY_MS,
   DENIED_RPC_PREFIXES,
   JSON_CONTENT_TYPE,
   MAX_RPC_BODY_BYTES,
   resolveClientIp,
-  RPC_USAGE_BUCKETS,
   SAFE_RPC_METHODS,
   TRUSTED_RPC_UPSTREAM_ORIGINS,
 } from "../config.mjs";
@@ -146,99 +142,12 @@ function recordRpcUsage(env, ctx, event) {
 // from the rpc_proxy_events D1 telemetry; cold/unmigrated D1 returns a
 // schema-stable zeroed payload (d1All swallows the missing-table error).
 export async function handleRpcUsage(request, env, url) {
-  const { label, days, error } = analyticsWindow(url);
+  const { label, error } = analyticsWindow(url);
   if (error) return analyticsQueryError(error);
-  const since = Date.now() - days * DAY_MS;
-  const bucketConfig = RPC_USAGE_BUCKETS[label];
-  const [totalsRows, latencyRows, endpointRows, networkRows, bucketRows] =
-    await Promise.all([
-      d1All(
-        env,
-        `SELECT COUNT(*) AS total,
-                SUM(CASE WHEN ok = 1 THEN 1 ELSE 0 END) AS ok_count,
-                SUM(CASE WHEN attempts > 1 THEN 1 ELSE 0 END) AS failover_count,
-                SUM(CASE WHEN cache = 'hit' THEN 1 ELSE 0 END) AS cache_hits,
-                AVG(latency_ms) AS avg_latency_ms
-         FROM rpc_proxy_events
-         WHERE observed_at >= ?`,
-        [since],
-      ),
-      d1All(
-        env,
-        `WITH ranked AS (
-           SELECT latency_ms,
-                  ROW_NUMBER() OVER (ORDER BY latency_ms) AS rn,
-                  COUNT(*) OVER () AS cnt
-           FROM rpc_proxy_events
-           WHERE observed_at >= ? AND latency_ms IS NOT NULL
-         )
-         SELECT MAX(CASE WHEN rn = CAST(0.50 * cnt AS INTEGER) + (0.50 * cnt > CAST(0.50 * cnt AS INTEGER)) THEN latency_ms END) AS p50,
-                MAX(CASE WHEN rn = CAST(0.95 * cnt AS INTEGER) + (0.95 * cnt > CAST(0.95 * cnt AS INTEGER)) THEN latency_ms END) AS p95
-         FROM ranked`,
-        [since],
-      ),
-      d1All(
-        env,
-        `SELECT endpoint_id, provider,
-                COUNT(*) AS requests,
-                SUM(CASE WHEN ok = 1 THEN 1 ELSE 0 END) AS ok_count,
-                AVG(latency_ms) AS avg_latency_ms
-         FROM rpc_proxy_events
-         WHERE observed_at >= ? AND endpoint_id IS NOT NULL
-         GROUP BY endpoint_id, provider
-         ORDER BY requests DESC
-         LIMIT 50`,
-        [since],
-      ),
-      d1All(
-        env,
-        `SELECT network,
-                COUNT(*) AS requests,
-                SUM(CASE WHEN ok = 1 THEN 1 ELSE 0 END) AS ok_count
-         FROM rpc_proxy_events
-         WHERE observed_at >= ?
-         GROUP BY network
-         ORDER BY requests DESC`,
-        [since],
-      ),
-      d1All(
-        env,
-        // Buckets are aligned to absolute boundaries but `since` is not, so a
-        // full window spans maxBuckets+1 buckets. Keep the most-recent
-        // maxBuckets (inner ORDER BY ts DESC LIMIT) — dropping the partial
-        // oldest bucket rather than the current one — then re-order ascending
-        // for the chart. A bare `ORDER BY ts ASC LIMIT` would drop the current
-        // bucket, leaving the series permanently missing its leading edge.
-        `SELECT ts, requests, errors, avg_latency_ms FROM (
-           SELECT CAST(observed_at / ? AS INTEGER) * ? AS ts,
-                  COUNT(*) AS requests,
-                  SUM(CASE WHEN ok = 1 THEN 0 ELSE 1 END) AS errors,
-                  AVG(latency_ms) AS avg_latency_ms
-           FROM rpc_proxy_events
-           WHERE observed_at >= ?
-           GROUP BY ts
-           ORDER BY ts DESC
-           LIMIT ?
-         )
-         ORDER BY ts ASC`,
-        [
-          bucketConfig.bucketMs,
-          bucketConfig.bucketMs,
-          since,
-          bucketConfig.maxBuckets,
-        ],
-      ),
-    ]);
   const meta = await readHealthMetaKv(env);
-  const data = formatRpcUsage({
+  const data = await loadRpcUsage(d1Runner(env), {
     window: label,
     observedAt: meta?.last_run_at || null,
-    totals: totalsRows[0],
-    latency: latencyRows[0],
-    endpointRows,
-    networkRows,
-    bucketRows,
-    bucketGranularity: bucketConfig.granularity,
   });
   return envelopeResponse(
     request,


### PR DESCRIPTION
## Summary

- Add `loadRpcUsage` in `src/rpc-usage-loader.mjs` so REST `GET /api/v1/rpc/usage` and MCP `get_rpc_usage` share the same D1 read contract over `rpc_proxy_events`.
- Refactor `handleRpcUsage` to delegate to the shared loader (no duplicated SQL).
- Add MCP tool `get_rpc_usage` with `window` (`7d`/`30d`, default `7d`); bump `MCP_SERVER_VERSION` to **1.11.0**.
- **Tight `get_rpc_usage` outputSchema** — mirrors `RpcUsageArtifact` from `schemas/api-components.schema.json`: typed `summary` (request counts, rates, `latency_ms.p50/p95/avg`), and endpoint/network/bucket array items with required field keys (not bare `{ type: "object" }` / `{ type: "array" }`).
- Tests: loader unit tests, MCP integration tests, Ajv validation of cold + populated payloads against the declared outputSchema, and `validate:mcp` cold-D1 smoke call.

No new REST response fields — reuses the existing `formatRpcUsage` shape, so no `schemas/**` or `public/metagraph/**` artifact updates are required.

## Test plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test -- tests/rpc-usage-loader.test.mjs tests/request-handlers-rpc-proxy.test.mjs tests/rpc-usage.test.mjs`
- [x] `npm test -- tests/mcp-server.test.mjs -t "get_rpc_usage"`
- [x] `npm run validate:mcp`