### PR TITLE
fix(python): serialize boolean query params as lowercase true/false

### DIFF
--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -176,6 +176,32 @@ def _jsonrpc_result(parsed: Any, method: str) -> Any:
     return parsed.get("result") if isinstance(parsed, dict) else None
 
 
+def _query_pairs(query: Mapping[str, Any]) -> List[Tuple[str, Any]]:
+    """Normalize a query mapping into ``urlencode``-ready ``(key, value)`` pairs.
+
+    Drops ``None`` values and coerces Python ``bool`` to the lowercase
+    ``"true"``/``"false"`` the API expects. ``str(True)`` would otherwise send
+    ``"True"``, which the API compares ``=== "true"`` and silently ignores — so a
+    boolean filter such as ``validator_permit=True`` would be dropped and return
+    unfiltered results (diverging from both the async/httpx client and the
+    TypeScript client). Booleans nested in a sequence value — expanded by
+    ``doseq=True`` — are coerced element-wise so list-valued filters normalize too.
+    """
+
+    def coerce(value: Any) -> Any:
+        # ``bool`` is a subclass of ``int``, so it must be handled before any
+        # numeric branch; here it maps straight to the API's wire form.
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (list, tuple)):
+            return [coerce(item) for item in value]
+        return value
+
+    return [
+        (key, coerce(value)) for key, value in query.items() if value is not None
+    ]
+
+
 def metagraphed_fetch(
     path: str,
     *,
@@ -200,7 +226,7 @@ def metagraphed_fetch(
     """
     url = base_url.rstrip("/") + _interpolate(path, path_params)
     if query:
-        pairs = [(key, value) for key, value in query.items() if value is not None]
+        pairs = _query_pairs(query)
         if pairs:
             url += "?" + urllib.parse.urlencode(pairs, doseq=True)
 

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -73,6 +73,48 @@ class ClientTest(unittest.TestCase):
         self.assertIn("limit=5", captured["url"])
         self.assertNotIn("cursor", captured["url"])
 
+    def test_bool_query_values_serialize_lowercase(self):
+        # Python's str(True) is "True", but the API compares query params
+        # === "true"; a bool filter must be sent as the lowercase wire form or it
+        # is silently ignored (regression: validator_permit=True was dropped, so
+        # the request returned unfiltered results).
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            return _FakeResponse({"ok": True})
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            metagraphed_fetch(
+                "/api/v1/subnets/7/metagraph",
+                query={"validator_permit": True, "changes": False},
+            )
+
+        self.assertIn("validator_permit=true", captured["url"])
+        self.assertIn("changes=false", captured["url"])
+        self.assertNotIn("True", captured["url"])
+        self.assertNotIn("False", captured["url"])
+
+    def test_sequence_query_values_expand_and_coerce(self):
+        # A list value expands via doseq; bools nested in it coerce element-wise
+        # to the same lowercase wire form.
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            return _FakeResponse({"ok": True})
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            metagraphed_fetch(
+                "/api/v1/surfaces",
+                query={"kind": ["docs", "openapi"], "flags": [True, False]},
+            )
+
+        self.assertIn("kind=docs", captured["url"])
+        self.assertIn("kind=openapi", captured["url"])
+        self.assertIn("flags=true", captured["url"])
+        self.assertIn("flags=false", captured["url"])
+
     def test_base_url_override(self):
         captured = {}
 


### PR DESCRIPTION
# Summary

This PR fixes boolean query parameter serialization in the Python synchronous SDK.

Previously, the synchronous client serialized Python `bool` values using `str()`, producing `"True"` and `"False"`. However, the API expects lowercase `"true"` and `"false"`, causing boolean query filters (such as `validator_permit`) to be ignored and requests to return unfiltered results.

The asynchronous Python client and the TypeScript client already serialize booleans correctly. This change aligns the synchronous client with the existing behavior.

## Root Cause

`metagraphed_fetch()` built query strings using `urllib.parse.urlencode()`, which converts Python booleans as:

- `True` → `"True"`
- `False` → `"False"`

The API performs strict string comparisons against lowercase values:

```js
query.validator_permit === "true"
```

As a result, requests such as:

```python
client.subnets(validator_permit=True)
```

were sent as:

```
?validator_permit=True
```

instead of:

```
?validator_permit=true
```

causing the filter to be ignored.

## Changes

### Source

**`python/src/metagraphed/client.py`**

- Added a new `_query_pairs()` helper to normalize query parameters.
- Converts Python booleans to lowercase `"true"` and `"false"`.
- Removes `None` values before serialization.
- Correctly serializes booleans contained inside sequence values used with `doseq=True`.
- Ensures `bool` values are handled before numeric types (`bool` is a subclass of `int`).

### Tests

**`python/tests/test_client.py`**

Added regression tests covering:

- Boolean query parameters serialize as lowercase.
- Sequence query parameters correctly expand with nested boolean values.
- Requests no longer contain `"True"` or `"False"` in the query string.


## Validation

- [x] `python -m unittest discover -s tests`
- [x] `python -m py_compile src/metagraphed/client.py tests/test_client.py`
- [x] Verified the new regression tests fail on `main` and pass with this fix.
- [x] Changes are limited to two files under `python/`.
