### PR TITLE
feat(mcp): add list_block_extrinsics and get_block_events tools (REST parity)

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -468,6 +468,22 @@ assert.ok(
     Array.isArray(healthTrendsCold.windows["7d"].subnets),
   "get_health_trends must return windows.7d.subnets[] on cold D1",
 );
+const blockExtrinsicsCold = await callOk("list_block_extrinsics", {
+  ref: "4200000",
+});
+assert.ok(
+  blockExtrinsicsCold.ref === "4200000" &&
+    blockExtrinsicsCold.block_number == null &&
+    Array.isArray(blockExtrinsicsCold.extrinsics),
+  "list_block_extrinsics must return ref + block_number:null + extrinsics[] on cold D1",
+);
+const blockEventsCold = await callOk("get_block_events", { ref: "4200000" });
+assert.ok(
+  blockEventsCold.ref === "4200000" &&
+    blockEventsCold.block_number == null &&
+    Array.isArray(blockEventsCold.events),
+  "get_block_events must return ref + block_number:null + events[] on cold D1",
+);
 
 // --- Negative paths --------------------------------------------------------
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/block-subresources.mjs
+++ b/src/block-subresources.mjs
@@ -1,0 +1,67 @@
+// Per-block sub-resources (#1845 extrinsics, #1852 events): shared D1 loaders for
+// REST handlers and MCP block-explorer tools. Ref is a numeric block_number or 0x
+// block_hash; unknown/cold refs return schema-stable null block_number + empty lists.
+
+import { ACCOUNT_EVENT_COLUMNS, buildBlockEvents } from "./account-events.mjs";
+import { buildBlockExtrinsics, EXTRINSIC_READ_COLUMNS } from "./extrinsics.mjs";
+import {
+  BLOCK_PAGINATION,
+  clampLimit,
+  clampOffset,
+  FEED_PAGINATION,
+} from "../workers/request-params.mjs";
+
+function strictBlockNumber(ref) {
+  if (!/^\d+$/.test(String(ref))) return null;
+  const value = Number(ref);
+  return Number.isSafeInteger(value) ? value : null;
+}
+
+export async function resolveBlockNumber(d1, ref) {
+  const isHash = /^0x[0-9a-fA-F]{64}$/.test(String(ref));
+  const refBlockNumber = isHash ? null : strictBlockNumber(ref);
+  if (!isHash && refBlockNumber === null) return null;
+  const rows = await d1(
+    isHash
+      ? `SELECT block_number FROM blocks WHERE block_hash = ? LIMIT 1`
+      : `SELECT block_number FROM blocks WHERE block_number = ? LIMIT 1`,
+    [isHash ? String(ref).toLowerCase() : refBlockNumber],
+  );
+  return rows[0]?.block_number ?? null;
+}
+
+export async function loadBlockExtrinsics(d1, ref, { limit, offset } = {}) {
+  const lim = clampLimit(limit, BLOCK_PAGINATION);
+  const off = clampOffset(offset);
+  const blockNumber = await resolveBlockNumber(d1, ref);
+  const rows =
+    blockNumber == null
+      ? []
+      : await d1(
+          `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE block_number = ? ORDER BY extrinsic_index ASC LIMIT ? OFFSET ?`,
+          [blockNumber, lim, off],
+        );
+  const data = buildBlockExtrinsics(rows, ref, blockNumber, {
+    limit: lim,
+    offset: off,
+  });
+  return { data, rows, blockNumber };
+}
+
+export async function loadBlockEvents(d1, ref, { limit, offset } = {}) {
+  const lim = clampLimit(limit, FEED_PAGINATION);
+  const off = clampOffset(offset);
+  const blockNumber = await resolveBlockNumber(d1, ref);
+  const rows =
+    blockNumber == null
+      ? []
+      : await d1(
+          `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE block_number = ? ORDER BY event_index ASC LIMIT ? OFFSET ?`,
+          [blockNumber, lim, off],
+        );
+  const data = buildBlockEvents(rows, ref, blockNumber, {
+    limit: lim,
+    offset: off,
+  });
+  return { data, rows, blockNumber };
+}

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -109,6 +109,7 @@ import { loadSubnetTurnover } from "./turnover.mjs";
 import { isFinneySs58Address, loadAccountBalance } from "./account-balance.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import { loadBlocks, loadBlock } from "./blocks.mjs";
