### PR TITLE
feat(mcp): add get_health_trends tool (REST parity for /api/v1/health/trends)

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -421,6 +421,12 @@ assert.ok(
     Array.isArray(rpcUsageCold.buckets),
   "get_rpc_usage must return window + endpoints[] + buckets[] on cold D1",
 );
+const healthTrendsCold = await callOk("get_health_trends", {});
+assert.ok(
+  healthTrendsCold.windows?.["7d"] &&
+    Array.isArray(healthTrendsCold.windows["7d"].subnets),
+  "get_health_trends must return windows.7d.subnets[] on cold D1",
+);
 
 // --- Negative paths --------------------------------------------------------
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/bulk-health-trends.mjs
+++ b/src/bulk-health-trends.mjs
@@ -1,0 +1,52 @@
+// Shared all-subnet bulk health trends D1 loader for REST + MCP parity.
+// Pure orchestration over surface_uptime_daily rows + formatBulkTrends; REST
+// handlers keep edge-cache + envelope wiring.
+
+import {
+  DAY_MS,
+  HEALTH_TREND_WINDOWS,
+  MAX_BULK_TREND_ROWS,
+} from "../workers/config.mjs";
+import { formatBulkTrends } from "./health-serving.mjs";
+import { dailyLatencyColumns } from "./health-sql.mjs";
+
+// Compact all-subnet 7d/30d daily uptime + latency trend matrix (#1164).
+// `d1` is a (sql, params) => rows runner — d1Runner(env) in the Worker,
+// mcpD1Runner(ctx) in the MCP server.
+export async function loadBulkHealthTrends(
+  d1,
+  { observedAt = null, now = Date.now() } = {},
+) {
+  const maxWindowDays = Math.max(...Object.values(HEALTH_TREND_WINDOWS));
+  const cutoffDay = new Date(now - maxWindowDays * DAY_MS)
+    .toISOString()
+    .slice(0, 10);
+  const rows = await d1(
+    `SELECT netuid,
+            day AS date,
+            SUM(samples) AS total,
+            SUM(ok_count) AS ok_count,
+            ${dailyLatencyColumns()}
+     FROM surface_uptime_daily
+     WHERE day >= ?
+     GROUP BY netuid, day
+     ORDER BY netuid, day
+     LIMIT ?`,
+    [cutoffDay, MAX_BULK_TREND_ROWS],
+  );
+  const windows = {};
+  for (const [label, days] of Object.entries(HEALTH_TREND_WINDOWS)) {
+    const windowCutoff = new Date(now - days * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
+    windows[label] = rows.filter(
+      (row) => String(row.day || row.date) >= windowCutoff,
+    );
+  }
+  const data = formatBulkTrends({
+    observedAt,
+    windows,
+    windowDays: HEALTH_TREND_WINDOWS,
+  });
+  return { data, rows };
+}

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -30,6 +30,7 @@ import {
   parseConcentrationHistoryWindow,
 } from "./concentration.mjs";
 import { loadChainSigners } from "./chain-query-loaders.mjs";
+import { loadBulkHealthTrends } from "./bulk-health-trends.mjs";
 import { loadRpcUsage } from "./rpc-usage-loader.mjs";
 import {
   loadCounterparties,
@@ -134,7 +135,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.11.0";
+export const MCP_SERVER_VERSION = "1.12.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -190,7 +191,9 @@ export const MCP_INSTRUCTIONS =
   "participation, get_subnet_economics returns a subnet's registration cost, " +
   "open slots, stake, emission split and validator/miner counts, " +
   "get_subnet_trajectory its week-over-week trend, get_subnet_uptime its " +
-  "long-term surface uptime history, get_subnet_health_percentiles its " +
+  "long-term surface uptime history, get_health_trends the all-subnet 7d/30d " +
+  "uptime + latency matrix, get_subnet_health_trends one subnet's per-surface " +
+  "health trends, get_subnet_health_percentiles its " +
   "per-surface p50/p95/p99 request-latency distribution, " +
   "get_subnet_concentration stake and " +
   "emission decentralization metrics (Gini, HHI, Nakamoto), " +
@@ -1378,6 +1381,28 @@ export const MCP_TOOLS = [
       return loadSubnetHealthTrends(mcpD1Runner(ctx), netuid, {
         observedAt: await mcpObservedAt(ctx),
       });
+    },
+  },
+  {
+    name: "get_health_trends",
+    title: "Get all-subnet health trends",
+    description:
+      "Fetch the compact all-subnet 7d/30d daily uptime + latency trend " +
+      "matrix aggregated from the live health-probe history (probed every " +
+      "~15 minutes). Each subnet carries daily points (uptime ratio, avg " +
+      "latency, sample counts) for sparklines and cross-subnet sorting. Use " +
+      "get_subnet_health_trends for one subnet's per-surface breakdown. " +
+      "Mirrors GET /api/v1/health/trends.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      const { data } = await loadBulkHealthTrends(mcpD1Runner(ctx), {
+        observedAt: await mcpObservedAt(ctx),
+      });
+      return data;
     },
   },
   {
@@ -3740,6 +3765,17 @@ const TOOL_OUTPUT_SCHEMAS = {
     properties: {
       schema_version: { type: "integer" },
       netuid: { type: "integer" },
+      observed_at: NULLABLE_STRING,
+      source: NULLABLE_STRING,
+      windows: { type: "object" },
+    },
+  },
+  get_health_trends: {
+    type: "object",
+    additionalProperties: true,
+    required: ["windows"],
+    properties: {
+      schema_version: { type: "integer" },
       observed_at: NULLABLE_STRING,
       source: NULLABLE_STRING,
       windows: { type: "object" },

--- a/tests/bulk-health-trends-loader.test.mjs
+++ b/tests/bulk-health-trends-loader.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadBulkHealthTrends } from "../src/bulk-health-trends.mjs";
+
+describe("loadBulkHealthTrends", () => {
+  test("aggregates surface_uptime_daily rows into both windows", async () => {
+    const now = Date.parse("2026-06-15T12:00:00.000Z");
+    let sqlSeen;
+    const d1 = async (sql, params) => {
+      sqlSeen = sql;
+      assert.match(sql, /FROM surface_uptime_daily/);
+      assert.equal(params[1], 10000);
+      return [
+        {
+          netuid: 7,
+          date: "2026-06-14",
+          total: 10,
+          ok_count: 9,
+          avg_latency_ms: 50,
+        },
+        {
+          netuid: 7,
+          date: "2026-06-01",
+          total: 4,
+          ok_count: 2,
+          avg_latency_ms: 80,
+        },
+      ];
+    };
+    const { data, rows } = await loadBulkHealthTrends(d1, {
+      observedAt: "2026-06-15T00:00:00.000Z",
+      now,
+    });
+    assert.equal(sqlSeen.includes("GROUP BY netuid, day"), true);
+    assert.equal(rows.length, 2);
+    assert.equal(data.observed_at, "2026-06-15T00:00:00.000Z");
+    assert.equal(data.windows["7d"].subnet_count, 1);
+    assert.equal(data.windows["7d"].subnets[0].netuid, 7);
+    assert.equal(data.windows["30d"].subnet_count, 1);
+    assert.equal(data.windows["30d"].subnets[0].points.length, 2);
+  });
+
+  test("returns schema-stable empty windows on cold D1", async () => {
+    const d1 = async () => [];
+    const { data } = await loadBulkHealthTrends(d1, {});
+    assert.equal(data.schema_version, 1);
+    assert.equal(data.windows["7d"].subnet_count, 0);
+    assert.deepEqual(data.windows["7d"].subnets, []);
+    assert.equal(data.windows["30d"].subnet_count, 0);
+    assert.deepEqual(data.windows["30d"].subnets, []);
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4129,6 +4129,53 @@ describe("MCP economics + metagraph data tools", () => {
     assert.deepEqual(out.windows["30d"].surfaces, []);
   });
 
+  test("get_health_trends returns schema-stable empty windows on cold D1", async () => {
+    const res = await callTool("get_health_trends", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.windows["7d"].subnet_count, 0);
+    assert.deepEqual(out.windows["7d"].subnets, []);
+    assert.equal(out.windows["30d"].subnet_count, 0);
+    assert.deepEqual(out.windows["30d"].subnets, []);
+  });
+
+  test("get_health_trends aggregates bulk trend rows from D1", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind() {
+              return {
+                async all() {
+                  assert.match(sql, /FROM surface_uptime_daily/);
+                  return {
+                    results: [
+                      {
+                        netuid: 7,
+                        date: "2026-06-28",
+                        total: 20,
+                        ok_count: 18,
+                        avg_latency_ms: 42,
+                      },
+                    ],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const deps = makeDeps({}, { "health:meta": { last_run_at: FRESH_RUN } });
+    const res = await callTool("get_health_trends", {}, { deps, env });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.observed_at, FRESH_RUN);
+    assert.equal(out.windows["7d"].subnet_count, 1);
+    assert.equal(out.windows["7d"].subnets[0].netuid, 7);
+    assert.equal(out.windows["7d"].subnets[0].samples, 20);
+  });
+
   test("get_chain_calls returns schema-stable empty calls on cold D1", async () => {
     const res = await callTool("get_chain_calls", { window: "7d" });
     const out = res.body.result.structuredContent;

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -30,8 +30,6 @@ import {
   ANALYTICS_WINDOWS,
   DEFAULT_ANALYTICS_WINDOW,
   DAY_MS,
-  HEALTH_TREND_WINDOWS,
-  MAX_BULK_TREND_ROWS,
   MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
   MAX_INCIDENT_ROWS,
 } from "../config.mjs";
@@ -43,9 +41,8 @@ import {
   publishedAt,
 } from "../responses.mjs";
 import { d1TimeoutMs, withTimeout } from "../storage.mjs";
-import { dailyLatencyColumns } from "../../src/health-sql.mjs";
+import { loadBulkHealthTrends } from "../../src/bulk-health-trends.mjs";
 import {
-  formatBulkTrends,
   formatGlobalIncidents,
   formatIncidents,
   INCIDENT_GAP_MS,
@@ -354,39 +351,9 @@ export async function handleBulkHealthTrends(
   }
 
   return withEdgeCache(request, ctx, env, "bulk-trends", async () => {
-    const nowMs = Date.now();
-    const maxWindowDays = Math.max(...Object.values(HEALTH_TREND_WINDOWS));
-    const cutoffDay = new Date(nowMs - maxWindowDays * DAY_MS)
-      .toISOString()
-      .slice(0, 10);
-    const rows = await d1All(
-      env,
-      `SELECT netuid,
-            day AS date,
-            SUM(samples) AS total,
-            SUM(ok_count) AS ok_count,
-            ${dailyLatencyColumns()}
-     FROM surface_uptime_daily
-     WHERE day >= ?
-     GROUP BY netuid, day
-     ORDER BY netuid, day
-     LIMIT ?`,
-      [cutoffDay, MAX_BULK_TREND_ROWS],
-    );
-    const windows = {};
-    for (const [label, days] of Object.entries(HEALTH_TREND_WINDOWS)) {
-      const windowCutoff = new Date(nowMs - days * DAY_MS)
-        .toISOString()
-        .slice(0, 10);
-      windows[label] = rows.filter(
-        (row) => String(row.day || row.date) >= windowCutoff,
-      );
-    }
     const meta = await readHealthMetaKv(env);
-    const data = formatBulkTrends({
+    const { data, rows } = await loadBulkHealthTrends(d1Runner(env), {
       observedAt: meta?.last_run_at || null,
-      windows,
-      windowDays: HEALTH_TREND_WINDOWS,
     });
     const response = await envelopeResponse(
       request,


### PR DESCRIPTION
## Summary

- Add `get_health_trends` MCP tool mirroring `GET /api/v1/health/trends` — the compact all-subnet 7d/30d daily uptime + latency matrix.
- Extract `loadBulkHealthTrends` into `src/bulk-health-trends.mjs` so REST (`handleBulkHealthTrends`) and MCP share one D1 read path.
- Bump MCP server card to `1.12.0`.

## Test plan

- [x] `npm test -- tests/bulk-health-trends-loader.test.mjs`
- [x] `npm test -- tests/mcp-server.test.mjs -t get_health_trends`
- [x] `npm test -- tests/request-handlers-analytics.test.mjs -t handleBulkHealthTrends`
- [ ] `node scripts/validate-mcp.mjs` (local cold-env `search_subnets` flake; new `get_health_trends` assertion added)
- [ ] CI `Validate` suite