### PR TITLE
fix(mcp): add sort parameter to get_chain_signers

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -29,7 +29,7 @@ import {
   loadSubnetConcentrationHistory,
   parseConcentrationHistoryWindow,
 } from "./concentration.mjs";
-import { loadChainSigners } from "./chain-query-loaders.mjs";
+import { CHAIN_SIGNERS_SORTS, loadChainSigners } from "./chain-query-loaders.mjs";
 import { loadBulkHealthTrends } from "./bulk-health-trends.mjs";
 import { loadRpcUsage } from "./rpc-usage-loader.mjs";
 import {
@@ -2764,9 +2764,9 @@ export const MCP_TOOLS = [
     title: "Get the most-active account signers",
     description:
       "Fetch the windowed most-active-account leaderboard: signers ranked by " +
-      "extrinsic count over the requested window (7d or 30d), with total fees, " +
-      "tips, and last signed block. Optionally scope to one pallet via " +
-      "call_module. Mirrors GET /api/v1/chain/signers.",
+      "extrinsic count (default) or total fees over the requested window " +
+      "(7d or 30d), with total fees, tips, and last signed block. Optionally " +
+      "scope to one pallet via call_module. Mirrors GET /api/v1/chain/signers.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2774,6 +2774,12 @@ export const MCP_TOOLS = [
           type: "string",
           enum: ["7d", "30d"],
           description: "Lookback window (default 7d).",
+        },
+        sort: {
+          type: "string",
+          enum: ["tx_count", "total_fee_tao"],
+          description:
+            "Rank signers by extrinsic count (default) or total fees paid.",
         },
         limit: {
           type: "integer",
@@ -2795,6 +2801,8 @@ export const MCP_TOOLS = [
         throw toolError("invalid_params", "window must be one of: 7d, 30d.");
       }
       const { label, days } = parsed;
+      const sort =
+        optionalEnum(args, "sort", CHAIN_SIGNERS_SORTS) || "tx_count";
       const limit = clampLimit(args?.limit, 50, 100);
       const callModule = optionalString(args, "call_module");
       if (callModule != null && callModule.length > 100) {
@@ -2809,6 +2817,7 @@ export const MCP_TOOLS = [
         observedAt: await mcpObservedAt(ctx),
         limit,
         callModule,
+        sort,
       });
       return data;
     },
@@ -4676,10 +4685,11 @@ const TOOL_OUTPUT_SCHEMAS = {
   get_chain_signers: {
     type: "object",
     additionalProperties: true,
-    required: ["window", "signer_count", "signers"],
+    required: ["window", "sort", "signer_count", "signers"],
     properties: {
       schema_version: { type: "integer" },
       window: { type: "string" },
+      sort: { type: "string", enum: ["tx_count", "total_fee_tao"] },
       observed_at: NULLABLE_STRING,
       signer_count: { type: "integer" },
       signers: objectItems({

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -29,7 +29,10 @@ import {
   loadSubnetConcentrationHistory,
   parseConcentrationHistoryWindow,
 } from "./concentration.mjs";
-import { CHAIN_SIGNERS_SORTS, loadChainSigners } from "./chain-query-loaders.mjs";
+import {
+  CHAIN_SIGNERS_SORTS,
+  loadChainSigners,
+} from "./chain-query-loaders.mjs";
 import { loadBulkHealthTrends } from "./bulk-health-trends.mjs";
 import { loadRpcUsage } from "./rpc-usage-loader.mjs";
 import {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1733,9 +1733,46 @@ describe("MCP get_chain_signers", () => {
     );
     const out = res.body.result.structuredContent;
     assert.equal(out.window, "7d");
+    assert.equal(out.sort, "tx_count");
     assert.equal(out.signer_count, 1);
     assert.equal(out.signers[0].tx_count, 12);
     assert.equal(out.signers[0].total_fee_tao, 1.5);
+  });
+
+  test("rejects an invalid sort", async () => {
+    const res = await callTool("get_chain_signers", { sort: "bogus" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /sort/i);
+  });
+
+  test("ranks signers by total_fee_tao when requested", async () => {
+    let capturedSql;
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capturedSql = sql;
+              return {
+                async all() {
+                  assert.match(sql, /FROM extrinsics/);
+                  assert.ok(params.includes(50));
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const res = await callTool(
+      "get_chain_signers",
+      { window: "7d", sort: "total_fee_tao", limit: 50 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.sort, "total_fee_tao");
+    assert.match(capturedSql, /ORDER BY total_fee_tao DESC, signer ASC/);
   });
 
   test("rejects an invalid window", async () => {


### PR DESCRIPTION

## Summary

The `get_chain_signers` MCP tool always ranked signers by extrinsic count, even though REST `GET /api/v1/chain/signers` supports `?sort=total_fee_tao` and the shared `loadChainSigners` loader already implements both sort modes.

## Bug

**Symptom:** Agents cannot request a fee-weighted signer leaderboard via MCP. REST callers use `?sort=total_fee_tao`; MCP always behaved as if `sort=tx_count`.

**Root cause:** REST validates and forwards `sort`:

```745:770:workers/request-handlers/analytics.mjs
  const sortError = validateEnumParam(url, "sort", CHAIN_SIGNERS_SORTS);
  // ...
  const sort = url.searchParams.get("sort") || "tx_count";
  // ...
      const { data, rows } = await loadChainSigners(d1Runner(env), {
        // ...
        sort,
      });
```

The MCP tool omitted `sort` from its `inputSchema` and never passed it to `loadChainSigners`, so the loader always used the default `tx_count`.

## Fix

1. Import `CHAIN_SIGNERS_SORTS` from `chain-query-loaders.mjs`.
2. Add optional `sort` (`tx_count` | `total_fee_tao`) to the `get_chain_signers` MCP `inputSchema` and tool description.
3. Validate with `optionalEnum`; default to `tx_count` when omitted (same as REST).
4. Pass `sort` through to `loadChainSigners`.
5. Include `sort` in the MCP output schema for `get_chain_signers`.
6. Add regression tests for invalid sort and `ORDER BY total_fee_tao DESC` SQL.

## What Changed

- `src/mcp-server.mjs` — `sort` input, handler wiring, output schema.
- `tests/mcp-server.test.mjs` — sort validation + fee-ranked SQL assertion.

## Validation

- [x] `npm run lint && npm run format:check`
- [x] `npm run validate`
- [x] `npm test -- tests/mcp-server.test.mjs -t get_chain_signers`
- [x] `npm run test:coverage`
- [x] `git diff --check`