### PR TITLE
fix(api): short-circuit inverted block range on subnet events before D1

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -360,6 +360,63 @@ export function buildSubnetEvents(
   };
 }
 
+// Paginated chain-event stream for one subnet (newest first), optional kind
+// filter, offset or keyset cursor. Clamps internally so REST and MCP agree; a
+// cursor overrides offset.
+export async function loadSubnetEvents(
+  d1,
+  netuid,
+  { kind, limit, offset, cursor, blockStart, blockEnd } = {},
+) {
+  const lim = clampLimit(limit, FEED_PAGINATION);
+  const off = clampOffset(offset);
+  // Inverted block-height bounds are a deterministic no-match. Short-circuit before
+  // D1 so REST and MCP callers cannot force a scan to prove an impossible empty page.
+  if (blockStart != null && blockEnd != null && blockStart > blockEnd) {
+    return buildSubnetEvents([], netuid, {
+      limit: lim,
+      offset: off,
+      nextCursor: null,
+    });
+  }
+  const cur = decodeCursor(cursor, 2);
+  const useCursor = Boolean(cur);
+  const params = [netuid];
+  let sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE netuid = ?`;
+  if (kind) {
+    sql += " AND event_kind = ?";
+    params.push(kind);
+  }
+  if (blockStart != null) {
+    sql += " AND block_number >= ?";
+    params.push(blockStart);
+  }
+  if (blockEnd != null) {
+    sql += " AND block_number <= ?";
+    params.push(blockEnd);
+  }
+  if (useCursor) {
+    sql += " AND (block_number, event_index) < (?, ?)";
+    params.push(cur[0], cur[1]);
+  }
+  sql += " ORDER BY block_number DESC, event_index DESC LIMIT ?";
+  params.push(lim);
+  if (!useCursor) {
+    sql += " OFFSET ?";
+    params.push(off);
+  }
+  const rows = await d1(sql, params);
+  const last = rows.length === lim ? rows[rows.length - 1] : null;
+  const nextCursor = last
+    ? encodeCursor([last.block_number, last.event_index])
+    : null;
+  return buildSubnetEvents(rows, netuid, {
+    limit: lim,
+    offset: off,
+    nextCursor,
+  });
+}
+
 // The decoded chain events in ONE block (#1852, block explorer): account_events
 // filtered by block_number, in natural read order (event_index ASC). Mirrors
 // buildBlockExtrinsics — ref is the original {ref} (numeric or 0x hash), so a

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -104,6 +104,7 @@ import {
   buildSubnetEvents,
   loadAccountSummary,
   loadAccountEvents,
+  loadSubnetEvents,
   loadAccountSubnets,
   loadAccountHistory,
   loadAccountExtrinsics,
@@ -584,44 +585,6 @@ async function loadNeuronHistory(ctx, netuid, uid, { label, days }) {
   params.push(MAX_HISTORY_POINTS);
   const rows = await run(sql, params);
   return buildNeuronHistory(rows, netuid, uid, { window: label });
-}
-
-// One subnet's first-party chain-event stream — mirrors handleSubnetEvents:
-// account_events filtered by netuid, newest first, optional kind filter, keyset
-// (cursor) pagination on (block_number, event_index) with offset as the
-// deprecated fallback. Cold D1 → event_count:0.
-async function loadSubnetEvents(ctx, netuid, { kind, limit, offset, cursor }) {
-  const run = mcpD1Runner(ctx);
-  const resolvedLimit = clampPageLimit(limit, FEED_PAGINATION);
-  const resolvedOffset = clampOffset(offset);
-  const cur = decodeCursor(cursor, 2);
-  const useCursor = Boolean(cur);
-  const params = [netuid];
-  let sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE netuid = ?`;
-  if (kind) {
-    sql += " AND event_kind = ?";
-    params.push(kind);
-  }
-  if (useCursor) {
-    sql += " AND (block_number, event_index) < (?, ?)";
-    params.push(cur[0], cur[1]);
-  }
-  sql += " ORDER BY block_number DESC, event_index DESC LIMIT ?";
-  params.push(resolvedLimit);
-  if (!useCursor) {
-    sql += " OFFSET ?";
-    params.push(resolvedOffset);
-  }
-  const rows = await run(sql, params);
-  const last = rows.length === resolvedLimit ? rows[rows.length - 1] : null;
-  const nextCursor = last
-    ? encodeCursor([last.block_number, last.event_index])
-    : null;
-  return buildSubnetEvents(rows, netuid, {
-    limit: resolvedLimit,
-    offset: resolvedOffset,
-    nextCursor,
-  });
 }
 
 // One provider's detail + (optionally) its endpoints, mirroring GET
