### PR TITLE
fix(api): cap chain activity success_rate above 1.0

### DIFF
--- a/src/chain-analytics.mjs
+++ b/src/chain-analytics.mjs
@@ -13,10 +13,13 @@ function toCount(value) {
 
 // Round a ratio to 4 dp without trailing float noise (0.99186… → 0.9919).
 // Sub-perfect ratios that would round up to 1.0 are clamped to 0.9999 so a
-// near-perfect day is never reported as a perfect success rate.
+// near-perfect day is never reported as a perfect success rate. Ratios above
+// 1.0 (stale aggregates where successful_extrinsics > extrinsic_count) cap at
+// 1.0 so the payload never reports an impossible >100% success rate.
 function round4(value) {
-  const rounded = Math.round(value * 1e4) / 1e4;
-  return rounded >= 1 && value < 1 ? 0.9999 : rounded;
+  const bounded = value > 1 ? 1 : value;
+  const rounded = Math.round(bounded * 1e4) / 1e4;
+  return rounded >= 1 && bounded < 1 ? 0.9999 : rounded;
 }
 
 // Coerce a D1 fee/tip cell (TAO float, numeric string, or null) to a finite

--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -116,6 +116,20 @@ test("success_rate clamps a sub-perfect ratio that rounds to 1.0", () => {
   assert.equal(d.success_rate, 0.9999); // 99_999/100_000 = 0.99999 → not 1
 });
 
+test("success_rate caps an over-100% ratio at 1.0 when counts disagree", () => {
+  const [d] = buildChainActivity({
+    window: "7d",
+    extrinsicRows: [
+      {
+        day: "2026-06-25",
+        extrinsic_count: 100,
+        successful_extrinsics: 105,
+      },
+    ],
+  }).days;
+  assert.equal(d.success_rate, 1);
+});
+
 test("a day with zero extrinsics reports success_rate null, never NaN", () => {
   const out = buildChainActivity({
     window: "7d",


### PR DESCRIPTION
## Summary
- Extend round4 in chain-analytics so success_rate never exceeds 1.0 when stale aggregates report successful_extrinsics above extrinsic_count.
- Complements the existing sub-perfect clamp to 0.9999 (#2020).

## Test plan
- [x] Unit test for 105/100 successful ratio caps at 1.0
- [x] Existing sub-perfect clamp test still passes