### PR TITLE
fix(schema): accept not-captured schema index entries

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -172,12 +172,15 @@ Each added surface must carry `authority: "community"` and a `review` block — 
 }
 ```
 
-You set **identity + proof + `review.state: community-submitted`** only. **Do not** add
-`verification`, health, or `curation` changes, and **do not** touch other surfaces or top-level fields
-in the file — a community PR that edits anything beyond appending its own community surface(s) is
-out-of-shape and gets routed to full review or closed. `review.state` is the human-governance axis: a
-maintainer flips it → `maintainer-reviewed` (or `rejected`) in place; machine verification + freshness
-is the separate probe overlay (the build's prober fills `verification`/health).
+You set **identity + proof + `review.state: community-submitted`** only. For an existing subnet
+manifest, **do not** add `verification`, health, or `curation` changes, and **do not** touch other
+surfaces or top-level fields in the file — a community PR that edits anything beyond appending its own
+community surface(s) is out-of-shape and gets routed to full review or closed. A missing subnet
+manifest is the exception: `subnet:new` creates the required top-level scaffold fields, then
+`surface:add` appends the community surface in that same new file. `review.state` is the
+human-governance axis: a maintainer flips it → `maintainer-reviewed` (or `rejected`) in place; machine
+verification + freshness is the separate probe overlay (the build's prober fills
+`verification`/health).
 
 > New subnet not yet in `registry/subnets/`? Scaffold it with `npm run subnet:new -- --netuid <n>`
 > first (one file), then add your surface to it in the same PR.
@@ -276,7 +279,9 @@ the PR template with the validation commands you actually ran. Sync with `main` 
 
 **Path A (surface):**
 
-- [ ] Exactly one `registry/subnets/<slug>.json` changed; only community surface(s) appended; no other file.
+- [ ] Exactly one `registry/subnets/<slug>.json` changed; existing manifests only append community
+      surface(s), while missing manifests may include the required `subnet:new` scaffold plus the
+      community surface(s); no other file.
 - [ ] Each surface: real public `url` + a proving `source_url`; right `kind`; `authority: community`;
       `review.state: community-submitted`; `public_safe: true`; no health/`verification`/secrets set by hand.
 - [ ] Not a duplicate of an existing surface or an open PR; not the same surface re-titled by `kind`.

--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -9,8 +9,10 @@ repo root (Node 22, `npm install` first).
 
 **Surfaces live in ONE file per subnet:** `registry/subnets/<slug>.json` → its `surfaces[]` array. A
 community contribution **appends a surface to that one file** with `authority: "community"` and
-`review.state: "community-submitted"`. The Gittensory Gate flips the review state in place on merge;
-the build's prober fills `verification`/health.
+`review.state: "community-submitted"`. If the subnet has no manifest on the base branch, the valid
+one-file shape is a new `subnet:new` scaffold plus the community surface in that same file. The
+Gittensory Gate flips the review state in place on merge; the build's prober fills
+`verification`/health.
 
 This **replaces** the old per-surface intake lane (`registry/candidates/community/<one-file-per-surface>.json`).
 That lane created the farm: one surface = one file = one PR = one merge, so a contributor split a single
@@ -61,8 +63,10 @@ sse · sdk · example · repo-registry · data-artifact` — all auto-reviewable
 > `/rpc` proxy + `/api/v1/rpc/*`). They stay valid in the schema (for `registry/subnets/root.json` +
 > the endpoint pipeline) but are excluded from the contributor surface template.
 
