### PR TITLE
fix(mcp): tie-break and keyset-cursor get_account_history for deterministic paging

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -4,6 +4,7 @@
 // the daily rollup, the prune, and the row→API shaping (#1347). Pure + exported
 // for tests; the Worker runs the D1 I/O.
 import {
+  DAY_PATTERN,
   FEED_PAGINATION,
   clampLimit,
   clampOffset,
@@ -612,10 +613,21 @@ const ACCOUNT_DAY_COLUMNS =
 // rollup. ?netuid narrows to one subnet; ?from / ?to are YYYY-MM-DD bounds
 // (lexicographic on the TEXT `day` column). Newest day first. Clamps limit to
 // 1-1000 (default 100); clamps offset to 0-1 000 000. Null-safe on cold store.
+//
+// account_events_daily holds one row per (hotkey, day, netuid), so `day` alone
+// is not a total order — an account active on several subnets has multiple rows
+// per day. Ordering by `day DESC` only left same-day rows in an unspecified
+// order, which made offset paging non-deterministic (a page boundary inside a
+// day could drop or repeat a same-day row). Tie-break on `netuid DESC` so the
+// order is total, and expose the same `(day, netuid)` keyset cursor the REST
+// handler (handleAccountHistory) and the sibling tail loaders use, so callers
+// can page stable head-growing windows. A cursor takes precedence over offset;
+// a cursor that does not decode to a valid YYYY-MM-DD day is ignored (falls back
+// to the first page), preserving the never-throw contract.
 export async function loadAccountHistory(
   d1,
   ss58,
-  { netuid, from, to, limit, offset } = {},
+  { netuid, from, to, limit, offset, cursor } = {},
 ) {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
@@ -633,10 +645,32 @@ export async function loadAccountHistory(
     sql += " AND day <= ?";
     params.push(to);
   }
-  sql += " ORDER BY day DESC LIMIT ? OFFSET ?";
-  params.push(lim, off);
+  const cur = decodeCursor(cursor, 2);
+  const cursorDay = cur
+    ? String(cur[0]).replace(/^(\d{4})(\d{2})(\d{2})$/, "$1-$2-$3")
+    : null;
+  const useCursor = Boolean(cursorDay && DAY_PATTERN.test(cursorDay));
+  if (useCursor) {
+    sql += " AND (day, netuid) < (?, ?)";
+    params.push(cursorDay, cur[1]);
+  }
+  sql += " ORDER BY day DESC, netuid DESC LIMIT ?";
+  params.push(lim);
+  if (!useCursor) {
+    sql += " OFFSET ?";
+    params.push(off);
+  }
   const rows = await d1(sql, params);
-  return buildAccountHistory(rows, ss58, { limit: lim, offset: off });
+  const last = rows.length === lim ? rows[rows.length - 1] : null;
+  const nextCursor =
+    last && typeof last.day === "string" && DAY_PATTERN.test(last.day)
+      ? encodeCursor([Number(last.day.replaceAll("-", "")), last.netuid])
+      : null;
+  return buildAccountHistory(rows, ss58, {
+    limit: lim,
+    offset: off,
+    nextCursor,
+  });
 }
 
 // Extrinsics signed by this account, newest first. Matched by the extrinsic

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -2069,10 +2069,11 @@ export const MCP_TOOLS = [
       "Fetch the per-day activity series for one account by its SS58 hotkey address, " +
       "from the account_events_daily rollup: event count, kinds seen, and first/last " +
       "block per day. Optionally filter to one subnet (netuid), a date range (from/to " +
-      "as YYYY-MM-DD), and page with limit (1-1000, default 100) / offset. Newest day " +
-      "first. Useful for understanding how active a wallet has been over time. Note: " +
-      "the rollup is hotkey-attributed only — a delegate-only SS58 address returns " +
-      "zero days even if it has events in get_account_events.",
+      "as YYYY-MM-DD), and page with limit (1-1000, default 100) plus either a cursor " +
+      "(pass the previous response's next_cursor for stable head-growing pages) or an " +
+      "offset. Newest day first. Useful for understanding how active a wallet has been " +
+      "over time. Note: the rollup is hotkey-attributed only — a delegate-only SS58 " +
+      "address returns zero days even if it has events in get_account_events.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2105,8 +2106,15 @@ export const MCP_TOOLS = [
         },
         offset: {
           type: "integer",
-          description: "Pagination offset. Default 0.",
+          description:
+            "Pagination offset. Default 0. Ignored when cursor is set.",
           minimum: 0,
+        },
+        cursor: {
+          type: "string",
+          description:
+            "Opaque keyset cursor from a previous response's next_cursor. " +
+            "Takes precedence over offset for stable head-growing pages.",
         },
       },
       required: ["ss58"],
