### PR TITLE
fix(api): short-circuit inverted block range on account extrinsics before D1

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -776,6 +776,15 @@ export async function loadAccountExtrinsics(
 ) {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
+  // Inverted block-height bounds are a deterministic no-match. Short-circuit before
+  // D1 so REST and MCP callers cannot force a scan to prove an impossible empty page.
+  if (blockStart != null && blockEnd != null && blockStart > blockEnd) {
+    return buildAccountExtrinsics([], ss58, {
+      limit: lim,
+      offset: off,
+      nextCursor: null,
+    });
+  }
   const params = [ss58];
   let sql = `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE signer = ?`;
   if (blockStart != null) {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -662,6 +662,21 @@ test("loadAccountExtrinsics applies the block_start/block_end range as bound par
   assert.deepEqual(captured.params, ["5Hk", 100, 900, 100, 0]);
 });
 
+test("loadAccountExtrinsics short-circuits an inverted block range before D1", async () => {
+  let called = false;
+  const out = await loadAccountExtrinsics(
+    async () => {
+      called = true;
+      return [];
+    },
+    "5Hk",
+    { blockStart: 500, blockEnd: 100, limit: 50, offset: 0 },
+  );
+  assert.equal(out.extrinsic_count, 0);
+  assert.deepEqual(out.extrinsics, []);
+  assert.equal(called, false);
+});
+
 test("loadAccountExtrinsics emits next_cursor for a full page", async () => {
   const out = await loadAccountExtrinsics(
     async () => [

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -674,6 +674,7 @@ test("loadAccountExtrinsics short-circuits an inverted block range before D1", a
   );
   assert.equal(out.extrinsic_count, 0);
   assert.deepEqual(out.extrinsics, []);
+  assert.equal(out.next_cursor, null);
   assert.equal(called, false);
 });
 

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1917,11 +1917,14 @@ describe("handleAccountExtrinsics", () => {
         req(`/api/v1/accounts/${SS58}/extrinsics`),
         env,
         SS58,
-        url(`/api/v1/accounts/${SS58}/extrinsics?block_start=500&block_end=100`),
+        url(
+          `/api/v1/accounts/${SS58}/extrinsics?block_start=500&block_end=100`,
+        ),
       ),
     );
     assert.equal(body.data.extrinsic_count, 0);
     assert.deepEqual(body.data.extrinsics, []);
+    assert.equal(body.data.next_cursor, null);
     assert.equal(captures.sql.length, 0);
   });
 

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1910,6 +1910,21 @@ describe("handleAccountExtrinsics", () => {
     assert.equal(body.meta.parameter, "block_end");
   });
 
+  test("short-circuits an inverted block_start>block_end window before D1", async () => {
+    const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
+    const body = await json(
+      await handleAccountExtrinsics(
+        req(`/api/v1/accounts/${SS58}/extrinsics`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/extrinsics?block_start=500&block_end=100`),
+      ),
+    );
+    assert.equal(body.data.extrinsic_count, 0);
+    assert.deepEqual(body.data.extrinsics, []);
+    assert.equal(captures.sql.length, 0);
+  });
+
   test("happy path returns signer-matched extrinsics", async () => {
     const { env } = dbWith({ extrinsics: [extrinsicRow()] });
     const body = await json(


### PR DESCRIPTION
## What

`GET /api/v1/accounts/{ss58}/extrinsics` accepts optional `?block_start=` / `?block_end=` height filters. When `block_start > block_end`, the range is impossible.

The global extrinsics feed (`loadExtrinsics`, #2496) and account history (`loadAccountHistory`, #2594) already short-circuit impossible windows before D1. Account-scoped extrinsics still queried D1 for a deterministically empty page.

## How

Add `block_start > block_end` to a pre-D1 guard in `loadAccountExtrinsics`, returning the existing schema-stable empty `buildAccountExtrinsics` payload. REST and MCP account tools share this loader — no duplicate handler guard needed.

## Why no linked issue

Standalone guard gap found by comparing account tail loaders with `loadExtrinsics` / `loadAccountHistory`. Closed PR #2510 targeted handler-level event feeds broadly; this completes the **account extrinsics** signer-scoped path in the shared loader. No open issue tracks this specific gap.

## Scope / risk

One guard in `loadAccountExtrinsics` plus loader + handler tests asserting zero D1 work. Valid filters unchanged.

## Tests

- `account-events.test.mjs`: `loadAccountExtrinsics short-circuits an inverted block range before D1`
- `request-handlers-entities.test.mjs`: inverted `block_start=500&block_end=100` returns empty feed with `captures.sql.length === 0`

## Test plan

- [x] Inverted block window returns empty feed without D1 (loader + REST handler)
- [x] Existing valid-range account extrinsics tests continue to pass
- [x] CI vitest suite (no local Node toolchain; relies on repo CI)
