### PR TITLE
fix(python): populate Provider.slug from the API's id key

### DIFF
--- a/python/src/metagraphed/models.py
+++ b/python/src/metagraphed/models.py
@@ -11,7 +11,7 @@ or the typed convenience methods such as ``client.subnets()``).
 from __future__ import annotations
 
 from dataclasses import dataclass, field, fields
-from typing import Any, List, Mapping, Optional
+from typing import Any, ClassVar, List, Mapping, Optional
 
 
 class _Model:
@@ -20,16 +20,33 @@ class _Model:
 
     raw: Mapping[str, Any]
 
+    # Per-model alias map: API response key -> dataclass field name. The API and
+    # the models mostly share names, but a few collections expose a field under a
+    # different key (e.g. providers carry their slug as ``id``); without an alias
+    # ``from_dict`` would leave the typed field ``None`` even though ``.raw`` has
+    # the value. Subclasses override this.
+    _aliases: ClassVar[Mapping[str, str]] = {}
+
+    @classmethod
+    def _known_kwargs(cls, mapping: Mapping[str, Any]) -> dict:
+        """Project an API dict onto this model's fields.
+
+        Direct name matches win; any ``_aliases`` entry (API key -> field) then
+        fills a field the API exposes under a different key, so a renamed key
+        such as provider ``id`` -> ``slug`` populates the typed field instead of
+        silently staying ``None``.
+        """
+        known = {f.name for f in fields(cls) if f.name != "raw"}  # type: ignore[arg-type]
+        kwargs = {name: mapping[name] for name in known if name in mapping}
+        for source, target in cls._aliases.items():
+            if target in known and target not in kwargs and source in mapping:
+                kwargs[target] = mapping[source]
+        return kwargs
+
     @classmethod
     def from_dict(cls, data: Any) -> Any:
         mapping = data if isinstance(data, Mapping) else {}
-        known = {f.name for f in fields(cls)}  # type: ignore[arg-type]
-        kwargs = {
-            name: mapping.get(name)
-            for name in known
-            if name != "raw" and name in mapping
-        }
-        instance = cls(**kwargs)  # type: ignore[call-arg]
+        instance = cls(**cls._known_kwargs(mapping))  # type: ignore[call-arg]
         instance.raw = dict(mapping)
         return instance
 
@@ -86,6 +103,8 @@ class Endpoint(_Model):
 
 @dataclass
 class Provider(_Model):
+    # The providers API exposes the provider slug as ``id`` (no ``slug`` key).
+    _aliases: ClassVar[Mapping[str, str]] = {"id": "slug"}
     slug: Optional[str] = None
     name: Optional[str] = None
     authority: Optional[str] = None

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -11,6 +11,7 @@ import metagraphed.client as client
 from metagraphed import (
     MetagraphedClient,
     MetagraphedError,
+    Provider,
     Subnet,
     Surface,
     metagraphed_fetch,
@@ -446,6 +447,29 @@ class FetchAllAndModelsTest(unittest.TestCase):
     def test_model_from_dict_tolerates_non_mapping(self):
         self.assertEqual(Subnet.from_dict(None).raw, {})
         self.assertIsNone(Subnet.from_dict(None).netuid)
+
+    def test_provider_slug_aliases_the_api_id_key(self):
+        # The providers API exposes the slug as `id` (there is no `slug` key), so
+        # Provider.slug must alias from `id` instead of silently staying None.
+        provider = Provider.from_dict(
+            {"id": "macrocosmos", "name": "Macrocosmos", "surface_count": 12}
+        )
+        self.assertEqual(provider.slug, "macrocosmos")
+        self.assertEqual(provider.name, "Macrocosmos")
+        self.assertEqual(provider.surface_count, 12)
+        self.assertEqual(provider.raw["id"], "macrocosmos")
+
+    def test_provider_explicit_slug_wins_over_alias(self):
+        # A direct `slug` (should the API ever send one) takes precedence over the
+        # `id` alias; the alias only fills an otherwise-unset field.
+        provider = Provider.from_dict({"id": "from-id", "slug": "from-slug"})
+        self.assertEqual(provider.slug, "from-slug")
+
+    def test_alias_does_not_leak_to_other_models(self):
+        # The alias map is per-model: a Subnet carrying an `id` must not pick it
+        # up as a slug (Subnet has no such alias).
+        subnet = Subnet.from_dict({"id": "x", "slug": "real-slug"})
+        self.assertEqual(subnet.slug, "real-slug")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary

This PR fixes an issue where `Provider.slug` was always `None` in the Python SDK.

The providers API returns the provider identifier under the `id` field, while the `Provider` model expects the field to be named `slug`. Since no mapping existed between the API response and the model, `Provider.from_dict()` never populated `slug`, causing the typed SDK to return `None` even though the identifier was available in the raw response.

This change introduces a generic alias mechanism for mapping API field names to model fields and applies it to the `Provider` model.

## Root Cause

The API response uses:

```json
{
  "id": "macrocosmos"
}
```

while the Python model defines:

```python
class Provider:
    slug: str
```

Because `from_dict()` only mapped fields with identical names, the `id` value was ignored and `slug` remained `None`.

## Changes

### Source

**`python/src/metagraphed/models.py`**

- Added `_Model._known_kwargs()` to map API response fields to model fields.
- Introduced a per-model `_aliases` mapping for field aliases.
- Updated `from_dict()` to use the alias mechanism during model construction.
- Added `Provider._aliases = {"id": "slug"}` to correctly populate the `slug` field.

### Tests

**`python/tests/test_client.py`**

Added regression tests to verify:

- `Provider.from_dict({"id": ...})` correctly populates `slug`.
- An explicitly provided `slug` takes precedence over the alias.
- Aliases remain isolated to individual models and do not affect unrelated models.

## Validation

- [x] `python -m unittest discover -s tests`
- [x] `python -m py_compile src/metagraphed/models.py tests/test_client.py`
- [x] Verified the regression test fails on `main` and passes with this fix.
- [x] Changes are limited to two files under `python/`.
