### PR TITLE
fix(api): tie-break account registrations by netuid for deterministic ordering

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -503,7 +503,7 @@ export async function loadAccountSummary(d1, ss58) {
         kindUnion.paramsFor(ss58),
       ),
       d1(
-        `SELECT ${REGISTRATION_COLUMNS} FROM neurons WHERE hotkey = ? ORDER BY stake_tao DESC`,
+        `SELECT ${REGISTRATION_COLUMNS} FROM neurons WHERE hotkey = ? ORDER BY stake_tao DESC, netuid ASC`,
         [ss58],
       ),
       d1(

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -730,6 +730,11 @@ test("loadAccountSummary tie-breaks leaderboard aggregates for stable output", a
       modules.sql,
     ),
   );
+  const regs = calls.find((c) => /FROM neurons WHERE hotkey = \?/.test(c.sql));
+  assert.ok(
+    /ORDER BY stake_tao DESC, netuid ASC/.test(regs.sql),
+    "registration list must tie-break equal stakes by netuid",
+  );
 });
 
 test("loadAccountSummary uses indexed union seeks for account_events (#2059)", async () => {


### PR DESCRIPTION
## Summary

`loadAccountSummary` reads neuron registrations with `ORDER BY stake_tao DESC` only. Equal-stake registrations have no deterministic tie-break, so `/api/v1/accounts/{ss58}` `registrations` can reorder between identical requests â€” the same class of non-deterministic `LIMIT`/ordering bug fixed elsewhere for validator lists (`stake_tao DESC, uid ASC`), chain-calls leaderboards (#2463), and rpc-usage leaderboards.

## What Changed

- Registration query now orders `ORDER BY stake_tao DESC, netuid ASC` for a stable total order on multi-subnet hotkeys with tied stake.
- Extended the existing `loadAccountSummary tie-breaks leaderboard aggregates` test to assert the registration SQL includes the netuid tie-break.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes (deterministic ordering only; response shape unchanged).

## Validation

- [x] `npx vitest run tests/account-events.test.mjs` (all passed)
- [x] `npx prettier --check src/account-events.mjs tests/account-events.test.mjs`
- [x] `git diff --check`
