### PR TITLE
fix(api): document counterparties limit bounds (#2584)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -62,7 +62,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?limit (<=100). */
+        /** Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present. */
         get: operations["accountCounterparties"];
         put?: never;
         post?: never;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4842,7 +4842,7 @@
     {
       "artifact_path": "/metagraph/accounts/{ss58}/counterparties.json",
       "cache": "short",
-      "description": "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?limit (<=100).",
+      "description": "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present.",
       "id": "account-counterparties",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/counterparties",
@@ -4853,6 +4853,7 @@
         {
           "name": "counterparty",
           "schema": {
+            "description": "Optional second SS58 address: switch from the ranked counterparties list to one relationship drilldown (fund-flow totals plus recent transfer evidence). Must differ from ss58.",
             "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
             "type": "string"
           }
@@ -4860,6 +4861,8 @@
         {
           "name": "limit",
           "schema": {
+            "default": 20,
+            "description": "Max counterparties to return in list mode (default 20), or max transfer evidence rows in relationship drilldown mode when ?counterparty is present (default 50).",
             "maximum": 100,
             "minimum": 1,
             "type": "integer"

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4861,7 +4861,6 @@
         {
           "name": "limit",
           "schema": {
-            "default": 20,
             "description": "Max counterparties to return in list mode (default 20), or max transfer evidence rows in relationship drilldown mode when ?counterparty is present (default 50).",
             "maximum": 100,
             "minimum": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -15815,7 +15815,6 @@
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 20,
               "description": "Max counterparties to return in list mode (default 20), or max transfer evidence rows in relationship drilldown mode when ?counterparty is present (default 50).",
               "maximum": 100,
               "minimum": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -15805,6 +15805,7 @@
             "name": "counterparty",
             "required": false,
             "schema": {
+              "description": "Optional second SS58 address: switch from the ranked counterparties list to one relationship drilldown (fund-flow totals plus recent transfer evidence). Must differ from ss58.",
               "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
               "type": "string"
             }
@@ -15814,6 +15815,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 20,
+              "description": "Max counterparties to return in list mode (default 20), or max transfer evidence rows in relationship drilldown mode when ?counterparty is present (default 50).",
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -15971,7 +15974,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?limit (<=100).",
+        "summary": "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present.",
         "tags": [
           "accounts",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -62,7 +62,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?limit (<=100). */
+        /** Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present. */
         get: operations["accountCounterparties"];
         put?: never;
         post?: never;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2050,15 +2050,30 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/counterparties",
     "/metagraph/accounts/{ss58}/counterparties.json",
-    "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?limit (<=100).",
+    "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present.",
     "short",
     ["accounts", "analytics"],
     [
       {
         name: "counterparty",
-        schema: { type: "string", pattern: "^[1-9A-HJ-NP-Za-km-z]{47,48}$" },
+        schema: {
+          type: "string",
+          pattern: "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
+          description:
+            "Optional second SS58 address: switch from the ranked counterparties list to one relationship drilldown (fund-flow totals plus recent transfer evidence). Must differ from ss58.",
+        },
       },
-      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
+      {
+        name: "limit",
+        schema: {
+          type: "integer",
+          minimum: 1,
+          maximum: 100,
+          default: 20,
+          description:
+            "Max counterparties to return in list mode (default 20), or max transfer evidence rows in relationship drilldown mode when ?counterparty is present (default 50).",
+        },
+      },
     ],
     [{ name: "ss58", schema: { type: "string" } }],
   ),

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2069,7 +2069,6 @@ export const API_ROUTES = [
           type: "integer",
           minimum: 1,
           maximum: 100,
-          default: 20,
           description:
             "Max counterparties to return in list mode (default 20), or max transfer evidence rows in relationship drilldown mode when ?counterparty is present (default 50).",
         },

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2257,7 +2257,10 @@ describe("handleAccountCounterparties", () => {
       const body = await errorJson(res);
       assert.equal(body.error.code, "invalid_query");
       assert.equal(body.meta.parameter, "limit");
-      assert.equal(body.error.message, "limit must be an integer from 1 to 100.");
+      assert.equal(
+        body.error.message,
+        "limit must be an integer from 1 to 100.",
+      );
       assert.equal(captures.sql.length, 0);
     }
   });
@@ -2383,7 +2386,10 @@ describe("handleAccountCounterparties relationship drilldown", () => {
       const body = await errorJson(res);
       assert.equal(body.error.code, "invalid_query");
       assert.equal(body.meta.parameter, "limit");
-      assert.equal(body.error.message, "limit must be an integer from 1 to 100.");
+      assert.equal(
+        body.error.message,
+        "limit must be an integer from 1 to 100.",
+      );
       assert.equal(captures.sql.length, 0);
     }
   });
@@ -2403,7 +2409,9 @@ describe("handleAccountCounterparties relationship drilldown", () => {
     });
     const body = await json(
       await handleAccountCounterparties(
-        req(`/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}`),
+        req(
+          `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}`,
+        ),
         env,
         SS58,
         url(
@@ -2414,6 +2422,36 @@ describe("handleAccountCounterparties relationship drilldown", () => {
     assert.equal(body.data.counterparty_count, 1);
     assert.equal(body.data.relationship.transfer_count, 80);
     assert.equal(body.data.relationship.transfers.length, 50);
+  });
+
+  test("accepts limit=100 at the documented upper bound in relationship mode", async () => {
+    const { env } = dbWith({
+      relationshipTransfers: Array.from({ length: 150 }, (_, index) =>
+        transferEventRow({
+          block_number: 5_000 - index,
+          event_index: index,
+          hotkey: index % 2 === 0 ? SS58 : COUNTERPARTY,
+          coldkey: index % 2 === 0 ? COUNTERPARTY : SS58,
+          amount_tao: index + 1,
+          observed_at: OBSERVED_AT - index * 1_000,
+        }),
+      ),
+    });
+    const body = await json(
+      await handleAccountCounterparties(
+        req(
+          `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}&limit=100`,
+        ),
+        env,
+        SS58,
+        url(
+          `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}&limit=100`,
+        ),
+      ),
+    );
+    assert.equal(body.data.counterparty_count, 1);
+    assert.equal(body.data.relationship.transfer_count, 150);
+    assert.equal(body.data.relationship.transfers.length, 100);
   });
 
   test("returns schema-stable empty pair detail on cold D1", async () => {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2256,8 +2256,56 @@ describe("handleAccountCounterparties", () => {
       );
       const body = await errorJson(res);
       assert.equal(body.error.code, "invalid_query");
+      assert.equal(body.meta.parameter, "limit");
+      assert.equal(body.error.message, "limit must be an integer from 1 to 100.");
       assert.equal(captures.sql.length, 0);
     }
+  });
+
+  test("accepts limit=100 at the documented upper bound", async () => {
+    const { env } = dbWith({
+      transfers: Array.from({ length: 150 }, (_, index) =>
+        transferEventRow({
+          hotkey: SS58,
+          coldkey: `CP-${index.toString().padStart(3, "0")}`,
+          amount_tao: index + 1,
+          block_number: 1_000 - index,
+        }),
+      ),
+    });
+    const body = await json(
+      await handleAccountCounterparties(
+        req(`/api/v1/accounts/${SS58}/counterparties?limit=100`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/counterparties?limit=100`),
+      ),
+    );
+    assert.equal(body.data.counterparty_count, 150);
+    assert.equal(body.data.counterparties.length, 100);
+  });
+
+  test("defaults limit to 20 when absent in list mode", async () => {
+    const { env } = dbWith({
+      transfers: Array.from({ length: 30 }, (_, index) =>
+        transferEventRow({
+          hotkey: SS58,
+          coldkey: `CP-${index.toString().padStart(3, "0")}`,
+          amount_tao: index + 1,
+          block_number: 2_000 - index,
+        }),
+      ),
+    });
+    const body = await json(
+      await handleAccountCounterparties(
+        req(`/api/v1/accounts/${SS58}/counterparties`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/counterparties`),
+      ),
+    );
+    assert.equal(body.data.counterparty_count, 30);
+    assert.equal(body.data.counterparties.length, 20);
   });
 
   test("returns schema-stable empty rollup on cold D1", async () => {
@@ -2334,8 +2382,38 @@ describe("handleAccountCounterparties relationship drilldown", () => {
       );
       const body = await errorJson(res);
       assert.equal(body.error.code, "invalid_query");
+      assert.equal(body.meta.parameter, "limit");
+      assert.equal(body.error.message, "limit must be an integer from 1 to 100.");
       assert.equal(captures.sql.length, 0);
     }
+  });
+
+  test("defaults limit to 50 when absent in relationship mode", async () => {
+    const { env } = dbWith({
+      relationshipTransfers: Array.from({ length: 80 }, (_, index) =>
+        transferEventRow({
+          block_number: 5_000 - index,
+          event_index: index,
+          hotkey: index % 2 === 0 ? SS58 : COUNTERPARTY,
+          coldkey: index % 2 === 0 ? COUNTERPARTY : SS58,
+          amount_tao: index + 1,
+          observed_at: OBSERVED_AT - index * 1_000,
+        }),
+      ),
+    });
+    const body = await json(
+      await handleAccountCounterparties(
+        req(`/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}`),
+        env,
+        SS58,
+        url(
+          `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}`,
+        ),
+      ),
+    );
+    assert.equal(body.data.counterparty_count, 1);
+    assert.equal(body.data.relationship.transfer_count, 80);
+    assert.equal(body.data.relationship.transfers.length, 50);
   });
 
   test("returns schema-stable empty pair detail on cold D1", async () => {


### PR DESCRIPTION
## Summary

- document the `/api/v1/accounts/{ss58}/counterparties` `limit` bounds/defaults and the `counterparty` drilldown switch in `src/contracts.mjs`
- omit a schema-level `default` for `limit` because the route runtime is conditional: `20` in list mode, `50` when `?counterparty=` is present
- regenerate the OpenAPI and API index artifacts from the corrected contract metadata
- add regression coverage for invalid `limit` values, `limit=100` in both route modes, and the default `limit` behavior in both list and relationship modes

## Template Used

- Backend/code change

## Risk

- Low: no runtime logic changed; this PR corrects contract metadata and test coverage only.

## Validation

- `npm run build`
- `npm test -- tests/request-handlers-entities.test.mjs`
- `npm test -- tests/openapi-sample.test.mjs`
- `npm run lint`
- `npm run format:check`
- `npm run validate:contract-drift`
- `npm run validate:openapi`
- `npm run validate:types`

Closes #2584