### PR TITLE
fix(health-serving): break leaderboard ties by netuid for deterministic order

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -884,7 +884,8 @@ export function formatLeaderboards({
     .sort(
       (a, b) =>
         (b.uptime_ratio ?? -1) - (a.uptime_ratio ?? -1) ||
-        (a.avg_latency_ms ?? Infinity) - (b.avg_latency_ms ?? Infinity),
+        (a.avg_latency_ms ?? Infinity) - (b.avg_latency_ms ?? Infinity) ||
+        a.netuid - b.netuid,
     )
     .slice(0, cap);
 
@@ -895,7 +896,7 @@ export function formatLeaderboards({
       latency_ms: roundInt(row.min_latency_ms),
     }))
     .filter((entry) => entry.latency_ms != null)
-    .sort((a, b) => a.latency_ms - b.latency_ms)
+    .sort((a, b) => a.latency_ms - b.latency_ms || a.netuid - b.netuid)
     .slice(0, cap);
 
   const completeBoard = (mostComplete || [])
@@ -905,7 +906,11 @@ export function formatLeaderboards({
       name: row.name ?? null,
       completeness_score: row.completeness_score ?? null,
     }))
-    .sort((a, b) => (b.completeness_score ?? -1) - (a.completeness_score ?? -1))
+    .sort(
+      (a, b) =>
+        (b.completeness_score ?? -1) - (a.completeness_score ?? -1) ||
+        a.netuid - b.netuid,
+    )
     .slice(0, cap);
 
   // Enrichment depth: how much curation/discovery has fleshed out a subnet's
