### PR TITLE
feat(feeds): add ?until= ISO-8601 upper bound for feed item filtering

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -580,11 +580,7 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
   }
 
   if (sinceMs != null && untilMs != null && sinceMs > untilMs) {
-    return fail(
-      "invalid_query",
-      "`since` must not be after `until`.",
-      400,
-    );
+    return fail("invalid_query", "`since` must not be after `until`.", 400);
   }
 
   let items;

--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -22,7 +22,9 @@
 //
 // Optional `?since=<ISO-8601>` returns only items at or after that instant
 // (e.g. ?since=2026-06-01 or ?since=2026-06-01T00:00:00Z), for incremental
-// polling; it composes with `?tag=`. A malformed `since` is a 400.
+// polling; optional `?until=<ISO-8601>` returns only items at or before that
+// instant (same accepted forms). Both compose with `?tag=`; `since` after
+// `until` is a 400. A malformed bound is a 400.
 
 import {
   EXPOSED_RESPONSE_HEADERS_VALUE,
@@ -319,6 +321,17 @@ function filterSince(items, sinceMs) {
   });
 }
 
+// Optional `?until=` filter: keep only items at or before `untilMs` (epoch ms).
+// A null bound is a no-op; unparseable timestamps are dropped, mirroring
+// filterSince so a malformed feed entry never leaks past an explicit `until`.
+function filterUntil(items, untilMs) {
+  if (untilMs == null) return items;
+  return items.filter((item) => {
+    const t = Date.parse(item.timestamp);
+    return !Number.isNaN(t) && t <= untilMs;
+  });
+}
+
 function jsonFeed(meta, items) {
   return `${JSON.stringify(
     {
@@ -538,8 +551,8 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
   }
   const format = resolveFeedFormat(url.pathname, request.headers.get("accept"));
 
-  // Optional `?since=` lower bound (parsed once, here, so a malformed value is
-  // rejected before any artifact work). null when the param is absent.
+  // Optional `?since=` / `?until=` bounds (parsed once, here, so malformed
+  // values are rejected before any artifact work). null when absent.
   let sinceMs = null;
   const sinceParam = url.searchParams.get("since");
   if (sinceParam != null) {
@@ -551,6 +564,27 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
         400,
       );
     }
+  }
+
+  let untilMs = null;
+  const untilParam = url.searchParams.get("until");
+  if (untilParam != null) {
+    untilMs = parseSinceParam(untilParam);
+    if (Number.isNaN(untilMs)) {
+      return fail(
+        "invalid_until",
+        "`until` must be an ISO-8601 date or date-time, e.g. 2026-06-01 or 2026-06-01T00:00:00Z.",
+        400,
+      );
+    }
+  }
+
+  if (sinceMs != null && untilMs != null && sinceMs > untilMs) {
+    return fail(
+      "invalid_query",
+      "`since` must not be after `until`.",
+      400,
+    );
   }
 
   let items;
@@ -606,6 +640,7 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
 
   items = filterByTag(items, url.searchParams.get("tag"));
   items = filterSince(items, sinceMs);
+  items = filterUntil(items, untilMs);
   items = sortAndCap(items);
   const meta = {
     title,
@@ -667,5 +702,6 @@ export const __test = {
   escapeXml,
   filterByTag,
   filterSince,
+  filterUntil,
   parseSinceParam,
 };

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -48,6 +48,7 @@ const {
   escapeXml,
   filterByTag,
   filterSince,
+  filterUntil,
   parseSinceParam,
 } = __test;
 
@@ -477,6 +478,34 @@ describe("feeds — filterSince", () => {
   });
 });
 
+describe("feeds — filterUntil", () => {
+  const items = [
+    { id: "old", timestamp: "2026-06-10T00:00:00.000Z" },
+    { id: "new", timestamp: "2026-06-20T00:00:00.000Z" },
+    { id: "bad", timestamp: "not-a-date" },
+  ];
+
+  test("a null bound is a no-op (returns the input)", () => {
+    assert.equal(filterUntil(items, null), items);
+  });
+
+  test("keeps items at or before the bound; drops unparseable timestamps", () => {
+    const kept = filterUntil(items, Date.parse("2026-06-15T00:00:00.000Z"));
+    assert.deepEqual(
+      kept.map((i) => i.id),
+      ["old"],
+    );
+  });
+
+  test("is inclusive of the exact bound", () => {
+    const kept = filterUntil(items, Date.parse("2026-06-20T00:00:00.000Z"));
+    assert.deepEqual(
+      kept.map((i) => i.id),
+      ["old", "new"],
+    );
+  });
+});
+
 describe("feeds — ?since= filter", () => {
   test("a future since yields an empty but valid feed (200)", async () => {
     const { res, text } = await feed(
@@ -508,6 +537,63 @@ describe("feeds — ?since= filter", () => {
       );
       assert.equal(res.status, 400, value);
     }
+  });
+});
+
+describe("feeds — ?until= filter", () => {
+  test("an until before all items yields an empty but valid feed (200)", async () => {
+    const { res, text } = await feed(
+      "/api/v1/feeds/registry.json?until=2026-01-01",
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(JSON.parse(text).items, []);
+  });
+
+  test("a future until keeps items and composes with ?tag=", async () => {
+    const { res, text } = await feed(
+      "/api/v1/feeds/registry.json?until=2030-01-01&tag=registry",
+    );
+    assert.equal(res.status, 200);
+    const items = JSON.parse(text).items;
+    assert.ok(items.length > 0);
+    assert.ok(items.every((it) => (it.tags || []).includes("registry")));
+  });
+
+  test("since and until bound a window inclusively", async () => {
+    const { res, text } = await feed(
+      "/api/v1/feeds/registry.json?since=2026-06-15&until=2026-06-15",
+    );
+    assert.equal(res.status, 200);
+    const items = JSON.parse(text).items;
+    assert.ok(items.length > 0);
+    for (const it of items) {
+      const t = Date.parse(it.date_published);
+      assert.ok(t >= Date.parse("2026-06-15T00:00:00.000Z"));
+      assert.ok(t <= Date.parse("2026-06-15T00:00:00.000Z"));
+    }
+  });
+
+  test("a malformed until is rejected with 400", async () => {
+    for (const value of [
+      "notadate",
+      "1",
+      "2026-02-31",
+      "Tue, 01 Jun 2026 00:00:00 GMT",
+    ]) {
+      const { res } = await feed(
+        `/api/v1/feeds/registry.json?until=${encodeURIComponent(value)}`,
+      );
+      assert.equal(res.status, 400, value);
+    }
+  });
+
+  test("since after until is rejected with 400 invalid_query", async () => {
+    const { res, text } = await feed(
+      "/api/v1/feeds/registry.json?since=2026-07-01&until=2026-06-01",
+    );
+    assert.equal(res.status, 400);
+    const body = JSON.parse(text);
+    assert.equal(body.error.code, "invalid_query");
   });
 });
 
@@ -987,7 +1073,7 @@ describe("feeds — Worker dispatch integration", () => {
     assert.equal(recentChecksQueries, 1);
   });
 
-  test("handleRequest keys edge-cached feeds by since", async () => {
+  test("handleRequest keys edge-cached feeds by since and until", async () => {
     installMockCache();
     let recentChecksQueries = 0;
     const env = {
@@ -1062,6 +1148,41 @@ describe("feeds — Worker dispatch integration", () => {
     assert.equal(
       invalid.headers.get("x-metagraph-error-code"),
       "invalid_since",
+    );
+
+    const untilFuture = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/feeds/incidents.json?until=2099-01-01",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(untilFuture.status, 200);
+    assert.ok((await untilFuture.json()).items.length > 0);
+    assert.equal(recentChecksQueries, 3);
+
+    const untilPast = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/feeds/incidents.json?until=2000-01-01",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(untilPast.status, 200);
+    assert.deepEqual((await untilPast.json()).items, []);
+    assert.equal(recentChecksQueries, 4);
+
+    const invalidUntil = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/feeds/incidents.json?until=notadate",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(invalidUntil.status, 400);
+    assert.equal(
+      invalidUntil.headers.get("x-metagraph-error-code"),
+      "invalid_until",
     );
   });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1011,6 +1011,10 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     if (since != null) {
       feedCacheParams.push(`since=${encodeURIComponent(since)}`);
     }
+    const until = url.searchParams.get("until");
+    if (until != null) {
+      feedCacheParams.push(`until=${encodeURIComponent(until)}`);
+    }
     const feedCachePath = `${url.pathname}?${feedCacheParams.join("&")}`;
     const feedRequest =
       request.method === "HEAD"


### PR DESCRIPTION
## Summary

- Add optional `?until=<ISO-8601>` upper bound to all public content feeds, mirroring the existing `?since=` lower bound.
- Reject malformed `until` (`400 invalid_until`) and inverted windows where `since > until` (`400 invalid_query`).
- Include `until` in the feed edge-cache key alongside `since` and `tag`.

Closes #2411

## What Changed

- `src/feeds.mjs` — `filterUntil`, bound parsing/validation, module docs
- `workers/api.mjs` — feed cache key includes `until`
- `tests/feeds.test.mjs` — unit + integration coverage for all branches

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. _(No schema/OpenAPI change — query param on existing feed routes only.)_

## Validation

- [x] `git diff --check`
- [x] `npm run lint`
- [x] `npm test -- tests/feeds.test.mjs` (83 passed)
