### PR TITLE
fix(graphql): exempt schema-only introspection meta-fields from depth/complexity limits

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -355,6 +355,18 @@ function buildFragmentMap(documentNode) {
   return fragments;
 }
 
+// Introspection root meta-fields (`__schema` / `__type`) resolve against the
+// schema document only — they have no per-row data fan-out — so they carry none
+// of the DoS risk the depth/complexity weights were sized for. Exempt them (and
+// their subtree) from both counters so the standard getIntrospectionQuery() that
+// every GraphQL tool sends (intrinsically deeper/wider than the data limits)
+// stays enabled over POST, matching the documented contract. Sibling data fields
+// in the same operation are still measured, so a mixed query stays bounded.
+const INTROSPECTION_ROOT_FIELDS = new Set(["__schema", "__type"]);
+function isIntrospectionRootField(sel) {
+  return sel.kind === "Field" && INTROSPECTION_ROOT_FIELDS.has(sel.name?.value);
+}
+
 // Depth/complexity must follow named fragment spreads. Otherwise a client moves
 // the whole (expensive) selection into a fragment and the operation's own
 // selection set is just a single transparent spread — counting as depth 0 /
@@ -369,6 +381,7 @@ function buildFragmentMap(documentNode) {
 function selectionDepth(selectionSet, fragments, visited, memo, max) {
   let deepest = 0;
   for (const sel of selectionSet.selections) {
+    if (isIntrospectionRootField(sel)) continue; // schema-only: depth 0
     let depth = 0;
     if (sel.kind === "FragmentSpread") {
       const fragName = sel.name.value;
@@ -432,6 +445,7 @@ export function maxDepthRule(max) {
 function selectionComplexity(selectionSet, fragments, visited, memo, max) {
   let count = 0;
   for (const sel of selectionSet.selections) {
+    if (isIntrospectionRootField(sel)) continue; // schema-only: no complexity cost
     if (sel.kind === "FragmentSpread") {
       const fragName = sel.name.value;
       const frag = fragments.get(fragName);

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { Blob } from "node:buffer";
-import { buildSchema, parse, validate } from "graphql";
+import { buildSchema, getIntrospectionQuery, parse, validate } from "graphql";
 import { describe, test } from "vitest";
 import {
   FIELD_COMPLEXITY,
@@ -234,6 +234,37 @@ describe("handleGraphQLRequest — validation rules", () => {
     );
     assert.ok(
       ext,
+      `expected DEPTH_LIMIT_EXCEEDED, got: ${JSON.stringify(body.errors)}`,
+    );
+  });
+
+  test("standard introspection query is accepted over POST", async () => {
+    // The full getIntrospectionQuery() is intrinsically deeper/wider than the
+    // data limits; exempting the schema-only __schema/__type roots keeps it
+    // working for tooling (GraphiQL/Apollo/codegen) as the contract promises.
+    const { status, body } = await gql(getIntrospectionQuery());
+    assert.equal(
+      status,
+      200,
+      `introspection must not be rejected, got: ${JSON.stringify(body.errors)}`,
+    );
+    assert.ok(body.data?.__schema?.types?.length > 0);
+  });
+
+  test("introspection exemption does not let sibling data fields bypass depth", async () => {
+    // A query that pairs __schema with an over-deep real data selection must
+    // still be rejected on the data portion — the exemption is scoped to the
+    // schema-only meta-field subtree, not the whole operation.
+    const deepData =
+      "subnets { items { ".repeat(GRAPHQL_MAX_DEPTH + 1) +
+      "netuid" +
+      " } }".repeat(GRAPHQL_MAX_DEPTH + 1);
+    const { status, body } = await gql(
+      `{ __schema { queryType { name } } ${deepData} }`,
+    );
+    assert.equal(status, 400);
+    assert.ok(
+      body.errors.find((e) => e.extensions?.code === "DEPTH_LIMIT_EXCEEDED"),
       `expected DEPTH_LIMIT_EXCEEDED, got: ${JSON.stringify(body.errors)}`,
     );
   });


### PR DESCRIPTION
## Summary

`handleGraphQLRequest` (`src/graphql.mjs`) runs the custom `maxDepthRule(7)` / `maxComplexityRule(50)` rules over every operation, including introspection. The standard introspection document every GraphQL tool sends (`graphql`'s own `getIntrospectionQuery()`) is intrinsically deeper than 7 and wider than 50 â€” its `__schema { types { fields { type { ofType { ofType { ofType ... } } } } } }` shape is depth 8 â€” so it is rejected with HTTP 400 (`Query depth 8 exceeds the limit of 7.` / `Query complexity 51 exceeds the limit of 50.`).

That directly contradicts the endpoint's documented contract: *"Introspection over POST stays enabled for tooling."* GraphiQL, Apollo Sandbox, and `graphql-codegen` all send this query and currently get a 400.

## What Changed

- The depth and complexity counters now exempt the schema-only introspection root meta-fields (`__schema` / `__type`) and their subtree. These resolve against the schema document only â€” no per-row data fan-out â€” so they carry none of the DoS risk the limits were sized for.
- The exemption is scoped to the meta-field subtree, not the whole operation: sibling data fields in the same operation are still measured, so a query that mixes introspection with real data stays bounded on its data portion.
- Tests: the full `getIntrospectionQuery()` now returns 200 with a populated `__schema`; a paired test proves an over-deep real data selection alongside `__schema` is still rejected with `DEPTH_LIMIT_EXCEEDED`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes (runtime validation-rule fix; the schema/SDL is unchanged).

## Validation

- [x] `npx vitest run tests/graphql.test.mjs` (93 passed)
- [x] `npx eslint src/graphql.mjs tests/graphql.test.mjs`
- [x] `npx prettier --check src/graphql.mjs tests/graphql.test.mjs`
- [x] `git diff --check`
