### PR TITLE
fix(api): add min_samples filter to subnet uptime route (#2582)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1592,7 +1592,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). */
+        /** Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). Optional `min_samples` excludes sparse days whose summed sample count falls below the bound. */
         get: operations["subnetUptime"];
         put?: never;
         post?: never;
@@ -18374,6 +18374,7 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "90d" | "1y";
+                min_samples?: number;
             };
             header?: never;
             path: {

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5425,7 +5425,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/uptime.json",
       "cache": "short",
-      "description": "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup).",
+      "description": "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). Optional `min_samples` excludes sparse days whose summed sample count falls below the bound.",
       "id": "subnet-uptime",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/uptime",
@@ -5441,6 +5441,13 @@
               "1y"
             ],
             "type": "string"
+          }
+        },
+        {
+          "name": "min_samples",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -786,7 +786,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-30.12",
-      "description": "Long-term daily uptime history per operational surface for one subnet (90d/1y window), served live from the surface_uptime_daily D1 rollup (no static file).",
+      "description": "Long-term daily uptime history per operational surface for one subnet (90d/1y window), served live from the surface_uptime_daily D1 rollup (no static file). Optional `min_samples` excludes sparse days whose summed sample count falls below the bound.",
       "id": "subnet-uptime",
       "path": "/metagraph/subnets/{netuid}/uptime.json",
       "schema_ref": "#/components/schemas/UptimeArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -34468,6 +34468,15 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "min_samples",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -34608,7 +34617,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup).",
+        "summary": "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). Optional `min_samples` excludes sparse days whose summed sample count falls below the bound.",
         "tags": [
           "health",
           "subnets",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1592,7 +1592,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). */
+        /** Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). Optional `min_samples` excludes sparse days whose summed sample count falls below the bound. */
         get: operations["subnetUptime"];
         put?: never;
         post?: never;
@@ -18374,6 +18374,7 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "90d" | "1y";
+                min_samples?: number;
             };
             header?: never;
             path: {

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1135,7 +1135,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "subnet-uptime",
     "/metagraph/subnets/{netuid}/uptime.json",
-    "Long-term daily uptime history per operational surface for one subnet (90d/1y window), served live from the surface_uptime_daily D1 rollup (no static file).",
+    "Long-term daily uptime history per operational surface for one subnet (90d/1y window), served live from the surface_uptime_daily D1 rollup (no static file). Optional `min_samples` excludes sparse days whose summed sample count falls below the bound.",
     "UptimeArtifact",
   ),
   artifact(

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2307,10 +2307,13 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/uptime",
     "/metagraph/subnets/{netuid}/uptime.json",
-    "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup).",
+    "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). Optional `min_samples` excludes sparse days whose summed sample count falls below the bound.",
     "short",
     ["health", "subnets", "analytics"],
-    [{ name: "window", schema: { type: "string", enum: ["90d", "1y"] } }],
+    [
+      { name: "window", schema: { type: "string", enum: ["90d", "1y"] } },
+      { name: "min_samples", schema: { type: "integer", minimum: 0 } },
+    ],
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -5,6 +5,7 @@
 import assert from "node:assert/strict";
 import { describe, test, beforeEach } from "vitest";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+import { MAX_UPTIME_ROWS } from "../workers/config.mjs";
 import {
   canonicalCompareCachePath,
   canonicalEconomicsTrendsCachePath,
@@ -289,6 +290,79 @@ describe("handleUptime", () => {
     assert.equal(body.data.surfaces[0].surface_id, "sn-7-acme-subnet-api");
     assert.equal(body.data.surfaces[0].days[0].uptime_ratio, 0.9);
   });
+
+  test("rejects a malformed min_samples value", async () => {
+    const res = await handleUptime(
+      req("/"),
+      {},
+      NETUID,
+      url("/?window=90d&min_samples=bogus"),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "min_samples");
+  });
+
+  test("adds a HAVING SUM(samples) >= ? clause when min_samples is present", async () => {
+    const seen = [];
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              seen.push({ sql, params });
+              return {
+                async all() {
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+
+    await json(
+      await handleUptime(
+        req("/"),
+        env,
+        NETUID,
+        url("/?window=1y&min_samples=3"),
+      ),
+    );
+
+    assert.match(seen[0].sql, /HAVING SUM\(samples\) >= \?/);
+    assert.equal(seen[0].params[0], NETUID);
+    assert.equal(seen[0].params[2], 3);
+    assert.equal(seen[0].params[3], MAX_UPTIME_ROWS);
+  });
+
+  test("omits the HAVING clause when min_samples is absent", async () => {
+    const seen = [];
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              seen.push({ sql, params });
+              return {
+                async all() {
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+
+    await json(
+      await handleUptime(req("/"), env, NETUID, url("/?window=90d")),
+    );
+
+    assert.doesNotMatch(seen[0].sql, /HAVING SUM\(samples\) >= \?/);
+    assert.equal(seen[0].params[0], NETUID);
+    assert.equal(seen[0].params[2], MAX_UPTIME_ROWS);
+  });
 });
 
 describe("handleLeaderboards", () => {
@@ -472,6 +546,15 @@ describe("canonicalUptimeCachePath", () => {
     );
   });
 
+  test("includes min_samples in the normalized cache key", () => {
+    assert.equal(
+      canonicalUptimeCachePath(
+        url("/api/v1/subnets/7/uptime?min_samples=3&window=90d"),
+      ),
+      "/api/v1/subnets/7/uptime?window=90d&min_samples=3",
+    );
+  });
+
   test("falls back to raw search on unknown query param", () => {
     const raw = "/api/v1/subnets/7/uptime?unknown=x";
     assert.equal(canonicalUptimeCachePath(url(raw)), raw);
@@ -479,6 +562,11 @@ describe("canonicalUptimeCachePath", () => {
 
   test("falls back to raw search on invalid window value", () => {
     const raw = "/api/v1/subnets/7/uptime?window=7d";
+    assert.equal(canonicalUptimeCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid min_samples value", () => {
+    const raw = "/api/v1/subnets/7/uptime?window=90d&min_samples=bogus";
     assert.equal(canonicalUptimeCachePath(url(raw)), raw);
   });
 });

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -298,6 +298,7 @@ describe("handleUptime", () => {
       NETUID,
       url("/?window=90d&min_samples=bogus"),
     );
+    assert.equal(res.status, 400);
     const body = await errorJson(res);
     assert.equal(body.meta.parameter, "min_samples");
   });
@@ -334,6 +335,41 @@ describe("handleUptime", () => {
     assert.equal(seen[0].params[0], NETUID);
     assert.equal(seen[0].params[2], 3);
     assert.equal(seen[0].params[3], MAX_UPTIME_ROWS);
+  });
+
+  test("min_samples excludes rows below the requested sample threshold", async () => {
+    const env = d1Env({
+      "FROM surface_uptime_daily": [
+        {
+          surface_id: "sn-7-kept-subnet-api",
+          surface_key: "kept",
+          day: "2026-06-02",
+          samples: 5,
+          ok_count: 5,
+          uptime_ratio: 1,
+          avg_latency_ms: 100,
+          latency_samples: 5,
+          p50: 100,
+          p95: 110,
+          p99: 120,
+          status: "ok",
+        },
+      ],
+    });
+
+    const body = await json(
+      await handleUptime(
+        req("/"),
+        env,
+        NETUID,
+        url("/?window=90d&min_samples=5"),
+      ),
+    );
+
+    assert.equal(body.data.surfaces.length, 1);
+    assert.equal(body.data.surfaces[0].surface_id, "sn-7-kept-subnet-api");
+    assert.equal(body.data.surfaces[0].days.length, 1);
+    assert.equal(body.data.surfaces[0].days[0].samples, 5);
   });
 
   test("omits the HAVING clause when min_samples is absent", async () => {

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -391,9 +391,7 @@ describe("handleUptime", () => {
       },
     };
 
-    await json(
-      await handleUptime(req("/"), env, NETUID, url("/?window=90d")),
-    );
+    await json(await handleUptime(req("/"), env, NETUID, url("/?window=90d")));
 
     assert.doesNotMatch(seen[0].sql, /HAVING SUM\(samples\) >= \?/);
     assert.equal(seen[0].params[0], NETUID);

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -10,6 +10,7 @@
 
 import { DAY_MS, MAX_UPTIME_ROWS, UPTIME_WINDOWS } from "../config.mjs";
 import { errorResponse } from "../http.mjs";
+import { parseNonNegativeIntParam } from "../request-params.mjs";
 import { readArtifact } from "../storage.mjs";
 import { contractVersion, envelopeResponse } from "../responses.mjs";
 import {
@@ -117,7 +118,7 @@ export async function handleEconomicsTrends(request, env, url) {
 
 // Long-term daily uptime history for one subnet's operational surfaces.
 export async function handleUptime(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "min_samples"]);
   if (validationError) return analyticsQueryError(validationError);
   const windowParam = url.searchParams.get("window") || "90d";
   if (!Object.hasOwn(UPTIME_WINDOWS, windowParam)) {
@@ -128,37 +129,48 @@ export async function handleUptime(request, env, netuid, url) {
       { parameter: "window" },
     );
   }
+  const minSamples = parseNonNegativeIntParam(
+    url.searchParams.get("min_samples"),
+    "min_samples",
+  );
+  if (minSamples.error) return analyticsQueryError(minSamples.error);
   const days = UPTIME_WINDOWS[windowParam];
   const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
     .toISOString()
     .slice(0, 10);
+  const params = [netuid, cutoff];
+  let sql = `SELECT MAX(surface_id) AS surface_id,
+                    COALESCE(surface_key, surface_id) AS surface_key,
+                    day,
+                    SUM(samples) AS samples,
+                    SUM(ok_count) AS ok_count,
+                    CASE
+                      WHEN SUM(samples) > 0 THEN ROUND(CAST(SUM(ok_count) AS REAL) / SUM(samples), 4)
+                      ELSE NULL
+                    END AS uptime_ratio,
+                    ${dailyLatencyColumns({ roundedAvg: true })},
+                    MAX(p50_latency_ms) AS p50,
+                    MAX(p95_latency_ms) AS p95,
+                    MAX(p99_latency_ms) AS p99,
+                    CASE
+                      WHEN SUM(samples) = 0 THEN 'unknown'
+                      WHEN SUM(ok_count) = SUM(samples) THEN 'ok'
+                      WHEN SUM(ok_count) = 0 THEN 'failed'
+                      ELSE 'degraded'
+                    END AS status
+             FROM surface_uptime_daily
+             WHERE netuid = ? AND day >= ?
+             GROUP BY COALESCE(surface_key, surface_id), day`;
+  if (minSamples.value !== null) {
+    sql += " HAVING SUM(samples) >= ?";
+    params.push(minSamples.value);
+  }
+  sql += " ORDER BY day DESC LIMIT ?";
+  params.push(MAX_UPTIME_ROWS);
   const rows = await d1All(
     env,
-    `SELECT MAX(surface_id) AS surface_id,
-            COALESCE(surface_key, surface_id) AS surface_key,
-            day,
-            SUM(samples) AS samples,
-            SUM(ok_count) AS ok_count,
-            CASE
-              WHEN SUM(samples) > 0 THEN ROUND(CAST(SUM(ok_count) AS REAL) / SUM(samples), 4)
-              ELSE NULL
-            END AS uptime_ratio,
-            ${dailyLatencyColumns({ roundedAvg: true })},
-            MAX(p50_latency_ms) AS p50,
-            MAX(p95_latency_ms) AS p95,
-            MAX(p99_latency_ms) AS p99,
-            CASE
-              WHEN SUM(samples) = 0 THEN 'unknown'
-              WHEN SUM(ok_count) = SUM(samples) THEN 'ok'
-              WHEN SUM(ok_count) = 0 THEN 'failed'
-              ELSE 'degraded'
-            END AS status
-     FROM surface_uptime_daily
-     WHERE netuid = ? AND day >= ?
-     GROUP BY COALESCE(surface_key, surface_id), day
-     ORDER BY day DESC
-     LIMIT ?`,
-    [netuid, cutoff, MAX_UPTIME_ROWS],
+    sql,
+    params,
   );
   const healthMeta = await readHealthMetaKv(env);
   const data = formatUptime({
@@ -187,12 +199,23 @@ export async function handleUptime(request, env, netuid, url) {
 // ?window=90d request both resolve to the same edge-cache entry — mirrors
 // canonicalSubnetConcentrationHistoryCachePath in entities.mjs.
 export function canonicalUptimeCachePath(url) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "min_samples"]);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam = url.searchParams.get("window") || "90d";
   if (!Object.hasOwn(UPTIME_WINDOWS, windowParam))
     return `${url.pathname}${url.search}`;
-  return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
+  const minSamples = parseNonNegativeIntParam(
+    url.searchParams.get("min_samples"),
+    "min_samples",
+  );
+  if (minSamples.error) return `${url.pathname}${url.search}`;
+  const params = new URLSearchParams({
+    window: windowParam,
+  });
+  if (minSamples.value !== null) {
+    params.set("min_samples", String(minSamples.value));
+  }
+  return `${url.pathname}?${params.toString()}`;
 }
 
 // Normalises the economics-trends URL so that a bare ?-free request and an explicit

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -209,9 +209,10 @@ export function canonicalUptimeCachePath(url) {
     "min_samples",
   );
   if (minSamples.error) return `${url.pathname}${url.search}`;
-  const params = new URLSearchParams({
-    window: windowParam,
-  });
+  const normalized = new URL(url.toString());
+  normalized.search = "";
+  const params = normalized.searchParams;
+  params.set("window", windowParam);
   if (minSamples.value !== null) {
     params.set("min_samples", String(minSamples.value));
   }

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -167,11 +167,7 @@ export async function handleUptime(request, env, netuid, url) {
   }
   sql += " ORDER BY day DESC LIMIT ?";
   params.push(MAX_UPTIME_ROWS);
-  const rows = await d1All(
-    env,
-    sql,
-    params,
-  );
+  const rows = await d1All(env, sql, params);
   const healthMeta = await readHealthMetaKv(env);
   const data = formatUptime({
     netuid,


### PR DESCRIPTION
## Summary
Adds validated `?min_samples=` support to `GET /api/v1/subnets/{netuid}/uptime`.
This change:
- accepts a non-negative integer `min_samples`
- filters uptime rows with `HAVING SUM(samples) >= ?`
- keeps invalid values on a clean `400` path
- updates the API contract and generated artifacts
- includes cache-key normalization for `min_samples`
## Related Issue
Closes: #2582 
## Change Type
- [x] Bug fix
- [x] API contract change
- [x] Tests
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor

## Real Behavior Proof

### Before
- `/api/v1/subnets/{netuid}/uptime` could not filter out low-sample days.
- `min_samples` was not accepted or documented.

### After
- `/api/v1/subnets/{netuid}/uptime?min_samples=3` returns only days where `SUM(samples) >= 3`.
- malformed `min_samples` returns `400`
- cache normalization includes `min_samples`
- OpenAPI/types expose the new query parameter

## Validation
- [x] `npm test -- --run tests/request-handlers-analytics-routes.test.mjs`
- [x] `npm run build`
- [x] `npm run validate:contract-drift`
- [x] `npm test -- --run tests/contracts.test.mjs tests/request-handlers-analytics-routes.test.mjs`

## Checklist
- [x] Scoped to one issue
- [x] Added regression coverage
- [x] Regenerated committed contract artifacts
- [x] No unrelated generated files included
- [x] No AI attribution in commit/PR text