### PR TITLE
fix(api): short-circuit an inverted block range on the account-events feed before D1

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -627,6 +627,16 @@ export async function loadAccountEvents(
 ) {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
+  // Inverted block-height bounds are a deterministic no-match. Short-circuit before
+  // D1 so REST and MCP callers cannot force a scan to prove an impossible empty
+  // page — parity with the extrinsics and transfers feeds (#2622/#2625).
+  if (blockStart != null && blockEnd != null && blockStart > blockEnd) {
+    return buildAccountEvents([], ss58, {
+      limit: lim,
+      offset: off,
+      nextCursor: null,
+    });
+  }
   const filterParts = [];
   const filterParams = [];
   if (kind) {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -1032,6 +1032,25 @@ test("loadAccountEvents is schema-stable when the D1 read yields nothing", async
   assert.equal(out.next_cursor, null); // no full page → no next cursor
 });
 
+test("loadAccountEvents short-circuits an inverted block range before D1", async () => {
+  // Parity with the extrinsics/transfers feeds (#2622/#2625): an inverted
+  // block_start > block_end range is a deterministic no-match, so it must return
+  // an empty page WITHOUT touching D1 — callers can't force a scan to prove it.
+  let called = false;
+  const out = await loadAccountEvents(
+    async () => {
+      called = true;
+      return [];
+    },
+    "5Hk",
+    { blockStart: 500, blockEnd: 100, limit: 50, offset: 0 },
+  );
+  assert.equal(out.event_count, 0);
+  assert.deepEqual(out.events, []);
+  assert.equal(out.next_cursor, null);
+  assert.equal(called, false);
+});
+
 test("loadAccountEvents propagates a rejecting D1 runner (no silent swallow)", async () => {
   // If the injected runner rejects (e.g. a non-swallowed downstream failure),
   // the loader must not mask it as an empty feed — the caller decides.


### PR DESCRIPTION
## Summary

- `loadAccountEvents` gained a `block_start`/`block_end` range filter (#2603), documented as "parity with the extrinsics and chain-events feeds". But unlike its siblings `loadAccountExtrinsics` (#2622) and `loadAccountTransfers` (#2625), it had **no inverted-range short-circuit**: a `block_start > block_end` request is a deterministic no-match, yet `loadAccountEvents` still assembled and ran the D1 union query.
- The sibling loaders explicitly guard this: *"Inverted block-height bounds are a deterministic no-match. Short-circuit before D1 so REST and MCP callers cannot force a scan to prove an impossible empty page."* Account-events was the one block-range-filtered feed missing that guard.

## What Changed

- `src/account-events.mjs`: add the same inverted-range guard to `loadAccountEvents` — when both bounds are present and `blockStart > blockEnd`, return the schema-stable empty page before touching D1. The valid single-block `start == end` case is preserved (`>` not `>=`), matching the siblings.
- `tests/account-events.test.mjs`: regression asserting the inverted range returns an empty feed with the injected D1 runner never called. Fails without the fix.

No schema/OpenAPI/contract change; behavior is identical for every non-inverted range (correct results either way — this removes a needless D1 scan and closes the same scan-avoidance gap the siblings already close).

### Reproduction (before)

`GET /api/v1/accounts/{ss58}/events?block_start=500&block_end=100` (or the MCP `get_account_events` equivalent) executed a full D1 union query guaranteed to return nothing, instead of short-circuiting like the extrinsics/transfers feeds.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — completes existing feed parity.)

## Validation

- [x] `npx vitest run tests/account-events.test.mjs` (73 pass; the new regression fails without the fix)
- [x] `npx eslint src/account-events.mjs tests/account-events.test.mjs` (clean)
- [x] `npx prettier --check` (clean)
- [x] `git diff --check`
