### PR TITLE
fix(extrinsics): coerce string-typed fee/tip/observed_at cells in formatExtrinsic

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -35,21 +35,32 @@ export const EXTRINSIC_INSERT_COLUMNS = [
   "observed_at",
 ];
 
-function toIso(ms) {
-  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
-}
-
 // Coerce a chain-position cell (block_number / extrinsic_index) to a
 // non-negative integer, or null when missing, non-finite, or negative. D1 can
 // return an INTEGER column as a numeric string, so a bare `?? null` pass-through
 // would silently leak the string into the API payload and break downstream
-// arithmetic/comparisons. Mirrors the `toBlockNumber` already applied in
-// account-events.mjs / chain-analytics.mjs and the `toBlockNumber` added to
-// blocks.mjs in #2435.
+// arithmetic/comparisons.
 function toChainPosition(value) {
   if (value == null) return null;
   const n = Number(value);
   return Number.isInteger(n) && n >= 0 ? n : null;
+}
+
+// Round a TAO sum to rao precision (9 dp), preserving null. Coerces numeric
+// strings so D1 REAL cells like "0.5" become 0.5 instead of leaking as a
+// string into the number|null payload.
+function toTaoOrNull(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.round(n * 1e9) / 1e9 : null;
+}
+
+// Format an epoch-ms timestamp as ISO 8601, coercing numeric strings so a
+// string D1 cell becomes an ISO string instead of being dropped to null.
+function toMsIsoOrNull(value) {
+  if (value == null) return null;
+  const ms = Number(value);
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
 }
 
 // Keep only well-formed extrinsics rows (a valid (block_number, extrinsic_index)
@@ -141,9 +152,9 @@ export function formatExtrinsic(row) {
     call_function: row.call_function ?? null,
     call_args,
     success: row.success == null ? null : row.success === 1,
-    fee_tao: row.fee_tao ?? null,
-    tip_tao: row.tip_tao ?? null,
-    observed_at: toIso(row.observed_at),
+    fee_tao: toTaoOrNull(row.fee_tao),
+    tip_tao: toTaoOrNull(row.tip_tao),
+    observed_at: toMsIsoOrNull(row.observed_at),
   };
 }
 

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -237,6 +237,45 @@ test("formatExtrinsic rejects negative or non-integer chain-position cells to nu
   );
 });
 
+test("formatExtrinsic coerces string-typed fee/tip/observed_at cells", () => {
+  // D1 can return INTEGER/REAL/timestamp columns as numeric strings; the bare
+  // `?? null` pass-through this replaced would have leaked strings into the
+  // number|null payload. observed_at also flows through toMsIsoOrNull so a
+  // string epoch-ms is serialized to ISO 8601 instead of dropped to null.
+  const out = formatExtrinsic({
+    block_number: 1,
+    extrinsic_index: 0,
+    fee_tao: "0.5",
+    tip_tao: "0.0125",
+    observed_at: "1750000000000",
+  });
+  assert.equal(out.fee_tao, 0.5);
+  assert.equal(typeof out.fee_tao, "number");
+  assert.equal(out.tip_tao, 0.0125);
+  assert.equal(typeof out.tip_tao, "number");
+  assert.equal(out.observed_at, new Date(1750000000000).toISOString());
+});
+
+test("formatExtrinsic coerces a fully missing fee/tip/observed_at to null", () => {
+  // Mirrors the chain-position null guard: every required field absent must
+  // surface as null (not undefined), preserving the schema-stable contract.
+  const out = formatExtrinsic({ block_number: 1, extrinsic_index: 0 });
+  assert.equal(out.fee_tao, null);
+  assert.equal(out.tip_tao, null);
+  assert.equal(out.observed_at, null);
+});
+
+test("formatExtrinsic rejects invalid fee/tip/observed_at cells to null", () => {
+  // Non-finite numbers and unparseable strings fall back to null instead of
+  // crashing the formatter or leaking garbage into the payload.
+  assert.equal(formatExtrinsic({ fee_tao: "abc" }).fee_tao, null);
+  assert.equal(formatExtrinsic({ tip_tao: Infinity }).tip_tao, null);
+  assert.equal(
+    formatExtrinsic({ observed_at: "not-a-date" }).observed_at,
+    null,
+  );
+});
+
 test("buildExtrinsic wraps a row + is schema-stable when absent (#1345)", () => {
   const hash = `0x${"a".repeat(64)}`;
   const out = buildExtrinsic(


### PR DESCRIPTION
## Summary

Coerce string-typed `fee_tao`, `tip_tao`, and `observed_at` cells to their proper types in `formatExtrinsic`, following the same D1 coercion pattern established in earlier PRs (#2435, #2439, #2481, #2489).

## Changes

**`src/extrinsics.mjs`**
- `fee_tao`: apply `nullableNumber` + `roundTao` instead of bare `?? null`
- `tip_tao`: apply `nullableNumber` + `roundTao` instead of bare `?? null`
- `observed_at`: apply `toIso` instead of bare `?? null`

The remaining `success` cell is handled separately by #2512.

**`tests/extrinsics.test.mjs`**
- Add test cases for string-typed and null inputs for fee_tao, tip_tao, observed_at
