### PR TITLE
fix(metagraph-neurons): coerce D1 string ratio cells in formatNeuron

### DIFF
--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -105,12 +105,18 @@ export function formatNeuron(row) {
     coldkey: row.coldkey ?? null,
     active: toD1Flag(row.active),
     validator_permit: toD1Flag(row.validator_permit),
-    rank: row.rank ?? null,
-    trust: row.trust ?? null,
-    validator_trust: row.validator_trust ?? null,
-    consensus: row.consensus ?? null,
-    incentive: row.incentive ?? null,
-    dividends: row.dividends ?? null,
+    rank: row.rank == null ? null : round(nullableNumber(row.rank)),
+    trust: row.trust == null ? null : round(nullableNumber(row.trust)),
+    validator_trust:
+      row.validator_trust == null
+        ? null
+        : round(nullableNumber(row.validator_trust)),
+    consensus:
+      row.consensus == null ? null : round(nullableNumber(row.consensus)),
+    incentive:
+      row.incentive == null ? null : round(nullableNumber(row.incentive)),
+    dividends:
+      row.dividends == null ? null : round(nullableNumber(row.dividends)),
     emission_tao: row.emission_tao == null ? null : roundTao(row.emission_tao),
     stake_tao: row.stake_tao == null ? null : roundTao(row.stake_tao),
     registered_at_block:

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -87,18 +87,25 @@ describe("metagraph-neurons builders", () => {
     assert.equal(n.is_immunity_period, false);
   });
 
-  test("formatNeuron coerces string-typed uid/registered_at_block and stake/emission cells", () => {
+  test("formatNeuron coerces string-typed uid/registered_at_block, stake/emission, and ratio cells", () => {
     // D1 can return INTEGER / REAL columns as numeric strings ("3" not 3,
     // "1000.5" not 1000.5); the bare `?? null` pass-through this replaced would
     // have leaked strings into the API payload. Same shape as the coercion in
     // blocks.mjs (#2435), extrinsics.mjs (#2439), and account-events.mjs
     // (#2481, #2489). stake/emission additionally round to rao precision so
-    // accumulated IEEE-754 float noise never reaches the payload.
+    // accumulated IEEE-754 float noise never reaches the payload. Ratio fields
+    // use nullableNumber + round, matching buildGlobalValidators (#2611).
     const n = formatNeuron({
       uid: "3",
       registered_at_block: "6702485",
       stake_tao: "1000.5",
       emission_tao: "22.123456789",
+      rank: "12",
+      trust: "0.25",
+      validator_trust: "0.4",
+      consensus: "0.88",
+      incentive: "0.01",
+      dividends: "0.02",
     });
     assert.equal(n.uid, 3);
     assert.equal(typeof n.uid, "number");
@@ -108,6 +115,25 @@ describe("metagraph-neurons builders", () => {
     assert.equal(typeof n.stake_tao, "number");
     assert.equal(n.emission_tao, 22.123456789);
     assert.equal(typeof n.emission_tao, "number");
+    assert.equal(n.rank, 12);
+    assert.equal(typeof n.rank, "number");
+    assert.equal(n.trust, 0.25);
+    assert.equal(typeof n.trust, "number");
+    assert.equal(n.validator_trust, 0.4);
+    assert.equal(n.consensus, 0.88);
+    assert.equal(n.incentive, 0.01);
+    assert.equal(n.dividends, 0.02);
+  });
+
+  test("formatNeuron nulls invalid or absent ratio cells", () => {
+    const n = formatNeuron({
+      rank: null,
+      trust: "not-a-number",
+      validator_trust: undefined,
+    });
+    assert.equal(n.rank, null);
+    assert.equal(n.trust, null);
+    assert.equal(n.validator_trust, null);
   });
 
   test("formatNeuron rounds stake_tao / emission_tao to rao precision (no IEEE-754 leak)", () => {


### PR DESCRIPTION
## Summary

Coerce D1 string-typed ratio columns in `formatNeuron` so neuron payloads stay numeric (retry of #2633 with full patch coverage).

## What Changed

- `formatNeuron` coerced uid/stake/emission but passed `rank`, `trust`, `validator_trust`, `consensus`, `incentive`, and `dividends` through raw (`?? null`), leaking D1 numeric strings into responses that require `["number","null"]`.
- Coerce each ratio field with `row.field == null ? null : round(nullableNumber(row.field))`, matching `buildGlobalValidators` and the existing stake/emission null guards.
- Extended the existing `formatNeuron` coercion test to cover all six ratio fields plus invalid/absent cells (codecov patch requires 99% on changed lines — #2633 was auto-closed at 66% patch coverage on a new helper).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (Aligns output with existing schema.)

## Validation

- [x] `npx vitest run tests/metagraph-neurons.test.mjs -t "formatNeuron"`
- [x] `git diff --check`
