### PR TITLE
fix(api): coerce string-typed block_number in the block-detail neighbor lookup

### DIFF
--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -457,6 +457,22 @@ test("GET /blocks/{ref} emits nearest stored prev/next neighbors (#1853)", async
   assert.equal(body.data.next_block_number, 1240);
 });
 
+test("GET /blocks/{ref} resolves neighbors when D1 returns block_number as a string (#1853)", async () => {
+  // D1 can return the INTEGER block_number as a numeric string. The REST detail
+  // handler must coerce the resolved anchor before the MAX/MIN neighbor lookup —
+  // a bare Number.isInteger("1234") is false, which skipped the query and wrongly
+  // reported prev/next_block_number: null for a block that has neighbors.
+  const env = dbWith({
+    detail: { block_number: "1234", block_hash: "0xabc", observed_at: 1 },
+    neighbors: { prev: 1230, next: 1240 },
+  });
+  const res = await handleRequest(req("/api/v1/blocks/1234"), env, {});
+  const body = await res.json();
+  assert.equal(body.data.block.block_number, 1234);
+  assert.equal(body.data.prev_block_number, 1230);
+  assert.equal(body.data.next_block_number, 1240);
+});
+
 test("GET /blocks/{ref} nulls neighbors at a window edge (#1853)", async () => {
   const env = dbWith({
     detail: { block_number: 1, block_hash: "0x1", observed_at: 1 },

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1397,8 +1397,15 @@ export async function handleBlock(request, env, ref) {
   // the block_number primary key instead of scanning the retained blocks table.
   let prev = null;
   let next = null;
-  const resolvedNumber = rows[0]?.block_number;
-  if (Number.isInteger(resolvedNumber)) {
+  // D1 can return the INTEGER block_number as a numeric string, and a bare
+  // Number.isInteger(rows[0]?.block_number) guard is false for "1234" — which
+  // would skip the neighbor query and make a resolved block wrongly report
+  // prev/next_block_number: null. Coerce the anchor first (mirrors formatBlock's
+  // toBlockNumber, and the string-cell fix applied to account-events #2489).
+  const resolvedRaw = Number(rows[0]?.block_number);
+  const resolvedNumber =
+    Number.isInteger(resolvedRaw) && resolvedRaw >= 0 ? resolvedRaw : null;
+  if (resolvedNumber !== null) {
     const nbr = await d1All(
       env,
       `SELECT (SELECT MAX(block_number) FROM blocks WHERE block_number < ?) AS prev, (SELECT MIN(block_number) FROM blocks WHERE block_number > ?) AS next`,


### PR DESCRIPTION
## Summary

- `handleBlock` (`GET /api/v1/blocks/{ref}`) in `workers/request-handlers/entities.mjs` guarded the prev/next neighbor query with `Number.isInteger` on the **raw** D1 `block_number` cell. D1 can return an INTEGER column as a numeric string, and `Number.isInteger("1234")` is `false`, so the neighbor query was skipped and a resolved block wrongly reported `prev_block_number: null` / `next_block_number: null`, breaking chain-walk navigation (#1853). `buildBlock`/`formatBlock` already coerce the block's own number, so the response showed a resolved block that falsely claims it has no neighbors.
- This is the REST-route sibling of the same string-cell coercion `formatBlock` applies (`toBlockNumber`) and the fix made to `formatAccountDay` in #2489.

## What Changed

- `workers/request-handlers/entities.mjs`: coerce the resolved anchor to a non-negative integer before the guard and the bound params (`Number(rows[0]?.block_number)` → `Number.isInteger(...) && >= 0 ? ... : null`, then `if (resolvedNumber !== null)`). Matches this file's existing local block-helper pattern (e.g. `strictBlockNumber`) rather than importing across the src/worker boundary.
- `tests/blocks.test.mjs`: route regression — `GET /api/v1/blocks/1234` with a `detail` row whose `block_number` is the string `"1234"` now resolves `prev_block_number: 1230` / `next_block_number: 1240`. The test fails without the fix.

No public API/OpenAPI/schema change — the block-detail response shape is unchanged.

### Reproduction (before)

```
GET /api/v1/blocks/1234
# D1 returns the detail cell as block_number: "1234"; neighbors prev 1230 / next 1240 exist
→ { data: { block: { block_number: 1234 }, prev_block_number: null, next_block_number: null } }
```

After: `prev_block_number: 1230, next_block_number: 1240`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (No generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — response shape unchanged.)

## Validation

- [x] `npx vitest run tests/blocks.test.mjs` (55 pass; the new route regression fails without the fix)
- [x] `npx eslint workers/request-handlers/entities.mjs tests/blocks.test.mjs` (clean)
- [x] `npx prettier --check` (clean)
- [x] `git diff --check`
