### PR TITLE
fix(contract-summary): flag structural changes that accompany an enum edit

### DIFF
--- a/scripts/contract-change-summary.mjs
+++ b/scripts/contract-change-summary.mjs
@@ -1,85 +1,82 @@
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { readJson, repoRoot, stableStringify } from "./lib.mjs";
 import path from "node:path";
 
-const baseRef =
-  process.env.METAGRAPH_CONTRACT_BASE_REF ||
-  (process.env.GITHUB_BASE_REF
-    ? `origin/${process.env.GITHUB_BASE_REF}`
-    : "HEAD~1");
 const schemaPath = "schemas/api-components.schema.json";
-const current = await readJson(path.join(repoRoot, schemaPath));
-const previous = readPreviousSchema(baseRef);
 
-if (!previous) {
-  console.log(
-    stableStringify({
-      schema_version: 1,
-      source: "contract-change-summary",
-      base_ref: baseRef,
-      status: "base_unavailable",
-      current_component_count: Object.keys(current.components.schemas).length,
-      notes: [
-        "Set METAGRAPH_CONTRACT_BASE_REF to compare against a specific branch or commit.",
-      ],
-    }),
-  );
-  process.exit(0);
-}
+// Classify the component-schema delta between two OpenAPI component maps into
+// additive / risky / breaking buckets for PR review (docs/api-stability.md).
+// Pure + exported so it is unit-testable without invoking git or the CLI.
+export function classifyContractChanges(
+  previousSchemas = {},
+  currentSchemas = {},
+) {
+  const previousNames = new Set(Object.keys(previousSchemas));
+  const currentNames = new Set(Object.keys(currentSchemas));
 
-const previousSchemas = previous.components.schemas || {};
-const currentSchemas = current.components.schemas || {};
-const previousNames = new Set(Object.keys(previousSchemas));
-const currentNames = new Set(Object.keys(currentSchemas));
+  const added = [...currentNames]
+    .filter((name) => !previousNames.has(name))
+    .sort();
+  const removed = [...previousNames]
+    .filter((name) => !currentNames.has(name))
+    .sort();
+  const changed = [...currentNames]
+    .filter(
+      (name) =>
+        previousNames.has(name) &&
+        stableStringify(previousSchemas[name]) !==
+          stableStringify(currentSchemas[name]),
+    )
+    .sort();
 
-const added = [...currentNames]
-  .filter((name) => !previousNames.has(name))
-  .sort();
-const removed = [...previousNames]
-  .filter((name) => !currentNames.has(name))
-  .sort();
-const changed = [...currentNames]
-  .filter(
-    (name) =>
-      previousNames.has(name) &&
-      stableStringify(previousSchemas[name]) !==
-        stableStringify(currentSchemas[name]),
-  )
-  .sort();
-
-const enumChanges = changed
-  .map((name) => enumChange(name, previousSchemas[name], currentSchemas[name]))
-  .filter(Boolean);
-const breaking = [
-  ...removed.map((name) => ({ component: name, reason: "component_removed" })),
-  ...enumChanges.flatMap((entry) =>
-    entry.removed_values.map((value) => ({
-      component: entry.component,
-      reason: "enum_value_removed",
-      value,
+  const enumChanges = changed
+    .map((name) =>
+      enumChange(name, previousSchemas[name], currentSchemas[name]),
+    )
+    .filter(Boolean);
+  const breaking = [
+    ...removed.map((name) => ({
+      component: name,
+      reason: "component_removed",
     })),
-  ),
-];
-const additive = [
-  ...added.map((name) => ({ component: name, reason: "component_added" })),
-  ...enumChanges.flatMap((entry) =>
-    entry.added_values.map((value) => ({
-      component: entry.component,
-      reason: "enum_value_added",
-      value,
-    })),
-  ),
-];
-const risky = changed
-  .filter((name) => !enumChanges.some((entry) => entry.component === name))
-  .map((name) => ({ component: name, reason: "schema_changed" }));
+    ...enumChanges.flatMap((entry) =>
+      entry.removed_values.map((value) => ({
+        component: entry.component,
+        reason: "enum_value_removed",
+        value,
+      })),
+    ),
+  ];
+  const additive = [
+    ...added.map((name) => ({ component: name, reason: "component_added" })),
+    ...enumChanges.flatMap((entry) =>
+      entry.added_values.map((value) => ({
+        component: entry.component,
+        reason: "enum_value_added",
+        value,
+      })),
+    ),
+  ];
+  // A changed component is risky when a NON-enum part of its schema changed. An
+  // enum-only delta (added/removed values) is already surfaced as additive/
+  // breaking, so a component with an enum delta is excluded from `risky` ONLY
+  // when that delta fully accounts for the change (the enum-stripped bodies are
+  // equal). If the schema also changed structurally alongside the enum edit
+  // (e.g. a new `deprecated`/`required`/type constraint), that structural change
+  // must still surface as risky rather than be swallowed as merely additive.
+  const risky = changed
+    .filter((name) => {
+      if (!enumChanges.some((entry) => entry.component === name)) {
+        return true;
+      }
+      const { enum: _previousEnum, ...previousRest } = previousSchemas[name];
+      const { enum: _currentEnum, ...currentRest } = currentSchemas[name];
+      return stableStringify(previousRest) !== stableStringify(currentRest);
+    })
+    .map((name) => ({ component: name, reason: "schema_changed" }));
 
-console.log(
-  stableStringify({
-    schema_version: 1,
-    source: "contract-change-summary",
-    base_ref: baseRef,
-    status: "ok",
+  return {
     classification:
       breaking.length > 0
         ? "breaking"
@@ -97,19 +94,7 @@ console.log(
     additive,
     risky,
     breaking,
-  }),
-);
-
-function readPreviousSchema(ref) {
-  const result = spawnSync("git", ["show", `${ref}:${schemaPath}`], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    stdio: "pipe",
-  });
-  if (result.status !== 0) {
-    return null;
-  }
-  return JSON.parse(result.stdout);
+  };
 }
 
 function enumChange(component, previousSchema, currentSchema) {
@@ -135,4 +120,59 @@ function enumChange(component, previousSchema, currentSchema) {
     added_values: addedValues,
     removed_values: removedValues,
   };
+}
+
+function readPreviousSchema(ref) {
+  const result = spawnSync("git", ["show", `${ref}:${schemaPath}`], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+  if (result.status !== 0) {
+    return null;
+  }
+  return JSON.parse(result.stdout);
+}
+
+// CLI: diff the committed contract against a base ref and print the summary.
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  const baseRef =
+    process.env.METAGRAPH_CONTRACT_BASE_REF ||
+    (process.env.GITHUB_BASE_REF
+      ? `origin/${process.env.GITHUB_BASE_REF}`
+      : "HEAD~1");
+  const current = await readJson(path.join(repoRoot, schemaPath));
+  const previous = readPreviousSchema(baseRef);
+
+  if (!previous) {
+    console.log(
+      stableStringify({
+        schema_version: 1,
+        source: "contract-change-summary",
+        base_ref: baseRef,
+        status: "base_unavailable",
+        current_component_count: Object.keys(current.components.schemas).length,
+        notes: [
+          "Set METAGRAPH_CONTRACT_BASE_REF to compare against a specific branch or commit.",
+        ],
+      }),
+    );
+    process.exit(0);
+  }
+
+  console.log(
+    stableStringify({
+      schema_version: 1,
+      source: "contract-change-summary",
+      base_ref: baseRef,
+      status: "ok",
+      ...classifyContractChanges(
+        previous.components.schemas || {},
+        current.components.schemas || {},
+      ),
+    }),
+  );
 }

--- a/tests/contract-change-summary.test.mjs
+++ b/tests/contract-change-summary.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { classifyContractChanges } from "../scripts/contract-change-summary.mjs";
+
+describe("classifyContractChanges", () => {
+  test("an enum-only addition is additive, not risky", () => {
+    const result = classifyContractChanges(
+      { Authority: { type: "string", enum: ["official", "community"] } },
+      { Authority: { type: "string", enum: ["official", "community", "dao"] } },
+    );
+    assert.deepEqual(result.additive, [
+      { component: "Authority", reason: "enum_value_added", value: "dao" },
+    ]);
+    assert.deepEqual(result.risky, []);
+    assert.equal(result.classification, "additive");
+  });
+
+  test("a component that gains an enum value AND changes structurally stays risky", () => {
+    // The enum grew (additive) but the schema also gained `deprecated: true`.
+    // The structural change must NOT be swallowed by the enum delta — a reviewer
+    // needs to see it flagged as risky.
+    const result = classifyContractChanges(
+      { Authority: { type: "string", enum: ["official", "community"] } },
+      {
+        Authority: {
+          type: "string",
+          enum: ["official", "community", "dao"],
+          deprecated: true,
+        },
+      },
+    );
+    assert.deepEqual(result.additive, [
+      { component: "Authority", reason: "enum_value_added", value: "dao" },
+    ]);
+    assert.deepEqual(result.risky, [
+      { component: "Authority", reason: "schema_changed" },
+    ]);
+    assert.equal(result.classification, "risky");
+    assert.equal(result.counts.risky_changes, 1);
+  });
+
+  test("a non-enum structural change with no enum delta is risky", () => {
+    const result = classifyContractChanges(
+      { Surface: { type: "object", required: ["id"] } },
+      { Surface: { type: "object", required: ["id", "url"] } },
+    );
+    assert.deepEqual(result.risky, [
+      { component: "Surface", reason: "schema_changed" },
+    ]);
+    assert.equal(result.classification, "risky");
+  });
+
+  test("a removed enum value is breaking and dominates the classification", () => {
+    const result = classifyContractChanges(
+      { Authority: { type: "string", enum: ["official", "community"] } },
+      { Authority: { type: "string", enum: ["official"] } },
+    );
+    assert.deepEqual(result.breaking, [
+      {
+        component: "Authority",
+        reason: "enum_value_removed",
+        value: "community",
+      },
+    ]);
+    assert.equal(result.classification, "breaking");
+  });
+});


### PR DESCRIPTION
## Summary

The contract-change classifier (`npm run contract:summary`, the PR-review helper from `docs/api-stability.md`) misclassified a component that changed **both** its enum set and its structure as merely **additive**, silently hiding the risky structural change from reviewers.

The `risky` bucket dropped any `changed` component that appeared in the enum-delta list *at all*. So when a component's schema gained an enum value (additive) **and** a non-enum change in the same commit — e.g. a new `deprecated: true`, a tightened `required`, or a type constraint — the enum delta was reported but the structural change vanished, and the overall `classification` came back `additive`.

## The fix

Exclude an enum-delta component from `risky` only when the enum delta **fully accounts** for the change (the enum-stripped bodies are equal); if a non-enum part also changed, still flag it `schema_changed`.

```js
const risky = changed
  .filter((name) => {
    if (!enumChanges.some((entry) => entry.component === name)) return true;
    const { enum: _p, ...previousRest } = previousSchemas[name];
    const { enum: _c, ...currentRest } = currentSchemas[name];
    return stableStringify(previousRest) !== stableStringify(currentRest);
  })
  .map((name) => ({ component: name, reason: "schema_changed" }));
```

## What Changed

- `scripts/contract-change-summary.mjs`:
  - **Behavioral fix:** the `risky` filter above.
  - **Refactor to make it testable:** extracted the classification into an exported pure `classifyContractChanges(previousSchemas, currentSchemas)` and guarded the CLI entry behind the standard `process.argv[1] === fileURLToPath(import.meta.url)` check (the same pattern `scripts/build-network-registry.mjs` uses to be both a CLI and an importable module). This is most of the line count — the CLI output is **byte-identical** (verified on both the `ok` and `base_unavailable` paths; see Validation).
- `tests/contract-change-summary.test.mjs` — new unit test covering: enum-only add → additive; **enum add + structural change → risky** (the fix); non-enum structural change → risky; enum removal → breaking.

No schema/contract change, so no regenerated committed artifacts.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (tooling-only; no contract change)

## Validation

- [x] `npx vitest run tests/contract-change-summary.test.mjs` — 4 passed
- [x] Confirmed the "enum add + structural change → risky" case **fails on the pre-fix filter** and **passes after** — while the other three classifications stay unchanged (surgical fix)
- [x] **CLI output byte-identical** before/after the refactor: `diff` of `METAGRAPH_CONTRACT_BASE_REF=HEAD~1 node scripts/contract-change-summary.mjs` and of the `base_unavailable` path both empty
- [x] `npx eslint scripts/contract-change-summary.mjs tests/contract-change-summary.test.mjs` — clean
- [x] `npx prettier --check --end-of-line auto` on both files — clean
- [x] `git diff --check` — clean
