### PR TITLE
feat(mcp): add get_account_stake_flow mirroring REST stake-flow

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -398,6 +398,16 @@ assert.ok(
   "balance_tao" in accountBalance && accountBalance.ss58 === SS58,
   "get_account_balance must return ss58 + balance_tao (null on cold RPC)",
 );
+const accountStakeFlow = await callOk("get_account_stake_flow", {
+  ss58: SS58,
+  window: "30d",
+});
+assert.ok(
+  Array.isArray(accountStakeFlow.subnets) &&
+    accountStakeFlow.address === SS58 &&
+    accountStakeFlow.window === "30d",
+  "get_account_stake_flow must return the AccountStakeFlowArtifact shape",
+);
 
 // Derive a real surface_id with a captured schema so get_api_schema resolves.
 const schemaService = apis.services.find((service) => service.schema_artifact);

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -110,6 +110,11 @@ import {
   parseHistoryWindow,
 } from "./neuron-history.mjs";
 import { loadSubnetTurnover } from "./turnover.mjs";
+import {
+  DEFAULT_STAKE_FLOW_WINDOW,
+  STAKE_FLOW_WINDOWS,
+  loadAccountStakeFlow,
+} from "./account-stake-flow.mjs";
 import { isFinneySs58Address, loadAccountBalance } from "./account-balance.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import { loadBlocks, loadBlock } from "./blocks.mjs";
@@ -146,7 +151,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.14.0";
+export const MCP_SERVER_VERSION = "1.15.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -227,7 +232,9 @@ export const MCP_INSTRUCTIONS =
   "UID — use these to decide where to mine or validate. For wallet lookup, " +
   "get_account summarizes what one hotkey or coldkey does across the network, " +
   "get_account_balance its live native-TAO balance (free+reserved) from finney RPC, " +
-  "get_account_events returns its chain-event history (optional kind filter), and " +
+  "get_account_events returns its chain-event history (optional kind filter), " +
+  "get_account_stake_flow its StakeAdded vs StakeRemoved flow per subnet over a " +
+  "7d/30d/90d window (net/gross flow, direction, concentration), and " +
   "get_account_subnets the subnets where it is registered. For chain-wide " +
   "activity analytics, get_chain_calls returns the extrinsic call-mix " +
   "(count + share per pallet/module) over a 7d/30d window, get_chain_fees the " +
