### PR TITLE
feat(mcp): add get_agent_resources tool (REST parity for /api/v1/agent-resources)

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -254,6 +254,11 @@ assert.ok(
 
 await callOk("get_agent_catalog", {});
 await callOk("get_agent_catalog", { netuid: 7 });
+const agentResources = await callOk("get_agent_resources", {});
+assert.ok(
+  agentResources.copyable_agent?.url && Array.isArray(agentResources.resources),
+  "get_agent_resources must return copyable_agent + resources[]",
+);
 await callOk("registry_summary", {});
 
 // Per-subnet gap artifacts are R2-only (review/gaps/{netuid}.json); the cold

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -141,7 +141,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.12.0";
+export const MCP_SERVER_VERSION = "1.13.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -188,7 +188,9 @@ export const MCP_INSTRUCTIONS =
   "to discover by intent (meaning-based), and ask for a grounded natural-" +
   "language answer with citations; get_subnet / get_subnet_health for detail, " +
   "list_subnet_apis + get_api_schema to integrate a subnet's API, and " +
-  "get_best_rpc_endpoint for a live-healthy Bittensor base-layer RPC endpoint. " +
+  "get_best_rpc_endpoint for a live-healthy Bittensor base-layer RPC endpoint, and " +
+  "get_agent_resources the AI-resources index (copyable agent, MCP install, skill, " +
+  "llms.txt, OpenAPI, agent-facing APIs). " +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
   "fixtures, examples, provenance, and candidate-review gaps, and " +
   "get_subnet_gaps for one subnet's interface gap priorities and contributor " +
@@ -2965,6 +2967,25 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_agent_resources",
+    title: "Get the AI-resources index",
+    description:
+      "Fetch the machine index of every AI-facing resource: the copyable agent " +
+      "at /agent.md, MCP server endpoint + install command + tool list, the " +
+      "Bittensor skill, llms.txt, OpenAPI, and the agent-facing REST APIs " +
+      "(agent-catalog, semantic-search, ask, fixtures, lineage, datasets). " +
+      "Use it to bootstrap an agent integration without hard-coding URLs. " +
+      "Mirrors GET /api/v1/agent-resources.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadArtifactData(ctx, "/metagraph/agent-resources.json");
+    },
+  },
+  {
     name: "get_lineage",
     title: "Get cross-network subnet lineage",
     description:
@@ -4660,6 +4681,21 @@ const TOOL_OUTPUT_SCHEMAS = {
       observed_at: NULLABLE_STRING,
       generated_at: NULLABLE_STRING,
       notes: NULLABLE_STRING,
+    },
+  },
+  get_agent_resources: {
+    type: "object",
+    additionalProperties: true,
+    required: ["copyable_agent", "mcp", "resources"],
+    properties: {
+      schema_version: { type: "integer" },
+      contract_version: NULLABLE_STRING,
+      generated_at: NULLABLE_STRING,
+      published_at: NULLABLE_STRING,
+      content_hash: NULLABLE_STRING,
+      copyable_agent: { type: "object" },
+      mcp: { type: "object" },
+      resources: { type: "array", items: { type: "object" } },
     },
   },
   get_lineage: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6191,6 +6191,29 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     );
   });
 
+  test("get_agent_resources returns the agent-resources index artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/agent-resources.json": {
+        schema_version: 1,
+        copyable_agent: {
+          title: "Bittensor integration agent",
+          url: "https://api.metagraph.sh/agent.md",
+        },
+        mcp: {
+          endpoint: "https://api.metagraph.sh/mcp",
+          tools: [{ name: "get_subnet", title: "Get subnet overview" }],
+        },
+        resources: [{ id: "agent", title: "Copyable AI agent", url: "x" }],
+      },
+    });
+    const res = await callTool("get_agent_resources", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.schema_version, 1);
+    assert.match(out.copyable_agent.url, /\/agent\.md$/);
+    assert.equal(out.mcp.tools[0].name, "get_subnet");
+    assert.equal(out.resources[0].id, "agent");
+  });
+
   test("get_lineage returns the lineage artifact", async () => {
     const deps = makeDeps({
       "/metagraph/lineage.json": {


### PR DESCRIPTION
Closes claytonlin1110/metagraphed#2

## Summary

- Add `get_agent_resources` MCP tool mirroring `GET /api/v1/agent-resources` — returns the committed `/metagraph/agent-resources.json` index (copyable agent, MCP install + tool list, skill, llms.txt, OpenAPI, agent-facing APIs).
- Bump MCP server card to `1.13.0`.

## Why this PR

Open PRs are heavily editing analytics, entities, health-serving, and block-explorer MCP paths (#2454, #2453, #2452, #2448, #2432). This change is artifact-only (like `list_fixtures` / `registry_summary`) and touches only `mcp-server.mjs` + tests — minimal merge conflict risk.

## Test plan

- [x] `npm test -- tests/mcp-server.test.mjs -t get_agent_resources`
- [x] `node scripts/validate-mcp.mjs`
- [ ] CI `Validate` suite