### PR TITLE
fix(api): expose x-metagraph-artifact-source on account route envelopes (#2581)

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1621,6 +1621,43 @@ describe("handleAccount", () => {
     assert.equal(body.meta.source, "chain-events");
   });
 
+  test("exposes x-metagraph-artifact-source matching meta.source", async () => {
+    const res = await handleAccount(
+      req(`/api/v1/accounts/${SS58}`),
+      emptyEnv(),
+      SS58,
+    );
+    const body = await json(res);
+    assert.equal(body.meta.source, "chain-events");
+    assert.equal(
+      res.headers.get("x-metagraph-artifact-source"),
+      body.meta.source,
+    );
+  });
+
+  test("304 still carries x-metagraph-artifact-source", async () => {
+    const first = await handleAccount(
+      req(`/api/v1/accounts/${SS58}`),
+      emptyEnv(),
+      SS58,
+    );
+    const etag = first.headers.get("etag");
+    assert.ok(etag);
+    const second = await handleAccount(
+      new Request(`https://api.metagraph.sh/api/v1/accounts/${SS58}`, {
+        headers: { "if-none-match": etag },
+      }),
+      emptyEnv(),
+      SS58,
+    );
+    assert.equal(second.status, 304);
+    assert.equal(
+      second.headers.get("x-metagraph-artifact-source"),
+      "chain-events",
+    );
+    assert.equal(second.headers.get("etag"), etag);
+  });
+
   test("happy path aggregates account_events + neurons + extrinsics activity", async () => {
     const { env } = dbWith({
       agg: {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -15,6 +15,7 @@ import {
   exposeCustomResponseHeaders,
   ifNoneMatchSatisfied,
   weakEtag,
+  X_METAGRAPH_ARTIFACT_SOURCE_HEADER,
 } from "./http.mjs";
 import {
   latestPointer,
@@ -1883,7 +1884,7 @@ async function handleRawArtifactRequest(
   const body = JSON.stringify(data);
   const headers = apiHeaders("standard");
   headers.set("content-type", JSON_CONTENT_TYPE);
-  headers.set("x-metagraph-artifact-source", artifact.source);
+  headers.set(X_METAGRAPH_ARTIFACT_SOURCE_HEADER, artifact.source);
   headers.set("x-metagraph-storage-tier", artifact.storage_tier);
   if (pub) {
     headers.set("x-metagraph-published-at", pub);

--- a/workers/http.mjs
+++ b/workers/http.mjs
@@ -11,6 +11,7 @@ import { JSON_CONTENT_TYPE } from "./config.mjs";
 // Access-Control-Expose-Headers, so this canonical list is exposed on every
 // CORS-open response. Keep in sync as new client-facing headers are added.
 const X_METAGRAPH_STALE_CONTRACT_HEADER = "x-metagraph-stale-contract";
+export const X_METAGRAPH_ARTIFACT_SOURCE_HEADER = "x-metagraph-artifact-source";
 
 const EXPOSED_RESPONSE_HEADERS = [
   "etag", // conditional-request validator (If-None-Match → 304)
@@ -27,7 +28,7 @@ const EXPOSED_RESPONSE_HEADERS = [
   "x-metagraph-events",
   "x-metagraph-health",
   "x-metagraph-cache-profile",
-  "x-metagraph-artifact-source",
+  X_METAGRAPH_ARTIFACT_SOURCE_HEADER,
   "x-metagraph-storage-tier",
   "x-metagraph-error-code",
   "x-metagraph-rpc-cache",

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -27,7 +27,7 @@ import {
   parsePagination,
 } from "../request-params.mjs";
 
-import { errorResponse } from "../http.mjs";
+import { errorResponse, X_METAGRAPH_ARTIFACT_SOURCE_HEADER } from "../http.mjs";
 import {
   contractVersion,
   envelopeResponse,
@@ -682,9 +682,13 @@ async function accountMeta(env, artifactPath, generatedAt) {
 }
 
 // Account routes stamp meta.source but browsers need the CORS-exposed header too.
-async function accountEnvelopeResponse(request, payload, cacheProfile = "short") {
+async function accountEnvelopeResponse(
+  request,
+  payload,
+  cacheProfile = "short",
+) {
   return envelopeResponse(request, payload, cacheProfile, {
-    "x-metagraph-artifact-source": payload.meta.source,
+    [X_METAGRAPH_ARTIFACT_SOURCE_HEADER]: payload.meta.source,
   });
 }
 

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -681,6 +681,13 @@ async function accountMeta(env, artifactPath, generatedAt) {
   };
 }
 
+// Account routes stamp meta.source but browsers need the CORS-exposed header too.
+async function accountEnvelopeResponse(request, payload, cacheProfile = "short") {
+  return envelopeResponse(request, payload, cacheProfile, {
+    "x-metagraph-artifact-source": payload.meta.source,
+  });
+}
+
 // GET /api/v1/accounts/{ss58}/stake-flow: the account's StakeAdded/StakeRemoved flow
 // per subnet over a 7d/30d/90d window — net + gross flow, an HHI concentration of where
 // its flow is focused, and a direction label. account_events-derived (source
@@ -705,7 +712,7 @@ export async function handleAccountStakeFlow(request, env, ss58, url) {
       windowLabel: windowParam,
     },
   );
-  return envelopeResponse(
+  return accountEnvelopeResponse(
     request,
     {
       data,
@@ -724,7 +731,7 @@ export async function handleAccountStakeFlow(request, env, ss58, url) {
 // (neurons, by hotkey). Cold/absent store → schema-stable zero (never 404).
 export async function handleAccount(request, env, ss58) {
   const data = await loadAccountSummary(d1Runner(env), ss58);
-  return envelopeResponse(
+  return accountEnvelopeResponse(
     request,
     {
       data,
@@ -772,7 +779,7 @@ export async function handleAccountEvents(request, env, ss58, url) {
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });
-  return envelopeResponse(
+  return accountEnvelopeResponse(
     request,
     {
       data,
@@ -871,7 +878,7 @@ export async function handleAccountHistory(request, env, ss58, url) {
       ? encodeCursor([Number(last.day.replaceAll("-", "")), last.netuid])
       : null;
   const data = buildAccountHistory(rows, ss58, { limit, offset, nextCursor });
-  return envelopeResponse(
+  return accountEnvelopeResponse(
     request,
     {
       data,
@@ -917,7 +924,7 @@ export async function handleAccountExtrinsics(request, env, ss58, url) {
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });
-  return envelopeResponse(
+  return accountEnvelopeResponse(
     request,
     {
       data,
@@ -981,7 +988,7 @@ export async function handleAccountTransfers(request, env, ss58, url) {
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });
-  return envelopeResponse(
+  return accountEnvelopeResponse(
     request,
     {
       data,
@@ -1028,7 +1035,7 @@ export async function handleAccountCounterparties(request, env, ss58, url) {
       counterparty,
       { limit },
     );
-    return envelopeResponse(
+    return accountEnvelopeResponse(
       request,
       {
         data,
@@ -1042,7 +1049,7 @@ export async function handleAccountCounterparties(request, env, ss58, url) {
     );
   }
   const data = await loadCounterparties(d1Runner(env), ss58, { limit });
-  return envelopeResponse(
+  return accountEnvelopeResponse(
     request,
     {
       data,
@@ -1060,7 +1067,7 @@ export async function handleAccountCounterparties(request, env, ss58, url) {
 // registered (the cross-subnet footprint), from the neurons tier.
 export async function handleAccountSubnets(request, env, ss58) {
   const data = await loadAccountSubnets(d1Runner(env), ss58);
-  return envelopeResponse(
+  return accountEnvelopeResponse(
     request,
     {
       data,


### PR DESCRIPTION
## Summary

- Add `accountEnvelopeResponse` so every `/api/v1/accounts/{ss58}/*` handler that stamps `meta.source: "chain-events"` also sets the matching `x-metagraph-artifact-source` response header.
- Reuse the existing CORS-exposed header name from `http.mjs` so browsers can read the backing tier without parsing the JSON body.
- Leave `handleAccountBalance` unchanged — its envelope meta has no `source` field.

Closes #2581

## Test plan

- [x] `npm test -- tests/request-handlers-entities.test.mjs --run -t "handleAccount"`
- [ ] `npm run validate` (full suite before push)
- [ ] `npm run test:coverage` (Codecov gate before push)

## Validation commands run

```sh
npm test -- tests/request-handlers-entities.test.mjs --run -t "handleAccount"