### PR TITLE
fix(mcp): REST parity - keyset cursor + netuid tie-break for get_account_history

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -4,6 +4,7 @@
 // the daily rollup, the prune, and the row→API shaping (#1347). Pure + exported
 // for tests; the Worker runs the D1 I/O.
 import {
+  DAY_PATTERN,
   FEED_PAGINATION,
   clampLimit,
   clampOffset,
@@ -616,10 +617,21 @@ const ACCOUNT_DAY_COLUMNS =
 // rollup. ?netuid narrows to one subnet; ?from / ?to are YYYY-MM-DD bounds
 // (lexicographic on the TEXT `day` column). Newest day first. Clamps limit to
 // 1-1000 (default 100); clamps offset to 0-1 000 000. Null-safe on cold store.
+//
+// account_events_daily holds one row per (hotkey, day, netuid), so `day` alone
+// is not a total order — an account active on several subnets has multiple rows
+// per day. Ordering by `day DESC` only left same-day rows in an unspecified
+// order, which made offset paging non-deterministic (a page boundary inside a
+// day could drop or repeat a same-day row). Tie-break on `netuid DESC` so the
+// order is total, and expose the same `(day, netuid)` keyset cursor the REST
+// handler (handleAccountHistory) and the sibling tail loaders use, so callers
+// can page stable head-growing windows. A cursor takes precedence over offset;
+// a cursor that does not decode to a valid YYYY-MM-DD day is ignored (falls back
+// to the first page), preserving the never-throw contract.
 export async function loadAccountHistory(
   d1,
   ss58,
-  { netuid, from, to, limit, offset } = {},
+  { netuid, from, to, limit, offset, cursor } = {},
 ) {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
@@ -637,10 +649,32 @@ export async function loadAccountHistory(
     sql += " AND day <= ?";
     params.push(to);
   }
-  sql += " ORDER BY day DESC LIMIT ? OFFSET ?";
-  params.push(lim, off);
+  const cur = decodeCursor(cursor, 2);
+  const cursorDay = cur
+    ? String(cur[0]).replace(/^(\d{4})(\d{2})(\d{2})$/, "$1-$2-$3")
+    : null;
+  const useCursor = Boolean(cursorDay && DAY_PATTERN.test(cursorDay));
+  if (useCursor) {
+    sql += " AND (day, netuid) < (?, ?)";
+    params.push(cursorDay, cur[1]);
+  }
+  sql += " ORDER BY day DESC, netuid DESC LIMIT ?";
+  params.push(lim);
+  if (!useCursor) {
+    sql += " OFFSET ?";
+    params.push(off);
+  }
   const rows = await d1(sql, params);
-  return buildAccountHistory(rows, ss58, { limit: lim, offset: off });
+  const last = rows.length === lim ? rows[rows.length - 1] : null;
+  const nextCursor =
+    last && typeof last.day === "string" && DAY_PATTERN.test(last.day)
+      ? encodeCursor([Number(last.day.replaceAll("-", "")), last.netuid])
+      : null;
+  return buildAccountHistory(rows, ss58, {
+    limit: lim,
+    offset: off,
+    nextCursor,
+  });
 }
 
 // Extrinsics signed by this account, newest first. Matched by the extrinsic

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -2194,10 +2194,11 @@ export const MCP_TOOLS = [
       "Fetch the per-day activity series for one account by its SS58 hotkey address, " +
       "from the account_events_daily rollup: event count, kinds seen, and first/last " +
       "block per day. Optionally filter to one subnet (netuid), a date range (from/to " +
-      "as YYYY-MM-DD), and page with limit (1-1000, default 100) / offset. Newest day " +
-      "first. Useful for understanding how active a wallet has been over time. Note: " +
-      "the rollup is hotkey-attributed only — a delegate-only SS58 address returns " +
-      "zero days even if it has events in get_account_events.",
+      "as YYYY-MM-DD), and page with limit (1-1000, default 100) plus either a cursor " +
+      "(pass the previous response's next_cursor for stable head-growing pages) or an " +
+      "offset. Newest day first. Useful for understanding how active a wallet has been " +
+      "over time. Note: the rollup is hotkey-attributed only — a delegate-only SS58 " +
+      "address returns zero days even if it has events in get_account_events.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2230,8 +2231,15 @@ export const MCP_TOOLS = [
         },
         offset: {
           type: "integer",
-          description: "Pagination offset. Default 0.",
+          description:
+            "Pagination offset. Default 0. Ignored when cursor is set.",
           minimum: 0,
+        },
+        cursor: {
+          type: "string",
+          description:
+            "Opaque keyset cursor from a previous response's next_cursor. " +
+            "Takes precedence over offset for stable head-growing pages.",
         },
       },
       required: ["ss58"],
