### PR TITLE
fix(health): normalize live surface status in subnet and D1 overlays

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -154,7 +154,7 @@ export function overlaySubnetHealth(staticArtifact, liveCurrent, netuid) {
       kind: live.kind,
       provider: live.provider,
       url: live.url,
-      status: live.status,
+      status: normalizeProbeStatus(live.status),
       classification: live.classification,
       latency_ms: live.latency_ms,
       status_code: live.status_code,
@@ -220,7 +220,7 @@ export function mergeRpcEndpoints(staticArtifact, liveRpcPool) {
     if (!live) return endpoint;
     return {
       ...endpoint,
-      status: live.status,
+      status: normalizeProbeStatus(live.status),
       classification: live.classification,
       latency_ms: live.latency_ms,
       archive_support: live.archive_support ?? endpoint.archive_support,
@@ -264,7 +264,7 @@ export function overlayRpcPoolEligibility(pool, liveRpcPool) {
         (live.consecutive_failures || 0) >= POOL_SUSTAINED_DOWN_FAILURES;
       return {
         ...endpoint,
-        status: live.status,
+        status: normalizeProbeStatus(live.status),
         latency_ms: live.latency_ms ?? endpoint.latency_ms,
         latest_block: live.latest_block ?? endpoint.latest_block ?? null,
         health_source: "live-cron-prober",
@@ -1273,7 +1273,7 @@ function liveFromD1Rows(rows) {
     kind: r.kind,
     provider: r.provider,
     url: r.url,
-    status: r.status,
+    status: normalizeProbeStatus(r.status),
     classification: r.classification,
     latency_ms: Number.isFinite(r.latency_ms) ? r.latency_ms : null,
     status_code: Number.isInteger(r.status_code) ? r.status_code : null,

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -502,6 +502,30 @@ describe("overlaySubnetHealth (additional paths)", () => {
     assert.equal(out.summary.status, "ok");
   });
 
+  test("folds unrecognized live status into unknown on each surface row", () => {
+    const live = {
+      last_run_at: "2026-06-13T00:00:00.000Z",
+      surfaces: [
+        {
+          surface_id: "sn7-api",
+          netuid: 7,
+          kind: "subnet-api",
+          provider: "prov",
+          url: "https://api",
+          status: "throttled",
+          classification: "rate-limited",
+          latency_ms: 120,
+          last_checked: "2026-06-13T00:00:00.000Z",
+          last_ok: "2026-06-13T00:00:00.000Z",
+        },
+      ],
+    };
+    const out = overlaySubnetHealth(null, live, 7);
+    assert.equal(out.surfaces[0].status, "unknown");
+    assert.equal(out.summary.status, "unknown");
+    assert.equal(out.summary.unknown_count, 1);
+  });
+
   test("static artifact without a surfaces array → treated as empty, live pushed", () => {
     const live = {
       last_run_at: null,
@@ -1303,6 +1327,8 @@ describe("resolveLiveHealth (KV → D1 → null)", () => {
     assert.equal(live.summary.status_counts.unknown, 1);
     assert.equal(live.summary.status_counts.throttled, undefined);
     assert.equal(live.summary.surface_count, 1);
+    assert.equal(live.surfaces[0].status, "unknown");
+    assert.equal(live.subnets[0].status, "unknown");
   });
 
   test("does not return stale D1-only surface_status rows", async () => {

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -142,6 +142,26 @@ describe("mergeRpcEndpoints", () => {
     assert.equal(merged.endpoints.find((e) => e.id === "b").status, "ok"); // no live → static
   });
 
+  test("folds unrecognized live status into unknown on the endpoint row", () => {
+    const stat = {
+      schema_version: 1,
+      endpoints: [{ id: "a", status: "ok", health_source: "probe-derived" }],
+    };
+    const live = {
+      last_run_at: "r",
+      endpoints: [
+        {
+          id: "a",
+          status: "throttled",
+          classification: "rate-limited",
+          latency_ms: 120,
+        },
+      ],
+    };
+    const a = mergeRpcEndpoints(stat, live).endpoints.find((e) => e.id === "a");
+    assert.equal(a.status, "unknown");
+  });
+
   test("a failing endpoint's observed_at is the sweep time, not its stale last_ok", () => {
     const stat = {
       schema_version: 1,
@@ -224,6 +244,21 @@ describe("overlayRpcPoolEligibility", () => {
     const out = overlayRpcPoolEligibility(pool, live);
     assert.equal(out.endpoints.find((e) => e.id === "a").pool_eligible, false);
     assert.equal(out.endpoints.find((e) => e.id === "b").pool_eligible, true);
+  });
+
+  test("folds unrecognized live status into unknown on the pool endpoint row", () => {
+    const live = {
+      endpoints: [
+        {
+          id: "a",
+          status: "throttled",
+          classification: "rate-limited",
+          consecutive_failures: 0,
+        },
+      ],
+    };
+    const out = overlayRpcPoolEligibility(pool, live);
+    assert.equal(out.endpoints.find((e) => e.id === "a").status, "unknown");
   });
 
   test("returns the static pool unchanged when live is cold", () => {


### PR DESCRIPTION
## Summary

Normalize unrecognized live probe statuses on per-surface health rows so they match the API contract (`ok | degraded | failed | unknown`) and the summary rollups that already bucket them as `unknown`.

## What Changed

- `overlaySubnetHealth`, `liveFromD1Rows`, `mergeRpcEndpoints`, and `overlayRpcPoolEligibility` emitted raw prober status strings (e.g. `throttled`) on each surface/endpoint row while sibling paths (`overlayArtifactEndpoints`, `overlayEndpointHealth`, `summarizeRows`, global `status_counts`) already normalized them to `unknown`.
- Apply `normalizeProbeStatus()` at each leak site so `surfaces[].status` agrees with `summary` / `subnets[].status`.
- Extended the D1-fallback regression test and added an `overlaySubnetHealth` test mirroring the existing `overlayArtifactEndpoints` throttled→unknown case.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change — aligns output with the existing enum.)

## Validation

- [x] `npx vitest run tests/health-serving.test.mjs -t "D1 fallback folds|folds unrecognized live status"`
- [x] `npx eslint src/health-serving.mjs tests/health-serving.test.mjs`
- [x] `git diff --check`
