### PR TITLE
fix(formatting): keep deriveDescriptionFromNotes surrogate-safe at the truncation boundary

### DIFF
--- a/scripts/lib/formatting.mjs
+++ b/scripts/lib/formatting.mjs
@@ -197,9 +197,14 @@ export function deriveDescriptionFromNotes(notes, { maxLength = 280 } = {}) {
   if (typeof notes !== "string") return null;
   const cleaned = cleanDescription(notes);
   if (!cleaned) return null;
-  if (cleaned.length <= maxLength) return cleaned;
-  return `${cleaned
+  // Slice by code points, not UTF-16 units (mirrors formatLlmMarkdownText): a raw
+  // .slice can cut an astral character in half and emit a lone surrogate when the
+  // truncation boundary or trailing-word cleanup falls between a surrogate pair.
+  const chars = Array.from(cleaned);
+  if (chars.length <= maxLength) return cleaned;
+  return `${chars
     .slice(0, maxLength)
+    .join("")
     .replace(/\s+\S*$/, "")
     .trimEnd()}…`;
 }

--- a/tests/formatting.test.mjs
+++ b/tests/formatting.test.mjs
@@ -382,4 +382,18 @@ describe("deriveDescriptionFromNotes", () => {
     assert.equal(result, "alpha beta…");
     assert.ok(result.length <= 13); // 12 + the single-char ellipsis
   });
+
+  test("does not split an astral character at the truncation boundary", () => {
+    // "abcd" + 😀 (a surrogate pair straddling index 4-5) followed by an unbroken
+    // tail with no whitespace, so the trailing-word cleanup can't rescue it. A raw
+    // .slice(0, 5) keeps the lone high surrogate; code-point slicing keeps the emoji.
+    const result = deriveDescriptionFromNotes("abcd😀efghijklmno", {
+      maxLength: 5,
+    });
+    assert.ok(
+      !/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(result),
+      "must not emit a lone high surrogate",
+    );
+    assert.ok(result.includes("😀"), "keeps the whole astral character");
+  });
 });


### PR DESCRIPTION
## Summary

Stop `deriveDescriptionFromNotes` from splitting an astral character (emoji, CJK extension, etc.) at the truncation boundary, which left a corrupt lone surrogate in the derived description.

## What Changed

- `deriveDescriptionFromNotes` in `scripts/lib/formatting.mjs` truncated with a raw `cleaned.slice(0, maxLength)`. `String.prototype.slice` cuts on UTF-16 code units, so when an astral character straddles index `maxLength` the slice keeps the lone **high surrogate** and drops its low surrogate. The trailing-partial-word cleanup `replace(/\s+\S*$/, "")` only removes the orphan when the slice contains whitespace, so an unbroken token longer than `maxLength` returns text ending in a lone surrogate (corrupt/invalid UTF-16).
- Switched to code-point slicing via `Array.from(cleaned)` (join back after slicing), and based the length guard on code points too — exactly mirroring the sibling `formatLlmMarkdownText`, which was already written surrogate-safe and has an astral-handling test.
- Added a regression test in `tests/formatting.test.mjs` (fails on the old code with a lone high surrogate, passes after the fix).

Pure helper logic change. Build output is unaffected: a clean `npm run build` produces an identical artifact diff with and without this change (verified locally), so no committed contract/data artifact goes stale.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change.)

## Validation

- [x] `npx vitest run tests/formatting.test.mjs` — 54 passed (includes the new regression test; confirmed it fails on the unfixed code)
- [x] `npx eslint scripts/lib/formatting.mjs tests/formatting.test.mjs` — clean
- [x] `npx prettier --check` (LF) — clean
- [x] `npm run build` — passed; no incremental tracked-artifact change attributable to this edit
