### PR TITLE
fix(api): tie-break account-summary leaderboard aggregates for deterministic output

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -499,7 +499,7 @@ export async function loadAccountSummary(d1, ss58) {
         aggUnion.paramsFor(ss58),
       ),
       d1(
-        `SELECT event_kind AS kind, COUNT(*) AS count FROM ${kindUnion.sql} GROUP BY event_kind ORDER BY count DESC`,
+        `SELECT event_kind AS kind, COUNT(*) AS count FROM ${kindUnion.sql} GROUP BY event_kind ORDER BY count DESC, event_kind ASC`,
         kindUnion.paramsFor(ss58),
       ),
       d1(
@@ -519,8 +519,12 @@ export async function loadAccountSummary(d1, ss58) {
         `SELECT COUNT(*) AS tx_count, MAX(block_number) AS last_tx_block, MAX(observed_at) AS last_tx_at, SUM(fee_tao) AS total_fee_tao FROM (SELECT block_number, observed_at, fee_tao FROM extrinsics WHERE signer = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT ?)`,
         [ss58, ACCOUNT_ACTIVITY_RECENT_LIMIT],
       ),
+      // Top call modules over the same bounded window. `count DESC` alone is not a
+      // total order, so when modules tie on count the trailing LIMIT 10 would keep
+      // an arbitrary subset (D1/SQLite group order is unspecified); call_module ASC
+      // makes both the membership and the ordering of the top-10 deterministic.
       d1(
-        `SELECT call_module, COUNT(*) AS count FROM (SELECT call_module FROM extrinsics WHERE signer = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT ?) GROUP BY call_module ORDER BY count DESC LIMIT 10`,
+        `SELECT call_module, COUNT(*) AS count FROM (SELECT call_module FROM extrinsics WHERE signer = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT ?) GROUP BY call_module ORDER BY count DESC, call_module ASC LIMIT 10`,
         [ss58, ACCOUNT_ACTIVITY_RECENT_LIMIT],
       ),
     ]);

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -710,6 +710,28 @@ test("loadAccountSummary bounds signing activity before aggregating", async () =
   assert.deepEqual(modules.params, ["5Hk", ACCOUNT_ACTIVITY_RECENT_LIMIT]);
 });
 
+test("loadAccountSummary tie-breaks leaderboard aggregates for stable output", async () => {
+  const calls = [];
+  await loadAccountSummary(async (sql) => {
+    calls.push({ sql });
+    return [];
+  }, "5Hk");
+
+  const kinds = calls.find((c) => /GROUP BY event_kind/.test(c.sql));
+  const modules = calls.find((c) => /GROUP BY call_module/.test(c.sql));
+  // `count DESC` alone is not a total order. Without a stable secondary key the
+  // per-kind ordering — and, for the trailing LIMIT 10, the membership of the
+  // top call modules — would vary with D1/SQLite group order on tied counts.
+  assert.ok(
+    /GROUP BY event_kind ORDER BY count DESC, event_kind ASC/.test(kinds.sql),
+  );
+  assert.ok(
+    /GROUP BY call_module ORDER BY count DESC, call_module ASC LIMIT 10/.test(
+      modules.sql,
+    ),
+  );
+});
+
 test("loadAccountSummary uses indexed union seeks for account_events (#2059)", async () => {
   const calls = [];
   await loadAccountSummary(async (sql, params) => {


### PR DESCRIPTION
## What

`loadAccountSummary` (powering the public `GET /api/v1/accounts/{ss58}` summary and the `get_account` MCP tool) builds two count-ordered aggregates whose `ORDER BY count DESC` is **not a total order**:

- `event_kinds` — per-kind event counts, and
- `activity.modules_called` — the signer's top call modules, capped by a trailing `LIMIT 10`.

On tied counts the underlying D1/SQLite group order is unspecified, so the response was nondeterministic:

- the `event_kinds` array could reorder between identical requests, and
- more importantly, when more than ten modules share boundary counts, the `LIMIT 10` kept an **arbitrary subset** — the membership of the top-modules list, not just its order, could change from one run to the next.

## How

Add a stable secondary sort key to each aggregate so ties resolve deterministically:

- `ORDER BY count DESC, event_kind ASC`
- `ORDER BY count DESC, call_module ASC LIMIT 10`

Both keys are the respective `GROUP BY` columns, so they are guaranteed distinct per row and give a total order. This is a pure ordering change — the aggregate values themselves are unchanged, and the same rows are returned except at the previously-ambiguous `LIMIT 10` boundary, which is now well-defined.

## Scope / risk

Two one-line SQL changes in a single loader plus one focused test. No schema, contract, or behavior change beyond making output byte-stable; no public field is added or removed.

## Tests

- `tests/account-events.test.mjs`: adds `loadAccountSummary tie-breaks leaderboard aggregates for stable output`, asserting both aggregates carry their stable secondary sort key (and that the top-modules query keeps it ahead of `LIMIT 10`). Existing `loadAccountSummary` tests continue to pass — they match the `GROUP BY …` query shapes, which are preserved.

I don't have a local Node/npm toolchain, so I verified by code inspection and by mirroring the existing `loadAccountSummary` SQL-assertion tests; CI runs the full vitest suite.
