### PR TITLE
chore(enrich): taostats identity gap-fills

### DIFF
--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -8,6 +8,8 @@
   "netuid": 94,
   "schema_version": 1,
   "slug": "sn-94",
+  "social": { "x": "https://x.com/bitsota" },
+  "source_repo": "https://github.com/AlveusLabs/SN94-BitSota",
   "status": "active",
   "surfaces": [
     {

--- a/registry/subnets/nodexo.json
+++ b/registry/subnets/nodexo.json
@@ -15,7 +15,7 @@
   "website_url": "https://nodexo.ai/",
   "docs_url": "https://docs.nodexo.ai/",
   "dashboard_url": "https://console.nodexo.ai/",
-  "source_repo": null,
+  "source_repo": "https://github.com/nodexo-ai/nodexo",
   "baseline_excluded_surface_ids": [
     "sn-106-taomarketcap-source-repo",
     "sn-106-taomarketcap-website",


### PR DESCRIPTION
Taostats identity gap-fills from third-party taostats API — human review required before merge.

## Subnets touched

| Subnet | Field | Value | Source |
|--------|-------|-------|--------|
| SN94 Bitsota | `source_repo` | https://github.com/AlveusLabs/SN94-BitSota | taostats `github_repo` |
| SN94 Bitsota | `social.x` | https://x.com/bitsota | taostats `twitter` |
| SN106 Nodexo | `source_repo` | https://github.com/nodexo-ai/nodexo | taostats `github_repo` (HTTP 200 verified) |

## What was skipped (and why)

- **SN29 (coldint)**: taostats twitter `@cacheon_ai` is wrong data (Cacheon is SN14) — skipped
- **SN40 (chunking)**: taostats name "Ralph" vs registry "Chunking" — name mismatch, skipped
- **SN58 (handshake58)**: taostats name "greevils" vs registry "Handshake58" — name mismatch, skipped  
- **SN28 (gm)**: taostats source_repo (`taostat/gm-miner`) — ambiguous ownership, skipped
- **SN110 (green-compute)**: taostats twitter `@vocence_bt` — not clearly corroborated, skipped
- **SN107 (minos)**: all fields already populated in main

## Provenance

All values sourced from `api.taostats.io/api/subnet/identity/v1` — third-party data.
Gap-fill only: no existing fields overwritten.