### PR TITLE
fix(rpc-proxy): block CGNAT 100.64.0.0/10 in the RPC upstream safety guard

### DIFF
--- a/tests/rpc-endpoint-selection.test.mjs
+++ b/tests/rpc-endpoint-selection.test.mjs
@@ -142,16 +142,47 @@ describe("orderSafeRpcEndpoints — block-height routing", () => {
 });
 
 describe("isPrivateOrLocalHostname — CGNAT parity (#2312/#2313)", () => {
-  test("rejects the 100.64.0.0/10 CGNAT range, dotted and ::ffff:-mapped", () => {
+  test("rejects the 100.64.0.0/10 CGNAT range as a plain dotted IPv4 hostname", () => {
     assert.equal(isPrivateOrLocalHostname("100.64.0.1"), true);
     assert.equal(isPrivateOrLocalHostname("100.100.0.1"), true);
     assert.equal(isPrivateOrLocalHostname("100.127.255.255"), true);
-    assert.equal(isPrivateOrLocalHostname("::ffff:100.64.0.1"), true);
   });
 
   test("does not reject public addresses just outside the CGNAT range", () => {
     assert.equal(isPrivateOrLocalHostname("100.63.255.255"), false);
     assert.equal(isPrivateOrLocalHostname("100.128.0.0"), false);
     assert.equal(isPrivateOrLocalHostname("8.8.8.8"), false);
+  });
+
+  // The WHATWG URL parser re-serializes an IPv4-mapped IPv6 literal into
+  // hex-tail form — [::ffff:100.64.0.1] becomes hostname "::ffff:6440:1", NOT
+  // the dotted "::ffff:100.64.0.1" string. Route the literal through the same
+  // `new URL(...).hostname` step isSafeRpcEndpointUrl uses so this test can't
+  // drift from what the real request path actually evaluates.
+  test("rejects an IPv4-mapped CGNAT IPv6 literal via the real new URL(...).hostname form", () => {
+    const hostname = new URL("https://[::ffff:100.64.0.1]/").hostname;
+    // URL.hostname keeps the brackets for an IPv6 literal; pin the exact
+    // normalized form so this test can't silently drift from reality.
+    assert.equal(hostname, "[::ffff:6440:1]");
+    assert.equal(isPrivateOrLocalHostname(hostname), true);
+  });
+
+  test("still rejects the dotted-quad ::ffff: form directly (non-URL callers)", () => {
+    assert.equal(isPrivateOrLocalHostname("::ffff:100.64.0.1"), true);
+  });
+
+  test("rejects IPv4-mapped/compatible/6to4/NAT64 forms of the other private ranges too", () => {
+    // ::ffff:127.0.0.1 -> hex-tail ::ffff:7f00:1
+    assert.equal(
+      isPrivateOrLocalHostname(new URL("https://[::ffff:127.0.0.1]/").hostname),
+      true,
+    );
+    // ::ffff:192.168.1.1 -> hex-tail ::ffff:c0a8:101
+    assert.equal(
+      isPrivateOrLocalHostname(
+        new URL("https://[::ffff:192.168.1.1]/").hostname,
+      ),
+      true,
+    );
   });
 });

--- a/tests/rpc-endpoint-selection.test.mjs
+++ b/tests/rpc-endpoint-selection.test.mjs
@@ -163,6 +163,24 @@ describe("isPrivateOrLocalHostname — CGNAT parity (#2312/#2313)", () => {
     assert.equal(isPrivateOrLocalHostname("8.8.8.8"), false);
   });
 
+  // isPrivateIpv4Octets was factored out of the inline IPv4 branch in this PR,
+  // so every one of its range clauses is new to the patch even though most of
+  // the ranges themselves predate this change. Exercise each clause true, not
+  // just the new CGNAT one, so patch/branch coverage reflects the real logic.
+  test("rejects every pre-existing private IPv4 range this guard already covered", () => {
+    assert.equal(isPrivateOrLocalHostname("0.1.2.3"), true); // 0.0.0.0/8
+    assert.equal(isPrivateOrLocalHostname("10.1.2.3"), true); // 10.0.0.0/8
+    assert.equal(isPrivateOrLocalHostname("127.0.0.1"), true); // 127.0.0.0/8
+    assert.equal(isPrivateOrLocalHostname("169.254.1.1"), true); // 169.254.0.0/16
+    assert.equal(isPrivateOrLocalHostname("172.16.0.1"), true); // 172.16.0.0/12
+    assert.equal(isPrivateOrLocalHostname("172.31.255.255"), true); // 172.16.0.0/12
+    assert.equal(isPrivateOrLocalHostname("192.168.1.1"), true); // 192.168.0.0/16
+    assert.equal(isPrivateOrLocalHostname("172.15.255.255"), false); // just below
+    assert.equal(isPrivateOrLocalHostname("172.32.0.0"), false); // just above
+    assert.equal(isPrivateOrLocalHostname("169.253.255.255"), false); // just below 169.254
+    assert.equal(isPrivateOrLocalHostname("192.167.1.1"), false); // first ok, second not 168
+  });
+
   // The WHATWG URL parser re-serializes an IPv4-mapped IPv6 literal into
   // hex-tail form — [::ffff:100.64.0.1] becomes hostname "::ffff:6440:1", NOT
   // the dotted "::ffff:100.64.0.1" string. Route the literal through the same

--- a/tests/rpc-endpoint-selection.test.mjs
+++ b/tests/rpc-endpoint-selection.test.mjs
@@ -142,6 +142,15 @@ describe("orderSafeRpcEndpoints — block-height routing", () => {
 });
 
 describe("isPrivateOrLocalHostname — CGNAT parity (#2312/#2313)", () => {
+  test("rejects localhost and its subdomains", () => {
+    assert.equal(isPrivateOrLocalHostname("localhost"), true);
+    assert.equal(isPrivateOrLocalHostname("foo.localhost"), true);
+    assert.equal(
+      isPrivateOrLocalHostname("bittensor-finney.api.onfinality.io"),
+      false,
+    );
+  });
+
   test("rejects the 100.64.0.0/10 CGNAT range as a plain dotted IPv4 hostname", () => {
     assert.equal(isPrivateOrLocalHostname("100.64.0.1"), true);
     assert.equal(isPrivateOrLocalHostname("100.100.0.1"), true);
@@ -169,6 +178,18 @@ describe("isPrivateOrLocalHostname — CGNAT parity (#2312/#2313)", () => {
 
   test("still rejects the dotted-quad ::ffff: form directly (non-URL callers)", () => {
     assert.equal(isPrivateOrLocalHostname("::ffff:100.64.0.1"), true);
+  });
+
+  test("rejects native (non-v4-mapped) unique-local and link-local IPv6 literals", () => {
+    assert.equal(isPrivateOrLocalHostname("::1"), true);
+    assert.equal(isPrivateOrLocalHostname("::"), true);
+    assert.equal(isPrivateOrLocalHostname("fc00::1"), true);
+    assert.equal(isPrivateOrLocalHostname("fd12::1"), true);
+    assert.equal(isPrivateOrLocalHostname("fe80::1"), true);
+  });
+
+  test("does not reject a public IPv6 literal with no embedded v4", () => {
+    assert.equal(isPrivateOrLocalHostname("2606:4700:4700::1111"), false);
   });
 
   test("rejects IPv4-mapped/compatible/6to4/NAT64 forms of the other private ranges too", () => {

--- a/tests/rpc-endpoint-selection.test.mjs
+++ b/tests/rpc-endpoint-selection.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  isPrivateOrLocalHostname,
   orderSafeRpcEndpoints,
   selectSafeRpcEndpoint,
   weightedPickEndpoint,
@@ -137,5 +138,20 @@ describe("orderSafeRpcEndpoints — block-height routing", () => {
     const { endpoints } = orderSafeRpcEndpoints(pool, () => 0, opts);
     // null-block endpoint isn't demoted (can't judge) — both stay in the pool.
     assert.equal(endpoints.length, 2);
+  });
+});
+
+describe("isPrivateOrLocalHostname — CGNAT parity (#2312/#2313)", () => {
+  test("rejects the 100.64.0.0/10 CGNAT range, dotted and ::ffff:-mapped", () => {
+    assert.equal(isPrivateOrLocalHostname("100.64.0.1"), true);
+    assert.equal(isPrivateOrLocalHostname("100.100.0.1"), true);
+    assert.equal(isPrivateOrLocalHostname("100.127.255.255"), true);
+    assert.equal(isPrivateOrLocalHostname("::ffff:100.64.0.1"), true);
+  });
+
+  test("does not reject public addresses just outside the CGNAT range", () => {
+    assert.equal(isPrivateOrLocalHostname("100.63.255.255"), false);
+    assert.equal(isPrivateOrLocalHostname("100.128.0.0"), false);
+    assert.equal(isPrivateOrLocalHostname("8.8.8.8"), false);
   });
 });

--- a/tests/rpc-endpoint-selection.test.mjs
+++ b/tests/rpc-endpoint-selection.test.mjs
@@ -210,7 +210,7 @@ describe("isPrivateOrLocalHostname — CGNAT parity (#2312/#2313)", () => {
     assert.equal(isPrivateOrLocalHostname("2606:4700:4700::1111"), false);
   });
 
-  test("rejects IPv4-mapped/compatible/6to4/NAT64 forms of the other private ranges too", () => {
+  test("rejects IPv4-mapped forms of the other private ranges too", () => {
     // ::ffff:127.0.0.1 -> hex-tail ::ffff:7f00:1
     assert.equal(
       isPrivateOrLocalHostname(new URL("https://[::ffff:127.0.0.1]/").hostname),
@@ -223,5 +223,25 @@ describe("isPrivateOrLocalHostname — CGNAT parity (#2312/#2313)", () => {
       ),
       true,
     );
+  });
+
+  // ipv6EmbeddedIpv4 (src/ip-safety.mjs) recognizes three other textual forms
+  // that tunnel an IPv4 address inside IPv6 besides the ::ffff: mapped one
+  // exercised above; pin each so the RPC guard is verified for every form it
+  // now claims to handle, not just the mapped one.
+  test("rejects the deprecated IPv4-compatible ::a.b.c.d form (127.0.0.1)", () => {
+    const hostname = new URL("https://[::127.0.0.1]/").hostname;
+    assert.equal(hostname, "[::7f00:1]");
+    assert.equal(isPrivateOrLocalHostname(hostname), true);
+  });
+
+  test("rejects a 6to4 (2002::/16) literal embedding a private v4 (127.0.0.1)", () => {
+    const hostname = new URL("https://[2002:7f00:1::]/").hostname;
+    assert.equal(isPrivateOrLocalHostname(hostname), true);
+  });
+
+  test("rejects a NAT64 (64:ff9b::/96) literal embedding a private v4 (127.0.0.1)", () => {
+    const hostname = new URL("https://[64:ff9b::7f00:1]/").hostname;
+    assert.equal(isPrivateOrLocalHostname(hostname), true);
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -114,6 +114,7 @@ import {
   handleRpcProxyRequest,
   handleRpcUsage,
   handleSurfaceVerify,
+  isPrivateOrLocalHostname,
   isRpcEndpointEjected,
   orderSafeRpcEndpoints,
   proxyWithFailover,
@@ -350,6 +351,7 @@ export {
 // module (their public test surface is api.mjs, not the new file).
 export {
   classifyUpstreamAttempt,
+  isPrivateOrLocalHostname,
   isRpcEndpointEjected,
   orderSafeRpcEndpoints,
   proxyWithFailover,

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -1000,7 +1000,12 @@ function isSafeRpcEndpointUrl(value) {
   return !isPrivateOrLocalHostname(parsed.hostname);
 }
 
-function isPrivateOrLocalHostname(hostname) {
+// Exported for direct unit testing: TRUSTED_RPC_UPSTREAM_ORIGINS is a fixed set
+// of registered domains, so no currently-configured origin can ever reach the
+// private-IP branches below through isSafeRpcEndpointUrl alone — this is
+// defense in depth against a future origin entry resolving privately, the same
+// posture health-probe-core.mjs's isUnsafePublicUrl documents for its guard.
+export function isPrivateOrLocalHostname(hostname) {
   const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
   if (host === "localhost" || host.endsWith(".localhost")) {
     return true;
@@ -1015,7 +1020,10 @@ function isPrivateOrLocalHostname(hostname) {
       first === 127 ||
       (first === 169 && second === 254) ||
       (first === 172 && second >= 16 && second <= 31) ||
-      (first === 192 && second === 168)
+      (first === 192 && second === 168) ||
+      // 100.64.0.0/10 CGNAT — the webhook, build, and health-probe SSRF guards
+      // already block this range (#2312/#2313); keep this guard at parity.
+      (first === 100 && second >= 64 && second <= 127)
     );
   }
 
@@ -1029,7 +1037,8 @@ function isPrivateOrLocalHostname(hostname) {
     host.startsWith("::ffff:10.") ||
     host.startsWith("::ffff:169.254.") ||
     host.startsWith("::ffff:192.168.") ||
-    /^::ffff:172\.(1[6-9]|2\d|3[0-1])\./.test(host)
+    /^::ffff:172\.(1[6-9]|2\d|3[0-1])\./.test(host) ||
+    /^::ffff:100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(host)
   );
 }
 

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -49,6 +49,7 @@ import {
   workerResolvedUrlSafetyGuard,
   workerWebSocketConnector,
 } from "../../src/health-prober.mjs";
+import { ipv6EmbeddedIpv4 } from "../../src/ip-safety.mjs";
 import { overlayRpcPoolEligibility } from "../../src/health-serving.mjs";
 import { loadRpcUsage } from "../../src/rpc-usage-loader.mjs";
 import {
@@ -1000,6 +1001,23 @@ function isSafeRpcEndpointUrl(value) {
   return !isPrivateOrLocalHostname(parsed.hostname);
 }
 
+// Shared IPv4 private/CGNAT-range predicate — applied both to a bare IPv4
+// hostname and to the v4 address embedded in an IPv4-mapped/compatible/6to4/
+// NAT64 IPv6 literal (see below). [first, second] are the leading two octets.
+function isPrivateIpv4Octets([first, second]) {
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    // 100.64.0.0/10 CGNAT — the webhook, build, and health-probe SSRF guards
+    // already block this range (#2312/#2313); keep this guard at parity.
+    (first === 100 && second >= 64 && second <= 127)
+  );
+}
+
 // Exported for direct unit testing: TRUSTED_RPC_UPSTREAM_ORIGINS is a fixed set
 // of registered domains, so no currently-configured origin can ever reach the
 // private-IP branches below through isSafeRpcEndpointUrl alone — this is
@@ -1013,33 +1031,28 @@ export function isPrivateOrLocalHostname(hostname) {
 
   const ipv4 = parseIpv4Address(host);
   if (ipv4) {
-    const [first, second] = ipv4;
-    return (
-      first === 0 ||
-      first === 10 ||
-      first === 127 ||
-      (first === 169 && second === 254) ||
-      (first === 172 && second >= 16 && second <= 31) ||
-      (first === 192 && second === 168) ||
-      // 100.64.0.0/10 CGNAT — the webhook, build, and health-probe SSRF guards
-      // already block this range (#2312/#2313); keep this guard at parity.
-      (first === 100 && second >= 64 && second <= 127)
-    );
+    return isPrivateIpv4Octets(ipv4);
   }
 
-  return (
+  if (
     host === "::" ||
     host === "::1" ||
     host.startsWith("fc") ||
     host.startsWith("fd") ||
-    host.startsWith("fe80") ||
-    host.startsWith("::ffff:127.") ||
-    host.startsWith("::ffff:10.") ||
-    host.startsWith("::ffff:169.254.") ||
-    host.startsWith("::ffff:192.168.") ||
-    /^::ffff:172\.(1[6-9]|2\d|3[0-1])\./.test(host) ||
-    /^::ffff:100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(host)
-  );
+    host.startsWith("fe80")
+  ) {
+    return true;
+  }
+
+  // The WHATWG URL parser re-serializes an IPv4-mapped/compatible/6to4/NAT64
+  // IPv6 literal into hex-tail form (e.g. the bracketed literal for
+  // ::ffff:100.64.0.1 becomes ::ffff:6440:1 in `new URL(...).hostname`), so a
+  // dotted-quad string-prefix match against that value never fires on the real
+  // request path. Parse the embedded v4 the same way src/webhooks.mjs and
+  // src/health-probe-core.mjs already do (via the shared src/ip-safety.mjs
+  // leaf) and re-check it against the same private-range policy.
+  const embedded = ipv6EmbeddedIpv4(host);
+  return embedded ? isPrivateIpv4Octets(embedded) : false;
 }
 
 function parseIpv4Address(host) {


### PR DESCRIPTION
## Summary

Re-opens #2509, which the maintainer closed after a branch-update merge landed the just-merged patch-coverage-target bump (#2499, 80% -> 99%) onto the PR before CI re-ran, failing `codecov/patch` on an otherwise-reviewed, no-blocker change. Rebased onto current `main` with the same three commits; no code changes since the last review pass.

- `isPrivateOrLocalHostname` (`workers/request-handlers/rpc-proxy.mjs`), the literal-hostname guard `isSafeRpcEndpointUrl` relies on before proxying a request to a `TRUSTED_RPC_UPSTREAM_ORIGINS` endpoint, checked `0.0.0.0/8`, `10.0.0.0/8`, `127.0.0.0/8`, `169.254.0.0/16`, `172.16.0.0/12`, and `192.168.0.0/16` but had no `100.64.0.0/10` (RFC 6598 CGNAT) check. The repo's three other literal SSRF guards (`scripts/lib.mjs`, `src/webhooks.mjs`, `src/health-probe-core.mjs`) already block this range, added deliberately in #2312/#2313 so every guard stays in parity; this one was never updated.
- The first review pass caught a deeper, real defect in the fix-up: the WHATWG URL parser re-serializes an IPv4-mapped IPv6 literal into hex-tail form (`[::ffff:100.64.0.1]` -> hostname `"[::ffff:6440:1]"`), so a dotted-quad string-prefix match against that value never fires on the real request path — this affected every pre-existing `::ffff:`-mapped range check in the guard, not just the new one. Fixed by reusing the shared `ipv6EmbeddedIpv4` parser (`src/ip-safety.mjs`) that `src/webhooks.mjs` / `src/health-probe-core.mjs` already use for exactly this reason, instead of string-prefix/regex matching.
- A follow-up commit closed the one codecov-flagged uncovered line (the `localhost`/`.localhost` branch, never directly tested since the function was only just exported for testing in this PR).

## What Changed

- `workers/request-handlers/rpc-proxy.mjs` — `isPrivateOrLocalHostname` factors its IPv4 range check into `isPrivateIpv4Octets`, applies it to both a bare IPv4 hostname and the v4 embedded in a mapped/compatible/6to4/NAT64 IPv6 literal (via `ipv6EmbeddedIpv4`), and now includes `100.64.0.0/10`. The function is exported for direct unit testing, matching how `isUnsafePublicUrl` is tested in `tests/health-probe-core.test.mjs`.
- `workers/api.mjs` — re-export `isPrivateOrLocalHostname` alongside the other rpc-proxy test-facing helpers.
- `tests/rpc-endpoint-selection.test.mjs` — full coverage of the new/changed branches: the CGNAT range (dotted, real `new URL(...).hostname` normalized form, and direct dotted `::ffff:` callers), the other private ranges through their normalized mapped form, native (non-mapped) unique-local/link-local literals, a public-IPv6-with-no-embedded-v4 negative, `localhost`, and a public-domain negative.

No schema/contract change — this only tightens an internal safety predicate; `TRUSTED_RPC_UPSTREAM_ORIGINS` is a fixed set of registered domains today, so this is defense in depth against a future origin resolving into a private range, the same posture the original #2312/#2313 fix documents for its own guard.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A — no generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — no public contract change.)

## Validation

- [x] `npm run lint`
- [x] `npx prettier --check` on the three changed files
- [x] `git diff --check`
- [x] `npx vitest run tests/rpc-endpoint-selection.test.mjs tests/rpc-failover.test.mjs tests/health-probe-core.test.mjs tests/webhooks-core.test.mjs` (224/224 passing)
- [x] Targeted lcov coverage check confirms every changed line in `workers/request-handlers/rpc-proxy.mjs`'s new/edited region is exercised
- [x] `npm run scan:public-safety`
