### PR TITLE
feat(registry): add SN13 Data Universe dashboard surface (Hugging Face Space)

### DIFF
--- a/registry/subnets/data-universe.json
+++ b/registry/subnets/data-universe.json
@@ -257,6 +257,30 @@
         "https://github.com/macrocosm-os/macrocosmos-py"
       ],
       "url": "https://constellation.api.cloud.macrocosmos.ai/sn13.v1.Sn13Service/OnDemandData"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-13-macrocosmos-dashboard",
+      "kind": "dashboard",
+      "name": "Data Universe dashboard (Hugging Face Space)",
+      "notes": "Official SN13 Data Universe dashboard hosted under the macrocosm-os Hugging Face organization. First-party dashboard complementing the third-party TaoMarketCap surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "since-2017-hub"
+      },
+      "source_urls": [
+        "https://huggingface.co/api/spaces/macrocosm-os/sn13-dashboard"
+      ],
+      "url": "https://huggingface.co/spaces/macrocosm-os/sn13-dashboard"
     }
   ],
   "website_url": "https://datauniverse.macrocosmos.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `dashboard` surface to `registry/subnets/data-universe.json`
(SN13 Data Universe): the official **macrocosm-os Hugging Face Space** dashboard.
This is the first first-party dashboard for SN13 — the only currently registered
`dashboard` is the third-party TaoMarketCap page, so it fills a real gap.

## Surface

- Netuid: 13
- Kind: dashboard
- Public URL: https://huggingface.co/spaces/macrocosm-os/sn13-dashboard
- Source URL (proves the claim):
  https://huggingface.co/api/spaces/macrocosm-os/sn13-dashboard — the platform's
  authoritative ownership record: `author: macrocosm-os` (the official Macrocosmos
  org, same namespace as their GitHub org), space id `macrocosm-os/sn13-dashboard`,
  card title "Sn13 Dashboard", `private: false`, `gated: false`. This independently
  proves the official subnet operator publishes this exact dashboard.
- Provider slug: macrocosmos

## No linked issue

There is no upstream tracking issue for this surface (no open SN13 dashboard /
surface-submission issue exists). Per the contribution guide a linked issue is
optional and a PR is judged on its own merit; this is intentionally a no-issue PR.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file (`data-universe.json`).
- [x] Generated with `npm run surface:add` — `authority: community`,
      `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`
      independently proves the subnet publishes this exact surface (owner-scoped HF org).
- [x] `notes` describe durable ownership/purpose only — no transient runtime state.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data,
      private URLs, private dashboards, validator internals, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface — distinct from the
      third-party TaoMarketCap dashboard and from the dead
      `sn13-dashboard.api.macrocosmos.ai` API host that was intentionally not promoted.

## Validation

- [x] `npm run validate:surface -- registry/subnets/data-universe.json` → passed (12 surfaces)
- [x] `npm run scan:public-safety` → passed
- Also green: `validate:intake`, `validate:private-boundary`; `git diff --check` clean.
