### PR TITLE
fix(api): tie-break counterparties scan on event_index and coerce string block_number

### DIFF
--- a/src/counterparties.mjs
+++ b/src/counterparties.mjs
@@ -11,6 +11,11 @@
 export const COUNTERPARTIES_READ_COLUMNS =
   "hotkey, coldkey, amount_tao, block_number";
 
+// The columns the inner scan must expose so the bounded newest-first read can
+// tie-break same-block rows on event_index (the output still projects only
+// COUNTERPARTIES_READ_COLUMNS — event_index is needed for ORDER BY, not the body).
+export const COUNTERPARTIES_SCAN_COLUMNS = `${COUNTERPARTIES_READ_COLUMNS}, event_index`;
+
 export const COUNTERPARTY_RELATIONSHIP_READ_COLUMNS =
   "block_number, event_index, hotkey, coldkey, netuid, amount_tao, observed_at";
 
@@ -102,11 +107,11 @@ export function buildCounterparties(rows, ss58, { limit = 20 } = {}) {
     entry.received += received;
     entry.count += 1;
     // `row` is non-null here (it produced a party), so no optional chain needed.
-    const block = row.block_number;
-    if (
-      typeof block === "number" &&
-      (entry.lastBlock == null || block > entry.lastBlock)
-    ) {
+    // Coerce the cell (D1 can return an INTEGER column as a numeric string) so a
+    // string block_number still updates last_block — matching the coercion the
+    // sibling buildCounterpartyRelationship already applies via nullableInteger.
+    const block = nullableInteger(row.block_number);
+    if (block != null && (entry.lastBlock == null || block > entry.lastBlock)) {
       entry.lastBlock = block;
     }
     byParty.set(party, entry);
@@ -236,7 +241,7 @@ export function buildCounterpartyRelationship(
 // hotkey/coldkey OR); buildCounterparties does the per-party rollup. Null-safe.
 export async function loadCounterparties(d1, ss58, { limit } = {}) {
   const rows = await d1(
-    `SELECT ${COUNTERPARTIES_READ_COLUMNS} FROM (SELECT ${COUNTERPARTIES_READ_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ? UNION ALL SELECT ${COUNTERPARTIES_READ_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ? AND hotkey <> ?) ORDER BY block_number DESC LIMIT ?`,
+    `SELECT ${COUNTERPARTIES_READ_COLUMNS} FROM (SELECT ${COUNTERPARTIES_SCAN_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ? UNION ALL SELECT ${COUNTERPARTIES_SCAN_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ? AND hotkey <> ?) ORDER BY block_number DESC, event_index DESC LIMIT ?`,
     [ss58, ss58, ss58, COUNTERPARTIES_SCAN_CAP],
   );
   return buildCounterparties(rows, ss58, { limit });

--- a/tests/counterparties.test.mjs
+++ b/tests/counterparties.test.mjs
@@ -65,6 +65,26 @@ describe("buildCounterparties", () => {
     assert.equal(data.counterparties[2].address, "B");
   });
 
+  test("coerces a numeric-string block_number into last_block and its tie-break (#2413)", () => {
+    // D1 can return an INTEGER column as a numeric string; last_block must still
+    // populate (matching buildCounterpartyRelationship) so the equal-volume
+    // tie-break prefers the more recent counterparty instead of collapsing to 0.
+    const data = buildCounterparties(
+      [
+        { hotkey: "ME", coldkey: "OLD", amount_tao: 100, block_number: "5" },
+        { hotkey: "ME", coldkey: "NEW", amount_tao: 100, block_number: "9" },
+      ],
+      ME,
+      { limit: 20 },
+    );
+    const newer = data.counterparties.find((c) => c.address === "NEW");
+    const older = data.counterparties.find((c) => c.address === "OLD");
+    assert.equal(newer.last_block, 9);
+    assert.equal(older.last_block, 5);
+    // Equal volume (100 each) -> the newer last_block ranks first.
+    assert.equal(data.counterparties[0].address, "NEW");
+  });
+
   test("skips self-transfers (account on both sides)", () => {
     const data = buildCounterparties(
       [
@@ -533,6 +553,11 @@ describe("loadCounterparties", () => {
     assert.match(sql, /UNION ALL/);
     assert.match(sql, /coldkey = \? AND hotkey <> \?/);
     assert.equal(sql.includes(" OR "), false);
+    // The bounded scan must tie-break same-block rows on event_index so the row
+    // cap truncates deterministically (newest-first), matching the relationship
+    // drill-down and the transfer feed (#2413).
+    assert.match(sql, /ORDER BY block_number DESC, event_index DESC/);
+    assert.match(sql, /event_index FROM account_events/);
     assert.deepEqual(params, [ME, ME, ME, COUNTERPARTIES_SCAN_CAP]);
     assert.equal(data.ss58, ME);
     assert.equal(data.counterparty_count, 2);


### PR DESCRIPTION
## Summary

`loadCounterparties` (`src/counterparties.mjs`) reads a bounded newest-first transfer scan but ordered only by `block_number DESC` before `LIMIT 5000`. When an account has more than 5000 transfers and the cap cuts through a block holding multiple transfers, SQLite's order among the tied rows is undefined, so the aggregate counterparty stats (`counterparty_count`, `total_sent_tao`/`total_received_tao`, ranking) depend on an arbitrary subset and can differ between identical requests. Every sibling scan (`loadCounterpartyRelationship`, `loadAccountTransfers`) already tie-breaks on `event_index`; this one did not.

This also coerces a numeric-string `block_number` in `buildCounterparties` so `last_block` and the equal-volume tie-break stay block-accurate, matching the coercion `buildCounterpartyRelationship` already applies.

Fixes #2413

## What Changed

- Added `COUNTERPARTIES_SCAN_COLUMNS` (read columns + `event_index`) used by the inner union subqueries so the outer scan can sort by `block_number DESC, event_index DESC`. The output projection still returns only `COUNTERPARTIES_READ_COLUMNS` â€” `event_index` is needed for the deterministic `ORDER BY`, not the response body.
- `buildCounterparties` now derives `last_block` via `nullableInteger(row.block_number)` (coercing a numeric-string cell) instead of requiring `typeof block === "number"`, so a string `block_number` still updates `last_block` and the equal-volume tie-break.
- Regression tests: the scan SQL asserts the `block_number DESC, event_index DESC` ordering and that the inner scan exposes `event_index`; a builder test proves a string `block_number` populates `last_block` and drives the tie-break.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes (pure runtime query/aggregation fix; contract untouched).

## Validation

- [x] `npx vitest run tests/counterparties.test.mjs` (27 passed)
- [x] `npx eslint src/counterparties.mjs tests/counterparties.test.mjs`
- [x] `git diff --check`
