### PR TITLE
fix(api): canonicalize chain analytics edge-cache keys on resolved defaults

### DIFF
--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -13,6 +13,10 @@ import {
   handleHealthPercentiles,
   handleHealthIncidents,
   handleGlobalIncidents,
+  handleChainCalls,
+  handleChainSigners,
+  handleChainTransfers,
+  handleChainFees,
   validateQueryParams,
   analyticsWindow,
   d1All,
@@ -131,6 +135,57 @@ function rowsForSql(sql) {
         p95: 500,
       },
     ];
+  }
+  if (sql.includes("FROM extrinsics")) {
+    if (sql.includes("COUNT(*) AS total") && !sql.includes("GROUP BY")) {
+      return [{ total: 10 }];
+    }
+    if (sql.includes("GROUP BY signer")) {
+      return [
+        {
+          signer: "5FHneW46xGXgs5mUive6eigkdRD2AYN6fy8616ckdp26RGGj",
+          tx_count: 3,
+          total_fee_tao: 1,
+          total_tip_tao: 0,
+          extrinsic_count: 3,
+          last_tx_block: 100,
+        },
+      ];
+    }
+    if (sql.includes("GROUP BY day")) {
+      return [
+        {
+          day: "2026-06-01",
+          extrinsic_count: 5,
+          total_fee_tao: 2,
+          total_tip_tao: 0.5,
+        },
+      ];
+    }
+    if (sql.includes("GROUP BY call_module")) {
+      return [{ call_module: "Balances", count: 4 }];
+    }
+    if (sql.includes("ROW_NUMBER() OVER")) {
+      return [{ day: "2026-06-01", median_fee_tao: 0.1, median_tip_tao: 0.01 }];
+    }
+  }
+  if (sql.includes("FROM account_events")) {
+    if (sql.includes("GROUP BY hotkey")) {
+      return [{ address: "5Ffrom", volume_tao: 10, transfer_count: 2 }];
+    }
+    if (sql.includes("GROUP BY coldkey")) {
+      return [{ address: "5Fto", volume_tao: 8, transfer_count: 1 }];
+    }
+    if (sql.includes("COUNT(*) AS transfer_count")) {
+      return [
+        {
+          transfer_count: 3,
+          total_volume_tao: 18,
+          unique_senders: 2,
+          unique_receivers: 1,
+        },
+      ];
+    }
   }
   return [];
 }
