### PR TITLE
fix(subnet-yield): report a null block_number as null, not a fabricated 0

### DIFF
--- a/src/subnet-yield.mjs
+++ b/src/subnet-yield.mjs
@@ -80,7 +80,12 @@ export function buildSubnetYield(rows, netuid) {
     if (uid == null) continue;
     if (capturedAt == null) {
       capturedAt = toIso(Number(row?.captured_at));
-      const block = Number(row?.block_number);
+      // block_number is a nullable INTEGER; guard null before Number() since
+      // Number(null) === 0 would fabricate the genesis height 0 for a row whose
+      // block is absent (the contract models it as ["integer","null"]). A
+      // numeric string like "8454388" from D1 must still pass.
+      const rawBlock = row?.block_number;
+      const block = rawBlock == null ? NaN : Number(rawBlock);
       blockNumber = Number.isFinite(block) ? block : null;
     }
     const stake = toNumber(row?.stake_tao);

--- a/tests/subnet-yield.test.mjs
+++ b/tests/subnet-yield.test.mjs
@@ -146,6 +146,16 @@ describe("buildSubnetYield", () => {
     assert.equal(d.block_number, null); // non-finite block -> null
   });
 
+  test("a null D1 block_number stays null, not a fabricated genesis 0", () => {
+    // block_number is a nullable INTEGER; Number(null) === 0 must not surface
+    // as the real chain height 0 (the contract models it as ["integer","null"]).
+    const d = buildSubnetYield(
+      [neuron(0, { validator: true, stake: 10, emission: 1, block: null })],
+      7,
+    );
+    assert.equal(d.block_number, null);
+  });
+
   test("ties break by uid, extra zero-stake UIDs sink, and a missing hotkey is null", () => {
     const d = buildSubnetYield(
       [


### PR DESCRIPTION
## Summary

`buildSubnetYield` reported a fabricated `block_number: 0` for a subnet whose snapshot's first neuron row has a **null** chain height, instead of the `null` the contract defines. This surfaces through both `GET /api/v1/subnets/{netuid}/yield` and the newly-added `get_subnet_yield` MCP tool (#2612), which share this shaper.

The snapshot block was stamped via `Number(row.block_number)`, and `Number(null) === 0` is finite, so a null cell became the genesis height `0`:

```js
const block = Number(row?.block_number);
blockNumber = Number.isFinite(block) ? block : null;
```

`block_number` is a nullable `INTEGER` in the `neurons` table and `loadSubnetYield` selects it unfiltered, so a null is reachable; the contract (`SubnetYieldArtifact`) and the MCP output schema both model it as `["integer","null"]`. This is the same coercion class the maintainers just fixed in the global validators leaderboard (#2611) and the neuron snapshot stamp / detail (#2623).

## What Changed

- `src/subnet-yield.mjs` — guard `block_number == null` before `Number()` so a null cell yields `null`, while a numeric string like `"8454388"` from D1 still passes. `captured_at` is `INTEGER NOT NULL`, so it is intentionally left unchanged.
- `tests/subnet-yield.test.mjs` — regression test: a neuron row with `block_number: null` yields `block_number: null` (the existing coercion test only covered a non-numeric *string* block, not `null`).

No schema/contract change, so no regenerated committed artifacts.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (no contract change; aligns runtime with the existing `["integer","null"]` contract)

## Validation

- [x] `npx vitest run tests/subnet-yield.test.mjs` — 14 passed
- [x] Confirmed the new test **fails on the pre-fix tree** (`block_number` was `0`) and **passes after** the fix
- [x] `npx eslint src/subnet-yield.mjs tests/subnet-yield.test.mjs` — clean
- [x] `npx prettier --check --end-of-line auto` on both files — clean
- [x] `git diff --check` — clean
