### PR TITLE
fix(api): short-circuit inverted block_start/block_end on event feeds before D1

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1625,6 +1625,23 @@ describe("handleAccountEvents", () => {
     assert.equal(body.meta.parameter, "block_end");
   });
 
+  test("short-circuits inverted block_start/block_end before querying D1", async () => {
+    const { env, captures } = dbWith({
+      accountEvents: [accountEventRow()],
+    });
+    const body = await json(
+      await handleAccountEvents(
+        req(`/api/v1/accounts/${SS58}/events`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/events?block_start=900&block_end=100`),
+      ),
+    );
+    assert.equal(body.data.event_count, 0);
+    assert.deepEqual(body.data.events, []);
+    assert.equal(captures.sql.length, 0);
+  });
+
   test("returns schema-stable empty events on cold D1", async () => {
     const body = await assertColdSchema(
       handleAccountEvents,
@@ -1815,6 +1832,23 @@ describe("handleAccountExtrinsics", () => {
     assert.equal(body.meta.parameter, "block_end");
   });
 
+  test("short-circuits inverted block_start/block_end before querying D1", async () => {
+    const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
+    const body = await json(
+      await handleAccountExtrinsics(
+        req(`/api/v1/accounts/${SS58}/extrinsics`),
+        env,
+        SS58,
+        url(
+          `/api/v1/accounts/${SS58}/extrinsics?block_start=900&block_end=100`,
+        ),
+      ),
+    );
+    assert.equal(body.data.extrinsic_count, 0);
+    assert.deepEqual(body.data.extrinsics, []);
+    assert.equal(captures.sql.length, 0);
+  });
+
   test("happy path returns signer-matched extrinsics", async () => {
     const { env } = dbWith({ extrinsics: [extrinsicRow()] });
     const body = await json(
@@ -1933,6 +1967,23 @@ describe("handleAccountTransfers", () => {
     );
     const body = await errorJson(res);
     assert.equal(body.meta.parameter, "block_end");
+  });
+
+  test("short-circuits inverted block_start/block_end before querying D1", async () => {
+    const { env, captures } = dbWith({
+      transfers: [transferEventRow()],
+    });
+    const body = await json(
+      await handleAccountTransfers(
+        req(`/api/v1/accounts/${SS58}/transfers`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/transfers?block_start=900&block_end=100`),
+      ),
+    );
+    assert.equal(body.data.transfer_count, 0);
+    assert.deepEqual(body.data.transfers, []);
+    assert.equal(captures.sql.length, 0);
   });
 
   test("returns schema-stable empty transfers on cold D1", async () => {
@@ -2502,6 +2553,23 @@ describe("handleSubnetEvents", () => {
     );
     const body = await errorJson(res);
     assert.equal(body.meta.parameter, "block_end");
+  });
+
+  test("short-circuits inverted block_start/block_end before querying D1", async () => {
+    const { env, captures } = dbWith({
+      subnetEvents: [accountEventRow()],
+    });
+    const body = await json(
+      await handleSubnetEvents(
+        req(`/api/v1/subnets/${NETUID}/events`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/events?block_start=900&block_end=100`),
+      ),
+    );
+    assert.equal(body.data.event_count, 0);
+    assert.deepEqual(body.data.events, []);
+    assert.equal(captures.sql.length, 0);
   });
 
   test("cursor uses keyset seek instead of offset", async () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -25,6 +25,7 @@ import {
   parseDateRange,
   parseNonNegativeIntParam,
   parsePagination,
+  isInvertedBlockRange,
 } from "../request-params.mjs";
 
 import { errorResponse } from "../http.mjs";
@@ -54,6 +55,7 @@ import {
 import {
   ACCOUNT_EVENT_COLUMNS,
   INGESTED_EVENT_KINDS,
+  buildAccountEvents,
   buildAccountTransfers,
   buildAccountHistory,
   buildSubnetEvents,
@@ -78,6 +80,7 @@ import {
   EXTRINSIC_RETENTION_MS,
   buildExtrinsic,
   buildExtrinsicFeed,
+  buildAccountExtrinsics,
 } from "../../src/extrinsics.mjs";
 import {
   loadBlockEvents,
@@ -693,6 +696,26 @@ export async function handleAccountEvents(request, env, ss58, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
+  if (isInvertedBlockRange(blockStart.value, blockEnd.value)) {
+    const { limit, offset } = parsePagination(url, FEED_PAGINATION);
+    const data = buildAccountEvents([], ss58, {
+      limit,
+      offset,
+      nextCursor: null,
+    });
+    return envelopeResponse(
+      request,
+      {
+        data,
+        meta: await accountMeta(
+          env,
+          `/metagraph/accounts/${ss58}/events.json`,
+          null,
+        ),
+      },
+      "short",
+    );
+  }
   const data = await loadAccountEvents(d1Runner(env), ss58, {
     limit: url.searchParams.get("limit"),
     offset: url.searchParams.get("offset"),
@@ -839,6 +862,26 @@ export async function handleAccountExtrinsics(request, env, ss58, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
+  if (isInvertedBlockRange(blockStart.value, blockEnd.value)) {
+    const { limit, offset } = parsePagination(url, FEED_PAGINATION);
+    const data = buildAccountExtrinsics([], ss58, {
+      limit,
+      offset,
+      nextCursor: null,
+    });
+    return envelopeResponse(
+      request,
+      {
+        data,
+        meta: await accountMeta(
+          env,
+          `/metagraph/accounts/${ss58}/extrinsics.json`,
+          null,
+        ),
+      },
+      "short",
+    );
+  }
   const data = await loadAccountExtrinsics(d1Runner(env), ss58, {
     limit: url.searchParams.get("limit"),
     offset: url.searchParams.get("offset"),
@@ -900,6 +943,27 @@ export async function handleAccountTransfers(request, env, ss58, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
+  if (isInvertedBlockRange(blockStart.value, blockEnd.value)) {
+    const data = buildAccountTransfers([], ss58, {
+      limit,
+      offset,
+      nextCursor: null,
+      direction:
+        direction === "sent" || direction === "received" ? direction : null,
+    });
+    return envelopeResponse(
+      request,
+      {
+        data,
+        meta: await accountMeta(
+          env,
+          `/metagraph/accounts/${ss58}/transfers.json`,
+          null,
+        ),
+      },
+      "short",
+    );
+  }
   // sent => this account is the sender (hotkey=from); received => recipient
   // (coldkey=to); default/all => either side. Keep the default read as two
   // side-specific seeks rather than an OR predicate so D1 cannot satisfy only
@@ -1089,6 +1153,25 @@ export async function handleSubnetEvents(request, env, netuid, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
+  if (isInvertedBlockRange(blockStart.value, blockEnd.value)) {
+    const data = buildSubnetEvents([], netuid, {
+      limit,
+      offset,
+      nextCursor: null,
+    });
+    return envelopeResponse(
+      request,
+      {
+        data,
+        meta: await accountMeta(
+          env,
+          `/metagraph/subnets/${netuid}/events.json`,
+          null,
+        ),
+      },
+      "short",
+    );
+  }
   // Keyset (cursor) pagination on (block_number, event_index), mirroring
   // loadAccountEvents; offset stays as a deprecated fallback, cursor wins.
   const cur = decodeCursor(cursor, 2);

--- a/workers/request-params.mjs
+++ b/workers/request-params.mjs
@@ -113,6 +113,12 @@ export function parseNonNegativeIntParam(raw, parameter) {
   return { value };
 }
 
+// True when both block bounds are present but start > end — a deterministic
+// no-match range. Handlers short-circuit before D1 (mirrors handleBlocks).
+export function isInvertedBlockRange(blockStart, blockEnd) {
+  return blockStart != null && blockEnd != null && blockStart > blockEnd;
+}
+
 export function parseDateRange(url) {
   const from = url.searchParams.get("from");
   const to = url.searchParams.get("to");


### PR DESCRIPTION
## Summary

`handleBlocks` and `handleExtrinsics` already short-circuit inverted `?block_start=` / `?block_end=` ranges before hitting D1, but the account and subnet **event feeds** did not: `handleAccountEvents`, `handleAccountExtrinsics`, `handleAccountTransfers`, and `handleSubnetEvents` still paid for a D1 round-trip on a deterministically empty query (`block_start=900&block_end=100` â†’ 200 + empty list).

## What Changed

- Added `isInvertedBlockRange()` in `workers/request-params.mjs` (shared guard).
- All four event-feed handlers now return a schema-stable empty feed without querying D1 when `block_start > block_end`, mirroring `handleBlocks`.
- Regression tests in `tests/request-handlers-entities.test.mjs` assert zero SQL captures for each handler.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes (performance/consistency guard only).

## Validation

- [x] `npx vitest run tests/request-handlers-entities.test.mjs` (all passed)
- [x] `npx prettier --check workers/request-handlers/entities.mjs workers/request-params.mjs tests/request-handlers-entities.test.mjs`
- [x] `git diff --check`
