### PR TITLE
fix(account-events): coerce string-typed netuid and event_count cells to Numbers in formatAccountDay

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -363,8 +363,13 @@ export function formatAccountDay(row) {
   if (!row || typeof row !== "object") return null;
   return {
     day: row.day ?? null,
-    netuid: row.netuid ?? null,
-    event_count: row.event_count ?? null,
+    // Coerce netuid / event_count (D1 INTEGER columns, can return as numeric
+    // strings) through toBlockNumber so a bare `?? null` pass-through never
+    // leaks the string form into the API payload. Same shape as the coercion
+    // applied in formatAccountEvent above (#2481) and the sibling formatters
+    // in blocks.mjs (#2435) / extrinsics.mjs (#2439).
+    netuid: toBlockNumber(row.netuid),
+    event_count: toBlockNumber(row.event_count),
     event_kinds:
       typeof row.event_kinds === "string" && row.event_kinds.length > 0
         ? row.event_kinds.split(",").filter(Boolean)

--- a/tests/account-events-branch-coverage.test.mjs
+++ b/tests/account-events-branch-coverage.test.mjs
@@ -91,6 +91,26 @@ describe("formatAccountDay", () => {
     assert.equal(formatAccountDay(null), null);
     assert.equal(formatAccountDay("x"), null);
   });
+
+  test("formatAccountDay coerces string-typed netuid and event_count cells to Numbers", () => {
+    // D1 can return an INTEGER column as a numeric string ("7" not 7); the bare
+    // `?? null` pass-through this replaced would have leaked strings into the API
+    // payload. Mirrors the coercion in formatAccountEvent (#2481), blocks.mjs
+    // (#2435), and extrinsics.mjs (#2439).
+    const out = formatAccountDay({ netuid: "7", event_count: "42" });
+    assert.equal(out.netuid, 7);
+    assert.equal(typeof out.netuid, "number");
+    assert.equal(out.event_count, 42);
+    assert.equal(typeof out.event_count, "number");
+  });
+
+  test("formatAccountDay rejects non-integer or negative netuid/event_count cells to null", () => {
+    // Guard the toBlockNumber helper for these fields: netuids are never negative
+    // on-chain, and counts are non-negative integers.
+    assert.equal(formatAccountDay({ netuid: -1 }).netuid, null);
+    assert.equal(formatAccountDay({ event_count: 1.5 }).event_count, null);
+    assert.equal(formatAccountDay({ netuid: "abc" }).netuid, null);
+  });
 });
 
 describe("buildAccountHistory", () => {


### PR DESCRIPTION
## Summary

`formatAccountDay` (`src/account-events.mjs`) projected the D1 `netuid` and `event_count` cells directly into the API payload as `row.x ?? null`, while the sibling integer columns in the same function (`first_block`, `last_block`) already went through `toBlockNumber`, and the sibling function `formatAccountEvent` (just fixed in #2481) also routes `netuid`/`uid` through `toBlockNumber`. D1 can return an INTEGER column as a numeric string (`7` instead of `7`), so the bare pass-through silently leaked strings into the JSON response.

This routes `netuid` and `event_count` through the same `toBlockNumber` helper â€” completing the coercion of every D1 INTEGER column in `account-events.mjs`.

## What changed

- **`src/account-events.mjs`** â€” replaced the bare `?? null` pass-throughs on `netuid` and `event_count` with `toBlockNumber(row.x)`. Missing, negative, or non-integer cells now fall back to `null`; string cells are coerced to their integer value.

- **`tests/account-events-branch-coverage.test.mjs`** â€” added two cases inside the existing `describe(formatAccountDay)` block: (1) string cells coerce to `number`; (2) negative / fractional / non-numeric cells fall back to `null`.

## Validation run

```
npx vitest run tests/account-events.test.mjs tests/account-events-branch-coverage.test.mjs
# Test Files  2 passed (2)
# Tests       74 passed (74)

npx eslint src/account-events.mjs tests/account-events-branch-coverage.test.mjs
# clean

npx prettier --check src/account-events.mjs tests/account-events-branch-coverage.test.mjs
# All matched files use Prettier code style

npm run validate
# Validated 129 native subnet(s), 129 curated overlay(s), 1213 surface(s), 125 provider(s), and 2037 candidate(s).
```

No schema/contract change â€” no schema edits, no `schemas/components/` changes, no client-version bump.