@@ -2243,12 +2251,14 @@ export const MCP_TOOLS = [
         typeof args?.netuid === "number" ? Math.floor(args.netuid) : undefined;
       const from = optionalString(args, "from");
       const to = optionalString(args, "to");
+      const cursor = optionalString(args, "cursor");
       return loadAccountHistory(mcpD1Runner(ctx), ss58, {
         netuid,
         from: from ?? undefined,
         to: to ?? undefined,
         limit: args?.limit,
         offset: args?.offset,
+        cursor: cursor ?? undefined,
       });
     },
   },

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -983,7 +983,12 @@ test("loadAccountHistory binds netuid/from/to filters and clamps pagination", as
   assert.ok(/AND netuid = \?/.test(captured.sql));
   assert.ok(/AND day >= \?/.test(captured.sql));
   assert.ok(/AND day <= \?/.test(captured.sql));
-  assert.ok(/ORDER BY day DESC LIMIT \? OFFSET \?/.test(captured.sql));
+  // Same-day rows are tie-broken on netuid so the order is total; no cursor →
+  // offset paging.
+  assert.ok(
+    /ORDER BY day DESC, netuid DESC LIMIT \? OFFSET \?/.test(captured.sql),
+  );
+  assert.ok(!/\(day, netuid\) < /.test(captured.sql));
   // limit 0 is below the floor → clamps to 1; offset 5 passes through.
   assert.deepEqual(captured.params, [
     "5Hk",
@@ -993,6 +998,49 @@ test("loadAccountHistory binds netuid/from/to filters and clamps pagination", as
     1,
     5,
   ]);
+});
+
+test("loadAccountHistory applies a (day, netuid) keyset cursor and drops offset", async () => {
+  let captured;
+  const out = await loadAccountHistory(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [
+        { day: "2026-06-20", netuid: 3, event_count: 2, event_kinds: "" },
+        { day: "2026-06-20", netuid: 1, event_count: 5, event_kinds: "" },
+      ];
+    },
+    "5Hk",
+    { limit: 2, offset: 99, cursor: encodeCursor([20260624, 7]) },
+  );
+  // Cursor path: keyset predicate present, OFFSET dropped, day re-hyphenated.
+  assert.ok(/AND \(day, netuid\) < \(\?, \?\)/.test(captured.sql));
+  assert.ok(/ORDER BY day DESC, netuid DESC LIMIT \?/.test(captured.sql));
+  assert.ok(!/OFFSET/.test(captured.sql));
+  assert.deepEqual(captured.params, ["5Hk", "2026-06-24", 7, 2]);
+  // A full page (rows.length === limit) yields a next_cursor from the last row.
+  assert.deepEqual(out.next_cursor, encodeCursor([20260620, 1]));
+});
+
+test("loadAccountHistory ignores a malformed cursor and emits no next_cursor on a short page", async () => {
+  let captured;
+  const out = await loadAccountHistory(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [
+        { day: "2026-06-20", netuid: 1, event_count: 5, event_kinds: "" },
+      ];
+    },
+    "5Hk",
+    { limit: 50, cursor: "not-a-valid-cursor" },
+  );
+  // Malformed cursor → first page (offset path), no keyset predicate, no throw.
+  assert.ok(!/\(day, netuid\) < /.test(captured.sql));
+  assert.ok(
+    /ORDER BY day DESC, netuid DESC LIMIT \? OFFSET \?/.test(captured.sql),
+  );
+  // Short page (rows.length < limit) → no next_cursor.
+  assert.equal(out.next_cursor, null);
 });
 
 test("loadAccountHistory ignores a non-integer netuid filter", async () => {


### PR DESCRIPTION
## Summary

- `account_events_daily` holds one row per `(hotkey, day, netuid)`, so `day` alone is not a total order. The MCP loader `loadAccountHistory` (`src/account-events.mjs`) still orders by `day DESC` only with offset paging, leaving same-day rows in an unspecified order - a page boundary inside a day can drop or repeat a row.
- The REST handler `handleAccountHistory` (`workers/request-handlers/entities.mjs`) was already given `ORDER BY day DESC, netuid DESC` plus a `(day, netuid)` keyset cursor (#2130). The MCP `get_account_history` tool calls the shared loader, which is the uncorrected twin. In-file siblings `loadAccountExtrinsics` / `loadAccountTransfers` in the same module already use the keyset pattern.
- Tie-break on `netuid DESC` for a total order, and add the same `(day, netuid)` keyset cursor + `next_cursor` the REST route and sibling loaders expose.

## What Changed

- `src/account-events.mjs` - `loadAccountHistory` orders by `day DESC, netuid DESC`, accepts `cursor`, applies `(day, netuid) < (?, ?)` when the cursor decodes to a valid `YYYY-MM-DD` day (cursor wins over offset; malformed cursor ? first page, never throws), and emits `next_cursor` from the last row of a full page.
- `src/mcp-server.mjs` - `get_account_history` exposes optional `cursor` and threads it through; description updated.
- `tests/account-events.test.mjs` - SQL-shape assertion updated; regression tests for keyset cursor path and malformed-cursor fallback.
- No schema/contract change: `next_cursor` is already part of `buildAccountHistory`; MCP server card is worker-computed.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none)

## Validation

- [x] `npx vitest run tests/account-events.test.mjs tests/mcp-server.test.mjs` (363 passed)
- [x] `npm run validate:mcp` (65 tools)
- [x] `git diff --check`

## Linked issue

No linked issue: issue creation on this repository is currently restricted for outside contributors (issues API returns 404). Per the contribution guide a linked issue is optional. This closes the documented REST/MCP parity gap for account-history paging.