### PR TITLE
fix(api): clamp reliability score so sub-perfect uptime never reports a perfect 100

### DIFF
--- a/src/reliability.mjs
+++ b/src/reliability.mjs
@@ -60,7 +60,15 @@ export function scoreFromStats({
             (avgLatencyMs - LATENCY_FREE_MS) * LATENCY_PENALTY_PER_MS,
           ),
         );
-  const score = Math.max(0, Math.round(uptimeScore - latencyPenalty));
+  // Anti-overstatement clamp, the same guard this file already applies to the
+  // displayed `uptime_ratio` (displayUptimeRatio above) and the turnover
+  // `stability_score`/retention composite (#2299): a sub-perfect uptime ratio in
+  // [0.995, 1) rounds up — `Math.round(99.5) === 100` — which would headline a
+  // flawless `score: 100` (grade A) for a surface that actually had downtime,
+  // contradicting its own sub-1 `uptime_ratio`. Only a genuine okCount === samples
+  // ratio (exactly 1) keeps the perfect 100; gradeFor(99) is still "A".
+  let score = Math.max(0, Math.round(uptimeScore - latencyPenalty));
+  if (score >= 100 && uptimeRatio < 1) score = 99;
   return {
     score,
     grade: gradeFor(score),

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -2540,6 +2540,28 @@ describe("computeReliability (score from uptime history)", () => {
     );
   });
 
+  test("a sub-perfect ratio that rounds to 100 is not reported as a perfect score", () => {
+    // 199/200 = 0.995 uptime, zero latency penalty → uptimeScore 99.5, and
+    // `Math.round(99.5) === 100`, which would otherwise headline a flawless
+    // score: 100 / grade A for a surface that actually had downtime — directly
+    // contradicting its own sub-1 uptime_ratio. Clamp the would-be-100 score to
+    // 99 (still grade A), mirroring the uptime_ratio and turnover guards.
+    const subPerfect = scoreFromStats({
+      samples: 200,
+      okCount: 199,
+      avgLatencyMs: 100,
+    });
+    assert.equal(subPerfect.score, 99);
+    assert.equal(subPerfect.grade, "A");
+    assert.equal(subPerfect.uptime_ratio, 0.995);
+    // a genuine okCount === samples window with no latency penalty still reports
+    // the perfect 100.
+    assert.equal(
+      scoreFromStats({ samples: 200, okCount: 200, avgLatencyMs: 100 }).score,
+      100,
+    );
+  });
+
   test("covers grade B, null latency, missing day, and nullish rows", () => {
     // grade B (95-98)
     assert.equal(


### PR DESCRIPTION
## Summary

- `scoreFromStats` in `src/reliability.mjs` rounded the reliability `score` with a bare `Math.round`, so a **sub-perfect** uptime window in `[99.5%, 100%)` with a low latency penalty rounded up to a flawless `score: 100` / `grade: "A"` — while the same object reports a sub-1 `uptime_ratio`, making the response internally contradictory.
- This is the exact anti-overstatement gap already closed for the turnover `stability_score`/retention composite (#2299), the badge uptime percent (#1796), and the displayed uptime ratio (#1799). The `uptime_ratio` in this very file is already guarded by `displayUptimeRatio`; the headline `score` returned beside it was not.

## What Changed

- `src/reliability.mjs`: clamp a would-be-`100` reliability score to `99` when the underlying `uptimeRatio` is sub-1, mirroring the existing `displayUptimeRatio` guard and `turnover.mjs`'s `if (stabilityScore >= 100 && meanRetention < 1) stabilityScore = 99;`. A genuine `okCount === samples` window (exactly `1.0`) still reports the perfect `100`; `gradeFor(99)` is still `"A"`, so a 99.5% surface stays grade A and only stops claiming a perfect score.
- `tests/health-serving.test.mjs`: regression test — `scoreFromStats({ samples: 200, okCount: 199, avgLatencyMs: 100 })` now yields `score: 99, grade: "A", uptime_ratio: 0.995`, and a true `200/200` window still yields `score: 100`.

No public schema/OpenAPI/contract change — `score` stays a number; this is pure scoring logic.

### Reproduction (before)

```js
scoreFromStats({ samples: 200, okCount: 199, avgLatencyMs: 100 })
// → { score: 100, grade: "A", uptime_ratio: 0.995, ... }  ← perfect score for a window with downtime
```

After: `{ score: 99, grade: "A", uptime_ratio: 0.995, ... }`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (No generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — `score` remains a number.)

## Validation

- [x] `npm run test` (full vitest suite)
- [x] `npx eslint src/reliability.mjs tests/health-serving.test.mjs` (clean)
- [x] `npx prettier --check` (clean)
- [x] `git diff --check`
