### PR TITLE
fix(analytics): average only ok probes in leaderboards and compare health SQL

### DIFF
--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -8,6 +8,7 @@ import {
   dailyLatencyColumns,
   latencyStatColumns,
   rankedChecksCte,
+  surfaceStatusAvgLatencySql,
 } from "./health-sql.mjs";
 import {
   formatGlobalIncidents,
@@ -425,7 +426,7 @@ export async function loadRegistryLeaderboards(
         `SELECT netuid,
               COUNT(*) AS total,
               SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
-              AVG(latency_ms) AS avg_latency_ms
+              ${surfaceStatusAvgLatencySql()} AS avg_latency_ms
        FROM surface_status
        GROUP BY netuid`,
         [],
@@ -498,7 +499,7 @@ export async function loadCompareSubnets(
           `SELECT netuid,
                 COUNT(*) AS surface_count,
                 SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
-                ROUND(AVG(latency_ms)) AS avg_latency_ms
+                ${surfaceStatusAvgLatencySql({ rounded: true })} AS avg_latency_ms
          FROM surface_status
          WHERE netuid IN (${netuids.map(() => "?").join(", ")})
          GROUP BY netuid`,

--- a/src/health-sql.mjs
+++ b/src/health-sql.mjs
@@ -10,6 +10,18 @@
 // A probe whose latency counts toward latency statistics.
 export const OK_LATENCY = "ok = 1 AND latency_ms IS NOT NULL";
 
+// `surface_status` stores textual status; latency averages over it must mirror
+// OK_LATENCY semantics (failures/timeouts can still carry elapsed-time latencies).
+export const SURFACE_STATUS_OK_LATENCY =
+  "status = 'ok' AND latency_ms IS NOT NULL";
+
+// Mean latency over `surface_status` rows, success-only. `rounded: true` wraps
+// the AVG in ROUND() for compare-style integer output.
+export function surfaceStatusAvgLatencySql({ rounded = false } = {}) {
+  const avg = `AVG(CASE WHEN ${SURFACE_STATUS_OK_LATENCY} THEN latency_ms END)`;
+  return rounded ? `ROUND(${avg})` : avg;
+}
+
 // CTE over `surface_checks` that ranks each stable surface's ok-latency rows by
 // latency (`rn`) and counts them (`lat_cnt`), passing all rows through so uptime
 // still totals over every check. The grp term in the PARTITION isolates

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -409,7 +409,10 @@ describe("analytics-live loaders", () => {
     const healthSql = surfaceStatusSql.find((sql) =>
       /SUM\(CASE WHEN status = 'ok'/.test(sql),
     );
-    assert.ok(healthSql, "expected leaderboards healthRows surface_status query");
+    assert.ok(
+      healthSql,
+      "expected leaderboards healthRows surface_status query",
+    );
     assert.match(healthSql, /status = 'ok'/);
     assert.match(healthSql, /AVG\(CASE WHEN/);
     assert.doesNotMatch(healthSql, /AVG\(latency_ms\)/);
@@ -421,7 +424,9 @@ describe("analytics-live loaders", () => {
       async (sql) => {
         if (/FROM surface_status/.test(sql)) {
           healthSql = sql;
-          return [{ netuid: 1, surface_count: 2, ok_count: 1, avg_latency_ms: 100 }];
+          return [
+            { netuid: 1, surface_count: 2, ok_count: 1, avg_latency_ms: 100 },
+          ];
         }
         return [];
       },

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -394,6 +394,49 @@ describe("analytics-live loaders", () => {
     assert.equal("fastest-rpc" in data.boards, false);
   });
 
+  test("loadRegistryLeaderboards SQL averages only ok surface_status latencies", async () => {
+    const surfaceStatusSql = [];
+    await loadRegistryLeaderboards(
+      async (sql) => {
+        if (/FROM surface_status/.test(sql)) {
+          surfaceStatusSql.push(sql);
+          return [{ netuid: 1, total: 2, ok_count: 1, avg_latency_ms: 100 }];
+        }
+        return [];
+      },
+      { profiles: [], economicsRows: [], observedAt: OBSERVED_AT },
+    );
+    const healthSql = surfaceStatusSql.find((sql) =>
+      /SUM\(CASE WHEN status = 'ok'/.test(sql),
+    );
+    assert.ok(healthSql, "expected leaderboards healthRows surface_status query");
+    assert.match(healthSql, /status = 'ok'/);
+    assert.match(healthSql, /AVG\(CASE WHEN/);
+    assert.doesNotMatch(healthSql, /AVG\(latency_ms\)/);
+  });
+
+  test("loadCompareSubnets health SQL averages only ok surface_status latencies", async () => {
+    let healthSql = "";
+    await loadCompareSubnets(
+      async (sql) => {
+        if (/FROM surface_status/.test(sql)) {
+          healthSql = sql;
+          return [{ netuid: 1, surface_count: 2, ok_count: 1, avg_latency_ms: 100 }];
+        }
+        return [];
+      },
+      {
+        profiles: [{ netuid: 1, slug: "a", name: "A" }],
+        netuids: [1],
+        dimensions: ["health"],
+        observedAt: OBSERVED_AT,
+      },
+    );
+    assert.match(healthSql, /status = 'ok'/);
+    assert.match(healthSql, /ROUND\(AVG\(CASE WHEN/);
+    assert.doesNotMatch(healthSql, /AVG\(latency_ms\)/);
+  });
+
   test("loadRegistryLeaderboards ranks most-reliable from surface_uptime_daily", async () => {
     const data = await loadRegistryLeaderboards(
       d1({

--- a/tests/health-sql.test.mjs
+++ b/tests/health-sql.test.mjs
@@ -2,14 +2,31 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   OK_LATENCY,
+  SURFACE_STATUS_OK_LATENCY,
   dailyLatencyColumns,
   latencyStatColumns,
   rankedChecksCte,
+  surfaceStatusAvgLatencySql,
 } from "../src/health-sql.mjs";
 
 describe("health-sql latency builders", () => {
   test("OK_LATENCY gates latency on a successful probe that recorded one", () => {
     assert.equal(OK_LATENCY, "ok = 1 AND latency_ms IS NOT NULL");
+  });
+
+  test("SURFACE_STATUS_OK_LATENCY mirrors OK_LATENCY over surface_status.status", () => {
+    assert.equal(
+      SURFACE_STATUS_OK_LATENCY,
+      "status = 'ok' AND latency_ms IS NOT NULL",
+    );
+  });
+
+  test("surfaceStatusAvgLatencySql averages only ok surface_status rows", () => {
+    const raw = surfaceStatusAvgLatencySql();
+    assert.ok(raw.includes(SURFACE_STATUS_OK_LATENCY));
+    assert.ok(raw.startsWith("AVG(CASE WHEN"));
+    const rounded = surfaceStatusAvgLatencySql({ rounded: true });
+    assert.ok(rounded.startsWith("ROUND(AVG(CASE WHEN"));
   });
 
   test("rankedChecksCte ranks ok-latency rows and inlines the WHERE clause", () => {

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -387,7 +387,12 @@ describe("handleLeaderboards", () => {
                     surfaceStatusSql.push(sql);
                     return {
                       results: [
-                        { netuid: 1, total: 2, ok_count: 1, avg_latency_ms: 100 },
+                        {
+                          netuid: 1,
+                          total: 2,
+                          ok_count: 1,
+                          avg_latency_ms: 100,
+                        },
                       ],
                     };
                   }
@@ -409,7 +414,10 @@ describe("handleLeaderboards", () => {
     const healthSql = surfaceStatusSql.find((sql) =>
       /SUM\(CASE WHEN status = 'ok'/.test(sql),
     );
-    assert.ok(healthSql, "expected leaderboards healthRows surface_status query");
+    assert.ok(
+      healthSql,
+      "expected leaderboards healthRows surface_status query",
+    );
     assert.match(healthSql, /status = 'ok'/);
     assert.match(healthSql, /AVG\(CASE WHEN/);
     assert.doesNotMatch(healthSql, /AVG\(latency_ms\)/);

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -373,6 +373,47 @@ describe("handleLeaderboards", () => {
     assert.equal(body.data.boards["most-reliable"].length, 1);
     assert.equal(body.data.boards["most-reliable"][0].netuid, 7);
   });
+
+  test("healthiest SQL averages only ok surface_status latencies", async () => {
+    const surfaceStatusSql = [];
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind() {
+              return {
+                async all() {
+                  if (/FROM surface_status/.test(sql)) {
+                    surfaceStatusSql.push(sql);
+                    return {
+                      results: [
+                        { netuid: 1, total: 2, ok_count: 1, avg_latency_ms: 100 },
+                      ],
+                    };
+                  }
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    await json(
+      await handleLeaderboards(
+        req("/"),
+        env,
+        url("/?board=healthiest&limit=5"),
+      ),
+    );
+    const healthSql = surfaceStatusSql.find((sql) =>
+      /SUM\(CASE WHEN status = 'ok'/.test(sql),
+    );
+    assert.ok(healthSql, "expected leaderboards healthRows surface_status query");
+    assert.match(healthSql, /status = 'ok'/);
+    assert.match(healthSql, /AVG\(CASE WHEN/);
+    assert.doesNotMatch(healthSql, /AVG\(latency_ms\)/);
+  });
 });
 
 describe("handleCompare", () => {

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -20,7 +20,10 @@ import {
   markD1FallbackResponse,
   validateQueryParams,
 } from "./analytics.mjs";
-import { dailyLatencyColumns } from "../../src/health-sql.mjs";
+import {
+  dailyLatencyColumns,
+  surfaceStatusAvgLatencySql,
+} from "../../src/health-sql.mjs";
 import {
   parseHistoryWindow,
   unsupportedWindowMessage,
@@ -316,7 +319,7 @@ export async function handleLeaderboards(request, env, url) {
         `SELECT netuid,
               COUNT(*) AS total,
               SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
-              AVG(latency_ms) AS avg_latency_ms
+              ${surfaceStatusAvgLatencySql()} AS avg_latency_ms
        FROM surface_status
        GROUP BY netuid`,
         [],
@@ -554,7 +557,7 @@ export async function handleCompare(request, env, url) {
           `SELECT netuid,
                 COUNT(*) AS surface_count,
                 SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
-                ROUND(AVG(latency_ms)) AS avg_latency_ms
+                ${surfaceStatusAvgLatencySql({ rounded: true })} AS avg_latency_ms
          FROM surface_status
          WHERE netuid IN (${requestedNetuids.map(() => "?").join(", ")})
          GROUP BY netuid`,


### PR DESCRIPTION

## Summary

The **healthiest** registry leaderboard and the **health** dimension of `/api/v1/compare` (and the matching MCP loaders) compute `avg_latency_ms` with a plain `AVG(latency_ms)` over all `surface_status` rows. That includes failed, degraded, and timeout probes whose elapsed-time latencies are stored on non-ok rows — the same class of inflation `#2601` fixed in `summarizeRows`, but these SQL paths were never updated.

The **fastest-rpc** board in the same query batch already filters `status = 'ok' AND latency_ms IS NOT NULL`; healthiest and compare do not, so tie-breaking and displayed latency on healthiest can be wrong whenever a subnet has failing surfaces with stored latencies.

## Root cause

`surface_status` can carry finite `latency_ms` on non-ok probes (timeouts store elapsed time; legacy rows may still have failure latencies). The shared `OK_LATENCY` convention in `src/health-sql.mjs` and `okLatencyMs()` in `src/health-probe-core.mjs` treat latency as **success-only**.

Affected queries (identical bug, duplicated in REST + MCP loaders):

| Location | Query |
| --- | --- |
| `workers/request-handlers/analytics-routes.mjs` ~319 | leaderboards `healthRows` |
| `workers/request-handlers/analytics-routes.mjs` ~557 | compare `healthRows` |
| `src/analytics-live.mjs` ~428 | `loadRegistryLeaderboards` |
| `src/analytics-live.mjs` ~501 | `loadCompareSubnets` |

Example today:

```sql
AVG(latency_ms) AS avg_latency_ms
FROM surface_status
GROUP BY netuid
```

Should mirror fastest-rpc / `OK_LATENCY` semantics:

```sql
AVG(CASE WHEN status = 'ok' AND latency_ms IS NOT NULL THEN latency_ms END) AS avg_latency_ms
```

## Impact

- **Healthiest board ranking**: secondary tie-break uses `(a.avg_latency_ms ?? Infinity) - (b.avg_latency_ms ?? Infinity)` — inflated means can reorder subnets with equal uptime.
- **Compare health dimension**: agents and dashboards see overstated `avg_latency_ms` for subnets with degraded/failed surfaces.
- **MCP parity**: `get_registry_leaderboards` and `compare_subnets` share the same inflated SQL via `analytics-live.mjs`.

## Proposed fix

1. Update all four queries to average only ok probes with non-null latency (same predicate as fastest-rpc).
2. Add regression tests in `tests/analytics.test.mjs` and/or `tests/analytics-live.test.mjs` with mixed ok/failed `surface_status` rows proving failed latencies are excluded.
3. Optionally extract a tiny shared SQL fragment next to `OK_LATENCY` if duplication feels brittle (not required for minimal fix).

## Test plan

- [x] `npm test -- tests/analytics.test.mjs tests/analytics-live.test.mjs tests/request-handlers-analytics-routes.test.mjs`
- [x] `npm run lint && npm run validate`
- [ ] New regression: subnet with one ok@100ms + one failed@8000ms → `avg_latency_ms === 100`, not 4050

## Notes

- No schema/OpenAPI change; response field names unchanged, values corrected.
- Related but distinct from closed #2601 (that fixed `summarizeRows` only); no open/closed issue covers these SQL paths.
