### PR TITLE
fix(python): terminate pagination cleanly on a null meta envelope

### DIFF
--- a/python/src/metagraphed/aio.py
+++ b/python/src/metagraphed/aio.py
@@ -26,6 +26,7 @@ from .client import (
     _default_headers,
     _interpolate,
     _jsonrpc_result,
+    _next_cursor,
 )
 from .models import AgentCatalogSubnet, Endpoint, Provider, Subnet, Surface
 
@@ -196,16 +197,7 @@ class AsyncMetagraphedClient:
                 path, path_params=path_params, query=page_query, headers=headers
             )
             yield page
-            pagination = (
-                page.get("meta", {}).get("pagination")
-                if isinstance(page, dict)
-                else None
-            )
-            cursor = (
-                pagination.get("next_cursor")
-                if isinstance(pagination, dict)
-                else None
-            )
+            cursor = _next_cursor(page)
             if cursor is None:
                 return
 

--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -280,6 +280,19 @@ def _error_detail(error: "urllib.error.HTTPError") -> str:
     return f": {raw[:200]}"
 
 
+def _next_cursor(page: Any) -> Optional[Any]:
+    """Return a list page's ``meta.pagination.next_cursor``, or ``None``.
+
+    Defensive at every level (mirrors :func:`_collection_rows`): a non-dict page,
+    a null/absent ``meta``, or a null/absent ``pagination`` all yield ``None`` so
+    pagination terminates cleanly instead of raising ``AttributeError`` on an
+    envelope whose ``meta`` is ``null`` rather than an object.
+    """
+    meta = page.get("meta") if isinstance(page, dict) else None
+    pagination = meta.get("pagination") if isinstance(meta, dict) else None
+    return pagination.get("next_cursor") if isinstance(pagination, dict) else None
+
+
 def metagraphed_paginate(
     path: str,
     *,
@@ -310,14 +323,7 @@ def metagraphed_paginate(
             backoff=backoff,
         )
         yield page
-        pagination = (
-            page.get("meta", {}).get("pagination")
-            if isinstance(page, dict)
-            else None
-        )
-        cursor = (
-            pagination.get("next_cursor") if isinstance(pagination, dict) else None
-        )
+        cursor = _next_cursor(page)
         if cursor is None:
             return
 

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -325,6 +325,34 @@ class ClientTest(unittest.TestCase):
         self.assertEqual(seen, [1, 2])
         self.assertIn("cursor=2", captured_urls[1])
 
+    def test_next_cursor_is_defensive_against_malformed_pages(self):
+        # Mirrors _collection_rows' guards: a non-dict page, a null/absent meta,
+        # or a null/absent pagination must yield None (terminate), never raise.
+        self.assertEqual(
+            client._next_cursor({"meta": {"pagination": {"next_cursor": "c2"}}}),
+            "c2",
+        )
+        self.assertIsNone(client._next_cursor({"meta": None}))
+        self.assertIsNone(client._next_cursor({"meta": {"pagination": None}}))
+        self.assertIsNone(client._next_cursor({"meta": {}}))
+        self.assertIsNone(client._next_cursor({}))
+        self.assertIsNone(client._next_cursor(None))
+        self.assertIsNone(client._next_cursor([1, 2]))
+
+    def test_paginate_terminates_on_null_meta_without_raising(self):
+        # Regression: a 200 whose envelope carries meta: null crashed cursor
+        # extraction with AttributeError, while _collection_rows handled the same
+        # page. Pagination must yield the page and stop cleanly instead.
+        def fake_urlopen(request, timeout=None):
+            return _FakeResponse({"ok": True, "data": [1, 2], "meta": None})
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            pages = list(metagraphed_paginate("/api/v1/subnets"))
+            rows = metagraphed_fetch_all("/api/v1/subnets")
+
+        self.assertEqual(len(pages), 1)
+        self.assertEqual(rows, [1, 2])
+
     def test_rpc_posts_jsonrpc_and_returns_result(self):
         captured = {}
 


### PR DESCRIPTION
## Summary

`metagraphed_paginate` (and the async `paginate`) extracted the next cursor via
`page.get("meta", {}).get("pagination")`, which raises `AttributeError` when a page
envelope carries `meta: null` instead of an object — so a single non-conforming list
page crashes `fetch_all` mid-iteration. The sibling `_collection_rows`, operating on
the *same page*, already guards this with `isinstance`, so the two paths disagreed on
how defensively they read a page.

## What Changed

- `python/src/metagraphed/client.py`
  - New `_next_cursor(page)` helper that reads `meta.pagination.next_cursor` with an
    `isinstance` guard at every level (mirrors `_collection_rows`): a non-dict page, a
    null/absent `meta`, or a null/absent `pagination` all yield `None`, so pagination
    terminates cleanly instead of raising.
  - `metagraphed_paginate` now calls `_next_cursor(page)`.
- `python/src/metagraphed/aio.py`
  - The async `paginate` imports and uses the same `_next_cursor`, removing the
    duplicated extraction so both clients share one defensive code path.
- `python/tests/test_client.py`
  - `test_next_cursor_is_defensive_against_malformed_pages` — 7 cases (valid cursor,
    null/absent meta, null/absent pagination, non-dict page).
  - `test_paginate_terminates_on_null_meta_without_raising` — `fetch_all` survives a
    `meta: null` page and returns its rows instead of crashing.

No public API/OpenAPI/schema/generated-artifact changes — internal to the Python SDK.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes.

## Validation

- [x] `python -m unittest discover -s tests` (from `python/`) — 44 pass, 10 skipped
      (async/httpx; httpx not installed locally). CI runs the same with httpx present.
- [x] `python -m py_compile src/metagraphed/client.py src/metagraphed/aio.py tests/test_client.py` — clean.
- [x] Regression: the original `fetch_all` crashes with `AttributeError: 'NoneType'
      object has no attribute 'get'` on a `meta: null` page (`_collection_rows` handled
      the same page); the new tests pass with the fix.
- [x] Diff scoped to three `python/` files; `python/` is in `.prettierignore`, so
      `format:check` does not apply.
