### PR TITLE
fix(api): short-circuit inverted block range on account events before D1

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -627,6 +627,15 @@ export async function loadAccountEvents(
 ) {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
+  // Inverted block-height bounds are a deterministic no-match. Short-circuit before
+  // D1 so REST and MCP callers cannot force a scan to prove an impossible empty page.
+  if (blockStart != null && blockEnd != null && blockStart > blockEnd) {
+    return buildAccountEvents([], ss58, {
+      limit: lim,
+      offset: off,
+      nextCursor: null,
+    });
+  }
   const filterParts = [];
   const filterParams = [];
   if (kind) {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -1081,6 +1081,22 @@ test("loadAccountEvents applies the ?kind filter as a bound param", async () => 
   ]);
 });
 
+test("loadAccountEvents short-circuits an inverted block range before D1", async () => {
+  let called = false;
+  const out = await loadAccountEvents(
+    async () => {
+      called = true;
+      return [];
+    },
+    "5Hk",
+    { blockStart: 500, blockEnd: 100, limit: 50, offset: 0 },
+  );
+  assert.equal(out.event_count, 0);
+  assert.deepEqual(out.events, []);
+  assert.equal(out.next_cursor, null);
+  assert.equal(called, false);
+});
+
 test("loadAccountEvents applies the block_start/block_end range as bound params", async () => {
   let captured;
   await loadAccountEvents(

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1742,6 +1742,23 @@ describe("handleAccountEvents", () => {
     assert.equal(body.meta.parameter, "block_end");
   });
 
+  test("short-circuits an inverted block_start>block_end window before D1", async () => {
+    const { env, captures } = dbWith({
+      accountEvents: [accountEventRow()],
+    });
+    const body = await json(
+      await handleAccountEvents(
+        req(`/api/v1/accounts/${SS58}/events`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/events?block_start=500&block_end=100`),
+      ),
+    );
+    assert.equal(body.data.event_count, 0);
+    assert.deepEqual(body.data.events, []);
+    assert.equal(captures.sql.length, 0);
+  });
+
   test("returns schema-stable empty events on cold D1", async () => {
     const body = await assertColdSchema(
       handleAccountEvents,


### PR DESCRIPTION
## Summary
- Add the same inverted block_start > block_end short-circuit to loadAccountEvents that account extrinsics (#2622) and transfers (#2625) already use.
- Return a schema-stable empty page without hitting D1 when the range is impossible.

## Test plan
- [x] loadAccountEvents unit test asserts D1 is not called on inverted range
- [x] handleAccountEvents route test asserts empty payload and zero SQL captures