### PR TITLE
feat(mcp): add get_subnet_movers tool (REST parity for GET /api/v1/subnets/movers)

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -340,6 +340,19 @@ assert.ok(
   Array.isArray(traj.points),
   "get_subnet_trajectory must return points[]",
 );
+const moversCold = await callOk("get_subnet_movers", {
+  window: "30d",
+  limit: 10,
+});
+assert.ok(
+  Array.isArray(moversCold.movers),
+  "get_subnet_movers must return movers[]",
+);
+assert.equal(
+  moversCold.sort,
+  "stake",
+  "get_subnet_movers must default sort to stake",
+);
 const econTrends = await callOk("get_economics_trends", { window: "30d" });
 assert.ok(
   Array.isArray(econTrends.days),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -107,6 +107,15 @@ import {
   parseHistoryWindow,
 } from "./neuron-history.mjs";
 import { loadSubnetTurnover } from "./turnover.mjs";
+import {
+  DEFAULT_MOVERS_SORT,
+  DEFAULT_MOVERS_WINDOW,
+  MOVERS_LIMIT_DEFAULT,
+  MOVERS_LIMIT_MAX,
+  MOVERS_SORTS,
+  MOVERS_WINDOWS,
+  loadSubnetMovers,
+} from "./movers.mjs";
 import { isFinneySs58Address, loadAccountBalance } from "./account-balance.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import { loadBlocks, loadBlock } from "./blocks.mjs";
@@ -143,7 +152,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.14.0";
+export const MCP_SERVER_VERSION = "1.15.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -212,7 +221,8 @@ export const MCP_INSTRUCTIONS =
   "emission decentralization metrics (Gini, HHI, Nakamoto), " +
   "get_subnet_concentration_history the decentralization trend over time, " +
   "get_subnet_turnover validator-set and registration churn between two " +
-  "boundary snapshots, get_registry_leaderboards the live " +
+  "boundary snapshots, get_subnet_movers the cross-subnet momentum " +
+  "leaderboard (stake/emission/validator change), get_registry_leaderboards the live " +
   "cross-subnet health/economics boards, compare_subnets a side-by-side view " +
   "across structure/economics/health, get_global_incidents recent cross-subnet " +
   "probe failures, get_chain_signers the windowed most-active-account " +
@@ -1671,6 +1681,55 @@ export const MCP_TOOLS = [
       return loadSubnetTurnover(mcpD1Runner(ctx), netuid, {
         windowLabel: label,
         windowDays: days,
+      });
+    },
+  },
+  {
+    name: "get_subnet_movers",
+    title: "Get cross-subnet momentum leaderboard",
+    description:
+      "Rank every subnet by how much its stake, emission, or validator count " +
+      "changed between the start and end neuron_daily snapshots in the " +
+      "requested window (7d, 30d, or 90d; default 30d). Sort by stake, " +
+      "emission, or validators (default stake). Use it to spot subnets gaining " +
+      "or losing participation momentum. Mirrors GET /api/v1/subnets/movers.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: ["7d", "30d", "90d"],
+          description: "Comparison window (default 30d).",
+        },
+        sort: {
+          type: "string",
+          enum: ["stake", "emission", "validators"],
+          description: "Metric to rank by (default stake).",
+        },
+        limit: {
+          type: "integer",
+          description: "Max subnets to return (1-100, default 20).",
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const windowLabel =
+        optionalEnum(args, "window", Object.keys(MOVERS_WINDOWS)) ??
+        DEFAULT_MOVERS_WINDOW;
+      const sort =
+        optionalEnum(args, "sort", MOVERS_SORTS) ?? DEFAULT_MOVERS_SORT;
+      const limit = clampLimit(
+        args?.limit,
+        MOVERS_LIMIT_DEFAULT,
+        MOVERS_LIMIT_MAX,
+      );
+      return loadSubnetMovers(mcpD1Runner(ctx), {
+        windowLabel,
+        sort,
+        limit,
       });
     },
   },
