### PR TITLE
feat(mcp): add get_subnet_health_incidents with shared REST loader

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -11,6 +11,7 @@ import {
 } from "./health-sql.mjs";
 import {
   formatGlobalIncidents,
+  formatIncidents,
   formatLeaderboards,
   formatPercentiles,
   formatTrends,
@@ -225,6 +226,97 @@ export async function loadSubnetPercentiles(
     [netuid, Date.now() - days * DAY_MS],
   );
   return formatPercentiles({ netuid, window: windowParam, observedAt, rows });
+}
+
+// Per-surface SLA + reconstructed downtime incidents for one subnet over a 7d/30d
+// window, from the live surface_checks history: an SLA rollup (samples + uptime
+// ratio) joined with gap-island-grouped failure incidents (consecutive failures
+// within the incident gap collapse into one, capped per surface). The query +
+// formatting live here so the REST handler (handleHealthIncidents) and the
+// get_subnet_health_incidents MCP tool share one read path (mirrors
+// loadSubnetPercentiles). Unknown window → 7d; cold/empty D1 → surfaces:[].
+export async function loadSubnetIncidents(
+  d1,
+  netuid,
+  { window = "7d", observedAt = null } = {},
+) {
+  const windowParam = Object.hasOwn(ANALYTICS_WINDOWS, window) ? window : "7d";
+  const since = Date.now() - ANALYTICS_WINDOWS[windowParam] * DAY_MS;
+  const [slaRows, incidentRows] = await Promise.all([
+    d1(
+      `SELECT MAX(surface_id) AS surface_id,
+              COALESCE(surface_key, surface_id) AS surface_key,
+              COUNT(*) AS total,
+              SUM(ok) AS ok_count
+       FROM surface_checks
+       WHERE netuid = ? AND checked_at >= ?
+       GROUP BY COALESCE(surface_key, surface_id)`,
+      [netuid, since],
+    ),
+    // Gap-island grouping in SQL: collapse consecutive failures (gap <= the
+    // incident threshold) into one incident row, then cap per surface_key so one
+    // flappy endpoint cannot starve sibling surfaces in the same subnet.
+    d1(
+      `WITH checks AS (
+         SELECT COALESCE(surface_key, surface_id) AS surface_key,
+                surface_id,
+                checked_at,
+                ok,
+                checked_at - LAG(checked_at)
+                  OVER (
+                    PARTITION BY COALESCE(surface_key, surface_id)
+                    ORDER BY checked_at
+                  ) AS gap
+         FROM surface_checks
+         WHERE netuid = ? AND checked_at >= ?
+       ),
+       grouped AS (
+         SELECT surface_key, surface_id, checked_at, ok,
+                SUM(CASE WHEN ok = 1 OR gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
+                  OVER (PARTITION BY surface_key ORDER BY checked_at) AS grp
+         FROM checks
+       ),
+       incidents AS (
+         SELECT MAX(surface_id) AS surface_id,
+                surface_key,
+                MIN(checked_at) AS started_at,
+                MAX(checked_at) AS ended_at,
+                COUNT(*) AS failed_samples
+         FROM grouped
+         WHERE ok = 0
+         GROUP BY surface_key, grp
+         HAVING COUNT(*) >= ?
+       )
+       SELECT surface_id,
+              surface_key,
+              started_at,
+              ended_at,
+              failed_samples
+       FROM (
+         SELECT surface_id,
+                surface_key,
+                started_at,
+                ended_at,
+                failed_samples,
+                ROW_NUMBER() OVER (
+                  PARTITION BY surface_key
+                  ORDER BY started_at
+                ) AS rn
+         FROM incidents
+       ) ranked
+       WHERE rn <= ?
+       ORDER BY surface_id, started_at`,
+      [netuid, since, INCIDENT_GAP_MS, MIN_INCIDENT_SAMPLES, MAX_INCIDENT_ROWS],
+    ),
+  ]);
+  return formatIncidents({
+    netuid,
+    window: windowParam,
+    observedAt,
+    slaRows,
+    incidentRows,
+    maxIncidents: MAX_INCIDENT_ROWS,
+  });
 }
 
 export async function loadGlobalIncidents(

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -41,6 +41,7 @@ import {
   loadGlobalIncidents,
   loadRegistryLeaderboards,
   loadSubnetHealthTrends,
+  loadSubnetIncidents,
   loadSubnetPercentiles,
   loadSubnetUptime,
   parseAnalyticsWindow,
@@ -134,7 +135,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.11.0";
+export const MCP_SERVER_VERSION = "1.12.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -192,6 +193,8 @@ export const MCP_INSTRUCTIONS =
   "get_subnet_trajectory its week-over-week trend, get_subnet_uptime its " +
   "long-term surface uptime history, get_subnet_health_percentiles its " +
   "per-surface p50/p95/p99 request-latency distribution, " +
+  "get_subnet_health_incidents its per-surface SLA + reconstructed downtime " +
+  "incidents, " +
   "get_subnet_concentration stake and " +
   "emission decentralization metrics (Gini, HHI, Nakamoto), " +
   "get_subnet_concentration_history the decentralization trend over time, " +
@@ -1411,6 +1414,44 @@ export const MCP_TOOLS = [
       }
       const { label } = parsed;
       return loadSubnetPercentiles(mcpD1Runner(ctx), netuid, {
+        window: label,
+        observedAt: await mcpObservedAt(ctx),
+      });
+    },
+  },
+  {
+    name: "get_subnet_health_incidents",
+    title: "Get subnet downtime incidents",
+    description:
+      "Fetch one subnet's per-surface SLA and reconstructed downtime incidents over " +
+      "a 7d or 30d window, from the live health-probe history: per operational " +
+      "surface the sample count, uptime ratio, incident count, total downtime (ms), " +
+      "and each incident's start/end, duration, and failed-sample count " +
+      "(consecutive probe failures collapsed into one incident). Use it to see when " +
+      "and how long a surface was actually down, where get_subnet_health_trends " +
+      "gives the uptime trend and get_subnet_health_percentiles the latency " +
+      "distribution. Mirrors GET /api/v1/subnets/{netuid}/health/incidents.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: ["7d", "30d"],
+          description: "Lookback window (default 7d).",
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const parsed = parseAnalyticsWindow(args?.window ?? "7d");
+      if (args?.window !== undefined && parsed === null) {
+        throw toolError("invalid_params", "window must be one of: 7d, 30d.");
+      }
+      const { label } = parsed;
+      return loadSubnetIncidents(mcpD1Runner(ctx), netuid, {
         window: label,
         observedAt: await mcpObservedAt(ctx),
       });
@@ -3770,6 +3811,31 @@ const TOOL_OUTPUT_SCHEMAS = {
             max: NULLABLE_INT,
           },
         },
