### PR TITLE
feat(api): add chain calls module filter

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -402,7 +402,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the extrinsic call-mix breakdown (count + share per call_module, or call_module/call_function with group_by=module_function) over a 7d or 30d window, ordered by count. Computed live from the first-party extrinsics D1 tier (#1989); schema-stable call_count:0/calls:[] when cold. */
+        /** Fetch the extrinsic call-mix breakdown (count + share per call_module, or call_module/call_function with group_by=module_function) over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. When scoped, total_extrinsics and share use the scoped module denominator. Computed live from the first-party extrinsics D1 tier (#1989); schema-stable call_count:0/calls:[] when cold. */
         get: operations["chainCalls"];
         put?: never;
         post?: never;
@@ -2293,7 +2293,7 @@ export interface components {
             count: number;
             share: number | null;
         };
-        /** @description Extrinsic call-mix breakdown (#1989) over a 7d/30d window: each call_module (or call_module/call_function with group_by=module_function) by count and share of all extrinsics. Served live from the extrinsics D1 tier at /api/v1/chain/calls (no static file); call_count is 0 and calls is empty when the store is cold. */
+        /** @description Extrinsic call-mix breakdown (#1989) over a 7d/30d window: each call_module (or call_module/call_function with group_by=module_function) by count and share of all extrinsics, or of the selected call_module when ?call_module= is supplied. Served live from the extrinsics D1 tier at /api/v1/chain/calls (no static file); call_count is 0 and calls is empty when the store is cold. */
         ChainCallsArtifact: {
             call_count: number;
             calls: components["schemas"]["ChainCallEntry"][];
@@ -7977,6 +7977,7 @@ export interface operations {
                 window?: "7d" | "30d";
                 group_by?: "module" | "module_function";
                 limit?: number;
+                call_module?: string;
             };
             header?: never;
             path?: never;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1,763 +1,763 @@
 {
   "artifact_contracts": [
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "contracts",
       "path": "/metagraph/contracts.json",
       "schema_ref": "#/components/schemas/ContractsArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "providers",
       "path": "/metagraph/providers.json",
       "schema_ref": "#/components/schemas/ProvidersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "provider-detail",
       "path": "/metagraph/providers/{slug}.json",
       "schema_ref": "#/components/schemas/ProviderArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",
       "schema_ref": "#/components/schemas/ProviderEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "api-index",
       "path": "/metagraph/api-index.json",
       "schema_ref": "#/components/schemas/ApiIndexArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "openapi",
       "path": "/metagraph/openapi.json",
       "schema_ref": "#/components/schemas/OpenApiArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "type-definitions",
       "path": "/metagraph/types.d.ts",
       "schema_ref": null,
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "changelog",
       "path": "/metagraph/changelog.json",
       "schema_ref": "#/components/schemas/ChangelogArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnets",
       "path": "/metagraph/subnets.json",
       "schema_ref": "#/components/schemas/SubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "metagraph-latest",
       "path": "/metagraph/metagraph/latest.json",
       "schema_ref": "#/components/schemas/SubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-detail",
       "path": "/metagraph/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-overview",
       "path": "/metagraph/overview/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetOverviewArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "profiles",
       "path": "/metagraph/profiles.json",
       "schema_ref": "#/components/schemas/SubnetProfilesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "profile-detail",
       "path": "/metagraph/profiles/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetProfileArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "surfaces",
       "path": "/metagraph/surfaces.json",
       "schema_ref": "#/components/schemas/SurfacesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "surface-aliases",
       "path": "/metagraph/surface-aliases.json",
       "schema_ref": "#/components/schemas/SurfaceAliasesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "surfaces-subnet",
       "path": "/metagraph/surfaces/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetSurfacesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "endpoints",
       "path": "/metagraph/endpoints.json",
       "schema_ref": "#/components/schemas/EndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "endpoints-subnet",
       "path": "/metagraph/endpoints/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "candidates",
       "path": "/metagraph/candidates.json",
       "schema_ref": "#/components/schemas/CandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "candidates-subnet",
       "path": "/metagraph/candidates/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetCandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "review-queue",
       "path": "/metagraph/review-queue.json",
       "schema_ref": "#/components/schemas/ReviewQueueArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "search",
       "path": "/metagraph/search.json",
       "schema_ref": "#/components/schemas/SearchArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "search-index",
       "path": "/metagraph/search-index.json",
       "schema_ref": "#/components/schemas/SearchIndexArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "coverage",
       "path": "/metagraph/coverage.json",
       "schema_ref": "#/components/schemas/CoverageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "coverage-depth",
       "path": "/metagraph/coverage-depth.json",
       "schema_ref": "#/components/schemas/CoverageDepthArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "economics",
       "path": "/metagraph/economics.json",
       "schema_ref": "#/components/schemas/EconomicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "economics-trends",
       "path": "/metagraph/economics/trends.json",
       "schema_ref": "#/components/schemas/EconomicsTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "registry-summary",
       "path": "/metagraph/registry-summary.json",
       "schema_ref": "#/components/schemas/RegistrySummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "lineage",
       "path": "/metagraph/lineage.json",
       "schema_ref": "#/components/schemas/LineageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "fixtures-index",
       "path": "/metagraph/fixtures.json",
       "schema_ref": "#/components/schemas/FixturesIndexArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "agent-resources",
       "path": "/metagraph/agent-resources.json",
       "schema_ref": "#/components/schemas/AgentResourcesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "fixture-detail",
       "path": "/metagraph/fixtures/{surface_id}.json",
       "schema_ref": "#/components/schemas/JsonObject",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "curation",
       "path": "/metagraph/curation.json",
       "schema_ref": "#/components/schemas/CurationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "gaps",
       "path": "/metagraph/gaps.json",
       "schema_ref": "#/components/schemas/GapsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "verification",
       "path": "/metagraph/verification/latest.json",
       "schema_ref": "#/components/schemas/VerificationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "verification-subnet",
       "path": "/metagraph/verification/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetVerificationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "freshness",
       "path": "/metagraph/freshness.json",
       "schema_ref": "#/components/schemas/FreshnessArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "source-health",
       "path": "/metagraph/source-health.json",
       "schema_ref": "#/components/schemas/SourceHealthArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "source-snapshots",
       "path": "/metagraph/source-snapshots.json",
       "schema_ref": "#/components/schemas/SourceSnapshotsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "evidence-ledger",
       "path": "/metagraph/evidence-ledger.json",
       "schema_ref": "#/components/schemas/EvidenceLedgerArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "evidence-subnet",
       "path": "/metagraph/evidence/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetEvidenceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "health-latest",
       "path": "/metagraph/health/latest.json",
       "schema_ref": "#/components/schemas/HealthLatestArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "health-summary",
       "path": "/metagraph/health/summary.json",
       "schema_ref": "#/components/schemas/HealthSummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "health-history",
       "path": "/metagraph/health/history/{date}.json",
       "schema_ref": "#/components/schemas/HealthHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "health-subnet",
       "path": "/metagraph/health/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthSubnetArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "health-badge",
       "path": "/metagraph/health/badges/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthBadgeArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "health-trends",
       "path": "/metagraph/health/trends/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "health-trends-bulk",
       "path": "/metagraph/health/trends.json",
       "schema_ref": "#/components/schemas/BulkHealthTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "health-percentiles",
       "path": "/metagraph/health/percentiles/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthPercentilesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "health-incidents",
       "path": "/metagraph/health/incidents/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-trajectory",
       "path": "/metagraph/subnets/{netuid}/trajectory.json",
       "schema_ref": "#/components/schemas/SubnetTrajectoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-concentration",
       "path": "/metagraph/subnets/{netuid}/concentration.json",
       "schema_ref": "#/components/schemas/SubnetConcentrationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-concentration-history",
       "path": "/metagraph/subnets/{netuid}/concentration/history.json",
       "schema_ref": "#/components/schemas/SubnetConcentrationHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-turnover",
       "path": "/metagraph/subnets/{netuid}/turnover.json",
       "schema_ref": "#/components/schemas/SubnetTurnoverArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-metagraph",
       "path": "/metagraph/subnets/{netuid}/metagraph.json",
       "schema_ref": "#/components/schemas/SubnetMetagraphArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-neuron",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}.json",
       "schema_ref": "#/components/schemas/NeuronDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-validators",
       "path": "/metagraph/subnets/{netuid}/validators.json",
       "schema_ref": "#/components/schemas/SubnetValidatorsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-events",
       "path": "/metagraph/subnets/{netuid}/events.json",
       "schema_ref": "#/components/schemas/SubnetEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-neuron-history",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}/history.json",
       "schema_ref": "#/components/schemas/NeuronHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-history",
       "path": "/metagraph/subnets/{netuid}/history.json",
       "schema_ref": "#/components/schemas/SubnetHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "account-summary",
       "path": "/metagraph/accounts/{ss58}.json",
       "schema_ref": "#/components/schemas/AccountSummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "account-events",
       "path": "/metagraph/accounts/{ss58}/events.json",
       "schema_ref": "#/components/schemas/AccountEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "account-history",
       "path": "/metagraph/accounts/{ss58}/history.json",
       "schema_ref": "#/components/schemas/AccountHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "account-extrinsics",
       "path": "/metagraph/accounts/{ss58}/extrinsics.json",
       "schema_ref": "#/components/schemas/AccountExtrinsicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "account-transfers",
       "path": "/metagraph/accounts/{ss58}/transfers.json",
       "schema_ref": "#/components/schemas/AccountTransfersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "account-counterparties",
       "path": "/metagraph/accounts/{ss58}/counterparties.json",
       "schema_ref": "#/components/schemas/AccountCounterpartiesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "account-subnets",
       "path": "/metagraph/accounts/{ss58}/subnets.json",
       "schema_ref": "#/components/schemas/AccountSubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "account-balance",
       "path": "/metagraph/accounts/{ss58}/balance.json",
       "schema_ref": "#/components/schemas/AccountBalanceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "blocks-feed",
       "path": "/metagraph/blocks.json",
       "schema_ref": "#/components/schemas/BlocksFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "block-detail",
       "path": "/metagraph/blocks/{ref}.json",
       "schema_ref": "#/components/schemas/BlockDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "block-extrinsics",
       "path": "/metagraph/blocks/{ref}/extrinsics.json",
       "schema_ref": "#/components/schemas/BlockExtrinsicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "block-events",
       "path": "/metagraph/blocks/{ref}/events.json",
       "schema_ref": "#/components/schemas/BlockEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "chain-events-feed",
       "path": "/metagraph/chain-events.json",
       "schema_ref": "#/components/schemas/ChainEventsFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "block-chain-events",
       "path": "/metagraph/blocks/{ref}/chain-events.json",
       "schema_ref": "#/components/schemas/BlockChainEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "chain-events-stats",
       "path": "/metagraph/chain-events/stats.json",
       "schema_ref": "#/components/schemas/ChainEventsStatsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "extrinsics-feed",
       "path": "/metagraph/extrinsics.json",
       "schema_ref": "#/components/schemas/ExtrinsicsFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "extrinsic-detail",
       "path": "/metagraph/extrinsics/{hash}.json",
       "schema_ref": "#/components/schemas/ExtrinsicDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "chain-activity",
       "path": "/metagraph/chain/activity.json",
       "schema_ref": "#/components/schemas/ChainActivityArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "chain-calls",
       "path": "/metagraph/chain/calls.json",
       "schema_ref": "#/components/schemas/ChainCallsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "chain-signers",
       "path": "/metagraph/chain/signers.json",
       "schema_ref": "#/components/schemas/ChainSignersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "chain-fees",
       "path": "/metagraph/chain/fees.json",
       "schema_ref": "#/components/schemas/ChainFeesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-uptime",
       "path": "/metagraph/subnets/{netuid}/uptime.json",
       "schema_ref": "#/components/schemas/UptimeArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "global-incidents",
       "path": "/metagraph/incidents.json",
       "schema_ref": "#/components/schemas/GlobalIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",
       "schema_ref": "#/components/schemas/RegistryLeaderboardsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "compare",
       "path": "/metagraph/compare.json",
       "schema_ref": "#/components/schemas/CompareArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "rpc-usage",
       "path": "/metagraph/rpc/usage.json",
       "schema_ref": "#/components/schemas/RpcUsageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
       "schema_ref": "#/components/schemas/RpcEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "rpc-pools",
       "path": "/metagraph/rpc/pools.json",
       "schema_ref": "#/components/schemas/RpcPoolsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "endpoint-pools",
       "path": "/metagraph/endpoint-pools.json",
       "schema_ref": "#/components/schemas/EndpointPoolsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "endpoint-incidents",
       "path": "/metagraph/endpoint-incidents.json",
       "schema_ref": "#/components/schemas/EndpointIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "operational-surfaces",
       "path": "/metagraph/operational-surfaces.json",
       "schema_ref": "#/components/schemas/OperationalSurfacesArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "agent-catalog",
       "path": "/metagraph/agent-catalog.json",
       "schema_ref": "#/components/schemas/AgentCatalogArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "agent-catalog-subnet",
       "path": "/metagraph/agent-catalog/{netuid}.json",
       "schema_ref": "#/components/schemas/AgentCatalogSubnetArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",
       "schema_ref": "#/components/schemas/SchemaDriftArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "schema-index",
       "path": "/metagraph/schemas/index.json",
       "schema_ref": "#/components/schemas/SchemaIndexArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "schema-snapshot",
       "path": "/metagraph/schemas/{surface_id}.json",
       "schema_ref": "#/components/schemas/JsonObject",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",
       "schema_ref": "#/components/schemas/AdapterArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "r2-manifest",
       "path": "/metagraph/r2-manifest.json",
       "schema_ref": "#/components/schemas/R2ManifestArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "review-curation",
       "path": "/metagraph/review/curation.json",
       "schema_ref": "#/components/schemas/ReviewCurationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "review-gap-priorities",
       "path": "/metagraph/review/gap-priorities.json",
       "schema_ref": "#/components/schemas/ReviewGapPrioritiesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "subnet-gaps",
       "path": "/metagraph/review/gaps/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetGapsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "review-profile-completeness",
       "path": "/metagraph/review/profile-completeness.json",
       "schema_ref": "#/components/schemas/ReviewProfileCompletenessArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "review-adapter-candidates",
       "path": "/metagraph/review/adapter-candidates.json",
       "schema_ref": "#/components/schemas/ReviewAdapterCandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "review-enrichment-queue",
       "path": "/metagraph/review/enrichment-queue.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentQueueArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "review-enrichment-evidence",
       "path": "/metagraph/review/enrichment-evidence.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentEvidenceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "review-enrichment-targets",
       "path": "/metagraph/review/enrichment-targets.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentTargetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
       "schema_ref": "#/components/schemas/ReviewDecisionsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "id": "build-summary",
       "path": "/metagraph/build-summary.json",
       "schema_ref": "#/components/schemas/BuildSummaryArtifact",
@@ -765,7 +765,7 @@
     }
   ],
   "base_path": "/api/v1",
