### PR TITLE
test(network-routing): cover the chain analytics family in the mainnet-only 404 contract

### DIFF
--- a/tests/network-routing.test.mjs
+++ b/tests/network-routing.test.mjs
@@ -329,7 +329,15 @@ describe("multi-network routing prefix (Phase 1)", () => {
       "/api/v1/testnet/incidents",
 
       "/api/v1/testnet/rpc/usage",
+      // The whole D1-backed chain analytics family is mainnet-only, not just
+      // chain/activity — cover the rest so a route dropped from the allow-list
+      // 404s with the network-named contract instead of leaking a testnet R2 key.
       "/api/v1/testnet/chain/activity",
+      "/api/v1/testnet/chain/calls",
+      "/api/v1/testnet/chain/fees",
+      "/api/v1/testnet/chain/signers",
+      "/api/v1/testnet/chain/transfers",
+      "/api/v1/testnet/chain/concentration",
     ]) {
       const { res, body } = await get(env, path);
       assert.equal(res.status, 404, path);


### PR DESCRIPTION
## Summary

The D1-backed chain analytics routes (`/api/v1/chain/*`) are all gated mainnet-only via `isMainnetOnlyApiPath`, so under a `/{network}/` prefix they must 404 with the network-named "only available on mainnet" message rather than fall through to a testnet R2 read that leaks the internal artifact key (the failure mode fixed in #2613). But the network-prefix 404 contract test only exercised **`chain/activity`** — the other five (`chain/calls`, `chain/fees`, `chain/signers`, `chain/transfers`, and the newer `chain/concentration` from #2606) had no coverage, so one could be dropped from the allow-list without any test catching it.

## What Changed

- `tests/network-routing.test.mjs` — extend the existing "D1-backed live routes 404 under testnet with a mainnet-only message" test to enumerate the full chain analytics family. No production code change — the routes are already correctly gated; this closes the regression-coverage gap for the contract established in #2613.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (test-only; no contract change)

## Validation

- [x] `npx vitest run tests/network-routing.test.mjs` — 19 passed (the routes are correctly gated today)
- [x] Verified the added coverage actually catches a regression: temporarily removing `/api/v1/chain/concentration` from `isMainnetOnlyApiPath` fails the test with `AssertionError: /api/v1/testnet/chain/concentration`; restored.
- [x] `npx eslint tests/network-routing.test.mjs` — clean
- [x] `npx prettier --check --end-of-line auto` — clean
- [x] `git diff --check` — clean
