### PR TITLE
fix(artifact-budgets): match the size-budget glob as a single path segment

### DIFF
--- a/scripts/artifact-budgets.mjs
+++ b/scripts/artifact-budgets.mjs
@@ -62,8 +62,14 @@ function budgetMatches(pattern, path) {
   if (!pattern.includes("*")) {
     return false;
   }
-  const [prefix, suffix] = pattern.split("*");
-  return path.startsWith(prefix) && path.endsWith(suffix);
+  // `*` is a single path-segment glob — it must not cross a `/`. A plain
+  // prefix/suffix check let `schemas/*.json` swallow `schemas/sn-6/openapi.json`
+  // and apply the wrong budget; anchor each `*` to one segment ([^/]*) so a
+  // nested artifact falls back to the default budget, as the patterns intend.
+  const regexSource = pattern
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, "[^/]*");
+  return new RegExp(`^${regexSource}$`).test(path);
 }
 
 function budget(path, warnBytes, failBytes) {

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -2213,6 +2213,25 @@ describe("script utility contracts", () => {
     });
   });
 
+  test("a single-segment budget glob does not match nested paths", () => {
+    const results = evaluateArtifactBudgets([
+      // Flat paths still match their single-segment glob (schemas budget warns
+      // at 1.5M / providers budget warns at 1M, so these stay "ok").
+      { path: "schemas/sn-6.json", size_bytes: 1_400_000 },
+      { path: "providers/acme/endpoints.json", size_bytes: 900_000 },
+      // Nested paths must NOT match `schemas/*.json` / `providers/*/endpoints.json`
+      // (the `*` can't cross `/`); they fall back to the default budget
+      // (warn 250k / fail 1M), so 300k is "warn" rather than the buggy "ok".
+      { path: "schemas/sn-6/openapi.json", size_bytes: 300_000 },
+      { path: "providers/acme/corp/endpoints.json", size_bytes: 300_000 },
+    ]);
+
+    assert.deepEqual(
+      results.map((result) => result.status),
+      ["ok", "ok", "warn", "warn"],
+    );
+  });
+
   test("loads canonical OpenAPI component schemas", async () => {
     const openapi = await buildCanonicalOpenApiArtifact(
       "1970-01-01T00:00:00.000Z",


### PR DESCRIPTION
## Summary

`budgetMatches` in `scripts/artifact-budgets.mjs` treated the `*` in a size-budget
pattern as a prefix/suffix wildcard that can cross `/`. The size-budget patterns are
single-path-segment globs (`schemas/*.json`, `providers/*/endpoints.json`,
`health/history/*.json`), so a nested path like `schemas/sn-6/openapi.json` would have
matched `schemas/*.json` and been graded against the wrong (larger) budget instead of
the default. This fixes the matcher to anchor each `*` to one path segment.

Current artifacts are all flat, so no existing artifact's budget changes today
(`npm run validate:artifact-budgets` reports the same warnings before and after) — this
is a forward-looking correctness fix that keeps the budgets honest if a nested
artifact path is ever introduced.

## What Changed

- `scripts/artifact-budgets.mjs` — `budgetMatches` now compiles the pattern to an
  anchored regex with `*` → `[^/]*` (single segment) instead of a `startsWith(prefix)
  && endsWith(suffix)` check, so `*` no longer spans `/`. Exact-match and non-wildcard
  patterns are unchanged.
- `tests/script-utils.test.mjs` — regression test asserting flat paths still match
  their single-segment glob while nested paths fall back to the default budget.

No schema, OpenAPI, route, or generated artifact is touched.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none — internal build-tooling fix)

## Validation

- [x] `tests/script-utils.test.mjs` budget tests pass (existing wildcard case + new
      single-segment regression case)
- [x] `npm run validate:artifact-budgets` (passes; warning set unchanged)
- [x] `npm run validate`
- [x] `npm run scan:public-safety`
- [x] `eslint` on the changed files
- [x] `prettier --check` on the changed files
- [x] `git diff --check`
