### PR TITLE
fix(api): coerce block detail anchor before neighbor lookup

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2898,6 +2898,23 @@ describe("handleBlock", () => {
     assert.equal(body.data.next_block_number, 1240);
   });
 
+  test("resolves neighbors when D1 returns a string-typed block_number", async () => {
+    const { env, captures } = dbWith({
+      blockDetail: blockRow({ block_number: "1234" }),
+      blockNeighbors: { prev: 1230, next: 1240 },
+    });
+    const body = await json(
+      await handleBlock(req(`/api/v1/blocks/1234`), env, "1234"),
+    );
+    const neighborParams = captures.params.find(
+      (p) => p.length === 2 && p[0] === 1234 && p[1] === 1234,
+    );
+    assert.ok(neighborParams, "neighbor anchor must bind as Number 1234");
+    assert.equal(body.data.block.block_number, 1234);
+    assert.equal(body.data.prev_block_number, 1230);
+    assert.equal(body.data.next_block_number, 1240);
+  });
+
   test("happy path resolves by 0x block_hash ref", async () => {
     const { env } = dbWith({ blockDetail: blockRow() });
     const body = await json(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -78,6 +78,7 @@ import {
   BLOCK_READ_COLUMNS,
   buildBlock,
   buildBlockFeed,
+  formatBlock,
 } from "../../src/blocks.mjs";
 import {
   EXTRINSIC_READ_COLUMNS,
@@ -1374,8 +1375,11 @@ export async function handleBlock(request, env, ref) {
   // the block_number primary key instead of scanning the retained blocks table.
   let prev = null;
   let next = null;
-  const resolvedNumber = rows[0]?.block_number;
-  if (Number.isInteger(resolvedNumber)) {
+  // Coerce through formatBlock (same as loadBlock's toBlockNumber): D1 can return
+  // INTEGER block_number as a numeric string; Number.isInteger("1234") is false
+  // and would skip the neighbor lookup (#2506 fixed loadBlock only).
+  const resolvedNumber = formatBlock(rows[0])?.block_number ?? null;
+  if (resolvedNumber != null) {
     const nbr = await d1All(
       env,
       `SELECT (SELECT MAX(block_number) FROM blocks WHERE block_number < ?) AS prev, (SELECT MIN(block_number) FROM blocks WHERE block_number > ?) AS next`,


### PR DESCRIPTION
## Summary

Fix `GET /api/v1/blocks/{ref}` returning `prev_block_number` / `next_block_number: null` when D1 returns `block_number` as a numeric string.

## What Changed

- `handleBlock` gated the neighbor subquery on `Number.isInteger(rows[0].block_number)`. D1 INTEGER columns often arrive as `"1234"`, so the lookup was skipped even though `formatBlock` already coerces the displayed `block_number`.
- Coerce the anchor through `formatBlock(rows[0])?.block_number` before binding the MAX/MIN neighbor query — the same pattern `loadBlock` uses after #2506.
- Added a handler regression test with `block_number: "1234"` in the mock row.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change.)

## Validation

- [x] `npx vitest run tests/request-handlers-entities.test.mjs -t "resolves neighbors when D1 returns a string"`
- [x] `git diff --check`
