### PR TITLE
fix(metagraph-neurons): coerce D1 string ratio cells in formatNeuron

### DIFF
--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -79,6 +79,13 @@ function round(value, dp = 6) {
   return Math.round(value * factor) / factor;
 }
 
+// Coerce a nullable D1 REAL/INTEGER ratio cell to a rounded number (or null).
+function ratioOrNull(value) {
+  if (value == null) return null;
+  const n = nullableNumber(value);
+  return n == null ? null : round(n);
+}
+
 // Coerce a D1 0/1 INTEGER flag cell to a boolean. Numeric strings like "0"
 // must not pass through Boolean(), which treats any non-empty string as true.
 // Mirrors the local toD1Flag added to formatRegistration by #2487.
@@ -105,12 +112,12 @@ export function formatNeuron(row) {
     coldkey: row.coldkey ?? null,
     active: toD1Flag(row.active),
     validator_permit: toD1Flag(row.validator_permit),
-    rank: row.rank ?? null,
-    trust: row.trust ?? null,
-    validator_trust: row.validator_trust ?? null,
-    consensus: row.consensus ?? null,
-    incentive: row.incentive ?? null,
-    dividends: row.dividends ?? null,
+    rank: ratioOrNull(row.rank),
+    trust: ratioOrNull(row.trust),
+    validator_trust: ratioOrNull(row.validator_trust),
+    consensus: ratioOrNull(row.consensus),
+    incentive: ratioOrNull(row.incentive),
+    dividends: ratioOrNull(row.dividends),
     emission_tao: row.emission_tao == null ? null : roundTao(row.emission_tao),
     stake_tao: row.stake_tao == null ? null : roundTao(row.stake_tao),
     registered_at_block:

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -110,6 +110,25 @@ describe("metagraph-neurons builders", () => {
     assert.equal(typeof n.emission_tao, "number");
   });
 
+  test("formatNeuron coerces string-typed ratio cells to numbers", () => {
+    const n = formatNeuron({
+      rank: "12",
+      trust: "0.25",
+      validator_trust: "0.4",
+      consensus: "0.88",
+      incentive: "0.01",
+      dividends: "0.02",
+    });
+    assert.equal(n.rank, 12);
+    assert.equal(typeof n.rank, "number");
+    assert.equal(n.trust, 0.25);
+    assert.equal(typeof n.trust, "number");
+    assert.equal(n.validator_trust, 0.4);
+    assert.equal(n.consensus, 0.88);
+    assert.equal(n.incentive, 0.01);
+    assert.equal(n.dividends, 0.02);
+  });
+
   test("formatNeuron rounds stake_tao / emission_tao to rao precision (no IEEE-754 leak)", () => {
     // Regression for the Gittensory Orb follow-up blocker on #2503: stake_tao /
     // emission_tao must be rounded to 1e-9 (rao) precision so a noisy REAL


### PR DESCRIPTION
## Summary

Coerce D1 string-typed ratio columns in `formatNeuron` so metagraph neuron payloads stay numeric.

## What Changed

- `formatNeuron` coerced uid, `registered_at_block`, stake, and emission cells but passed `rank`, `trust`, `validator_trust`, `consensus`, `incentive`, and `dividends` through raw (`row.field ?? null`). D1 REAL/INTEGER columns often arrive as numeric strings (`"0.4"`), violating the schema `["number","null"]` contract on neuron detail and subnet metagraph responses.
- Added `ratioOrNull` (`nullableNumber` + `round`, matching `buildGlobalValidators`) for all six ratio fields.
- Regression test in `tests/metagraph-neurons.test.mjs`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (Aligns output with existing schema.)

## Validation

- [x] `npx vitest run tests/metagraph-neurons.test.mjs -t "formatNeuron coerces string-typed ratio"`
- [x] `git diff --check`