@@ -4293,6 +4352,68 @@ const TOOL_OUTPUT_SCHEMAS = {
       uids_deregistered: { type: "integer" },
       neuron_retention: { type: ["number", "null"] },
       stability_score: { type: ["integer", "null"] },
+    },
+  },
+  get_subnet_movers: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "schema_version",
+      "window",
+      "start_date",
+      "end_date",
+      "sort",
+      "subnet_count",
+      "movers",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      start_date: NULLABLE_STRING,
+      end_date: NULLABLE_STRING,
+      sort: { type: "string" },
+      subnet_count: { type: "integer" },
+      movers: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: true,
+          required: [
+            "netuid",
+            "stake_start_tao",
+            "stake_end_tao",
+            "stake_delta_tao",
+            "stake_pct_change",
+            "emission_start_tao",
+            "emission_end_tao",
+            "emission_delta_tao",
+            "emission_pct_change",
+            "validators_start",
+            "validators_end",
+            "validators_delta",
+            "neurons_start",
+            "neurons_end",
+            "neurons_delta",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            stake_start_tao: { type: "number" },
+            stake_end_tao: { type: "number" },
+            stake_delta_tao: { type: "number" },
+            stake_pct_change: { type: ["number", "null"] },
+            emission_start_tao: { type: "number" },
+            emission_end_tao: { type: "number" },
+            emission_delta_tao: { type: "number" },
+            emission_pct_change: { type: ["number", "null"] },
+            validators_start: { type: "integer" },
+            validators_end: { type: "integer" },
+            validators_delta: { type: "integer" },
+            neurons_start: { type: "integer" },
+            neurons_end: { type: "integer" },
+            neurons_delta: { type: "integer" },
+          },
+        },
+      },
     },
   },
   get_subnet_uptime: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3974,6 +3974,8 @@ describe("MCP economics + metagraph data tools", () => {
     neuronDaily = [],
     turnoverBounds = [],
     turnoverRows = [],
+    moversBounds = [],
+    moversAggRows = [],
   } = {}) {
     return {
       prepare(sql) {
@@ -3999,7 +4001,12 @@ describe("MCP economics + metagraph data tools", () => {
                 }
                 if (sql.includes("FROM neuron_daily")) {
                   if (/MIN\(snapshot_date\) AS start_date/.test(sql)) {
-                    return Promise.resolve({ results: turnoverBounds });
+                    const bounds =
+                      moversBounds.length > 0 ? moversBounds : turnoverBounds;
+                    return Promise.resolve({ results: bounds });
+                  }
+                  if (/GROUP BY netuid, snapshot_date/.test(sql)) {
+                    return Promise.resolve({ results: moversAggRows });
                   }
                   if (/snapshot_date IN/.test(sql)) {
                     return Promise.resolve({ results: turnoverRows });
@@ -4329,6 +4336,89 @@ describe("MCP economics + metagraph data tools", () => {
     });
     assert.equal(res.body.result.isError, true);
     assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("get_subnet_movers returns schema-stable empty on cold D1", async () => {
+    const res = await callTool("get_subnet_movers", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.sort, "stake");
+    assert.deepEqual(out.movers, []);
+    assert.equal(out.subnet_count, 0);
+  });
+
+  test("get_subnet_movers ranks subnets by stake delta between boundary snapshots", async () => {
+    const res = await callTool(
+      "get_subnet_movers",
+      { window: "30d", sort: "stake", limit: 10 },
+      {
+        env: {
+          METAGRAPH_HEALTH_DB: metagraphD1({
+            moversBounds: [
+              { start_date: "2026-06-01", end_date: "2026-06-30" },
+            ],
+            moversAggRows: [
+              {
+                netuid: 1,
+                snapshot_date: "2026-06-01",
+                neuron_count: 10,
+                validator_count: 3,
+                total_stake_tao: 100,
+                total_emission_tao: 5,
+              },
+              {
+                netuid: 1,
+                snapshot_date: "2026-06-30",
+                neuron_count: 12,
+                validator_count: 4,
+                total_stake_tao: 250,
+                total_emission_tao: 9,
+              },
+              {
+                netuid: 7,
+                snapshot_date: "2026-06-01",
+                neuron_count: 5,
+                validator_count: 2,
+                total_stake_tao: 50,
+                total_emission_tao: 2,
+              },
+              {
+                netuid: 7,
+                snapshot_date: "2026-06-30",
+                neuron_count: 6,
+                validator_count: 2,
+                total_stake_tao: 60,
+                total_emission_tao: 3,
+              },
+            ],
+          }),
+        },
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.start_date, "2026-06-01");
+    assert.equal(out.end_date, "2026-06-30");
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.movers.length, 2);
+    assert.equal(out.movers[0].netuid, 1);
+    assert.equal(out.movers[0].stake_delta_tao, 150);
+    assert.equal(out.movers[1].netuid, 7);
+    assert.equal(out.movers[1].stake_delta_tao, 10);
+  });
+
+  test("get_subnet_movers rejects an invalid window", async () => {
+    const res = await callTool("get_subnet_movers", { window: "1y" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Argument `window` must be one of/,
+    );
+  });
+
+  test("get_subnet_movers rejects an invalid sort", async () => {
+    const res = await callTool("get_subnet_movers", { sort: "latency" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /sort.*must be one of/);
   });
 
   test("get_subnet_turnover accepts the all window without a date cutoff", async () => {


### PR DESCRIPTION
## Summary

- Add MCP tool **`get_subnet_movers`** — REST parity for `GET /api/v1/subnets/movers`.
- Agents can rank subnets by stake, emission, or validator change over a 7d/30d/90d window without raw HTTP.
- Bump MCP server version **1.14.0 → 1.15.0** (`server.json` + `MCP_SERVER_VERSION`).

## Changes

| File | What |
|------|------|
| `src/mcp-server.mjs` | New tool, output schema, server instructions; version bump |
| `server.json` | Version `1.15.0` |
| `scripts/validate-mcp.mjs` | Cold-env happy-path call |
| `tests/mcp-server.test.mjs` | Cold D1 empty, mocked D1 ranking, invalid window/sort |

## Tool contract

**Name:** `get_subnet_movers`

**Args (all optional):**

| Arg | Values | Default |
|-----|--------|---------|
| `window` | `7d`, `30d`, `90d` | `30d` |
| `sort` | `stake`, `emission`, `validators` | `stake` |
| `limit` | 1–100 | `20` |

**Returns:** `SubnetMoversArtifact` shape — `window`, `start_date`, `end_date`, `sort`, `subnet_count`, `movers[]` with per-subnet stake/emission/validator deltas.

Cold or single-snapshot D1 degrades to an empty `movers[]` (never throws), matching the REST route.

## Test plan

- [x] `npm test -- tests/mcp-server.test.mjs -t "get_subnet_movers"`
- [x] `npm run validate:mcp`