### PR TITLE
fix(api): forward a HEAD chain-events probe to DATA_API as GET

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -99,6 +99,44 @@ describe("Worker runtime", () => {
     assert.equal(body.meta.source, "data-worker-postgres");
   });
 
+  test("forwards a GET to DATA_API for a HEAD chain-events probe (not a 405)", async () => {
+    // DATA_API is GET-only. A HEAD probe must still get the bodiless 200 that
+    // every other GET route returns for HEAD — not the data Worker's 405 — so
+    // the proxy forwards a GET on its behalf and envelopeResponse strips the body.
+    let forwardedMethod = null;
+    const response = await handleRequest(
+      new Request("https://metagraph.sh/api/v1/chain-events", {
+        method: "HEAD",
+      }),
+      {
+        ...env,
+        DATA_API: {
+          fetch(req) {
+            forwardedMethod = req.method;
+            if (req.method !== "GET") {
+              return new Response(
+                JSON.stringify({ error: "method not allowed" }),
+                {
+                  status: 405,
+                  headers: { "content-type": "application/json" },
+                },
+              );
+            }
+            return new Response(
+              JSON.stringify({ window_blocks: 500, groups: 0, activity: [] }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
+          },
+        },
+      },
+      {},
+    );
+    assert.equal(forwardedMethod, "GET");
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "");
+    assert.ok(response.headers.get("etag"));
+  });
+
   test("maps a DATA_API upstream error to a clean error envelope", async () => {
     const response = await handleRequest(
       new Request("https://metagraph.sh/api/v1/chain-events"),

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -850,7 +850,16 @@ async function handleChainEventsProxy(request, env, url) {
       503,
     );
   }
-  const upstream = await env.DATA_API.fetch(request);
+  // DATA_API is GET-only (it 405s any other method), so a HEAD probe must be
+  // forwarded as a GET or it would return a 405 error envelope instead of the
+  // bodiless 200 that HEAD yields on every other GET route (and that this route's
+  // own CORS preflight advertises). envelopeResponse(request, …) below still
+  // strips the body for HEAD, so the client gets the correct empty 200.
+  const upstream = await env.DATA_API.fetch(
+    request.method === "HEAD"
+      ? new Request(request.url, { method: "GET", headers: request.headers })
+      : request,
+  );
   let body;
   try {
     body = await upstream.json();


### PR DESCRIPTION
## Summary

- `handleChainEventsProxy` in `workers/api.mjs` forwarded the incoming request **verbatim** to the GET-only `DATA_API` Worker, which rejects any non-GET method with `405`. So a `HEAD` request to `/api/v1/chain-events`, `/api/v1/chain-events/stats`, or `/api/v1/blocks/{n}/chain-events` returned a `405 data_query_failed` envelope instead of the bodiless `200` that `HEAD` yields on every other GET route — and that this route's own CORS preflight advertises (`access-control-allow-methods: GET, HEAD, OPTIONS`).
- The chain-events proxy branch runs before the shared read-only method gate (which allows `GET`/`HEAD`), so `HEAD` legitimately reaches the proxy; only the verbatim forward turned it into a 405.

## What Changed

- `workers/api.mjs`: when the method is `HEAD`, forward a `GET` to `DATA_API` on the client's behalf. `envelopeResponse(request, …)` already strips the body for `HEAD`, so the caller gets the correct empty `200` with the canonical ETag/cache/CORS headers. `GET` requests are unchanged.
- `tests/worker-runtime.test.mjs`: regression — a `HEAD /api/v1/chain-events` with a GET-only `DATA_API` mock now forwards a `GET` and returns a bodiless `200` (asserts forwarded method, `200`, empty body, ETag present). The test fails without the fix.

No public schema/OpenAPI/contract change — this restores the documented `HEAD` contract for these routes.

### Reproduction (before)

```
HEAD /api/v1/chain-events        # DATA_API bound, rate limit not tripped
→ 405 { ok: false, error: { code: "data_query_failed", message: "method not allowed" } }
```

After: `200` with an empty body and canonical envelope headers, matching `HEAD /api/v1/subnets`, `HEAD /health`, etc.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (No generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — restores the existing HEAD contract.)

## Validation

- [x] `npx vitest run tests/worker-runtime.test.mjs` (46 pass; the new regression fails without the fix)
- [x] `npx eslint workers/api.mjs tests/worker-runtime.test.mjs` (clean)
- [x] `npx prettier --check` (clean)
- [x] `git diff --check`
