### PR TITLE
feat(mcp): add get_chain_transfers mirroring REST chain transfers

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -461,6 +461,16 @@ assert.ok(
     feesCold.window === "7d",
   "get_chain_fees must return window + daily[] + top_fee_payers[] on cold D1",
 );
+const transfersCold = await callOk("get_chain_transfers", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  transfersCold.window === "7d" &&
+    Array.isArray(transfersCold.top_senders) &&
+    Array.isArray(transfersCold.top_receivers),
+  "get_chain_transfers must return window + top_senders[] + top_receivers[] on cold D1",
+);
 const networkActivityCold = await callOk("get_network_activity", {
   window: "7d",
 });

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -36,6 +36,13 @@ import {
 import { loadBulkHealthTrends } from "./bulk-health-trends.mjs";
 import { loadRpcUsage } from "./rpc-usage-loader.mjs";
 import {
+  loadChainTransfers,
+  CHAIN_TRANSFER_LIMIT_DEFAULT,
+  CHAIN_TRANSFER_LIMIT_MAX,
+  CHAIN_TRANSFER_WINDOWS,
+  DEFAULT_CHAIN_TRANSFER_WINDOW,
+} from "./chain-transfers.mjs";
+import {
   loadEconomicsTrends,
   parseEconomicsTrendsWindow,
 } from "./economics-trends.mjs";
@@ -147,7 +154,11 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.15.0";
+export const MCP_SERVER_VERSION = "1.16.0";
+
+// Window labels accepted by get_chain_transfers — derived from the loader constant
+// so input/output schemas and runtime validation cannot drift.
+const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -234,7 +245,8 @@ export const MCP_INSTRUCTIONS =
   "get_account_subnets the subnets where it is registered. For chain-wide " +
   "activity analytics, get_chain_calls returns the extrinsic call-mix " +
   "(count + share per pallet/module) over a 7d/30d window, get_chain_fees the " +
-  "fee/tip market series plus top payers, get_network_activity the daily " +
+  "fee/tip market series plus top payers, get_chain_transfers network-wide " +
+  "native-TAO transfer volume plus top senders/receivers, get_network_activity the daily " +
   "network-activity time series (blocks/extrinsics/events/signers), and " +
   "get_chain_activity the recent pallet.method event distribution, and " +
   "list_chain_events the raw recent decoded event feed (filterable by " +
@@ -3218,6 +3230,55 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_chain_transfers",
+    title: "Get network-wide native-TAO transfer analytics",
+    description:
+      "Fetch network-wide Balances.Transfer analytics over the requested window " +
+      "(7d or 30d): total transfer volume and count, distinct senders/receivers, " +
+      "the top senders and receivers ranked by volume, and the top senders' share " +
+      "of total volume (a concentration signal). The network-level companion of " +
+      "get_account_transfers and get_account_counterparties. Mirrors " +
+      "GET /api/v1/chain/transfers.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_TRANSFER_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_CHAIN_TRANSFER_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max top senders/receivers to return (1-${CHAIN_TRANSFER_LIMIT_MAX}, default ${CHAIN_TRANSFER_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_TRANSFER_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window =
+        optionalString(args, "window") ?? DEFAULT_CHAIN_TRANSFER_WINDOW;
+      if (!Object.hasOwn(CHAIN_TRANSFER_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_TRANSFER_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_TRANSFER_LIMIT_DEFAULT,
+        CHAIN_TRANSFER_LIMIT_MAX,
+      );
+      return loadChainTransfers(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: CHAIN_TRANSFER_WINDOWS[window],
+        observedAt: await mcpObservedAt(ctx),
+        limit,
+      });
+    },
+  },
+  {
     name: "get_network_activity",
     title: "Get daily network-activity aggregates",
     description:
@@ -4215,6 +4276,16 @@ const ACCOUNT_EVENT_ITEM = {
   observed_at: NULLABLE_STRING,
   extrinsic_index: NULLABLE_INT,
 };
+const CHAIN_TRANSFER_PARTY_ITEM = {
+  type: "object",
+  additionalProperties: false,
+  required: ["address", "volume_tao", "transfer_count"],
+  properties: {
+    address: { type: "string" },
+    volume_tao: { type: "number" },
+    transfer_count: { type: "integer", minimum: 0 },
+  },
+};
 // Shared block item shape for list_blocks (each block in the feed).
 const BLOCK_ITEM = {
   block_number: NULLABLE_INT,
@@ -5112,6 +5183,43 @@ const TOOL_OUTPUT_SCHEMAS = {
         total_tip_tao: { type: ["number", "null"] },
         extrinsic_count: NULLABLE_INT,
       }),
+    },
+  },
+  get_chain_transfers: {
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "schema_version",
+      "window",
+      "observed_at",
+      "total_volume_tao",
+      "transfer_count",
+      "unique_senders",
+      "unique_receivers",
+      "top_sender_share",
+      "top_senders",
+      "top_receivers",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      window: {
+        type: ["string", "null"],
+        enum: [...CHAIN_TRANSFER_WINDOW_KEYS, null],
+      },
+      observed_at: NULLABLE_STRING,
+      total_volume_tao: { type: "number" },
+      transfer_count: { type: "integer", minimum: 0 },
+      unique_senders: { type: "integer", minimum: 0 },
+      unique_receivers: { type: "integer", minimum: 0 },
+      top_sender_share: { type: ["number", "null"] },
+      top_senders: {
+        type: "array",
+        items: CHAIN_TRANSFER_PARTY_ITEM,
+      },
+      top_receivers: {
+        type: "array",
+        items: CHAIN_TRANSFER_PARTY_ITEM,
+      },
     },
   },
   get_network_activity: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -2109,6 +2109,93 @@ describe("MCP get_chain_fees", () => {
   });
 });
 