-Subnet-level fields you must **not** touch in a community PR: `curation` (`level` + `review_state`),
-`status`, `categories`, `baseline_excluded_*`, `social`, `contact`. Those are maintainer/build-owned.
+Subnet-level fields you must **not** touch in an existing-manifest community PR: `curation` (`level` +
+`review_state`), `status`, `categories`, `baseline_excluded_*`, `social`, `contact`. Those are
+maintainer/build-owned after the manifest exists. New subnet manifests are the exception: `subnet:new`
+must create the required scaffold fields before the first surface is added.
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/add-subnet-surface.yml
+++ b/.github/ISSUE_TEMPLATE/add-subnet-surface.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Surfaces live in **one file per subnet** — `registry/subnets/<slug>.json`. The fastest path is a direct PR: run `npm run surface:add` and open a PR that changes **only that one file** (see `CONTRIBUTING.md` → Community submissions). It lands with `authority: community` and `review.state: community-submitted`, and the build's prober owns verification/health.
+        Surfaces live in **one file per subnet** — `registry/subnets/<slug>.json`. The fastest path is a direct PR: run `npm run surface:add` and open a PR that changes **only that one file**; if the subnet has no file yet, run `npm run subnet:new` first and add the surface to that same new file (see `CONTRIBUTING.md` → Community submissions). It lands with `authority: community` and `review.state: community-submitted`, and the build's prober owns verification/health.
 
         Use this issue only to **request** a surface if you can't open a PR. Issue submissions do not auto-publish — they are a request a maintainer or contributor turns into a PR.
   - type: input

--- a/.github/PULL_REQUEST_TEMPLATE/surface.md
+++ b/.github/PULL_REQUEST_TEMPLATE/surface.md
@@ -1,7 +1,9 @@
 ## Add or update a subnet surface
 
-This PR appends or updates surface(s) on exactly one subnet's file —
-`registry/subnets/<slug>.json`.
+This PR appends or updates surface(s) on exactly one subnet manifest —
+`registry/subnets/<slug>.json`. If the manifest did not exist on the base
+branch, this PR may include the required `subnet:new` scaffold fields in that
+same new file.
 
 ## Surface
 
@@ -13,8 +15,10 @@ This PR appends or updates surface(s) on exactly one subnet's file —
 
 ## Checklist
 
-- [ ] Changes exactly one `registry/subnets/<slug>.json` file (optionally plus one
-      `registry/providers/*.json` for a debut provider).
+- [ ] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an
+      existing manifest, or a `subnet:new` scaffold plus surface(s) for a missing
+      manifest (optionally plus one `registry/providers/*.json` for a debut
+      provider).
 - [ ] Generated with `npm run surface:add` — lands `authority: community` and
       `review.state: community-submitted`.
 - [ ] The `url` is public and safe for read-only probes; the `source_url`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,9 @@ Use the matching PR template so the submission gate can classify your PR
 correctly:
 
 - [Subnet surface](?template=surface.md): one `registry/subnets/<slug>.json`
-  file — a community surface added with `npm run surface:add` (optionally plus
-  one `registry/providers/*.json` for a debut provider).
+  file — a community surface added with `npm run surface:add`; for a missing
+  subnet manifest, scaffold it first with `npm run subnet:new` in the same file
+  (optionally plus one `registry/providers/*.json` for a debut provider).
 - [Provider/operator profile](?template=provider-profile.md): one
   `registry/providers/*.json` file only.
 - [Backend/code change](?template=backend-code.md): scripts, schemas,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,9 @@ Skipping the rebuild trips `validate:contract-drift` in CI. Schemas are the sour
 
 ## Community submissions
 
-Surfaces live in **one file per subnet**: `registry/subnets/<slug>.json` → its `surfaces[]` array. A community contribution **adds a surface to that one file** — `npm run surface:add` writes it with `authority: "community"` and `review.state: "community-submitted"`. There is no per-surface candidate file anymore (recreating `registry/candidates/community/*.json` is rejected by CI), so you can't farm one surface per PR: **one subnet = one file = one PR.**
+Surfaces live in **one file per subnet**: `registry/subnets/<slug>.json` → its `surfaces[]` array. A community contribution **adds a surface to that one file** — `npm run surface:add` writes it with `authority: "community"` and `review.state: "community-submitted"`. If the subnet has no manifest yet, scaffold that one subnet file first with `npm run subnet:new`, then add the surface to the same file. There is no per-surface candidate file anymore (recreating `registry/candidates/community/*.json` is rejected by CI), so you can't farm one surface per PR: **one subnet = one file = one PR.**
 
