### PR TITLE
fix(api): unify window validation error messages across routes

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -1653,10 +1653,8 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const parsed = parseEconomicsTrendsWindow(args?.window);
       if (args?.window !== undefined && parsed === null) {
-        throw toolError(
-          "invalid_params",
-          "window must be one of: 7d, 30d, 90d, 1y, all.",
-        );
+        const { error } = parseHistoryWindow(args.window);
+        throw toolError("invalid_params", error.message);
       }
       const { label, days } = parsed;
       const { data } = await loadEconomicsTrends(mcpD1Runner(ctx), {

--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -27,13 +27,17 @@ export const DEFAULT_HISTORY_WINDOW = "30d";
 // Bounds any single time-series response (1y = 365 daily points < this cap).
 export const MAX_HISTORY_POINTS = 400;
 
+export function unsupportedWindowMessage(value, windows) {
+  return `"${value}" is not a supported window. Supported: ${Object.keys(windows).join(", ")}.`;
+}
+
 export function parseHistoryWindow(value) {
   const v = typeof value === "string" && value ? value : DEFAULT_HISTORY_WINDOW;
   if (!Object.prototype.hasOwnProperty.call(HISTORY_WINDOWS, v)) {
     return {
       error: {
         parameter: "window",
-        message: `window must be one of: ${Object.keys(HISTORY_WINDOWS).join(", ")}`,
+        message: unsupportedWindowMessage(v, HISTORY_WINDOWS),
       },
     };
   }

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -2426,7 +2426,13 @@ describe("worker /api/v1/subnets/{netuid}/uptime route", () => {
         {},
       );
       assert.equal(res.status, 400);
-      assert.equal((await res.json()).error.code, "invalid_query");
+      const body = await res.json();
+      assert.equal(body.error.code, "invalid_query");
+      assert.equal(
+        body.error.message,
+        `"${windowParam}" is not a supported window. Supported: 90d, 1y.`,
+      );
+      assert.equal(body.meta.parameter, "window");
     }
   });
 });

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4372,7 +4372,7 @@ describe("MCP economics + metagraph data tools", () => {
       { env: d1Env },
     );
     assert.equal(res.body.result.isError, true);
-    assert.match(res.body.result.content[0].text, /window must be one of/);
+    assert.match(res.body.result.content[0].text, /is not a supported window/);
   });
 
   test("get_economics_trends returns schema-stable empty days on cold D1", async () => {
@@ -4527,7 +4527,7 @@ describe("MCP economics + metagraph data tools", () => {
       window: "400d",
     });
     assert.equal(res.body.result.isError, true);
-    assert.match(res.body.result.content[0].text, /window must be one of/);
+    assert.match(res.body.result.content[0].text, /is not a supported window/);
   });
 
   test("get_subnet_turnover accepts the all window without a date cutoff", async () => {

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -80,7 +80,8 @@ describe("parseHistoryWindow", () => {
   test("rejects an unsupported window (NOT silently coerced like analyticsWindow)", () => {
     assert.deepEqual(parseHistoryWindow("400d").error, {
       parameter: "window",
-      message: "window must be one of: 7d, 30d, 90d, 1y, all",
+      message:
+        '"400d" is not a supported window. Supported: 7d, 30d, 90d, 1y, all.',
     });
     assert.equal(parseHistoryWindow("bogus").error.parameter, "window");
   });
@@ -521,7 +522,7 @@ describe("history endpoints (via the Worker dispatch)", () => {
     assert.equal(body.error.code, "invalid_query");
     assert.equal(
       body.error.message,
-      "window must be one of: 7d, 30d, 90d, 1y, all",
+      '"400d" is not a supported window. Supported: 7d, 30d, 90d, 1y, all.',
     );
     assert.equal(body.meta.parameter, "window");
   });

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -18,6 +18,8 @@ import {
   handleTrajectory,
   handleUptime,
 } from "../workers/request-handlers/analytics-routes.mjs";
+import { unsupportedWindowMessage, HISTORY_WINDOWS } from "../src/neuron-history.mjs";
+import { UPTIME_WINDOWS } from "../workers/config.mjs";
 
 const NETUID = 7;
 const OBSERVED_AT = "2026-06-24T12:00:00.000Z";
@@ -148,6 +150,10 @@ describe("handleEconomicsTrends", () => {
     const res = await handleEconomicsTrends(req("/"), {}, url("/?window=99d"));
     const body = await errorJson(res);
     assert.equal(body.meta.parameter, "window");
+    assert.equal(
+      body.error.message,
+      unsupportedWindowMessage("99d", HISTORY_WINDOWS),
+    );
   });
 
   test("aggregates per-day across subnets (sums + weighted/median price)", async () => {
@@ -249,6 +255,10 @@ describe("handleUptime", () => {
     const res = await handleUptime(req("/"), {}, NETUID, url("/?window=30d"));
     const body = await errorJson(res);
     assert.equal(body.meta.parameter, "window");
+    assert.equal(
+      body.error.message,
+      unsupportedWindowMessage("30d", UPTIME_WINDOWS),
+    );
   });
 
   test("rejects duplicate window parameters", async () => {

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -18,7 +18,10 @@ import {
   handleTrajectory,
   handleUptime,
 } from "../workers/request-handlers/analytics-routes.mjs";
-import { unsupportedWindowMessage, HISTORY_WINDOWS } from "../src/neuron-history.mjs";
+import {
+  unsupportedWindowMessage,
+  HISTORY_WINDOWS,
+} from "../src/neuron-history.mjs";
 import { UPTIME_WINDOWS } from "../workers/config.mjs";
 
 const NETUID = 7;

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -10,6 +10,8 @@ import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
 import { buildOpenApiArtifact } from "../src/contracts.mjs";
 import { encodeCursor } from "../src/cursor.mjs";
+import { MOVERS_WINDOWS } from "../src/movers.mjs";
+import { unsupportedWindowMessage } from "../src/neuron-history.mjs";
 import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
 import {
   handleSubnetMetagraph,
@@ -1459,12 +1461,17 @@ describe("handleSubnetMovers", () => {
   });
 
   test("rejects an unsupported window with 400", async () => {
-    await errorJson(
+    const body = await errorJson(
       await handleSubnetMovers(
         req("/api/v1/subnets/movers"),
         emptyEnv(),
         url("/api/v1/subnets/movers?window=1y"),
       ),
+    );
+    assert.equal(body.meta.parameter, "window");
+    assert.equal(
+      body.error.message,
+      unsupportedWindowMessage("1y", MOVERS_WINDOWS),
     );
   });
 

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -21,7 +21,10 @@ import {
   validateQueryParams,
 } from "./analytics.mjs";
 import { dailyLatencyColumns } from "../../src/health-sql.mjs";
-import { parseHistoryWindow } from "../../src/neuron-history.mjs";
+import {
+  parseHistoryWindow,
+  unsupportedWindowMessage,
+} from "../../src/neuron-history.mjs";
 import { loadEconomicsTrends } from "../../src/economics-trends.mjs";
 import {
   formatLeaderboards,
@@ -121,12 +124,10 @@ export async function handleUptime(request, env, netuid, url) {
   if (validationError) return analyticsQueryError(validationError);
   const windowParam = url.searchParams.get("window") || "90d";
   if (!Object.hasOwn(UPTIME_WINDOWS, windowParam)) {
-    return errorResponse(
-      "invalid_query",
-      "Query parameter `window` must be one of: 90d, 1y.",
-      400,
-      { parameter: "window" },
-    );
+    return analyticsQueryError({
+      parameter: "window",
+      message: unsupportedWindowMessage(windowParam, UPTIME_WINDOWS),
+    });
   }
   const days = UPTIME_WINDOWS[windowParam];
   const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -53,6 +53,7 @@ import {
   buildNeuronHistory,
   buildSubnetHistory,
   parseHistoryWindow,
+  unsupportedWindowMessage,
   NEURON_DAILY_READ_COLUMNS,
   MAX_HISTORY_POINTS,
 } from "../../src/neuron-history.mjs";
@@ -561,9 +562,7 @@ export async function handleSubnetStakeFlow(request, env, netuid, url) {
   if (!Object.hasOwn(STAKE_FLOW_WINDOWS, windowParam)) {
     return analyticsQueryError({
       parameter: "window",
-      message: `"${windowParam}" is not a supported window. Supported: ${Object.keys(
-        STAKE_FLOW_WINDOWS,
-      ).join(", ")}.`,
+      message: unsupportedWindowMessage(windowParam, STAKE_FLOW_WINDOWS),
     });
   }
   const { data, generatedAt } = await loadSubnetStakeFlow(
@@ -603,9 +602,7 @@ export async function handleSubnetMovers(request, env, url) {
   if (!Object.hasOwn(MOVERS_WINDOWS, windowParam)) {
     return analyticsQueryError({
       parameter: "window",
-      message: `"${windowParam}" is not a supported window. Supported: ${Object.keys(
-        MOVERS_WINDOWS,
-      ).join(", ")}.`,
+      message: unsupportedWindowMessage(windowParam, MOVERS_WINDOWS),
     });
   }
   const sortParam = url.searchParams.get("sort") || DEFAULT_MOVERS_SORT;
@@ -670,9 +667,7 @@ export async function handleAccountStakeFlow(request, env, ss58, url) {
   if (!Object.hasOwn(STAKE_FLOW_WINDOWS, windowParam)) {
     return analyticsQueryError({
       parameter: "window",
-      message: `"${windowParam}" is not a supported window. Supported: ${Object.keys(
-        STAKE_FLOW_WINDOWS,
-      ).join(", ")}.`,
+      message: unsupportedWindowMessage(windowParam, STAKE_FLOW_WINDOWS),
     });
   }
   const { data, generatedAt } = await loadAccountStakeFlow(


### PR DESCRIPTION
## Summary

- Add shared `unsupportedWindowMessage` helper in `src/neuron-history.mjs` and use it in `parseHistoryWindow` (economics/trends) and `handleUptime`
- Refactor movers and stake-flow handlers to use the same helper (message unchanged for movers)
- Extend unit tests so each route's invalid-window path asserts the unified 400 message; valid-window paths unchanged

Closes #2583

## Test plan

- [x] `npm test -- tests/neuron-history.test.mjs tests/request-handlers-analytics-routes.test.mjs tests/request-handlers-entities.test.mjs --run`
- [x] `npm test -- tests/health-serving.test.mjs -t uptime --run`
- [ ] CI green