### PR TITLE
fix(api): tie-break chain-calls leaderboard for deterministic LIMIT output

### DIFF
--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -482,7 +482,8 @@ export async function loadCompareSubnets(
 
 // Extrinsic call-mix breakdown (#1989): counts + share per call_module (or
 // call_module/call_function). The share denominator is the full-window extrinsic
-// count read separately, so the truncated LIMIT tail never skews shares. Mirrors
+// count read separately, so the truncated LIMIT tail never skews shares. Tie-break
+// on the GROUP BY keys so tied counts keep a stable LIMIT membership. Mirrors
 // REST's handleChainCalls and the get_chain_calls MCP tool (#2364).
 export async function loadChainCalls(
   d1,
@@ -506,6 +507,10 @@ export async function loadChainCalls(
     groupBy === "module_function"
       ? "call_module, call_function"
       : "call_module";
+  const orderByCols =
+    groupBy === "module_function"
+      ? "count DESC, call_module ASC, call_function ASC"
+      : "count DESC, call_module ASC";
   const callModuleFilter =
     typeof callModule === "string" && callModule.length > 0 ? callModule : null;
   const moduleClause = callModuleFilter ? " AND call_module = ?" : "";
@@ -515,7 +520,7 @@ export async function loadChainCalls(
        FROM extrinsics
        WHERE observed_at >= ? AND call_module IS NOT NULL${moduleClause}
        GROUP BY ${groupCols}
-       ORDER BY count DESC
+       ORDER BY ${orderByCols}
        LIMIT ?`,
       callModuleFilter ? [cutoff, callModuleFilter, limit] : [cutoff, limit],
     ),

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -485,7 +485,7 @@ describe("analytics-live loaders", () => {
     });
     assert.match(
       captured[0].sql,
-      /GROUP BY call_module[\s\S]*ORDER BY count DESC, call_module ASC LIMIT \?/,
+      /GROUP BY call_module[\s\S]*ORDER BY count DESC, call_module ASC\s+LIMIT \?/,
     );
 
     captured.length = 0;
@@ -497,7 +497,7 @@ describe("analytics-live loaders", () => {
     });
     assert.match(
       captured[0].sql,
-      /GROUP BY call_module, call_function[\s\S]*ORDER BY count DESC, call_module ASC, call_function ASC LIMIT \?/,
+      /GROUP BY call_module, call_function[\s\S]*ORDER BY count DESC, call_module ASC, call_function ASC\s+LIMIT \?/,
     );
   });
 

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -469,6 +469,38 @@ describe("analytics-live loaders", () => {
     assert.equal(data.calls[0].share, 0.5);
   });
 
+  test("loadChainCalls tie-breaks grouped rows for stable LIMIT membership", async () => {
+    const captured = [];
+    const run = async (sql, params) => {
+      captured.push({ sql, params });
+      if (/COUNT\(\*\) AS total/.test(sql)) return [{ total: 0 }];
+      return [];
+    };
+
+    await loadChainCalls(run, {
+      window: "7d",
+      groupBy: "module",
+      limit: 5,
+      now: Date.UTC(2026, 5, 26),
+    });
+    assert.match(
+      captured[0].sql,
+      /GROUP BY call_module[\s\S]*ORDER BY count DESC, call_module ASC LIMIT \?/,
+    );
+
+    captured.length = 0;
+    await loadChainCalls(run, {
+      window: "7d",
+      groupBy: "module_function",
+      limit: 5,
+      now: Date.UTC(2026, 5, 26),
+    });
+    assert.match(
+      captured[0].sql,
+      /GROUP BY call_module, call_function[\s\S]*ORDER BY count DESC, call_module ASC, call_function ASC LIMIT \?/,
+    );
+  });
+
   test("loadChainCalls groups by call_module and call_function when requested", async () => {
     const captured = [];
     const run = async (sql, params) => {


### PR DESCRIPTION
## What

`loadChainCalls` (powering `GET /api/v1/chain/calls` and the `get_chain_calls` MCP tool) ranks grouped extrinsic counts with `ORDER BY count DESC` and a trailing `LIMIT`. That sort key is **not a total order**: when multiple `call_module` rows (or `call_module`/`call_function` pairs) share the same count, D1/SQLite group order is unspecified, so:

- the returned calls array could reorder between identical requests, and
- at the `LIMIT` boundary, **membership** of the truncated tail could change — not just ordering.

Shares stay honest because the denominator is a separate full-window count, but the truncated list itself was nondeterministic.

## How

Add stable secondary sort keys on the respective `GROUP BY` columns:

- module grouping: `ORDER BY count DESC, call_module ASC`
- module_function grouping: `ORDER BY count DESC, call_module ASC, call_function ASC`

This is a pure ordering change — aggregate values and share math are unchanged; only tie resolution and `LIMIT` membership become well-defined.

## Scope / risk

Two dynamic `ORDER BY` branches in a single loader plus one focused test. No schema, contract, or public field changes.

## Tests

- `tests/analytics-live.test.mjs`: adds `loadChainCalls tie-breaks grouped rows for stable LIMIT membership`, asserting both group-by modes carry their stable secondary sort keys ahead of `LIMIT ?`. Existing chain-calls route and MCP tests continue to match — they assert `ORDER BY count DESC`, which remains a prefix of the new clauses.

I don't have a local Node/npm toolchain; CI runs the full vitest suite.
