### PR TITLE
fix(backfill): upsert the chain_events tier in the historical backfill

### DIFF
--- a/scripts/backfill-chain.py
+++ b/scripts/backfill-chain.py
@@ -110,6 +110,17 @@ def _flush(conn, decoded_batch):
             rows["account_events"],
             "block_number, event_index",
         )
+        # The generic all-events tier (ADR 0013): rows_from_decoded produces it and
+        # the live indexer upserts it too, so a backfilled range must fill it or the
+        # deep-history /api/v1/chain-events reads are silently empty (schema drift the
+        # module docstring promises against). Same conflict key as account_events.
+        ic._upsert(
+            conn,
+            "chain_events",
+            ic.CHAIN_EVENT_COLS,
+            rows["chain_events"],
+            "block_number, event_index",
+        )
 
 
 def run():

--- a/scripts/test_backfill_chain.py
+++ b/scripts/test_backfill_chain.py
@@ -31,5 +31,34 @@ class BackfillRange(unittest.TestCase):
         self.assertEqual((frm, to), (7_000_000, 8_500_000))
 
 
+class Flush(unittest.TestCase):
+    def test_flush_upserts_every_decoded_tier_incl_chain_events(self):
+        # Regression: _flush must upsert every tier rows_from_decoded produces. The
+        # live indexer upserts chain_events (index-chain.py) and the module docstring
+        # promises "zero decode/schema drift", so a backfilled range must fill the
+        # generic all-events tier too — otherwise deep-history /api/v1/chain-events
+        # reads are silently empty for backfilled blocks.
+        calls = []
+        original = bf.ic._upsert
+        bf.ic._upsert = lambda conn, table, cols, rows, conflict: calls.append(table)
+        try:
+            bf._flush(
+                object(),
+                [
+                    {
+                        "blocks": [{"block_number": 1}],
+                        "extrinsics": [],
+                        "account_events": [],
+                        "chain_events": [{"block_number": 1, "event_index": 0}],
+                    }
+                ],
+            )
+        finally:
+            bf.ic._upsert = original
+        self.assertEqual(
+            calls, ["blocks", "extrinsics", "account_events", "chain_events"]
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- The one-time historical chain backfill (`scripts/backfill-chain.py`, ADR 0013) decodes each block with the indexer's shared `rows_from_decoded`, which produces four tiers — `blocks`, `extrinsics`, `account_events`, and the generic all-events tier `chain_events`. But `_flush` only upserted the first three, silently dropping the decoded `chain_events`.
- The **live** indexer upserts `chain_events` from the same `rows_from_decoded` output (`index-chain.py`: `_upsert(conn, "chain_events", CHAIN_EVENT_COLS, rows["chain_events"], "block_number, event_index")`). So any block range filled by the backfill (rather than the live follower) has **no** `chain_events` rows — the deep-history `/api/v1/chain-events` reads (the Postgres DATA_API tier) return nothing for those blocks. This directly contradicts the module docstring's promise that it "reuses the indexer's verified decode + idempotent upserts ... so there is zero decode/schema drift."

## What Changed

- `scripts/backfill-chain.py`: `_flush` now also upserts `chain_events`, mirroring the live indexer exactly (same `ic.CHAIN_EVENT_COLS` and `(block_number, event_index)` conflict key). No other behavior changes; the upsert is idempotent like the others.
- `scripts/test_backfill_chain.py`: regression asserting `_flush` upserts every tier `rows_from_decoded` produces (`blocks`, `extrinsics`, `account_events`, `chain_events`). Fails without the fix.

No schema/OpenAPI/contract change; no JS/registry/artifact change.

### Reproduction (before)

Run the backfill over any block range, then query `/api/v1/chain-events` for those blocks: `blocks`/`extrinsics`/`account_events` are present but `chain_events` is empty — even though the same blocks would have full `chain_events` if the live indexer had ingested them.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (No generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — pipeline-only fix.)

## Validation

- [x] `python scripts/test_backfill_chain.py` (5 tests pass; the new regression fails without the fix)
- [x] `git diff --check` clean
- [x] Change mirrors the live indexer path (`index-chain.py`), so there is no decode/schema drift.
