### PR TITLE
fix(account-events): bound the account-summary event aggregates to the newest N

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1869,11 +1869,15 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file). */
+        /** @description Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file). The event aggregates (event_count, subnet_count, event_kinds, first_*) are computed over the account's most recent events, bounded for cost; when event_scan_capped is true they are a lower bound over that window, not all-time totals. */
         AccountSummaryArtifact: {
             activity?: components["schemas"]["AccountActivity"];
+            /** @description Number of account_events counted. A lower bound over the account's most recent events (not an all-time total) when event_scan_capped is true. */
             event_count: number;
+            /** @description Per-kind event counts over the counted events; a lower bound over the most recent events when event_scan_capped is true. */
             event_kinds?: components["schemas"]["AccountEventKindCount"][];
+            /** @description True when the event aggregates hit the newest-events scan cap: event_count / subnet_count / event_kinds are then a lower bound over the account's most recent events, not all-time totals, and first_block / first_seen_at are null. */
+            event_scan_capped?: boolean;
             first_block?: number | null;
             /** Format: date-time */
             first_seen_at?: string | null;
@@ -1884,6 +1888,7 @@ export interface components {
             registrations: components["schemas"]["AccountRegistration"][];
             schema_version: number;
             ss58: string;
+            /** @description Distinct subnets across the counted events. A lower bound over the most recent events when event_scan_capped is true. */
             subnet_count?: number;
         } & {
             [key: string]: unknown;
@@ -5544,6 +5549,7 @@ export interface operations {
                      *             "kind": "example"
                      *           }
                      *         ],
+                     *         "event_scan_capped": false,
                      *         "first_block": 5000000,
                      *         "first_seen_at": "2026-06-01T00:00:00.000Z",
                      *         "last_block": 5000000,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -814,20 +814,26 @@
       },
       "AccountSummaryArtifact": {
         "additionalProperties": true,
-        "description": "Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file).",
+        "description": "Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file). The event aggregates (event_count, subnet_count, event_kinds, first_*) are computed over the account's most recent events, bounded for cost; when event_scan_capped is true they are a lower bound over that window, not all-time totals.",
         "properties": {
           "activity": {
             "$ref": "#/components/schemas/AccountActivity"
           },
           "event_count": {
+            "description": "Number of account_events counted. A lower bound over the account's most recent events (not an all-time total) when event_scan_capped is true.",
             "minimum": 0,
             "type": "integer"
           },
           "event_kinds": {
+            "description": "Per-kind event counts over the counted events; a lower bound over the most recent events when event_scan_capped is true.",
             "items": {
               "$ref": "#/components/schemas/AccountEventKindCount"
             },
             "type": "array"
+          },
+          "event_scan_capped": {
+            "description": "True when the event aggregates hit the newest-events scan cap: event_count / subnet_count / event_kinds are then a lower bound over the account's most recent events, not all-time totals, and first_block / first_seen_at are null.",
+            "type": "boolean"
           },
           "first_block": {
             "type": [
@@ -874,6 +880,7 @@
             "type": "string"
           },
           "subnet_count": {
+            "description": "Distinct subnets across the counted events. A lower bound over the most recent events when event_scan_capped is true.",
             "minimum": 0,
             "type": "integer"
           }
@@ -15136,6 +15143,7 @@
                         "kind": "example"
                       }
                     ],
+                    "event_scan_capped": false,
                     "first_block": 5000000,
                     "first_seen_at": "2026-06-01T00:00:00.000Z",
                     "last_block": 5000000,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1869,11 +1869,15 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file). */
