### PR TITLE
fix(api): short-circuit inverted block range on extrinsics feed before D1

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -3350,6 +3350,20 @@ describe("handleExtrinsics", () => {
     );
   });
 
+  test("short-circuits an inverted block_start>block_end window before D1", async () => {
+    const { env, captures } = dbWith({ extrinsics: [] });
+    const body = await json(
+      await handleExtrinsics(
+        req("/api/v1/extrinsics"),
+        env,
+        url("/api/v1/extrinsics?block_start=500&block_end=100"),
+      ),
+    );
+    assert.equal(body.data.extrinsic_count, 0);
+    assert.deepEqual(body.data.extrinsics, []);
+    assert.equal(captures.sql.length, 0);
+  });
+
   test("a valid recent window is NOT short-circuited and queries D1", async () => {
     const { env, captures } = dbWith({ extrinsics: [] });
     const now = Date.now();


### PR DESCRIPTION
## What

`GET /api/v1/extrinsics` accepts optional `?block_start=` / `?block_end=` height filters (inclusive). When `block_start > block_end`, the range is impossible — no row can satisfy both bounds.

`handleBlocks` already short-circuits this case (and inverted `from > to`) before touching D1. `handleExtrinsics` short-circuited impossible **time** windows but still built SQL for inverted **block** ranges, forcing a D1 scan that deterministically returns an empty page.

## How

Add `block_start > block_end` to the existing pre-D1 guard in `handleExtrinsics`, returning the same schema-stable empty `buildExtrinsicFeed` payload the time-window short-circuits use. No contract or response-shape change for valid requests.

## Why no linked issue

Standalone guard gap found by comparing the blocks and extrinsics feed handlers. Open PR #2510 covers the same pattern on **event** feeds; this completes the sibling **extrinsics** explorer feed path. No open issue tracks this specific handler gap.

## Scope / risk

One conditional in `handleExtrinsics` plus one handler test asserting zero D1 queries. Valid ranges and other filters unchanged.

## Tests

- `request-handlers-entities.test.mjs`: `short-circuits an inverted block_start>block_end window before D1` — asserts empty feed and no `FROM extrinsics` SQL.

## Test plan

- [x] Inverted `block_start=500&block_end=100` returns empty feed without D1
- [x] Existing inverted `from>to` and valid-window tests continue to pass
- [x] CI vitest suite (no local Node toolchain; relies on repo CI)
