### PR TITLE
fix(mcp): add call_module filter to get_chain_calls

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -2713,10 +2713,10 @@ export const MCP_TOOLS = [
     description:
       "Fetch the extrinsic call-mix breakdown over a 7d or 30d window: each " +
       "call_module (or call_module/call_function with group_by=module_function) " +
-      "by count and share of all extrinsics. Use it to see which pallets and " +
-      "calls dominate on-chain traffic before drilling into specific blocks " +
-      "(get_block) or extrinsics (list_extrinsics). Mirrors " +
-      "GET /api/v1/chain/calls.",
+      "by count and share of all extrinsics. Optionally scope to one pallet via " +
+      "call_module. Use it to see which pallets and calls dominate on-chain traffic " +
+      "before drilling into specific blocks (get_block) or extrinsics " +
+      "(list_extrinsics). Mirrors GET /api/v1/chain/calls.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2737,6 +2737,11 @@ export const MCP_TOOLS = [
           minimum: 1,
           maximum: 100,
         },
+        call_module: {
+          type: "string",
+          description:
+            "Optional pallet filter (e.g. Balances); omit for all modules.",
+        },
       },
       required: [],
       additionalProperties: false,
@@ -2751,9 +2756,17 @@ export const MCP_TOOLS = [
         optionalEnum(args, "group_by", ["module", "module_function"]) ||
         "module";
       const limit = clampLimit(args?.limit, 50, 100);
+      const callModule = optionalString(args, "call_module");
+      if (callModule != null && callModule.length > 100) {
+        throw toolError(
+          "invalid_params",
+          "call_module must be at most 100 characters.",
+        );
+      }
       return loadChainCalls(mcpD1Runner(ctx), {
         window: label,
         groupBy,
+        callModule,
         limit,
         observedAt: await mcpObservedAt(ctx),
       });

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -143,7 +143,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.13.0";
+export const MCP_SERVER_VERSION = "1.14.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4478,6 +4478,66 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.calls[0].share, 0.5);
   });
 
+  test("get_chain_calls rejects an over-long call_module", async () => {
+    const res = await callTool(
+      "get_chain_calls",
+      { call_module: "x".repeat(101) },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /call_module/i);
+  });
+
+  test("get_chain_calls scopes grouped rows and totals by call_module", async () => {
+    const captured = [];
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              captured.push({ sql, params });
+              const rows = /GROUP BY call_module, call_function/.test(sql)
+                ? [
+                    {
+                      call_module: "SubtensorModule",
+                      call_function: "add_stake",
+                      count: 50,
+                    },
+                  ]
+                : /COUNT\(\*\) AS total/.test(sql)
+                  ? [{ total: 80 }]
+                  : [];
+              return { all: () => Promise.resolve({ results: rows }) };
+            },
+          };
+        },
+      },
+    };
+    const deps = makeDeps({}, { "health:meta": { last_run_at: FRESH_RUN } });
+    const res = await callTool(
+      "get_chain_calls",
+      {
+        window: "7d",
+        group_by: "module_function",
+        call_module: "SubtensorModule",
+        limit: 3,
+      },
+      { deps, env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.group_by, "module_function");
+    assert.equal(out.total_extrinsics, 80);
+    assert.equal(out.calls[0].share, 0.625);
+    const extrinsicsQueries = captured.filter((q) =>
+      /FROM extrinsics/.test(q.sql),
+    );
+    assert.equal(extrinsicsQueries.length, 2);
+    for (const q of extrinsicsQueries) {
+      assert.match(q.sql, /AND call_module = \?/);
+      assert.ok(q.params.includes("SubtensorModule"));
+    }
+  });
+
   test("get_registry_leaderboards returns boards from committed profiles", async () => {
     const res = await callTool(
       "get_registry_leaderboards",


### PR DESCRIPTION

## Summary

The `get_chain_calls` MCP tool could not scope call-mix analytics to a single pallet, even though REST `GET /api/v1/chain/calls` supports `?call_module=` and the shared `loadChainCalls` loader already implements the filter. Sibling MCP tools (`get_chain_fees`, `get_chain_signers`) already expose `call_module`; `get_chain_calls` was the outlier.

## Bug

**Symptom:** Agents calling `get_chain_calls` always receive network-wide call-mix totals and shares. There is no way to mirror REST requests like `/api/v1/chain/calls?call_module=SubtensorModule&group_by=module_function`.

**Root cause:** REST forwards `call_module` into the shared loader:

```694:716:workers/request-handlers/analytics.mjs
  const callModule = url.searchParams.get("call_module");
  const callModuleError = validateMaxLength(url, "call_module", 100);
  if (callModuleError) return analyticsQueryError(callModuleError);
  // ...
      const data = await loadChainCalls(d1, {
        window: label,
        groupBy,
        callModule,
        limit,
```

The MCP tool schema and handler omitted the parameter entirely — only `window`, `group_by`, and `limit` were wired through to `loadChainCalls`.

## Fix

1. Add optional `call_module` to the `get_chain_calls` MCP `inputSchema` (same shape as `get_chain_fees` / `get_chain_signers`).
2. Validate max length (100 chars) and trim via `optionalString`.
3. Pass `callModule` into `loadChainCalls` so grouped rows and the share denominator both use the scoped module filter (same as REST).
4. Add MCP regression tests for over-long `call_module` and scoped module-function grouping.

## What Changed

- `src/mcp-server.mjs` — `call_module` input + handler wiring for `get_chain_calls`.
- `tests/mcp-server.test.mjs` — regression tests for validation and scoped SQL.

No OpenAPI/schema regeneration required (REST contract already documents `call_module`; this closes MCP parity only).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run lint && npm run format:check`
- [x] `npm run validate`
- [x] `npm test -- tests/mcp-server.test.mjs -t get_chain_calls`
- [x] `npm run test:coverage`
- [x] `git diff --check`