+import { loadBlockEvents, loadBlockExtrinsics } from "./block-subresources.mjs";
 import { loadExtrinsics, loadExtrinsic } from "./extrinsics.mjs";
 import {
   aiEnabled,
@@ -141,7 +142,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.12.0";
+export const MCP_SERVER_VERSION = "1.13.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -2501,6 +2502,90 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "list_block_extrinsics",
+    title: "List extrinsics in one block",
+    description:
+      "Fetch the extrinsics in one block by ref (numeric block_number or 0x " +
+      "block_hash), in natural read order (extrinsic_index ASC). Page with limit " +
+      "(1-100, default 50) / offset. Returns block_number:null + extrinsics:[] when " +
+      "the ref is unknown or the store is cold — never errors. Use get_block to " +
+      "resolve a block header first. Mirrors GET /api/v1/blocks/{ref}/extrinsics.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ref: {
+          type: "string",
+          description:
+            "Block reference: a numeric block number as a string (e.g. '4200000') " +
+            "or a 0x block hash (e.g. '0xabc...64hex').",
+        },
+        limit: {
+          type: "integer",
+          description: "Max extrinsics to return (1-100, default 50).",
+          minimum: 1,
+          maximum: 100,
+        },
+        offset: {
+          type: "integer",
+          description: "Pagination offset. Default 0.",
+          minimum: 0,
+        },
+      },
+      required: ["ref"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const ref = requireString(args, "ref");
+      const { data } = await loadBlockExtrinsics(mcpD1Runner(ctx), ref, {
+        limit: args?.limit,
+        offset: args?.offset,
+      });
+      return data;
+    },
+  },
+  {
+    name: "get_block_events",
+    title: "Get decoded events in one block",
+    description:
+      "Fetch the decoded chain events in one block by ref (numeric block_number " +
+      "or 0x block_hash), in natural read order (event_index ASC). Page with limit " +
+      "(1-1000, default 100) / offset. Returns block_number:null + events:[] when " +
+      "the ref is unknown or the store is cold — never errors. Use get_block to " +
+      "resolve a block header first. Mirrors GET /api/v1/blocks/{ref}/events.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ref: {
+          type: "string",
+          description:
+            "Block reference: a numeric block number as a string (e.g. '4200000') " +
+            "or a 0x block hash (e.g. '0xabc...64hex').",
+        },
+        limit: {
+          type: "integer",
+          description: "Max events to return (1-1000, default 100).",
+          minimum: 1,
+          maximum: 1000,
+        },
+        offset: {
+          type: "integer",
+          description: "Pagination offset. Default 0.",
+          minimum: 0,
+        },
+      },
+      required: ["ref"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const ref = requireString(args, "ref");
+      const { data } = await loadBlockEvents(mcpD1Runner(ctx), ref, {
+        limit: args?.limit,
+        offset: args?.offset,
+      });
+      return data;
+    },
+  },
+  {
     name: "list_extrinsics",
     title: "List extrinsics with optional filters",
     description:
@@ -4460,6 +4545,34 @@ const TOOL_OUTPUT_SCHEMAS = {
       block: { type: ["object", "null"], additionalProperties: true },
       prev_block_number: NULLABLE_INT,
       next_block_number: NULLABLE_INT,
+    },
+  },
+  list_block_extrinsics: {
+    type: "object",
+    additionalProperties: true,
+    required: ["ref", "extrinsic_count", "extrinsics"],
+    properties: {
+      schema_version: { type: "integer" },
+      ref: ANY,
+      block_number: NULLABLE_INT,
+      extrinsic_count: { type: "integer" },
+      limit: NULLABLE_INT,
+      offset: NULLABLE_INT,
+      extrinsics: objectItems(EXTRINSIC_ITEM),
+    },
+  },
+  get_block_events: {
+    type: "object",
+    additionalProperties: true,
+    required: ["ref", "event_count", "events"],
+    properties: {
+      schema_version: { type: "integer" },
+      ref: ANY,
+      block_number: NULLABLE_INT,
+      event_count: { type: "integer" },
+      limit: NULLABLE_INT,
+      offset: NULLABLE_INT,
+      events: objectItems(ACCOUNT_EVENT_ITEM),
     },
   },
   list_extrinsics: {

--- a/tests/block-subresources.test.mjs
+++ b/tests/block-subresources.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  loadBlockEvents,
+  loadBlockExtrinsics,
+  resolveBlockNumber,
+} from "../src/block-subresources.mjs";
+
+function d1With(fixtures = {}, capture = []) {
+  return async (sql, params) => {
+    capture.push({ sql, params });
+    if (/FROM blocks WHERE block_hash/.test(sql))
+      return fixtures.blockByHash ?? [];
+    if (/FROM blocks WHERE block_number/.test(sql))
+      return fixtures.blockByNumber ?? [];
+    if (/FROM extrinsics WHERE block_number/.test(sql))
+      return fixtures.extrinsics ?? [];
+    if (/FROM account_events WHERE block_number/.test(sql))
+      return fixtures.events ?? [];
+    return [];
+  };
+}
+
+const BLOCK = { block_number: 4_200_000 };
+const EXTRINSIC = {
+  block_number: 4_200_000,
+  extrinsic_index: 1,
+  extrinsic_hash: "0x" + "c".repeat(64),
+  signer: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+  call_module: "SubtensorModule",
+  call_function: "set_weights",
+  call_args: null,
+  success: 1,
+  fee_tao: 0.0005,
+  tip_tao: null,
+  observed_at: 1_750_009_000_000,
+};
+const EVENT = {
+  block_number: 4_200_000,
+  event_index: 0,
+  event_kind: "WeightsSet",
+  hotkey: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+  coldkey: null,
+  netuid: 7,
+  uid: 3,
+  amount_tao: null,
+  observed_at: 1_750_009_000_000,
+};
+
+describe("resolveBlockNumber", () => {
+  test("resolves a numeric block_number ref", async () => {
+    const capture = [];
+    const d1 = d1With({ blockByNumber: [BLOCK] }, capture);
+    const n = await resolveBlockNumber(d1, "4200000");
+    assert.equal(n, 4_200_000);
+    assert.equal(capture.length, 1);
+    assert.match(capture[0].sql, /block_number = \?/);
+    assert.deepEqual(capture[0].params, [4_200_000]);
+  });
+
+  test("resolves a 0x hash ref (lowercased bind param)", async () => {
+    const hash = "0x" + "A".repeat(64);
+    const capture = [];
+    const d1 = d1With({ blockByHash: [BLOCK] }, capture);
+    const n = await resolveBlockNumber(d1, hash);
+    assert.equal(n, 4_200_000);
+    assert.match(capture[0].sql, /block_hash = \?/);
+    assert.equal(capture[0].params[0], hash.toLowerCase());
+  });
+
+  test("returns null for a malformed ref without querying D1", async () => {
+    const capture = [];
+    const d1 = d1With({}, capture);
+    const n = await resolveBlockNumber(d1, "not-a-block");
+    assert.equal(n, null);
+    assert.equal(capture.length, 0);
+  });
+
+  test("returns null when the block row is missing", async () => {
+    const d1 = d1With({ blockByNumber: [] });
+    const n = await resolveBlockNumber(d1, "9999999");
+    assert.equal(n, null);
+  });
+});
+
+describe("loadBlockExtrinsics", () => {
+  test("returns extrinsics in block read order", async () => {
+    const capture = [];
+    const d1 = d1With(
+      { blockByNumber: [BLOCK], extrinsics: [EXTRINSIC] },
+      capture,
+    );
+    const { data } = await loadBlockExtrinsics(d1, "4200000");
+    assert.equal(data.ref, "4200000");
+    assert.equal(data.block_number, 4_200_000);
+    assert.equal(data.extrinsic_count, 1);
+    assert.equal(data.extrinsics[0].call_function, "set_weights");
+    const q = capture.find((c) => /FROM extrinsics/.test(c.sql));
+    assert.ok(/ORDER BY extrinsic_index ASC/.test(q.sql));
+    assert.deepEqual(q.params.slice(0, 3), [4_200_000, 50, 0]);
+  });
+
+  test("cold / unknown ref yields schema-stable empty payload", async () => {
+    const capture = [];
+    const d1 = d1With({}, capture);
+    const { data } = await loadBlockExtrinsics(d1, "9999999");
+    assert.equal(data.block_number, null);
+    assert.equal(data.extrinsic_count, 0);
+    assert.deepEqual(data.extrinsics, []);
+    assert.equal(
+      capture.some((c) => /FROM extrinsics/.test(c.sql)),
+      false,
+    );
+  });
+
+  test("clamps limit and offset for pagination", async () => {
+    const capture = [];
+    const d1 = d1With({ blockByNumber: [BLOCK], extrinsics: [] }, capture);
+    await loadBlockExtrinsics(d1, "4200000", { limit: 500, offset: -3 });
+    const q = capture.find((c) => /FROM extrinsics/.test(c.sql));
+    assert.deepEqual(q.params.slice(1), [100, 0]);
+  });
+});
+
+describe("loadBlockEvents", () => {
+  test("returns events in block read order", async () => {
+    const capture = [];
+    const d1 = d1With({ blockByNumber: [BLOCK], events: [EVENT] }, capture);
+    const { data } = await loadBlockEvents(d1, "4200000");
+    assert.equal(data.ref, "4200000");
+    assert.equal(data.block_number, 4_200_000);
+    assert.equal(data.event_count, 1);
+    assert.equal(data.events[0].event_kind, "WeightsSet");
+    const q = capture.find((c) => /FROM account_events/.test(c.sql));
+    assert.ok(/ORDER BY event_index ASC/.test(q.sql));
+    assert.deepEqual(q.params.slice(0, 3), [4_200_000, 100, 0]);
+  });
+
+  test("cold / unknown ref yields schema-stable empty payload", async () => {
+    const capture = [];
+    const d1 = d1With({}, capture);
+    const { data } = await loadBlockEvents(d1, "not-a-block");
+    assert.equal(data.block_number, null);
+    assert.deepEqual(data.events, []);
+    assert.equal(
+      capture.some((c) => /FROM account_events/.test(c.sql)),
+      false,
+    );
+  });
+
+  test("clamps feed pagination limit", async () => {
+    const capture = [];
+    const d1 = d1With({ blockByNumber: [BLOCK], events: [] }, capture);
+    await loadBlockEvents(d1, "4200000", { limit: 9999, offset: 0 });
+    const q = capture.find((c) => /FROM account_events/.test(c.sql));
+    assert.equal(q.params[1], 1000);
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5461,7 +5461,7 @@ describe("MCP account tail tools (history, extrinsics, transfers)", () => {
   });
 });
 
-describe("MCP block-explorer tools (list_blocks, get_block, list_extrinsics, get_extrinsic)", () => {
+describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsics, get_block_events, list_extrinsics, get_extrinsic)", () => {
   // Tests for the chain block-explorer MCP surface.
 
   function chainD1(fixtures = {}, capture = []) {
@@ -5503,12 +5503,28 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_extrinsics, get
                       results: fixtures.extrinsic ? [fixtures.extrinsic] : [],
                     });
                   if (
+                    /FROM extrinsics WHERE block_number = \? ORDER BY extrinsic_index/.test(
+                      sql,
+                    )
+                  )
+                    return Promise.resolve({
+                      results: fixtures.blockExtrinsics || [],
+                    });
+                  if (
                     /FROM extrinsics WHERE block_number = \? AND extrinsic_index/.test(
                       sql,
                     )
                   )
                     return Promise.resolve({
                       results: fixtures.extrinsic ? [fixtures.extrinsic] : [],
+                    });
+                  if (
+                    /FROM account_events WHERE block_number = \? ORDER BY event_index/.test(
+                      sql,
+                    )
+                  )
+                    return Promise.resolve({
+                      results: fixtures.blockEvents || [],
                     });
                   if (/FROM extrinsics/.test(sql))
                     return Promise.resolve({
@@ -5546,6 +5562,18 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_extrinsics, get
     success: 1,
     fee_tao: 0.0005,
     tip_tao: null,
+    observed_at: 1750009000000,
+  };
+
+  const EVENT_ROW = {
+    block_number: 4200000,
+    event_index: 0,
+    event_kind: "WeightsSet",
+    hotkey: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+    coldkey: null,
+    netuid: 7,
+    uid: 3,
+    amount_tao: null,
     observed_at: 1750009000000,
   };
 
@@ -5630,6 +5658,78 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_extrinsics, get
     const res = await callTool("get_block", {});
     assert.equal(res.body.result.isError, true);
     assert.match(res.body.result.content[0].text, /ref/);
+  });
+
+  test("list_block_extrinsics returns per-block extrinsics in read order", async () => {
+    const capture = [];
+    const env = chainD1(
+      { block: BLOCK_ROW, blockExtrinsics: [EXTRINSIC_ROW] },
+      capture,
+    );
+    const res = await callTool(
+      "list_block_extrinsics",
+      { ref: "4200000" },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.ref, "4200000");
+    assert.equal(out.block_number, 4200000);
+    assert.equal(out.extrinsic_count, 1);
+    assert.equal(out.extrinsics[0].call_module, "SubtensorModule");
+    const q = capture.find((c) =>
+      /FROM extrinsics WHERE block_number = \? ORDER BY extrinsic_index/.test(
+        c.sql,
+      ),
+    );
+    assert.ok(q, "must query extrinsics by resolved block_number");
+    assert.deepEqual(q.params.slice(0, 3), [4200000, 50, 0]);
+  });
+
+  test("list_block_extrinsics accepts a 0x hash ref", async () => {
+    const capture = [];
+    const env = chainD1(
+      { block: BLOCK_ROW, blockExtrinsics: [EXTRINSIC_ROW] },
+      capture,
+    );
+    const hash = "0x" + "a".repeat(64);
+    await callTool("list_block_extrinsics", { ref: hash }, { env });
+    const q = capture.find((c) => /block_hash = \?/.test(c.sql));
+    assert.ok(q, "hash ref must resolve via blocks.block_hash");
+  });
+
+  test("list_block_extrinsics returns empty payload for unknown ref", async () => {
+    const res = await callTool("list_block_extrinsics", { ref: "9999999" });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.block_number, null);
+    assert.deepEqual(out.extrinsics, []);
+  });
+
+  test("get_block_events returns per-block events in read order", async () => {
+    const capture = [];
+    const env = chainD1(
+      { block: BLOCK_ROW, blockEvents: [EVENT_ROW] },
+      capture,
+    );
+    const res = await callTool("get_block_events", { ref: "4200000" }, { env });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.ref, "4200000");
+    assert.equal(out.block_number, 4200000);
+    assert.equal(out.event_count, 1);
+    assert.equal(out.events[0].event_kind, "WeightsSet");
+    const q = capture.find((c) =>
+      /FROM account_events WHERE block_number = \? ORDER BY event_index/.test(
+        c.sql,
+      ),
+    );
+    assert.ok(q, "must query account_events by resolved block_number");
+    assert.deepEqual(q.params.slice(0, 3), [4200000, 100, 0]);
+  });
+
+  test("get_block_events returns empty payload for unknown ref", async () => {
+    const res = await callTool("get_block_events", { ref: "9999999" });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.block_number, null);
+    assert.deepEqual(out.events, []);
   });
 
   test("list_extrinsics returns extrinsic feed with correct fields", async () => {
@@ -5731,6 +5831,16 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_extrinsics, get
       [
         "get_block",
         chainD1({ block: BLOCK_ROW, prev: 4199999, next: 4200001 }),
+        { ref: "4200000" },
+      ],
+      [
+        "list_block_extrinsics",
+        chainD1({ block: BLOCK_ROW, blockExtrinsics: [EXTRINSIC_ROW] }),
+        { ref: "4200000" },
+      ],
+      [
+        "get_block_events",
+        chainD1({ block: BLOCK_ROW, blockEvents: [EVENT_ROW] }),
         { ref: "4200000" },
       ],
       ["list_extrinsics", chainD1({ extrinsics: [EXTRINSIC_ROW] }), {}],

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -57,7 +57,6 @@ import {
   buildAccountTransfers,
   buildAccountHistory,
   buildSubnetEvents,
-  buildBlockEvents,
   formatAccountEvent,
   loadAccountSummary,
   loadAccountEvents,
@@ -77,10 +76,13 @@ import {
 import {
   EXTRINSIC_READ_COLUMNS,
   EXTRINSIC_RETENTION_MS,
-  buildBlockExtrinsics,
   buildExtrinsic,
   buildExtrinsicFeed,
 } from "../../src/extrinsics.mjs";
+import {
+  loadBlockEvents,
+  loadBlockExtrinsics,
+} from "../../src/block-subresources.mjs";
 import {
   CONCENTRATION_HISTORY_ROW_CAP,
   CONCENTRATION_READ_COLUMNS,
@@ -1197,28 +1199,10 @@ export async function handleBlockExtrinsics(request, env, ref, url) {
   const validationError = validateQueryParams(url, ["limit", "offset"]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset } = parsePagination(url, BLOCK_PAGINATION);
-  const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
-  const refBlockNumber = isHash ? null : strictBlockNumber(ref);
-  const blockRows =
-    isHash || refBlockNumber !== null
-      ? await d1All(
-          env,
-          isHash
-            ? `SELECT block_number FROM blocks WHERE block_hash = ? LIMIT 1`
-            : `SELECT block_number FROM blocks WHERE block_number = ? LIMIT 1`,
-          [isHash ? ref.toLowerCase() : refBlockNumber],
-        )
-      : [];
-  const blockNumber = blockRows[0]?.block_number ?? null;
-  const rows =
-    blockNumber == null
-      ? []
-      : await d1All(
-          env,
-          `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE block_number = ? ORDER BY extrinsic_index ASC LIMIT ? OFFSET ?`,
-          [blockNumber, limit, offset],
-        );
-  const data = buildBlockExtrinsics(rows, ref, blockNumber, { limit, offset });
+  const { data } = await loadBlockExtrinsics(d1Runner(env), ref, {
+    limit,
+    offset,
+  });
   return envelopeResponse(
     request,
     {
@@ -1243,28 +1227,10 @@ export async function handleBlockEvents(request, env, ref, url) {
   const validationError = validateQueryParams(url, ["limit", "offset"]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset } = parsePagination(url, FEED_PAGINATION);
-  const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
-  const refBlockNumber = isHash ? null : strictBlockNumber(ref);
-  const blockRows =
-    isHash || refBlockNumber !== null
-      ? await d1All(
-          env,
-          isHash
-            ? `SELECT block_number FROM blocks WHERE block_hash = ? LIMIT 1`
-            : `SELECT block_number FROM blocks WHERE block_number = ? LIMIT 1`,
-          [isHash ? ref.toLowerCase() : refBlockNumber],
-        )
-      : [];
-  const blockNumber = blockRows[0]?.block_number ?? null;
-  const rows =
-    blockNumber == null
-      ? []
-      : await d1All(
-          env,
-          `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE block_number = ? ORDER BY event_index ASC LIMIT ? OFFSET ?`,
-          [blockNumber, limit, offset],
-        );
-  const data = buildBlockEvents(rows, ref, blockNumber, { limit, offset });
+  const { data } = await loadBlockEvents(d1Runner(env), ref, {
+    limit,
+    offset,
+  });
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

Adds MCP block-explorer parity for two existing REST sub-resources that had no agent tools yet:

| REST | MCP tool |
|------|----------|
| `GET /api/v1/blocks/{ref}/extrinsics` | `list_block_extrinsics` |
| `GET /api/v1/blocks/{ref}/events` | `get_block_events` |

Both tools accept a numeric `block_number` or `0x` `block_hash` ref, support pagination (`limit`/`offset`), and degrade to schema-stable empty payloads (`block_number: null` + empty array) when the ref is unknown or D1 is cold — never throw.

### Implementation

- **`src/block-subresources.mjs`** — shared `resolveBlockNumber`, `loadBlockExtrinsics`, `loadBlockEvents` loaders (single source of truth for REST + MCP).
- **`workers/request-handlers/entities.mjs`** — `handleBlockExtrinsics` / `handleBlockEvents` refactored to call the shared loaders via `d1Runner(env)` (behavior unchanged).
- **`src/mcp-server.mjs`** — register both tools with JSON Schema 2020-12 `outputSchema`s reusing `EXTRINSIC_ITEM` / `ACCOUNT_EVENT_ITEM`; MCP SemVer **1.12.0 → 1.13.0**.
- **Tests** — `tests/block-subresources.test.mjs` (loader + ref resolution + pagination branches), extended block-explorer MCP tests, `validate-mcp.mjs` cold smoke for both tools.

## Registry Safety

- Read-only D1 queries only; no writes, no external fetches.
- Ref validation mirrors existing block handlers (numeric or 64-char hex hash).
- Pagination uses existing `BLOCK_PAGINATION` / `FEED_PAGINATION` clamps.

## Validation

- [x] `vitest run tests/block-subresources.test.mjs tests/mcp-server.test.mjs tests/block-events.test.mjs tests/blocks.test.mjs`
- [x] `node scripts/validate-mcp.mjs` (64 tools)
- [x] eslint on touched modules

## Test plan

- [ ] CI green (unit + validate-mcp + Codecov)
- [ ] `list_block_extrinsics` with numeric ref returns extrinsics in `extrinsic_index ASC` order
- [ ] `get_block_events` with `0x` hash ref resolves block then returns events in `event_index ASC` order
- [ ] Unknown ref on cold D1 returns `block_number: null` and empty arrays

