### PR TITLE
feat(registry): enrich SN28 gm — add OpenAPI + model-catalog surfaces

### DIFF
--- a/registry/subnets/gm.json
+++ b/registry/subnets/gm.json
@@ -33,7 +33,40 @@
       "SubnetRadar published Discord-derived news about a TEE-enabled model routing marketplace, but that is not treated as an official operational interface."
     ]
   },
-  "surfaces": [],
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-28-gm-openapi",
+      "kind": "openapi",
+      "name": "gm Gateway API OpenAPI spec",
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dhgoal"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://saygm.com/openapi.json",
+      "source_urls": ["https://saygm.com/", "https://saygm.com/openapi.json"],
+      "url": "https://saygm.com/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-28-gm-subnet-api",
+      "kind": "subnet-api",
+      "name": "gm model catalog API",
+      "provider": "gm",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dhgoal"
+      },
+      "source_urls": ["https://saygm.com/", "https://saygm.com/openapi.json"],
+      "url": "https://api.saygm.com/v1/models"
+    }
+  ],
   "social": {
     "x": "https://x.com/say_gm_"
   },


### PR DESCRIPTION
## Add or update a subnet surface

Adds two verified public integration surfaces to `registry/subnets/gm.json` (SN28 **gm**) and scaffolds the debut `gm` provider. Generated with `npm run surface:add`; append-only to the existing manifest.

**Closes #2030**

## Surface

**1. OpenAPI 3.1 spec**
- Netuid: 28
- Kind: `openapi`
- Public URL: https://saygm.com/openapi.json
- Source URL (proves the claim): https://saygm.com/ , https://saygm.com/openapi.json
- Provider slug: `gm`

**2. Model-catalog API**
- Netuid: 28
- Kind: `subnet-api`
- Public URL: https://api.saygm.com/v1/models
- Source URL (proves the claim): https://saygm.com/ , https://saygm.com/openapi.json
- Provider slug: `gm`

### Source proof
The spec served at `saygm.com/openapi.json` self-identifies as **"gm Gateway API"** and declares `base_url: https://api.saygm.com/v1`, and SN28's registry identity already lists `website_url: https://saygm.com/` — establishing that both `saygm.com` and `api.saygm.com` are operated by the SN28 gm team. Both endpoints return HTTP 200, are unauthenticated, and public-safe (the model catalog is an OpenAI-compatible `{"object":"list"}` of models with pricing + TEE tier).

## Checklist
- [x] Changes exactly one `registry/subnets/<slug>.json` (append-only) plus one `registry/providers/*.json` for the debut `gm` provider
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`
- [x] `url` is public and safe for read-only probes; `source_url` independently proves the subnet publishes it
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, private URLs, or generated `public/metagraph/**` artifacts
- [x] Does not duplicate an existing Metagraphed surface (gm had no reviewed surfaces)
- [x] Links a tracked issue (`Closes #2030`)

## Validation
- [x] `npm run validate:surface` → passed (451 surfaces across 101 files)
- [x] `npm run scan:public-safety` → passed
