### PR TITLE
fix(data-api): clamp fractional sub-1 chain-events limit to a minimum of 1

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -74,6 +74,15 @@ test("limit is clamped and defaults safely", async () => {
   expect(res.status).toBe(200); // clamp to MAX_LIMIT, no error
 });
 
+test("chain-events preserves a minimum limit after flooring a fractional value", async () => {
+  // A fractional 0<n<1 limit floored to 0 binds LIMIT 0 and then dereferences
+  // rows[-1] for the cursor (TypeError → 502); it must clamp up to 1 instead.
+  const res = await req("/api/v1/chain-events?limit=0.5");
+  expect(res.status).toBe(200);
+  expect(sqlCalls.at(-1).values).toContain(1);
+  expect(sqlCalls.at(-1).values).not.toContain(0);
+});
+
 test("chain-events accepts block + extrinsic filters (extrinsic-detail view)", async () => {
   const res = await req("/api/v1/chain-events?block=5870000&extrinsic=3");
   expect(res.status).toBe(200);

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -33,7 +33,9 @@ function json(data, status = 200) {
 function clampLimit(raw) {
   const n = Number(raw);
   if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
-  return Math.min(Math.floor(n), MAX_LIMIT);
+  // Floor to a minimum of 1 (mirrors clampStatsBlocks): a fractional 0<n<1 floors
+  // to 0 otherwise, binding LIMIT 0 and then dereferencing rows[-1] for the cursor.
+  return Math.min(Math.max(Math.floor(n), 1), MAX_LIMIT);
 }
 
 function clampStatsBlocks(raw) {


### PR DESCRIPTION
## Summary

Fix an HTTP 502 on `GET /api/v1/chain-events` when `limit` is a fractional value in the open interval `(0, 1)` (e.g. `?limit=0.5`).

## What Changed

- `clampLimit` in `workers/data-api.mjs` floored a fractional `0 < n < 1` limit to `0`: it passed the `n <= 0` guard, then `Math.floor(0.5) === 0`. `LIMIT 0` returns zero rows, and the cursor line then evaluates `rows.length === limit` → `0 === 0` and dereferences `rows[rows.length - 1].block_number` (`rows[-1]` → `undefined`) → `TypeError` → caught by the handler → **HTTP 502**.
- Added the `Math.max(..., 1)` lower guard so the value clamps up to the minimum valid bound of `1`, exactly mirroring the sibling `clampStatsBlocks` used by `GET /api/v1/chain-events/stats?blocks=` (which already has this guard and a matching "preserves minimum block window after flooring" test).
- Added a regression test in `tests/data-api.test.mjs`.

Behavior-only fix in the data Worker — no schema/contract/OpenAPI or generated-artifact change.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change.)

## Validation

- [x] `npx vitest run tests/data-api.test.mjs` — 14 passed (includes the new regression test)
- [x] `npx eslint workers/data-api.mjs tests/data-api.test.mjs` — clean
- [x] `npx prettier --check` (LF) — clean
- [x] `git diff --check` — clean
