### PR TITLE
fix(feeds): key incident feed items on started_at for ?until= windows

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -287,7 +287,10 @@ function incidentItems(incidents, netuid) {
             `${ongoing ? "is currently down" : `was down for ~${minutes}m`}` +
             `${inc.failed_samples ? `, ${inc.failed_samples} failed probes` : ""}.`,
         ),
-        timestamp: ended || started || new Date().toISOString(),
+        // Window filters (?since= / ?until=) key on when the incident *started*,
+        // not when it resolved — otherwise a resolved incident that began inside
+        // a bounded window vanishes from that window once ended_at moves past ?until=.
+        timestamp: started || ended || new Date().toISOString(),
         tags: [
           "incident",
           `sn${surface.netuid}`,

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -378,6 +378,21 @@ describe("feeds — item builders", () => {
     );
   });
 
+  test("incidentItems falls back to ended_at when started_at is absent", () => {
+    const incidents = {
+      surfaces: [
+        {
+          netuid: 1,
+          surface_id: "api",
+          incidents: [{ ended_at: Date.parse("2026-06-20T00:00:00.000Z") }],
+        },
+      ],
+    };
+    const item = incidentItems(incidents)[0];
+    assert.equal(item.timestamp, "2026-06-20T00:00:00.000Z");
+    assert.ok(item.tags.includes("resolved"));
+  });
+
   test("gapsItems builds ranked enrichment targets with lane/kind tags", () => {
     const items = gapsItems(ENRICHMENT_QUEUE);
     assert.equal(items.length, 3);

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -349,6 +349,35 @@ describe("feeds — item builders", () => {
     assert.equal(incidentItems(null).length, 0);
   });
 
+  test("resolved incidents filter on started_at, not ended_at, for ?until= windows", () => {
+    const incidents = {
+      surfaces: [
+        {
+          netuid: 7,
+          surface_id: "api",
+          incidents: [
+            {
+              started_at: Date.parse("2026-06-12T00:00:00.000Z"),
+              ended_at: Date.parse("2026-06-20T00:00:00.000Z"),
+              duration_ms: 8 * 24 * 60 * 60 * 1000,
+            },
+          ],
+        },
+      ],
+    };
+    const item = incidentItems(incidents)[0];
+    assert.equal(item.timestamp, "2026-06-12T00:00:00.000Z");
+    // Incident was active during June 15; ?until=2026-06-15 (inclusive UTC day)
+    // must keep it even though it ended on the 20th.
+    const untilMs = Date.parse("2026-06-15T23:59:59.999Z");
+    const kept = filterUntil([item], untilMs);
+    assert.equal(
+      kept.length,
+      1,
+      "must not drop once resolved_at moves past until",
+    );
+  });
+
   test("gapsItems builds ranked enrichment targets with lane/kind tags", () => {
     const items = gapsItems(ENRICHMENT_QUEUE);
     assert.equal(items.length, 3);

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -393,6 +393,21 @@ describe("feeds — item builders", () => {
     assert.ok(item.tags.includes("resolved"));
   });
 
+  test("incidentItems uses a request-time ISO timestamp when both dates are absent", () => {
+    const incidents = {
+      surfaces: [
+        {
+          netuid: 1,
+          surface_id: "api",
+          incidents: [{}],
+        },
+      ],
+    };
+    const item = incidentItems(incidents)[0];
+    assert.ok(Number.isFinite(Date.parse(item.timestamp)));
+    assert.ok(item.tags.includes("ongoing"));
+  });
+
   test("gapsItems builds ranked enrichment targets with lane/kind tags", () => {
     const items = gapsItems(ENRICHMENT_QUEUE);
     assert.equal(items.length, 3);


### PR DESCRIPTION
## Summary

Resolved incident feed items used `ended_at` as their `timestamp` for `?since=` / `?until=` window filtering. An incident that **started** inside a bounded window but **ended** after `?until=` therefore disappeared from that window once it resolved â€” even though it was active during the window. Ongoing incidents already keyed on `started_at`, so the feed was state-dependent and non-replayable across the ongoingâ†’resolved transition.

## What Changed

- `incidentItems` now keys `timestamp` on `started_at` (falling back to `ended_at` only when start is unparseable), matching the documented window-filter contract for bounded polling.
- Regression test: a resolved incident that started June 12 and ended June 20 stays visible under `?until=2026-06-15` (inclusive UTC day).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes (feed item timestamp semantics only).

## Validation

- [x] `npx vitest run tests/feeds.test.mjs` (all passed)
- [x] `npx prettier --check src/feeds.mjs tests/feeds.test.mjs`
- [x] `git diff --check`
