### PR TITLE
fix(api): short-circuit inverted block range on account transfers before D1

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -820,6 +820,16 @@ export async function loadAccountTransfers(
 ) {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
+  // Inverted block-height bounds are a deterministic no-match. Short-circuit before
+  // D1 so REST and MCP callers cannot force a scan to prove an impossible empty page.
+  if (blockStart != null && blockEnd != null && blockStart > blockEnd) {
+    return buildAccountTransfers([], ss58, {
+      limit: lim,
+      offset: off,
+      nextCursor: null,
+      direction,
+    });
+  }
   const cur = decodeCursor(cursor, 2);
   const useCursor = Boolean(cur);
   const blockRangeClause = `${blockStart != null ? " AND block_number >= ?" : ""}${blockEnd != null ? " AND block_number <= ?" : ""}`;

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -615,6 +615,22 @@ test("loadAccountTransfers applies the block_start/block_end range to both sides
   ]);
 });
 
+test("loadAccountTransfers short-circuits an inverted block range before D1", async () => {
+  let called = false;
+  const out = await loadAccountTransfers(
+    async () => {
+      called = true;
+      return [];
+    },
+    "5Hk",
+    { blockStart: 500, blockEnd: 100, limit: 50, offset: 0 },
+  );
+  assert.equal(out.transfer_count, 0);
+  assert.deepEqual(out.transfers, []);
+  assert.equal(out.next_cursor, null);
+  assert.equal(called, false);
+});
+
 test("loadAccountTransfers uses cursor keyset pagination over offset", async () => {
   let captured;
   const out = await loadAccountTransfers(

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2067,6 +2067,22 @@ describe("handleAccountTransfers", () => {
     assert.equal(body.meta.parameter, "block_end");
   });
 
+  test("short-circuits an inverted block_start>block_end window before D1", async () => {
+    const { env, captures } = dbWith({ transfers: [transferEventRow()] });
+    const body = await json(
+      await handleAccountTransfers(
+        req(`/api/v1/accounts/${SS58}/transfers`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/transfers?block_start=500&block_end=100`),
+      ),
+    );
+    assert.equal(body.data.transfer_count, 0);
+    assert.deepEqual(body.data.transfers, []);
+    assert.equal(body.data.next_cursor, null);
+    assert.equal(captures.sql.length, 0);
+  });
+
   test("returns schema-stable empty transfers on cold D1", async () => {
     const body = await assertColdSchema(
       handleAccountTransfers,


### PR DESCRIPTION
## What

`GET /api/v1/accounts/{ss58}/transfers` accepts optional `?block_start=` / `?block_end=` height filters. When `block_start > block_end`, the range is impossible.

The global extrinsics feed (`loadExtrinsics`, #2496), account history (`loadAccountHistory`, #2594), and account extrinsics (`loadAccountExtrinsics`, #2622) already short-circuit impossible windows before D1. Account-scoped transfers still queried D1 for a deterministically empty page.

## How

Add `block_start > block_end` to a pre-D1 guard in `loadAccountTransfers`, returning the existing schema-stable empty `buildAccountTransfers` payload. REST and MCP account tools share this loader — no duplicate handler guard needed.

## Why no linked issue

Standalone guard gap found by comparing account tail loaders with `loadExtrinsics` / `loadAccountHistory`. Closed PR #2510 targeted handler-level event feeds broadly; this completes the **account transfers** path in the shared loader. No open issue tracks this specific gap.

## Scope / risk

One guard in `loadAccountTransfers` plus loader + handler tests asserting zero D1 work. Valid filters unchanged.

## Tests

- `account-events.test.mjs`: `loadAccountTransfers short-circuits an inverted block range before D1`
- `request-handlers-entities.test.mjs`: inverted `block_start=500&block_end=100` returns empty feed with `captures.sql.length === 0` and `next_cursor === null`

## Test plan

- [x] Inverted block window returns empty feed without D1 (loader + REST handler)
- [x] Existing valid-range account transfers tests continue to pass
- [x] CI vitest + lint/format checks
