### PR TITLE
feat(mcp): add get_subnet_gaps tool (REST parity for GET /api/v1/subnets/{netuid}/gaps)

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -6,7 +6,7 @@
 // MCP endpoint is not artifact-backed and must not enter the
 // `checks.length === API_ROUTES.length` invariant.
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import Ajv2020 from "ajv/dist/2020.js";
 import { handleRequest } from "../workers/api.mjs";
 import {
@@ -18,7 +18,7 @@ import {
   buildAnthropicToolSpecs,
   buildOpenAIToolSpecs,
 } from "../src/agent-tool-specs.mjs";
-import { createLocalArtifactEnv } from "./lib.mjs";
+import { artifactFilePath, createLocalArtifactEnv } from "./lib.mjs";
 
 const env = createLocalArtifactEnv();
 const MCP_URL = "https://api.metagraph.sh/mcp";
@@ -256,13 +256,31 @@ await callOk("get_agent_catalog", {});
 await callOk("get_agent_catalog", { netuid: 7 });
 await callOk("registry_summary", {});
 
-const subnetGaps = await callOk("get_subnet_gaps", { netuid: 7 });
-assert.ok(
-  Array.isArray(subnetGaps.priorities) &&
-    Array.isArray(subnetGaps.enrichment_queue),
-  "get_subnet_gaps must return priorities[] + enrichment_queue[]",
-);
-assert.equal(subnetGaps.netuid, 7, "get_subnet_gaps must echo the netuid");
+// Per-subnet gap artifacts are R2-only (review/gaps/{netuid}.json); the cold
+// env has them only after `npm run build` stages dist/. Exercise the happy path
+// when staged, otherwise assert the not_found guard.
+const gapsArtifactPath = artifactFilePath("review/gaps/7.json");
+if (existsSync(gapsArtifactPath)) {
+  const subnetGaps = await callOk("get_subnet_gaps", { netuid: 7 });
+  assert.ok(
+    Array.isArray(subnetGaps.priorities) &&
+      Array.isArray(subnetGaps.enrichment_queue),
+    "get_subnet_gaps must return priorities[] + enrichment_queue[]",
+  );
+  assert.equal(subnetGaps.netuid, 7, "get_subnet_gaps must echo the netuid");
+} else {
+  const subnetGapsCold = await call("get_subnet_gaps", { netuid: 7 });
+  assert.equal(
+    subnetGapsCold.isError,
+    true,
+    "get_subnet_gaps must isError when the R2 gap artifact is absent",
+  );
+  assert.match(
+    subnetGapsCold.content[0]?.text,
+    /No gap report exists/i,
+    "get_subnet_gaps must report not_found when the artifact is missing",
+  );
+}
 
 // Economic opportunity boards project from the committed economics.json in the
 // cold local env; assert the call succeeds and returns the economic boards.

--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -256,6 +256,14 @@ await callOk("get_agent_catalog", {});
 await callOk("get_agent_catalog", { netuid: 7 });
 await callOk("registry_summary", {});
 
+const subnetGaps = await callOk("get_subnet_gaps", { netuid: 7 });
+assert.ok(
+  Array.isArray(subnetGaps.priorities) &&
+    Array.isArray(subnetGaps.enrichment_queue),
+  "get_subnet_gaps must return priorities[] + enrichment_queue[]",
+);
+assert.equal(subnetGaps.netuid, 7, "get_subnet_gaps must echo the netuid");
+
 // Economic opportunity boards project from the committed economics.json in the
 // cold local env; assert the call succeeds and returns the economic boards.
 const opportunities = await callOk("find_subnet_opportunities", { limit: 5 });

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -134,7 +134,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.11.0";
+export const MCP_SERVER_VERSION = "1.12.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -183,7 +183,9 @@ export const MCP_INSTRUCTIONS =
   "list_subnet_apis + get_api_schema to integrate a subnet's API, and " +
   "get_best_rpc_endpoint for a live-healthy Bittensor base-layer RPC endpoint. " +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
-  "fixtures, examples, provenance, and candidate-review gaps. " +
+  "fixtures, examples, provenance, and candidate-review gaps, and " +
+  "get_subnet_gaps for one subnet's interface gap priorities and contributor " +
+  "enrichment queue. " +
   "For goal-shaped flows, find_subnet_for_task turns a plain-language task into " +
   "callable subnets and how_do_i_call returns concrete call instructions " +
   "(base URL, auth, schema, health) for one subnet. For on-chain economics and " +
@@ -3078,6 +3080,44 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_subnet_gaps",
+    title: "Get subnet interface gaps",
+    description:
+      "Fetch one subnet's interface gap priorities and contributor enrichment " +
+      "queue: missing surface kinds, priority scores, recommended actions, and " +
+      "copyable submission hints. This is the per-subnet contribution flywheel " +
+      "view behind GET /api/v1/subnets/{netuid}/gaps — distinct from " +
+      "list_enrichment_targets, which ranks the registry-wide coverage-depth " +
+      "scorecard.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: {
+          type: "integer",
+          description: "Subnet netuid.",
+          minimum: 0,
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const gaps = await loadOptionalArtifact(
+        ctx,
+        `/metagraph/review/gaps/${netuid}.json`,
+      );
+      if (!gaps) {
+        throw toolError(
+          "not_found",
+          `No gap report exists for netuid ${netuid}. Use list_subnets or ` +
+            "search_subnets to discover valid netuids.",
+        );
+      }
+      return gaps;
+    },
+  },
+  {
     name: "find_subnet_opportunities",
     title: "Rank subnets by economic opportunity",
     description:
@@ -4456,6 +4496,21 @@ const TOOL_OUTPUT_SCHEMAS = {
         recommended_next_action: NULLABLE_STRING,
         dimensions: { type: "object" },
       }),
