### PR TITLE
fix(extrinsics): coerce string-typed block_number and extrinsic_index cells to Numbers in formatExtrinsic

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -39,6 +39,19 @@ function toIso(ms) {
   return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
 }
 
+// Coerce a chain-position cell (block_number / extrinsic_index) to a
+// non-negative integer, or null when missing, non-finite, or negative. D1 can
+// return an INTEGER column as a numeric string, so a bare `?? null` pass-through
+// would silently leak the string into the API payload and break downstream
+// arithmetic/comparisons. Mirrors the `toBlockNumber` already applied in
+// account-events.mjs / chain-analytics.mjs and the `toBlockNumber` added to
+// blocks.mjs in #2435.
+function toChainPosition(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 0 ? n : null;
+}
+
 // Keep only well-formed extrinsics rows (a valid (block_number, extrinsic_index)
 // primary key + an integer timestamp). Shared by the staged-batch loader so
 // garbage is rejected before it touches D1.
@@ -120,8 +133,8 @@ export function formatExtrinsic(row) {
     }
   }
   return {
-    block_number: row.block_number ?? null,
-    extrinsic_index: row.extrinsic_index ?? null,
+    block_number: toChainPosition(row.block_number),
+    extrinsic_index: toChainPosition(row.extrinsic_index),
     extrinsic_hash: row.extrinsic_hash ?? null,
     signer: row.signer ?? null,
     call_module: row.call_module ?? null,

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -196,6 +196,37 @@ test("formatExtrinsic is null-safe on junk + sparse rows", () => {
   assert.equal(out.observed_at, null);
 });
 
+test("formatExtrinsic coerces string-typed chain-position cells to Numbers", () => {
+  // D1 can return an INTEGER column as a numeric string ("1" not 1); the bare
+  // `?? null` pass-through this replaced would have leaked strings into the API
+  // payload and broken downstream arithmetic/comparisons.
+  const out = formatExtrinsic({
+    block_number: "8400000",
+    extrinsic_index: "3",
+  });
+  assert.equal(out.block_number, 8400000);
+  assert.equal(typeof out.block_number, "number");
+  assert.equal(out.extrinsic_index, 3);
+  assert.equal(typeof out.extrinsic_index, "number");
+});
+
+test("formatExtrinsic rejects negative or non-integer chain-position cells to null", () => {
+  // Guard the toChainPosition helper: negatives and floats are not valid chain
+  // positions, so the formatter must fall back to null rather than coerce them.
+  assert.equal(
+    formatExtrinsic({ block_number: -1, extrinsic_index: 0 }).block_number,
+    null,
+  );
+  assert.equal(
+    formatExtrinsic({ block_number: 1, extrinsic_index: 1.5 }).extrinsic_index,
+    null,
+  );
+  assert.equal(
+    formatExtrinsic({ block_number: "abc", extrinsic_index: 0 }).block_number,
+    null,
+  );
+});
+
 test("buildExtrinsic wraps a row + is schema-stable when absent (#1345)", () => {
   const hash = `0x${"a".repeat(64)}`;
   const out = buildExtrinsic(

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -210,6 +210,16 @@ test("formatExtrinsic coerces string-typed chain-position cells to Numbers", () 
   assert.equal(typeof out.extrinsic_index, "number");
 });
 
+test("formatExtrinsic coerces a fully missing chain-position to null (both fields)", () => {
+  // A row without block_number / extrinsic_index keys must still yield null for
+  // both — exercises the `value == null` short-circuit in toChainPosition that
+  // the partial-row cases above don't reach (every input above was a defined
+  // primitive, so the helper's null guard was never hit).
+  const out = formatExtrinsic({});
+  assert.equal(out.block_number, null);
+  assert.equal(out.extrinsic_index, null);
+});
+
 test("formatExtrinsic rejects negative or non-integer chain-position cells to null", () => {
   // Guard the toChainPosition helper: negatives and floats are not valid chain
   // positions, so the formatter must fall back to null rather than coerce them.


### PR DESCRIPTION
## Summary

`formatExtrinsic` (`src/extrinsics.mjs`) projected the D1 `block_number` and `extrinsic_index` cells directly into the API payload as `row.x ?? null`. D1 can return an INTEGER column as a numeric string (`8400000` instead of `8400000`), so the bare pass-through silently leaked strings into the JSON response and broke any downstream arithmetic or comparison.

This adds a local `toChainPosition` helper (matching the `toBlockNumber` pattern in `account-events.mjs` and the `toBlockNumber` added to `blocks.mjs` in #2435) and routes both chain-position fields through it.

## What changed

- **`src/extrinsics.mjs`** â€” added a local `toChainPosition` helper; replaced the bare `?? null` pass-throughs on `block_number` and `extrinsic_index` with `toChainPosition(row.x)`. Missing, negative, or non-integer cells now fall back to `null`; string cells are coerced to their integer value.

- **`tests/extrinsics.test.mjs`** â€” added two cases: (1) string cells coerce to `number`; (2) negative / fractional / non-numeric cells fall back to `null`.

## Validation run

```
npx vitest run tests/extrinsics.test.mjs
# Test Files  1 passed (1)
# Tests       40 passed (40)

npx eslint src/extrinsics.mjs tests/extrinsics.test.mjs
# clean

npx prettier --check src/extrinsics.mjs tests/extrinsics.test.mjs
# All matched files use Prettier code style

npm run validate
# Validated 129 native subnet(s), 129 curated overlay(s), 1213 surface(s), 125 provider(s), and 2037 candidate(s).
```

No schema/contract change â€” no `npm run build` or artifact regeneration needed.