### PR TITLE
feat(registry): add SN74 Gittensor dash/prices data-artifact surface

### DIFF
--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -397,6 +397,28 @@
       },
       "source_urls": ["https://api.gittensor.io/swagger-json"],
       "url": "https://api.gittensor.io/prs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-data-artifact-api-gittensor-io-6",
+      "kind": "data-artifact",
+      "name": "Gittensor TAO and Alpha token prices",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "confidence": "medium",
+        "state": "community-submitted",
+        "submitted_by": "carlh7777"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger"],
+      "url": "https://api.gittensor.io/dash/prices"
     }
   ],
   "website_url": "https://gittensor.io/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly **one** surface to `registry/subnets/gittensor.json`.

Closes #427

## Surface

- **Netuid:** 74
- **Kind:** `data-artifact`
- **Public URL:** https://api.gittensor.io/dash/prices
- **Source URL:** https://api.gittensor.io/swagger
- **Provider slug:** `gittensor`

## Summary

Resubmit after Gittensory gate blocked the prior two-surface append. This PR adds only the public `GET /dash/prices` endpoint (TAO/Alpha token prices), documented in the Gittensor OpenAPI spec.

`dash/commits` will follow in a separate PR.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file
- [x] Appends exactly one new `surfaces[]` entry
- [x] `authority: community`, `review.state: community-submitted`
- [x] Public URL is safe for read-only probes; source URL proves the claim
- [x] No auth, secrets, or generated `public/metagraph/**` artifacts
- [x] Does not duplicate an existing surface
- [x] Links tracked issue (`Closes #427`)

## Validation

```bash
npm run validate:surface -- registry/subnets/gittensor.json
npm run scan:public-safety
```
