### PR TITLE
feat(mcp): add get_subnet_stake_flow mirroring REST /subnets/{netuid}/stake-flow

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -107,6 +107,11 @@ import {
   parseHistoryWindow,
 } from "./neuron-history.mjs";
 import { loadSubnetTurnover } from "./turnover.mjs";
+import {
+  DEFAULT_STAKE_FLOW_WINDOW,
+  STAKE_FLOW_WINDOWS,
+  loadSubnetStakeFlow,
+} from "./stake-flow.mjs";
 import { isFinneySs58Address, loadAccountBalance } from "./account-balance.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import { loadBlocks, loadBlock } from "./blocks.mjs";
@@ -143,7 +148,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.13.0";
+export const MCP_SERVER_VERSION = "1.14.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -212,7 +217,8 @@ export const MCP_INSTRUCTIONS =
   "emission decentralization metrics (Gini, HHI, Nakamoto), " +
   "get_subnet_concentration_history the decentralization trend over time, " +
   "get_subnet_turnover validator-set and registration churn between two " +
-  "boundary snapshots, get_registry_leaderboards the live " +
+  "boundary snapshots, get_subnet_stake_flow its net stake flow (TAO staked vs " +
+  "unstaked) over a 7d/30d/90d window, get_registry_leaderboards the live " +
   "cross-subnet health/economics boards, compare_subnets a side-by-side view " +
   "across structure/economics/health, get_global_incidents recent cross-subnet " +
   "probe failures, get_chain_signers the windowed most-active-account " +
@@ -1672,6 +1678,46 @@ export const MCP_TOOLS = [
         windowLabel: label,
         windowDays: days,
       });
+    },
+  },
+  {
+    name: "get_subnet_stake_flow",
+    title: "Get subnet net stake flow",
+    description:
+      "Fetch one subnet's net stake flow over a recent window: how much TAO entered " +
+      "(StakeAdded) vs left (StakeRemoved), the net flow (positive = inflow, " +
+      "negative = outflow), and the stake/unstake event counts, summed from the " +
+      "live account-events stream. Window is 7d, 30d (default), or 90d. Use it to " +
+      "see whether capital is flowing into or out of a subnet — a recent-momentum " +
+      "signal alongside get_subnet_economics (current stake) and get_subnet_turnover " +
+      "(validator churn). Mirrors GET /api/v1/subnets/{netuid}/stake-flow.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: ["7d", "30d", "90d"],
+          description: "Lookback window (default 30d).",
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_STAKE_FLOW_WINDOW;
+      if (!Object.hasOwn(STAKE_FLOW_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${Object.keys(STAKE_FLOW_WINDOWS).join(", ")}.`,
+        );
+      }
+      const { data } = await loadSubnetStakeFlow(mcpD1Runner(ctx), netuid, {
+        windowLabel: window,
+      });
+      return data;
     },
   },
   {
@@ -4280,6 +4326,21 @@ const TOOL_OUTPUT_SCHEMAS = {
       uids_deregistered: { type: "integer" },
       neuron_retention: { type: ["number", "null"] },
       stability_score: { type: ["integer", "null"] },
+    },
+  },
+  get_subnet_stake_flow: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "net_flow_tao"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      total_staked_tao: ANY,
+      total_unstaked_tao: ANY,
+      net_flow_tao: ANY,
+      stake_events: { type: "integer" },
+      unstake_events: { type: "integer" },
     },
   },
   get_subnet_uptime: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4365,6 +4365,85 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.validator_retention, 1);
   });
 
+  // get_subnet_stake_flow sums the StakeAdded/StakeRemoved account_events; a
+  // self-contained env returns the GROUP BY event_kind rows for that read.
+  function stakeFlowEnv(rows = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind() {
+              return {
+                all() {
+                  return Promise.resolve({
+                    results: /FROM account_events/.test(sql) ? rows : [],
+                  });
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("get_subnet_stake_flow sums StakeAdded vs StakeRemoved into net flow", async () => {
+    const env = stakeFlowEnv([
+      {
+        event_kind: "StakeAdded",
+        total_tao: 300,
+        event_count: 5,
+        last_observed: 1750000000000,
+      },
+      {
+        event_kind: "StakeRemoved",
+        total_tao: 120,
+        event_count: 2,
+        last_observed: 1750000001000,
+      },
+    ]);
+    const res = await callTool(
+      "get_subnet_stake_flow",
+      { netuid: 7, window: "7d" },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.window, "7d");
+    assert.equal(out.total_staked_tao, 300);
+    assert.equal(out.total_unstaked_tao, 120);
+    assert.equal(out.net_flow_tao, 180); // 300 - 120
+    assert.equal(out.stake_events, 5);
+    assert.equal(out.unstake_events, 2);
+  });
+
+  test("get_subnet_stake_flow defaults to the 30d window", async () => {
+    const res = await callTool(
+      "get_subnet_stake_flow",
+      { netuid: 7 },
+      { env: stakeFlowEnv() },
+    );
+    assert.equal(res.body.result.structuredContent.window, "30d");
+  });
+
+  test("get_subnet_stake_flow degrades to zeroed flow on cold D1", async () => {
+    const res = await callTool("get_subnet_stake_flow", { netuid: 7 });
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.net_flow_tao, 0);
+    assert.equal(out.stake_events, 0);
+  });
+
+  test("get_subnet_stake_flow rejects an unsupported window", async () => {
+    const res = await callTool(
+      "get_subnet_stake_flow",
+      { netuid: 7, window: "1y" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
   test("the D1-backed tools degrade to schema-stable empty payloads when D1 is cold", async () => {
     const meta = await callTool("get_subnet_metagraph", { netuid: 7 });
     assert.equal(meta.body.result.isError, false);


### PR DESCRIPTION
## Summary

- Surface one subnet's net stake flow (live REST route
  `GET /api/v1/subnets/{netuid}/stake-flow`) as an MCP tool — a
  recent-capital-movement signal alongside get_subnet_economics (current stake)
  and get_subnet_turnover (validator churn).

## What Changed

- Add MCP tool `get_subnet_stake_flow` in `src/mcp-server.mjs`: TAO staked
  (StakeAdded) vs unstaked (StakeRemoved), the net flow (positive = inflow,
  negative = outflow), and stake/unstake event counts over a 7d/30d/90d window.
  Adds its `TOOL_OUTPUT_SCHEMAS` entry and lists it in MCP_INSTRUCTIONS.
- Wire the tool to the existing shared `loadSubnetStakeFlow` loader
  (`src/stake-flow.mjs`) — REST and MCP share one read path; no loader or REST
  handler change needed, and no REST/contract change.
- Bump `MCP_SERVER_VERSION` and `server.json` 1.13.0 → 1.14.0 (MINOR), per the
  documented add-a-tool bump policy.
- Tests: tool tests (StakeAdded/StakeRemoved net-flow sum, 30d default, cold-D1
  zeroed flow, unsupported-window rejection) in `tests/mcp-server.test.mjs`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public REST API/OpenAPI/schema change (MCP tool only; reuses the existing loader).

## Validation

- [x] `npm run validate:mcp` — 66 tools, lifecycle + all tools/call (server.json == MCP_SERVER_VERSION)
- [x] vitest: mcp-server + stake-flow (322 pass)
- [x] eslint + prettier on changed files
- [x] `git diff --check`
