### PR TITLE
fix(api): edge-cache resolved block detail with the static profile (#2586)

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2918,6 +2918,55 @@ describe("handleBlock", () => {
     assert.ok(idx !== -1, "expected a block_hash lookup");
     assert.equal(captures.params[idx][0], lowerHash);
   });
+
+  test("uses the static cache profile when the block resolves", async () => {
+    const { env } = dbWith({
+      blockDetail: blockRow(),
+      blockNeighbors: { prev: 1230, next: 1240 },
+    });
+    const res = await handleBlock(
+      req(`/api/v1/blocks/${BLOCK_NUM}`),
+      env,
+      String(BLOCK_NUM),
+    );
+    assert.match(res.headers.get("cache-control"), /max-age=600/);
+    assert.equal(res.headers.get("x-metagraph-cache-profile"), "static");
+  });
+
+  test("keeps the short cache profile when the block is unknown", async () => {
+    const res = await handleBlock(
+      req(`/api/v1/blocks/${BLOCK_NUM}`),
+      emptyEnv(),
+      String(BLOCK_NUM),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("cache-control"), /max-age=60/);
+    assert.equal(res.headers.get("x-metagraph-cache-profile"), "short");
+  });
+
+  test("still emits a 304 for a resolved block when If-None-Match matches", async () => {
+    const { env } = dbWith({
+      blockDetail: blockRow(),
+      blockNeighbors: { prev: 1230, next: 1240 },
+    });
+    const first = await handleBlock(
+      req(`/api/v1/blocks/${BLOCK_NUM}`),
+      env,
+      String(BLOCK_NUM),
+    );
+    const etag = first.headers.get("etag");
+    assert.ok(etag);
+    const second = await handleBlock(
+      new Request(`https://api.metagraph.sh/api/v1/blocks/${BLOCK_NUM}`, {
+        headers: { "if-none-match": etag },
+      }),
+      env,
+      String(BLOCK_NUM),
+    );
+    assert.equal(second.status, 304);
+    assert.match(second.headers.get("cache-control"), /max-age=600/);
+    assert.equal(second.headers.get("etag"), etag);
+  });
 });
 
 describe("handleBlockExtrinsics", () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1385,6 +1385,9 @@ export async function handleBlock(request, env, ref) {
     next = nbr[0]?.next ?? null;
   }
   const data = buildBlock(rows[0], ref, { prev, next });
+  // Finalized block detail is immutable once resolved; a cold/unknown ref stays
+  // on the short profile so clients re-check when the block lands.
+  const cacheProfile = rows[0] ? "static" : "short";
   return envelopeResponse(
     request,
     {
@@ -1395,7 +1398,7 @@ export async function handleBlock(request, env, ref) {
         data.block?.observed_at ?? null,
       ),
     },
-    "short",
+    cacheProfile,
   );
 }
 


### PR DESCRIPTION
## Summary

- Serve `GET /api/v1/blocks/{ref}` with the `static` cache profile (`max-age=600`) when the block resolves from D1, since finalized block detail is immutable.
- Keep the `short` profile (`max-age=60`) for cold/unknown refs so clients re-check when the block lands.
- Add regression tests covering both cache branches and ETag/304 behaviour on resolved blocks.

Closes #2586

## Test plan

- [x] `npm test -- tests/request-handlers-entities.test.mjs --run -t "handleBlock"`
- [ ] `npm run validate` (full suite before push)
- [ ] `npm run test:coverage` (Codecov gate before push)

## Validation commands run

```sh
npm test -- tests/request-handlers-entities.test.mjs --run -t "handleBlock"