### PR TITLE
feat(mcp): add get_subnet_health_percentiles with shared REST loader

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -12,6 +12,7 @@ import {
 import {
   formatGlobalIncidents,
   formatLeaderboards,
+  formatPercentiles,
   formatTrends,
   formatUptime,
   INCIDENT_GAP_MS,
@@ -198,6 +199,32 @@ export async function loadSubnetHealthTrends(
     windows[label] = rows;
   }
   return formatTrends({ netuid, observedAt, windows });
+}
+
+// p50/p95/p99 (+avg/min/max) request-latency percentiles per operational surface
+// for one subnet over a 7d/30d window, from the live surface_checks history. The
+// query + formatting live here so the REST handler (handleHealthPercentiles) and
+// the get_subnet_health_percentiles MCP tool share one read path (mirrors
+// loadSubnetHealthTrends, #2335). Defensively defaults an unknown window to 7d;
+// cold/empty D1 → a schema-stable surfaces:[] payload.
+export async function loadSubnetPercentiles(
+  d1,
+  netuid,
+  { window = "7d", observedAt = null } = {},
+) {
+  const windowParam = Object.hasOwn(ANALYTICS_WINDOWS, window) ? window : "7d";
+  const days = ANALYTICS_WINDOWS[windowParam];
+  const rows = await d1(
+    `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
+       SELECT MAX(surface_id) AS surface_id,
+              surface_key,
+              ${latencyStatColumns()}
+       FROM ranked
+       GROUP BY surface_key
+       HAVING MAX(lat_cnt) > 0`,
+    [netuid, Date.now() - days * DAY_MS],
+  );
+  return formatPercentiles({ netuid, window: windowParam, observedAt, rows });
 }
 
 export async function loadGlobalIncidents(

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -40,6 +40,7 @@ import {
   loadGlobalIncidents,
   loadRegistryLeaderboards,
   loadSubnetHealthTrends,
+  loadSubnetPercentiles,
   loadSubnetUptime,
   parseAnalyticsWindow,
   parseCompareDimensionList,
@@ -132,7 +133,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.10.0";
+export const MCP_SERVER_VERSION = "1.11.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -188,7 +189,9 @@ export const MCP_INSTRUCTIONS =
   "participation, get_subnet_economics returns a subnet's registration cost, " +
   "open slots, stake, emission split and validator/miner counts, " +
   "get_subnet_trajectory its week-over-week trend, get_subnet_uptime its " +
-  "long-term surface uptime history, get_subnet_concentration stake and " +
+  "long-term surface uptime history, get_subnet_health_percentiles its " +
+  "per-surface p50/p95/p99 request-latency distribution, " +
+  "get_subnet_concentration stake and " +
   "emission decentralization metrics (Gini, HHI, Nakamoto), " +
   "get_subnet_concentration_history the decentralization trend over time, " +
   "get_subnet_turnover validator-set and registration churn between two " +
@@ -1370,6 +1373,42 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
       return loadSubnetHealthTrends(mcpD1Runner(ctx), netuid, {
+        observedAt: await mcpObservedAt(ctx),
+      });
+    },
+  },
+  {
+    name: "get_subnet_health_percentiles",
+    title: "Get subnet latency percentiles",
+    description:
+      "Fetch one subnet's request-latency percentiles per operational surface over " +
+      "a 7d or 30d window, from the live health-probe history: p50/p95/p99 plus " +
+      "avg/min/max latency in ms and the healthy-sample count behind them. Use it " +
+      "to see a surface's latency distribution and tail behavior, where " +
+      "get_subnet_health_trends gives the uptime+latency trend and get_subnet_health " +
+      "the current status. Mirrors GET /api/v1/subnets/{netuid}/health/percentiles.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: ["7d", "30d"],
+          description: "Lookback window (default 7d).",
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const parsed = parseAnalyticsWindow(args?.window ?? "7d");
+      if (args?.window !== undefined && parsed === null) {
+        throw toolError("invalid_params", "window must be one of: 7d, 30d.");
+      }
+      const { label } = parsed;
+      return loadSubnetPercentiles(mcpD1Runner(ctx), netuid, {
+        window: label,
         observedAt: await mcpObservedAt(ctx),
       });
     },
@@ -3593,6 +3632,34 @@ const TOOL_OUTPUT_SCHEMAS = {
       observed_at: NULLABLE_STRING,
       source: NULLABLE_STRING,
       windows: { type: "object" },
+    },
+  },
+  get_subnet_health_percentiles: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "surfaces"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      source: NULLABLE_STRING,
+      surfaces: objectItems({
+        surface_id: NULLABLE_STRING,
+        samples: { type: "integer" },
+        latency_ms: {
+          type: "object",
+          additionalProperties: true,
+          properties: {
+            p50: NULLABLE_INT,
+            p95: NULLABLE_INT,
+            p99: NULLABLE_INT,
+            avg: NULLABLE_INT,
+            min: NULLABLE_INT,
+            max: NULLABLE_INT,
+          },
+        },
+      }),
     },
   },
   get_subnet_economics: {

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -10,6 +10,7 @@ import {
   loadGlobalIncidents,
   loadRegistryLeaderboards,
   loadSubnetHealthTrends,
+  loadSubnetPercentiles,
   loadSubnetUptime,
   parseAnalyticsWindow,
   parseCompareDimensionList,
@@ -210,6 +211,44 @@ describe("analytics-live loaders", () => {
       assert.equal(data.windows[label].surfaces[0].uptime_ratio, 0.95);
       assert.equal(data.windows[label].surfaces[0].latency_ms.p95, 110);
     }
+  });
+
+  test("loadSubnetPercentiles returns schema-stable empty surfaces on cold D1", async () => {
+    const data = await loadSubnetPercentiles(d1(), NETUID, {
+      window: "7d",
+      observedAt: OBSERVED_AT,
+    });
+    assert.equal(data.netuid, NETUID);
+    assert.equal(data.window, "7d");
+    assert.equal(data.observed_at, OBSERVED_AT);
+    assert.deepEqual(data.surfaces, []);
+  });
+
+  test("loadSubnetPercentiles shapes per-surface latency percentiles; unknown window → 7d", async () => {
+    const data = await loadSubnetPercentiles(
+      d1({
+        "FROM ranked": [
+          {
+            surface_id: "api-root",
+            surface_key: "api-root",
+            latency_samples: 95,
+            p50: 80,
+            p95: 110,
+            p99: 130,
+            avg_latency_ms: 90,
+            min_latency_ms: 40,
+            max_latency_ms: 200,
+          },
+        ],
+      }),
+      NETUID,
+      { window: "bogus", observedAt: OBSERVED_AT },
+    );
+    assert.equal(data.window, "7d"); // an unknown window defaults to 7d
+    assert.equal(data.surfaces[0].surface_id, "api-root");
+    assert.equal(data.surfaces[0].samples, 95);
+    assert.equal(data.surfaces[0].latency_ms.p95, 110);
+    assert.equal(data.surfaces[0].latency_ms.max, 200);
   });
 
   test("loadRegistryLeaderboards returns all boards object", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4174,6 +4174,58 @@ describe("MCP economics + metagraph data tools", () => {
     }
   });
 
+  test("get_subnet_health_percentiles shapes per-surface latency percentiles from ranked rows", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: metagraphD1({
+        incidentRows: [
+          {
+            surface_id: "api-root",
+            surface_key: "api-root",
+            latency_samples: 95,
+            p50: 80,
+            p95: 110,
+            p99: 130,
+            avg_latency_ms: 90,
+            min_latency_ms: 40,
+            max_latency_ms: 200,
+          },
+        ],
+      }),
+    };
+    const deps = makeDeps({}, { "health:meta": { last_run_at: FRESH_RUN } });
+    const res = await callTool(
+      "get_subnet_health_percentiles",
+      { netuid: 7, window: "30d" },
+      { deps, env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.window, "30d");
+    assert.equal(out.observed_at, FRESH_RUN);
+    assert.equal(out.surfaces[0].surface_id, "api-root");
+    assert.equal(out.surfaces[0].samples, 95);
+    assert.equal(out.surfaces[0].latency_ms.p95, 110);
+    assert.equal(out.surfaces[0].latency_ms.max, 200);
+  });
+
+  test("get_subnet_health_percentiles returns schema-stable empty surfaces (default 7d) on cold D1", async () => {
+    const res = await callTool("get_subnet_health_percentiles", { netuid: 7 });
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d");
+    assert.deepEqual(out.surfaces, []);
+  });
+
+  test("get_subnet_health_percentiles rejects an invalid window", async () => {
+    const res = await callTool(
+      "get_subnet_health_percentiles",
+      { netuid: 7, window: "99d" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
   test("get_registry_leaderboards can filter to one board", async () => {
     const res = await callTool(
       "get_registry_leaderboards",

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -43,22 +43,18 @@ import {
   publishedAt,
 } from "../responses.mjs";
 import { d1TimeoutMs, withTimeout } from "../storage.mjs";
-import {
-  dailyLatencyColumns,
-  latencyStatColumns,
-  rankedChecksCte,
-} from "../../src/health-sql.mjs";
+import { dailyLatencyColumns } from "../../src/health-sql.mjs";
 import {
   formatBulkTrends,
   formatGlobalIncidents,
   formatIncidents,
-  formatPercentiles,
   INCIDENT_GAP_MS,
   MIN_INCIDENT_SAMPLES,
 } from "../../src/health-serving.mjs";
 import {
   loadChainCalls,
   loadSubnetHealthTrends,
+  loadSubnetPercentiles,
 } from "../../src/analytics-live.mjs";
 import {
   buildChainActivity,
@@ -459,7 +455,9 @@ export async function handleHealthTrends(request, env, netuid, url, ctx = {}) {
   });
 }
 
-// p50/p95/p99 latency percentiles per surface, computed in D1.
+// p50/p95/p99 latency percentiles per surface, computed in D1. The query +
+// formatting live in loadSubnetPercentiles (src/analytics-live.mjs) so the
+// get_subnet_health_percentiles MCP tool shares this exact read path.
 export async function handleHealthPercentiles(
   request,
   env,
@@ -467,7 +465,7 @@ export async function handleHealthPercentiles(
   url,
   ctx = {},
 ) {
-  const { label, days, error } = analyticsWindow(url);
+  const { label, error } = analyticsWindow(url);
   if (error) return analyticsQueryError(error);
   return withEdgeCache(
     request,
@@ -475,23 +473,19 @@ export async function handleHealthPercentiles(
     env,
     "percentiles",
     async () => {
-      const rows = await d1All(
-        env,
-        `${rankedChecksCte("netuid = ? AND checked_at >= ?")}
-     SELECT MAX(surface_id) AS surface_id,
-            surface_key,
-            ${latencyStatColumns()}
-     FROM ranked
-     GROUP BY surface_key
-     HAVING MAX(lat_cnt) > 0`,
-        [netuid, Date.now() - days * DAY_MS],
-      );
+      // Wrap d1All so a failure is still logged + marked as a D1 fallback (the
+      // dark-serve contract), since the formatted result no longer exposes the
+      // raw rows hasD1FallbackRows used to check (mirrors handleHealthTrends).
+      let usedFallback = false;
+      const d1 = async (sql, params) => {
+        const rows = await d1All(env, sql, params);
+        if (hasD1FallbackRows(rows)) usedFallback = true;
+        return rows;
+      };
       const meta = await readHealthMetaKv(env);
-      const data = formatPercentiles({
-        netuid,
+      const data = await loadSubnetPercentiles(d1, netuid, {
         window: label,
         observedAt: meta?.last_run_at || null,
-        rows,
       });
       const response = await envelopeResponse(
         request,
@@ -505,9 +499,7 @@ export async function handleHealthPercentiles(
         },
         "short",
       );
-      return hasD1FallbackRows(rows)
-        ? markD1FallbackResponse(response)
-        : response;
+      return usedFallback ? markD1FallbackResponse(response) : response;
     },
     canonicalHealthWindowCachePath(url),
   );


### PR DESCRIPTION
## Summary

- Surface one subnet's per-operational-surface request-latency percentiles (live
  REST route `GET /api/v1/subnets/{netuid}/health/percentiles`) as an MCP tool —
  the latency-distribution companion to get_subnet_health_trends (trend) and
  get_subnet_health (current status).

## What Changed

- Add MCP tool `get_subnet_health_percentiles` in `src/mcp-server.mjs`: p50/p95/p99
  plus avg/min/max latency (ms) and the healthy-sample count per surface, over a
  7d/30d window. Adds its `TOOL_OUTPUT_SCHEMAS` entry and lists it in MCP_INSTRUCTIONS.
- Bump `MCP_SERVER_VERSION` and `server.json` 1.11.0 → 1.12.0 (MINOR), per the
  documented add-a-tool bump policy.
- Extract `loadSubnetPercentiles` into `src/analytics-live.mjs` (shared-REST-loader
  idiom, mirroring `loadSubnetHealthTrends`) and route both `handleHealthPercentiles`
  and the MCP tool through it. The REST handler keeps its edge-cache + D1-fallback
  wiring (wraps d1All to track usedFallback); response is byte-identical.
- Tests: loader unit tests (cold D1, per-surface percentiles, window defaulting) in
  `tests/analytics-live.test.mjs`; tool tests (happy path, cold-D1 default 7d,
  invalid window) in `tests/mcp-server.test.mjs`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public REST API/OpenAPI/schema change (MCP tool only; REST response byte-identical).

## Validation

- [x] `npm run validate:mcp` — 57 tools, lifecycle + all tools/call (server.json == MCP_SERVER_VERSION)
- [x] vitest: analytics-live + mcp-server + request-handlers-analytics + analytics (460 pass)
- [x] eslint + prettier on changed files
- [x] `git diff --check`