@@ -2482,6 +2489,53 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_account_stake_flow",
+    title: "Get an account's stake flow scorecard",
+    description:
+      "Fetch one account's StakeAdded vs StakeRemoved flow per subnet over a recent " +
+      "window: per-subnet net and gross TAO flow with a direction label " +
+      "(accumulating/exiting/churning/idle), plus account totals, an HHI " +
+      "concentration of where the flow is focused, and the dominant subnet. " +
+      "Window is 7d, 30d (default), or 90d. Hotkey-attributed only (same as the " +
+      "REST route). Use it to see whether an account is net staking in or exiting " +
+      "across subnets — a recent-capital-movement signal alongside get_account " +
+      "(current registrations) and get_account_events (raw event feed). Mirrors " +
+      "GET /api/v1/accounts/{ss58}/stake-flow.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ss58: {
+          type: "string",
+          description:
+            "The account's SS58 hotkey address, base58, 47-48 chars.",
+          pattern: SS58_PATTERN_SOURCE,
+        },
+        window: {
+          type: "string",
+          enum: ["7d", "30d", "90d"],
+          description: "Lookback window (default 30d).",
+        },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const ss58 = requireSs58(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_STAKE_FLOW_WINDOW;
+      if (!Object.hasOwn(STAKE_FLOW_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${Object.keys(STAKE_FLOW_WINDOWS).join(", ")}.`,
+        );
+      }
+      const { data } = await loadAccountStakeFlow(mcpD1Runner(ctx), ss58, {
+        windowLabel: window,
+      });
+      return data;
+    },
+  },
+  {
     name: "get_account_counterparties",
     title: "Rank an account's transfer counterparties",
     description:
@@ -4064,6 +4118,36 @@ const ACCOUNT_EVENT_ITEM = {
   observed_at: NULLABLE_STRING,
   extrinsic_index: NULLABLE_INT,
 };
+const STAKE_FLOW_DIRECTION = {
+  type: "string",
+  enum: ["accumulating", "exiting", "churning", "idle"],
+};
+const ACCOUNT_STAKE_FLOW_SUBNET_ITEM = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "netuid",
+    "staked_tao",
+    "unstaked_tao",
+    "net_flow_tao",
+    "gross_flow_tao",
+    "flow_ratio",
+    "direction",
+    "stake_events",
+    "unstake_events",
+  ],
+  properties: {
+    netuid: { type: "integer", minimum: 0 },
+    staked_tao: { type: "number" },
+    unstaked_tao: { type: "number" },
+    net_flow_tao: { type: "number" },
+    gross_flow_tao: { type: "number" },
+    flow_ratio: { type: ["number", "null"] },
+    direction: STAKE_FLOW_DIRECTION,
+    stake_events: { type: "integer", minimum: 0 },
+    unstake_events: { type: "integer", minimum: 0 },
+  },
+};
 // Shared block item shape for list_blocks (each block in the feed).
 const BLOCK_ITEM = {
   block_number: NULLABLE_INT,
@@ -4732,6 +4816,50 @@ const TOOL_OUTPUT_SCHEMAS = {
         direction: NULLABLE_STRING,
         observed_at: NULLABLE_STRING,
       }),
+    },
+  },
+  get_account_stake_flow: {
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "schema_version",
+      "address",
+      "window",
+      "total_staked_tao",
+      "total_unstaked_tao",
+      "net_flow_tao",
+      "gross_flow_tao",
+      "flow_ratio",
+      "direction",
+      "stake_events",
+      "unstake_events",
+      "subnet_count",
+      "concentration",
+      "dominant_netuid",
+      "subnets",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      address: { type: "string" },
+      window: {
+        type: ["string", "null"],
+        enum: ["7d", "30d", "90d", null],
+      },
+      total_staked_tao: { type: "number" },
+      total_unstaked_tao: { type: "number" },
+      net_flow_tao: { type: "number" },
+      gross_flow_tao: { type: "number" },
+      flow_ratio: { type: ["number", "null"] },
+      direction: STAKE_FLOW_DIRECTION,
+      stake_events: { type: "integer", minimum: 0 },
+      unstake_events: { type: "integer", minimum: 0 },
+      subnet_count: { type: "integer", minimum: 0 },
+      concentration: { type: ["number", "null"] },
+      dominant_netuid: { type: ["integer", "null"], minimum: 0 },
+      subnets: {
+        type: "array",
+        items: ACCOUNT_STAKE_FLOW_SUBNET_ITEM,
+      },
     },
   },
   get_account_counterparties: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -2293,6 +2293,106 @@ describe("MCP get_rpc_usage", () => {
   });
 });
 
+describe("MCP get_account_stake_flow", () => {
+  const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+  function accountStakeFlowD1(rows = [], capture = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                all() {
+                  return Promise.resolve({
+                    results:
+                      /FROM account_events/.test(sql) &&
+                      /GROUP BY netuid, event_kind/.test(sql)
+                        ? rows
+                        : [],
+                  });
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("folds StakeAdded vs StakeRemoved into per-subnet net flow", async () => {
+    const capture = [];
+    const env = accountStakeFlowD1(
+      [
+        {
+          netuid: 1,
+          event_kind: "StakeAdded",
+          total_tao: 100,
+          event_count: 2,
+          last_observed: 5000,
+        },
+        {
+          netuid: 1,
+          event_kind: "StakeRemoved",
+          total_tao: 30,
+          event_count: 1,
+          last_observed: 6000,
+        },
+      ],
+      capture,
+    );
+    const res = await callTool(
+      "get_account_stake_flow",
+      { ss58: SS58, window: "7d" },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.address, SS58);
+    assert.equal(out.window, "7d");
+    assert.equal(out.net_flow_tao, 70);
+    assert.equal(out.direction, "accumulating");
+    assert.equal(out.subnet_count, 1);
+    assert.equal(out.subnets[0].netuid, 1);
+    const q = capture[0];
+    assert.match(q.sql, /WHERE hotkey = \?/);
+    assert.match(q.sql, /GROUP BY netuid, event_kind/);
+    assert.equal(q.params[0], SS58);
+    assert.equal(q.params[1], "StakeAdded");
+    assert.equal(q.params[2], "StakeRemoved");
+  });
+
+  test("defaults to the 30d window", async () => {
+    const res = await callTool(
+      "get_account_stake_flow",
+      { ss58: SS58 },
+      { env: accountStakeFlowD1() },
+    );
+    assert.equal(res.body.result.structuredContent.window, "30d");
+  });
+
+  test("degrades to schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_account_stake_flow", { ss58: SS58 });
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.net_flow_tao, 0);
+    assert.equal(out.subnet_count, 0);
+    assert.equal(out.concentration, null);
+    assert.equal(out.dominant_netuid, null);
+    assert.deepEqual(out.subnets, []);
+  });
+
+  test("rejects an unsupported window", async () => {
+    const res = await callTool(
+      "get_account_stake_flow",
+      { ss58: SS58, window: "1y" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+});
+
 describe("MCP get_account_counterparties", () => {
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
   const CP = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy";


### PR DESCRIPTION
## Summary

- Add MCP tool `get_account_stake_flow` for the live REST route `GET /api/v1/accounts/{ss58}/stake-flow`: per-subnet StakeAdded vs StakeRemoved net/gross flow, direction label, HHI concentration, and dominant subnet over a 7d/30d/90d window.
- Wire the tool to the existing shared `loadAccountStakeFlow` loader (`src/account-stake-flow.mjs`) so REST and MCP share one read path; no REST or schema artifact changes.
- Add a typed `TOOL_OUTPUT_SCHEMAS` entry matching `AccountStakeFlowArtifact`, MCP integration tests, and `validate:mcp` coverage. Bump `MCP_SERVER_VERSION` and `server.json` to 1.15.0.

## Test plan

- [x] `npx vitest run tests/mcp-server.test.mjs -t "get_account_stake_flow"`
- [x] `npm run validate:mcp` — 67 tools, lifecycle + all tools/call
- [x] `npm run lint`
- [x] `npm run format:check`