@@ -331,37 +386,160 @@ describe("validateQueryParams", () => {
 });
 
 describe("canonicalAnalyticsCacheRoute", () => {
-  test("normalizes decoded query values for cache keys", () => {
-    const plain = url(
-      "/api/v1/chain/signers?call_module=Balances&limit=10&window=30d&sort=total_fee_tao",
+  test("canonicalizes resolved window/limit/sort for chain signers", () => {
+    const bare = url("/api/v1/chain/signers");
+    const explicit = url(
+      "/api/v1/chain/signers?window=7d&sort=tx_count&limit=50",
     );
-    const encoded = url(
-      "/api/v1/chain/signers?limit=10&call_module=%42alances&sort=total_fee_tao&window=30d",
-    );
-
+    const key = canonicalAnalyticsCacheRoute(bare, {
+      window: DEFAULT_ANALYTICS_WINDOW,
+      extras: { limit: 50, sort: "tx_count" },
+    });
     assert.equal(
-      canonicalAnalyticsCacheRoute(plain, ["limit", "call_module", "sort"]),
-      "/api/v1/chain/signers?window=30d&limit=10&call_module=Balances&sort=total_fee_tao",
+      key,
+      `/api/v1/chain/signers?window=${DEFAULT_ANALYTICS_WINDOW}&limit=50&sort=tx_count`,
     );
     assert.equal(
-      canonicalAnalyticsCacheRoute(encoded, ["limit", "call_module", "sort"]),
-      canonicalAnalyticsCacheRoute(plain, ["limit", "call_module", "sort"]),
+      canonicalAnalyticsCacheRoute(explicit, {
+        window: DEFAULT_ANALYTICS_WINDOW,
+        extras: { limit: 50, sort: "tx_count" },
+      }),
+      key,
     );
   });
 
-  test("includes the chain calls grouping and module filter in canonical order", () => {
+  test("includes optional call_module when scoped", () => {
+    const requestUrl = url(
+      "/api/v1/chain/signers?call_module=Balances&limit=10&window=30d&sort=total_fee_tao",
+    );
+    assert.equal(
+      canonicalAnalyticsCacheRoute(requestUrl, {
+        window: "30d",
+        extras: {
+          limit: 10,
+          sort: "total_fee_tao",
+          call_module: "Balances",
+        },
+      }),
+      "/api/v1/chain/signers?window=30d&limit=10&sort=total_fee_tao&call_module=Balances",
+    );
+  });
+
+  test("includes resolved group_by and limit for chain calls", () => {
+    const bare = url("/api/v1/chain/calls");
+    const explicit = url(
+      "/api/v1/chain/calls?window=7d&group_by=module&limit=50",
+    );
+    const key = canonicalAnalyticsCacheRoute(bare, {
+      window: DEFAULT_ANALYTICS_WINDOW,
+      extras: { group_by: "module", limit: 50 },
+    });
+    assert.equal(
+      key,
+      `/api/v1/chain/calls?window=${DEFAULT_ANALYTICS_WINDOW}&group_by=module&limit=50`,
+    );
+    assert.equal(
+      canonicalAnalyticsCacheRoute(explicit, {
+        window: DEFAULT_ANALYTICS_WINDOW,
+        extras: { group_by: "module", limit: 50 },
+      }),
+      key,
+    );
+  });
+
+  test("includes call_module filter for scoped chain calls", () => {
     const requestUrl = url(
       "/api/v1/chain/calls?call_module=SubtensorModule&limit=10&group_by=module_function&window=30d",
     );
 
     assert.equal(
-      canonicalAnalyticsCacheRoute(requestUrl, [
-        "group_by",
-        "limit",
-        "call_module",
-      ]),
+      canonicalAnalyticsCacheRoute(requestUrl, {
+        window: "30d",
+        extras: {
+          group_by: "module_function",
+          limit: 10,
+          call_module: "SubtensorModule",
+        },
+      }),
       "/api/v1/chain/calls?window=30d&group_by=module_function&limit=10&call_module=SubtensorModule",
     );
+  });
+
+  test("canonicalizes default limit for chain transfers and fees", () => {
+    assert.equal(
+      canonicalAnalyticsCacheRoute(url("/api/v1/chain/transfers"), {
+        window: DEFAULT_ANALYTICS_WINDOW,
+        extras: { limit: 25 },
+      }),
+      `/api/v1/chain/transfers?window=${DEFAULT_ANALYTICS_WINDOW}&limit=25`,
+    );
+    assert.equal(
+      canonicalAnalyticsCacheRoute(url("/api/v1/chain/fees"), {
+        window: DEFAULT_ANALYTICS_WINDOW,
+        extras: { limit: 25 },
+      }),
+      `/api/v1/chain/fees?window=${DEFAULT_ANALYTICS_WINDOW}&limit=25`,
+    );
+  });
+});
+
+describe("chain analytics handlers", () => {
+  test("handleChainSigners serves bare and scoped requests", async () => {
+    const queries = [];
+    const env = analyticsEnv(queries);
+    const bare = await handleChainSigners(
+      req("/api/v1/chain/signers"),
+      env,
+      url("/api/v1/chain/signers"),
+      ctx,
+    );
+    await json(bare);
+    const scoped = await handleChainSigners(
+      req(
+        "/api/v1/chain/signers?call_module=Balances&limit=10&sort=total_fee_tao",
+      ),
+      env,
+      url(
+        "/api/v1/chain/signers?call_module=Balances&limit=10&sort=total_fee_tao",
+      ),
+      ctx,
+    );
+    const body = await json(scoped);
+    assert.equal(body.data.signers.length, 1);
+    assert.ok(queries.some((q) => /GROUP BY signer/.test(q.sql)));
+  });
+
+  test("handleChainCalls, transfers, and fees return schema-stable payloads", async () => {
+    const queries = [];
+    const env = analyticsEnv(queries);
+    const calls = await json(
+      await handleChainCalls(
+        req("/api/v1/chain/calls"),
+        env,
+        url("/api/v1/chain/calls"),
+        ctx,
+      ),
+    );
+    assert.equal(calls.data.schema_version, 1);
+    const signers = await json(
+      await handleChainTransfers(
+        req("/api/v1/chain/transfers"),
+        env,
+        url("/api/v1/chain/transfers"),
+        ctx,
+      ),
+    );
+    assert.equal(signers.data.schema_version, 1);
+    const fees = await json(
+      await handleChainFees(
+        req("/api/v1/chain/fees?call_module=Balances"),
+        env,
+        url("/api/v1/chain/fees?call_module=Balances"),
+        ctx,
+      ),
+    );
+    assert.equal(fees.data.schema_version, 1);
+    assert.ok(queries.some((q) => /call_module = \?/.test(q.sql)));
   });
 });
 

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -466,19 +466,62 @@ describe("canonicalAnalyticsCacheRoute", () => {
   });
 
   test("canonicalizes default limit for chain transfers and fees", () => {
+    const bareTransfers = url("/api/v1/chain/transfers");
+    const explicitTransfers = url(
+      `/api/v1/chain/transfers?window=${DEFAULT_ANALYTICS_WINDOW}&limit=25`,
+    );
+    const transfersKey = canonicalAnalyticsCacheRoute(bareTransfers, {
+      window: DEFAULT_ANALYTICS_WINDOW,
+      extras: { limit: 25 },
+    });
     assert.equal(
-      canonicalAnalyticsCacheRoute(url("/api/v1/chain/transfers"), {
+      transfersKey,
+      `/api/v1/chain/transfers?window=${DEFAULT_ANALYTICS_WINDOW}&limit=25`,
+    );
+    assert.equal(
+      canonicalAnalyticsCacheRoute(explicitTransfers, {
         window: DEFAULT_ANALYTICS_WINDOW,
         extras: { limit: 25 },
       }),
-      `/api/v1/chain/transfers?window=${DEFAULT_ANALYTICS_WINDOW}&limit=25`,
+      transfersKey,
+    );
+
+    const bareFees = url("/api/v1/chain/fees");
+    const explicitFees = url(
+      `/api/v1/chain/fees?window=${DEFAULT_ANALYTICS_WINDOW}&limit=25`,
+    );
+    const feesKey = canonicalAnalyticsCacheRoute(bareFees, {
+      window: DEFAULT_ANALYTICS_WINDOW,
+      extras: { limit: 25 },
+    });
+    assert.equal(
+      feesKey,
+      `/api/v1/chain/fees?window=${DEFAULT_ANALYTICS_WINDOW}&limit=25`,
+    );
+    assert.equal(
+      canonicalAnalyticsCacheRoute(explicitFees, {
+        window: DEFAULT_ANALYTICS_WINDOW,
+        extras: { limit: 25 },
+      }),
+      feesKey,
+    );
+  });
+
+  test("omits null or empty-string optional extras from the cache key", () => {
+    const key = `/api/v1/chain/fees?window=${DEFAULT_ANALYTICS_WINDOW}&limit=25`;
+    assert.equal(
+      canonicalAnalyticsCacheRoute(url("/api/v1/chain/fees"), {
+        window: DEFAULT_ANALYTICS_WINDOW,
+        extras: { limit: 25, call_module: null },
+      }),
+      key,
     );
     assert.equal(
       canonicalAnalyticsCacheRoute(url("/api/v1/chain/fees"), {
         window: DEFAULT_ANALYTICS_WINDOW,
-        extras: { limit: 25 },
+        extras: { limit: 25, call_module: "" },
       }),
-      `/api/v1/chain/fees?window=${DEFAULT_ANALYTICS_WINDOW}&limit=25`,
+      key,
     );
   });
 });
@@ -521,7 +564,7 @@ describe("chain analytics handlers", () => {
       ),
     );
     assert.equal(calls.data.schema_version, 1);
-    const signers = await json(
+    const transfers = await json(
       await handleChainTransfers(
         req("/api/v1/chain/transfers"),
         env,
@@ -529,7 +572,7 @@ describe("chain analytics handlers", () => {
         ctx,
       ),
     );
-    assert.equal(signers.data.schema_version, 1);
+    assert.equal(transfers.data.schema_version, 1);
     const fees = await json(
       await handleChainFees(
         req("/api/v1/chain/fees?call_module=Balances"),

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -49,6 +49,12 @@ const NETUID = 7;
 const LAST_RUN_AT = "2026-06-18T00:00:00.000Z";
 const ctx = { waitUntil: (promise) => promise };
 
+function recentUtcDay(daysAgo) {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  return d.toISOString().slice(0, 10);
+}
+
 function req(path, init = {}) {
   return new Request(`https://api.metagraph.sh${path}`, init);
 }
@@ -113,11 +119,13 @@ function rowsForSql(sql) {
     ];
   }
   if (sql.includes("FROM surface_uptime_daily")) {
+    const recent = recentUtcDay(1);
+    const older = recentUtcDay(20);
     return [
       {
         netuid: NETUID,
-        day: "2026-06-24",
-        date: "2026-06-24",
+        day: recent,
+        date: recent,
         total: 100,
         ok_count: 98,
         latency_samples: 96,
@@ -126,8 +134,8 @@ function rowsForSql(sql) {
       },
       {
         netuid: NETUID,
-        day: "2026-06-01",
-        date: "2026-06-01",
+        day: older,
+        date: older,
         total: 50,
         ok_count: 45,
         latency_samples: 48,

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -95,14 +95,19 @@ function validateQueryParams(url, allowedParams) {
   return null;
 }
 
-function canonicalAnalyticsCacheRoute(url, params = []) {
+// Build an edge-cache key from RESOLVED query values so a bare path, an explicit
+// ?window=<default>, and omitted defaulted params all share one cache entry —
+// mirrors handleChainActivity and canonicalHealthWindowCachePath. Optional
+// filters (call_module) are included only when set.
+function canonicalAnalyticsCacheRoute(url, { window, extras = {} } = {}) {
   const search = new URL("https://cache-key.invalid/").searchParams;
-  for (const param of [ANALYTICS_WINDOW_PARAM, ...params]) {
-    const value = url.searchParams.get(param);
-    if (value !== null) search.set(param, value);
+  search.set(ANALYTICS_WINDOW_PARAM, window);
+  for (const key of ["group_by", "limit", "sort", "call_module"]) {
+    if (!Object.hasOwn(extras, key)) continue;
+    const value = extras[key];
+    if (value != null && value !== "") search.set(key, String(value));
   }
-  const query = search.toString();
-  return `${url.pathname}${query ? `?${query}` : ""}`;
+  return `${url.pathname}?${search.toString()}`;
 }
 
 function analyticsWindow(url, extraParams = []) {
@@ -746,7 +751,14 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
       );
       return usedFallback ? markD1FallbackResponse(response) : response;
     },
-    canonicalAnalyticsCacheRoute(url, ["group_by", "limit", "call_module"]),
+    canonicalAnalyticsCacheRoute(url, {
+      window: label,
+      extras: {
+        group_by: groupBy,
+        limit,
+        ...(callModule ? { call_module: callModule } : {}),
+      },
+    }),
   );
 }
 
@@ -803,7 +815,14 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
         ? markD1FallbackResponse(response)
         : response;
     },
-    canonicalAnalyticsCacheRoute(url, ["limit", "call_module", "sort"]),
+    canonicalAnalyticsCacheRoute(url, {
+      window: label,
+      extras: {
+        limit,
+        sort,
+        ...(callModule ? { call_module: callModule } : {}),
+      },
+    }),
   );
 }
 
@@ -845,7 +864,10 @@ export async function handleChainTransfers(request, env, url, ctx = {}) {
         "short",
       );
     },
-    canonicalAnalyticsCacheRoute(url, ["limit"]),
+    canonicalAnalyticsCacheRoute(url, {
+      window: label,
+      extras: { limit },
+    }),
   );
 }
 
@@ -897,7 +919,13 @@ export async function handleChainFees(request, env, url, ctx = {}) {
         ? markD1FallbackResponse(response)
         : response;
     },
-    canonicalAnalyticsCacheRoute(url, ["limit", "call_module"]),
+    canonicalAnalyticsCacheRoute(url, {
+      window: label,
+      extras: {
+        limit,
+        ...(callModule ? { call_module: callModule } : {}),
+      },
+    }),
   );
 }
 


### PR DESCRIPTION
## Summary

- The chain analytics routes `/api/v1/chain/{calls,signers,transfers,fees}` cache responses via `canonicalAnalyticsCacheRoute`, which only included query params **present in the URL**. Omitted params still resolve to handler defaults (`window?7d`, `limit?50/25`, `sort?tx_count`, `group_by?module`), so equivalent requests fragmented the edge cache (e.g. bare `/chain/signers` vs `?window=7d&sort=tx_count&limit=50`).
- `handleChainActivity` and `canonicalHealthWindowCachePath` already canonicalize on the **resolved** window; the four chain leaderboard routes did not.
- Build cache keys from resolved values passed by each handler so bare paths, explicit defaults, and reordered variants share one entry. Optional `call_module` filters stay omitted when absent.

## What Changed

- `workers/request-handlers/analytics.mjs` - `canonicalAnalyticsCacheRoute` now accepts `{ window, extras }` with resolved defaults; `handleChainCalls`, `handleChainSigners`, `handleChainTransfers`, and `handleChainFees` pass their resolved `label`/`limit`/`sort`/`group_by`/`call_module`.
- `tests/request-handlers-analytics.test.mjs` - regression coverage: bare ? explicit-default keys for signers/calls/transfers/fees; optional `call_module` included when scoped.
- No schema/contract change.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none)

## Validation

- [x] `npx vitest run tests/request-handlers-analytics.test.mjs` (109 passed)
- [x] `git diff --check`

## Linked issue

No linked issue: issue creation on this repository is currently restricted for outside contributors (issues API returns 404). Per the contribution guide a linked issue is optional.