### PR TITLE
fix(scan): catch secrets under underscore-prefixed credential names in public-safety scan

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -37,8 +37,13 @@ const patterns = [
   },
   {
     name: "token-like assignment",
+    // The optional `[a-z0-9]+[_-]` prefix catches underscore/hyphen-joined
+    // credential names (client_secret, db_password, my_secret): a leading `\b`
+    // has no boundary after the underscore in `client_secret`, so the bare
+    // `secret`/`password` alternatives would otherwise miss the most common
+    // real-world key names while still matching bare `secret=`/`password=`.
     regex:
-      /\b(?:api[_-]?key|access[_-]?token|auth[_-]?token|secret|password)\s*[:=]\s*["']?[A-Za-z0-9_./+=-]{16,}/i,
+      /\b(?:[a-z0-9]+[_-])?(?:api[_-]?key|access[_-]?token|auth[_-]?token|secret|password)\s*[:=]\s*["']?[A-Za-z0-9_./+=-]{16,}/i,
   },
   // `soft` patterns are terminology heuristics (not actual secrets). They are
   // skipped for mirrored third-party OpenAPI specs, where wording like "seed

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -177,6 +177,29 @@ describe("captured-fixture body scan", () => {
     }
   });
 
+  test("flags a secret assigned to an underscore/hyphen-prefixed credential name", async () => {
+    // Regression: the token-like assignment rule missed compound key names like
+    // client_secret / db_password because a leading \b has no word boundary after
+    // the underscore in client_secret. These are the most common real credential
+    // variable names, so a leaked value under them must still be flagged; bare
+    // secret=/password= must keep matching too.
+    const leaks = [
+      "client_secret=abcdefghijklmnop1234",
+      "db_password=abcdefghijklmnop1234",
+      "secret=abcdefghijklmnop1234",
+    ];
+    await fs.writeFile(TEST_PUBLIC_PATH, `${leaks.join("\n")}\n`, "utf8");
+    const output = runScanOutput();
+    for (const [index] of leaks.entries()) {
+      assert.ok(
+        output.includes(
+          `${TEST_PUBLIC_FILE}:${index + 1}: token-like assignment`,
+        ),
+        `secret on line ${index + 1} must be flagged; got:\n${output}`,
+      );
+    }
+  });
+
   test("does not flag soft Bittensor terminology in a mirrored fixture body", async () => {
     // Regression for the publish-wedging false positive: upstream API docs
     // legitimately say "miner hotkey" / "validator hotkey path".


### PR DESCRIPTION
## Summary

- The `token-like assignment` hard-secret rule in `scripts/scan-public-safety.mjs` anchored the bare `secret`/`password` keywords with a leading `\b`. Because `_` is a word character, there is no word boundary after the underscore in a compound key name, so `client_secret=…`, `db_password=…`, `my_secret:…` — the most common real-world credential variable names — **did not match**, and a genuine leaked value under them slipped past `scan:public-safety` as a false negative.
- The rule already encodes underscore/hyphen joins for the sibling alternatives (`api[_-]?key`, `access[_-]?token`, `auth[_-]?token`), so the gap for `secret`/`password` was an inconsistency, not a design choice.

## What Changed

- `scripts/scan-public-safety.mjs`: add an optional `(?:[a-z0-9]+[_-])?` prefix before the keyword group so compound credential names match, while bare `secret=`/`password=` and the 16+ char value floor still apply.
- `tests/public-safety.test.mjs`: regression asserting `client_secret=…`, `db_password=…`, and bare `secret=…` are all flagged `token-like assignment`. Fails without the fix.

Verified the scanner still reports `Public-safety scan passed.` on the whole tree — the broadening closes the leak gap with **no new false positives** on committed files.

### Reproduction (before)

A file committed anywhere in the tree containing:

```
client_secret=abcdefghijklmnop1234
```

was **not** flagged by `npm run scan:public-safety` — even though a bare `secret=abcdefghijklmnop1234` was. After the fix, both are flagged.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state. (The regression uses obvious placeholder values; the scanner still passes.)
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — scanner rule only.)

## Validation

- [x] `npx vitest run tests/public-safety.test.mjs` — the new regression passes; it fails without the fix
- [x] `npm run scan:public-safety` — `Public-safety scan passed.` (no new false positives on the tree)
- [x] `npx eslint scripts/scan-public-safety.mjs tests/public-safety.test.mjs` (clean)
- [x] `npx prettier --check` (clean)
- [x] `git diff --check`
