### PR TITLE
fix(blocks): coerce a string-typed block_number cell to a Number in formatBlock

### DIFF
--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -32,6 +32,18 @@ function toIso(ms) {
   return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
 }
 
+// Coerce a block-height cell to a non-negative integer, or null when missing,
+// non-finite, or negative. D1 can return an INTEGER column as a numeric string,
+// so a bare `row.block_number ?? null` would silently leak the string into the
+// API payload (and break downstream arithmetic/comparisons). Mirrors the
+// `toBlockNumber` already applied in account-events.mjs / chain-analytics.mjs
+// and the `nullableInteger` coercion added to counterparties in #2414.
+function toBlockNumber(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 0 ? n : null;
+}
+
 // Keep only well-formed blocks rows (a valid block_number primary key + a
 // non-empty hash + an integer timestamp). Shared by the staged-batch loader so
 // garbage is rejected before it touches D1.
@@ -101,7 +113,7 @@ export const BLOCK_READ_COLUMNS =
 export function formatBlock(row) {
   if (!row || typeof row !== "object") return null;
   return {
-    block_number: row.block_number ?? null,
+    block_number: toBlockNumber(row.block_number),
     block_hash: row.block_hash ?? null,
     parent_hash: row.parent_hash ?? null,
     author: row.author ?? null,

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -127,6 +127,23 @@ test("formatBlock defaults a missing block_number to null (every field nullable)
   assert.equal(out.block_hash, "0xabc");
 });
 
+test("formatBlock coerces a string-typed block_number cell to a Number", () => {
+  // D1 can return an INTEGER column as a numeric string ("1000" not 1000); the
+  // bare `?? null` pass-through this replaced would have leaked the string into
+  // the API payload and broken downstream arithmetic/comparisons.
+  const out = formatBlock({ block_number: "1000", block_hash: "0xabc" });
+  assert.equal(out.block_number, 1000);
+  assert.equal(typeof out.block_number, "number");
+});
+
+test("formatBlock rejects a negative or non-integer block_number cell to null", () => {
+  // Guard the toBlockNumber helper: negatives and floats are not valid block
+  // heights, so the formatter must fall back to null rather than coerce them.
+  assert.equal(formatBlock({ block_number: -1 }).block_number, null);
+  assert.equal(formatBlock({ block_number: 1.5 }).block_number, null);
+  assert.equal(formatBlock({ block_number: "abc" }).block_number, null);
+});
+
 test("buildBlock defaults a null/absent ref to null (regression)", () => {
   // A caller that passes no ref must get ref:null, never undefined — keeps the
   // detail artifact JSON-stable when the lookup key itself is missing.


### PR DESCRIPTION
## Summary

`formatBlock` (`src/blocks.mjs`) projected the D1 `block_number` cell directly into the API payload as `row.block_number ?? null`. D1 can return an INTEGER column as a numeric string (`1000` instead of `1000`), so the bare pass-through silently leaked strings into the JSON response and broke any downstream arithmetic or comparison.

This adds a local `toBlockNumber` helper (matching `account-events.mjs:80` and `chain-analytics.mjs:33`) and routes `formatBlock`'s `block_number` field through it â€” the same class of coercion already applied to `account_events` and `chain_analytics`, and the `nullableInteger` coercion merged for counterparties in #2414.

## What changed

- **`src/blocks.mjs`** â€” added a local `toBlockNumber` helper; replaced the bare `?? null` pass-through with `toBlockNumber(row.block_number)`. Missing, negative, or non-integer cells now fall back to `null`; string cells are coerced to their integer value.

- **`tests/blocks.test.mjs`** â€” added two cases: (1) a string cell coerces to a `number`; (2) negative / fractional / non-numeric cells fall back to `null`.

## Validation run

```
npx vitest run tests/blocks.test.mjs
# Test Files  1 passed (1)
# Tests       53 passed (53)

npx eslint src/blocks.mjs tests/blocks.test.mjs
# clean

npx prettier --check src/blocks.mjs tests/blocks.test.mjs
# All matched files use Prettier code style

npm run validate
# Validated 129 native subnet(s), 129 curated overlay(s), 1213 surface(s), 125 provider(s), and 2037 candidate(s).
```

No schema/contract change â€” no `npm run build` or artifact regeneration needed.