### PR TITLE
fix(graphql): backfill single-subnet computed registry metrics

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -759,7 +759,16 @@ const rootValue = {
     // and bundles surfaces/endpoints, so those resolve from this one read;
     // economics is overlaid live at serve time, so it loads lazily.
     const identity = data.subnet ?? data;
-    return subnetNode(identity, {
+    // The detail artifact omits the list artifact's computed registry metrics
+    // (integration_readiness, official_surface_count, gap_count, first_party),
+    // so without this backfill the single-subnet path returns them null while
+    // `subnets` populates them. Read the matching subnets.json row — memoized and
+    // shared per request, so at most one extra read; the detail identity still
+    // wins on any shared key.
+    const listRow = (
+      await loadRows(context, ARTIFACT.subnets, "subnets", netuid)
+    )[0];
+    return subnetNode(listRow ? { ...listRow, ...identity } : identity, {
       surfaces: data.surfaces,
       endpoints: data.endpoints,
     });

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -527,6 +527,49 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     assert.equal(body.data.subnet.name, "Tao Subnet");
   });
 
+  test("subnet backfills the list-only computed metrics the detail artifact omits", async () => {
+    // The detail artifact omits integration_readiness/official_surface_count/
+    // gap_count/first_party, which only the list artifact computes. Without the
+    // backfill the single-subnet path returns them null while `subnets` does not.
+    const env = fixtureEnv({
+      "/metagraph/subnets/7.json": {
+        netuid: 7,
+        name: "Detail Name",
+        slug: "x",
+      },
+      "/metagraph/subnets.json": {
+        subnets: [
+          {
+            netuid: 7,
+            name: "List Name",
+            integration_readiness: 86,
+            official_surface_count: 0,
+            gap_count: 0,
+            first_party: false,
+          },
+        ],
+      },
+    });
+    const { status, body } = await gql(
+      `{ subnet(netuid: 7) {
+        name
+        integration_readiness
+        official_surface_count
+        gap_count
+        first_party
+      } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const s = body.data.subnet;
+    assert.equal(s.integration_readiness, 86);
+    assert.equal(s.official_surface_count, 0);
+    assert.equal(s.gap_count, 0);
+    assert.equal(s.first_party, false);
+    // The detail artifact stays authoritative for identity on shared keys.
+    assert.equal(s.name, "Detail Name");
+  });
+
   test("providers normalises missing netuids to empty array", async () => {
     const env = fixtureEnv({
       "/metagraph/providers.json": {


### PR DESCRIPTION
# Summary

This PR fixes inconsistent field resolution in the GraphQL `subnet(netuid)` query.

Previously, `subnet(netuid)` returned `null` for the following computed registry fields:

- `integration_readiness`
- `official_surface_count`
- `gap_count`
- `first_party`

while the `subnets` query returned the correct values for the same subnet.

This resulted in inconsistent GraphQL responses depending on which query path was used.

## Root Cause

The two GraphQL resolvers read from different data sources:

- `subnets` reads from `subnets.json`, which includes the computed registry metrics.
- `subnet(netuid)` reads from the per-subnet detail artifact (`/metagraph/subnets/{netuid}.json`), which omits those computed fields.

Since the detail artifact lacks these properties, GraphQL's default field resolver returned `null`.

## Changes

### Source

**`src/graphql.mjs`**

- Updated the `subnet(netuid)` resolver to backfill missing computed registry fields from the corresponding entry in `subnets.json`.
- Reused the existing request-scoped cached loader (`loadRows` → `once`) so the list artifact is read at most once per request.
- Preserved precedence for values from the detail artifact by merging as:

```js
{
  ...listRow,
  ...identity
}
```

- Falls back to the detail artifact when no matching list entry exists.

### Tests

**`tests/graphql.test.mjs`**

Added a regression test verifying that:

- `subnet(netuid)` correctly returns the computed registry metrics when they exist only in `subnets.json`.
- The detail artifact continues to override overlapping identity fields such as `name`.

## Impact

- ✅ `subnet(netuid)` and `subnets` now return consistent values.
- ✅ Computed registry metrics are available through both query paths.
- ✅ No changes to GraphQL schema or API contract.
- ✅ Request-scoped caching prevents unnecessary additional reads.

## Validation

- [x] `npx vitest run tests/graphql.test.mjs`
- [x] `npm run lint`
- [x] `npx prettier --check`
- [x] Verified the regression test fails on `main` and passes with this fix.
- [x] Reproduced against the live API (`subnet(netuid: 7)` previously returned `null` while `subnets` returned the expected values).