+    },
+  },
+  get_subnet_gaps: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "priorities", "enrichment_queue"],
+    properties: {
+      schema_version: { type: "integer" },
+      contract_version: NULLABLE_STRING,
+      generated_at: NULLABLE_STRING,
+      netuid: { type: "integer" },
+      slug: NULLABLE_STRING,
+      name: NULLABLE_STRING,
+      priorities: { type: "array", items: { type: "object" } },
+      enrichment_queue: { type: "array", items: { type: "object" } },
     },
   },
   find_subnet_for_task: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1345,6 +1345,58 @@ describe("MCP tools (injected deps)", () => {
     assert.match(res.body.result.content[0].text, /No resource/);
   });
 
+  test("get_subnet_gaps returns the per-subnet gap artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/review/gaps/7.json": {
+        schema_version: 1,
+        netuid: 7,
+        slug: "allways",
+        name: "Allways",
+        priorities: [
+          {
+            netuid: 7,
+            slug: "allways",
+            name: "Allways",
+            missing_kinds: ["docs"],
+            priority_score: 72,
+            suggested_next_action: "Submit official docs evidence",
+            candidate_count: 1,
+            curation_level: "verified",
+            review_state: "maintainer-reviewed",
+            surface_count: 4,
+            verified_candidate_count: 1,
+          },
+        ],
+        enrichment_queue: [
+          {
+            netuid: 7,
+            lane: "direct-submission",
+            missing_kinds: ["docs"],
+            recommended_action: "Submit official docs evidence",
+            contribution_hint:
+              "Submit one official public docs candidate with npm run surface:add.",
+          },
+        ],
+      },
+    });
+    const res = await callTool("get_subnet_gaps", { netuid: 7 }, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.priorities[0].missing_kinds[0], "docs");
+    assert.equal(out.enrichment_queue[0].lane, "direct-submission");
+  });
+
+  test("get_subnet_gaps is not_found when the artifact is missing", async () => {
+    const res = await callTool("get_subnet_gaps", { netuid: 99999 });
+    assert.equal(res.body.result.isError, true);
+    assert.equal(res.body.result.structuredContent.error.code, "not_found");
+  });
+
+  test("get_subnet_gaps rejects invalid netuid", async () => {
+    const res = await callTool("get_subnet_gaps", { netuid: -1 });
+    assert.equal(res.body.result.isError, true);
+  });
+
   const opportunityDeps = makeDeps({
     "/metagraph/economics.json": {
       captured_at: "2026-06-20T00:00:00Z",


### PR DESCRIPTION
## Summary

Add `get_subnet_gaps` — an MCP tool mirroring `GET /api/v1/subnets/{netuid}/gaps`. It reads the existing R2-tier artifact at `/metagraph/review/gaps/{netuid}.json` and returns `priorities` (interface gap priorities) plus `enrichment_queue` (contributor lanes, missing kinds, recommended actions, submission hints). This complements `list_enrichment_targets`, which ranks the registry-wide coverage-depth scorecard rather than the per-subnet contribution flywheel view.

## What Changed

- `src/mcp-server.mjs` — new `get_subnet_gaps` tool, output schema, MCP instructions note; bump `MCP_SERVER_VERSION` to `1.12.0` (minor: additive tool)
- `server.json` — MCP Registry listing version `1.12.0`
- `scripts/validate-mcp.mjs` — `tools/call` for `get_subnet_gaps` (happy path when staged R2 artifact exists after build; `not_found` guard on cold env)
- `tests/mcp-server.test.mjs` — artifact return, not_found, invalid netuid

## Intentionally excluded

- No OpenAPI / schema / `npm run build` — MCP tool additions do not change the REST contract or committed artifacts
- No server-card regen — worker-computed at request time

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts edited by hand.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes.

## Validation

- [x] `npm run validate:mcp`
- [x] `npm test -- tests/mcp-server.test.mjs`
- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run test:coverage`

## Test plan

- [ ] `get_subnet_gaps({ netuid: 7 })` returns `priorities[]` and `enrichment_queue[]` when the staged R2 artifact exists (post-build); returns `not_found` on a cold env without it
- [ ] `get_subnet_gaps({ netuid: 99999 })` returns `not_found`
- [ ] `get_subnet_gaps({ netuid: -1 })` returns `invalid_params`
- [ ] `tools/list` advertises the new tool at MCP server version `1.12.0`
- [ ] `/.well-known/agent-tools/openai.json` and `anthropic.json` include the new tool (projected from `listToolDefinitions()`)

## Example

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "tools/call",
  "params": {
    "name": "get_subnet_gaps",
    "arguments": { "netuid": 7 }
  }
}
```

REST equivalent: `GET https://api.metagraph.sh/api/v1/subnets/7/gaps`
