### PR TITLE
fix(rpc-proxy): never cache a null JSON-RPC result under the block-read TTL

### DIFF
--- a/tests/rpc-cache.test.mjs
+++ b/tests/rpc-cache.test.mjs
@@ -160,6 +160,48 @@ describe("RPC response cache flow", () => {
     });
   });
 
+  test("a null result (block not produced yet) is never cached", async () => {
+    // chain_getBlockHash(N) returns result:null until block N exists. Caching
+    // that under the 3600s block-read TTL would replay the stale null after the
+    // block is produced. The first (null) call must not be cached, so the second
+    // call re-queries upstream and returns the now-available real hash.
+    const cache = makeCache();
+    let fetchCount = 0;
+    const fetchImpl = async () => {
+      fetchCount += 1;
+      const result = fetchCount === 1 ? null : "0xrealhash";
+      return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }), {
+        status: 200,
+      });
+    };
+    await withGlobals({ cache, fetchImpl }, async () => {
+      const waits = [];
+      const ctx = { waitUntil: (p) => waits.push(p) };
+      const r1 = await handleRequest(
+        reqFor("chain_getBlockHash", [999999999]),
+        env,
+        ctx,
+      );
+      assert.equal(r1.headers.get("x-metagraph-rpc-cache"), "miss");
+      assert.equal((await r1.json()).result, null);
+      await Promise.all(waits);
+      assert.equal(cache.store.size, 0, "a null result must never be cached");
+
+      const r2 = await handleRequest(
+        reqFor("chain_getBlockHash", [999999999]),
+        env,
+        ctx,
+      );
+      assert.equal(r2.headers.get("x-metagraph-rpc-cache"), "miss");
+      assert.equal(
+        fetchCount,
+        2,
+        "second call must re-query upstream, not replay null",
+      );
+      assert.equal((await r2.json()).result, "0xrealhash");
+    });
+  });
+
   test("cache hits preserve the current request id (no cross-caller replay)", async () => {
     const cache = makeCache();
     let fetchCount = 0;

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -506,7 +506,16 @@ export async function handleRpcProxyRequest(request, env, url, ctx = {}) {
     } catch {
       // body is not JSON; leave parsed null so it is not cached.
     }
-    if (parsed && parsed.result !== undefined && parsed.error === undefined) {
+    if (
+      parsed &&
+      parsed.result !== undefined &&
+      parsed.result !== null &&
+      parsed.error === undefined
+    ) {
+      // A `null` result is the "not available yet" sentinel for these reads —
+      // chain_getBlockHash(N) returns null until block N is produced — so it is
+      // NOT immutable and must never be pinned under the long block-read TTL, or
+      // callers keep replaying the stale null after the real hash exists.
       // Persist ONLY the cacheable `result` — not the upstream envelope, which
       // carries the priming caller's `id`. The envelope is rebuilt per request
       // on a cache hit above.


### PR DESCRIPTION
## Summary

The RPC proxy's response cache pinned a transient `result: null` under the long block-read TTL, so callers kept replaying a stale `null` after the real value became available.

`handleRpcProxyRequest` stored any successful reply whose `result` was not `undefined` — including `result: null`. `rpcCachePolicy` marks `chain_getBlockHash` with a numeric arg as cacheable for **`ttl: 3600`**, on the premise that a block hash is immutable. But a Substrate/Bittensor node returns `{"result": null}` for `chain_getBlockHash(N)` when block **N has not been produced yet**. That `null` got cached for up to an hour; once block N was produced (Bittensor block time ~12s), every proxied `chain_getBlockHash(N)` kept serving the stale cached `null` instead of the now-available hash. A `null` is definitionally *not* immutable — it's the "not available yet" sentinel — so it violates the immutability premise the 3600s TTL relies on.

## What Changed

- `workers/request-handlers/rpc-proxy.mjs` — the cache-store guard now also requires `parsed.result !== null`. A `null` result is never cached; the next call re-queries upstream. Non-null results are unaffected, and the same guard is safe for the other cacheable reads (`chain_getBlock`/`chain_getHeader` by hash and the quasi-static `system_*` reads never legitimately need a `null` cached — a cache miss simply re-fetches, never serves stale).
- `tests/rpc-cache.test.mjs` — regression test: a first call returning `result: null` (block not produced) is not cached (`cache.store.size === 0`), and a second call re-queries upstream (`fetchCount === 2`) and returns the now-available real hash, rather than a cache hit replaying `null`.

No schema/contract change, so no regenerated artifacts.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (no contract change; behavior-only fix to cache correctness)

## Validation

- [x] `npx vitest run tests/rpc-cache.test.mjs` — 10 passed (9 existing + the new regression case)
- [x] Confirmed the regression test **fails on the pre-fix tree** (the null was cached and replayed as a hit) and **passes after** the fix
- [x] Existing cache tests unaffected — they store non-null results (`"0xhash"`), which the new guard still caches
- [x] `npx eslint workers/request-handlers/rpc-proxy.mjs tests/rpc-cache.test.mjs` — clean
- [x] `npx prettier --check --end-of-line auto` on both files — clean
- [x] `git diff --check` — clean