-> Change **only** the one `registry/subnets/<slug>.json` — no generated artifacts. First-time provider? Pass `--provider-name` + `--provider-url` and `surface:add` scaffolds the `registry/providers/<slug>.json` stub for you in the same PR; provider identity still gets reviewed before it's trusted.
+> Change **only** the one `registry/subnets/<slug>.json` — no generated artifacts. For an existing subnet manifest, that means appending your community surface without changing top-level subnet metadata. For a missing subnet manifest, the required `subnet:new` scaffold fields are expected in the new file. First-time provider? Pass `--provider-name` + `--provider-url` and `surface:add` scaffolds the `registry/providers/<slug>.json` stub for you in the same PR; provider identity still gets reviewed before it's trusted.
 
 > **Plagiarism is not tolerated.** Copying another contributor's PR, surface, or work and submitting it as your own — including duplicated or lightly reworded copies filed under a different account — is a hard violation. Don't copy others to farm Gittensor rewards: anyone attempting to cheat or copy for gain is **permanently blocked from contributing across all of our repositories**. See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
 
@@ -83,12 +83,12 @@ A good surface PR is small: one public `url`, one `source_url` proving the claim
 
 **Accepted vs rejected at a glance** — the visible checklist (the final merge decision is the review gate's):
 
-| ✅ Tends to get accepted                                                                                          | ❌ Gets closed / routed to manual                                                                    |
-| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Exactly one `registry/subnets/<slug>.json` changed (+ an optional `providers/*.json` for a debut)                 | Touches generated artifacts, scripts, or workflows                                                   |
-| A surface with a public `url` **plus** a `source_url` that proves the claim                                       | `source_url` 404s or doesn't back the claim                                                          |
-| `authority: community` + `review.state: community-submitted`, an auto-review `kind`, an active netuid, a provider | A surface the subnet already exposes — duplicate                                                     |
-| `auth_required: false`, `public_safe: true`                                                                       | Secrets/PATs/wallet paths, private/localhost URLs, unproven ownership, or a recreated candidate file |
+| ✅ Tends to get accepted                                                                                                                                                     | ❌ Gets closed / routed to manual                                                                    |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Exactly one subnet manifest changed: append to an existing file, or create the missing `subnet:new` scaffold plus the surface (+ an optional `providers/*.json` for a debut) | Touches generated artifacts, scripts, or workflows                                                   |
+| A surface with a public `url` **plus** a `source_url` that proves the claim                                                                                                  | `source_url` 404s or doesn't back the claim                                                          |
+| `authority: community` + `review.state: community-submitted`, an auto-review `kind`, an active netuid, a provider                                                            | A surface the subnet already exposes — duplicate                                                     |
+| `auth_required: false`, `public_safe: true`                                                                                                                                  | Secrets/PATs/wallet paths, private/localhost URLs, unproven ownership, or a recreated candidate file |
 
 Callable surface with documented limits? Add an optional structured `rate_limit` — `{ requests, window, burst?, scope?, cost_notes? }` (`requests` + `window` required) — so agents and SDKs can pace calls. It's integration-only: metagraphed never enforces it and it doesn't feed completeness.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Deeper docs: [`docs/api-stability.md`](docs/api-stability.md) (the `/api/v1` con
 Issues are labeled `good first issue` and `help wanted` — start there.
 
 - **Schema-first edits** require `npm run build` (regenerates `openapi.json` + types).
-- **Community submissions** are PR-first: add a surface to exactly one `registry/subnets/<slug>.json` file (via `npm run surface:add`), no generated artifacts.
+- **Community submissions** are PR-first: add a surface to exactly one `registry/subnets/<slug>.json` file (via `npm run surface:add`; use `npm run subnet:new` first when that subnet has no file yet), no generated artifacts.
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`docs/curation-playbook.md`](docs/curation-playbook.md).
 

--- a/docs/adr/0008-subnet-data-model.md
+++ b/docs/adr/0008-subnet-data-model.md
@@ -37,9 +37,11 @@ directories**:
   A surface can be `maintainer-reviewed` (human) yet `unknown` health (machine),
   and vice versa.
 
-A data contribution therefore edits **exactly one** `registry/subnets/<slug>.json`,
-appending surface(s) with `authority: "community"` and
-`review.state: "community-submitted"` — and nothing else.
+A data contribution therefore edits **exactly one** `registry/subnets/<slug>.json`.
+For an existing manifest, it appends surface(s) with `authority: "community"` and
+`review.state: "community-submitted"` — and nothing else. For a missing manifest,
+the same one-file contribution may create the required `subnet:new` scaffold and
+add the surface(s) to it.
 
 Base-layer network endpoints (`subtensor-rpc`/`subtensor-wss`/`archive`) are the
 one carve-out: maintainer-curated infra on `root.json` (netuid 0), not the

--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -256,6 +256,8 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `npm run validate:docs`: validate public docs against current artifact and API contracts.
 - `npm run validate:intake`: validate GitHub issue intake templates.
 - `npm run surface:add`: append a community surface to a subnet's file.
+- `npm run subnet:new`: scaffold a missing subnet manifest before adding its
+  first surface in the same file.
 - `npm run validate:workflows`: validate workflow hardening rules.
 - `npm run worker:deploy:dry-run`: validate Worker/Wrangler deployment shape without contacting Cloudflare.
 - `npm run sync:summary`: generate a registry-refresh PR summary from actual artifact diffs.

--- a/docs/curation-playbook.md
+++ b/docs/curation-playbook.md
@@ -89,9 +89,12 @@ complete.
 
 ## Best Auto-Review Contributions
 
-Direct PRs should add surface(s) to exactly one `registry/subnets/<slug>.json`
-file (its `surfaces[]` array) and no generated artifacts. The per-candidate-file
-lane (`registry/candidates/community/*.json`) is retired and rejected by CI.
+Direct PRs should change exactly one `registry/subnets/<slug>.json` file and no
+generated artifacts. Existing subnet manifests should only append surface(s) to
+their `surfaces[]` array. If the subnet has no manifest yet, run
+`npm run subnet:new` first, then add the surface(s) to that same new file. The
+per-candidate-file lane (`registry/candidates/community/*.json`) is retired and
+rejected by CI.
 
 Use:
 

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -4181,7 +4181,7 @@ export interface components {
                 [key: string]: unknown;
             };
             /** @enum {unknown} */
-            status: "captured" | "error" | "not-found" | "too-large" | "unsafe";
+            status: "captured" | "error" | "not-captured" | "not-found" | "too-large" | "unsafe";
             subnet_slug?: string;
             surface_id: string;
             /** Format: uri */

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -10335,6 +10335,7 @@
             "enum": [
               "captured",
               "error",
+              "not-captured",
               "not-found",
               "too-large",
               "unsafe"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4181,7 +4181,7 @@ export interface components {
                 [key: string]: unknown;
             };
             /** @enum {unknown} */
-            status: "captured" | "error" | "not-found" | "too-large" | "unsafe";
+            status: "captured" | "error" | "not-captured" | "not-found" | "too-large" | "unsafe";
             subnet_slug?: string;
             surface_id: string;
             /** Format: uri */

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -10313,6 +10313,7 @@
             "enum": [
               "captured",
               "error",
+              "not-captured",
               "not-found",
               "too-large",
               "unsafe"

--- a/schemas/components/09-schemas-adapters-r2.schema.json
+++ b/schemas/components/09-schemas-adapters-r2.schema.json
@@ -107,7 +107,14 @@
             "additionalProperties": true
           },
           "status": {
-            "enum": ["captured", "error", "not-found", "too-large", "unsafe"]
+            "enum": [
+              "captured",
+              "error",
+              "not-captured",
+              "not-found",
+              "too-large",
+              "unsafe"
+            ]
           },
           "subnet_slug": {
             "type": "string"

--- a/scripts/enrichment-issues.mjs
+++ b/scripts/enrichment-issues.mjs
@@ -147,7 +147,7 @@ function issueBody(netuid, name, kinds) {
 Search for the subnet's official ${kindList} (project site / GitHub / docs / Bittensor). Confirm each link is real, public, no-auth, and genuinely SN${netuid}'s — cross-reference the subnet name + Bittensor. ⚠️ Many subnets simply don't expose a public API yet, and on-chain identity links are often **stale/dead** — verify each link actually resolves before submitting. If the subnet genuinely exposes no such public surface, comment here so a maintainer can close it.
 
 ### Submit — one subnet, one file
-Surfaces live in **one file per subnet**: \`registry/subnets/<slug>.json\` → its \`surfaces[]\` array. First find the provider slug for the team/operator behind the surface (a wrong slug is the #1 validation failure): \`npm run providers:list\`. Then append the surface to the subnet's file:
+Surfaces live in **one file per subnet**: \`registry/subnets/<slug>.json\` → its \`surfaces[]\` array. First find the provider slug for the team/operator behind the surface (a wrong slug is the #1 validation failure): \`npm run providers:list\`. If the subnet has no manifest yet, scaffold it first with \`npm run subnet:new -- --netuid ${netuid} --write\`. Then append the surface to the subnet's file:
 \`\`\`bash
 npm run surface:add -- --netuid ${netuid} --kind ${primary} \\
   --url <real-public-url> --source-url <link-that-proves-it> \\
@@ -155,7 +155,7 @@ npm run surface:add -- --netuid ${netuid} --kind ${primary} \\
 \`\`\`
 \`surface:add\` writes it with \`authority: "community"\` and \`review.state: "community-submitted"\`.
 
-Open a PR touching **exactly one** \`registry/subnets/<slug>.json\` file — the review gate validates + reviews it. (The per-candidate-file lane is retired: recreating \`registry/candidates/community/*.json\` is rejected by CI.)
+Open a PR touching **exactly one** \`registry/subnets/<slug>.json\` file — append-only for an existing manifest, or a \`subnet:new\` scaffold plus surface for a missing manifest. The review gate validates + reviews it. (The per-candidate-file lane is retired: recreating \`registry/candidates/community/*.json\` is rejected by CI.)
 
 **Rules:** a real \`url\` that resolves · a \`source_url\` that proves it's official · one file · no generated artifacts · \`public_safe: true\` · \`auth_required: false\`. Full guide: [CONTRIBUTING → Community submissions](https://github.com/JSONbored/metagraphed/blob/main/CONTRIBUTING.md#community-submissions).`;
 }

--- a/scripts/validate-contract-drift.mjs
+++ b/scripts/validate-contract-drift.mjs
@@ -35,8 +35,11 @@ if (!openApiMatches) {
 }
 
 const typegen = spawnSync(
-  "npx",
-  ["openapi-typescript", "public/metagraph/openapi.json"],
+  process.execPath,
+  [
+    path.join(repoRoot, "node_modules/openapi-typescript/bin/cli.js"),
+    "public/metagraph/openapi.json",
+  ],
   {
     cwd: repoRoot,
     encoding: "utf8",

--- a/scripts/validate-types.mjs
+++ b/scripts/validate-types.mjs
@@ -8,8 +8,11 @@ const outputPaths = [
   path.join(repoRoot, "public/metagraph/types.d.ts"),
 ];
 const result = spawnSync(
-  "npx",
-  ["openapi-typescript", "public/metagraph/openapi.json"],
+  process.execPath,
+  [
+    path.join(repoRoot, "node_modules/openapi-typescript/bin/cli.js"),
+    "public/metagraph/openapi.json",
+  ],
   {
     cwd: repoRoot,
     encoding: "utf8",

--- a/tests/committed-seed-gate.test.mjs
+++ b/tests/committed-seed-gate.test.mjs
@@ -4,6 +4,8 @@
 // using a synthetic env so the real public/ files are never touched.
 
 import path from "node:path";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
 import { describe, expect, it } from "vitest";
 import {
   committedSeedRoutes,
@@ -32,6 +34,53 @@ describe("committed cold-start seed gate", () => {
     const { checked, errors } = await runCommittedSeedGate({ env, openapi });
     expect(checked).toBeGreaterThan(0);
     expect(errors).toEqual([]);
+  });
+
+  it("accepts not-captured schema-index placeholders", () => {
+    const operation = openapi.paths["/api/v1/schemas"].get;
+    const responseSchema =
+      operation.responses["200"].content["application/json"].schema;
+    const ajv = new Ajv2020({
+      allErrors: true,
+      allowUnionTypes: true,
+      strict: false,
+      validateFormats: true,
+    });
+    addFormats(ajv);
+    const validate = ajv.compile({
+      components: openapi.components,
+      ...responseSchema,
+    });
+    const body = {
+      ok: true,
+      schema_version: 1,
+      data: {
+        schema_version: 1,
+        contract_version: "test",
+        generated_at: "1970-01-01T00:00:00.000Z",
+        source: "openapi-snapshot",
+        schemas: [
+          {
+            netuid: 59,
+            subnet_slug: "sn-59",
+            surface_id: "sn-59-babelbit-openapi",
+            url: "https://api.babelbit.ai/openapi.json",
+            schema_url: "https://api.babelbit.ai/openapi.json",
+            status: "not-captured",
+            drift_status: "not-captured",
+            hash: null,
+            previous_hash: null,
+            path: null,
+            error: null,
+          },
+        ],
+      },
+      meta: {
+        contract_version: "test",
+      },
+    };
+
+    expect(validate(body), JSON.stringify(validate.errors, null, 2)).toBe(true);
   });
 
   it("flags a committed contract seed that no longer matches the schema", async () => {


### PR DESCRIPTION
## Summary
Fix the schema-index contract path for newly added OpenAPI surfaces that have not been snapshotted yet, and clarify that missing subnet manifests may be scaffolded with `subnet:new` before adding the first community surface.

## What changed
- Add `not-captured` as a valid `SchemaIndexEntry.status` value and regenerate the OpenAPI/type artifacts.
- Add committed-seed regression coverage for `/api/v1/schemas` responses containing not-captured schema-index placeholders.
- Align type validation scripts with `generate-types` by invoking the local `openapi-typescript` CLI instead of going through `npx`.
- Clarify contributor docs, PR/issue templates, generated enrichment issue text, and the repo-local metagraphed skill for the existing-manifest vs missing-manifest distinction.

## Why
New OpenAPI surface PRs can legitimately add a surface before a schema snapshot exists. The builder already creates not-captured schema-index placeholders for that case, so the public contract needs to allow that placeholder state. The docs/templates also need to make clear that a new subnet manifest scaffold is valid when the manifest is absent on the base branch.

## Validation
- `npx -y -p node@22 node scripts/build.mjs`
- `npx -y -p node@22 -c 'git diff --check && npm run lint && npm run format:check && npm run validate && npm run validate:contract-drift && npm run validate:schemas && npm run validate:api && npm run validate:openapi && npm run validate:types && npm run validate:committed-seed && npm run validate:docs && npm run validate:intake && npm run validate:workflows && npm run scan:public-safety && node node_modules/vitest/vitest.mjs run tests/committed-seed-gate.test.mjs'