### PR TITLE
fix(api): return the empty turnover block when a boundary snapshot is absent

### DIFF
--- a/src/turnover.mjs
+++ b/src/turnover.mjs
@@ -142,6 +142,14 @@ export function buildTurnover(
 
   const startRows = list.filter((row) => row?.snapshot_date === startDate);
   const endRows = list.filter((row) => row?.snapshot_date === endDate);
+  // A boundary date that resolves to no rows isn't comparable: jaccard(∅, ∅) = 1
+  // would otherwise report a flawless retention/stability_score of 100 for a
+  // window with no boundary data. Honor the documented "no resolvable boundary
+  // dates yields the empty block" contract. (A snapshot that genuinely exists
+  // with zero validators still has rows, so it keeps computing.)
+  if (startRows.length === 0 || endRows.length === 0) {
+    return { ...base, ...EMPTY_TURNOVER };
+  }
 
   // Validator-set churn, keyed by hotkey (the validating entity).
   const startValidators = validatorHotkeys(startRows);
@@ -218,6 +226,11 @@ export function buildTurnoverChanges(
 
   const startRows = list.filter((row) => row?.snapshot_date === startDate);
   const endRows = list.filter((row) => row?.snapshot_date === endDate);
+  // Mirror buildTurnover: a boundary date with no rows is not resolvable, so
+  // return the empty changes block instead of inventing entered/exited churn.
+  if (startRows.length === 0 || endRows.length === 0) {
+    return { ...base, ...EMPTY_TURNOVER_CHANGES };
+  }
   const startValidators = validatorHotkeyMap(startRows);
   const endValidators = validatorHotkeyMap(endRows);
 

--- a/tests/turnover.test.mjs
+++ b/tests/turnover.test.mjs
@@ -40,7 +40,14 @@ describe("buildTurnover", () => {
     // Only a mid-window snapshot exists; the requested boundary dates have no
     // rows. jaccard(empty, empty) = 1 must NOT surface as perfect retention.
     const data = buildTurnover(
-      [{ snapshot_date: "2026-06-15", uid: 0, hotkey: "H0", validator_permit: 1 }],
+      [
+        {
+          snapshot_date: "2026-06-15",
+          uid: 0,
+          hotkey: "H0",
+          validator_permit: 1,
+        },
+      ],
       1,
       { window: "30d", startDate: "2026-06-01", endDate: "2026-06-30" },
     );
@@ -56,7 +63,14 @@ describe("buildTurnover", () => {
     // Start resolves, end does not — without the guard this would report
     // validator_retention 0 (everyone "exited") instead of no-data.
     const data = buildTurnover(
-      [{ snapshot_date: "2026-06-01", uid: 0, hotkey: "V1", validator_permit: 1 }],
+      [
+        {
+          snapshot_date: "2026-06-01",
+          uid: 0,
+          hotkey: "V1",
+          validator_permit: 1,
+        },
+      ],
       1,
       { window: "30d", startDate: "2026-06-01", endDate: "2026-06-30" },
     );
@@ -243,7 +257,14 @@ describe("buildTurnoverChanges", () => {
 
   test("rows present but neither boundary date resolves yields empty detail (#2415)", () => {
     const data = buildTurnoverChanges(
-      [{ snapshot_date: "2026-06-15", uid: 0, hotkey: "H0", validator_permit: 1 }],
+      [
+        {
+          snapshot_date: "2026-06-15",
+          uid: 0,
+          hotkey: "H0",
+          validator_permit: 1,
+        },
+      ],
       7,
       { window: "30d", startDate: "2026-06-01", endDate: "2026-06-30" },
     );

--- a/tests/turnover.test.mjs
+++ b/tests/turnover.test.mjs
@@ -36,6 +36,35 @@ describe("buildTurnover", () => {
     assert.equal(buildTurnover([], 7, {}).window, null);
   });
 
+  test("rows present but neither boundary date resolves is not comparable (#2415)", () => {
+    // Only a mid-window snapshot exists; the requested boundary dates have no
+    // rows. jaccard(empty, empty) = 1 must NOT surface as perfect retention.
+    const data = buildTurnover(
+      [{ snapshot_date: "2026-06-15", uid: 0, hotkey: "H0", validator_permit: 1 }],
+      1,
+      { window: "30d", startDate: "2026-06-01", endDate: "2026-06-30" },
+    );
+    assert.equal(data.comparable, false);
+    assert.equal(data.validator_retention, null);
+    assert.equal(data.neuron_retention, null);
+    assert.equal(data.stability_score, null);
+    assert.equal(data.validators_start, 0);
+    assert.equal(data.neurons_end, 0);
+  });
+
+  test("a missing end snapshot is not read as total churn (#2415)", () => {
+    // Start resolves, end does not — without the guard this would report
+    // validator_retention 0 (everyone "exited") instead of no-data.
+    const data = buildTurnover(
+      [{ snapshot_date: "2026-06-01", uid: 0, hotkey: "V1", validator_permit: 1 }],
+      1,
+      { window: "30d", startDate: "2026-06-01", endDate: "2026-06-30" },
+    );
+    assert.equal(data.comparable, false);
+    assert.equal(data.validator_retention, null);
+    assert.equal(data.stability_score, null);
+  });
+
   test("computes validator churn, deregistrations, and retention between two snapshots", () => {
     const rows = [
       // start: validators V1 (uid0), V2 (uid1); miner M1 (uid2)
@@ -210,6 +239,19 @@ describe("buildTurnoverChanges", () => {
       assert.deepEqual(data.validators_exited, []);
       assert.deepEqual(data.uid_reassignments, []);
     }
+  });
+
+  test("rows present but neither boundary date resolves yields empty detail (#2415)", () => {
+    const data = buildTurnoverChanges(
+      [{ snapshot_date: "2026-06-15", uid: 0, hotkey: "H0", validator_permit: 1 }],
+      7,
+      { window: "30d", startDate: "2026-06-01", endDate: "2026-06-30" },
+    );
+    assert.equal(data.comparable, false);
+    assert.equal(data.validators_entered_count, 0);
+    assert.deepEqual(data.validators_entered, []);
+    assert.deepEqual(data.validators_exited, []);
+    assert.deepEqual(data.uid_reassignments, []);
   });
 
   test("lists validator entries, exits, and UID reassignments", () => {


### PR DESCRIPTION
## Summary

`buildTurnover` / `buildTurnoverChanges` (`src/turnover.mjs`) document themselves as null-safe for "no resolvable boundary dates", but the only guard checked `list.length === 0` â€” never whether the supplied rows actually contain rows for `startDate` / `endDate`. When `rows` is non-empty but holds no rows for either boundary date, both boundary row sets filter to `[]`, `jaccard(âˆ…, âˆ…)` returns `1`, and the endpoint reports `validator_retention: 1`, `neuron_retention: 1`, `stability_score: 100`, `comparable: true` â€” a flawless, fully-stable subnet for a window with no boundary data.

Fixes #2415

## What Changed

- After resolving the boundary row sets, both builders now return the schema-stable empty block (`EMPTY_TURNOVER` / `EMPTY_TURNOVER_CHANGES`) when **either** boundary date resolves to zero rows, honoring the documented "no resolvable boundary dates yields the empty block" contract.
- The guard keys on row presence per boundary date, not on validator-set emptiness, so a snapshot that genuinely exists with zero validators (rows present, all `validator_permit = 0`) still computes as before.
- Regression tests: rows present but neither boundary date resolves -> `comparable: false` with null retentions / `stability_score`; a missing end snapshot is no longer read as total churn; matching coverage for `buildTurnoverChanges`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes (pure null-safety fix; the empty-block shape is unchanged).

## Validation

- [x] `npx vitest run tests/turnover.test.mjs` (20 passed)
- [x] `npx eslint src/turnover.mjs tests/turnover.test.mjs`
- [x] `git diff --check`
