### PR TITLE
fix(ci): use a colon-prefixed branch for fork tokenless Codecov uploads

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -103,13 +103,20 @@ jobs:
           override_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
           fail_ci_if_error: true
 
+      # override_branch is prefixed with the fork owner (owner:branch): Codecov only treats a branch
+      # string with a colon-separated prefix as "unprotected"/tokenless-eligible; a bare branch name
+      # looks like it could be a real (possibly protected) branch on the base repo and gets rejected with
+      # "Token required because branch is protected" even with zero token configuration anywhere.
+      # codecov-cli's own auto-detection never adds this prefix either (verified in its source), so it
+      # must be supplied explicitly. override_commit/override_pr are unaffected -- that check only
+      # inspects the branch string.
       - name: Upload coverage to Codecov (fork PR tokenless)
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage/lcov.info
           disable_search: true
-          override_branch: ${{ github.event.pull_request.head.ref }}
+          override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
           override_commit: ${{ github.event.pull_request.head.sha }}
           override_pr: ${{ github.event.pull_request.number }}
           fail_ci_if_error: true
@@ -134,7 +141,7 @@ jobs:
           files: ./reports/junit/vitest.xml
           report_type: test_results
           disable_search: true
-          override_branch: ${{ github.event.pull_request.head.ref }}
+          override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
           override_commit: ${{ github.event.pull_request.head.sha }}
           override_pr: ${{ github.event.pull_request.number }}
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Fixes the same live issue hit on gittensory (JSONbored/gittensory#2496 CI run) and now confirmed to apply here too: `override_branch` on the fork-tokenless Codecov upload steps (added in #2595) was set to the bare fork branch name. Codecov's server rejects tokenless uploads on a branch string with no colon-separated prefix, since that looks like it could be a real (possibly protected) branch on the base repo — `Upload queued for processing failed: {"message":"Token required because branch is protected"}`.
- Confirmed directly in `codecov-cli`'s source (`services/commit/__init__.py`): `if branch and ":" in branch: ... elif token is None: # protected, warns/rejects`. `codecov-cli`'s own auto-detection (`helpers/ci_adapters/github_actions.py`, `_get_branch()`) never adds this prefix either, so it must be supplied explicitly.
- Fix: prefix `override_branch` with the fork owner (`${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}`) on both fork-tokenless steps. `override_commit`/`override_pr` are untouched.

## What Changed
- `.github/workflows/validate.yml`: `override_branch` on the two "(fork PR tokenless)" steps now uses the `owner:branch` format instead of a bare branch name.

## Why
Follow-up to #2595. Same root cause as gittensory PR #2363 — both repos got the identical `override_branch` pattern in their respective PRs this session, and both need the identical fix.

## Registry Safety
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. — N/A.
- [x] R2-only/high-churn detail artifacts are not committed. — N/A.
- [x] Public API/OpenAPI/schema changes are intentional and documented. — N/A.

## Validation
- [x] `npm run validate:workflows` — passes locally.
- [ ] Full `npm run check`/`validate`/`test:coverage` suite not run locally this session (same local Node/`sharp` native-binary sandbox limitation as #2595 — unrelated to this one-line-per-step YAML diff). Relying on this repo's own CI to confirm green.
- [x] `git diff --check`