### PR TITLE
feat(mcp): add get_subnet_yield mirroring REST /subnets/{netuid}/yield

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -368,6 +368,12 @@ assert.ok(
   Array.isArray(vals.validators),
   "list_subnet_validators must return validators[]",
 );
+const yieldCard = await callOk("get_subnet_yield", { netuid: 7 });
+assert.ok(
+  Array.isArray(yieldCard.neurons),
+  "get_subnet_yield must return neurons[]",
+);
+assert.equal(yieldCard.netuid, 7, "get_subnet_yield must echo the netuid");
 const neuron = await callOk("get_neuron", { netuid: 7, uid: 0 });
 assert.ok("neuron" in neuron, "get_neuron must return a neuron field");
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -110,6 +110,7 @@ import {
   parseHistoryWindow,
 } from "./neuron-history.mjs";
 import { loadSubnetTurnover } from "./turnover.mjs";
+import { loadSubnetYield } from "./subnet-yield.mjs";
 import { isFinneySs58Address, loadAccountBalance } from "./account-balance.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import { loadBlocks, loadBlock } from "./blocks.mjs";
@@ -146,7 +147,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.14.0";
+export const MCP_SERVER_VERSION = "1.15.0";
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -215,7 +216,9 @@ export const MCP_INSTRUCTIONS =
   "emission decentralization metrics (Gini, HHI, Nakamoto), " +
   "get_subnet_concentration_history the decentralization trend over time, " +
   "get_subnet_turnover validator-set and registration churn between two " +
-  "boundary snapshots, get_registry_leaderboards the live " +
+  "boundary snapshots, get_subnet_yield per-UID emission-per-stake return " +
+  "rates plus distribution percentiles over the current metagraph snapshot, " +
+  "get_registry_leaderboards the live " +
   "cross-subnet health/economics boards, compare_subnets a side-by-side view " +
   "across structure/economics/health, get_global_incidents recent cross-subnet " +
   "probe failures, get_chain_signers the windowed most-active-account " +
@@ -1752,6 +1755,30 @@ export const MCP_TOOLS = [
         windowLabel: label,
         windowDays: days,
       });
+    },
+  },
+  {
+    name: "get_subnet_yield",
+    title: "Get subnet emission yield distribution",
+    description:
+      "Fetch one subnet's per-UID emission yield (emission_tao over " +
+      "stake_tao) from the current metagraph snapshot: each UID ranked by " +
+      "return rate with stake, emission, role, and an above/below/at-median " +
+      "label, plus subnet aggregate yield and mean/p25/median/p75/p90 " +
+      "percentiles over UIDs with stake. Zero-stake UIDs get null yield and " +
+      "sink to the bottom. Snapshot-based (no time window). Mirrors " +
+      "GET /api/v1/subnets/{netuid}/yield.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      return loadSubnetYield(mcpD1Runner(ctx), netuid);
     },
   },
   {
@@ -4447,6 +4474,29 @@ const TOOL_OUTPUT_SCHEMAS = {
         emission_nakamoto_coefficient: ANY,
         emission_top_10pct_share: ANY,
       }),
+    },
+  },
+  get_subnet_yield: {
+    type: "object",
+    additionalProperties: true,
+    required: ["netuid", "neuron_count", "neurons"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      captured_at: NULLABLE_STRING,
+      block_number: NULLABLE_INT,
+      neuron_count: { type: "integer" },
+      validator_count: { type: "integer" },
+      miner_count: { type: "integer" },
+      total_stake_tao: { type: ["number", "null"] },
+      total_emission_tao: { type: ["number", "null"] },
+      subnet_yield: { type: ["number", "null"] },
+      mean_yield: { type: ["number", "null"] },
+      median_yield: { type: ["number", "null"] },
+      p25_yield: { type: ["number", "null"] },
+      p75_yield: { type: ["number", "null"] },
+      p90_yield: { type: ["number", "null"] },
+      neurons: { type: "array", items: { type: "object" } },
     },
   },
   get_subnet_turnover: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4564,6 +4564,56 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.validator_retention, 1);
   });
 
+  test("get_subnet_yield returns schema-stable empty on cold D1", async () => {
+    const res = await callTool("get_subnet_yield", { netuid: 7 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.neuron_count, 0);
+    assert.equal(out.subnet_yield, null);
+    assert.deepEqual(out.neurons, []);
+  });
+
+  test("get_subnet_yield ranks UIDs by emission-per-stake return", async () => {
+    const res = await callTool(
+      "get_subnet_yield",
+      { netuid: 7 },
+      {
+        env: {
+          METAGRAPH_HEALTH_DB: metagraphD1({
+            neurons: [
+              {
+                uid: 0,
+                hotkey: "5Hk0",
+                validator_permit: 1,
+                stake_tao: 10,
+                emission_tao: 1,
+                captured_at: 1750000000000,
+                block_number: 5000,
+              },
+              {
+                uid: 1,
+                hotkey: "5Hk1",
+                validator_permit: 0,
+                stake_tao: 10,
+                emission_tao: 3,
+                captured_at: 1750000000000,
+                block_number: 5000,
+              },
+            ],
+          }),
+        },
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.neuron_count, 2);
+    assert.equal(out.validator_count, 1);
+    assert.equal(out.subnet_yield, 0.2);
+    assert.equal(out.neurons[0].uid, 1);
+    assert.equal(out.neurons[0].yield, 0.3);
+    assert.equal(out.neurons[1].uid, 0);
+    assert.equal(out.neurons[1].yield, 0.1);
+  });
+
   test("the D1-backed tools degrade to schema-stable empty payloads when D1 is cold", async () => {
     const meta = await callTool("get_subnet_metagraph", { netuid: 7 });
     assert.equal(meta.body.result.isError, false);


### PR DESCRIPTION
## Summary

Adds MCP block-explorer parity for the live per-subnet emission yield route that landed in #2495. Agents can now read per-UID return rates from the current metagraph snapshot without falling back to HTTP.

| REST | MCP tool |
|------|----------|
| \GET /api/v1/subnets/{netuid}/yield\ | \get_subnet_yield\ |

### Implementation

- **\src/mcp-server.mjs\** — register \get_subnet_yield\, wire it to the shared \loadSubnetYield\ loader (\src/subnet-yield.mjs\), add \TOOL_OUTPUT_SCHEMAS\ entry, and list it in MCP instructions. MCP SemVer **1.14.0 → 1.15.0**.
- **\server.json\** — version **1.15.0** (registry listing stays in sync with \MCP_SERVER_VERSION\).
- **Tests** — cold-D1 empty-card test plus a mocked-neurons ranking test in \	ests/mcp-server.test.mjs\; \scripts/validate-mcp.mjs\ cold smoke for the new tool.

Both tools accept \
etuid\ only (snapshot-based, no window). Cold or empty D1 degrades to the schema-stable zeroed card with an empty \
eurons[]\, mirroring \get_subnet_metagraph\ and \list_subnet_validators\.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None touched — MCP tool only; reuses the existing loader.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public REST API/OpenAPI/schema change (MCP parity only).

## Validation

- [x] \git diff --check\
- [ ] \
px vitest run tests/mcp-server.test.mjs -t get_subnet_yield\ — no local Node 22 toolchain on this machine; CI runs the full vitest + validate-mcp suite on Linux.
- [ ] \
pm run validate:mcp\ — same; covered by repo CI.
