### PR TITLE
fix(api): restore most-reliable board in MCP registry leaderboards

### DIFF
--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -393,32 +393,49 @@ export async function loadRegistryLeaderboards(
   const sevenDaysAgo = new Date(Date.now() - 7 * DAY_MS)
     .toISOString()
     .slice(0, 10);
-  const [healthRows, rpcRows, growthSamples] = await Promise.all([
-    d1(
-      `SELECT netuid,
+  // `fastest-growing` uses a short completeness window; `most-reliable` is
+  // intentionally more durable and ranks the last 30d of uptime history
+  // (mirrors handleLeaderboards in analytics-routes.mjs).
+  const thirtyDaysAgo = new Date(Date.now() - 30 * DAY_MS)
+    .toISOString()
+    .slice(0, 10);
+  const [healthRows, rpcRows, growthSamples, reliabilityRows] =
+    await Promise.all([
+      d1(
+        `SELECT netuid,
               COUNT(*) AS total,
               SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
               AVG(latency_ms) AS avg_latency_ms
        FROM surface_status
        GROUP BY netuid`,
-      [],
-    ),
-    d1(
-      `SELECT netuid, MIN(latency_ms) AS min_latency_ms
+        [],
+      ),
+      d1(
+        `SELECT netuid, MIN(latency_ms) AS min_latency_ms
        FROM surface_status
        WHERE kind IN ('subtensor-rpc', 'subtensor-wss')
          AND status = 'ok' AND latency_ms IS NOT NULL
        GROUP BY netuid`,
-      [],
-    ),
-    d1(
-      `SELECT netuid, snapshot_date, completeness_score
+        [],
+      ),
+      d1(
+        `SELECT netuid, snapshot_date, completeness_score
        FROM subnet_snapshots
        WHERE snapshot_date >= ?
        ORDER BY netuid, snapshot_date`,
-      [sevenDaysAgo],
-    ),
-  ]);
+        [sevenDaysAgo],
+      ),
+      d1(
+        `SELECT netuid,
+              SUM(samples) AS samples,
+              SUM(ok_count) AS ok_count,
+              ${dailyLatencyColumns({ roundedAvg: true })}
+       FROM surface_uptime_daily
+       WHERE day >= ?
+       GROUP BY netuid`,
+        [thirtyDaysAgo],
+      ),
+    ]);
   return formatLeaderboards({
     board,
     limit,
@@ -427,6 +444,7 @@ export async function loadRegistryLeaderboards(
     rpcRows,
     mostComplete,
     growthRows: growthRowsFromSamples(growthSamples),
+    reliabilityRows,
     economicsRows,
     subnetMeta,
   });

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -354,6 +354,33 @@ describe("analytics-live loaders", () => {
     assert.equal("fastest-rpc" in data.boards, false);
   });
 
+  test("loadRegistryLeaderboards ranks most-reliable from surface_uptime_daily", async () => {
+    const data = await loadRegistryLeaderboards(
+      d1({
+        "FROM surface_uptime_daily": [
+          {
+            netuid: 7,
+            samples: 100,
+            ok_count: 100,
+            avg_latency_ms: 50,
+            latency_samples: 100,
+          },
+        ],
+      }),
+      {
+        profiles: [{ netuid: 7, slug: "apex", name: "Apex" }],
+        economicsRows: [],
+        board: "most-reliable",
+        limit: 5,
+        observedAt: OBSERVED_AT,
+      },
+    );
+    assert.equal(data.boards["most-reliable"].length, 1);
+    assert.equal(data.boards["most-reliable"][0].netuid, 7);
+    assert.equal(data.boards["most-reliable"][0].score, 100);
+    assert.equal("healthiest" in data.boards, false);
+  });
+
   test("loadCompareSubnets composes requested dimensions", async () => {
     const data = await loadCompareSubnets(
       d1({


### PR DESCRIPTION
## Summary

The `get_registry_leaderboards` MCP tool always returns an empty `most-reliable` board even when D1 has 30 days of uptime history, because the shared `loadRegistryLeaderboards` loader never queries `surface_uptime_daily` for reliability rollups. REST `GET /api/v1/registry/leaderboards` runs that query via `handleLeaderboards`; MCP does not.

## Bug

**Symptom:** Agents calling `get_registry_leaderboards` (or requesting `board: "most-reliable"`) get `boards["most-reliable"]: []` while the REST endpoint returns ranked subnets with scores and grades.

**Root cause:** `loadRegistryLeaderboards` in `src/analytics-live.mjs` loads health, RPC latency, and growth samples, but omits the 30-day `surface_uptime_daily` aggregation that `handleLeaderboards` in `workers/request-handlers/analytics-routes.mjs` passes as `reliabilityRows` to `formatLeaderboards`. The MCP tool calls the loader, not the REST handler:

```1743:1748:src/mcp-server.mjs
      return loadRegistryLeaderboards(mcpD1Runner(ctx), {
        profiles,
        economicsRows: await loadEconomicsSubnetRows(ctx),
        board: optionalString(args, "board"),
        limit: args?.limit,
        observedAt: await mcpObservedAt(ctx),
```

`formatLeaderboards` builds `most-reliable` exclusively from `reliabilityRows`:

```953:958:src/health-serving.mjs
  const mostReliable = (reliabilityRows || [])
    .map((row) => {
      const score = scoreFromStats({
        samples: Number(row.samples) || 0,
```

REST already runs the missing query (added/restored in #1927 / #2068):

```341:349:workers/request-handlers/analytics-routes.mjs
      d1All(
        env,
        `SELECT netuid,
              SUM(samples) AS samples,
              SUM(ok_count) AS ok_count,
              ${dailyLatencyColumns({ roundedAvg: true })}
       FROM surface_uptime_daily
       WHERE day >= ?
       GROUP BY netuid`,
        [thirtyDaysAgo],
```

## Proposed fix

1. Extend `loadRegistryLeaderboards` to mirror `handleLeaderboards`:
   - Compute `thirtyDaysAgo` (same 30d cutoff as REST).
   - Add a fourth parallel D1 read against `surface_uptime_daily` grouped by `netuid`.
   - Pass the rows as `reliabilityRows` into `formatLeaderboards`.
2. Keep SQL/column shape identical to `handleLeaderboards` so REST and MCP stay parity-aligned.
3. Add regression coverage in `tests/analytics-live.test.mjs`:
   - Mock uptime rollup rows.
   - Assert `loadRegistryLeaderboards(..., { board: "most-reliable" })` returns non-empty entries with expected `score` / `grade` fields.
4. Optionally extend `tests/mcp-server.test.mjs` with a D1 fixture that asserts `get_registry_leaderboards` populates `most-reliable`.

## What Changed

- `src/analytics-live.mjs` — add reliability rollup query + pass `reliabilityRows`.
- `tests/analytics-live.test.mjs` — regression test for MCP/shared loader path.
- (Optional) `tests/mcp-server.test.mjs` — end-to-end MCP assertion.

No schema or OpenAPI regeneration expected (response shape already documents `most-reliable`; payload was just empty).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run lint && npm run format:check`
- [x] `npm run validate`
- [x] `npm test -- tests/analytics-live.test.mjs tests/mcp-server.test.mjs tests/request-handlers-analytics-routes.test.mjs`
- [x] `npm run test:coverage`
- [x] `git diff --check`
