### PR TITLE
feat(mcp): add get_chain_concentration mirroring REST chain concentration

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -471,6 +471,13 @@ assert.ok(
     Array.isArray(transfersCold.top_receivers),
   "get_chain_transfers must return window + top_senders[] + top_receivers[] on cold D1",
 );
+const chainConcentrationCold = await callOk("get_chain_concentration", {});
+assert.ok(
+  chainConcentrationCold.neuron_count === 0 &&
+    chainConcentrationCold.subnet_count === 0 &&
+    chainConcentrationCold.stake === null,
+  "get_chain_concentration must return schema-stable null blocks on cold D1",
+);
 const networkActivityCold = await callOk("get_network_activity", {
   window: "7d",
 });

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -27,6 +27,7 @@ import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
 import {
   loadSubnetConcentration,
   loadSubnetConcentrationHistory,
+  loadChainConcentration,
   parseConcentrationHistoryWindow,
 } from "./concentration.mjs";
 import {
@@ -154,7 +155,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.16.0";
+export const MCP_SERVER_VERSION = "1.17.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -225,6 +226,7 @@ export const MCP_INSTRUCTIONS =
   "incidents, " +
   "get_subnet_concentration stake and " +
   "emission decentralization metrics (Gini, HHI, Nakamoto), " +
+  "get_chain_concentration the same lenses network-wide across every subnet, " +
   "get_subnet_concentration_history the decentralization trend over time, " +
   "get_subnet_turnover validator-set and registration churn between two " +
   "boundary snapshots, get_subnet_yield per-UID emission-per-stake return " +
@@ -1710,6 +1712,26 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
       return loadSubnetConcentration(mcpD1Runner(ctx), netuid);
+    },
+  },
+  {
+    name: "get_chain_concentration",
+    title: "Get network-wide stake/emission concentration",
+    description:
+      "Fetch network-wide stake and emission decentralization metrics aggregated " +
+      "across every subnet's neurons: Gini, HHI, Nakamoto coefficient, " +
+      "top-percentile shares, and entropy over per-UID, per-entity (coldkey " +
+      "collapsed across subnets), and validator-only consensus-power " +
+      "distributions. Snapshot-based (no time window). Use it to see whether " +
+      "capital and emissions are broadly distributed or captured network-wide. " +
+      "Mirrors GET /api/v1/chain/concentration.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadChainConcentration(mcpD1Runner(ctx));
     },
   },
   {
@@ -4641,6 +4663,36 @@ const TOOL_OUTPUT_SCHEMAS = {
       netuid: { type: "integer" },
       neuron_count: { type: "integer" },
       entity_count: { type: "integer" },
+      uids_per_entity: { type: ["number", "null"] },
+      captured_at: NULLABLE_STRING,
+      stake: { type: ["object", "null"] },
+      emission: { type: ["object", "null"] },
+      entity_stake: { type: ["object", "null"] },
+      entity_emission: { type: ["object", "null"] },
+      validator_stake: { type: ["object", "null"] },
+    },
+  },
+  get_chain_concentration: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "schema_version",
+      "subnet_count",
+      "neuron_count",
+      "entity_count",
+      "uids_per_entity",
+      "captured_at",
+      "stake",
+      "emission",
+      "entity_stake",
+      "entity_emission",
+      "validator_stake",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      subnet_count: { type: "integer", minimum: 0 },
+      neuron_count: { type: "integer", minimum: 0 },
+      entity_count: { type: "integer", minimum: 0 },
       uids_per_entity: { type: ["number", "null"] },
       captured_at: NULLABLE_STRING,
       stake: { type: ["object", "null"] },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4506,6 +4506,50 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.stake.holders, 2);
   });
 
+  test("get_chain_concentration returns schema-stable null blocks on cold D1", async () => {
+    const res = await callTool("get_chain_concentration", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(out.subnet_count, 0);
+    assert.equal(out.neuron_count, 0);
+    assert.equal(out.stake, null);
+    assert.equal(out.emission, null);
+  });
+
+  test("get_chain_concentration aggregates neurons across all subnets", async () => {
+    const res = await callTool(
+      "get_chain_concentration",
+      {},
+      {
+        env: {
+          METAGRAPH_HEALTH_DB: metagraphD1({
+            neurons: [
+              {
+                ...ROW,
+                netuid: 1,
+                stake_tao: 10,
+                emission_tao: 1,
+                coldkey: "ck-a",
+              },
+              {
+                ...MINER,
+                netuid: 2,
+                stake_tao: 20,
+                emission_tao: 2,
+                coldkey: "ck-b",
+              },
+            ],
+          }),
+        },
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.neuron_count, 2);
+    assert.equal(out.entity_count, 2);
+    assert.equal(out.stake.holders, 2);
+    assert.equal(out.stake.total, 30);
+  });
+
   test("get_subnet_concentration_history defaults to 30d and returns points", async () => {
     const res = await callTool(
       "get_subnet_concentration_history",


### PR DESCRIPTION
## Summary

- Add MCP tool `get_chain_concentration` for the live REST route `GET /api/v1/chain/concentration`: network-wide stake and emission decentralization metrics (Gini, HHI, Nakamoto, top-percentile shares, entropy) across per-UID, per-entity, and validator-only lenses.
- Wire the tool to the shared `loadChainConcentration` loader (`src/concentration.mjs`); REST and MCP share one read path. Snapshot-based with no query parameters.
- Add a typed `TOOL_OUTPUT_SCHEMAS` entry matching `ChainConcentrationArtifact`, MCP integration tests, and `validate:mcp` coverage. Bump `MCP_SERVER_VERSION` and `server.json` to **1.17.0**.

## Test plan

- [x] `npx vitest run tests/mcp-server.test.mjs -t "get_chain_concentration"`
- [x] `npm run validate:mcp` — 69 tools, lifecycle + all tools/call
- [x] `npm run lint`
- [x] `npm run format:check`