### PR TITLE
fix(api): expose x-metagraph-artifact-source on the inverted-range history short-circuit

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1888,17 +1888,23 @@ describe("handleAccountHistory", () => {
 
   test("short-circuits an inverted from>to date window before D1", async () => {
     const { env, captures } = dbWith({ accountEventsDaily: [accountDayRow()] });
-    const body = await json(
-      await handleAccountHistory(
-        req(`/api/v1/accounts/${SS58}/history`),
-        env,
-        SS58,
-        url(`/api/v1/accounts/${SS58}/history?from=2026-06-30&to=2026-06-01`),
-      ),
+    const res = await handleAccountHistory(
+      req(`/api/v1/accounts/${SS58}/history`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/history?from=2026-06-30&to=2026-06-01`),
     );
+    const body = await json(res);
     assert.equal(body.data.day_count, 0);
     assert.deepEqual(body.data.days, []);
     assert.equal(captures.sql.length, 0);
+    // The inverted-range short-circuit must still expose the artifact-source
+    // header every other account envelope carries (#2618), not drop it.
+    assert.equal(body.meta.source, "chain-events");
+    assert.equal(
+      res.headers.get("x-metagraph-artifact-source"),
+      "chain-events",
+    );
   });
 });
 

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -860,7 +860,7 @@ export async function handleAccountHistory(request, env, ss58, url) {
       offset,
       nextCursor: null,
     });
-    return envelopeResponse(
+    return accountEnvelopeResponse(
       request,
       {
         data,


### PR DESCRIPTION
## Summary

`GET /api/v1/accounts/{ss58}/history` dropped the `x-metagraph-artifact-source` response header when the caller passed an inverted date window (`from > to`), even though it carries it on every other query.

Commit #2618/#2581 established the contract that every account-route envelope exposes the CORS-visible `x-metagraph-artifact-source` header (matching `meta.source`), and introduced `accountEnvelopeResponse()` to stamp it. But `handleAccountHistory`'s early short-circuit for an inverted `from > to` window still returned via the plain `envelopeResponse()`, which does not set the header. Both branches build identical meta via `accountMeta()` (`source: "chain-events"`), so the header was present or absent purely on whether the requested range happened to be inverted — a client reading the artifact source from the header loses it on exactly that request shape.

## What Changed

- `workers/request-handlers/entities.mjs` — the inverted-range short-circuit in `handleAccountHistory` now returns via `accountEnvelopeResponse()` (same argument shape as `envelopeResponse`), matching every other account handler.
- `tests/request-handlers-entities.test.mjs` — extended the existing "short-circuits an inverted from>to date window" test to also assert `res.headers.get("x-metagraph-artifact-source") === "chain-events"`.

No schema/contract change, so no regenerated committed artifacts.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (no contract change; restores the #2618 header contract on a branch that missed it)

## Validation

- [x] `npx vitest run tests/request-handlers-entities.test.mjs` — 224 passed
- [x] Confirmed the extended test **fails on the pre-fix tree** (header absent) and **passes after** the fix
- [x] `npx eslint workers/request-handlers/entities.mjs tests/request-handlers-entities.test.mjs` — clean
- [x] `npx prettier --check --end-of-line auto` on both files — clean
- [x] `git diff --check` — clean
