### PR TITLE
fix(api): trim whitespace in compare dimensions parsing

### DIFF
--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -111,10 +111,7 @@ export function parseCompareDimensions(dimensionsRaw) {
   if (dimensionsRaw === null || dimensionsRaw === undefined) {
     return COMPARE_DIMENSIONS;
   }
-  const requested = String(dimensionsRaw).split(",");
-  const unknown = requested.find((d) => !COMPARE_DIMENSIONS.includes(d));
-  if (unknown !== undefined) return null;
-  return COMPARE_DIMENSIONS.filter((d) => requested.includes(d));
+  return compareDimensionsFromTokens(String(dimensionsRaw).split(","));
 }
 
 export function parseCompareDimensionList(dimensions) {
@@ -122,9 +119,19 @@ export function parseCompareDimensionList(dimensions) {
     return COMPARE_DIMENSIONS;
   }
   if (!Array.isArray(dimensions) || dimensions.length === 0) return null;
-  const unknown = dimensions.find((d) => !COMPARE_DIMENSIONS.includes(d));
+  return compareDimensionsFromTokens(dimensions);
+}
+
+function compareDimensionsFromTokens(tokens) {
+  const requested = [];
+  for (const token of tokens) {
+    const trimmed = String(token).trim();
+    if (trimmed === "") return null;
+    requested.push(trimmed);
+  }
+  const unknown = requested.find((d) => !COMPARE_DIMENSIONS.includes(d));
   if (unknown !== undefined) return null;
-  return COMPARE_DIMENSIONS.filter((d) => dimensions.includes(d));
+  return COMPARE_DIMENSIONS.filter((d) => requested.includes(d));
 }
 
 export async function loadSubnetUptime(

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -752,10 +752,19 @@ describe("analytics-live window parsers", () => {
   test("parseCompareDimensionList rejects unknown dimensions", () => {
     assert.deepEqual(parseCompareDimensionList(["structure"]), ["structure"]);
     assert.equal(parseCompareDimensionList(["bogus"]), null);
+    assert.deepEqual(parseCompareDimensionList(["structure", " health"]), [
+      "structure",
+      "health",
+    ]);
+    assert.equal(parseCompareDimensionList(["structure", ""]), null);
   });
 
   test("parseCompareDimensions mirrors REST comma-list input", () => {
     assert.deepEqual(parseCompareDimensions("structure,health"), [
+      "structure",
+      "health",
+    ]);
+    assert.deepEqual(parseCompareDimensions("structure, health"), [
       "structure",
       "health",
     ]);
@@ -765,5 +774,6 @@ describe("analytics-live window parsers", () => {
       "health",
     ]);
     assert.equal(parseCompareDimensions("bogus"), null);
+    assert.equal(parseCompareDimensions("structure,,health"), null);
   });
 });

--- a/tests/compare.test.mjs
+++ b/tests/compare.test.mjs
@@ -223,6 +223,24 @@ describe("GET /api/v1/compare", () => {
     assert.deepEqual(body.data.dimensions, ["structure", "health"]);
   });
 
+  test("dimensions tolerate whitespace around comma-separated entries", async () => {
+    const { body } = await get(
+      "/api/v1/compare?netuids=1&dimensions=structure,%20health",
+    );
+    assert.deepEqual(body.data.dimensions, ["structure", "health"]);
+    const [s] = body.data.subnets;
+    assert.equal("structure" in s, true);
+    assert.equal("health" in s, true);
+  });
+
+  test("rejects empty dimension tokens", async () => {
+    const { status, body } = await get(
+      "/api/v1/compare?netuids=1&dimensions=structure,,health",
+    );
+    assert.equal(status, 400);
+    assert.equal(body.meta.parameter, "dimensions");
+  });
+
   test("an unknown netuid is found:false, never a 404", async () => {
     const { status, body } = await get("/api/v1/compare?netuids=99999");
     assert.equal(status, 200);

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -414,7 +414,12 @@ function compareNetuids(netuidsRaw) {
 
 function compareDimensions(dimensionsRaw) {
   if (dimensionsRaw === null) return COMPARE_DIMENSIONS;
-  const requested = dimensionsRaw.split(",");
+  const requested = [];
+  for (const part of dimensionsRaw.split(",")) {
+    const trimmed = part.trim();
+    if (trimmed === "") return null;
+    requested.push(trimmed);
+  }
   const unknown = requested.find((d) => !COMPARE_DIMENSIONS.includes(d));
   if (unknown !== undefined) return null;
   return COMPARE_DIMENSIONS.filter((d) => requested.includes(d));
@@ -525,12 +530,15 @@ export async function handleCompare(request, env, url) {
   const dimensionsRaw = url.searchParams.get("dimensions");
   const dimensions = compareDimensions(dimensionsRaw);
   if (!dimensions) {
-    const unknown = dimensionsRaw
-      .split(",")
-      .find((d) => !COMPARE_DIMENSIONS.includes(d));
+    const tokens = dimensionsRaw.split(",").map((d) => d.trim());
+    const unknown =
+      tokens.find((d) => d === "") ??
+      tokens.find((d) => !COMPARE_DIMENSIONS.includes(d));
     return errorResponse(
       "invalid_query",
-      `Unknown dimension "${unknown}". Valid dimensions: ${COMPARE_DIMENSIONS.join(", ")}.`,
+      unknown === ""
+        ? "dimensions must not contain empty entries."
+        : `Unknown dimension "${unknown}". Valid dimensions: ${COMPARE_DIMENSIONS.join(", ")}.`,
       400,
       { parameter: "dimensions" },
     );


### PR DESCRIPTION
## Summary

`GET /api/v1/compare` rejects otherwise valid `dimensions` values when comma-separated entries contain leading or trailing spaces (for example `structure, health`). The parser treats `" health"` as an unknown dimension instead of `health`. MCP and GraphQL share the same strict matching via `parseCompareDimensionList`, so the failure is consistent across surfaces but still surprising for callers.

## Bug

**Symptom:** Requests like `/api/v1/compare?netuids=1&dimensions=structure, health` return `400 invalid_query` with `Unknown dimension " health"`.

**Root cause:** Dimension tokens are split on commas but never trimmed before validation:

```415:420:workers/request-handlers/analytics-routes.mjs
function compareDimensions(dimensionsRaw) {
  if (dimensionsRaw === null) return COMPARE_DIMENSIONS;
  const requested = dimensionsRaw.split(",");
  const unknown = requested.find((d) => !COMPARE_DIMENSIONS.includes(d));
  if (unknown !== undefined) return null;
  return COMPARE_DIMENSIONS.filter((d) => requested.includes(d));
```

The shared MCP/GraphQL helper duplicates the same logic:

```110:117:src/analytics-live.mjs
export function parseCompareDimensions(dimensionsRaw) {
  if (dimensionsRaw === null || dimensionsRaw === undefined) {
    return COMPARE_DIMENSIONS;
  }
  const requested = String(dimensionsRaw).split(",");
  const unknown = requested.find((d) => !COMPARE_DIMENSIONS.includes(d));
  if (unknown !== undefined) return null;
  return COMPARE_DIMENSIONS.filter((d) => requested.includes(d));
```

**Expected behavior:** Trim each token after splitting (and reject empty tokens), matching common query-string ergonomics. Canonical dimension order (`structure`, `economics`, `health`) should remain unchanged.

**Reproduction:**

```sh
curl -s "https://api.metagraph.sh/api/v1/compare?netuids=1&dimensions=structure,%20health" | jq .error
# → invalid_query, unknown dimension " health"
```

Compare with the working form (no space): `dimensions=structure,health`.


## What Changed

- `src/analytics-live.mjs` — trim + empty-token guard in compare dimension parsers.
- `workers/request-handlers/analytics-routes.mjs` — same normalization in `compareDimensions` (or delegate to shared helper).
- `tests/compare.test.mjs` — accept `dimensions=structure, health` (200, canonical order).
- `tests/analytics-live.test.mjs` — parser unit tests for spaced and empty tokens.

No OpenAPI/schema regeneration expected (parameter semantics unchanged; validation becomes slightly more permissive).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run lint && npm run format:check`
- [x] `npm run validate`
- [x] `npm test -- tests/compare.test.mjs tests/analytics-live.test.mjs`
- [x] `npm run test:coverage`
- [x] `git diff --check`
