### PR TITLE
fix(metagraph): report null block_number as null in the global validators leaderboard

### DIFF
--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -61,6 +61,10 @@ function nullableNumber(value) {
 }
 
 function nonNegativeInt(value) {
+  // Guard null first: Number(null) === 0, so a null column (block_number is a
+  // nullable INTEGER) would masquerade as the real chain height / netuid / uid 0
+  // instead of "absent". A numeric string like "10" from D1 must still pass.
+  if (value == null) return null;
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
 }

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -325,6 +325,38 @@ describe("metagraph-neurons builders", () => {
     );
   });
 
+  test("buildGlobalValidators reports a null block_number as null, not a fabricated 0", () => {
+    // block_number is a nullable INTEGER column and the /validators query does not
+    // filter it, so a validator's newest capture can carry block_number: null.
+    // Number(null) === 0 must NOT surface as the real chain height 0 (block 0 is
+    // the genesis block, a height the neuron was never captured at).
+    const data = buildGlobalValidators(
+      [
+        {
+          ...ROW,
+          netuid: 1,
+          uid: 0,
+          hotkey: "hk-null-block",
+          block_number: null,
+          captured_at: 2000,
+        },
+        {
+          ...ROW,
+          netuid: 2,
+          uid: 1,
+          hotkey: "hk-null-block",
+          block_number: 99,
+          captured_at: 1000,
+        },
+      ],
+      { sort: "subnet_count", limit: 10 },
+    );
+    // Newest capture (captured_at 2000) has no block height → both the per-validator
+    // and top-level block numbers must be null.
+    assert.equal(data.block_number, null);
+    assert.equal(data.validators[0].latest_block_number, null);
+  });
+
   test("builders drop malformed rows and count only real neurons", () => {
     // A null/non-object row can't be a Neuron, so it must not leak into the
     // array — and the count tracks the array (neuron_count === neurons.length),


### PR DESCRIPTION
## Summary

`GET /api/v1/validators` (the global validator leaderboard) reported a fabricated `block_number: 0` / `latest_block_number: 0` for a validator whose newest capture has a **null** chain height, instead of the `null` the schema defines for an absent block.

`buildGlobalValidators` coerces the height through `nonNegativeInt`, and `Number(null) === 0` passes its `Number.isSafeInteger(parsed) && parsed >= 0` guard — so a null column returned the real genesis height `0` rather than falling through to `null`. `neurons.block_number` is a nullable INTEGER (`migrations/0007_neurons.sql:31`) and `loadGlobalValidators` does not filter it, so this is reachable. The contract already models an absent block as null (`GlobalValidatorsArtifact.block_number` and `GlobalValidatorEntry.latest_block_number` are both `["integer","null"]`), and the sibling `captured_at` already nulls correctly — so today the payload can emit `captured_at: null` next to a bogus `block_number: 0`.

## What Changed

- `src/metagraph-neurons.mjs` — `nonNegativeInt` now guards `value == null` before `Number(...)`, returning `null` for a null column while still accepting numeric strings (e.g. `"10"`). This also correctly rejects a null `netuid`/`uid`, routing such rows to the existing skip guard instead of mis-attributing them to subnet/UID 0.
- `tests/metagraph-neurons.test.mjs` — regression test: a validator whose newest capture has `block_number: null` reports `null` (not `0`) for both the per-validator `latest_block_number` and the artifact-level `block_number`. The test fails on the pre-fix code and passes after.

No schema/contract change, so no regenerated artifacts.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (no contract change; the fix aligns runtime output with the existing `["integer","null"]` contract)

## Validation

- [x] `npx vitest run tests/metagraph-neurons.test.mjs` — 29 passed (28 existing + the new regression case)
- [x] Regression test confirmed failing on the pre-fix tree, passing after the fix
- [x] `npx eslint src/metagraph-neurons.mjs tests/metagraph-neurons.test.mjs` — clean
- [x] `npx prettier --check --end-of-line auto` on both files — clean
- [x] `git diff --check` — clean