+        /** @description Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file). The event aggregates (event_count, subnet_count, event_kinds, first_*) are computed over the account's most recent events, bounded for cost; when event_scan_capped is true they are a lower bound over that window, not all-time totals. */
         AccountSummaryArtifact: {
             activity?: components["schemas"]["AccountActivity"];
+            /** @description Number of account_events counted. A lower bound over the account's most recent events (not an all-time total) when event_scan_capped is true. */
             event_count: number;
+            /** @description Per-kind event counts over the counted events; a lower bound over the most recent events when event_scan_capped is true. */
             event_kinds?: components["schemas"]["AccountEventKindCount"][];
+            /** @description True when the event aggregates hit the newest-events scan cap: event_count / subnet_count / event_kinds are then a lower bound over the account's most recent events, not all-time totals, and first_block / first_seen_at are null. */
+            event_scan_capped?: boolean;
             first_block?: number | null;
             /** Format: date-time */
             first_seen_at?: string | null;
@@ -1884,6 +1888,7 @@ export interface components {
             registrations: components["schemas"]["AccountRegistration"][];
             schema_version: number;
             ss58: string;
+            /** @description Distinct subnets across the counted events. A lower bound over the most recent events when event_scan_capped is true. */
             subnet_count?: number;
         } & {
             [key: string]: unknown;
@@ -5544,6 +5549,7 @@ export interface operations {
                      *             "kind": "example"
                      *           }
                      *         ],
+                     *         "event_scan_capped": false,
                      *         "first_block": 5000000,
                      *         "first_seen_at": "2026-06-01T00:00:00.000Z",
                      *         "last_block": 5000000,

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -800,20 +800,26 @@
       },
       "AccountSummaryArtifact": {
         "additionalProperties": true,
-        "description": "Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file).",
+        "description": "Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file). The event aggregates (event_count, subnet_count, event_kinds, first_*) are computed over the account's most recent events, bounded for cost; when event_scan_capped is true they are a lower bound over that window, not all-time totals.",
         "properties": {
           "activity": {
             "$ref": "#/components/schemas/AccountActivity"
           },
           "event_count": {
+            "description": "Number of account_events counted. A lower bound over the account's most recent events (not an all-time total) when event_scan_capped is true.",
             "minimum": 0,
             "type": "integer"
           },
           "event_kinds": {
+            "description": "Per-kind event counts over the counted events; a lower bound over the most recent events when event_scan_capped is true.",
             "items": {
               "$ref": "#/components/schemas/AccountEventKindCount"
             },
             "type": "array"
+          },
+          "event_scan_capped": {
+            "description": "True when the event aggregates hit the newest-events scan cap: event_count / subnet_count / event_kinds are then a lower bound over the account's most recent events, not all-time totals, and first_block / first_seen_at are null.",
+            "type": "boolean"
           },
           "first_block": {
             "type": [
@@ -860,6 +866,7 @@
             "type": "string"
           },
           "subnet_count": {
+            "description": "Distinct subnets across the counted events. A lower bound over the most recent events when event_scan_capped is true.",
             "minimum": 0,
             "type": "integer"
           }

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1649,13 +1649,21 @@
       "AccountSummaryArtifact": {
         "type": "object",
         "additionalProperties": true,
-        "description": "Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file).",
+        "description": "Cross-subnet activity summary for one account, by hotkey OR coldkey (#1347): event-history aggregates from the account_events tier joined to current registrations from the neurons tier. Served live from D1 at /api/v1/accounts/{ss58} (no static file). The event aggregates (event_count, subnet_count, event_kinds, first_*) are computed over the account's most recent events, bounded for cost; when event_scan_capped is true they are a lower bound over that window, not all-time totals.",
         "required": ["schema_version", "ss58", "event_count", "registrations"],
         "properties": {
           "schema_version": { "type": "integer" },
           "ss58": { "type": "string" },
-          "event_count": { "type": "integer", "minimum": 0 },
-          "subnet_count": { "type": "integer", "minimum": 0 },
+          "event_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of account_events counted. A lower bound over the account's most recent events (not an all-time total) when event_scan_capped is true."
+          },
+          "subnet_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Distinct subnets across the counted events. A lower bound over the most recent events when event_scan_capped is true."
+          },
           "first_block": { "type": ["integer", "null"] },
           "last_block": { "type": ["integer", "null"] },
           "first_seen_at": {
@@ -1663,8 +1671,13 @@
             "format": "date-time"
           },
           "last_seen_at": { "type": ["string", "null"], "format": "date-time" },
+          "event_scan_capped": {
+            "type": "boolean",
+            "description": "True when the event aggregates hit the newest-events scan cap: event_count / subnet_count / event_kinds are then a lower bound over the account's most recent events, not all-time totals, and first_block / first_seen_at are null."
+          },
           "event_kinds": {
             "type": "array",
+            "description": "Per-kind event counts over the counted events; a lower bound over the most recent events when event_scan_capped is true.",
             "items": { "$ref": "#/components/schemas/AccountEventKindCount" }
           },
           "registrations": {

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -285,17 +285,29 @@ export function formatAccountActivity(agg, modules) {
 
 export function buildAccountSummary(
   ss58,
-  { agg, kinds, registrations, recent, activity, modules } = {},
+  { agg, kinds, scanned, registrations, recent, activity, modules } = {},
 ) {
   const a = agg || {};
+  const eventCount = a.c ?? 0;
+  // event_count / subnet_count / event_kinds are aggregated over exactly the
+  // account's newest ACCOUNT_EVENT_SUMMARY_SCAN_CAP events. `scanned` is a probe
+  // COUNT over CAP+1: when it exceeds CAP the account has more events than that
+  // window, so those totals are a lower bound and the window's MIN(block_number) /
+  // MIN(observed_at) are its floor, not the account's all-time first — flag it and
+  // null first_*. `> CAP` (not `>=`) means an account with EXACTLY CAP events is
+  // complete (the probe found no extra row), so its totals + first_* stay exact.
+  // last_* stay exact regardless (the newest events include the latest).
+  const eventScanCapped =
+    (scanned ?? eventCount) > ACCOUNT_EVENT_SUMMARY_SCAN_CAP;
   return {
     schema_version: 1,
     ss58,
-    event_count: a.c ?? 0,
+    event_count: eventCount,
     subnet_count: a.sc ?? 0,
-    first_block: toBlockNumber(a.fb),
+    event_scan_capped: eventScanCapped,
+    first_block: eventScanCapped ? null : toBlockNumber(a.fb),
     last_block: toBlockNumber(a.lb),
-    first_seen_at: toIso(a.fo),
+    first_seen_at: eventScanCapped ? null : toIso(a.fo),
     last_seen_at: toIso(a.lo),
     event_kinds: (kinds || [])
       .filter((k) => k && k.kind)
@@ -501,53 +513,103 @@ const REGISTRATION_COLUMNS = "netuid, uid, stake_tao, validator_permit, active";
 // high-volume signers on every unauthenticated request.
 export const ACCOUNT_ACTIVITY_RECENT_LIMIT = 1000;
 
+// Bound the account-summary EVENT aggregates the same way: a public, unauthenticated
+// GET /accounts/{ss58} must not aggregate a high-volume coldkey's entire 365-day
+// retained event history (EVENT_RETENTION_MS) on every request. Each key branch seeks
+// its own newest N through its feed index, then the union is re-sorted and capped to N,
+// so an aggregate over it sees exactly the account's newest N events — never up to 2N,
+// never the full history.
+export const ACCOUNT_EVENT_SUMMARY_SCAN_CAP = 5000;
+const SUMMARY_SCAN_COLUMNS =
+  "netuid, block_number, event_index, observed_at, event_kind";
+
+// A bounded, feed-ordered scan of the account's newest `limit` events (indexed
+// UNION-of-seeks, re-sorted and capped to `limit`). The summary aggregates over
+// the newest CAP; a probe over CAP+1 counts one extra row only to detect that the
+// account has more than CAP events (so an exactly-CAP account is not falsely
+// flagged, and the aggregate window stays exactly the documented CAP events).
+function accountEventBoundedScan(limit) {
+  // Each branch's ordered LIMIT seek is wrapped in a subquery: SQLite/D1 rejects
+  // an ORDER BY/LIMIT placed directly on a compound (UNION ALL) SELECT term, so
+  // the seek must be a nested SELECT, not a bare term.
+  const branch = (index, keyFilter) =>
+    `SELECT ${SUMMARY_SCAN_COLUMNS} FROM (` +
+    `SELECT ${SUMMARY_SCAN_COLUMNS} FROM account_events INDEXED BY ${index} ` +
+    `WHERE ${keyFilter} ORDER BY block_number DESC, event_index DESC LIMIT ?)`;
+  return {
+    sql:
+      `(SELECT ${SUMMARY_SCAN_COLUMNS} FROM (` +
+      branch(ACCOUNT_EVENT_HOTKEY_INDEX, "hotkey = ?") +
+      " UNION ALL " +
+      branch(
+        ACCOUNT_EVENT_COLDKEY_INDEX,
+        "coldkey = ? AND (hotkey IS NULL OR hotkey <> ?)",
+      ) +
+      ") ORDER BY block_number DESC, event_index DESC LIMIT ?)",
+    paramsFor(ss58) {
+      return [ss58, limit, ss58, ss58, limit, limit];
+    },
+  };
+}
+
 // Cross-subnet summary: event aggregates, per-kind counts, the 10 newest events,
 // current registrations, and bounded signing-activity aggregates from the extrinsics tier.
 export async function loadAccountSummary(d1, ss58) {
-  const aggUnion = accountEventIndexedUnion(
-    "netuid, block_number, observed_at",
-  );
-  const kindUnion = accountEventIndexedUnion("event_kind");
+  // Aggregate over exactly the newest CAP events; a probe over CAP+1 rows detects
+  // whether the account has more (so event_count/subnet_count/event_kinds are the
+  // documented CAP-event window and event_scan_capped trips only on real truncation).
+  const cap = ACCOUNT_EVENT_SUMMARY_SCAN_CAP;
+  const windowScan = accountEventBoundedScan(cap);
+  const probeScan = accountEventBoundedScan(cap + 1);
   const recentUnion = accountEventIndexedUnion(ACCOUNT_EVENT_COLUMNS);
-  const [aggRows, kindRows, regRows, recentRows, activityRows, moduleRows] =
-    await Promise.all([
-      d1(
-        `SELECT COUNT(*) AS c, COUNT(DISTINCT netuid) AS sc, MIN(block_number) AS fb, MAX(block_number) AS lb, MIN(observed_at) AS fo, MAX(observed_at) AS lo FROM ${aggUnion.sql}`,
-        aggUnion.paramsFor(ss58),
-      ),
-      d1(
-        `SELECT event_kind AS kind, COUNT(*) AS count FROM ${kindUnion.sql} GROUP BY event_kind ORDER BY count DESC, event_kind ASC`,
-        kindUnion.paramsFor(ss58),
-      ),
-      d1(
-        `SELECT ${REGISTRATION_COLUMNS} FROM neurons WHERE hotkey = ? ORDER BY stake_tao DESC, netuid ASC`,
-        [ss58],
-      ),
-      d1(
-        `SELECT * FROM ${recentUnion.sql} ORDER BY block_number DESC, event_index DESC LIMIT 10`,
-        recentUnion.paramsFor(ss58),
-      ),
-      // Signing activity from the extrinsics tier, matched by signer and
-      // explicitly bounded to the newest rows before aggregation. The inner
-      // signer-scoped, feed-ordered seek is served by idx_extrinsics_signer_block,
-      // so the bound is an indexed LIMIT, not a sort-then-truncate over the
-      // signer's full retained history.
-      d1(
-        `SELECT COUNT(*) AS tx_count, MAX(block_number) AS last_tx_block, MAX(observed_at) AS last_tx_at, SUM(fee_tao) AS total_fee_tao FROM (SELECT block_number, observed_at, fee_tao FROM extrinsics WHERE signer = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT ?)`,
-        [ss58, ACCOUNT_ACTIVITY_RECENT_LIMIT],
-      ),
-      // Top call modules over the same bounded window. `count DESC` alone is not a
-      // total order, so when modules tie on count the trailing LIMIT 10 would keep
-      // an arbitrary subset (D1/SQLite group order is unspecified); call_module ASC
-      // makes both the membership and the ordering of the top-10 deterministic.
-      d1(
-        `SELECT call_module, COUNT(*) AS count FROM (SELECT call_module FROM extrinsics WHERE signer = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT ?) GROUP BY call_module ORDER BY count DESC, call_module ASC LIMIT 10`,
-        [ss58, ACCOUNT_ACTIVITY_RECENT_LIMIT],
-      ),
-    ]);
+  const [
+    aggRows,
+    kindRows,
+    probeRows,
+    regRows,
+    recentRows,
+    activityRows,
+    moduleRows,
+  ] = await Promise.all([
+    d1(
+      `SELECT COUNT(*) AS c, COUNT(DISTINCT netuid) AS sc, MIN(block_number) AS fb, MAX(block_number) AS lb, MIN(observed_at) AS fo, MAX(observed_at) AS lo FROM ${windowScan.sql}`,
+      windowScan.paramsFor(ss58),
+    ),
+    d1(
+      `SELECT event_kind AS kind, COUNT(*) AS count FROM ${windowScan.sql} GROUP BY event_kind ORDER BY count DESC, event_kind ASC`,
+      windowScan.paramsFor(ss58),
+    ),
+    d1(`SELECT COUNT(*) AS n FROM ${probeScan.sql}`, probeScan.paramsFor(ss58)),
+    d1(
+      `SELECT ${REGISTRATION_COLUMNS} FROM neurons WHERE hotkey = ? ORDER BY stake_tao DESC, netuid ASC`,
+      [ss58],
+    ),
+    d1(
+      `SELECT * FROM ${recentUnion.sql} ORDER BY block_number DESC, event_index DESC LIMIT 10`,
+      recentUnion.paramsFor(ss58),
+    ),
+    // Signing activity from the extrinsics tier, matched by signer and
+    // explicitly bounded to the newest rows before aggregation. The inner
+    // signer-scoped, feed-ordered seek is served by idx_extrinsics_signer_block,
+    // so the bound is an indexed LIMIT, not a sort-then-truncate over the
+    // signer's full retained history.
+    d1(
+      `SELECT COUNT(*) AS tx_count, MAX(block_number) AS last_tx_block, MAX(observed_at) AS last_tx_at, SUM(fee_tao) AS total_fee_tao FROM (SELECT block_number, observed_at, fee_tao FROM extrinsics WHERE signer = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT ?)`,
+      [ss58, ACCOUNT_ACTIVITY_RECENT_LIMIT],
+    ),
+    // Top call modules over the same bounded window. `count DESC` alone is not a
+    // total order, so when modules tie on count the trailing LIMIT 10 would keep
+    // an arbitrary subset (D1/SQLite group order is unspecified); call_module ASC
+    // makes both the membership and the ordering of the top-10 deterministic.
+    d1(
+      `SELECT call_module, COUNT(*) AS count FROM (SELECT call_module FROM extrinsics WHERE signer = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT ?) GROUP BY call_module ORDER BY count DESC, call_module ASC LIMIT 10`,
+      [ss58, ACCOUNT_ACTIVITY_RECENT_LIMIT],
+    ),
+  ]);
   return buildAccountSummary(ss58, {
     agg: aggRows[0],
     kinds: kindRows,
+    scanned: probeRows[0]?.n,
     registrations: regRows,
     recent: recentRows,
     activity: activityRows[0],

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -17,6 +17,7 @@ import {
   loadAccountExtrinsics,
   loadAccountSubnets,
   ACCOUNT_ACTIVITY_RECENT_LIMIT,
+  ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
   eventInsertStatements,
   utcDayBounds,
   rollupAccountEventsDaily,
@@ -792,6 +793,104 @@ test("loadAccountSummary bounds signing activity before aggregating", async () =
   assert.deepEqual(modules.params, ["5Hk", ACCOUNT_ACTIVITY_RECENT_LIMIT]);
 });
 
+test("loadAccountSummary bounds the event aggregates to the newest N events", async () => {
+  // The event COUNT/MIN/MAX aggregate and the per-kind GROUP BY must aggregate
+  // over a bounded newest-N union, not the account's full 365-day retained
+  // history (parity with the extrinsics activity cap above) — a high-volume
+  // coldkey otherwise forces a full-history scan on every unauthenticated request.
+  const calls = [];
+  await loadAccountSummary(async (sql, params) => {
+    calls.push({ sql, params });
+    return [];
+  }, "5Hk");
+
+  const agg = calls.find((c) => /MIN\(block_number\) AS fb/.test(c.sql));
+  const kinds = calls.find((c) => /GROUP BY event_kind/.test(c.sql));
+  const probe = calls.find((c) => /SELECT COUNT\(\*\) AS n FROM/.test(c.sql));
+  // The two aggregates run over exactly the newest CAP events...
+  const cap = ACCOUNT_EVENT_SUMMARY_SCAN_CAP;
+  for (const q of [agg, kinds]) {
+    // Each key branch is a feed-ordered, indexed LIMIT seek...
+    assert.match(
+      q.sql,
+      /INDEXED BY idx_account_events_hotkey[\s\S]*ORDER BY block_number DESC, event_index DESC LIMIT \?/,
+    );
+    assert.match(q.sql, /INDEXED BY idx_account_events_coldkey/);
+    assert.match(q.sql, /UNION ALL/);
+    // Each ordered-LIMIT seek is subquery-wrapped: SQLite/D1 rejects an
+    // ORDER BY/LIMIT placed directly on a UNION ALL term, so the branch must end
+    // `LIMIT ?)` (closed subquery), never a bare `LIMIT ? UNION ALL`.
+    assert.doesNotMatch(q.sql, /LIMIT \? UNION ALL/);
+    assert.match(q.sql, /LIMIT \?\) UNION ALL/);
+    // ...and the union itself is re-sorted and capped to N.
+    assert.match(
+      q.sql,
+      /\) ORDER BY block_number DESC, event_index DESC LIMIT \?\)/,
+    );
+    assert.deepEqual(q.params, ["5Hk", cap, "5Hk", "5Hk", cap, cap]);
+  }
+  // ...and a separate probe scans CAP+1 only to detect truncation.
+  assert.deepEqual(probe.params, [
+    "5Hk",
+    cap + 1,
+    "5Hk",
+    "5Hk",
+    cap + 1,
+    cap + 1,
+  ]);
+});
+
+test("buildAccountSummary nulls all-time first_* when the event scan is capped", async () => {
+  // The probe (scanned) found a row past the cap, so the account genuinely has
+  // more than CAP events: the aggregate window (agg.c === CAP) is a lower bound and
+  // MIN(block)/MIN(observed) are its floor, not the account's true first — null them.
+  const capped = buildAccountSummary("5Hk", {
+    agg: {
+      c: ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
+      sc: 3,
+      fb: 100,
+      lb: 900,
+      fo: 1000,
+      lo: 9000,
+    },
+    scanned: ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1,
+  });
+  // event_count is exactly the CAP window (not CAP+1); event_scan_capped labels it
+  // so a consumer never reads it as an all-time total.
+  assert.equal(capped.event_count, ACCOUNT_EVENT_SUMMARY_SCAN_CAP);
+  assert.equal(capped.event_scan_capped, true);
+  assert.equal(capped.first_block, null);
+  assert.equal(capped.first_seen_at, null);
+  // last_* stay exact — the newest events include the latest.
+  assert.equal(capped.last_block, 900);
+
+  // Boundary: an account with EXACTLY CAP events — the probe found no extra row
+  // (scanned === CAP) — is complete, so not capped and first_* are the true first.
+  const exactlyCap = buildAccountSummary("5Hk", {
+    agg: {
+      c: ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
+      sc: 3,
+      fb: 100,
+      lb: 900,
+      fo: 1000,
+    },
+    scanned: ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
+  });
+  assert.equal(exactlyCap.event_scan_capped, false);
+  assert.equal(exactlyCap.first_block, 100);
+  assert.ok(exactlyCap.first_seen_at);
+
+  // Well under the cap the aggregate spans the account's full history, so the
+  // totals are exact all-time values and first_* are reported.
+  const full = buildAccountSummary("5Hk", {
+    agg: { c: 10, sc: 2, fb: 100, lb: 900, fo: 1000, lo: 9000 },
+    scanned: 10,
+  });
+  assert.equal(full.event_scan_capped, false);
+  assert.equal(full.first_block, 100);
+  assert.ok(full.first_seen_at);
+});
+
 test("loadAccountSummary tie-breaks leaderboard aggregates for stable output", async () => {
   const calls = [];
   await loadAccountSummary(async (sql) => {
@@ -829,7 +928,9 @@ test("loadAccountSummary uses indexed union seeks for account_events (#2059)", a
   const eventReads = calls.filter((c) =>
     /idx_account_events_hotkey/.test(c.sql),
   );
-  assert.equal(eventReads.length, 3);
+  // The four account_events reads: aggregate + per-kind (newest CAP), the CAP+1
+  // truncation probe, and the newest-10 recent-events list.
+  assert.equal(eventReads.length, 4);
   for (const { sql } of eventReads) {
     assert.doesNotMatch(sql, /hotkey = \? OR coldkey = \?/);
     assert.match(sql, /INDEXED BY idx_account_events_hotkey/);


### PR DESCRIPTION
# Summary

This PR prevents expensive full-history scans in the account summary endpoint.

Previously, `GET /api/v1/accounts/{ss58}` aggregated an account's entire retained `account_events` history when generating the account summary. For high-volume accounts, this resulted in full-history index scans on every request, increasing database load and making the endpoint susceptible to read amplification despite short-term caching.

This change bounds event aggregation to the newest configured number of events, matching the optimization already used for extrinsic activity.

## Root Cause

`loadAccountSummary()` performed two event aggregates (`COUNT/MIN/MAX` and `GROUP BY event_kind`) over the complete `account_events` history without applying a scan limit.

For high-volume accounts—particularly coldkeys that aggregate activity across multiple hotkeys—each request could trigger expensive full-history scans.

Although the endpoint is cached, the cache is keyed by account and expires after a short period, allowing repeated requests across different busy accounts to bypass the cache and repeatedly execute expensive queries.

## Changes

### Source

**`src/account-events.mjs`**

- Added `accountEventBoundedScan()` to limit event aggregation to the newest `ACCOUNT_EVENT_SUMMARY_SCAN_CAP` events.
- Each branch (`hotkey` and `coldkey`) independently retrieves its newest events using indexed ordering.
- Merges, re-sorts, and applies a final limit to ensure the aggregate operates on only the newest events.
- Updated `loadAccountSummary()` to use the bounded scan for all account event aggregates.
- Updated `buildAccountSummary()` to return `null` for `first_block` and `first_seen_at` whenever the scan reaches the configured cap, avoiding misleading "first seen" values while preserving accurate latest activity.

### Tests

**`tests/account-events.test.mjs`**

Added regression tests verifying:

- Event aggregates operate on the bounded newest-event scan.
- Both query branches apply the expected limits.
- `first_block` and `first_seen_at` are nullified when the scan reaches the configured cap.
- Values remain unchanged when the total event count is below the cap.

## Impact

- ✅ Prevents expensive full-history scans for high-volume accounts.
- ✅ Reduces database read amplification.
- ✅ Preserves accurate recent activity while avoiding misleading historical metadata.
- ✅ Response format remains unchanged.

## Validation

- [x] `npx vitest run tests/account-events.test.mjs`
- [x] `npx vitest run tests/request-handlers-entities.test.mjs tests/mcp-server.test.mjs tests/account-events-branch-coverage.test.mjs`
- [x] Verified the new regression tests fail on `main` and pass with this fix.
- [x] `npm run lint`
- [x] `npx prettier --check`
