### PR TITLE
fix(health): count only ok probes in summarizeRows avg_latency_ms

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -15,6 +15,7 @@ import {
 import {
   rollupSubnetStatus,
   normalizeProbeStatus,
+  okLatencyMs,
 } from "./health-probe-core.mjs";
 import { dailyLatencyColumns } from "./health-sql.mjs";
 import { KV_ECONOMICS_CURRENT, KV_HEALTH_CURRENT } from "./kv-keys.mjs";
@@ -114,8 +115,10 @@ export function summarizeRows(rows) {
   const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
   const latencies = [];
   for (const row of rows) {
-    counts[normalizeProbeStatus(row.status)] += 1;
-    if (Number.isFinite(row.latency_ms)) latencies.push(row.latency_ms);
+    const status = normalizeProbeStatus(row.status);
+    counts[status] += 1;
+    const latency = okLatencyMs(status, row.latency_ms);
+    if (latency != null) latencies.push(latency);
   }
   return {
     status: rollupSubnetStatus({ ...counts, total: rows.length }),

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -476,6 +476,14 @@ describe("summarizeRows / rollupStatus", () => {
     assert.equal(out.last_checked, "2026-06-11T00:05:00.000Z"); // latest
     assert.equal(out.last_ok, "2026-06-11T00:00:00.000Z"); // latest non-null
   });
+  test("avg_latency_ms counts ok probes only", () => {
+    const out = summarizeRows([
+      row("ok", { latency_ms: 100 }),
+      row("failed", { latency_ms: 9000 }),
+    ]);
+    assert.equal(out.avg_latency_ms, 100);
+    assert.equal(out.latency_sample_count, 1);
+  });
 });
 
 describe("OPERATIONAL_KINDS export", () => {


### PR DESCRIPTION
## Summary

Stop `summarizeRows` from inflating `avg_latency_ms` with failure probe latencies.

## What Changed

- `summarizeRows` pushed every finite `latency_ms` into the average, including `failed` / `degraded` rows. The prober write path, SQL `OK_LATENCY` aggregates, and `okLatencyMs` in `health-probe-core.mjs` all treat latency as **success-only** (failures store null latency for averaging).
- Legacy D1 `surface_status` rows can still carry elapsed-time latency on failed probes, so the D1 fallback path (`liveFromD1Rows` → `summarizeRows`) could report a wildly inflated `avg_latency_ms` while status counts were correct.
- Use `okLatencyMs(normalizeProbeStatus(row.status), row.latency_ms)` when building the latency sample list; added a regression test (`ok` @ 100ms + `failed` @ 9000ms → avg 100).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change.)

## Validation

- [x] `npx vitest run tests/health-serving.test.mjs -t "summarizeRows"`
- [x] `git diff --check`
