### PR TITLE
feat(mcp): add cursor and block range filters to get_account_transfers

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -744,38 +744,59 @@ export async function loadAccountExtrinsics(
 export async function loadAccountTransfers(
   d1,
   ss58,
-  { direction, limit, offset, blockStart, blockEnd } = {},
+  { direction, limit, offset, cursor, blockStart, blockEnd } = {},
 ) {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
-  const rangeClause = `${blockStart != null ? " AND block_number >= ?" : ""}${blockEnd != null ? " AND block_number <= ?" : ""}`;
-  const pushRangeParams = (params) => {
+  const cur = decodeCursor(cursor, 2);
+  const useCursor = Boolean(cur);
+  const blockRangeClause = `${blockStart != null ? " AND block_number >= ?" : ""}${blockEnd != null ? " AND block_number <= ?" : ""}`;
+  const cursorClause = useCursor
+    ? " AND (block_number, event_index) < (?, ?)"
+    : "";
+  const pushBlockRangeParams = (params) => {
     if (blockStart != null) params.push(blockStart);
     if (blockEnd != null) params.push(blockEnd);
+  };
+  const pushCursorParams = (params) => {
+    if (useCursor) params.push(cur[0], cur[1]);
   };
   let sql;
   let params;
   if (direction === "sent") {
     params = [ss58];
-    pushRangeParams(params);
-    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ?${rangeClause}`;
+    pushBlockRangeParams(params);
+    pushCursorParams(params);
+    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ?${blockRangeClause}${cursorClause}`;
   } else if (direction === "received") {
     params = [ss58];
-    pushRangeParams(params);
-    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ?${rangeClause}`;
+    pushBlockRangeParams(params);
+    pushCursorParams(params);
+    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ?${blockRangeClause}${cursorClause}`;
   } else {
     params = [ss58];
-    pushRangeParams(params);
+    pushBlockRangeParams(params);
+    pushCursorParams(params);
     params.push(ss58, ss58);
-    pushRangeParams(params);
-    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM (SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ?${rangeClause} UNION ALL SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ? AND hotkey <> ?${rangeClause})`;
+    pushBlockRangeParams(params);
+    pushCursorParams(params);
+    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM (SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ?${blockRangeClause}${cursorClause} UNION ALL SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ? AND hotkey <> ?${blockRangeClause}${cursorClause})`;
   }
-  sql += " ORDER BY block_number DESC, event_index DESC LIMIT ? OFFSET ?";
-  params.push(lim, off);
+  sql += " ORDER BY block_number DESC, event_index DESC LIMIT ?";
+  params.push(lim);
+  if (!useCursor) {
+    sql += " OFFSET ?";
+    params.push(off);
+  }
   const rows = await d1(sql, params);
+  const last = rows.length === lim ? rows[rows.length - 1] : null;
+  const nextCursor = last
+    ? encodeCursor([last.block_number, last.event_index])
+    : null;
   return buildAccountTransfers(rows, ss58, {
     limit: lim,
     offset: off,
+    nextCursor,
     direction,
   });
 }

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -2414,9 +2414,10 @@ export const MCP_TOOLS = [
       "Fetch the native-TAO Balances.Transfer feed for one account by its SS58 address, " +
       "newest first: from address, to address, amount in TAO, and direction (sent/ " +
       "received). Filter by direction with direction='sent' or 'received'; omit for " +
-      "both sides. Page with limit (1-1000, default 100) / offset. This is the native " +
-      "chain-level TAO transfer feed only, NOT a full balance ledger — stake flows are " +
-      "separate events visible in get_account_events.",
+      "both sides. Optionally constrain block height with block_start/block_end " +
+      "(inclusive). Page with limit (1-1000, default 100) / offset, or follow " +
+      "next_cursor for stable keyset pagination. Mirrors " +
+      "GET /api/v1/accounts/{ss58}/transfers.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2433,6 +2434,18 @@ export const MCP_TOOLS = [
             "or omit for both. Any other value is treated as both-sides.",
           enum: ["sent", "received"],
         },
+        block_start: {
+          type: "integer",
+          description:
+            "Optional inclusive lower block bound; omit for no lower limit.",
+          minimum: 0,
+        },
+        block_end: {
+          type: "integer",
+          description:
+            "Optional inclusive upper block bound; omit for no upper limit.",
+          minimum: 0,
+        },
         limit: {
           type: "integer",
           description: "Max transfers to return (1-1000, default 100).",
@@ -2444,6 +2457,12 @@ export const MCP_TOOLS = [
           description: "Pagination offset. Default 0.",
           minimum: 0,
         },
+        cursor: {
+          type: "string",
+          description:
+            "Opaque keyset cursor from a previous response's next_cursor; takes " +
+            "precedence over offset for stable deep pagination.",
+        },
       },
       required: ["ss58"],
       additionalProperties: false,
@@ -2451,10 +2470,14 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const ss58 = requireSs58(args);
       const direction = optionalString(args, "direction");
+      const cursor = optionalString(args, "cursor");
       return loadAccountTransfers(mcpD1Runner(ctx), ss58, {
         direction: direction ?? undefined,
+        blockStart: optionalNonNegativeInt(args, "block_start"),
+        blockEnd: optionalNonNegativeInt(args, "block_end"),
         limit: args?.limit,
         offset: args?.offset,
+        cursor: cursor ?? undefined,
       });
     },
   },
