### PR TITLE
fix(metagraph-neurons): coerce string-typed block_number in the snapshot stamp and neuron detail

### DIFF
--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -127,7 +127,11 @@ function snapshotStamp(rows) {
   const first = rows[0] || {};
   return {
     captured_at: toIso(first.captured_at),
-    block_number: first.block_number ?? null,
+    // Coerce like buildGlobalValidators (#2611): block_number is a nullable D1
+    // INTEGER that can come back as a numeric string, so a bare `?? null` would
+    // leak "8454388" into the ["integer","null"] contract field. nonNegativeInt
+    // maps null→null and numeric strings→real integers.
+    block_number: nonNegativeInt(first.block_number),
   };
 }
 
@@ -165,7 +169,9 @@ export function buildNeuronDetail(row, netuid) {
     schema_version: 1,
     netuid,
     captured_at: toIso(row?.captured_at),
-    block_number: row?.block_number ?? null,
+    // Same D1 numeric-string coercion as snapshotStamp / buildGlobalValidators
+    // (#2611): keep the top-level block_number an integer or null, never a string.
+    block_number: nonNegativeInt(row?.block_number),
     neuron: formatNeuron(row),
   };
 }

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -167,6 +167,30 @@ describe("metagraph-neurons builders", () => {
     assert.equal(data.validators[0].validator_permit, true);
   });
 
+  test("coerces a string-typed D1 block_number to an integer in the snapshot stamp + neuron detail", () => {
+    // block_number is a nullable D1 INTEGER that can come back as a numeric
+    // string; the snapshot stamp (metagraph/validators) and neuron-detail top
+    // level must emit an integer or null, never leak the string into the
+    // ["integer","null"] contract field. Mirrors the buildGlobalValidators fix
+    // (#2611) for the remaining emission sites.
+    const meta = buildSubnetMetagraph([{ ...ROW, block_number: "8454388" }], 7);
+    assert.equal(meta.block_number, 8454388);
+    assert.equal(typeof meta.block_number, "number");
+    const vals = buildSubnetValidators(
+      [{ ...ROW, block_number: "8454388" }],
+      7,
+    );
+    assert.equal(vals.block_number, 8454388);
+    const detail = buildNeuronDetail({ ...ROW, block_number: "8454388" }, 7);
+    assert.equal(detail.block_number, 8454388);
+    assert.equal(typeof detail.block_number, "number");
+    // a null block_number stays null (not a fabricated 0).
+    assert.equal(
+      buildNeuronDetail({ ...ROW, block_number: null }, 7).block_number,
+      null,
+    );
+  });
+
   test("buildGlobalValidators groups validator identities across subnets", () => {
     const data = buildGlobalValidators(
       [


### PR DESCRIPTION
## Summary

- #2611 fixed `buildGlobalValidators` to coerce `block_number` (a nullable D1 INTEGER that can return as a numeric string). But the sibling emission sites in the same file were left passing it through raw:
  - `snapshotStamp` — feeds `block_number` into `buildSubnetMetagraph` (`/api/v1/subnets/{netuid}/metagraph`) and `buildSubnetValidators` (`/api/v1/subnets/{netuid}/validators`).
  - `buildNeuronDetail` — the top-level `block_number` of `/api/v1/subnets/{netuid}/neurons/{uid}`.
- Both emitted `block_number ?? null`, so a numeric-string cell (`"8454388"`) leaked a string into a field the contract models as `["integer","null"]` — the same defect #2611 closed for the leaderboard, just in the un-swept siblings.

## What Changed

- `src/metagraph-neurons.mjs`: coerce `block_number` in `snapshotStamp` and `buildNeuronDetail` through the same `nonNegativeInt` helper `buildGlobalValidators` uses (null→null, numeric string→integer). No other behavior change.
- `tests/metagraph-neurons.test.mjs`: regression asserting the metagraph, validators, and neuron-detail `block_number` coerce a `"8454388"` string to the integer `8454388` and keep an explicit `null` as `null`. Fails without the fix.

No schema/OpenAPI/contract change — the contract already models `block_number` as `["integer","null"]`; this makes the served value honor it.

### Reproduction (before)

When D1 returns `block_number` as a string, `GET /api/v1/subnets/{netuid}/neurons/{uid}` (and `/metagraph`, `/validators`) return `"block_number": "8454388"` instead of `8454388`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (No generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — value now honors the existing `["integer","null"]` contract.)

## Validation

- [x] `npx vitest run tests/metagraph-neurons.test.mjs` (34 pass; the new regression fails without the fix)
- [x] `npx eslint src/metagraph-neurons.mjs tests/metagraph-neurons.test.mjs` (clean)
- [x] `npx prettier --check` (clean)
- [x] `git diff --check`
