### PR TITLE
feat(mcp): add get_economics_trends tool (REST parity)

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -314,6 +314,11 @@ assert.ok(
   Array.isArray(traj.points),
   "get_subnet_trajectory must return points[]",
 );
+const econTrends = await callOk("get_economics_trends", { window: "30d" });
+assert.ok(
+  Array.isArray(econTrends.days),
+  "get_economics_trends must return days[]",
+);
 const chainCalls = await callOk("get_chain_calls", { window: "7d", limit: 10 });
 assert.ok(
   Array.isArray(chainCalls.calls),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/economics-trends.mjs
+++ b/src/economics-trends.mjs
@@ -1,0 +1,44 @@
+// Network-wide economics trends D1 loader for REST + MCP parity (#1307).
+// Pure orchestration over subnet_snapshots rows + buildEconomicsTrends; REST
+// handlers keep edge-cache + envelope wiring.
+
+import { DAY_MS } from "../workers/config.mjs";
+import {
+  buildEconomicsTrends,
+  DEFAULT_HISTORY_WINDOW,
+  parseHistoryWindow,
+} from "./neuron-history.mjs";
+
+// ~129 subnets × 365 days ≈ 47k rows for `all`; generous but finite.
+export const ECONOMICS_TRENDS_ROW_CAP = 60000;
+
+export function parseEconomicsTrendsWindow(window) {
+  const parsed = parseHistoryWindow(
+    window === undefined || window === null ? DEFAULT_HISTORY_WINDOW : window,
+  );
+  if (parsed.error) return null;
+  return parsed;
+}
+
+export async function loadEconomicsTrends(
+  d1,
+  { windowLabel, windowDays = null, now = Date.now() } = {},
+) {
+  const params = [];
+  let sql =
+    "SELECT snapshot_date, total_stake_tao, alpha_price_tao, " +
+    "validator_count, miner_count, emission_share " +
+    "FROM subnet_snapshots WHERE TRUE";
+  if (windowDays != null) {
+    const cutoff = new Date(now - windowDays * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
+    sql += " AND snapshot_date >= ?";
+    params.push(cutoff);
+  }
+  sql += " ORDER BY snapshot_date DESC LIMIT ?";
+  params.push(ECONOMICS_TRENDS_ROW_CAP);
+  const rows = await d1(sql, params);
+  const data = buildEconomicsTrends(rows, { window: windowLabel });
+  return { data, rows };
+}

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -32,6 +32,10 @@ import {
 import { loadChainSigners } from "./chain-query-loaders.mjs";
 import { loadRpcUsage } from "./rpc-usage-loader.mjs";
 import {
+  loadEconomicsTrends,
+  parseEconomicsTrendsWindow,
+} from "./economics-trends.mjs";
+import {
   loadCounterparties,
   loadCounterpartyRelationship,
 } from "./counterparties.mjs";
@@ -134,7 +138,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.11.0";
+export const MCP_SERVER_VERSION = "1.12.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -188,7 +192,8 @@ export const MCP_INSTRUCTIONS =
   "callable subnets and how_do_i_call returns concrete call instructions " +
   "(base URL, auth, schema, health) for one subnet. For on-chain economics and " +
   "participation, get_subnet_economics returns a subnet's registration cost, " +
-  "open slots, stake, emission split and validator/miner counts, " +
+  "open slots, and alpha price, get_economics_trends the network-wide " +
+  "per-day economics series (stake, alpha price, validator/miner counts), " +
   "get_subnet_trajectory its week-over-week trend, get_subnet_uptime its " +
   "long-term surface uptime history, get_subnet_health_percentiles its " +
   "per-surface p50/p95/p99 request-latency distribution, " +
@@ -1459,6 +1464,41 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
       return loadSubnetTrajectory(mcpD1Runner(ctx), netuid);
+    },
+  },
+  {
+    name: "get_economics_trends",
+    title: "Get network-wide economics trends",
+    description:
+      "Fetch the network-wide economics time series aggregated per UTC day " +
+      "across all subnets: total stake, stake-weighted and median alpha price, " +
+      "total validator and miner counts, and mean emission share. Mirrors " +
+      "GET /api/v1/economics/trends.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: ["7d", "30d", "90d", "1y", "all"],
+          description: "Lookback window (default 30d).",
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const parsed = parseEconomicsTrendsWindow(args?.window);
+      if (args?.window !== undefined && parsed === null) {
+        throw toolError(
+          "invalid_params",
+          "window must be one of: 7d, 30d, 90d, 1y, all.",
+        );
+      }
+      const { label, days } = parsed;
+      const { data } = await loadEconomicsTrends(mcpD1Runner(ctx), {
+        windowLabel: label,
+        windowDays: days,
+      });
+      return data;
     },
   },
   {
@@ -3795,6 +3835,26 @@ const TOOL_OUTPUT_SCHEMAS = {
       point_count: { type: "integer" },
       points: { type: "array", items: { type: "object" } },
       deltas: { type: "object" },
+    },
+  },
+  get_economics_trends: {
+    type: "object",
+    additionalProperties: true,
+    required: ["window", "day_count", "days"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      day_count: { type: "integer" },
+      days: objectItems({
+        snapshot_date: NULLABLE_STRING,
+        subnet_count: NULLABLE_INT,
+        total_stake_tao: { type: ["number", "null"] },
+        alpha_price_tao_weighted: { type: ["number", "null"] },
+        alpha_price_tao_median: { type: ["number", "null"] },
+        validator_count: NULLABLE_INT,
+        miner_count: NULLABLE_INT,
+        mean_emission_share: { type: ["number", "null"] },
+      }),
     },
   },
   get_subnet_concentration: {

--- a/tests/economics-trends-loader.test.mjs
+++ b/tests/economics-trends-loader.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  ECONOMICS_TRENDS_ROW_CAP,
+  loadEconomicsTrends,
+  parseEconomicsTrendsWindow,
+} from "../src/economics-trends.mjs";
+
+describe("parseEconomicsTrendsWindow", () => {
+  test("defaults to 30d when window is omitted", () => {
+    assert.deepEqual(parseEconomicsTrendsWindow(undefined), {
+      label: "30d",
+      days: 30,
+    });
+  });
+
+  test("returns null for an unknown window label", () => {
+    assert.equal(parseEconomicsTrendsWindow("99d"), null);
+  });
+
+  test("accepts all windows without a day bound", () => {
+    assert.deepEqual(parseEconomicsTrendsWindow("all"), {
+      label: "all",
+      days: null,
+    });
+  });
+});
+
+describe("loadEconomicsTrends", () => {
+  test("queries subnet_snapshots and rolls rows through buildEconomicsTrends", async () => {
+    const now = Date.parse("2026-06-25T00:00:00Z");
+    let capturedSql = "";
+    let capturedParams = [];
+    const d1 = async (sql, params) => {
+      capturedSql = sql;
+      capturedParams = params;
+      return [
+        {
+          snapshot_date: "2026-06-10",
+          total_stake_tao: 1000,
+          alpha_price_tao: 0.06,
+          validator_count: 12,
+          miner_count: 200,
+          emission_share: 0.05,
+        },
+      ];
+    };
+    const { data, rows } = await loadEconomicsTrends(d1, {
+      windowLabel: "7d",
+      windowDays: 7,
+      now,
+    });
+    assert.match(capturedSql, /FROM subnet_snapshots/);
+    assert.equal(capturedParams.at(-1), ECONOMICS_TRENDS_ROW_CAP);
+    assert.equal(capturedParams[0], "2026-06-18");
+    assert.equal(rows.length, 1);
+    assert.equal(data.window, "7d");
+    assert.equal(data.day_count, 1);
+    assert.equal(data.days[0].total_stake_tao, 1000);
+  });
+
+  test("omits the date lower bound for the all window", async () => {
+    const d1 = async (sql, params) => {
+      assert.doesNotMatch(sql, /snapshot_date >=/);
+      assert.equal(params.at(-1), ECONOMICS_TRENDS_ROW_CAP);
+      return [];
+    };
+    const { data } = await loadEconomicsTrends(d1, {
+      windowLabel: "all",
+      windowDays: null,
+    });
+    assert.equal(data.window, "all");
+    assert.equal(data.day_count, 0);
+    assert.deepEqual(data.days, []);
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3798,6 +3798,7 @@ describe("MCP economics + metagraph data tools", () => {
     METAGRAPH_HEALTH_DB: metagraphD1({
       neurons: [ROW, MINER],
       snapshots: SNAPSHOTS,
+      growthSamples: SNAPSHOTS,
       surfaceStatus: [
         { netuid: 1, surface_count: 5, ok_count: 4, avg_latency_ms: 100 },
         { netuid: 7, surface_count: 3, ok_count: 2, avg_latency_ms: 120 },
@@ -3914,6 +3915,33 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.points[0].date, "2026-06-01");
     assert.equal(out.points[1].validator_count, 12);
     assert.equal(out.deltas["7d"].completeness_score, 7);
+  });
+
+  test("get_economics_trends defaults to 30d and rolls subnet_snapshots rows", async () => {
+    const res = await callTool("get_economics_trends", {}, { env: d1Env });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.day_count, 2);
+    assert.equal(out.days[0].snapshot_date, "2026-06-01");
+    assert.equal(out.days[1].total_stake_tao, 1000);
+  });
+
+  test("get_economics_trends rejects an invalid window", async () => {
+    const res = await callTool(
+      "get_economics_trends",
+      { window: "99d" },
+      { env: d1Env },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("get_economics_trends returns schema-stable empty days on cold D1", async () => {
+    const res = await callTool("get_economics_trends", { window: "7d" });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.day_count, 0);
+    assert.deepEqual(out.days, []);
   });
 
   test("get_subnet_concentration returns schema-stable null blocks on cold D1", async () => {

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -21,10 +21,8 @@ import {
   validateQueryParams,
 } from "./analytics.mjs";
 import { dailyLatencyColumns } from "../../src/health-sql.mjs";
-import {
-  buildEconomicsTrends,
-  parseHistoryWindow,
-} from "../../src/neuron-history.mjs";
+import { parseHistoryWindow } from "../../src/neuron-history.mjs";
+import { loadEconomicsTrends } from "../../src/economics-trends.mjs";
 import {
   formatLeaderboards,
   formatTrajectory,
@@ -94,10 +92,7 @@ export async function handleTrajectory(request, env, netuid, url) {
 // stake, stake-weighted + median alpha price, total validator/miner counts, mean
 // emission share). Same source as the per-subnet trajectory; raw rows (not a GROUP
 // BY) so the weighted/median price is computed in the pure builder. Schema-stable
-// (day_count:0, days:[]) on a cold rollup. Bounded by ECONOMICS_TRENDS_ROW_CAP:
-// ~129 subnets × 365 days ≈ 47k rows for `all`, so the cap is generous but finite.
-const ECONOMICS_TRENDS_ROW_CAP = 60000;
-
+// (day_count:0, days:[]) on a cold rollup. Bounded by ECONOMICS_TRENDS_ROW_CAP.
 export async function handleEconomicsTrends(request, env, url) {
   const validationError = validateQueryParams(url, ["window"]);
   if (validationError) return analyticsQueryError(validationError);
@@ -105,22 +100,10 @@ export async function handleEconomicsTrends(request, env, url) {
     url.searchParams.get("window"),
   );
   if (error) return analyticsQueryError(error);
-  const params = [];
-  let sql =
-    "SELECT snapshot_date, total_stake_tao, alpha_price_tao, " +
-    "validator_count, miner_count, emission_share " +
-    "FROM subnet_snapshots WHERE TRUE";
-  if (days != null) {
-    const cutoff = new Date(Date.now() - days * DAY_MS)
-      .toISOString()
-      .slice(0, 10);
-    sql += " AND snapshot_date >= ?";
-    params.push(cutoff);
-  }
-  sql += " ORDER BY snapshot_date DESC LIMIT ?";
-  params.push(ECONOMICS_TRENDS_ROW_CAP);
-  const rows = await d1All(env, sql, params);
-  const data = buildEconomicsTrends(rows, { window: label });
+  const { data, rows } = await loadEconomicsTrends(
+    (sql, params) => d1All(env, sql, params),
+    { windowLabel: label, windowDays: days },
+  );
   return envelopeWithD1Fallback(
     request,
     {


### PR DESCRIPTION
## Summary

Adds **`get_economics_trends`** MCP tool — parity with `GET /api/v1/economics/trends` — so agents can query the network-wide per-UTC-day economics series (total stake, stake-weighted + median alpha price, validator/miner counts, mean emission share) over `7d`/`30d`/`90d`/`1y`/`all` windows.

Closes #2425

## Scope

| area | change |
| --- | --- |
| `src/economics-trends.mjs` | new `loadEconomicsTrends` + `parseEconomicsTrendsWindow` loader (shared REST + MCP D1 path) |
| `workers/request-handlers/analytics-routes.mjs` | thin refactor `handleEconomicsTrends` → loader |
| `src/mcp-server.mjs` | register tool + output schema; bump **1.11.0 → 1.12.0** |
| `server.json` | registry version **1.12.0** |
| tests | loader unit tests, MCP handler tests, `validate-mcp.mjs` cold smoke |

## REST ↔ MCP parity

| REST | MCP | params |
| --- | --- | --- |
| `GET /api/v1/economics/trends` | `get_economics_trends` | `window` (7d/30d/90d/1y/all, default 30d) |

Response: `buildEconomicsTrends` shape — `window`, `day_count`, `days[]`.

## Registry Safety

- [x] Read-only tool — no registry mutation
- [x] No new secrets or auth surfaces
- [x] Output schema registered in `TOOL_OUTPUT_SCHEMAS`
- [x] MCP SemVer minor bump (new tool per #393 policy)

## Validation

- [x] `npx vitest run tests/economics-trends-loader.test.mjs tests/mcp-server.test.mjs -t get_economics_trends` — pass
- [x] `npx vitest run tests/request-handlers-analytics-routes.test.mjs -t handleEconomicsTrends` — pass
- [x] `node scripts/validate-mcp.mjs` — pass (58 tools)
- [x] `eslint` + `prettier` on touched files

## Test plan

- [x] `loadEconomicsTrends` applies window cutoff + row cap; `all` omits date bound
- [x] MCP `get_economics_trends` happy path, invalid window, cold D1 empty payload
- [x] `validate-mcp.mjs` cold-path smoke for `get_economics_trends`

