### PR TITLE
fix(api): add netuid filter to account events route (#2585)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -79,7 +79,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
+        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= or ?netuid= filters, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
         get: operations["accountEvents"];
         put?: never;
         post?: never;
@@ -6035,6 +6035,7 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: string;
+                netuid?: number;
                 block_start?: number;
                 block_end?: number;
                 limit?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4632,7 +4632,7 @@
     {
       "artifact_path": "/metagraph/accounts/{ss58}/events.json",
       "cache": "short",
-      "description": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+      "description": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= or ?netuid= filters, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
       "id": "account-events",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/events",
@@ -4644,6 +4644,14 @@
           "name": "kind",
           "schema": {
             "type": "string"
+          }
+        },
+        {
+          "name": "netuid",
+          "schema": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
           }
         },
         {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -16000,6 +16000,15 @@
           },
           {
             "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
             "name": "block_start",
             "required": false,
             "schema": {
@@ -16162,7 +16171,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+        "summary": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= or ?netuid= filters, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
         "tags": [
           "accounts",
           "analytics"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -16003,6 +16003,7 @@
             "name": "netuid",
             "required": false,
             "schema": {
+              "maximum": 9007199254740991,
               "minimum": 0,
               "type": "integer"
             }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -79,7 +79,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
+        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= or ?netuid= filters, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
         get: operations["accountEvents"];
         put?: never;
         post?: never;
@@ -6035,6 +6035,7 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: string;
+                netuid?: number;
                 block_start?: number;
                 block_end?: number;
                 limit?: number;

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -623,7 +623,7 @@ export async function loadAccountSummary(d1, ss58) {
 export async function loadAccountEvents(
   d1,
   ss58,
-  { limit, offset, kind, cursor, blockStart, blockEnd } = {},
+  { limit, offset, kind, cursor, blockStart, blockEnd, netuid } = {},
 ) {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
@@ -643,6 +643,10 @@ export async function loadAccountEvents(
   if (blockEnd != null) {
     filterParts.push("AND block_number <= ?");
     filterParams.push(blockEnd);
+  }
+  if (netuid != null) {
+    filterParts.push("AND netuid = ?");
+    filterParams.push(netuid);
   }
   const cur = decodeCursor(cursor, 2);
   const useCursor = Boolean(cur);

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1982,7 +1982,10 @@ export const API_ROUTES = [
     ["accounts", "analytics"],
     [
       { name: "kind", schema: { type: "string" } },
-      { name: "netuid", schema: { type: "integer", minimum: 0 } },
+      {
+        name: "netuid",
+        schema: { type: "integer", minimum: 0, maximum: 9007199254740991 },
+      },
       { name: "block_start", schema: { type: "integer", minimum: 0 } },
       { name: "block_end", schema: { type: "integer", minimum: 0 } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1977,11 +1977,12 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/events",
     "/metagraph/accounts/{ss58}/events.json",
-    "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+    "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= or ?netuid= filters, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
     "short",
     ["accounts", "analytics"],
     [
       { name: "kind", schema: { type: "string" } },
+      { name: "netuid", schema: { type: "integer", minimum: 0 } },
       { name: "block_start", schema: { type: "integer", minimum: 0 } },
       { name: "block_end", schema: { type: "integer", minimum: 0 } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -1081,6 +1081,28 @@ test("loadAccountEvents applies the ?kind filter as a bound param", async () => 
   ]);
 });
 
+test("loadAccountEvents applies the ?netuid filter as a bound param", async () => {
+  let captured;
+  await loadAccountEvents(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [];
+    },
+    "5Hk",
+    { netuid: 7 },
+  );
+  assert.ok(/AND netuid = \?/.test(captured.sql));
+  assert.deepEqual(captured.params, [
+    "5Hk",
+    7,
+    "5Hk",
+    "5Hk",
+    7,
+    100,
+    0,
+  ]);
+});
+
 test("loadAccountEvents applies the block_start/block_end range as bound params", async () => {
   let captured;
   await loadAccountEvents(

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -1092,15 +1092,7 @@ test("loadAccountEvents applies the ?netuid filter as a bound param", async () =
     { netuid: 7 },
   );
   assert.ok(/AND netuid = \?/.test(captured.sql));
-  assert.deepEqual(captured.params, [
-    "5Hk",
-    7,
-    "5Hk",
-    "5Hk",
-    7,
-    100,
-    0,
-  ]);
+  assert.deepEqual(captured.params, ["5Hk", 7, "5Hk", "5Hk", 7, 100, 0]);
 });
 
 test("loadAccountEvents applies the block_start/block_end range as bound params", async () => {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1808,6 +1808,27 @@ describe("handleAccountEvents", () => {
     );
   });
 
+  test("netuid filter narrows results", async () => {
+    const { env, captures } = dbWith({
+      accountEvents: [accountEventRow({ netuid: 7 })],
+    });
+    const body = await json(
+      await handleAccountEvents(
+        req(`/api/v1/accounts/${SS58}/events`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/events?netuid=7`),
+      ),
+    );
+    assert.ok(
+      captures.sql.some((s) => /netuid = \?/.test(s)),
+      "expected netuid filter in SQL",
+    );
+    const idx = captures.sql.findIndex((s) => /FROM account_events/.test(s));
+    assert.ok(captures.params[idx].includes(7));
+    assert.equal(body.data.events[0].netuid, 7);
+  });
+
   test("cursor uses keyset seek instead of offset", async () => {
     const { env, captures } = dbWith({
       accountEvents: [accountEventRow({ block_number: 150, event_index: 2 })],

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1742,6 +1742,28 @@ describe("handleAccountEvents", () => {
     assert.equal(body.meta.parameter, "block_end");
   });
 
+  test("rejects a non-integer netuid with 400", async () => {
+    const res = await handleAccountEvents(
+      req(`/api/v1/accounts/${SS58}/events`),
+      emptyEnv(),
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events?netuid=abc`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "netuid");
+  });
+
+  test("rejects a negative netuid with 400", async () => {
+    const res = await handleAccountEvents(
+      req(`/api/v1/accounts/${SS58}/events`),
+      emptyEnv(),
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events?netuid=-1`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "netuid");
+  });
+
   test("returns schema-stable empty events on cold D1", async () => {
     const body = await assertColdSchema(
       handleAccountEvents,

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1764,6 +1764,17 @@ describe("handleAccountEvents", () => {
     assert.equal(body.meta.parameter, "netuid");
   });
 
+  test("rejects a netuid above Number.MAX_SAFE_INTEGER with 400", async () => {
+    const res = await handleAccountEvents(
+      req(`/api/v1/accounts/${SS58}/events`),
+      emptyEnv(),
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events?netuid=9007199254740992`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "netuid");
+  });
+
   test("returns schema-stable empty events on cold D1", async () => {
     const body = await assertColdSchema(
       handleAccountEvents,

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -775,6 +775,7 @@ export async function handleAccountEvents(request, env, ss58, url) {
     "limit",
     "offset",
     "cursor",
+    "netuid",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   // Optional block-height range filter, parity with the extrinsics and
@@ -791,6 +792,18 @@ export async function handleAccountEvents(request, env, ss58, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
+  const netuid = url.searchParams.get("netuid");
+  if (
+    netuid != null &&
+    (!/^\d+$/.test(netuid) || !Number.isSafeInteger(Number(netuid)))
+  ) {
+    return errorResponse(
+      "invalid_param",
+      "netuid must be a non-negative integer.",
+      400,
+      { parameter: "netuid" },
+    );
+  }
   const data = await loadAccountEvents(d1Runner(env), ss58, {
     limit: url.searchParams.get("limit"),
     offset: url.searchParams.get("offset"),
@@ -798,6 +811,7 @@ export async function handleAccountEvents(request, env, ss58, url) {
     cursor: url.searchParams.get("cursor"),
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
+    netuid: netuid != null ? Number(netuid) : undefined,
   });
   return accountEnvelopeResponse(
     request,


### PR DESCRIPTION
## Summary

- Resolves #2585
- Adds `netuid` filter to the account events route (`GET /api/v1/accounts/{ss58}/events`) for parity with the `/history` route.
- Ensures only events on the specified subnet are loaded when `netuid` query parameter is provided.
- Validates the `netuid` parameter to be a non-negative safe integer and rejects malformed inputs with 400.

## What Changed

- **`workers/request-handlers/entities.mjs`**: Added `"netuid"` to the allow-list in `validateQueryParams` for the account events route. Added validation logic to ensure it is a non-negative safe integer and return 400 `invalid_param` otherwise. Passed it down to the data loader.
- **`src/account-events.mjs`**: Destructured `netuid` from options parameter in `loadAccountEvents` and added it as a bound `AND netuid = ?` predicate for SQLite D1 query seeks.
- **`src/contracts.mjs`**: Updated the OpenAPI description and parameters array for the `account-events` route to document `netuid`.
- **OpenAPI Schema & Types**: Re-ran the generation scripts (`openapi:generate` & `types:generate`) to update `openapi.json` and generated TypeScript definitions.
- **`tests/account-events.test.mjs`**: Added unit tests to assert the `netuid` filter generates the expected SQL bindings.
- **`tests/request-handlers-entities.test.mjs`**: Added validation tests to verify malformed/negative `netuid` values return 400.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run check` (via `npm run lint` and `npm run format:check`)
- [x] `npm run openapi:generate`
- [x] `npm run types:generate`
- [x] `npx vitest run tests/account-events.test.mjs tests/request-handlers-entities.test.mjs`