### PR TITLE
chore(enrich): taostats identity gap-fill for SN107 Minos

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -8,7 +8,10 @@
   "netuid": 107,
   "schema_version": 1,
   "slug": "sn-107",
+  "social": { "x": "https://x.com/theminos_ai" },
+  "source_repo": "https://github.com/minos-protocol/minos_subnet",
   "status": "active",
+  "website_url": "https://theminos.ai/",
   "surfaces": [
     {
       "auth_required": false,


### PR DESCRIPTION
## Provenance

Third-party gap-fill from [api.taostats.io](https://api.taostats.io/api/subnet/identity/v1), for human review. No field that already had a value was overwritten.

## Subnet touched (1 file, per the one-file-per-subnet convention)

| SN | Slug | Fields filled |
|----|------|---------------|
| 107 | minos | `source_repo` ← minos-protocol/minos_subnet; `website_url` ← theminos.ai; `social.x` ← x.com/theminos_ai |

## Split from the original combined PR

Split out of #2608, which originally bundled SN28 gm, SN94 bitsota, and SN107 minos in one diff — that violates the registry convention that a data contribution touch exactly one `registry/subnets/<slug>.json` file. `minos.json` is `curation.level: community-seeded` / `review_state: unreviewed` with no prior conflicting claims, so this gap-fill doesn't contradict any existing maintainer review (unlike the dropped SN28 gm entry — see #2608).