-  "contract_version": "2026-06-30.4",
+  "contract_version": "2026-06-30.5",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "openapi_url": "/api/v1/openapi.json",
   "primary_domain": "api.metagraph.sh",
@@ -5111,7 +5111,7 @@
     {
       "artifact_path": "/metagraph/chain/calls.json",
       "cache": "short",
-      "description": "Fetch the extrinsic call-mix breakdown (count + share per call_module, or call_module/call_function with group_by=module_function) over a 7d or 30d window, ordered by count. Computed live from the first-party extrinsics D1 tier (#1989); schema-stable call_count:0/calls:[] when cold.",
+      "description": "Fetch the extrinsic call-mix breakdown (count + share per call_module, or call_module/call_function with group_by=module_function) over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. When scoped, total_extrinsics and share use the scoped module denominator. Computed live from the first-party extrinsics D1 tier (#1989); schema-stable call_count:0/calls:[] when cold.",
       "id": "chain-calls",
       "method": "GET",
       "path": "/api/v1/chain/calls",
@@ -5145,6 +5145,13 @@
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
+          }
+        },
+        {
+          "name": "call_module",
+          "schema": {
+            "maxLength": 100,
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -2,7 +2,7 @@
   "artifacts": [
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Public artifact contract metadata for metagraph.sh consumers.",
       "id": "contracts",
       "path": "/metagraph/contracts.json",
@@ -11,7 +11,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Provider/source registry.",
       "id": "providers",
       "path": "/metagraph/providers.json",
@@ -20,7 +20,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Per-provider detail payload.",
       "id": "provider-detail",
       "path": "/metagraph/providers/{slug}.json",
@@ -29,7 +29,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Endpoint resources for one provider or operator.",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",
@@ -38,7 +38,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Clean API route index for metagraph.sh consumers.",
       "id": "api-index",
       "path": "/metagraph/api-index.json",
@@ -47,7 +47,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "OpenAPI 3.1 contract for the metagraph.sh backend API.",
       "id": "openapi",
       "path": "/metagraph/openapi.json",
@@ -56,7 +56,7 @@
     },
     {
       "content_type": "text/plain; charset=utf-8",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Generated TypeScript definitions for metagraph.sh backend consumers.",
       "id": "type-definitions",
       "path": "/metagraph/types.d.ts",
@@ -65,7 +65,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Reviewable generated artifact and subnet-change summary.",
       "id": "changelog",
       "path": "/metagraph/changelog.json",
@@ -74,7 +74,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "All active Finney subnets with compact registry metadata.",
       "id": "subnets",
       "path": "/metagraph/subnets.json",
@@ -83,7 +83,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Latest normalized all-subnet metagraph index with chain-native state and registry coverage metadata.",
       "id": "metagraph-latest",
       "path": "/metagraph/metagraph/latest.json",
@@ -92,7 +92,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Per-subnet detail payload.",
       "id": "subnet-detail",
       "path": "/metagraph/subnets/{netuid}.json",
@@ -101,7 +101,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Composed per-subnet overview: profile + health + curation + gaps + counts.",
       "id": "subnet-overview",
       "path": "/metagraph/overview/{netuid}.json",
@@ -110,7 +110,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Public-safe subnet identity and completeness profiles.",
       "id": "profiles",
       "path": "/metagraph/profiles.json",
@@ -119,7 +119,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Per-subnet public-safe profile detail.",
       "id": "profile-detail",
       "path": "/metagraph/profiles/{netuid}.json",
@@ -128,7 +128,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Curated public interface surfaces only.",
       "id": "surfaces",
       "path": "/metagraph/surfaces.json",
@@ -137,7 +137,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Deprecated surface display-id aliases mapped to stable surface keys for renamed surfaces.",
       "id": "surface-aliases",
       "path": "/metagraph/surface-aliases.json",
@@ -146,7 +146,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Curated public interface surfaces for one subnet.",
       "id": "surfaces-subnet",
       "path": "/metagraph/surfaces/{netuid}.json",
@@ -155,7 +155,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Generalized endpoint/resource registry derived from curated surfaces and probe observations.",
       "id": "endpoints",
       "path": "/metagraph/endpoints.json",
@@ -164,7 +164,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Generalized endpoint/resource registry for one subnet.",
       "id": "endpoints-subnet",
       "path": "/metagraph/endpoints/{netuid}.json",
@@ -173,7 +173,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Unpromoted candidate surfaces from public discovery.",
       "id": "candidates",
       "path": "/metagraph/candidates.json",
@@ -182,7 +182,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Unpromoted candidate surfaces for one subnet.",
       "id": "candidates-subnet",
       "path": "/metagraph/candidates/{netuid}.json",
@@ -191,7 +191,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Candidate surfaces queued for maintainer review.",
       "id": "review-queue",
       "path": "/metagraph/review-queue.json",
@@ -200,7 +200,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Compact search index for subnets, surfaces, and providers.",
       "id": "search",
       "path": "/metagraph/search.json",
@@ -209,7 +209,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Slim search index (the same documents as search.json without the per-document token blobs) for fast browser typeahead and listing.",
       "id": "search-index",
       "path": "/metagraph/search-index.json",
@@ -218,7 +218,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Registry coverage counts and source precedence.",
       "id": "coverage",
       "path": "/metagraph/coverage.json",
@@ -227,7 +227,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Machine-usable coverage depth scorecard with per-subnet readiness dimensions and a ranked enrichment queue.",
       "id": "coverage-depth",
       "path": "/metagraph/coverage-depth.json",
@@ -236,7 +236,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Per-subnet validator and economic metrics from the chain: validator/miner counts, total + max stake, registration cost, alpha price, and derived price-weighted emission share.",
       "id": "economics",
       "path": "/metagraph/economics.json",
@@ -245,7 +245,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Network-wide economics time series (#1307) aggregated per UTC day across all subnets from the daily subnet_snapshots D1 rollup (the same source the per-subnet trajectory reads), served live at /api/v1/economics/trends (no static file).",
       "id": "economics-trends",
       "path": "/metagraph/economics/trends.json",
@@ -254,7 +254,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Registry-wide summary: completeness rollup, top subnets, level counts, latest changes.",
       "id": "registry-summary",
       "path": "/metagraph/registry-summary.json",
@@ -263,7 +263,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Cross-network subnet lineage: maintainer-approved mainnet ↔ testnet pairs with reviewed match evidence.",
       "id": "lineage",
       "path": "/metagraph/lineage.json",
@@ -272,7 +272,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Index of captured live request/response fixtures (which surfaces carry a sanitized sample).",
       "id": "fixtures-index",
       "path": "/metagraph/fixtures.json",
@@ -281,7 +281,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Machine index of every AI resource: the copyable agent, the MCP server + tools, the skill, llms.txt, OpenAPI, and the agent-facing APIs.",
       "id": "agent-resources",
       "path": "/metagraph/agent-resources.json",
@@ -290,7 +290,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "A captured, sanitized live request/response sample for one surface.",
       "id": "fixture-detail",
       "path": "/metagraph/fixtures/{surface_id}.json",
@@ -299,7 +299,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Curation state and gaps for every active subnet.",
       "id": "curation",
       "path": "/metagraph/curation.json",
@@ -308,7 +308,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Missing public interface facets by subnet.",
       "id": "gaps",
       "path": "/metagraph/gaps.json",
@@ -317,7 +317,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Latest candidate verification snapshot.",
       "id": "verification",
       "path": "/metagraph/verification/latest.json",
@@ -326,7 +326,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Latest candidate verification snapshot for one subnet.",
       "id": "verification-subnet",
       "path": "/metagraph/verification/subnets/{netuid}.json",
@@ -335,7 +335,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Freshness and staleness summary for generated backend data.",
       "id": "freshness",
       "path": "/metagraph/freshness.json",
@@ -344,7 +344,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Upstream source and provider health summary.",
       "id": "source-health",
       "path": "/metagraph/source-health.json",
@@ -353,7 +353,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Compact hashes and counts for canonical source inputs.",
       "id": "source-snapshots",
       "path": "/metagraph/source-snapshots.json",
@@ -362,7 +362,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Public evidence ledger for subnet and surface claims.",
       "id": "evidence-ledger",
       "path": "/metagraph/evidence-ledger.json",
@@ -371,7 +371,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Public evidence ledger claims for one subnet.",
       "id": "evidence-subnet",
       "path": "/metagraph/evidence/{netuid}.json",
@@ -380,7 +380,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Latest surface health snapshot.",
       "id": "health-latest",
       "path": "/metagraph/health/latest.json",
@@ -389,7 +389,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Global and per-subnet health rollup.",
       "id": "health-summary",
       "path": "/metagraph/health/summary.json",
@@ -398,7 +398,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Compact daily health-history snapshot.",
       "id": "health-history",
       "path": "/metagraph/health/history/{date}.json",
@@ -407,7 +407,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Per-subnet health payload for metagraph.sh consumers.",
       "id": "health-subnet",
       "path": "/metagraph/health/subnets/{netuid}.json",
@@ -416,7 +416,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Badge data contract for status rendering.",
       "id": "health-badge",
       "path": "/metagraph/health/badges/{netuid}.json",
@@ -425,7 +425,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Computed 7d/30d uptime + success-only latency trends (mean, p50/p95/p99 tail, and healthy-sample count) for one subnet's operational surfaces. Served live from D1 at /api/v1/subnets/{netuid}/health/trends (no static file).",
       "id": "health-trends",
       "path": "/metagraph/health/trends/{netuid}.json",
@@ -434,7 +434,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Compact all-subnet 7d/30d daily uptime + success-only latency trend matrix (mean + healthy-sample count). Served live from D1 at /api/v1/health/trends (no static file).",
       "id": "health-trends-bulk",
       "path": "/metagraph/health/trends.json",
@@ -443,7 +443,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Latency percentiles (p50/p95/p99 + avg/min/max) per operational surface for one subnet, computed live from D1 at /api/v1/subnets/{netuid}/health/percentiles (no static file).",
       "id": "health-percentiles",
       "path": "/metagraph/health/percentiles/{netuid}.json",
@@ -452,7 +452,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "SLA (uptime ratio) and reconstructed downtime incidents per operational surface for one subnet, computed live from D1 at /api/v1/subnets/{netuid}/health/incidents (no static file).",
       "id": "health-incidents",
       "path": "/metagraph/health/incidents/{netuid}.json",
@@ -461,7 +461,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Week-over-week structural trajectory (completeness + surface/endpoint counts) for one subnet from daily snapshots, served live from D1 at /api/v1/subnets/{netuid}/trajectory (no static file).",
       "id": "subnet-trajectory",
       "path": "/metagraph/subnets/{netuid}/trajectory.json",
@@ -470,7 +470,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Stake & emission concentration metrics (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) for one subnet across three lenses — per-UID, per-entity (coldkeys collapsed to the true control distribution), and validator-only consensus power — served live from the neurons D1 tier at /api/v1/subnets/{netuid}/concentration (no static file).",
       "id": "subnet-concentration",
       "path": "/metagraph/subnets/{netuid}/concentration.json",
@@ -479,7 +479,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/concentration/history (no static file).",
       "id": "subnet-concentration-history",
       "path": "/metagraph/subnets/{netuid}/concentration/history.json",
@@ -488,7 +488,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + Jaccard retention, UID deregistrations, and a 0-100 stability score — served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/turnover (no static file).",
       "id": "subnet-turnover",
       "path": "/metagraph/subnets/{netuid}/turnover.json",
@@ -497,7 +497,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Per-UID metagraph (stake, trust, consensus, incentive, dividends, emission, validator_permit, rank, axon) for one subnet, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/metagraph (no static file).",
       "id": "subnet-metagraph",
       "path": "/metagraph/subnets/{netuid}/metagraph.json",
@@ -506,7 +506,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "A single neuron's metagraph state by UID, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/neurons/{uid} (no static file).",
       "id": "subnet-neuron",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}.json",
@@ -515,7 +515,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Validators (validator_permit) of one subnet ranked by stake, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/validators (no static file).",
       "id": "subnet-validators",
       "path": "/metagraph/subnets/{netuid}/validators.json",
@@ -524,7 +524,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "First-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, served live from the account_events D1 tier filtered by netuid at /api/v1/subnets/{netuid}/events (no static file).",
       "id": "subnet-events",
       "path": "/metagraph/subnets/{netuid}/events.json",
@@ -533,7 +533,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Per-UID daily metagraph history (stake/trust/emission/rank over time) for one UID, served live from the neuron_daily D1 rollup tier at /api/v1/subnets/{netuid}/neurons/{uid}/history (no static file).",
       "id": "subnet-neuron-history",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}/history.json",
@@ -542,7 +542,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Per-subnet daily aggregate history (neuron/validator counts + stake/emission totals) for one subnet, served live from the neuron_daily D1 rollup tier at /api/v1/subnets/{netuid}/history (no static file).",
       "id": "subnet-history",
       "path": "/metagraph/subnets/{netuid}/history.json",
@@ -551,7 +551,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Cross-subnet activity summary for one account (hotkey or coldkey): chain-event aggregates joined to current registrations, served live from D1 at /api/v1/accounts/{ss58} (no static file).",
       "id": "account-summary",
       "path": "/metagraph/accounts/{ss58}.json",
@@ -560,7 +560,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events (no static file).",
       "id": "account-events",
       "path": "/metagraph/accounts/{ss58}/events.json",
@@ -569,7 +569,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Durable per-day activity series for one account (hotkey-keyed, newest day first), served live from the account_events_daily rollup at /api/v1/accounts/{ss58}/history (no static file).",
       "id": "account-history",
       "path": "/metagraph/accounts/{ss58}/history.json",
@@ -578,7 +578,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Paginated extrinsics this account signed (by signer), newest first, served live from the extrinsics D1 tier at /api/v1/accounts/{ss58}/extrinsics (no static file).",
       "id": "account-extrinsics",
       "path": "/metagraph/accounts/{ss58}/extrinsics.json",
@@ -587,7 +587,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers (no static file).",
       "id": "account-transfers",
       "path": "/metagraph/accounts/{ss58}/transfers.json",
@@ -596,7 +596,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Per-counterparty fund-flow rollup for one account, with optional ?counterparty=<ss58> relationship evidence — native-TAO transfers from the account_events D1 tier at /api/v1/accounts/{ss58}/counterparties (no static file).",
       "id": "account-counterparties",
       "path": "/metagraph/accounts/{ss58}/counterparties.json",
@@ -605,7 +605,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "The subnets where an account's hotkey is currently registered, served live from the neurons D1 tier at /api/v1/accounts/{ss58}/subnets (no static file).",
       "id": "account-subnets",
       "path": "/metagraph/accounts/{ss58}/subnets.json",
@@ -614,7 +614,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Live TAO balance (free+reserved, in TAO) for a finney account, queried from the RPC at request time with 60s KV cache. balance_tao is null on RPC failure. (#1818)",
       "id": "account-balance",
       "path": "/metagraph/accounts/{ss58}/balance.json",
@@ -623,7 +623,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "The recent-block feed (newest first) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks (no static file).",
       "id": "blocks-feed",
       "path": "/metagraph/blocks.json",
@@ -632,7 +632,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks/{ref} (no static file).",
       "id": "block-detail",
       "path": "/metagraph/blocks/{ref}.json",
@@ -641,7 +641,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "The extrinsics in one block (by numeric block_number or 0x block_hash), in natural order, served live from the first-party extrinsics D1 tier at /api/v1/blocks/{ref}/extrinsics (no static file).",
       "id": "block-extrinsics",
       "path": "/metagraph/blocks/{ref}/extrinsics.json",
@@ -650,7 +650,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "The decoded chain events in one block (by numeric block_number or 0x block_hash), in natural order, served live from the first-party account_events D1 tier filtered by block_number at /api/v1/blocks/{ref}/events (no static file).",
       "id": "block-events",
       "path": "/metagraph/blocks/{ref}/events.json",
@@ -659,7 +659,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events (no static file). Distinct from the curated account-attributed event stream; empty before the all-events backfill runs.",
       "id": "chain-events-feed",
       "path": "/metagraph/chain-events.json",
@@ -668,7 +668,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Every raw pallet-level event in one block (event_index ascending) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/blocks/{ref}/chain-events (no static file). Distinct from /blocks/{ref}/events (the curated account-attributed D1 stream).",
       "id": "block-chain-events",
       "path": "/metagraph/blocks/{ref}/chain-events.json",
@@ -677,7 +677,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Chain-activity aggregate (pallet.method event distribution over the most recent N blocks) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events/stats (no static file) and consumed by the get_chain_activity MCP tool.",
       "id": "chain-events-stats",
       "path": "/metagraph/chain-events/stats.json",
@@ -686,7 +686,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "The recent-extrinsic feed (newest first) for the block explorer (#1345), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics (no static file).",
       "id": "extrinsics-feed",
       "path": "/metagraph/extrinsics.json",
@@ -695,7 +695,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics/{hash} (no static file).",
       "id": "extrinsic-detail",
       "path": "/metagraph/extrinsics/{hash}.json",
@@ -704,7 +704,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Daily network-activity aggregates (extrinsic/event/block counts, success rate, unique signers) over a 7d or 30d window for the block explorer (#1987), computed live from the first-party chain D1 tiers at /api/v1/chain/activity (no static file).",
       "id": "chain-activity",
       "path": "/metagraph/chain/activity.json",
@@ -713,7 +713,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Extrinsic call-mix breakdown (count + share per call_module / call_function) over a 7d or 30d window for the block explorer (#1989), computed live from the first-party extrinsics D1 tier at /api/v1/chain/calls (no static file).",
       "id": "chain-calls",
       "path": "/metagraph/chain/calls.json",
@@ -722,7 +722,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Windowed most-active-account leaderboard (signers ranked by extrinsic count, with fees/tips + newest block) over a 7d or 30d window for the block explorer (#1990), computed live from the first-party extrinsics D1 tier at /api/v1/chain/signers (no static file).",
       "id": "chain-signers",
       "path": "/metagraph/chain/signers.json",
@@ -731,7 +731,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Fee/tip market analytics (daily totals + averages and a top-fee-payer list) over a 7d or 30d window for the block explorer (#1988), computed live from the first-party extrinsics D1 tier at /api/v1/chain/fees (no static file).",
       "id": "chain-fees",
       "path": "/metagraph/chain/fees.json",
@@ -740,7 +740,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Long-term daily uptime history per operational surface for one subnet (90d/1y window), served live from the surface_uptime_daily D1 rollup (no static file).",
       "id": "subnet-uptime",
       "path": "/metagraph/subnets/{netuid}/uptime.json",
@@ -749,7 +749,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window, served live from D1 at /api/v1/incidents (no static file).",
       "id": "global-incidents",
       "path": "/metagraph/incidents.json",
@@ -758,7 +758,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Registry leaderboards — operational (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable) and economic opportunity (open-slots, cheapest-registration, highest-emission, validator-headroom) — computed live from D1 + registry projections + the economics tier at /api/v1/registry/leaderboards (no static file).",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",
@@ -767,7 +767,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Cross-subnet comparison — registry structure (completeness + surface counts), the live economics tier, and the live per-subnet health rollup placed side by side for the requested netuids in requested order — computed live from registry projections + the economics tier + D1 at /api/v1/compare (no static file).",
       "id": "compare",
       "path": "/metagraph/compare.json",
@@ -776,7 +776,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets) over a 7d/30d window, computed live from the rpc_proxy_events telemetry at /api/v1/rpc/usage (no static file).",
       "id": "rpc-usage",
       "path": "/metagraph/rpc/usage.json",
@@ -785,7 +785,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Bittensor base-layer RPC endpoint registry and probe status.",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
@@ -794,7 +794,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Endpoint pool scoring for future read-only RPC routing.",
       "id": "rpc-pools",
       "path": "/metagraph/rpc/pools.json",
@@ -803,7 +803,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Generalized endpoint pool scoring for future read-only routing.",
       "id": "endpoint-pools",
       "path": "/metagraph/endpoint-pools.json",
@@ -812,7 +812,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Probe-derived endpoint incident summary and active endpoint failures.",
       "id": "endpoint-incidents",
       "path": "/metagraph/endpoint-incidents.json",
@@ -821,7 +821,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Operational surfaces (RPC/WSS/subnet-api/SSE/data-artifact) probed live by the cron health prober; input list for the 15-minute scheduled prober.",
       "id": "operational-surfaces",
       "path": "/metagraph/operational-surfaces.json",
@@ -830,7 +830,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Compact index of subnets exposing callable services (subnet-api/openapi/sse/data-artifact) — the machine-readable 'which subnet does X + how to call it' index for AI agents.",
       "id": "agent-catalog",
       "path": "/metagraph/agent-catalog.json",
@@ -839,7 +839,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Per-subnet agent capability catalog: each callable service with its base URL, auth, machine-readable schema, and live-build health/eligibility.",
       "id": "agent-catalog-subnet",
       "path": "/metagraph/agent-catalog/{netuid}.json",
@@ -848,7 +848,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "OpenAPI schema snapshot/drift status.",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",
@@ -857,7 +857,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Index of captured machine-readable schemas.",
       "id": "schema-index",
       "path": "/metagraph/schemas/index.json",
@@ -866,7 +866,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Captured machine-readable OpenAPI/Swagger schema snapshot detail.",
       "id": "schema-snapshot",
       "path": "/metagraph/schemas/{surface_id}.json",
@@ -875,7 +875,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Adapter-backed public metrics by subnet slug.",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",
@@ -884,7 +884,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "R2 upload manifest for generated artifact history.",
       "id": "r2-manifest",
       "path": "/metagraph/r2-manifest.json",
@@ -893,7 +893,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Maintainer curation and adapter candidate report.",
       "id": "review-curation",
       "path": "/metagraph/review/curation.json",
@@ -902,7 +902,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Subnet interface gap priorities.",
       "id": "review-gap-priorities",
       "path": "/metagraph/review/gap-priorities.json",
@@ -911,7 +911,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Interface gap priorities and enrichment queue for one subnet.",
       "id": "subnet-gaps",
       "path": "/metagraph/review/gaps/{netuid}.json",
@@ -920,7 +920,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Profile completeness and contributor targeting report.",
       "id": "review-profile-completeness",
       "path": "/metagraph/review/profile-completeness.json",
@@ -929,7 +929,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Subnets worth deeper adapter work.",
       "id": "review-adapter-candidates",
       "path": "/metagraph/review/adapter-candidates.json",
@@ -938,7 +938,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Prioritized all-subnet enrichment work queue for contributor-safe registry improvements.",
       "id": "review-enrichment-queue",
       "path": "/metagraph/review/enrichment-queue.json",
@@ -947,7 +947,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Detailed candidate evidence by missing or contributor-target surface kind for enrichment work.",
       "id": "review-enrichment-evidence",
       "path": "/metagraph/review/enrichment-evidence.json",
@@ -956,7 +956,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Contributor-oriented enrichment target pack grouped by submission kind, review route, and evidence action.",
       "id": "review-enrichment-targets",
       "path": "/metagraph/review/enrichment-targets.json",
@@ -965,7 +965,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Public-safe maintainer review decision ledger.",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
@@ -974,7 +974,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.4",
+      "contract_version": "2026-06-30.5",
       "description": "Generated build summary.",
       "id": "build-summary",
       "path": "/metagraph/build-summary.json",
@@ -983,7 +983,7 @@
     }
   ],
   "base_path": "/metagraph",
-  "contract_version": "2026-06-30.4",
+  "contract_version": "2026-06-30.5",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "name": "Metagraphed public backend artifact contract",
   "notes": [

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -2613,7 +2613,7 @@
       },
       "ChainCallsArtifact": {
         "additionalProperties": true,
-        "description": "Extrinsic call-mix breakdown (#1989) over a 7d/30d window: each call_module (or call_module/call_function with group_by=module_function) by count and share of all extrinsics. Served live from the extrinsics D1 tier at /api/v1/chain/calls (no static file); call_count is 0 and calls is empty when the store is cold.",
+        "description": "Extrinsic call-mix breakdown (#1989) over a 7d/30d window: each call_module (or call_module/call_function with group_by=module_function) by count and share of all extrinsics, or of the selected call_module when ?call_module= is supplied. Served live from the extrinsics D1 tier at /api/v1/chain/calls (no static file); call_count is 0 and calls is empty when the store is cold.",
         "properties": {
           "call_count": {
             "minimum": 0,
@@ -14393,7 +14393,7 @@
   "info": {
     "description": "Public, read-only API over canonical Metagraphed registry artifacts for Bittensor subnet interfaces. **No authentication** — every operation is an unauthenticated GET. Responses use a stable JSON envelope `{ ok, schema_version, data, meta }` (errors: `{ ok: false, error }`) and carry `ETag` + `Cache-Control` for conditional caching. Rate-limited per client. Multi-network: insert a `/{network}/` segment after `/api/v1/` (mainnet is the default — omit it) to read testnet data, e.g. `/api/v1/testnet/subnets`. Testnet exposes the subset of routes that have data; `/api/v1/lineage` tracks which testnet subnets have graduated.",
     "title": "Metagraphed API",
-    "version": "2026-06-30.4"
+    "version": "2026-06-30.5"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -18242,6 +18242,15 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "in": "query",
+            "name": "call_module",
+            "required": false,
+            "schema": {
+              "maxLength": 100,
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -18364,7 +18373,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the extrinsic call-mix breakdown (count + share per call_module, or call_module/call_function with group_by=module_function) over a 7d or 30d window, ordered by count. Computed live from the first-party extrinsics D1 tier (#1989); schema-stable call_count:0/calls:[] when cold.",
+        "summary": "Fetch the extrinsic call-mix breakdown (count + share per call_module, or call_module/call_function with group_by=module_function) over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. When scoped, total_extrinsics and share use the scoped module denominator. Computed live from the first-party extrinsics D1 tier (#1989); schema-stable call_count:0/calls:[] when cold.",
         "tags": [
           "chain",
           "analytics"
@@ -33939,7 +33948,7 @@
   ],
   "x-metagraphed": {
     "canonical_artifact_base_path": "/metagraph",
-    "contract_version": "2026-06-30.4",
+    "contract_version": "2026-06-30.5",
     "generated_at": "1970-01-01T00:00:00.000Z",
     "notes": "OpenAPI describes Worker response envelopes and canonical artifact payloads. Raw /metagraph JSON remains the reviewed source contract.",
     "schema_version": 1

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -402,7 +402,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the extrinsic call-mix breakdown (count + share per call_module, or call_module/call_function with group_by=module_function) over a 7d or 30d window, ordered by count. Computed live from the first-party extrinsics D1 tier (#1989); schema-stable call_count:0/calls:[] when cold. */
+        /** Fetch the extrinsic call-mix breakdown (count + share per call_module, or call_module/call_function with group_by=module_function) over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. When scoped, total_extrinsics and share use the scoped module denominator. Computed live from the first-party extrinsics D1 tier (#1989); schema-stable call_count:0/calls:[] when cold. */
         get: operations["chainCalls"];
         put?: never;
         post?: never;
@@ -2293,7 +2293,7 @@ export interface components {
             count: number;
             share: number | null;
         };
-        /** @description Extrinsic call-mix breakdown (#1989) over a 7d/30d window: each call_module (or call_module/call_function with group_by=module_function) by count and share of all extrinsics. Served live from the extrinsics D1 tier at /api/v1/chain/calls (no static file); call_count is 0 and calls is empty when the store is cold. */
+        /** @description Extrinsic call-mix breakdown (#1989) over a 7d/30d window: each call_module (or call_module/call_function with group_by=module_function) by count and share of all extrinsics, or of the selected call_module when ?call_module= is supplied. Served live from the extrinsics D1 tier at /api/v1/chain/calls (no static file); call_count is 0 and calls is empty when the store is cold. */
         ChainCallsArtifact: {
             call_count: number;
             calls: components["schemas"]["ChainCallEntry"][];
@@ -7977,6 +7977,7 @@ export interface operations {
                 window?: "7d" | "30d";
                 group_by?: "module" | "module_function";
                 limit?: number;
+                call_module?: string;
             };
             header?: never;
             path?: never;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -2599,7 +2599,7 @@
       },
       "ChainCallsArtifact": {
         "additionalProperties": true,
-        "description": "Extrinsic call-mix breakdown (#1989) over a 7d/30d window: each call_module (or call_module/call_function with group_by=module_function) by count and share of all extrinsics. Served live from the extrinsics D1 tier at /api/v1/chain/calls (no static file); call_count is 0 and calls is empty when the store is cold.",
+        "description": "Extrinsic call-mix breakdown (#1989) over a 7d/30d window: each call_module (or call_module/call_function with group_by=module_function) by count and share of all extrinsics, or of the selected call_module when ?call_module= is supplied. Served live from the extrinsics D1 tier at /api/v1/chain/calls (no static file); call_count is 0 and calls is empty when the store is cold.",
         "properties": {
           "call_count": {
             "minimum": 0,

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -2001,7 +2001,7 @@
       "ChainCallsArtifact": {
         "type": "object",
         "additionalProperties": true,
-        "description": "Extrinsic call-mix breakdown (#1989) over a 7d/30d window: each call_module (or call_module/call_function with group_by=module_function) by count and share of all extrinsics. Served live from the extrinsics D1 tier at /api/v1/chain/calls (no static file); call_count is 0 and calls is empty when the store is cold.",
+        "description": "Extrinsic call-mix breakdown (#1989) over a 7d/30d window: each call_module (or call_module/call_function with group_by=module_function) by count and share of all extrinsics, or of the selected call_module when ?call_module= is supplied. Served live from the extrinsics D1 tier at /api/v1/chain/calls (no static file); call_count is 0 and calls is empty when the store is cold.",
         "required": [
           "schema_version",
           "window",

--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -393,6 +393,7 @@ export async function loadChainCalls(
   {
     window = "7d",
     groupBy = "module",
+    callModule = null,
     limit = 50,
     observedAt = null,
     now = Date.now(),
@@ -409,19 +410,23 @@ export async function loadChainCalls(
     groupBy === "module_function"
       ? "call_module, call_function"
       : "call_module";
+  const callModuleFilter =
+    typeof callModule === "string" && callModule.length > 0 ? callModule : null;
+  const moduleClause = callModuleFilter ? " AND call_module = ?" : "";
   const [rows, totalRows] = await Promise.all([
     d1(
       `SELECT ${selectCols}, COUNT(*) AS count
        FROM extrinsics
-       WHERE observed_at >= ? AND call_module IS NOT NULL
+       WHERE observed_at >= ? AND call_module IS NOT NULL${moduleClause}
        GROUP BY ${groupCols}
        ORDER BY count DESC
        LIMIT ?`,
-      [cutoff, limit],
+      callModuleFilter ? [cutoff, callModuleFilter, limit] : [cutoff, limit],
     ),
-    d1(`SELECT COUNT(*) AS total FROM extrinsics WHERE observed_at >= ?`, [
-      cutoff,
-    ]),
+    d1(
+      `SELECT COUNT(*) AS total FROM extrinsics WHERE observed_at >= ?${moduleClause}`,
+      callModuleFilter ? [cutoff, callModuleFilter] : [cutoff],
+    ),
   ]);
   return buildChainCalls({
     window: windowLabel,

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2,7 +2,7 @@ import { artifactStorageTierForPath } from "./artifact-storage.mjs";
 import { DOMAIN_TAGS } from "./domain-tags.mjs";
 import { sampleFromSchema } from "./openapi-sample.mjs";
 
-export const CONTRACT_VERSION = "2026-06-30.4";
+export const CONTRACT_VERSION = "2026-06-30.5";
 export const SCHEMA_VERSION = 1;
 // The API + artifacts are served from the api subdomain; the bare apex
 // (metagraph.sh) is the metagraphed-ui UI. PRIMARY_DOMAIN drives the OpenAPI
@@ -2119,7 +2119,7 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/chain/calls",
     "/metagraph/chain/calls.json",
-    "Fetch the extrinsic call-mix breakdown (count + share per call_module, or call_module/call_function with group_by=module_function) over a 7d or 30d window, ordered by count. Computed live from the first-party extrinsics D1 tier (#1989); schema-stable call_count:0/calls:[] when cold.",
+    "Fetch the extrinsic call-mix breakdown (count + share per call_module, or call_module/call_function with group_by=module_function) over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. When scoped, total_extrinsics and share use the scoped module denominator. Computed live from the first-party extrinsics D1 tier (#1989); schema-stable call_count:0/calls:[] when cold.",
     "short",
     ["chain", "analytics"],
     [
@@ -2129,6 +2129,7 @@ export const API_ROUTES = [
         schema: { type: "string", enum: ["module", "module_function"] },
       },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
+      { name: "call_module", schema: { type: "string", maxLength: 100 } },
     ],
     [],
   ),

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -446,6 +446,39 @@ describe("analytics-live loaders", () => {
     assert.equal(data.calls[0].call_function, "add_stake");
   });
 
+  test("loadChainCalls scopes grouped rows and totals by call_module", async () => {
+    const captured = [];
+    const run = async (sql, params) => {
+      captured.push({ sql, params });
+      if (/GROUP BY call_module, call_function/.test(sql)) {
+        return [
+          {
+            call_module: "SubtensorModule",
+            call_function: "add_stake",
+            count: 50,
+          },
+        ];
+      }
+      if (/COUNT\(\*\) AS total/.test(sql)) return [{ total: 80 }];
+      return [];
+    };
+    const data = await loadChainCalls(run, {
+      window: "7d",
+      groupBy: "module_function",
+      callModule: "SubtensorModule",
+      limit: 3,
+      observedAt: OBSERVED_AT,
+      now: Date.UTC(2026, 5, 26),
+    });
+
+    assert.match(captured[0].sql, /AND call_module = \?/);
+    assert.match(captured[1].sql, /AND call_module = \?/);
+    assert.deepEqual(captured[0].params.slice(1), ["SubtensorModule", 3]);
+    assert.deepEqual(captured[1].params.slice(1), ["SubtensorModule"]);
+    assert.equal(data.total_extrinsics, 80);
+    assert.equal(data.calls[0].share, 0.625);
+  });
+
   test("loadChainCalls falls back to 7d for an unknown window label", async () => {
     const data = await loadChainCalls(d1(), {
       window: "90d",

--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -362,13 +362,65 @@ test("GET /api/v1/chain/calls groups by call_module with honest share + 400 on j
   assert.equal(bad.status, 400);
 });
 
+test("GET /api/v1/chain/calls scopes module-function groups by call_module", async () => {
+  const captured = [];
+  const env = {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind(...params) {
+            captured.push({ sql, params });
+            const rows = /GROUP BY call_module, call_function/.test(sql)
+              ? [
+                  {
+                    call_module: "SubtensorModule",
+                    call_function: "add_stake",
+                    count: 50,
+                  },
+                ]
+              : /COUNT\(\*\) AS total/.test(sql)
+                ? [{ total: 80 }]
+                : [];
+            return { all: () => Promise.resolve({ results: rows }) };
+          },
+        };
+      },
+    },
+  };
+  const res = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/chain/calls?call_module=SubtensorModule&group_by=module_function&limit=1",
+    ),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.group_by, "module_function");
+  assert.equal(body.data.total_extrinsics, 80);
+  assert.equal(body.data.calls[0].call_function, "add_stake");
+  assert.equal(body.data.calls[0].share, 0.625);
+
+  const extrinsicsQueries = captured.filter((q) =>
+    /FROM extrinsics/.test(q.sql),
+  );
+  assert.equal(extrinsicsQueries.length, 2);
+  for (const q of extrinsicsQueries) {
+    assert.match(q.sql, /AND call_module = \?/);
+    assert.ok(q.params.includes("SubtensorModule"));
+  }
+});
+
 test("GET /api/v1/chain/calls rejects inert group_by and non-canonical limits", async () => {
   const env = createLocalArtifactEnv();
+  const long = "x".repeat(101);
   for (const [path, parameter] of [
     ["/api/v1/chain/calls?group_by=x1", "group_by"],
     ["/api/v1/chain/calls?limit=abc1", "limit"],
     ["/api/v1/chain/calls?limit=001", "limit"],
     ["/api/v1/chain/calls?limit=999999", "limit"],
+    [`/api/v1/chain/calls?call_module=${long}`, "call_module"],
   ]) {
     const res = await handleRequest(
       new Request(`https://api.metagraph.sh${path}`),

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -19,7 +19,7 @@ import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
 
 describe("public contract registry", () => {
   test("keeps API routes and artifacts unique", () => {
-    assert.equal(CONTRACT_VERSION, "2026-06-30.4");
+    assert.equal(CONTRACT_VERSION, "2026-06-30.5");
     assert.equal(CACHE_SECONDS.short, 60);
     assert.equal(
       new Set(API_ROUTES.map((route) => route.id)).size,

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -348,6 +348,21 @@ describe("canonicalAnalyticsCacheRoute", () => {
       canonicalAnalyticsCacheRoute(plain, ["limit", "call_module"]),
     );
   });
+
+  test("includes the chain calls grouping and module filter in canonical order", () => {
+    const requestUrl = url(
+      "/api/v1/chain/calls?call_module=SubtensorModule&limit=10&group_by=module_function&window=30d",
+    );
+
+    assert.equal(
+      canonicalAnalyticsCacheRoute(requestUrl, [
+        "group_by",
+        "limit",
+        "call_module",
+      ]),
+      "/api/v1/chain/calls?window=30d&group_by=module_function&limit=10&call_module=SubtensorModule",
+    );
+  });
 });
 
 describe("canonicalHealthWindowCachePath", () => {

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -803,7 +803,11 @@ export async function handleChainActivity(request, env, url, ctx = {}) {
 // call_module/call_function). The share denominator is the full-window extrinsic
 // count read separately, so the truncated LIMIT tail never skews shares.
 export async function handleChainCalls(request, env, url, ctx = {}) {
-  const { label, error } = analyticsWindow(url, ["group_by", "limit"]);
+  const { label, error } = analyticsWindow(url, [
+    "group_by",
+    "limit",
+    "call_module",
+  ]);
   if (error) return analyticsQueryError(error);
   const groupByError = validateEnumParam(url, "group_by", [
     "module",
@@ -816,34 +820,45 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
   });
   if (limitError) return analyticsQueryError(limitError);
   const groupBy = url.searchParams.get("group_by") || "module";
-  return withEdgeCache(request, ctx, env, "chain-calls", async () => {
-    let usedFallback = false;
-    const d1 = async (sql, params) => {
-      const rows = await d1All(env, sql, params);
-      if (hasD1FallbackRows(rows)) usedFallback = true;
-      return rows;
-    };
-    const meta = await readHealthMetaKv(env);
-    const data = await loadChainCalls(d1, {
-      window: label,
-      groupBy,
-      limit,
-      observedAt: meta?.last_run_at || null,
-    });
-    const response = await envelopeResponse(
-      request,
-      {
-        data,
-        meta: await analyticsMeta(
-          env,
-          "/metagraph/chain/calls.json",
-          data.observed_at,
-        ),
-      },
-      "short",
-    );
-    return usedFallback ? markD1FallbackResponse(response) : response;
-  });
+  const callModule = url.searchParams.get("call_module");
+  const callModuleError = validateMaxLength(url, "call_module", 100);
+  if (callModuleError) return analyticsQueryError(callModuleError);
+  return withEdgeCache(
+    request,
+    ctx,
+    env,
+    "chain-calls",
+    async () => {
+      let usedFallback = false;
+      const d1 = async (sql, params) => {
+        const rows = await d1All(env, sql, params);
+        if (hasD1FallbackRows(rows)) usedFallback = true;
+        return rows;
+      };
+      const meta = await readHealthMetaKv(env);
+      const data = await loadChainCalls(d1, {
+        window: label,
+        groupBy,
+        callModule,
+        limit,
+        observedAt: meta?.last_run_at || null,
+      });
+      const response = await envelopeResponse(
+        request,
+        {
+          data,
+          meta: await analyticsMeta(
+            env,
+            "/metagraph/chain/calls.json",
+            data.observed_at,
+          ),
+        },
+        "short",
+      );
+      return usedFallback ? markD1FallbackResponse(response) : response;
+    },
+    canonicalAnalyticsCacheRoute(url, ["group_by", "limit", "call_module"]),
+  );
 }
 
 // Windowed most-active-account leaderboard (#1990): signers ranked by extrinsic


### PR DESCRIPTION
## Summary
Adds a module-scoped drilldown to `GET /api/v1/chain/calls` so explorer clients can request the busiest calls/functions inside a selected pallet with `?call_module=`.

Closes #2419

## What changed
- Added optional `call_module` support to the chain calls live loader and Worker handler.
- Scoped both grouped rows and the `total_extrinsics`/`share` denominator when the filter is present.
- Canonicalized the edge-cache key for the new filter alongside `window`, `group_by`, and `limit`.
- Updated the public schema/contract/OpenAPI/type artifacts and bumped the contract version.
- Added focused loader, route, validation, and cache-key coverage.

## Why
The aggregate call mix is useful for spotting busy pallets, but explorer clients also need a tight way to rank the specific calls within one pallet without fetching the broader extrinsic feed and grouping client-side.

## Validation
- `npm run build`
- `npm exec vitest -- run tests/analytics-live.test.mjs tests/chain-analytics.test.mjs tests/request-handlers-analytics.test.mjs tests/contracts.test.mjs`
- `npm run lint`
- `npm run format:check`
- `npm run validate`
- `npm run validate:contract-drift`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:generated-client`
- `npm run validate:openapi-examples`
- `npm run test:coverage` — 140 test files, 3505 tests, 99.22% line coverage
- `cd python && uv run --extra test python -m unittest discover -s tests` — 37 tests, 1 skipped
- `git diff --check`

## Notes
- `npm run pipeline:check` was attempted, but stopped while `sync:subnets:dry-run` was blocked in the external testnet native-subnet fetch; the build, contract validators, lint/format, coverage suite, Python suite, and focused route tests completed successfully.