### PR TITLE
feat(mcp): add block_start/block_end filter to get_subnet_events for REST parity

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -590,7 +590,11 @@ async function loadNeuronHistory(ctx, netuid, uid, { label, days }) {
 // account_events filtered by netuid, newest first, optional kind filter, keyset
 // (cursor) pagination on (block_number, event_index) with offset as the
 // deprecated fallback. Cold D1 → event_count:0.
-async function loadSubnetEvents(ctx, netuid, { kind, limit, offset, cursor }) {
+async function loadSubnetEvents(
+  ctx,
+  netuid,
+  { kind, limit, offset, cursor, blockStart, blockEnd },
+) {
   const run = mcpD1Runner(ctx);
   const resolvedLimit = clampPageLimit(limit, FEED_PAGINATION);
   const resolvedOffset = clampOffset(offset);
@@ -601,6 +605,16 @@ async function loadSubnetEvents(ctx, netuid, { kind, limit, offset, cursor }) {
   if (kind) {
     sql += " AND event_kind = ?";
     params.push(kind);
+  }
+  // Optional inclusive block-height range — parity with the REST route
+  // (handleSubnetEvents) and the sibling get_account_events MCP tool.
+  if (blockStart != null) {
+    sql += " AND block_number >= ?";
+    params.push(blockStart);
+  }
+  if (blockEnd != null) {
+    sql += " AND block_number <= ?";
+    params.push(blockEnd);
   }
   if (useCursor) {
     sql += " AND (block_number, event_index) < (?, ?)";
@@ -2108,7 +2122,8 @@ export const MCP_TOOLS = [
       "Fetch the paginated first-party chain-event stream for one subnet by its " +
       "netuid, newest first: each event's kind, block, UID, hot/cold keys, " +
       "amount, and timestamp. Optionally filter by event kind (e.g. StakeAdded, " +
-      "NeuronRegistered, AxonServed, WeightsSet) and page with limit (1-1000, " +
+      "NeuronRegistered, AxonServed, WeightsSet), constrain block height with " +
+      "block_start/block_end (inclusive), and page with limit (1-1000, " +
       "default 100) / offset, or follow next_cursor for stable keyset pagination. " +
       "Use it to watch what is happening on one subnet right now. Events are " +
       "decoded directly from the chain. Mirrors GET /api/v1/subnets/{netuid}/events.",
@@ -2121,6 +2136,18 @@ export const MCP_TOOLS = [
           description:
             "Optional event-kind filter, e.g. 'StakeAdded' or 'WeightsSet'. " +
             "Omit for all kinds; an unknown kind simply matches nothing.",
+        },
+        block_start: {
+          type: "integer",
+          description:
+            "Optional inclusive lower block bound; omit for no lower limit.",
+          minimum: 0,
+        },
+        block_end: {
+          type: "integer",
+          description:
+            "Optional inclusive upper block bound; omit for no upper limit.",
+          minimum: 0,
         },
         limit: {
           type: "integer",
@@ -2152,6 +2179,8 @@ export const MCP_TOOLS = [
         limit: args?.limit,
         offset: args?.offset,
         cursor,
+        blockStart: optionalNonNegativeInt(args, "block_start"),
+        blockEnd: optionalNonNegativeInt(args, "block_end"),
       });
     },
   },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6882,6 +6882,32 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
     assert.ok(q.params.includes(1000));
   });
 
+  test("get_subnet_events applies block_start/block_end, parity with the REST route", async () => {
+    const capture = [];
+    const env = parityD1({ events: [] }, capture);
+    await callTool(
+      "get_subnet_events",
+      { netuid: 1, block_start: 100, block_end: 900, limit: 1 },
+      { env },
+    );
+    const q = capture.find((c) => /FROM account_events/.test(c.sql));
+    assert.ok(/block_number >= \?/.test(q.sql));
+    assert.ok(/block_number <= \?/.test(q.sql));
+    // netuid, the inclusive block bounds, the limit, then the default OFFSET 0 —
+    // all bound params, never interpolated.
+    assert.deepEqual(q.params, [1, 100, 900, 1, 0]);
+  });
+
+  test("get_subnet_events rejects a non-integer block_start", async () => {
+    const res = await callTool(
+      "get_subnet_events",
+      { netuid: 1, block_start: "bad" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /block_start/i);
+  });
+
   test("the parity history/events tools degrade to empty payloads on cold D1", async () => {
     const history = await callTool("get_subnet_history", { netuid: 1 });
     assert.equal(history.body.result.isError, false);


### PR DESCRIPTION
## Summary

The `get_subnet_events` MCP tool is documented as "Mirrors GET /api/v1/subnets/{netuid}/events", but it omitted the inclusive block-height range filter (`block_start` / `block_end`) that the REST route supports — and that **every sibling events/extrinsics MCP tool already exposes** (`get_account_events` #2603, `get_account_extrinsics`, `get_account_transfers`, …). So an agent could filter a subnet's event stream by block range over REST but not through MCP.

## What Changed

- `src/mcp-server.mjs`:
  - `get_subnet_events` tool — added `block_start` / `block_end` to the input schema (same shape/description as the sibling tools; `type: integer, minimum: 0`), mentioned them in the tool description, and threaded them through the handler via the shared `optionalNonNegativeInt` validator.
  - `loadSubnetEvents` — apply the bounds as `AND block_number >= ?` / `AND block_number <= ?`, **exactly mirroring** the REST handler `handleSubnetEvents` and the `get_account_events` loader (both bound params, never interpolated; a `null` bound is omitted).
- `tests/mcp-server.test.mjs` — two regression tests: (1) `block_start`/`block_end` reach the SQL as the correct bound params; (2) a non-integer `block_start` is rejected as `invalid_params` (mirroring the account-events tests).

The MCP server card is worker-computed (no committed artifact), so no regeneration is required.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (MCP tool schema only; the REST contract is unchanged — this brings the MCP tool up to the existing REST behavior)

## Validation

- [x] `npx vitest run tests/mcp-server.test.mjs` — 335 passed (incl. the 2 new cases)
- [x] Confirmed the block-range test **fails without the loader change** (SQL lacks the `block_number` clauses) and **passes with it**
- [x] `npm run validate:mcp` — passed (68 tools, lifecycle + all tools/call)
- [x] `npm run validate:ai` — passed
- [x] `npx eslint` + `npx prettier --check --end-of-line auto` on both files — clean
- [x] `git diff --check` — clean
