### PR TITLE
fix(build): exclude build-summary.json from its own artifact inventory

### DIFF
--- a/scripts/refresh-build-summary.mjs
+++ b/scripts/refresh-build-summary.mjs
@@ -79,7 +79,7 @@ async function collectArtifactSizes({ publicRoot, r2Root }) {
       return;
     }
     const relativePath = path.relative(r2Root, filePath).replace(/\\/g, "/");
-    if (relativePath === "r2-manifest.json") {
+    if (["build-summary.json", "r2-manifest.json"].includes(relativePath)) {
       return;
     }
     const raw = await fs.readFile(filePath);

--- a/tests/refresh-build-summary.test.mjs
+++ b/tests/refresh-build-summary.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "vitest";
+import { r2StagingRoot, repoRoot } from "../scripts/lib.mjs";
+
+// build-summary.json lives at the R2 staging root (#1003). It is the artifact the
+// refresh script rewrites, so — like the canonical writer in build-artifacts.mjs
+// and r2-manifest.mjs — it must exclude build-summary.json (and r2-manifest.json)
+// from its own artifact inventory. A stale self-entry would inflate
+// artifact_count / artifact_size_bytes and embed a hash of the pre-rewrite file.
+test("refresh-build-summary excludes build-summary.json from its own inventory", () => {
+  const summaryPath = path.join(r2StagingRoot, "build-summary.json");
+  if (!existsSync(summaryPath)) {
+    // Requires a populated R2 staging tier (npm run build / artifacts:prepare-local).
+    return;
+  }
+
+  execFileSync(process.execPath, ["scripts/refresh-build-summary.mjs"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+
+  const summary = JSON.parse(readFileSync(summaryPath, "utf8"));
+  const selfEntries = summary.artifacts.filter(
+    (artifact) =>
+      artifact.path === "build-summary.json" ||
+      artifact.path === "r2-manifest.json",
+  );
+
+  assert.deepEqual(selfEntries, []);
+});


### PR DESCRIPTION
## Summary

`build-summary.json` listed itself in its own published-artifact inventory, with the hash and size of the pre-rewrite file.

`collectArtifactSizes` in `scripts/refresh-build-summary.mjs` walks two roots to inventory published artifacts: the public tier and the R2 staging tier. The public-tier walk excludes both `build-summary.json` and `r2-manifest.json`, but the R2-tier walk excluded **only** `r2-manifest.json`. Since `build-summary.json` is R2-only (#1003) and lives at the R2 staging root — as the very file this script rewrites — the R2 walk picked it up and added a self-referential entry to `artifacts[]`. Its recorded `sha256`/`size_bytes` are of the *pre-rewrite* file (stale the instant the new summary is written), and it inflates `artifact_count` / `artifact_size_bytes` by one artifact.

## What Changed

- `scripts/refresh-build-summary.mjs` — the R2-tier walk now excludes `["build-summary.json", "r2-manifest.json"]`, matching:
  - the sibling public-tier walk in the same function,
  - the canonical inventory walk in `scripts/build-artifacts.mjs` (`build-summary.json`, `changelog.json`, `r2-manifest.json`), and
  - `scripts/r2-manifest.mjs` (`build-summary.json`, `r2-manifest.json`).
- `tests/refresh-build-summary.test.mjs` — regression test (execFileSync-style, mirroring `tests/r2-upload.test.mjs`): runs the script against the populated R2 staging tier and asserts no self-entry for `build-summary.json` / `r2-manifest.json` remains in the inventory.

No schema/contract change, so no regenerated committed artifacts.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (no contract change — this corrects generated build metadata to match the two canonical writers)

## Validation

- [x] `npx vitest run tests/refresh-build-summary.test.mjs` — 1 passed
- [x] Confirmed the regression test **fails on the pre-fix tree** (a `build-summary.json` self-entry is present, `artifact_count` one too high) and **passes after** the fix
- [x] Verified against a populated local R2 staging tier: pre-fix `artifact_count` was one higher and included the self-entry; post-fix the self-entry is gone
- [x] `npx eslint scripts/refresh-build-summary.mjs tests/refresh-build-summary.test.mjs` — clean
- [x] `npx prettier --check --end-of-line auto` on both files — clean
- [x] `git diff --check` — clean