@@ -4699,6 +4722,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       transfer_count: { type: "integer" },
       limit: NULLABLE_INT,
       offset: NULLABLE_INT,
+      next_cursor: NULLABLE_STRING,
       transfers: objectItems({
         block_number: NULLABLE_INT,
         event_index: NULLABLE_INT,

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -608,6 +608,38 @@ test("loadAccountTransfers applies the block_start/block_end range to both sides
   ]);
 });
 
+test("loadAccountTransfers uses cursor keyset pagination over offset", async () => {
+  let captured;
+  const out = await loadAccountTransfers(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [
+        {
+          block_number: 150,
+          event_index: 4,
+          hotkey: "5Hk",
+          coldkey: "5Other",
+          amount_tao: 1,
+          observed_at: 1,
+        },
+      ];
+    },
+    "5Hk",
+    {
+      blockStart: 100,
+      blockEnd: 900,
+      cursor: encodeCursor([200, 2]),
+      limit: 1,
+      offset: 99,
+      direction: "sent",
+    },
+  );
+  assert.ok(/\(block_number, event_index\) < \(\?, \?\)/.test(captured.sql));
+  assert.ok(!/OFFSET/.test(captured.sql));
+  assert.deepEqual(captured.params, ["5Hk", 100, 900, 200, 2, 1]);
+  assert.equal(out.next_cursor, encodeCursor([150, 4]));
+});
+
 test("loadAccountExtrinsics applies the block_start/block_end range as bound params", async () => {
   let captured;
   await loadAccountExtrinsics(

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5725,6 +5725,59 @@ describe("MCP account tail tools (history, extrinsics, transfers)", () => {
     assert.ok(!/hotkey = \?/.test(q.sql), "received must not match hotkey");
   });
 
+  test("get_account_transfers applies block_start/block_end and cursor pagination", async () => {
+    const capture = [];
+    const env = tailD1(
+      {
+        transfers: [
+          {
+            block_number: 150,
+            event_index: 4,
+            event_kind: "Transfer",
+            hotkey: SS58,
+            coldkey: "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
+            amount_tao: 10.5,
+            observed_at: 1750009000000,
+            extrinsic_index: null,
+          },
+        ],
+      },
+      capture,
+    );
+    const res = await callTool(
+      "get_account_transfers",
+      {
+        ss58: SS58,
+        direction: "sent",
+        block_start: 100,
+        block_end: 900,
+        cursor: "200.2",
+        limit: 1,
+        offset: 99,
+      },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.transfer_count, 1);
+    assert.equal(out.next_cursor, "150.4");
+    const q = capture.find((c) => /event_kind = 'Transfer'/.test(c.sql));
+    assert.ok(/block_number >= \?/.test(q.sql));
+    assert.ok(/block_number <= \?/.test(q.sql));
+    assert.ok(/\(block_number, event_index\) < \(\?, \?\)/.test(q.sql));
+    assert.ok(!/OFFSET/.test(q.sql));
+    assert.deepEqual(q.params, [SS58, 100, 900, 200, 2, 1]);
+  });
+
+  test("get_account_transfers rejects a non-integer block_end", async () => {
+    const res = await callTool(
+      "get_account_transfers",
+      { ss58: SS58, block_end: "bad" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /block_end/i);
+  });
+
   test("get_account_transfers degrades to empty payload on cold D1", async () => {
     const res = await callTool("get_account_transfers", { ss58: SS58 });
     assert.equal(res.body.result.isError, false);

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -54,13 +54,13 @@ import {
 import {
   ACCOUNT_EVENT_COLUMNS,
   INGESTED_EVENT_KINDS,
-  buildAccountTransfers,
   buildAccountHistory,
   buildSubnetEvents,
   formatAccountEvent,
   loadAccountSummary,
   loadAccountEvents,
   loadAccountExtrinsics,
+  loadAccountTransfers,
   loadAccountSubnets,
 } from "../../src/account-events.mjs";
 import {
@@ -900,61 +900,15 @@ export async function handleAccountTransfers(request, env, ss58, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
-  // sent => this account is the sender (hotkey=from); received => recipient
-  // (coldkey=to); default/all => either side. Keep the default read as two
-  // side-specific seeks rather than an OR predicate so D1 cannot satisfy only
-  // event_kind='Transfer' from the pair index and then filter all Transfer rows.
-  // Self-transfers are returned once, matching the old OR semantics.
-  const cur = decodeCursor(cursor, 2);
-  const useCursor = Boolean(cur);
-  const blockRangeClause = `${blockStart.value != null ? " AND block_number >= ?" : ""}${blockEnd.value != null ? " AND block_number <= ?" : ""}`;
-  const cursorClause = useCursor
-    ? " AND (block_number, event_index) < (?, ?)"
-    : "";
-  const pushBlockRangeParams = (target) => {
-    if (blockStart.value != null) target.push(blockStart.value);
-    if (blockEnd.value != null) target.push(blockEnd.value);
-  };
-  const pushCursorParams = (target) => {
-    if (useCursor) target.push(cur[0], cur[1]);
-  };
-  let params;
-  let sql;
-  if (direction === "sent") {
-    params = [ss58];
-    pushBlockRangeParams(params);
-    pushCursorParams(params);
-    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ?${blockRangeClause}${cursorClause}`;
-  } else if (direction === "received") {
-    params = [ss58];
-    pushBlockRangeParams(params);
-    pushCursorParams(params);
-    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ?${blockRangeClause}${cursorClause}`;
-  } else {
-    params = [ss58];
-    pushBlockRangeParams(params);
-    pushCursorParams(params);
-    params.push(ss58, ss58);
-    pushBlockRangeParams(params);
-    pushCursorParams(params);
-    sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM (SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_hotkey WHERE event_kind = 'Transfer' AND hotkey = ?${blockRangeClause}${cursorClause} UNION ALL SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events INDEXED BY idx_account_events_coldkey WHERE event_kind = 'Transfer' AND coldkey = ? AND hotkey <> ?${blockRangeClause}${cursorClause})`;
-  }
-  sql += " ORDER BY block_number DESC, event_index DESC LIMIT ?";
-  params.push(limit);
-  if (!useCursor) {
-    sql += " OFFSET ?";
-    params.push(offset);
-  }
-  const rows = await d1All(env, sql, params);
-  const last = rows.length === limit ? rows[rows.length - 1] : null;
-  const nextCursor = last
-    ? encodeCursor([last.block_number, last.event_index])
-    : null;
-  const data = buildAccountTransfers(rows, ss58, {
+  const normalizedDirection =
+    direction === "sent" || direction === "received" ? direction : undefined;
+  const data = await loadAccountTransfers(d1Runner(env), ss58, {
+    direction: normalizedDirection,
     limit,
     offset,
-    nextCursor,
-    direction,
+    cursor,
+    blockStart: blockStart.value,
+    blockEnd: blockEnd.value,
   });
   return envelopeResponse(
     request,


### PR DESCRIPTION
## Summary

- Extend `loadAccountTransfers` with keyset `cursor` pagination (matching the REST handler’s seek semantics).
- Refactor `handleAccountTransfers` to delegate to the shared loader — no duplicated SQL.
- Expose REST parity on MCP `get_account_transfers`: optional `block_start`/`block_end` and `cursor`, plus `next_cursor` on the outputSchema.

Follows the same pattern as the merged `get_account_extrinsics` pagination PR (#2438). No new REST response fields — no `schemas/**` or artifact updates.

## Test plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test -- tests/account-events.test.mjs -t "loadAccountTransfers"`
- [x] `npm test -- tests/mcp-server.test.mjs -t "get_account_transfers"`
- [x] `npm run validate:mcp`