### PR TITLE
fix(account-events): coerce string-typed netuid and uid cells to Numbers in formatAccountEvent

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -103,8 +103,13 @@ export function formatAccountEvent(row) {
     event_kind: row.event_kind ?? null,
     hotkey: row.hotkey ?? null,
     coldkey: row.coldkey ?? null,
-    netuid: row.netuid ?? null,
-    uid: row.uid ?? null,
+    // Coerce netuid / uid (D1 INTEGER columns, can return as numeric strings)
+    // through toBlockNumber so a bare `?? null` pass-through never leaks the
+    // string form into the API payload. Same shape as the coercion applied to
+    // block_number / event_index / extrinsic_index directly below — and to the
+    // sibling formatters in blocks.mjs (#2435) and extrinsics.mjs (#2439).
+    netuid: toBlockNumber(row.netuid),
+    uid: toBlockNumber(row.uid),
     amount_tao: row.amount_tao ?? null,
     alpha_amount: row.alpha_amount ?? null,
     observed_at: toIso(row.observed_at),

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -134,6 +134,27 @@ test("formatAccountEvent is null-safe on junk + sparse rows", () => {
   assert.equal(out.observed_at, null);
 });
 
+test("formatAccountEvent coerces string-typed netuid and uid cells to Numbers", () => {
+  // D1 can return an INTEGER column as a numeric string ("7" not 7); the bare
+  // `?? null` pass-through this replaced would have leaked strings into the API
+  // payload. Mirrors the coercion in blocks.mjs (#2435) and extrinsics.mjs
+  // (#2439) — and the block_number / event_index / extrinsic_index coercion
+  // already applied in this same function.
+  const out = formatAccountEvent({ netuid: "7", uid: "42", block_number: 1 });
+  assert.equal(out.netuid, 7);
+  assert.equal(typeof out.netuid, "number");
+  assert.equal(out.uid, 42);
+  assert.equal(typeof out.uid, "number");
+});
+
+test("formatAccountEvent rejects non-integer or negative netuid/uid cells to null", () => {
+  // Guard the toBlockNumber helper for these fields: netuids are never negative
+  // on-chain, and a uid above Number.MAX_SAFE_INTEGER would lose precision.
+  assert.equal(formatAccountEvent({ netuid: -1 }).netuid, null);
+  assert.equal(formatAccountEvent({ uid: 1.5 }).uid, null);
+  assert.equal(formatAccountEvent({ netuid: "abc" }).netuid, null);
+});
+
 test("utcDayBounds returns the UTC day window", () => {
   const b = utcDayBounds(Date.UTC(2026, 5, 21, 14, 30, 0));
   assert.equal(b.date, "2026-06-21");


### PR DESCRIPTION
## Summary

`formatAccountEvent` (`src/account-events.mjs`) projected the D1 `netuid` and `uid` cells directly into the API payload as `row.x ?? null`, while the sibling integer columns in the same function (`block_number`, `event_index`, `extrinsic_index`) already went through `toBlockNumber`. D1 can return an INTEGER column as a numeric string (`7` instead of `7`), so the bare pass-through silently leaked strings into the JSON response and broke any downstream arithmetic or comparison.

This routes `netuid` and `uid` through the same `toBlockNumber` helper that the other integer fields in this function already use â€” the same class of coercion applied to the sibling formatters `formatBlock` (#2435) and `formatExtrinsic` (#2439).

## What changed

- **`src/account-events.mjs`** â€” replaced the bare `?? null` pass-throughs on `netuid` and `uid` with `toBlockNumber(row.x)`. Missing, negative, or non-integer cells now fall back to `null`; string cells are coerced to their integer value.

- **`tests/account-events.test.mjs`** â€” added two cases: (1) string cells coerce to `number`; (2) negative / fractional / non-numeric cells fall back to `null`.

## Validation run

```
npx vitest run tests/account-events.test.mjs
# Test Files  1 passed (1)
# Tests       59 passed (59)

npx eslint src/account-events.mjs tests/account-events.test.mjs
# clean

npx prettier --check src/account-events.mjs tests/account-events.test.mjs
# All matched files use Prettier code style

npm run build
npm run validate
# Validated 129 native subnet(s), 129 curated overlay(s), 1213 surface(s), 125 provider(s), and 2037 candidate(s).
```

No schema/contract change â€” no schema edits, no `schemas/components/` changes, no client-version bump. The `npm run build` is run only to refresh local artifacts before `validate`; no regenerated artifacts are committed in this PR.