### PR TITLE
fix(account-events): short-circuit inverted block range before D1

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -627,6 +627,15 @@ export async function loadAccountEvents(
 ) {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
+  // Inverted block-height bounds are a deterministic no-match. Short-circuit before
+  // D1 so REST and MCP callers cannot force a scan to prove an impossible empty page.
+  if (blockStart != null && blockEnd != null && blockStart > blockEnd) {
+    return buildAccountEvents([], ss58, {
+      limit: lim,
+      offset: off,
+      nextCursor: null,
+    });
+  }
   const filterParts = [];
   const filterParams = [];
   if (kind) {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -631,6 +631,22 @@ test("loadAccountTransfers short-circuits an inverted block range before D1", as
   assert.equal(called, false);
 });
 
+test("loadAccountEvents short-circuits an inverted block range before D1", async () => {
+  let called = false;
+  const out = await loadAccountEvents(
+    async () => {
+      called = true;
+      return [];
+    },
+    "5Hk",
+    { blockStart: 500, blockEnd: 100, limit: 50, offset: 0 },
+  );
+  assert.equal(out.event_count, 0);
+  assert.deepEqual(out.events, []);
+  assert.equal(out.next_cursor, null);
+  assert.equal(called, false);
+});
+
 test("loadAccountTransfers uses cursor keyset pagination over offset", async () => {
   let captured;
   const out = await loadAccountTransfers(


### PR DESCRIPTION
## Summary

Stop `loadAccountEvents` from querying D1 when `block_start` exceeds `block_end`.

## What Changed

- `loadAccountEvents` built and ran the indexed UNION query even for an impossible block range (`block_start > block_end`), while sibling loaders `loadAccountExtrinsics` (#2622) and `loadAccountTransfers` (#2625) already short-circuit to an empty page.
- Added the same inverted-range guard before SQL assembly; REST `handleAccountEvents` and MCP account tools inherit the fix via the shared loader.
- Regression test in `tests/account-events.test.mjs`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No contract change.)

## Validation

- [x] `npx vitest run tests/account-events.test.mjs -t "loadAccountEvents short-circuits"`
- [x] `git diff --check`
