### PR TITLE
fix(api): tag plural inflections (agents/chatbots/threats/prompts) in domain-tag rules

### DIFF
--- a/src/domain-tags.mjs
+++ b/src/domain-tags.mjs
@@ -10,7 +10,7 @@
 const DOMAIN_TAG_RULES = [
   [
     "agents",
-    /\b(agent|agentic|autonomous (?:agent|software)|tool[- ]?use|workflow automat\w*)\b/i,
+    /\b(agents?|agentic|autonomous (?:agents?|software)|tool[- ]?use|workflow automat\w*)\b/i,
   ],
   [
     "compute",
@@ -26,7 +26,7 @@ const DOMAIN_TAG_RULES = [
   ],
   [
     "inference",
-    /\b(inference|llms?|large language model|language model|text[- ]generation|chatbot|prompt(?:ing)?|completion(?:s)?)\b/i,
+    /\b(inference|llms?|large language model|language model|text[- ]generation|chatbots?|prompt(?:s|ing)?|completion(?:s)?)\b/i,
   ],
   [
     "media",
@@ -54,7 +54,7 @@ const DOMAIN_TAG_RULES = [
   ],
   [
     "security",
-    /\b(cyber ?security|deepfakes?|fraud|threat|malware|vulnerab\w*|exploit\w*|phishing|anomaly detection)\b/i,
+    /\b(cyber ?security|deepfakes?|fraud|threats?|malware|vulnerab\w*|exploit\w*|phishing|anomaly detection)\b/i,
   ],
   [
     "storage",

--- a/tests/domain-tags.test.mjs
+++ b/tests/domain-tags.test.mjs
@@ -18,6 +18,42 @@ describe("deriveDomainTags", () => {
     assert.deepEqual(tags, ["inference", "training"]);
   });
 
+  test("tags the plural 'agents' the same as the singular 'agent'", () => {
+    // Real on-chain descriptions phrase it both ways; the plural must not be
+    // dropped from the ?domain=agents facet.
+    for (const description of [
+      "AI commerce agents",
+      "Software Engineering Agents",
+      "autonomous agents",
+      "Designed for AI Agents",
+    ]) {
+      assert.deepEqual(
+        deriveDomainTags({ description }),
+        ["agents"],
+        `expected ["agents"] for ${JSON.stringify(description)}`,
+      );
+    }
+    // The singular still works (no regression).
+    assert.deepEqual(deriveDomainTags({ description: "an agent network" }), [
+      "agents",
+    ]);
+  });
+
+  test("tags plural inflections of chatbot / threat / prompt", () => {
+    assert.deepEqual(
+      deriveDomainTags({ description: "A network of chatbots" }),
+      ["inference"],
+    );
+    assert.deepEqual(
+      deriveDomainTags({ description: "Detecting security threats" }),
+      ["security"],
+    );
+    assert.deepEqual(
+      deriveDomainTags({ description: "A marketplace for prompts" }),
+      ["inference"],
+    );
+  });
+
   test("accepts curated categories that are already in the vocabulary", () => {
     const tags = deriveDomainTags({
       categories: ["Finance", "privacy"],


### PR DESCRIPTION
## Summary

`deriveDomainTags` (`src/domain-tags.mjs`) classifies a subnet into the `?domain=` vocabulary by testing its on-chain identity text against per-tag regexes. The `agents` rule matched only the singular `agent`/`agentic`; because each alternative is bounded by `\bâ€¦\b`, the plural **"agents" never matched** (after `agent` the trailing `s` is a word char, so the closing `\b` fails). Real Bittensor subnets describe themselves with the plural "agents" and were therefore absent from `/api/v1/subnets?domain=agents`. The same singular-only gap existed for `chatbot`, `threat`, and `prompt(?:ing)?`. Sibling rules in the same vocabulary already handle plurals (`datasets?`, `images?`, `avatars?`, `drones?`, `llms?`), so this was an oversight, not a deliberate narrowing.

Verified against live on-chain descriptions in `registry/native/finney-subnets.json` (e.g. "AI commerce agents", "Software Engineering Agents", "autonomous agents") â€” all previously produced `[]`.

## What Changed

- `agents` rule: `agent` -> `agents?` and `autonomous (?:agent|software)` -> `autonomous (?:agents?|software)`.
- `inference` rule: `chatbot` -> `chatbots?`, `prompt(?:ing)?` -> `prompt(?:s|ing)?`.
- `security` rule: `threat` -> `threats?`.
- Patterns stay ReDoS-safe (literal alternations, bounded `\w*`, no nested quantifiers) and the output is still drawn only from the fixed tag vocabulary â€” no new tags, no schema/enum change.
- Tests: new coverage asserting the plural forms tag identically to the singular (the `agents` tag had no test before), plus `chatbots`/`threats`/`prompts`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes â€” the `?domain=` enum (DOMAIN_TAGS) is unchanged; only the text-matching coverage widens. Verified `npm run build` produces no committed-artifact change attributable to this edit (domain tags are not baked into committed build artifacts).

## Validation

- [x] `npx vitest run tests/domain-tags.test.mjs` (7 passed)
- [x] `npx eslint src/domain-tags.mjs tests/domain-tags.test.mjs`
- [x] `npx prettier --check src/domain-tags.mjs tests/domain-tags.test.mjs`
- [x] `git diff --check`
