### PR TITLE
fix(webhooks): reject IPv4 multicast/reserved (224.0.0.0/3) in the SSRF address guard

### DIFF
--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -67,7 +67,7 @@ const PRIVATE_IPV4_PATTERNS = [
   /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./, // 100.64.0.0/10 CGNAT
   /^192\.0\.0\./,
   /^198\.1[89]\./,
-  /^255\./,
+  /^(22[4-9]|2[3-5]\d)\./, // 224.0.0.0/3 — multicast 224/4 + reserved 240/4 (incl 255/8 broadcast); not unicast, matching the prober's a>=224 guard (#1538)
 ];
 
 function normalizedHostname(value) {

--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -75,6 +75,17 @@ describe("isPublicWebhookAddress", () => {
     assert.equal(isPublicWebhookAddress("100.64.0.1"), false);
   });
 
+  test("IPv4 multicast / reserved (224.0.0.0/3) → false", () => {
+    // 224.0.0.0/3 (multicast 224/4 + reserved/Class-E 240/4, incl 255/8) is not
+    // unicast and is never a valid public webhook target — the prober guard
+    // already rejects a>=224, so this guard must too.
+    assert.equal(isPublicWebhookAddress("224.0.0.1"), false); // all-systems multicast
+    assert.equal(isPublicWebhookAddress("239.255.255.250"), false); // SSDP multicast
+    assert.equal(isPublicWebhookAddress("240.0.0.1"), false); // reserved/Class-E
+    // The last unicast address (223.255.255.255) stays public.
+    assert.equal(isPublicWebhookAddress("223.255.255.255"), true);
+  });
+
   test("public IPv4 literal → true", () => {
     assert.equal(isPublicWebhookAddress("8.8.8.8"), true);
   });


### PR DESCRIPTION
## Summary

The webhook SSRF guard `isPublicWebhookAddress` (`src/webhooks.mjs`) only blocked
`255/8` in the high IPv4 range, so **multicast** (`224.0.0.0/4`, e.g. `224.0.0.1`,
`239.255.255.250`) and **reserved/Class-E** (`240.0.0.0/4`) literals were classified
as **public** and passed the subscription URL guard. None of `224.0.0.0/3` is a valid
public unicast destination. The sibling prober guard already rejects this whole range
(`a >= 224` in `isUnsafeIpAddress`, `src/health-prober.mjs`), and the two guards are
documented to enforce the same reserved ranges (#1538) — this closes the IPv4 side of
that divergence. It is the IPv4 companion to the IPv6-multicast fix in #2447, in a
separate code region (`PRIVATE_IPV4_PATTERNS`).

## What Changed

- `src/webhooks.mjs` — replace the `/^255\./` entry in `PRIVATE_IPV4_PATTERNS` with
  `/^(22[4-9]|2[3-5]\d)\./`, blocking all of `224.0.0.0/3` (multicast `224/4` +
  reserved `240/4`, including the `255/8` broadcast range it already covered). Because
  the embedded-v4 recheck (6to4/NAT64) shares these patterns, tunnelled multicast/
  reserved v4 is rejected too. The last unicast address `223.255.255.255` and all
  ordinary public IPv4 stay public.
- `tests/webhooks-core.test.mjs` — regression test asserting `224.0.0.1`,
  `239.255.255.250`, `240.0.0.1` return `false` and `223.255.255.255` stays `true`.

No schema, OpenAPI, route, or generated artifact is touched, so no rebuild is required.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none — behavior fix only)

## Validation

- [x] `tests/webhooks-core.test.mjs`, `tests/webhooks.test.mjs` — pass (92 tests,
      incl. the new IPv4 multicast/reserved regression case)
- [x] `npm run validate`
- [x] `npm run scan:public-safety`
- [x] `eslint` on the changed files
- [x] `prettier --check` on the changed files
- [x] `git diff --check`

Schema/OpenAPI/types/artifact-budget/docs/intake/workflow validators are not
applicable — this change touches only `src/webhooks.mjs` logic and its test.
