### PR TITLE
fix(cursor): accept D1 numeric-string parts in encodeCursor

### DIFF
--- a/src/cursor.mjs
+++ b/src/cursor.mjs
@@ -23,10 +23,11 @@ function cursorPart(value) {
   return null;
 }
 
-// Encode an array of non-negative SAFE integers into a cursor token. Returns null
-// for an empty/invalid input (the caller then emits no next_cursor). Parts must be
-// safe integers — a value above Number.MAX_SAFE_INTEGER can't survive the
-// Number()/round-trip the decoder performs, so it is not a representable cursor.
+// Encode cursor parts into a dot-joined token. Each part may be a non-negative
+// safe integer or a digit string that normalizes to one (D1 INTEGER columns often
+// arrive as strings). Returns null for empty/invalid input (no next_cursor).
+// Values above Number.MAX_SAFE_INTEGER are rejected — they cannot survive the
+// Number() round-trip the decoder performs.
 export function encodeCursor(parts) {
   if (!Array.isArray(parts) || parts.length === 0) return null;
   const normalized = [];

--- a/src/cursor.mjs
+++ b/src/cursor.mjs
@@ -12,14 +12,30 @@
 // over D1. Callers should treat the token as opaque. Exposed as `?cursor=` + a
 // `next_cursor` body field.
 
+// Normalize one cursor part: non-negative safe integers, or D1-style numeric
+// strings (decodeCursor accepts `/^\d+$/` segments; encode must be symmetric).
+function cursorPart(value) {
+  if (Number.isSafeInteger(value) && value >= 0) return value;
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    const n = Number(value);
+    if (Number.isSafeInteger(n) && n >= 0) return n;
+  }
+  return null;
+}
+
 // Encode an array of non-negative SAFE integers into a cursor token. Returns null
 // for an empty/invalid input (the caller then emits no next_cursor). Parts must be
 // safe integers — a value above Number.MAX_SAFE_INTEGER can't survive the
 // Number()/round-trip the decoder performs, so it is not a representable cursor.
 export function encodeCursor(parts) {
   if (!Array.isArray(parts) || parts.length === 0) return null;
-  if (parts.some((p) => !Number.isSafeInteger(p) || p < 0)) return null;
-  return parts.join(".");
+  const normalized = [];
+  for (const part of parts) {
+    const n = cursorPart(part);
+    if (n == null) return null;
+    normalized.push(n);
+  }
+  return normalized.join(".");
 }
 
 // Decode a cursor token back to exactly `arity` non-negative integers. Returns

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -387,6 +387,36 @@ test("GET /blocks?cursor= seeks by keyset + emits next_cursor (#1851)", async ()
   assert.equal(body.data.next_cursor, encodeCursor([150]));
 });
 
+test("GET /blocks emits next_cursor when D1 returns numeric-string block_number", async () => {
+  const env = {
+    METAGRAPH_HEALTH_DB: {
+      prepare() {
+        return {
+          bind() {
+            return {
+              async all() {
+                return {
+                  results: [
+                    {
+                      block_number: "150",
+                      block_hash: "0x150",
+                      observed_at: 1,
+                    },
+                  ],
+                };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+  const res = await handleRequest(req("/api/v1/blocks?limit=1"), env, {});
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.next_cursor, encodeCursor([150]));
+});
+
 test("GET /blocks emits next_cursor:null when the page is not full (#1851)", async () => {
   const env = dbWith({
     feed: [{ block_number: 9, block_hash: "0x9", observed_at: 1 }],

--- a/tests/cursor.test.mjs
+++ b/tests/cursor.test.mjs
@@ -34,6 +34,7 @@ test("encodeCursor rejects empty/negative/non-integer input", () => {
   assert.equal(encodeCursor([-1]), null);
   assert.equal(encodeCursor([1.5]), null);
   assert.equal(encodeCursor("nope"), null);
+  assert.equal(encodeCursor(["12x"]), null);
   assert.equal(encodeCursor(["9007199254740993"]), null);
 });
 

--- a/tests/cursor.test.mjs
+++ b/tests/cursor.test.mjs
@@ -22,11 +22,19 @@ test("cursor tokens are URL-safe (digits + dots only)", () => {
   assert.deepEqual(decodeCursor(token, 2), [4294967295, 4294967294]);
 });
 
+test("encodeCursor round-trips D1 numeric-string PK parts", () => {
+  const token = encodeCursor(["7270283", "2"]);
+  assert.equal(token, "7270283.2");
+  assert.deepEqual(decodeCursor(token, 2), [7270283, 2]);
+  assert.equal(encodeCursor(["150"]), "150");
+});
+
 test("encodeCursor rejects empty/negative/non-integer input", () => {
   assert.equal(encodeCursor([]), null);
   assert.equal(encodeCursor([-1]), null);
   assert.equal(encodeCursor([1.5]), null);
   assert.equal(encodeCursor("nope"), null);
+  assert.equal(encodeCursor(["9007199254740993"]), null);
 });
 
 test("decodeCursor returns null on malformed/garbage/arity-mismatch", () => {


### PR DESCRIPTION
## Summary

Restore keyset pagination cursors when D1 returns numeric-string primary keys (the common `INTEGER` column shape).

## What Changed

- `encodeCursor` rejected any part that was not already a `Number.isSafeInteger`, but D1 loaders pass raw row cells (`block_number`, `event_index`, etc.) straight through — and those columns often arrive as numeric strings.
- On a full page this made `encodeCursor([last.block_number, ...])` return `null`, so clients lost `next_cursor` even though `decodeCursor` already accepts `/^\d+$/` segments. The encode/decode pair was asymmetric.
- Added `cursorPart()` normalization (safe integers + digit strings, with the same `MAX_SAFE_INTEGER` gate as decode) and regression tests in `tests/cursor.test.mjs` plus a blocks-feed integration case with `block_number: "150"`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change.)

## Validation

- [x] `npx vitest run tests/cursor.test.mjs tests/blocks.test.mjs -t "encodeCursor|numeric-string block_number"`
- [x] `npx eslint src/cursor.mjs tests/cursor.test.mjs tests/blocks.test.mjs`
- [x] `git diff --check`
