### PR TITLE
fix(api): normalize empty and whitespace tokens in list field projection (#2579)

### DIFF
--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -38,10 +38,51 @@ function pageLink(path) {
 }
 
 describe("list-query field projection", () => {
-  test("rejects malformed field lists", () => {
+  test("rejects empty or whitespace-only field lists", () => {
+    for (const path of [
+      "/api/v1/subnets?fields=",
+      "/api/v1/subnets?fields=%20%20",
+      "/api/v1/subnets?fields=,,",
+    ]) {
+      const result = applyQueryFilters(
+        { subnets: [{ netuid: 7, name: "Allways", slug: "allways" }] },
+        query(path),
+        "subnets",
+      );
+
+      assert.equal(result.error.parameter, "fields");
+      assert.match(result.error.message, /comma-separated/);
+    }
+  });
+
+  test("trims field tokens and drops empty segments", () => {
     const result = applyQueryFilters(
       { subnets: [{ netuid: 7, name: "Allways", slug: "allways" }] },
-      query("/api/v1/subnets?fields=netuid,,name"),
+      query("/api/v1/subnets?fields=,name"),
+      "subnets",
+    );
+
+    assert.equal(result.error, undefined);
+    assert.deepEqual(result.meta.projection.fields, ["name"]);
+    assert.deepEqual(result.data.subnets, [{ name: "Allways" }]);
+  });
+
+  test("trims surrounding whitespace on field names", () => {
+    const result = applyQueryFilters(
+      { subnets: [{ netuid: 7, name: "Allways", slug: "allways" }] },
+      query("/api/v1/subnets?fields=netuid,%20name"),
+      "subnets",
+    );
+
+    assert.equal(result.error, undefined);
+    assert.deepEqual(result.meta.projection.fields, ["netuid", "name"]);
+    assert.deepEqual(result.data.subnets, [{ netuid: 7, name: "Allways" }]);
+  });
+
+  test("rejects genuinely malformed field names", () => {
+    const result = applyQueryFilters(
+      { subnets: [{ netuid: 7, name: "Allways", slug: "allways" }] },
+      query("/api/v1/subnets?fields=netuid,@name"),
       "subnets",
     );
 

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -428,7 +428,11 @@ function parseProjection(params, rows, dataKey) {
   if (!params.has("fields")) {
     return { fields: null };
   }
-  const requested = params.get("fields").split(",");
+  const requested = params
+    .get("fields")
+    .split(",")
+    .map((field) => field.trim())
+    .filter((field) => field.length > 0);
   if (
     requested.length === 0 ||
     requested.some((field) => !FIELD_NAME_PATTERN.test(field))


### PR DESCRIPTION
## Summary

- Normalize `?fields=` in `parseProjection` by trimming each comma-separated token and dropping empties before validation.
- Return the dedicated "fields must be a comma-separated list…" 400 when the normalized list is empty or contains malformed names, instead of surfacing a confusing unsupported-field error for blank tokens.
- Accept trimmed input such as `?fields=,name` and `?fields=netuid, name`.

Closes #2579

## Test plan

- [x] `npm test -- tests/list-query.test.mjs --run -t "field projection"`
- [ ] `npm run validate` (full suite before push)
- [ ] `npm run test:coverage` (Codecov gate before push)

## Validation commands run

```sh
npm test -- tests/list-query.test.mjs --run -t "field projection"