@@ -2118,12 +2126,14 @@ export const MCP_TOOLS = [
         typeof args?.netuid === "number" ? Math.floor(args.netuid) : undefined;
       const from = optionalString(args, "from");
       const to = optionalString(args, "to");
+      const cursor = optionalString(args, "cursor");
       return loadAccountHistory(mcpD1Runner(ctx), ss58, {
         netuid,
         from: from ?? undefined,
         to: to ?? undefined,
         limit: args?.limit,
         offset: args?.offset,
+        cursor: cursor ?? undefined,
       });
     },
   },

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -961,7 +961,12 @@ test("loadAccountHistory binds netuid/from/to filters and clamps pagination", as
   assert.ok(/AND netuid = \?/.test(captured.sql));
   assert.ok(/AND day >= \?/.test(captured.sql));
   assert.ok(/AND day <= \?/.test(captured.sql));
-  assert.ok(/ORDER BY day DESC LIMIT \? OFFSET \?/.test(captured.sql));
+  // Same-day rows are tie-broken on netuid so the order is total; no cursor →
+  // offset paging.
+  assert.ok(
+    /ORDER BY day DESC, netuid DESC LIMIT \? OFFSET \?/.test(captured.sql),
+  );
+  assert.ok(!/\(day, netuid\) < /.test(captured.sql));
   // limit 0 is below the floor → clamps to 1; offset 5 passes through.
   assert.deepEqual(captured.params, [
     "5Hk",
@@ -971,6 +976,49 @@ test("loadAccountHistory binds netuid/from/to filters and clamps pagination", as
     1,
     5,
   ]);
+});
+
+test("loadAccountHistory applies a (day, netuid) keyset cursor and drops offset", async () => {
+  let captured;
+  const out = await loadAccountHistory(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [
+        { day: "2026-06-20", netuid: 3, event_count: 2, event_kinds: "" },
+        { day: "2026-06-20", netuid: 1, event_count: 5, event_kinds: "" },
+      ];
+    },
+    "5Hk",
+    { limit: 2, offset: 99, cursor: encodeCursor([20260624, 7]) },
+  );
+  // Cursor path: keyset predicate present, OFFSET dropped, day re-hyphenated.
+  assert.ok(/AND \(day, netuid\) < \(\?, \?\)/.test(captured.sql));
+  assert.ok(/ORDER BY day DESC, netuid DESC LIMIT \?/.test(captured.sql));
+  assert.ok(!/OFFSET/.test(captured.sql));
+  assert.deepEqual(captured.params, ["5Hk", "2026-06-24", 7, 2]);
+  // A full page (rows.length === limit) yields a next_cursor from the last row.
+  assert.deepEqual(out.next_cursor, encodeCursor([20260620, 1]));
+});
+
+test("loadAccountHistory ignores a malformed cursor and emits no next_cursor on a short page", async () => {
+  let captured;
+  const out = await loadAccountHistory(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [
+        { day: "2026-06-20", netuid: 1, event_count: 5, event_kinds: "" },
+      ];
+    },
+    "5Hk",
+    { limit: 50, cursor: "not-a-valid-cursor" },
+  );
+  // Malformed cursor → first page (offset path), no keyset predicate, no throw.
+  assert.ok(!/\(day, netuid\) < /.test(captured.sql));
+  assert.ok(
+    /ORDER BY day DESC, netuid DESC LIMIT \? OFFSET \?/.test(captured.sql),
+  );
+  // Short page (rows.length < limit) → no next_cursor.
+  assert.equal(out.next_cursor, null);
 });
 
 test("loadAccountHistory ignores a non-integer netuid filter", async () => {


### PR DESCRIPTION
## Summary

- The MCP `get_account_history` tool reads `account_events_daily`, which holds one row per `(hotkey, day, netuid)`. The loader (`loadAccountHistory`) ordered by `day DESC` only - `day` alone is not a total order, so same-day rows (an account active on several subnets) came back in an unspecified order.
- With offset paging over that non-total order, a page boundary that lands inside a day could silently drop or repeat a same-day row across pages. The REST endpoint (`handleAccountHistory`) was already given a `(day, netuid)` tie-break + keyset cursor; the MCP loader is the uncorrected twin, and its own in-file siblings `loadAccountExtrinsics` / `loadAccountTransfers` already use the keyset pattern.
- Tie-break ordering on `netuid DESC` so the order is total (deterministic same-day paging), and add the same `(day, netuid)` keyset cursor the REST handler and sibling loaders expose, so callers can page stable head-growing windows via `next_cursor`.

## What Changed

- `src/account-events.mjs` - `loadAccountHistory` now orders by `day DESC, netuid DESC`, accepts a `cursor`, applies a `(day, netuid) < (?, ?)` keyset predicate (cursor takes precedence over offset; a cursor that does not decode to a valid `YYYY-MM-DD` day is ignored ? first page, never throws), and computes `next_cursor` from the last row of a full page. Mirrors `handleAccountHistory` (`workers/request-handlers/entities.mjs`) and the in-file tail loaders. `DAY_PATTERN` imported from `workers/request-params.mjs`.
- `src/mcp-server.mjs` - the `get_account_history` tool exposes an optional opaque `cursor` (precedence over offset) and threads it through; description updated.
- `tests/account-events.test.mjs` - updated the SQL-shape assertion to the `day DESC, netuid DESC` total order; added regression coverage for the keyset cursor path (predicate present, offset dropped, `day` re-hyphenated, `next_cursor` emitted on a full page) and for a malformed cursor (ignored ? first page, no `next_cursor` on a short page).
- No schema/contract change: `next_cursor` is already part of the account-history payload shape (`buildAccountHistory`); the MCP server card is worker-computed (no committed artifact).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none - behavior + MCP tool input)

## Validation

- [x] `npx prettier --check` + `npx eslint` on the changed files
- [x] `npx vitest run tests/account-events.test.mjs tests/account-events-branch-coverage.test.mjs` (73 passed)
- [x] `npx vitest run tests/mcp-server.test.mjs` (278 passed)
- [x] `npm run validate:mcp` (57 tools, lifecycle + all tools/call)
- [x] `npm run build` then `npm run validate` (green; no contract/artifact drift)
- [x] `git diff --check`

## Linked issue

No linked issue: issue creation on this repository is currently restricted for outside contributors (the issues API returns 404), so an issue could not be filed to track this. Per the contribution guide a linked issue is optional and a PR is judged on its own merit. This is a self-contained, test-covered correctness fix that mirrors an already-merged sibling implementation in the same area.