### PR TITLE
fix(api): tie-break rpc-usage leaderboards for deterministic LIMIT output

### DIFF
--- a/src/rpc-usage-loader.mjs
+++ b/src/rpc-usage-loader.mjs
@@ -11,8 +11,9 @@ import { formatRpcUsage } from "./health-serving.mjs";
 
 // RPC reverse-proxy usage analytics (B3): request volume, latency p50/p95,
 // failover + error rate, cache-hit rate, per-endpoint distribution, and bounded
-// time buckets. `d1` is a (sql, params) => rows runner — d1Runner(env) in the
-// Worker, mcpD1Runner(ctx) in the MCP server.
+// time buckets. Endpoint/network leaderboards tie-break on their GROUP BY keys
+// so tied request counts keep stable LIMIT membership. `d1` is a (sql, params) =>
+// rows runner — d1Runner(env) in the Worker, mcpD1Runner(ctx) in the MCP server.
 export async function loadRpcUsage(
   d1,
   { window = "7d", observedAt = null, now = Date.now() } = {},
@@ -54,7 +55,7 @@ export async function loadRpcUsage(
          FROM rpc_proxy_events
          WHERE observed_at >= ? AND endpoint_id IS NOT NULL
          GROUP BY endpoint_id, provider
-         ORDER BY requests DESC
+         ORDER BY requests DESC, endpoint_id ASC, provider ASC
          LIMIT 50`,
         [since],
       ),
@@ -65,7 +66,7 @@ export async function loadRpcUsage(
          FROM rpc_proxy_events
          WHERE observed_at >= ?
          GROUP BY network
-         ORDER BY requests DESC`,
+         ORDER BY requests DESC, network ASC`,
         [since],
       ),
       d1(

--- a/tests/rpc-usage-loader.test.mjs
+++ b/tests/rpc-usage-loader.test.mjs
@@ -73,4 +73,24 @@ describe("loadRpcUsage", () => {
     assert.equal(data.window, "7d");
     assert.equal(data.bucket_granularity, "1h");
   });
+
+  test("tie-breaks endpoint and network leaderboards for stable output", async () => {
+    const captured = [];
+    const d1 = async (sql) => {
+      captured.push(sql);
+      return [];
+    };
+    await loadRpcUsage(d1, { now: 1_700_000_000_000 });
+
+    const endpoints = captured.find((sql) => /GROUP BY endpoint_id/.test(sql));
+    const networks = captured.find((sql) => /GROUP BY network/.test(sql));
+    assert.match(
+      endpoints,
+      /GROUP BY endpoint_id, provider[\s\S]*ORDER BY requests DESC, endpoint_id ASC, provider ASC\s+LIMIT 50/,
+    );
+    assert.match(
+      networks,
+      /GROUP BY network[\s\S]*ORDER BY requests DESC, network ASC/,
+    );
+  });
 });


### PR DESCRIPTION
## What

`loadRpcUsage` (powering `GET /api/v1/rpc/usage` and the `get_rpc_usage` MCP tool) builds two request-count leaderboards with `ORDER BY requests DESC`. The endpoint query also applies `LIMIT 50`. That sort key is **not a total order**: when multiple endpoints (grouped by `endpoint_id`, `provider`) or networks share the same request count, D1/SQLite group order is unspecified, so:

- the endpoint list's **membership** at the `LIMIT 50` boundary could change between identical requests, and
- both leaderboard arrays could reorder on ties.

## How

Add stable secondary sort keys on the respective `GROUP BY` columns:

- endpoints: `ORDER BY requests DESC, endpoint_id ASC, provider ASC LIMIT 50`
- networks: `ORDER BY requests DESC, network ASC`

This is a pure ordering change — aggregate values are unchanged; only tie resolution and endpoint `LIMIT` membership become well-defined.

## Scope / risk

Two one-line SQL changes in a single shared loader plus one focused test. No schema, contract, or public field changes.

## Tests

- `tests/rpc-usage-loader.test.mjs`: adds `tie-breaks endpoint and network leaderboards for stable output`, asserting both queries carry their stable secondary sort keys (with multiline-whitespace-tolerant regex around `LIMIT 50`).

No linked issue: standalone correctness fix discovered by code inspection — same nondeterministic `ORDER BY … DESC` + `LIMIT` pattern fixed in account-summary, chain-calls, and health leaderboards. No open issue or PR covers rpc-usage tie-breaking.

I don't have a local Node/npm toolchain; CI runs the full vitest suite.
