### PR TITLE
feat(account-events): ingest PrometheusServed events

### DIFF
--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -285,6 +285,7 @@ EXTRACTORS = {
     "StakeRemoved": _stake,
     "StakeMoved": _moved,
     "AxonServed": _axon,
+    "PrometheusServed": _axon,  # [netuid, hotkey]
     "WeightsSet": _weights,
     "RootClaimed": _root,
     # Subnet lifecycle (#1816)

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -337,6 +337,25 @@ class TransferExtractorTest(unittest.TestCase):
         self.assertIsNone(result["amount_tao"])
 
 
+class PrometheusServedExtractorTest(unittest.TestCase):
+    """Tests for the SubtensorModule.PrometheusServed extractor (#2554)."""
+
+    def test_positional_netuid_hotkey(self):
+        result = _extract("PrometheusServed", [7, _SS58_A])
+        self.assertEqual(result["netuid"], 7)
+        self.assertEqual(result["hotkey"], _SS58_A)
+        self.assertIsNone(result["coldkey"])
+        self.assertIsNone(result["uid"])
+
+    def test_invalid_hotkey_gives_null(self):
+        result = _extract("PrometheusServed", [7, "not-an-address"])
+        self.assertEqual(result["netuid"], 7)
+        self.assertIsNone(result["hotkey"])
+
+    def test_empty_shape_drift_is_skipped(self):
+        self.assertIsNone(_extract("PrometheusServed", []))
+
+
 class _Ev:
     """Minimal stand-in for a decoded event (`.value` is the SCALE-decoded dict)."""
 

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -50,6 +50,7 @@ export const INDEXED_EVENT_KINDS = [
   "StakeRemoved",
   "StakeMoved",
   "AxonServed",
+  "PrometheusServed",
   "WeightsSet",
   "RootClaimed",
 ];

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -4,6 +4,7 @@ import {
   ACCOUNT_EVENT_COLUMNS,
   EVENT_INSERT_COLUMNS,
   INDEXED_EVENT_KINDS,
+  INGESTED_EVENT_KINDS,
   EVENT_RETENTION_MS,
   formatAccountEvent,
   formatAccountDay,
@@ -100,9 +101,14 @@ test("INDEXED_EVENT_KINDS covers the core entity events", () => {
     "StakeRemoved",
     "WeightsSet",
     "AxonServed",
+    "PrometheusServed",
   ]) {
     assert.ok(INDEXED_EVENT_KINDS.includes(k), `missing ${k}`);
   }
+});
+
+test("INGESTED_EVENT_KINDS accepts PrometheusServed for kind filters", () => {
+  assert.ok(INGESTED_EVENT_KINDS.includes("PrometheusServed"));
 });
 
 test("formatAccountEvent maps a D1 row to an API event (ISO time)", () => {


### PR DESCRIPTION
## Summary

Adds `PrometheusServed` to the curated account-events ingestion path so neuron telemetry endpoint serves can be queried alongside the existing `AxonServed` activity.

Closes #2554

## What Changed

- Maps `SubtensorModule.PrometheusServed` to the existing `[netuid, hotkey]` extractor used by `AxonServed`.
- Adds `PrometheusServed` to the accepted account-event kind set for public `?kind=` filters.
- Adds Python extractor regression coverage and JS kind-list coverage.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema shape change; `event_kind` remains the existing string field.

## Validation

- [x] `python3 scripts/test_fetch_events.py`
- [x] `npm test -- tests/account-events.test.mjs`
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:coverage`
- [x] `git diff --check`

## Notes

No migration is needed; the event fits the existing `netuid` and `hotkey` account_events columns. Current Finney metadata exposes `PrometheusServed` with `[NetUid, AccountId]` fields.
