### PR TITLE
feat(feeds): add ?until= ISO-8601 upper bound for feed item filtering

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -23,6 +23,10 @@
 // Optional `?since=<ISO-8601>` returns only items at or after that instant
 // (e.g. ?since=2026-06-01 or ?since=2026-06-01T00:00:00Z), for incremental
 // polling; it composes with `?tag=`. A malformed `since` is a 400.
+//
+// Optional `?until=<ISO-8601>` returns only items at or before that instant
+// (same strict parsing as `since`) and composes with `?since=` and `?tag=` to
+// page a bounded window; a malformed `until` is a 400.
 
 import {
   EXPOSED_RESPONSE_HEADERS_VALUE,
@@ -319,6 +323,17 @@ function filterSince(items, sinceMs) {
   });
 }
 
+// Optional `?until=` filter: keep only items at or before `untilMs` (epoch ms).
+// A null bound (absent param) is a no-op; items whose timestamp can't be parsed
+// are dropped, so a malformed feed entry never leaks past an explicit `until`.
+function filterUntil(items, untilMs) {
+  if (untilMs == null) return items;
+  return items.filter((item) => {
+    const t = Date.parse(item.timestamp);
+    return !Number.isNaN(t) && t <= untilMs;
+  });
+}
+
 function jsonFeed(meta, items) {
   return `${JSON.stringify(
     {
@@ -553,6 +568,21 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
     }
   }
 
+  // Optional `?until=` upper bound (same strict ISO-8601 contract as `since`),
+  // parsed up front so a malformed value is rejected before any artifact work.
+  let untilMs = null;
+  const untilParam = url.searchParams.get("until");
+  if (untilParam != null) {
+    untilMs = parseSinceParam(untilParam);
+    if (Number.isNaN(untilMs)) {
+      return fail(
+        "invalid_until",
+        "`until` must be an ISO-8601 date or date-time, e.g. 2026-06-30 or 2026-06-30T00:00:00Z.",
+        400,
+      );
+    }
+  }
+
   let items;
   let title;
   let description;
@@ -606,6 +636,7 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
 
   items = filterByTag(items, url.searchParams.get("tag"));
   items = filterSince(items, sinceMs);
+  items = filterUntil(items, untilMs);
   items = sortAndCap(items);
   const meta = {
     title,
@@ -667,5 +698,6 @@ export const __test = {
   escapeXml,
   filterByTag,
   filterSince,
+  filterUntil,
   parseSinceParam,
 };

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -48,6 +48,7 @@ const {
   escapeXml,
   filterByTag,
   filterSince,
+  filterUntil,
   parseSinceParam,
 } = __test;
 
@@ -477,6 +478,34 @@ describe("feeds — filterSince", () => {
   });
 });
 
+describe("feeds — filterUntil", () => {
+  const items = [
+    { id: "old", timestamp: "2026-06-10T00:00:00.000Z" },
+    { id: "new", timestamp: "2026-06-20T00:00:00.000Z" },
+    { id: "bad", timestamp: "not-a-date" },
+  ];
+
+  test("a null bound is a no-op (returns the input)", () => {
+    assert.equal(filterUntil(items, null), items);
+  });
+
+  test("keeps items at or before the bound; drops unparseable timestamps", () => {
+    const kept = filterUntil(items, Date.parse("2026-06-15T00:00:00.000Z"));
+    assert.deepEqual(
+      kept.map((i) => i.id),
+      ["old"],
+    );
+  });
+
+  test("is inclusive of the exact bound", () => {
+    const kept = filterUntil(items, Date.parse("2026-06-10T00:00:00.000Z"));
+    assert.deepEqual(
+      kept.map((i) => i.id),
+      ["old"],
+    );
+  });
+});
+
 describe("feeds — ?since= filter", () => {
   test("a future since yields an empty but valid feed (200)", async () => {
     const { res, text } = await feed(
@@ -505,6 +534,48 @@ describe("feeds — ?since= filter", () => {
     ]) {
       const { res } = await feed(
         `/api/v1/feeds/registry.json?since=${encodeURIComponent(value)}`,
+      );
+      assert.equal(res.status, 400, value);
+    }
+  });
+});
+
+describe("feeds — ?until= filter", () => {
+  test("a past until yields an empty but valid feed (200)", async () => {
+    const { res, text } = await feed(
+      "/api/v1/feeds/registry.json?until=2000-01-01",
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(JSON.parse(text).items, []);
+  });
+
+  test("a future until keeps items and composes with ?since= and ?tag=", async () => {
+    const { res, text } = await feed(
+      "/api/v1/feeds/registry.json?since=2000-01-01&until=2099-01-01&tag=registry",
+    );
+    assert.equal(res.status, 200);
+    const items = JSON.parse(text).items;
+    assert.ok(items.length > 0);
+    assert.ok(items.every((it) => (it.tags || []).includes("registry")));
+  });
+
+  test("a since/until window excludes items outside the bounds", async () => {
+    const { res, text } = await feed(
+      "/api/v1/feeds/registry.json?since=2000-01-01&until=2000-01-02",
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(JSON.parse(text).items, []);
+  });
+
+  test("a malformed until is rejected with 400", async () => {
+    for (const value of [
+      "notadate",
+      "1",
+      "2026-02-31",
+      "Tue, 01 Jun 2026 00:00:00 GMT",
+    ]) {
+      const { res } = await feed(
+        `/api/v1/feeds/registry.json?until=${encodeURIComponent(value)}`,
       );
       assert.equal(res.status, 400, value);
     }
@@ -1062,6 +1133,82 @@ describe("feeds — Worker dispatch integration", () => {
     assert.equal(
       invalid.headers.get("x-metagraph-error-code"),
       "invalid_since",
+    );
+  });
+
+  test("handleRequest keys edge-cached feeds by until", async () => {
+    installMockCache();
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind() {
+              return {
+                all: () => {
+                  if (sql.includes("recent_checks")) {
+                    return Promise.resolve({
+                      results: [
+                        {
+                          netuid: 7,
+                          surface_id: "allways-api",
+                          surface_key: "allways-api",
+                          started_at: 1781266255266,
+                          ended_at: 1781499480737,
+                          failed_samples: 1945,
+                        },
+                      ],
+                    });
+                  }
+                  return Promise.resolve({ results: [] });
+                },
+              };
+            },
+          };
+        },
+      },
+      METAGRAPH_CONTROL: {
+        async get(key) {
+          if (key === "health:meta") {
+            return { last_run_at: "2026-06-15T00:00:00.000Z" };
+          }
+          return null;
+        },
+      },
+    };
+    const ctx = { waitUntil: (promise) => promise };
+
+    // A past `until` excludes every item. If the edge-cache key ignored
+    // `until`, the later unfiltered request would be served this empty body.
+    const past = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/feeds/incidents.json?until=2000-01-01",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(past.status, 200);
+    assert.deepEqual((await past.json()).items, []);
+
+    const unfiltered = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/feeds/incidents.json"),
+      env,
+      ctx,
+    );
+    assert.equal(unfiltered.status, 200);
+    assert.ok((await unfiltered.json()).items.length > 0);
+
+    const invalid = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/feeds/incidents.json?until=notadate",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(invalid.status, 400);
+    assert.equal(
+      invalid.headers.get("x-metagraph-error-code"),
+      "invalid_until",
     );
   });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1011,6 +1011,10 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     if (since != null) {
       feedCacheParams.push(`since=${encodeURIComponent(since)}`);
     }
+    const until = url.searchParams.get("until");
+    if (until != null) {
+      feedCacheParams.push(`until=${encodeURIComponent(until)}`);
+    }
     const feedCachePath = `${url.pathname}?${feedCacheParams.join("&")}`;
     const feedRequest =
       request.method === "HEAD"


### PR DESCRIPTION
## Summary

- Adds an optional `?until=<ISO-8601>` upper bound to the feed endpoints — the symmetric counterpart to the existing `?since=` lower bound — so clients can request a bounded time window (`?since=…&until=…`) for incremental polling and backfill. Closes #2411.

## What Changed

- `src/feeds.mjs`
  - New `filterUntil(items, untilMs)` helper, a mirror of `filterSince` (keeps items at or before the bound; drops unparseable timestamps).
  - Parses/validates `until` up front using the existing strict `parseSinceParam`, returning a `400 invalid_until` on malformed input (same contract and error envelope as `since`).
  - Applies `filterUntil` in the filter pipeline after `filterSince`, so `?since=` and `?until=` compose into a window.
  - Exports `filterUntil` from `__test` and extends the module header doc comment.
- `workers/api.mjs`
  - Includes `until` in the feeds edge-cache key, so different `until` values never collide in the edge cache (parity with the existing `since` handling).
- `tests/feeds.test.mjs`
  - Adds `filterUntil` unit tests, `?until=` integration tests (past → empty 200, future + composition with `?since=`/`?tag=`, a `since`/`until` window, malformed → 400), and an edge-cache-key test mirroring the existing `since` coverage.

The change is intentionally a structural mirror of the already-tested `?since=` path; no public schema/OpenAPI changes (feeds are computed live at request time, not part of the committed contract).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (No generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — feeds are computed live and `?since=` is likewise documented only via inline comments.)

## Validation

> Note: this was prepared in an environment without a Node toolchain, so I could not execute the suite locally. The new tests mirror the existing, passing `?since=` suite one-for-one. Please run CI / the commands below.

- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`
