### PR TITLE
fix(api): tie-break chain-fees top payers for deterministic LIMIT output

### DIFF
--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -597,6 +597,8 @@ export async function loadChainFees(
        GROUP BY day`,
       dailyParams,
     ),
+    // Top-fee-payer leaderboard: tie-break on signer ASC so equal-fee signers
+    // have stable LIMIT membership (mirrors loadChainSigners in chain-query-loaders).
     d1(
       `SELECT signer,
               SUM(COALESCE(fee_tao, 0)) AS total_fee_tao,
@@ -605,7 +607,7 @@ export async function loadChainFees(
        FROM extrinsics
        WHERE observed_at >= ? AND signer IS NOT NULL${moduleClause}
        GROUP BY signer
-       ORDER BY total_fee_tao DESC
+       ORDER BY total_fee_tao DESC, signer ASC
        LIMIT ?`,
       payerParams,
     ),

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -666,7 +666,7 @@ describe("loadChainFees", () => {
       now - 7 * 24 * 60 * 60 * 1000,
       "SubtensorModule",
     ]);
-    assert.match(calls[1].sql, /ORDER BY total_fee_tao DESC/);
+    assert.match(calls[1].sql, /ORDER BY total_fee_tao DESC, signer ASC/);
     assert.deepEqual(calls[1].params, [
       now - 7 * 24 * 60 * 60 * 1000,
       "SubtensorModule",
@@ -716,6 +716,51 @@ describe("loadChainFees", () => {
     assert.equal(calls[0].params.length, 1);
     assert.doesNotMatch(calls[2].sql, /call_module = \?/);
     assert.equal(calls[2].params.length, 1);
+  });
+
+  test("loadChainFees tie-breaks top_fee_payers for stable LIMIT membership", async () => {
+    const captured = [];
+    const signerA = "5FHneW46xGXgs5mUive6eigkdRD2AYN6fy8616ckdp26RGGj";
+    const signerB = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+    const run = async (sql, params) => {
+      captured.push({ sql, params });
+      if (/ROW_NUMBER\(\) OVER/.test(sql)) return [];
+      if (/GROUP BY day/.test(sql)) return [];
+      if (/GROUP BY signer/.test(sql)) {
+        // Simulate D1 honoring ORDER BY total_fee_tao DESC, signer ASC.
+        const rows = [
+          {
+            signer: signerA,
+            total_fee_tao: 5,
+            total_tip_tao: 0,
+            extrinsic_count: 2,
+          },
+          {
+            signer: signerB,
+            total_fee_tao: 5,
+            total_tip_tao: 0,
+            extrinsic_count: 3,
+          },
+        ];
+        const lim = params[params.length - 1];
+        return rows.slice(0, lim);
+      }
+      return [];
+    };
+    const { data } = await loadChainFees(run, {
+      window: "7d",
+      limit: 1,
+      observedAt: OBSERVED_AT,
+      now: Date.UTC(2026, 5, 26),
+    });
+    const payerSql = captured.find((c) => /GROUP BY signer/.test(c.sql));
+    assert.match(
+      payerSql.sql,
+      /ORDER BY total_fee_tao DESC, signer ASC\s+LIMIT \?/,
+    );
+    assert.equal(data.top_fee_payers.length, 1);
+    assert.equal(data.top_fee_payers[0].signer, signerA);
+    assert.equal(data.top_fee_payers[0].total_fee_tao, 5);
   });
 
   test("falls back to 7d for an unknown window label", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1823,7 +1823,7 @@ describe("MCP get_chain_fees", () => {
                       ],
                     };
                   }
-                  assert.match(sql, /ORDER BY total_fee_tao DESC/);
+                  assert.match(sql, /ORDER BY total_fee_tao DESC, signer ASC/);
                   assert.ok(params.includes(25));
                   return {
                     results: [


### PR DESCRIPTION
## Summary

- `GET /api/v1/chain/fees` and the MCP `get_chain_fees` tool share `loadChainFees` (`src/analytics-live.mjs`), which ranks `top_fee_payers` with `ORDER BY total_fee_tao DESC LIMIT ?` only.
- When two signers tie on `total_fee_tao`, SQLite/D1 order is unspecified, so which payers land in the capped leaderboard and their relative order can flip between requests - the same nondeterministic LIMIT membership bug fixed for chain-calls (#2463) and rpc-usage (#2469).
- Add `signer ASC` as the tie-break, mirroring `loadChainSigners` (`src/chain-query-loaders.mjs`: `ORDER BY ${sortBy} DESC, signer ASC`). One loader fix covers REST and MCP.

## What Changed

- `src/analytics-live.mjs` - `loadChainFees` top-payer query now uses `ORDER BY total_fee_tao DESC, signer ASC LIMIT ?` with an inline comment citing the chain-signers sibling.
- `tests/analytics-live.test.mjs` - tightened the existing scoped-SQL assertion; added regression coverage that the payer query carries the tie-break and that `limit: 1` keeps the lexicographically first signer when fees tie.
- `tests/mcp-server.test.mjs` - updated `get_chain_fees` SQL assertion to require `signer ASC`.
- No schema/contract change.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none)

## Validation

- [x] `npx prettier --check` + `npx eslint` on changed files
- [x] `npx vitest run tests/analytics-live.test.mjs` (42 passed)
- [x] `npx vitest run tests/mcp-server.test.mjs -t "get_chain_fees"` (passed)
- [x] `git diff --check`

## Linked issue

No linked issue: issue creation on this repository is currently restricted for outside contributors (issues API returns 404). Per the contribution guide a linked issue is optional. This is a self-contained deterministic-ordering fix aligned with recently merged siblings (#2463, #2469).