+describe("MCP get_chain_transfers", () => {
+  function chainTransfersD1(
+    {
+      totals = {
+        transfer_count: 10,
+        total_volume_tao: 100,
+        unique_senders: 4,
+        unique_receivers: 6,
+      },
+      senders = [{ address: "5Sa", volume_tao: 80, transfer_count: 5 }],
+      receivers = [{ address: "5Rx", volume_tao: 60, transfer_count: 4 }],
+    } = {},
+    capture = [],
+  ) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  if (/COUNT\(DISTINCT hotkey\)/.test(sql)) {
+                    return { results: [totals] };
+                  }
+                  if (/GROUP BY hotkey/.test(sql)) {
+                    return { results: senders };
+                  }
+                  if (/GROUP BY coldkey/.test(sql)) {
+                    return { results: receivers };
+                  }
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("aggregates volume and ranks top senders/receivers", async () => {
+    const capture = [];
+    const env = chainTransfersD1({}, capture);
+    const res = await callTool(
+      "get_chain_transfers",
+      { window: "7d", limit: 5 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.equal(out.total_volume_tao, 100);
+    assert.equal(out.top_senders[0].address, "5Sa");
+    assert.equal(out.top_receivers[0].address, "5Rx");
+    assert.equal(out.top_sender_share, 0.8);
+    const senders = capture.find((c) => /GROUP BY hotkey/.test(c.sql));
+    assert.match(senders.sql, /event_kind = \?/);
+    assert.equal(senders.params.at(-1), 5);
+  });
+
+  test("defaults to the 7d window", async () => {
+    const res = await callTool(
+      "get_chain_transfers",
+      {},
+      { env: chainTransfersD1() },
+    );
+    assert.equal(res.body.result.structuredContent.window, "7d");
+  });
+
+  test("rejects an unsupported window", async () => {
+    const res = await callTool("get_chain_transfers", { window: "1y" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("degrades to schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_chain_transfers", { window: "30d" });
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "30d");
+    assert.equal(out.total_volume_tao, 0);
+    assert.equal(out.top_sender_share, null);
+    assert.deepEqual(out.top_senders, []);
+    assert.deepEqual(out.top_receivers, []);
+  });
+});
+
 describe("MCP get_network_activity", () => {
   test("merges extrinsics + blocks tiers from D1", async () => {
     const env = {


### PR DESCRIPTION
## Summary

- Add MCP tool `get_chain_transfers` for the live REST route `GET /api/v1/chain/transfers`: network-wide Balances.Transfer volume, distinct senders/receivers, top senders/receivers leaderboards, and top-sender concentration over a 7d/30d window.
- Wire the tool to the shared `loadChainTransfers` loader (`src/chain-transfers.mjs`); REST and MCP share one read path. Window labels in the input schema, output schema, and runtime validation are all derived from `CHAIN_TRANSFER_WINDOWS` so they cannot drift.
- Add a typed `TOOL_OUTPUT_SCHEMAS` entry matching `ChainTransfersArtifact`, MCP integration tests, and `validate:mcp` coverage. Bump `MCP_SERVER_VERSION` and `server.json` to **1.16.0**.

## Test plan

- [x] `npx vitest run tests/mcp-server.test.mjs -t "get_chain_transfers"`
- [x] `npm run validate:mcp` — 68 tools, lifecycle + all tools/call
- [x] `npm run lint`
- [x] `npm run format:check`