### PR TITLE
fix(scan): flag link-local 169.254.0.0/16 URLs in the public-safety scan

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -27,8 +27,12 @@ const patterns = [
   },
   {
     name: "private or loopback URL",
+    // Includes link-local 169.254.0.0/16 — the cloud-metadata endpoint
+    // (169.254.169.254) is the canonical SSRF/credential-theft target and is
+    // classified unsafe by lib.mjs isUnsafeUrl, so a leaked URL to it must be
+    // flagged alongside the RFC1918 ranges.
     regex:
-      /(?:https?|wss?):\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[0-1])\.\d+\.\d+)/i,
+      /(?:https?|wss?):\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|10\.\d+\.\d+\.\d+|169\.254\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[0-1])\.\d+\.\d+)/i,
     // The standard local subtensor RPC endpoint is documented setup guidance for
     // the `local` network surface (llms.txt / setup docs), not a leaked internal
     // URL. Scoped to the exact well-known endpoint; any other loopback URL on the

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -177,6 +177,27 @@ describe("captured-fixture body scan", () => {
     }
   });
 
+  test("flags a link-local cloud-metadata URL as a private/loopback leak", async () => {
+    // 169.254.169.254 is the AWS/GCP metadata endpoint — the canonical SSRF /
+    // credential-theft target and unsafe per lib.mjs isUnsafeUrl, so a leaked URL
+    // to the 169.254.0.0/16 link-local range must be flagged like the RFC1918
+    // ranges. (A bare `169.254.169.254` in prose, with no URL scheme, is not.)
+    const lines = [
+      "http://169.254.169.254/latest/meta-data/",
+      "https://169.254.42.7/admin",
+    ];
+    await fs.writeFile(TEST_PUBLIC_PATH, `${lines.join("\n")}\n`, "utf8");
+    const output = runScanOutput();
+    for (const [index] of lines.entries()) {
+      assert.ok(
+        output.includes(
+          `${TEST_PUBLIC_FILE}:${index + 1}: private or loopback URL`,
+        ),
+        `link-local URL on line ${index + 1} must be flagged; got:\n${output}`,
+      );
+    }
+  });
+
   test("does not flag soft Bittensor terminology in a mirrored fixture body", async () => {
     // Regression for the publish-wedging false positive: upstream API docs
     // legitimately say "miner hotkey" / "validator hotkey path".


### PR DESCRIPTION
## Summary

- The `private or loopback URL` rule in `scripts/scan-public-safety.mjs` matched the RFC1918 ranges (`10/8`, `172.16-31`, `192.168/16`) plus `localhost`/`127.0.0.1`/`0.0.0.0`, but **not** link-local `169.254.0.0/16`. So a leaked URL to the cloud-metadata endpoint `http://169.254.169.254/…` — the canonical SSRF / credential-theft target — passed `scan:public-safety`.
- The repo's own `lib.mjs` `isUnsafeUrl` (used to validate surface URLs) already classifies `169.254.169.254` as unsafe, and `tests/public-safety.test.mjs` asserts it. The file scanner was inconsistent with that definition of a private address.

## What Changed

- `scripts/scan-public-safety.mjs`: add `169\.254\.\d+\.\d+` to the host alternation of the `private or loopback URL` regex.
- `tests/public-safety.test.mjs`: regression asserting `http://169.254.169.254/latest/meta-data/` and `https://169.254.42.7/admin` are flagged. Fails without the fix.

A bare `169.254.169.254` in prose (no URL scheme — e.g. ADR 0004's block-range description) still does not match, so the scanner stays clean on the tree (verified: `Public-safety scan passed.`). No new false positives.

### Reproduction (before)

A committed doc/fixture containing `http://169.254.169.254/latest/meta-data/` was **not** flagged by `npm run scan:public-safety`, even though `http://127.0.0.1/` and `http://10.0.0.5/` were. After the fix, all three are flagged.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — scanner rule only.)

## Validation

- [x] `npx vitest run tests/public-safety.test.mjs` — the new regression passes; it fails without the fix
- [x] `npm run scan:public-safety` — `Public-safety scan passed.` (the ADR prose mention of 169.254 is not a URL, so no new false positive)
- [x] `npx eslint scripts/scan-public-safety.mjs tests/public-safety.test.mjs` (clean)
- [x] `npx prettier --check` (clean)
- [x] `git diff --check`