+      }),
+    },
+  },
+  get_subnet_health_incidents: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "surfaces"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      source: NULLABLE_STRING,
+      surfaces: objectItems({
+        surface_id: NULLABLE_STRING,
+        samples: { type: "integer" },
+        uptime_ratio: { type: ["number", "null"] },
+        incident_count: { type: "integer" },
+        downtime_ms: { type: "integer" },
+        incidents: objectItems({
+          started_at: NULLABLE_INT,
+          ended_at: NULLABLE_INT,
+          duration_ms: NULLABLE_INT,
+          failed_samples: { type: "integer" },
+        }),
       }),
     },
   },

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -10,6 +10,7 @@ import {
   loadGlobalIncidents,
   loadRegistryLeaderboards,
   loadSubnetHealthTrends,
+  loadSubnetIncidents,
   loadSubnetPercentiles,
   loadSubnetUptime,
   parseAnalyticsWindow,
@@ -249,6 +250,54 @@ describe("analytics-live loaders", () => {
     assert.equal(data.surfaces[0].samples, 95);
     assert.equal(data.surfaces[0].latency_ms.p95, 110);
     assert.equal(data.surfaces[0].latency_ms.max, 200);
+  });
+
+  test("loadSubnetIncidents returns schema-stable empty surfaces on cold D1", async () => {
+    const data = await loadSubnetIncidents(d1(), NETUID, {
+      window: "7d",
+      observedAt: OBSERVED_AT,
+    });
+    assert.equal(data.netuid, NETUID);
+    assert.equal(data.window, "7d");
+    assert.equal(data.observed_at, OBSERVED_AT);
+    assert.deepEqual(data.surfaces, []);
+  });
+
+  test("loadSubnetIncidents joins SLA rows with gap-island incidents; unknown window → 7d", async () => {
+    const data = await loadSubnetIncidents(
+      d1({
+        // The SLA rollup (samples + ok_count) and the gap-island incident scan are
+        // two distinct reads against surface_checks; match each by a unique clause.
+        "COUNT\\(\\*\\) AS total": [
+          {
+            surface_id: "api-root",
+            surface_key: "api-root",
+            total: 100,
+            ok_count: 96,
+          },
+        ],
+        "WITH checks AS": [
+          {
+            surface_id: "api-root",
+            surface_key: "api-root",
+            started_at: 1000,
+            ended_at: 1300,
+            failed_samples: 4,
+          },
+        ],
+      }),
+      NETUID,
+      { window: "bogus", observedAt: OBSERVED_AT },
+    );
+    assert.equal(data.window, "7d"); // an unknown window defaults to 7d
+    const surface = data.surfaces[0];
+    assert.equal(surface.surface_id, "api-root");
+    assert.equal(surface.samples, 100);
+    assert.equal(surface.uptime_ratio, 0.96); // 96 / 100
+    assert.equal(surface.incident_count, 1);
+    assert.equal(surface.downtime_ms, 300); // 1300 - 1000
+    assert.equal(surface.incidents[0].duration_ms, 300);
+    assert.equal(surface.incidents[0].failed_samples, 4);
   });
 
   test("loadRegistryLeaderboards returns all boards object", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4355,6 +4355,87 @@ describe("MCP economics + metagraph data tools", () => {
     assert.match(res.body.result.content[0].text, /window/);
   });
 
+  // get_subnet_health_incidents issues TWO surface_checks reads (SLA rollup +
+  // gap-island incident scan); route each to the right rows by a unique clause.
+  function incidentsEnv(slaRows = [], incidentRows = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind() {
+              return {
+                all() {
+                  return Promise.resolve({
+                    results: /WITH checks AS/.test(sql)
+                      ? incidentRows
+                      : slaRows,
+                  });
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("get_subnet_health_incidents joins SLA + downtime incidents from D1", async () => {
+    const env = incidentsEnv(
+      [
+        {
+          surface_id: "api-root",
+          surface_key: "api-root",
+          total: 100,
+          ok_count: 96,
+        },
+      ],
+      [
+        {
+          surface_id: "api-root",
+          surface_key: "api-root",
+          started_at: 1000,
+          ended_at: 1300,
+          failed_samples: 4,
+        },
+      ],
+    );
+    const deps = makeDeps({}, { "health:meta": { last_run_at: FRESH_RUN } });
+    const res = await callTool(
+      "get_subnet_health_incidents",
+      { netuid: 7, window: "30d" },
+      { deps, env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.window, "30d");
+    assert.equal(out.observed_at, FRESH_RUN);
+    const surface = out.surfaces[0];
+    assert.equal(surface.surface_id, "api-root");
+    assert.equal(surface.samples, 100);
+    assert.equal(surface.uptime_ratio, 0.96);
+    assert.equal(surface.incident_count, 1);
+    assert.equal(surface.downtime_ms, 300);
+    assert.equal(surface.incidents[0].failed_samples, 4);
+  });
+
+  test("get_subnet_health_incidents returns schema-stable empty surfaces (default 7d) on cold D1", async () => {
+    const res = await callTool("get_subnet_health_incidents", { netuid: 7 });
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d");
+    assert.deepEqual(out.surfaces, []);
+  });
+
+  test("get_subnet_health_incidents rejects an invalid window", async () => {
+    const res = await callTool(
+      "get_subnet_health_incidents",
+      { netuid: 7, window: "99d" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
   test("get_registry_leaderboards can filter to one board", async () => {
     const res = await callTool(
       "get_registry_leaderboards",

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -47,13 +47,13 @@ import { dailyLatencyColumns } from "../../src/health-sql.mjs";
 import {
   formatBulkTrends,
   formatGlobalIncidents,
-  formatIncidents,
   INCIDENT_GAP_MS,
   MIN_INCIDENT_SAMPLES,
 } from "../../src/health-serving.mjs";
 import {
   loadChainCalls,
   loadSubnetHealthTrends,
+  loadSubnetIncidents,
   loadSubnetPercentiles,
 } from "../../src/analytics-live.mjs";
 import {
@@ -513,7 +513,7 @@ export async function handleHealthIncidents(
   url,
   ctx = {},
 ) {
-  const { label, days, error } = analyticsWindow(url);
+  const { label, error } = analyticsWindow(url);
   if (error) return analyticsQueryError(error);
   return withEdgeCache(
     request,
@@ -521,90 +521,20 @@ export async function handleHealthIncidents(
     env,
     "incidents",
     async () => {
-      const since = Date.now() - days * DAY_MS;
-      const [slaRows, incidentRows] = await Promise.all([
-        d1All(
-          env,
-          `SELECT MAX(surface_id) AS surface_id,
-              COALESCE(surface_key, surface_id) AS surface_key,
-              COUNT(*) AS total,
-              SUM(ok) AS ok_count
-       FROM surface_checks
-       WHERE netuid = ? AND checked_at >= ?
-       GROUP BY COALESCE(surface_key, surface_id)`,
-          [netuid, since],
-        ),
-        // Gap-island grouping in SQL: collapse consecutive failures (gap <= the
-        // incident threshold) into one incident row, then cap per surface_key so
-        // one flappy endpoint cannot starve sibling surfaces in the same subnet.
-        d1All(
-          env,
-          `WITH checks AS (
-         SELECT COALESCE(surface_key, surface_id) AS surface_key,
-                surface_id,
-                checked_at,
-                ok,
-                checked_at - LAG(checked_at)
-                  OVER (
-                    PARTITION BY COALESCE(surface_key, surface_id)
-                    ORDER BY checked_at
-                  ) AS gap
-         FROM surface_checks
-         WHERE netuid = ? AND checked_at >= ?
-       ),
-       grouped AS (
-         SELECT surface_key, surface_id, checked_at, ok,
-                SUM(CASE WHEN ok = 1 OR gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
-                  OVER (PARTITION BY surface_key ORDER BY checked_at) AS grp
-         FROM checks
-       ),
-       incidents AS (
-         SELECT MAX(surface_id) AS surface_id,
-                surface_key,
-                MIN(checked_at) AS started_at,
-                MAX(checked_at) AS ended_at,
-                COUNT(*) AS failed_samples
-         FROM grouped
-         WHERE ok = 0
-         GROUP BY surface_key, grp
-         HAVING COUNT(*) >= ?
-       )
-       SELECT surface_id,
-              surface_key,
-              started_at,
-              ended_at,
-              failed_samples
-       FROM (
-         SELECT surface_id,
-                surface_key,
-                started_at,
-                ended_at,
-                failed_samples,
-                ROW_NUMBER() OVER (
-                  PARTITION BY surface_key
-                  ORDER BY started_at
-                ) AS rn
-         FROM incidents
-       ) ranked
-       WHERE rn <= ?
-       ORDER BY surface_id, started_at`,
-          [
-            netuid,
-            since,
-            INCIDENT_GAP_MS,
-            MIN_INCIDENT_SAMPLES,
-            MAX_INCIDENT_ROWS,
-          ],
-        ),
-      ]);
+      // Wrap d1All so a failure in either read is still logged + marked as a D1
+      // fallback (the dark-serve contract), since the formatted result no longer
+      // exposes the raw row arrays hasD1FallbackRows used to check (mirrors
+      // handleHealthTrends / handleHealthPercentiles).
+      let usedFallback = false;
+      const d1 = async (sql, params) => {
+        const rows = await d1All(env, sql, params);
+        if (hasD1FallbackRows(rows)) usedFallback = true;
+        return rows;
+      };
       const meta = await readHealthMetaKv(env);
-      const data = formatIncidents({
-        netuid,
+      const data = await loadSubnetIncidents(d1, netuid, {
         window: label,
         observedAt: meta?.last_run_at || null,
-        slaRows,
-        incidentRows,
-        maxIncidents: MAX_INCIDENT_ROWS,
       });
       const response = await envelopeResponse(
         request,
@@ -618,9 +548,7 @@ export async function handleHealthIncidents(
         },
         "short",
       );
-      return hasD1FallbackRows(slaRows, incidentRows)
-        ? markD1FallbackResponse(response)
-        : response;
+      return usedFallback ? markD1FallbackResponse(response) : response;
     },
     canonicalHealthWindowCachePath(url),
   );


### PR DESCRIPTION
## Summary

- Surface one subnet's per-surface SLA and reconstructed downtime incidents (live
  REST route `GET /api/v1/subnets/{netuid}/health/incidents`) as an MCP tool — the
  downtime companion to get_subnet_health_trends (uptime trend) and
  get_subnet_health_percentiles (latency distribution).

## What Changed

- Add MCP tool `get_subnet_health_incidents` in `src/mcp-server.mjs`: per operational
  surface the sample count, uptime ratio, incident count, total downtime (ms), and
  each incident's start/end, duration, and failed-sample count, over a 7d/30d window.
  Adds its `TOOL_OUTPUT_SCHEMAS` entry and lists it in MCP_INSTRUCTIONS.
- Bump `MCP_SERVER_VERSION` and `server.json` 1.11.0 → 1.12.0 (MINOR), per the
  documented add-a-tool bump policy.
- Extract `loadSubnetIncidents` into `src/analytics-live.mjs` (shared-REST-loader
  idiom, mirroring `loadSubnetPercentiles`) and route both `handleHealthIncidents`
  and the MCP tool through it — the SLA rollup + gap-island incident reads now live
  in one place. The REST handler keeps its edge-cache + D1-fallback wiring (wraps
  d1All to track usedFallback across both reads); response is byte-identical.
- Tests: loader unit tests (cold D1, SLA+incident join, window defaulting) in
  `tests/analytics-live.test.mjs`; tool tests (happy path, cold-D1 default 7d,
  invalid window) in `tests/mcp-server.test.mjs`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public REST API/OpenAPI/schema change (MCP tool only; REST response byte-identical).

## Validation

- [x] `npm run validate:mcp` — 58 tools, lifecycle + all tools/call (server.json == MCP_SERVER_VERSION)
- [x] vitest: analytics-live + mcp-server + request-handlers-analytics (417 pass)
- [x] eslint + prettier on changed files
- [x] `git diff --check`
