### PR TITLE
fix(ci): pin PR checkout to head sha and fix Codecov attribution

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,6 +37,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # Pin to the contributor's actual pushed commit, not GitHub's default
+          # refs/pull/:N/merge preview -- keeps CI deterministic for a given sha
+          # (a PR can't start failing just because main moved) and matches what
+          # Codecov's patch status is measuring. See the coverage upload steps
+          # below for why this specifically also fixes commit attribution.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -79,6 +85,12 @@ jobs:
       # local backstop. Same-repo PRs and main pushes use the repository token;
       # fork PRs use Codecov's public-repo tokenless upload path instead.
       # Missing coverage or upload errors fail the test job.
+      #
+      # Explicit override_branch/commit/pr on BOTH paths below: GITHUB_SHA is the
+      # ephemeral refs/pull/:N/merge commit on pull_request events, and the
+      # checkout step above pins to the real head sha instead (so tests run the
+      # contributor's actual commit) -- so auto-detection would otherwise attach
+      # the report to a merge sha that never appears in the PR's own checks list.
       - name: Upload coverage to Codecov
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -86,6 +98,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           disable_search: true
+          override_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          override_commit: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          override_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
           fail_ci_if_error: true
 
       - name: Upload coverage to Codecov (fork PR tokenless)
@@ -94,6 +109,9 @@ jobs:
         with:
           files: ./coverage/lcov.info
           disable_search: true
+          override_branch: ${{ github.event.pull_request.head.ref }}
+          override_commit: ${{ github.event.pull_request.head.sha }}
+          override_pr: ${{ github.event.pull_request.number }}
           fail_ci_if_error: true
 
       - name: Upload Vitest results to Codecov
@@ -104,6 +122,9 @@ jobs:
           files: ./reports/junit/vitest.xml
           report_type: test_results
           disable_search: true
+          override_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          override_commit: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          override_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
           fail_ci_if_error: false
 
       - name: Upload Vitest results to Codecov (fork PR tokenless)
@@ -113,6 +134,9 @@ jobs:
           files: ./reports/junit/vitest.xml
           report_type: test_results
           disable_search: true
+          override_branch: ${{ github.event.pull_request.head.ref }}
+          override_commit: ${{ github.event.pull_request.head.sha }}
+          override_pr: ${{ github.event.pull_request.number }}
           fail_ci_if_error: false
 
       # The two filesystem-mutating artifact writers, run serially LAST so they
@@ -131,6 +155,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # Same pin as the `test` job's checkout -- keep both jobs testing the
+          # identical commit.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       # Compute the deletion-filtered list of files this PR submits, inline in the
       # trusted workflow (PR contents are untrusted). It feeds ONLY the


### PR DESCRIPTION
## Summary
- Pins the `test` and `checks` jobs' checkout to `github.event.pull_request.head.sha` for `pull_request` events, instead of GitHub's default `refs/pull/:N/merge` preview — matching how `gittensory` (the sibling repo) checks out PRs, and making CI deterministic for a given commit (a PR can no longer start failing purely because `main` moved underneath it).
- Adds explicit `override_branch`/`override_commit`/`override_pr` to all four Codecov upload steps (trusted-token + fork-tokenless, coverage + test-results). This was needed *because* of the checkout change above: `GITHUB_SHA` is always the ephemeral auto-merge commit on `pull_request` events, and `codecov-cli`'s fallback to recover the real head sha assumes `HEAD` is that 2-parent merge commit — which stops being true once checkout pins to the real head commit directly.

## What Changed
- `.github/workflows/validate.yml`: `ref:` added to both checkout steps; `override_*` fields added to the four Codecov upload steps.

## Why
Follow-up to #2499 (merged earlier today), which added the fork-tokenless Codecov upload. While making the equivalent fix in `gittensory`, its gate's own AI review caught that an *unqualified* tokenless upload can attribute coverage to the wrong SHA when checkout pins to the PR head commit instead of the default merge-ref. Auditing this repo found the two checkout strategies had already diverged for unrelated historical reasons — `gittensory` pins to head sha (deliberately, for reproducibility) and `metagraphed` didn't. Standardizing on the pinned-head-sha approach here removes that inconsistency, closes the theoretical attribution gap this repo would otherwise have accumulated as soon as the checkout is ever changed to match `gittensory`, and makes `test`/`checks` results reproducible for a given commit rather than dependent on whatever `main` looks like at run time.

## Registry Safety
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. — N/A, no generated artifacts touched.
- [x] R2-only/high-churn detail artifacts are not committed. — N/A.
- [x] Public API/OpenAPI/schema changes are intentional and documented. — N/A, no API/schema change.

## Validation
- [x] `npm run validate:workflows` — passes locally (this is the invariant #2499 added for the trusted/fork-tokenless split; unaffected by the new override fields, verified against the script's substring checks).
- [ ] The rest of the checklist below was **not** run locally in this session: the local sandbox's Node/`sharp` native-binary setup couldn't complete `npm ci` (unrelated to this diff — no JS/TS source was touched, only workflow YAML). Relying on this repo's own CI (fresh Linux runners, no such issue) to confirm `npm run check` / `validate` / `test:coverage` / etc. are green before merge.
- [x] `git diff --check`

## Notes
This only changes *which commit* CI tests and *how Codecov attributes* the upload — it does not change the 99% patch coverage target, the coverage suite itself, or any contributor-facing gate criteria.