### PR TITLE
ci(codecov): raise patch coverage target

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,24 +71,48 @@ jobs:
           VITEST_JUNIT_PATH: reports/junit/vitest.xml
         run: npm run test:ci
 
+      - name: Verify coverage report exists
+        run: test -s coverage/lcov.info
+
       # Upload coverage to Codecov — the primary PR coverage gate (delta-based
       # project + patch, see codecov.yml). vitest's thresholds are now just a
-      # local backstop. Runs on PRs AND main pushes (main = the comparison base);
-      # the upload failing never fails CI (the gate is Codecov's own status).
+      # local backstop. Same-repo PRs and main pushes use the repository token;
+      # fork PRs use Codecov's public-repo tokenless upload path instead.
+      # Missing coverage or upload errors fail the test job.
       - name: Upload coverage to Codecov
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
-          fail_ci_if_error: false
+          disable_search: true
+          fail_ci_if_error: true
+
+      - name: Upload coverage to Codecov (fork PR tokenless)
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./coverage/lcov.info
+          disable_search: true
+          fail_ci_if_error: true
 
       - name: Upload Vitest results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./reports/junit/vitest.xml
           report_type: test_results
+          disable_search: true
+          fail_ci_if_error: false
+
+      - name: Upload Vitest results to Codecov (fork PR tokenless)
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./reports/junit/vitest.xml
+          report_type: test_results
+          disable_search: true
           fail_ci_if_error: false
 
       # The two filesystem-mutating artifact writers, run serially LAST so they

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,8 +16,9 @@ coverage:
         informational: false
     patch:
       default:
-        target: 80% # 80% of the lines a PR changes must be covered
+        target: 99% # near-zero slack for changed runtime code
         threshold: 0%
+        only_pulls: true
         informational: false
 
 comment:

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -93,6 +93,27 @@ for (const workflow of workflows) {
       workflow,
       "validate workflow must detect rebuilt-but-untracked public artifacts after build",
     );
+    check(
+      content.includes(
+        "github.event.pull_request.head.repo.full_name == github.repository",
+      ) &&
+        content.includes(
+          "github.event.pull_request.head.repo.full_name != github.repository",
+        ) &&
+        workflowStepBlock(content, "Upload coverage to Codecov").includes(
+          "token: ${{ secrets.CODECOV_TOKEN }}",
+        ) &&
+        !workflowStepBlock(
+          content,
+          "Upload coverage to Codecov (fork PR tokenless)",
+        ).includes("secrets.CODECOV_TOKEN") &&
+        workflowStepBlock(
+          content,
+          "Upload coverage to Codecov (fork PR tokenless)",
+        ).includes("fail_ci_if_error: true"),
+      workflow,
+      "validate workflow must split Codecov coverage uploads into trusted-token and fork-tokenless paths",
+    );
   }
   if (
     ["validate.yml", "sync-subnets.yml", "publish-cloudflare.yml"].includes(
@@ -241,6 +262,14 @@ function workflowJobBlock(content, jobName) {
     ),
   );
   return match?.[0] || "";
+}
+
+function workflowStepBlock(content, stepName) {
+  const marker = `- name: ${stepName}`;
+  const start = content.indexOf(marker);
+  if (start === -1) return "";
+  const next = content.indexOf("\n      - name:", start + marker.length);
+  return content.slice(start, next === -1 ? undefined : next);
 }
 
 function stepBlock(content, stepName) {


### PR DESCRIPTION
## Summary
- raises the Codecov patch coverage target from 80% to 99%
- limits the patch status to pull requests, where patch coverage is meaningful
- requires the CI coverage report to exist before upload
- uploads only the expected lcov report and fails the test job if the coverage upload errors
- splits Codecov coverage uploads so same-repo/main runs use `CODECOV_TOKEN`, while fork PRs use Codecov's public-repo tokenless upload path without referencing repository secrets
- adds a workflow validator invariant for the trusted-token versus fork-tokenless Codecov upload split
- leaves project/global coverage behavior unchanged

## Why
PR-local coverage should enforce the stricter bar for newly changed runtime lines without making total project coverage more brittle. Missing local coverage output and failed coverage uploads should fail in CI instead of being hidden behind a passing test job. Direct branch pushes do not need a patch status.

Fork PR validation still needs to work without repository secrets. The workflow now makes that explicit: trusted same-repo/main uploads use the Codecov token, and fork PR uploads omit the token and use Codecov's tokenless public-repo path.

## Validation
- `git diff --check`
- `npx prettier --check codecov.yml .github/workflows/validate.yml scripts/validate-workflows.mjs`
- `npm run validate:workflows`
- `npm run lint`
