### PR TITLE
fix(api): 404 mainnet-only D1 analytics routes under a network prefix

### DIFF
--- a/tests/network-routing.test.mjs
+++ b/tests/network-routing.test.mjs
@@ -318,6 +318,14 @@ describe("multi-network routing prefix (Phase 1)", () => {
       "/api/v1/testnet/subnets/7/validators",
       "/api/v1/testnet/subnets/7/events",
       "/api/v1/testnet/subnets/7/health",
+      // D1-backed per-subnet analytics: also mainnet-only, must not fall through
+      // to a testnet R2 read that leaks the internal artifact key.
+      "/api/v1/testnet/subnets/7/concentration",
+      "/api/v1/testnet/subnets/7/concentration/history",
+      "/api/v1/testnet/subnets/7/turnover",
+      "/api/v1/testnet/subnets/7/stake-flow",
+      "/api/v1/testnet/subnets/7/yield",
+      `/api/v1/testnet/accounts/${SS58}/stake-flow`,
       "/api/v1/testnet/incidents",
 
       "/api/v1/testnet/rpc/usage",

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1674,6 +1674,11 @@ function isMainnetOnlyApiPath(pathname) {
     SUBNET_VALIDATORS_PATH_PATTERN.test(pathname) ||
     SUBNET_EVENTS_PATH_PATTERN.test(pathname) ||
     SUBNET_HISTORY_PATH_PATTERN.test(pathname) ||
+    SUBNET_CONCENTRATION_PATH_PATTERN.test(pathname) ||
+    SUBNET_CONCENTRATION_HISTORY_PATH_PATTERN.test(pathname) ||
+    SUBNET_TURNOVER_PATH_PATTERN.test(pathname) ||
+    SUBNET_STAKE_FLOW_PATH_PATTERN.test(pathname) ||
+    SUBNET_YIELD_PATH_PATTERN.test(pathname) ||
     ACCOUNT_PATH_PATTERN.test(pathname) ||
     ACCOUNT_EVENTS_PATH_PATTERN.test(pathname) ||
     ACCOUNT_HISTORY_PATH_PATTERN.test(pathname) ||
@@ -1681,6 +1686,7 @@ function isMainnetOnlyApiPath(pathname) {
     ACCOUNT_EXTRINSICS_PATH_PATTERN.test(pathname) ||
     ACCOUNT_TRANSFERS_PATH_PATTERN.test(pathname) ||
     ACCOUNT_COUNTERPARTIES_PATH_PATTERN.test(pathname) ||
+    ACCOUNT_STAKE_FLOW_PATH_PATTERN.test(pathname) ||
     ACCOUNT_BALANCE_PATH_PATTERN.test(pathname) ||
     BLOCKS_FEED_PATH_PATTERN.test(pathname) ||
     BLOCK_DETAIL_PATH_PATTERN.test(pathname) ||


### PR DESCRIPTION
## Summary

Under a `/{network}/` prefix (e.g. `testnet`), six mainnet-only D1-backed routes fell through the mainnet-only gate and leaked the **internal R2 artifact key** in their 404 message instead of returning the canonical mainnet-only 404.

`handleNetworkScopedRequest` relies on `isMainnetOnlyApiPath(pathname)` to reject live/D1 routes that aren't network-partitioned, returning `404 { meta.network, "…only available on mainnet…" }`. That allow-list enumerated most per-subnet/per-account D1 routes but **omitted six** that `handleRequest` only dispatches on mainnet:

- `/api/v1/subnets/{n}/concentration`
- `/api/v1/subnets/{n}/concentration/history`
- `/api/v1/subnets/{n}/turnover`
- `/api/v1/subnets/{n}/stake-flow`
- `/api/v1/subnets/{n}/yield`
- `/api/v1/accounts/{ss58}/stake-flow`

For these, a request like `GET /api/v1/testnet/subnets/7/concentration` skipped the gate and fell through to a testnet R2 read of a key that never exists, returning:

```
404  meta.network: undefined
error.message: "Artifact not found in R2: latest/testnet/subnets/7/concentration.json"
```

That both breaks the documented contract (sibling routes like `/metagraph` correctly return `meta.network: "testnet"` + "only available on mainnet") **and discloses the internal storage-key layout** — and for the account route it echoes the submitted SS58 back inside the R2 key string.

## What Changed

- `workers/api.mjs` — add the six missing patterns to `isMainnetOnlyApiPath` (`SUBNET_CONCENTRATION_PATH_PATTERN`, `SUBNET_CONCENTRATION_HISTORY_PATH_PATTERN`, `SUBNET_TURNOVER_PATH_PATTERN`, `SUBNET_STAKE_FLOW_PATH_PATTERN`, `SUBNET_YIELD_PATH_PATTERN`, `ACCOUNT_STAKE_FLOW_PATH_PATTERN`). All six identifiers were already imported. I verified the fix is **complete**: after it, the set of `*_PATH_PATTERN`s `handleRequest` dispatches minus the ones in the allow-list is empty.
- `tests/network-routing.test.mjs` — extend the existing "D1-backed live routes 404 under testnet with a mainnet-only message" contract test to cover all six routes.

No schema/contract change, so no regenerated artifacts. Only network-prefixed routing behavior changes; mainnet (bare-path) behavior is untouched, since `isMainnetOnlyApiPath` is called only from `handleNetworkScopedRequest`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (no contract change; this makes runtime match the already-tested mainnet-only 404 contract)

## Validation

- [x] `npx vitest run tests/network-routing.test.mjs` — 19 passed
- [x] Confirmed the extended contract test **fails on the pre-fix tree** (the six routes returned the leaked R2-key message with `meta.network: undefined`) and **passes after** the fix
- [x] Completeness check: every subnet/account/block/extrinsic `*_PATH_PATTERN` dispatched in `handleRequest` is now in the allow-list
- [x] `npx eslint workers/api.mjs tests/network-routing.test.mjs` — clean
- [x] `npx prettier --check --end-of-line auto` on both files — clean
- [x] `git diff --check` — clean
