### PR TITLE
fix(api): expose x-metagraph-artifact-source on the account-history inverted-range short-circuit

### DIFF
--- a/tests/account-history.test.mjs
+++ b/tests/account-history.test.mjs
@@ -167,3 +167,33 @@ test("GET /accounts/{ss58}/history ignores a malformed cursor (first page)", asy
   assert.ok(/OFFSET/.test(sql));
   assert.ok(!/\(day, netuid\) </.test(sql));
 });
+
+test("GET /accounts/{ss58}/history exposes x-metagraph-artifact-source on both the normal and inverted-range short-circuit paths (#2618)", async () => {
+  // The normal path stamps meta.source and exposes the CORS header; the inverted
+  // from>to short-circuit stamps the same meta.source, so it must expose the
+  // header too — it must not be dropped just because the range is empty.
+  const normal = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/history`),
+    dbWith({ days: [DAY] }),
+    {},
+  );
+  assert.equal(
+    normal.headers.get("x-metagraph-artifact-source"),
+    "chain-events",
+  );
+
+  const { env, captured } = dbCapture([DAY]);
+  const inverted = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/history?from=2026-06-30&to=2026-06-01`),
+    env,
+    {},
+  );
+  assert.equal(inverted.status, 200);
+  assert.equal((await inverted.json()).data.day_count, 0);
+  // Short-circuited before D1 — no account_events_daily scan.
+  assert.ok(!captured.some((q) => /FROM account_events_daily/.test(q.sql)));
+  assert.equal(
+    inverted.headers.get("x-metagraph-artifact-source"),
+    "chain-events",
+  );
+});

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -836,7 +836,11 @@ export async function handleAccountHistory(request, env, ss58, url) {
       offset,
       nextCursor: null,
     });
-    return envelopeResponse(
+    // Use the account envelope so this short-circuit exposes the
+    // x-metagraph-artifact-source header too — the normal path below does (#2618),
+    // and the payload stamps the same meta.source, so a browser must not lose the
+    // CORS-exposed header just because the range was inverted.
+    return accountEnvelopeResponse(
       request,
       {
         data,


### PR DESCRIPTION
## Summary

- #2618 routed the account handlers through `accountEnvelopeResponse` so browsers receive the CORS-exposed `x-metagraph-artifact-source` header. But `handleAccountHistory`'s inverted `from > to` short-circuit (the deterministic empty-page path added by #2594) still returned via the plain `envelopeResponse`.
- That short-circuit stamps the same `meta.source` (`accountMeta` → `"chain-events"`) as the normal path, so `GET`/`HEAD /api/v1/accounts/{ss58}/history?from=…&to=…` with an inverted range returned the correct empty page **without** the `x-metagraph-artifact-source` header that the same route exposes for every other query — an observable header inconsistency on one endpoint.

## What Changed

- `workers/request-handlers/entities.mjs`: return the inverted-range short-circuit through `accountEnvelopeResponse` (same meta, now with the exposed header), matching the handler's normal path.
- `tests/account-history.test.mjs`: regression asserting both the normal and inverted-range responses carry `x-metagraph-artifact-source: chain-events`, and that the short-circuit still skips the `account_events_daily` D1 scan. Fails without the fix.

One-line behavioral change; no schema/OpenAPI/contract change.

### Reproduction (before)

```
GET /api/v1/accounts/{ss58}/history?from=2026-06-30&to=2026-06-01
→ 200, empty page, but NO x-metagraph-artifact-source header
   (a normal-range query on the same route DOES return it)
```

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — completes #2618's header exposure.)

## Validation

- [x] `npx vitest run tests/account-history.test.mjs` (8 pass; the new regression fails without the fix)
- [x] `npx eslint workers/request-handlers/entities.mjs tests/account-history.test.mjs` (clean)
- [x] `npx prettier --check` (clean)
- [x] `git diff --check`
