### PR TITLE
fix(webhooks): reject IPv6 multicast (ff00::/8) in the SSRF address guard

### DIFF
--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -104,6 +104,7 @@ export function isPublicWebhookAddress(value) {
       host.startsWith("fe") || // fe00::/8 reserved: link-local fe80::/10 + deprecated site-local fec0::/10
       host.startsWith("fc") || // unique-local fc00::/7
       host.startsWith("fd") ||
+      host.startsWith("ff") || // ff00::/8 multicast — not global unicast (2000::/3), matching the prober guard (#1538)
       host.startsWith("::ffff:") // IPv4-mapped
     ) {
       return false;

--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -42,6 +42,15 @@ describe("isPublicWebhookAddress", () => {
     assert.equal(isPublicWebhookAddress("feff::1"), false);
   });
 
+  test("IPv6 multicast (ff00::/8) → false", () => {
+    // Multicast is not global unicast (2000::/3) and is never a valid public
+    // webhook target. The fe00::/8 pass missed it; the prober guard already
+    // rejects every ff-prefixed literal (#1538), so this one must too.
+    assert.equal(isPublicWebhookAddress("ff02::1"), false); // link-local all-nodes
+    assert.equal(isPublicWebhookAddress("ff00::1"), false);
+    assert.equal(isPublicWebhookAddress("ff05::1:3"), false); // site-local
+  });
+
   test("public IPv6 → true", () => {
     assert.equal(isPublicWebhookAddress("2606:4700:4700::1111"), true);
   });


### PR DESCRIPTION
## Summary

The webhook SSRF guard `isPublicWebhookAddress` (`src/webhooks.mjs`) classified
IPv6 **multicast** literals (`ff00::/8`, e.g. `ff02::1`) as **public**, so they
passed the subscription URL guard (`https://[ff02::1]/hook` was accepted).
Multicast is not global unicast (`2000::/3`) and is never a valid public webhook
target. The sibling prober guard already rejects every `ff`-prefixed literal
(`host.startsWith("ff")` in `isUnsafeIpAddress`, `src/health-prober.mjs`), and the
two guards are documented to enforce the same reserved ranges (#1538) — this
closes the divergence. It is the same class of gap previously fixed for the
`fe00::/8` reserved range.

## What Changed

- `src/webhooks.mjs` — add `host.startsWith("ff")` to the IPv6 reserved-prefix
  block in `isPublicWebhookAddress`, so `ff00::/8` multicast is rejected. Genuine
  global-unicast addresses (`2000::/3`) and 6to4/NAT64 wrappers of public IPv4 are
  unaffected.
- `tests/webhooks-core.test.mjs` — regression test asserting `ff02::1`, `ff00::1`,
  and `ff05::1:3` return `false`, mirroring the existing `fe00::/8` case.

No schema, OpenAPI, route, or generated artifact is touched, so no rebuild is
required (`validate:contract-drift` unaffected).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none — behavior fix only)

## Validation

- [x] `tests/webhooks-core.test.mjs`, `tests/webhooks.test.mjs`,
      `tests/webhooks-redelivery.test.mjs`, `tests/webhooks-worker.test.mjs`,
      `tests/health-prober.test.mjs` — all pass (228 tests, incl. the new
      multicast regression case)
- [x] `npm run validate`
- [x] `npm run scan:public-safety`
- [x] `eslint` on the changed files
- [x] `prettier --check` on the changed files
- [x] `git diff --check`

Schema/OpenAPI/types/artifact-budget/docs/intake/workflow validators are not
applicable — this change touches only `src/webhooks.mjs` logic and its test, with
no contract, route, doc, or artifact change, so no `npm run build` regeneration is
needed.