@@ -924,7 +929,8 @@ export function formatLeaderboards({
     .sort(
       (a, b) =>
         b.surface_count - a.surface_count ||
-        b.operational_interface_count - a.operational_interface_count,
+        b.operational_interface_count - a.operational_interface_count ||
+        a.netuid - b.netuid,
     )
     .slice(0, cap);
 
@@ -938,7 +944,10 @@ export function formatLeaderboards({
       (entry) =>
         entry.completeness_delta != null && entry.completeness_delta > 0,
     )
-    .sort((a, b) => b.completeness_delta - a.completeness_delta)
+    .sort(
+      (a, b) =>
+        b.completeness_delta - a.completeness_delta || a.netuid - b.netuid,
+    )
     .slice(0, cap);
 
   // Durable reliability ranking: the windowed score (uptime ratio minus a

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -286,6 +286,101 @@ describe("formatLeaderboards", () => {
       [4, 9, 7],
     );
   });
+  // Every registry board must end with an ascending-netuid tiebreak so tied
+  // rows order deterministically (and the limit cap selects a stable
+  // membership) instead of inheriting the unordered GROUP BY / profiles-artifact
+  // input order. Each test reverses the input to prove order-independence.
+  test("healthiest breaks uptime/latency ties by netuid", () => {
+    const tied = [
+      { netuid: 5, total: 4, ok_count: 4, avg_latency_ms: 100 },
+      { netuid: 2, total: 4, ok_count: 4, avg_latency_ms: 100 },
+      { netuid: 9, total: 4, ok_count: 4, avg_latency_ms: 100 },
+    ];
+    const order = (healthRows) =>
+      formatLeaderboards({
+        ...inputs,
+        healthRows,
+        board: "healthiest",
+      }).boards.healthiest.map((e) => e.netuid);
+    assert.deepEqual(order(tied), [2, 5, 9]);
+    assert.deepEqual(order([...tied].reverse()), [2, 5, 9]);
+  });
+  test("fastest-rpc breaks latency ties by netuid", () => {
+    const tied = [
+      { netuid: 5, min_latency_ms: 100 },
+      { netuid: 2, min_latency_ms: 100 },
+      { netuid: 9, min_latency_ms: 100 },
+    ];
+    const order = (rpcRows) =>
+      formatLeaderboards({ ...inputs, rpcRows, board: "fastest-rpc" }).boards[
+        "fastest-rpc"
+      ].map((e) => e.netuid);
+    assert.deepEqual(order(tied), [2, 5, 9]);
+    assert.deepEqual(order([...tied].reverse()), [2, 5, 9]);
+  });
+  test("most-complete breaks score ties by netuid", () => {
+    const tied = [
+      { netuid: 5, slug: "five", name: "Five", completeness_score: 90 },
+      { netuid: 2, slug: "two", name: "Two", completeness_score: 90 },
+      { netuid: 9, slug: "nine", name: "Nine", completeness_score: 90 },
+    ];
+    const order = (mostComplete) =>
+      formatLeaderboards({
+        ...inputs,
+        mostComplete,
+        board: "most-complete",
+      }).boards["most-complete"].map((e) => e.netuid);
+    assert.deepEqual(order(tied), [2, 5, 9]);
+    assert.deepEqual(order([...tied].reverse()), [2, 5, 9]);
+  });
+  test("most-enriched breaks surface-count ties by netuid", () => {
+    const tied = [
+      {
+        netuid: 5,
+        slug: "five",
+        name: "Five",
+        surface_count: 8,
+        operational_interface_count: 2,
+      },
+      {
+        netuid: 2,
+        slug: "two",
+        name: "Two",
+        surface_count: 8,
+        operational_interface_count: 2,
+      },
+      {
+        netuid: 9,
+        slug: "nine",
+        name: "Nine",
+        surface_count: 8,
+        operational_interface_count: 2,
+      },
+    ];
+    const order = (mostComplete) =>
+      formatLeaderboards({
+        ...inputs,
+        mostComplete,
+        board: "most-enriched",
+      }).boards["most-enriched"].map((e) => e.netuid);
+    assert.deepEqual(order(tied), [2, 5, 9]);
+    assert.deepEqual(order([...tied].reverse()), [2, 5, 9]);
+  });
+  test("fastest-growing breaks delta ties by netuid", () => {
+    const tied = [
+      { netuid: 5, delta: 7 },
+      { netuid: 2, delta: 7 },
+      { netuid: 9, delta: 7 },
+    ];
+    const order = (growthRows) =>
+      formatLeaderboards({
+        ...inputs,
+        growthRows,
+        board: "fastest-growing",
+      }).boards["fastest-growing"].map((e) => e.netuid);
+    assert.deepEqual(order(tied), [2, 5, 9]);
+    assert.deepEqual(order([...tied].reverse()), [2, 5, 9]);
+  });
   test("most-enriched excludes zero-surface subnets", () => {
     const out = formatLeaderboards({
       ...inputs,


### PR DESCRIPTION
# Summary

This PR fixes nondeterministic ordering in several registry leaderboards.

Previously, five leaderboards sorted only by their primary score metric without a deterministic tie-breaker. 
When multiple entries had the same score, their ordering depended on the input order, which could lead to inconsistent leaderboard rankings and unstable pagination.

This change adds `netuid` as the final ascending tie-breaker, ensuring deterministic ordering while preserving the existing primary sorting behavior.

## Root Cause

The following leaderboards lacked a deterministic secondary sort key:

- `healthiest`
- `fastest-rpc`
- `most-complete`
- `most-enriched`
- `fastest-growing`

As a result:

- Entries with identical scores could appear in different orders.
- Paginated results could contain different members across executions.
- Ordering depended on the source collection or SQL query order.

Other leaderboards already used `netuid` as a stable tie-breaker, making this behavior inconsistent across the project.

## Changes

### Source

**`src/health-serving.mjs`**

Added a final comparator:

```js
|| a.netuid - b.netuid
```

to the following leaderboards:

- `healthiest`
- `fastest-rpc`
- `most-complete`
- `most-enriched`
- `fastest-growing`

The primary ranking metrics remain unchanged.

### Tests

**`tests/analytics.test.mjs`**

Added regression tests that verify:

- Deterministic ordering for tied scores.
- Ascending `netuid` is used as the tie-breaker.
- Reversing the input produces identical leaderboard output.

## Validation

- [x] `npm run lint`
- [x] `npx vitest run tests/analytics.test.mjs`
- [x] `prettier --check`
- [ ] `npm run test:coverage`
- [ ] `git diff --check`
