### PR TITLE
feat(mcp): add cursor and block range filters to get_account_extrinsics

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -678,6 +678,18 @@ function requireNonNegativeInt(args, key) {
   return value;
 }
 
+function optionalNonNegativeInt(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null) return null;
+  if (!Number.isInteger(value) || value < 0) {
+    throw toolError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-negative integer.`,
+    );
+  }
+  return value;
+}
+
 function requireNetuid(args) {
   return requireNonNegativeInt(args, "netuid");
 }
@@ -2134,8 +2146,10 @@ export const MCP_TOOLS = [
       "Fetch the extrinsics (transactions) signed by one account by its SS58 address, " +
       "newest first: block, extrinsic index, hash, call module and function, success " +
       "flag, and fee. Matched by the extrinsic signer only (not the hotkey or coldkey " +
-      "union used by get_account_events). Page with limit (1-1000, default 100) / " +
-      "offset. Useful for seeing exactly which extrinsics a wallet submitted.",
+      "union used by get_account_events). Optionally constrain block height with " +
+      "block_start/block_end (inclusive). Page with limit (1-1000, default 100) / " +
+      "offset, or follow next_cursor for stable keyset pagination. Mirrors " +
+      "GET /api/v1/accounts/{ss58}/extrinsics.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2144,6 +2158,18 @@ export const MCP_TOOLS = [
           description:
             "The account's SS58 address (the extrinsic signer), base58, 47-48 chars.",
           pattern: SS58_PATTERN_SOURCE,
+        },
+        block_start: {
+          type: "integer",
+          description:
+            "Optional inclusive lower block bound; omit for no lower limit.",
+          minimum: 0,
+        },
+        block_end: {
+          type: "integer",
+          description:
+            "Optional inclusive upper block bound; omit for no upper limit.",
+          minimum: 0,
         },
         limit: {
           type: "integer",
@@ -2156,15 +2182,25 @@ export const MCP_TOOLS = [
           description: "Pagination offset. Default 0.",
           minimum: 0,
         },
+        cursor: {
+          type: "string",
+          description:
+            "Opaque keyset cursor from a previous response's next_cursor; takes " +
+            "precedence over offset for stable deep pagination.",
+        },
       },
       required: ["ss58"],
       additionalProperties: false,
     },
     async handler(args, ctx) {
       const ss58 = requireSs58(args);
+      const cursor = optionalString(args, "cursor");
       return loadAccountExtrinsics(mcpD1Runner(ctx), ss58, {
+        blockStart: optionalNonNegativeInt(args, "block_start"),
+        blockEnd: optionalNonNegativeInt(args, "block_end"),
         limit: args?.limit,
         offset: args?.offset,
+        cursor: cursor ?? undefined,
       });
     },
   },
@@ -4095,6 +4131,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       extrinsic_count: { type: "integer" },
       limit: NULLABLE_INT,
       offset: NULLABLE_INT,
+      next_cursor: NULLABLE_STRING,
       extrinsics: objectItems(EXTRINSIC_ITEM),
     },
   },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4973,6 +4973,61 @@ describe("MCP account tail tools (history, extrinsics, transfers)", () => {
     assert.deepEqual(res.body.result.structuredContent.extrinsics, []);
   });
 
+  test("get_account_extrinsics applies block_start/block_end and cursor pagination", async () => {
+    const capture = [];
+    const env = tailD1(
+      {
+        extrinsics: [
+          {
+            block_number: 150,
+            extrinsic_index: 4,
+            extrinsic_hash: "0xabc",
+            signer: SS58,
+            call_module: "Balances",
+            call_function: "transfer",
+            call_args: null,
+            success: 1,
+            fee_tao: 0.001,
+            tip_tao: null,
+            observed_at: 1750009000000,
+          },
+        ],
+      },
+      capture,
+    );
+    const res = await callTool(
+      "get_account_extrinsics",
+      {
+        ss58: SS58,
+        block_start: 100,
+        block_end: 900,
+        cursor: "200.2",
+        limit: 1,
+        offset: 99,
+      },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.extrinsic_count, 1);
+    assert.equal(out.next_cursor, "150.4");
+    const q = capture.find((c) => /FROM extrinsics WHERE signer/.test(c.sql));
+    assert.ok(/block_number >= \?/.test(q.sql));
+    assert.ok(/block_number <= \?/.test(q.sql));
+    assert.ok(/\(block_number, extrinsic_index\) < \(\?, \?\)/.test(q.sql));
+    assert.ok(!/OFFSET/.test(q.sql));
+    assert.deepEqual(q.params, [SS58, 100, 900, 200, 2, 1]);
+  });
+
+  test("get_account_extrinsics rejects a non-integer block_start", async () => {
+    const res = await callTool(
+      "get_account_extrinsics",
+      { ss58: SS58, block_start: "bad" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /block_start/i);
+  });
+
   test("get_account_transfers returns transfers with direction field", async () => {
     const env = tailD1({
       transfers: [


### PR DESCRIPTION
## Summary

- Extend MCP `get_account_extrinsics` with the pagination/filter params already supported by REST `GET /api/v1/accounts/{ss58}/extrinsics` (#2398 block range, #2409 cursor): optional `block_start`/`block_end` and `cursor` (keyset over `next_cursor`).
- Wire through the existing `loadAccountExtrinsics` loader — no duplicated SQL.
- Add `next_cursor` to the tool outputSchema and MCP integration tests for block bounds, cursor pagination, and invalid-param rejection.

No new REST response fields or schema/artifact changes.

## Test plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test -- tests/mcp-server.test.mjs -t "get_account_extrinsics"`
- [x] `npm run validate:mcp`