### PR TITLE
fix(feeds): make a bare-date ?until= inclusive of the whole UTC day

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -26,7 +26,10 @@
 //
 // Optional `?until=<ISO-8601>` returns only items at or before that instant
 // (same strict parsing as `since`) and composes with `?since=` and `?tag=` to
-// page a bounded window; a malformed `until` is a 400.
+// page a bounded window; a malformed `until` is a 400. A bare calendar date is
+// inclusive of the whole UTC day (end-of-day), so `?until=2026-06-30` keeps
+// every item from June 30 rather than only the midnight tick — symmetric with
+// the inclusive start-of-day a bare-date `?since=` resolves to.
 
 import {
   EXPOSED_RESPONSE_HEADERS_VALUE,
@@ -451,17 +454,27 @@ export function parseFeedPath(pathname) {
   return null;
 }
 
-// Strictly parse the public `?since=` contract instead of delegating validation
-// to Date.parse(), which accepts implementation-defined inputs and normalizes
-// overflow dates. Accepted forms are an ISO calendar date (UTC midnight) or an
-// ISO date-time with an explicit UTC/offset designator.
-function parseSinceParam(value) {
+// Strictly parse the public `?since=`/`?until=` contract instead of delegating
+// validation to Date.parse(), which accepts implementation-defined inputs and
+// normalizes overflow dates. Accepted forms are an ISO calendar date or an ISO
+// date-time with an explicit UTC/offset designator.
+//
+// A bare calendar date denotes a whole UTC day. For a lower bound (`since`) that
+// resolves to the day's first instant (UTC midnight); for an upper bound
+// (`until`, `endOfDay: true`) it resolves to the day's last instant
+// (23:59:59.999Z) so the bound stays inclusive of the named day — `?until=DATE`
+// keeps every item from that day rather than dropping all but the midnight tick.
+// A date-time (with an explicit time) is an exact instant, unaffected by the flag.
+function parseSinceParam(value, { endOfDay = false } = {}) {
   const raw = String(value);
   const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
   if (dateOnly) {
     const [, year, month, day] = dateOnly;
     const ms = Date.UTC(Number(year), Number(month) - 1, Number(day));
-    return new Date(ms).toISOString().slice(0, 10) === raw ? ms : Number.NaN;
+    if (new Date(ms).toISOString().slice(0, 10) !== raw) return Number.NaN;
+    return endOfDay
+      ? Date.UTC(Number(year), Number(month) - 1, Number(day) + 1) - 1
+      : ms;
   }
 
   const match =
@@ -573,7 +586,9 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
   let untilMs = null;
   const untilParam = url.searchParams.get("until");
   if (untilParam != null) {
-    untilMs = parseSinceParam(untilParam);
+    // A bare-date `until` is inclusive of the whole named day (end-of-day),
+    // mirroring the inclusive start-of-day a bare-date `since` resolves to.
+    untilMs = parseSinceParam(untilParam, { endOfDay: true });
     if (Number.isNaN(untilMs)) {
       return fail(
         "invalid_until",

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -580,6 +580,47 @@ describe("feeds — ?until= filter", () => {
       assert.equal(res.status, 400, value);
     }
   });
+
+  test("a bare-date until is inclusive of the whole UTC day (end-of-day)", () => {
+    // The upper bound for a bare calendar date is the day's final millisecond,
+    // so every item stamped during that day is kept — not just the midnight
+    // tick. This mirrors the inclusive start-of-day a bare-date since resolves
+    // to (regression for the date-only until midnight-truncation asymmetry).
+    const untilMs = parseSinceParam("2026-06-30", { endOfDay: true });
+    assert.equal(
+      new Date(untilMs).toISOString(),
+      "2026-06-30T23:59:59.999Z",
+      "bare-date until resolves to end-of-day",
+    );
+
+    const items = [
+      { id: "midnight", timestamp: "2026-06-30T00:00:00.000Z" },
+      { id: "midday", timestamp: "2026-06-30T12:00:00.000Z" },
+      { id: "last-tick", timestamp: "2026-06-30T23:59:59.999Z" },
+      { id: "next-day", timestamp: "2026-07-01T00:00:00.000Z" },
+    ];
+    assert.deepEqual(
+      filterUntil(items, untilMs).map((i) => i.id),
+      ["midnight", "midday", "last-tick"],
+      "keeps all of June 30, excludes July 1",
+    );
+
+    // A same-day since/until pair is a non-empty single-day window, not empty.
+    const sinceMs = parseSinceParam("2026-06-30");
+    assert.deepEqual(
+      filterUntil(filterSince(items, sinceMs), untilMs).map((i) => i.id),
+      ["midnight", "midday", "last-tick"],
+    );
+  });
+
+  test("an explicit date-time until is an exact instant (endOfDay is a no-op)", () => {
+    const exact = "2026-06-30T12:00:00.000Z";
+    assert.equal(
+      parseSinceParam(exact, { endOfDay: true }),
+      Date.parse(exact),
+      "a date-time bound is unaffected by the end-of-day flag",
+    );
+  });
 });
 
 describe("feeds — serializers", () => {


### PR DESCRIPTION
## Summary

- The public content feeds accept an optional `?until=<ISO-8601>` upper bound (#2411), but a bare calendar date is parsed to UTC midnight and then applied as `timestamp <= untilMs`, so `?until=2026-06-30` drops every item that occurred during June 30 (anything after `00:00:00Z`) and keeps only an item stamped exactly at midnight.
- That makes `until` an effectively exclusive start-of-day bound, asymmetric with the inclusive `since`: a single-day window `?since=2026-06-30&until=2026-06-30` returns essentially nothing, and any "everything through day D" poll silently omits all of day D - contradicting the module contract that frames `until` as the inclusive partner of `since` for paging a bounded window.
- Resolve a bare-date `until` to the day's final millisecond (end-of-day, `23:59:59.999Z`) so the bound is inclusive of the whole named UTC day, symmetric with the inclusive start-of-day a bare-date `since` resolves to. An explicit date-time `until` (with a time + zone) stays an exact instant.

## What Changed

- `src/feeds.mjs` - `parseSinceParam` takes an `{ endOfDay }` option; for a bare calendar date it returns the day's last millisecond when `endOfDay` is set, otherwise UTC midnight (date-time inputs are unaffected). `handleFeedRequest` parses `?until=` with `{ endOfDay: true }`; `?since=` keeps start-of-day. Module/contract comments updated to document the inclusive end-of-day semantics.
- `tests/feeds.test.mjs` - regression coverage: a bare-date `until` resolves to `23:59:59.999Z` and `filterUntil` keeps all items from that day (midnight, midday, last tick) while excluding the next day; a same-day `since`/`until` pair is a non-empty single-day window; an explicit date-time `until` is an exact instant (the flag is a no-op).
- No schema/contract change: the `until` query param already exists; only the bare-date resolution changes (worker-computed feed, no committed artifact).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none - behavior-only fix)

## Validation

- [x] `npx prettier --check src/feeds.mjs tests/feeds.test.mjs`
- [x] `npx eslint src/feeds.mjs tests/feeds.test.mjs`
- [x] `npx vitest run tests/feeds.test.mjs` (85 passed)
- [x] `npm run build` then `npm run validate` (green; no contract/artifact drift)
- [x] `git diff --check`

## Linked issue

No linked issue: issue creation on this repository is currently restricted for outside contributors (the issues API returns 404), so an issue could not be filed to track this. Per the contribution guide a linked issue is optional and a PR is judged on its own merit. This is a self-contained, test-covered correctness fix that mirrors an already-merged sibling implementation in the same area.