@@ -2147,7 +2110,7 @@ export const MCP_TOOLS = [
       const netuid = requireNetuid(args);
       const kind = optionalString(args, "kind");
       const cursor = optionalString(args, "cursor");
-      return loadSubnetEvents(ctx, netuid, {
+      return loadSubnetEvents(mcpD1Runner(ctx), netuid, {
         kind,
         limit: args?.limit,
         offset: args?.offset,

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -14,6 +14,7 @@ import {
   buildAccountSubnets,
   loadAccountSummary,
   loadAccountEvents,
+  loadSubnetEvents,
   loadAccountHistory,
   loadAccountExtrinsics,
   loadAccountSubnets,
@@ -1104,6 +1105,23 @@ test("loadAccountEvents applies the block_start/block_end range as bound params"
     100,
     0,
   ]);
+});
+
+test("loadSubnetEvents short-circuits an inverted block range before D1", async () => {
+  let called = false;
+  const out = await loadSubnetEvents(
+    async () => {
+      called = true;
+      return [];
+    },
+    7,
+    { blockStart: 500, blockEnd: 100, limit: 50, offset: 0 },
+  );
+  assert.equal(out.netuid, 7);
+  assert.equal(out.event_count, 0);
+  assert.deepEqual(out.events, []);
+  assert.equal(out.next_cursor, null);
+  assert.equal(called, false);
 });
 
 test("loadAccountEvents emits a next_cursor only on a full page", async () => {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2648,6 +2648,24 @@ describe("handleSubnetEvents", () => {
     assert.ok(captures.params.some((p) => p.includes(100) && p.includes(900)));
   });
 
+  test("short-circuits an inverted block_start>block_end window before D1", async () => {
+    const { env, captures } = dbWith({
+      subnetEvents: [accountEventRow({ block_number: 500 })],
+    });
+    const body = await json(
+      await handleSubnetEvents(
+        req(`/api/v1/subnets/${NETUID}/events`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/events?block_start=500&block_end=100`),
+      ),
+    );
+    assert.equal(body.data.event_count, 0);
+    assert.deepEqual(body.data.events, []);
+    assert.equal(body.data.next_cursor, null);
+    assert.equal(captures.sql.length, 0);
+  });
+
   test("rejects a non-integer block_start with 400", async () => {
     const res = await handleSubnetEvents(
       req(`/api/v1/subnets/${NETUID}/events`),

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -62,10 +62,10 @@ import {
   ACCOUNT_EVENT_COLUMNS,
   INGESTED_EVENT_KINDS,
   buildAccountHistory,
-  buildSubnetEvents,
   formatAccountEvent,
   loadAccountSummary,
   loadAccountEvents,
+  loadSubnetEvents,
   loadAccountExtrinsics,
   loadAccountTransfers,
   loadAccountSubnets,
@@ -1142,7 +1142,6 @@ export async function handleSubnetEvents(request, env, netuid, url) {
     "cursor",
   ]);
   if (validationError) return analyticsQueryError(validationError);
-  const { limit, offset, cursor } = parsePagination(url, FEED_PAGINATION);
   const kind = url.searchParams.get("kind");
   // Reject an unknown ?kind= up front, validated against the FULL ingested set
   // (not just INDEXED_EVENT_KINDS, which would wrongly reject Transfer/NetworkAdded
@@ -1167,40 +1166,14 @@ export async function handleSubnetEvents(request, env, netuid, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
-  // Keyset (cursor) pagination on (block_number, event_index), mirroring
-  // loadAccountEvents; offset stays as a deprecated fallback, cursor wins.
-  const cur = decodeCursor(cursor, 2);
-  const useCursor = Boolean(cur);
-  const params = [netuid];
-  let sql = `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE netuid = ?`;
-  if (kind) {
-    sql += " AND event_kind = ?";
-    params.push(kind);
-  }
-  if (blockStart.value != null) {
-    sql += " AND block_number >= ?";
-    params.push(blockStart.value);
-  }
-  if (blockEnd.value != null) {
-    sql += " AND block_number <= ?";
-    params.push(blockEnd.value);
-  }
-  if (useCursor) {
-    sql += " AND (block_number, event_index) < (?, ?)";
-    params.push(cur[0], cur[1]);
-  }
-  sql += " ORDER BY block_number DESC, event_index DESC LIMIT ?";
-  params.push(limit);
-  if (!useCursor) {
-    sql += " OFFSET ?";
-    params.push(offset);
-  }
-  const rows = await d1All(env, sql, params);
-  const last = rows.length === limit ? rows[rows.length - 1] : null;
-  const nextCursor = last
-    ? encodeCursor([last.block_number, last.event_index])
-    : null;
-  const data = buildSubnetEvents(rows, netuid, { limit, offset, nextCursor });
+  const data = await loadSubnetEvents(d1Runner(env), netuid, {
+    limit: url.searchParams.get("limit"),
+    offset: url.searchParams.get("offset"),
+    kind: url.searchParams.get("kind"),
+    cursor: url.searchParams.get("cursor"),
+    blockStart: blockStart.value,
+    blockEnd: blockEnd.value,
+  });
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## What

`GET /api/v1/subnets/{netuid}/events` accepts optional `?block_start=` / `?block_end=` height filters. When `block_start > block_end`, the range is impossible.

Account-scoped feeds (`loadAccountEvents`, `loadAccountExtrinsics`, `loadAccountTransfers`) and global feeds (`loadExtrinsics`, `loadBlocks`) already short-circuit impossible windows before D1. The per-subnet event stream still queried D1 for a deterministically empty page.

## How

Extract a shared `loadSubnetEvents` loader in `account-events.mjs` (matching the account tail-loader pattern) with a pre-D1 `block_start > block_end` guard. Refactor `handleSubnetEvents` and MCP `get_subnet_events` to call it so REST and MCP stay aligned.

## Why no linked issue

Standalone guard gap found by comparing the subnet events handler with sibling feeds that already short-circuit. Open PR #2632 covers the account-scoped `loadAccountEvents` path; this completes the **subnet-scoped** event stream. No open issue tracks this specific gap.

## Scope / risk

One shared loader + handler/MCP wiring plus loader + REST handler tests asserting zero D1 work. Valid filters unchanged.

## Tests

- `account-events.test.mjs`: `loadSubnetEvents short-circuits an inverted block range before D1`
- `request-handlers-entities.test.mjs`: inverted `block_start=500&block_end=100` returns empty feed with `captures.sql.length === 0` and `next_cursor === null`

## Test plan

- [x] Inverted block window returns empty feed without D1 (loader + REST handler)
- [x] Existing subnet events tests continue to pass
- [x] CI vitest + lint/format checks
