### PR TITLE
feat(mcp): stake-flow and movers economics parity bundle

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -374,6 +374,25 @@ assert.ok(
   "get_subnet_yield must return neurons[]",
 );
 assert.equal(yieldCard.netuid, 7, "get_subnet_yield must echo the netuid");
+const stakeFlowCold = await callOk("get_subnet_stake_flow", {
+  netuid: 7,
+  window: "30d",
+});
+assert.equal(stakeFlowCold.netuid, 7, "get_subnet_stake_flow must echo netuid");
+assert.equal(
+  stakeFlowCold.net_flow_tao,
+  0,
+  "get_subnet_stake_flow must degrade to zeros on cold D1",
+);
+const moversCold = await callOk("get_subnet_movers", {
+  window: "30d",
+  sort: "stake",
+  limit: 5,
+});
+assert.ok(
+  Array.isArray(moversCold.movers),
+  "get_subnet_movers must return movers[]",
+);
 const neuron = await callOk("get_neuron", { netuid: 7, uid: 0 });
 assert.ok("neuron" in neuron, "get_neuron must return a neuron field");
 
@@ -398,6 +417,19 @@ const accountSubnets = await callOk("get_account_subnets", { ss58: SS58 });
 assert.ok(
   Array.isArray(accountSubnets.subnets),
   "get_account_subnets must return subnets[]",
+);
+const accountStakeFlow = await callOk("get_account_stake_flow", {
+  ss58: SS58,
+  window: "30d",
+});
+assert.ok(
+  Array.isArray(accountStakeFlow.subnets),
+  "get_account_stake_flow must return subnets[]",
+);
+assert.equal(
+  accountStakeFlow.address,
+  SS58,
+  "get_account_stake_flow must echo the address",
 );
 const accountBalance = await callOk("get_account_balance", { ss58: SS58 });
 assert.ok(

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -119,6 +119,21 @@ import {
 } from "./neuron-history.mjs";
 import { loadSubnetTurnover } from "./turnover.mjs";
 import { loadSubnetYield } from "./subnet-yield.mjs";
+import {
+  loadSubnetStakeFlow,
+  STAKE_FLOW_WINDOWS,
+  DEFAULT_STAKE_FLOW_WINDOW,
+} from "./stake-flow.mjs";
+import { loadAccountStakeFlow } from "./account-stake-flow.mjs";
+import {
+  loadSubnetMovers,
+  MOVERS_WINDOWS,
+  MOVERS_SORTS,
+  DEFAULT_MOVERS_WINDOW,
+  DEFAULT_MOVERS_SORT,
+  MOVERS_LIMIT_DEFAULT,
+  MOVERS_LIMIT_MAX,
+} from "./movers.mjs";
 import { isFinneySs58Address, loadAccountBalance } from "./account-balance.mjs";
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import { loadBlocks, loadBlock } from "./blocks.mjs";
@@ -155,11 +170,13 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.16.0";
+export const MCP_SERVER_VERSION = "1.17.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
+const STAKE_FLOW_WINDOW_KEYS = Object.keys(STAKE_FLOW_WINDOWS);
+const MOVERS_WINDOW_KEYS = Object.keys(MOVERS_WINDOWS);
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
@@ -228,7 +245,9 @@ export const MCP_INSTRUCTIONS =
   "emission decentralization metrics (Gini, HHI, Nakamoto), " +
   "get_subnet_concentration_history the decentralization trend over time, " +
   "get_subnet_turnover validator-set and registration churn between two " +
-  "boundary snapshots, get_subnet_yield per-UID emission-per-stake return " +
+  "boundary snapshots, get_subnet_stake_flow net capital in/out for one " +
+  "subnet (StakeAdded vs StakeRemoved), get_subnet_movers the cross-subnet " +
+  "stake/emission/validator momentum leaderboard, get_subnet_yield per-UID " +
   "rates plus distribution percentiles over the current metagraph snapshot, " +
   "get_registry_leaderboards the live " +
   "cross-subnet health/economics boards, compare_subnets a side-by-side view " +
@@ -243,7 +262,8 @@ export const MCP_INSTRUCTIONS =
   "get_account summarizes what one hotkey or coldkey does across the network, " +
   "get_account_balance its live native-TAO balance (free+reserved) from finney RPC, " +
   "get_account_events returns its chain-event history (optional kind filter), and " +
-  "get_account_subnets the subnets where it is registered. For chain-wide " +
+  "get_account_subnets the subnets where it is registered, get_account_stake_flow " +
+  "its per-subnet staking flow with direction and concentration labels. For chain-wide " +
   "activity analytics, get_chain_calls returns the extrinsic call-mix " +
   "(count + share per pallet/module) over a 7d/30d window, get_chain_fees the " +
   "fee/tip market series plus top payers, get_chain_transfers network-wide " +
@@ -1855,6 +1875,104 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_subnet_stake_flow",
+    title: "Get subnet net stake flow",
+    description:
+      "Fetch one subnet's net stake flow over the requested window " +
+      "(7d, 30d, or 90d; default 30d): TAO staked (StakeAdded) vs unstaked " +
+      "(StakeRemoved), the net capital flow, and event counts, summed live " +
+      "from the account_events stream. Use it to see whether capital is " +
+      "entering or leaving a subnet. Mirrors " +
+      "GET /api/v1/subnets/{netuid}/stake-flow.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: STAKE_FLOW_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_STAKE_FLOW_WINDOW}).`,
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_STAKE_FLOW_WINDOW;
+      if (!Object.hasOwn(STAKE_FLOW_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${STAKE_FLOW_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const { data } = await loadSubnetStakeFlow(mcpD1Runner(ctx), netuid, {
+        windowLabel: window,
+      });
+      return data;
+    },
+  },
+  {
+    name: "get_subnet_movers",
+    title: "Get cross-subnet momentum leaderboard",
+    description:
+      "Fetch the cross-subnet movers leaderboard over the requested window " +
+      "(7d, 30d, or 90d; default 30d): every subnet ranked by its change in " +
+      "stake, emission, or validator count between the window's start and end " +
+      "neuron_daily snapshots. Sort by stake (default), emission, or " +
+      "validators; cap with limit (1-100, default 20). Mirrors " +
+      "GET /api/v1/subnets/movers.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: MOVERS_WINDOW_KEYS,
+          description: `Comparison window (default ${DEFAULT_MOVERS_WINDOW}).`,
+        },
+        sort: {
+          type: "string",
+          enum: MOVERS_SORTS,
+          description: `Rank metric (default ${DEFAULT_MOVERS_SORT}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max movers to return (1-${MOVERS_LIMIT_MAX}, default ${MOVERS_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: MOVERS_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window = optionalString(args, "window") ?? DEFAULT_MOVERS_WINDOW;
+      if (!Object.hasOwn(MOVERS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${MOVERS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const sort = optionalString(args, "sort") ?? DEFAULT_MOVERS_SORT;
+      if (!MOVERS_SORTS.includes(sort)) {
+        throw toolError(
+          "invalid_params",
+          `sort must be one of: ${MOVERS_SORTS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        MOVERS_LIMIT_DEFAULT,
+        MOVERS_LIMIT_MAX,
+      );
+      return loadSubnetMovers(mcpD1Runner(ctx), {
+        windowLabel: window,
+        sort,
+        limit,
+      });
+    },
+  },
+  {
     name: "get_subnet_uptime",
     title: "Get subnet uptime history",
     description:
@@ -2379,6 +2497,49 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const ss58 = requireSs58(args);
       return loadAccountSubnets(mcpD1Runner(ctx), ss58);
+    },
+  },
+  {
+    name: "get_account_stake_flow",
+    title: "Get an account's staking flow scorecard",
+    description:
+      "Fetch one account's StakeAdded vs StakeRemoved flow per subnet over the " +
+      "requested window (7d, 30d, or 90d; default 30d): per-subnet net and gross " +
+      "flow with direction labels, account totals, an HHI concentration of where " +
+      "its flow is focused, and the dominant subnet. Mirrors " +
+      "GET /api/v1/accounts/{ss58}/stake-flow.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ss58: {
+          type: "string",
+          description:
+            "The account's SS58 hotkey address, base58, 47-48 chars.",
+          pattern: SS58_PATTERN_SOURCE,
+        },
+        window: {
+          type: "string",
+          enum: STAKE_FLOW_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_STAKE_FLOW_WINDOW}).`,
+        },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const ss58 = requireSs58(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_STAKE_FLOW_WINDOW;
+      if (!Object.hasOwn(STAKE_FLOW_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${STAKE_FLOW_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const { data } = await loadAccountStakeFlow(mcpD1Runner(ctx), ss58, {
+        windowLabel: window,
+      });
+      return data;
     },
   },
   {
@@ -4746,6 +4907,59 @@ const TOOL_OUTPUT_SCHEMAS = {
       neurons: { type: "array", items: { type: "object" } },
     },
   },
+  get_subnet_stake_flow: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "netuid",
+      "window",
+      "total_staked_tao",
+      "total_unstaked_tao",
+      "net_flow_tao",
+      "stake_events",
+      "unstake_events",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      total_staked_tao: ANY,
+      total_unstaked_tao: ANY,
+      net_flow_tao: ANY,
+      stake_events: { type: "integer" },
+      unstake_events: { type: "integer" },
+    },
+  },
+  get_subnet_movers: {
+    type: "object",
+    additionalProperties: true,
+    required: ["window", "sort", "subnet_count", "movers"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      start_date: NULLABLE_STRING,
+      end_date: NULLABLE_STRING,
+      sort: NULLABLE_STRING,
+      subnet_count: { type: "integer" },
+      movers: objectItems({
+        netuid: { type: "integer" },
+        stake_start_tao: ANY,
+        stake_end_tao: ANY,
+        stake_delta_tao: ANY,
+        stake_pct_change: { type: ["number", "null"] },
+        emission_start_tao: ANY,
+        emission_end_tao: ANY,
+        emission_delta_tao: ANY,
+        emission_pct_change: { type: ["number", "null"] },
+        validators_start: { type: "integer" },
+        validators_end: { type: "integer" },
+        validators_delta: { type: "integer" },
+        neurons_start: { type: "integer" },
+        neurons_end: { type: "integer" },
+        neurons_delta: { type: "integer" },
+      }),
+    },
+  },
   get_subnet_turnover: {
     type: "object",
     additionalProperties: true,
@@ -4973,6 +5187,50 @@ const TOOL_OUTPUT_SCHEMAS = {
       ss58: { type: "string" },
       subnet_count: { type: "integer" },
       subnets: objectItems(ACCOUNT_REGISTRATION_ITEM),
+    },
+  },
+  get_account_stake_flow: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "address",
+      "window",
+      "total_staked_tao",
+      "total_unstaked_tao",
+      "net_flow_tao",
+      "gross_flow_tao",
+      "direction",
+      "stake_events",
+      "unstake_events",
+      "subnet_count",
+      "subnets",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      address: { type: "string" },
+      window: NULLABLE_STRING,
+      total_staked_tao: ANY,
+      total_unstaked_tao: ANY,
+      net_flow_tao: ANY,
+      gross_flow_tao: ANY,
+      flow_ratio: { type: ["number", "null"] },
+      direction: NULLABLE_STRING,
+      stake_events: { type: "integer" },
+      unstake_events: { type: "integer" },
+      subnet_count: { type: "integer" },
+      concentration: { type: ["number", "null"] },
+      dominant_netuid: NULLABLE_INT,
+      subnets: objectItems({
+        netuid: { type: "integer" },
+        staked_tao: ANY,
+        unstaked_tao: ANY,
+        net_flow_tao: ANY,
+        gross_flow_tao: ANY,
+        flow_ratio: { type: ["number", "null"] },
+        direction: NULLABLE_STRING,
+        stake_events: { type: "integer" },
+        unstake_events: { type: "integer" },
+      }),
     },
   },
   get_account_history: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -2509,7 +2509,13 @@ describe("MCP stake-flow and movers economics tools", () => {
       window: "1y",
     });
     assert.equal(res.body.result.isError, true);
-    assert.match(res.body.result.content[0].text, /window/);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("get_subnet_stake_flow rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_stake_flow", { window: "30d" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /netuid/i);
   });
 
   test("get_subnet_stake_flow degrades to zeros on cold D1", async () => {
@@ -2563,6 +2569,24 @@ describe("MCP stake-flow and movers economics tools", () => {
     assert.match(res.body.result.content[0].text, /ss58/i);
   });
 
+  test("get_account_stake_flow rejects an unsupported window", async () => {
+    const res = await callTool("get_account_stake_flow", {
+      ss58: SS58,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("get_account_stake_flow degrades to zeros on cold D1", async () => {
+    const res = await callTool("get_account_stake_flow", { ss58: SS58 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.address, SS58);
+    assert.equal(out.window, "30d");
+    assert.equal(out.subnet_count, 0);
+    assert.deepEqual(out.subnets, []);
+  });
+
   test("get_subnet_movers ranks subnets by stake delta", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
@@ -2607,7 +2631,52 @@ describe("MCP stake-flow and movers economics tools", () => {
   test("get_subnet_movers rejects an invalid sort", async () => {
     const res = await callTool("get_subnet_movers", { sort: "liquidity" });
     assert.equal(res.body.result.isError, true);
-    assert.match(res.body.result.content[0].text, /sort/);
+    assert.match(res.body.result.content[0].text, /sort must be one of/);
+  });
+
+  test("get_subnet_movers rejects an unsupported window", async () => {
+    const res = await callTool("get_subnet_movers", { window: "1y" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("get_subnet_movers ranks subnets by emission delta", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
+    try {
+      const res = await callTool(
+        "get_subnet_movers",
+        { window: "7d", sort: "emission", limit: 10 },
+        {
+          env: moversD1({
+            bounds: [{ start_date: "2026-06-23", end_date: "2026-06-30" }],
+            aggregateRows: [
+              {
+                netuid: 3,
+                snapshot_date: "2026-06-23",
+                neuron_count: 5,
+                validator_count: 2,
+                total_stake_tao: 50,
+                total_emission_tao: 1,
+              },
+              {
+                netuid: 3,
+                snapshot_date: "2026-06-30",
+                neuron_count: 5,
+                validator_count: 2,
+                total_stake_tao: 50,
+                total_emission_tao: 4,
+              },
+            ],
+          }),
+        },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(out.sort, "emission");
+      assert.equal(out.movers[0].emission_delta_tao, 3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("get_subnet_movers degrades to an empty leaderboard on cold D1", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { describe, test, vi } from "vitest";
 import Ajv2020 from "ajv/dist/2020.js";
 import {
   MCP_TOOLS,
@@ -2400,6 +2400,278 @@ describe("MCP get_chain_transfers", () => {
     assert.equal(out.top_sender_share, null);
     assert.deepEqual(out.top_senders, []);
     assert.deepEqual(out.top_receivers, []);
+  });
+});
+
+describe("MCP stake-flow and movers economics tools", () => {
+  const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+  function stakeFlowD1(rows = [], capture = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  if (
+                    /FROM account_events/.test(sql) &&
+                    /GROUP BY event_kind/.test(sql)
+                  ) {
+                    return { results: rows };
+                  }
+                  if (
+                    /FROM account_events/.test(sql) &&
+                    /GROUP BY netuid, event_kind/.test(sql)
+                  ) {
+                    return { results: rows };
+                  }
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  function moversD1({ bounds, aggregateRows } = {}, capture = []) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  if (/MIN\(snapshot_date\) AS start_date/.test(sql)) {
+                    return { results: bounds };
+                  }
+                  if (/GROUP BY netuid, snapshot_date/.test(sql)) {
+                    return { results: aggregateRows };
+                  }
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("get_subnet_stake_flow aggregates StakeAdded and StakeRemoved", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
+    try {
+      const capture = [];
+      const res = await callTool(
+        "get_subnet_stake_flow",
+        { netuid: 7, window: "30d" },
+        {
+          env: stakeFlowD1(
+            [
+              {
+                event_kind: "StakeAdded",
+                total_tao: 200,
+                event_count: 4,
+                last_observed: 1_717_000_000_000,
+              },
+              {
+                event_kind: "StakeRemoved",
+                total_tao: 50,
+                event_count: 2,
+                last_observed: 1_717_000_000_000,
+              },
+            ],
+            capture,
+          ),
+        },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(out.netuid, 7);
+      assert.equal(out.window, "30d");
+      assert.equal(out.total_staked_tao, 200);
+      assert.equal(out.total_unstaked_tao, 50);
+      assert.equal(out.net_flow_tao, 150);
+      assert.match(capture[0].sql, /FROM account_events/);
+      assert.equal(capture[0].params[0], 7);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("get_subnet_stake_flow rejects an unsupported window", async () => {
+    const res = await callTool("get_subnet_stake_flow", {
+      netuid: 7,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_subnet_stake_flow degrades to zeros on cold D1", async () => {
+    const res = await callTool("get_subnet_stake_flow", { netuid: 7 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.net_flow_tao, 0);
+    assert.equal(out.stake_events, 0);
+  });
+
+  test("get_account_stake_flow shapes per-subnet direction labels", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
+    try {
+      const res = await callTool(
+        "get_account_stake_flow",
+        { ss58: SS58, window: "7d" },
+        {
+          env: stakeFlowD1([
+            {
+              netuid: 7,
+              event_kind: "StakeAdded",
+              total_tao: 100,
+              event_count: 2,
+              last_observed: 1_717_000_000_000,
+            },
+            {
+              netuid: 9,
+              event_kind: "StakeRemoved",
+              total_tao: 40,
+              event_count: 1,
+              last_observed: 1_717_000_000_000,
+            },
+          ]),
+        },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(out.address, SS58);
+      assert.equal(out.window, "7d");
+      assert.equal(out.subnet_count, 2);
+      assert.equal(out.subnets[0].direction, "accumulating");
+      assert.equal(out.direction, "accumulating");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("get_account_stake_flow rejects a missing ss58", async () => {
+    const res = await callTool("get_account_stake_flow", {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /ss58/i);
+  });
+
+  test("get_subnet_movers ranks subnets by stake delta", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
+    try {
+      const res = await callTool(
+        "get_subnet_movers",
+        { window: "30d", sort: "stake", limit: 5 },
+        {
+          env: moversD1({
+            bounds: [{ start_date: "2026-05-31", end_date: "2026-06-30" }],
+            aggregateRows: [
+              {
+                netuid: 7,
+                snapshot_date: "2026-05-31",
+                neuron_count: 10,
+                validator_count: 3,
+                total_stake_tao: 100,
+                total_emission_tao: 5,
+              },
+              {
+                netuid: 7,
+                snapshot_date: "2026-06-30",
+                neuron_count: 12,
+                validator_count: 4,
+                total_stake_tao: 250,
+                total_emission_tao: 9,
+              },
+            ],
+          }),
+        },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(out.window, "30d");
+      assert.equal(out.sort, "stake");
+      assert.equal(out.movers[0].netuid, 7);
+      assert.equal(out.movers[0].stake_delta_tao, 150);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("get_subnet_movers rejects an invalid sort", async () => {
+    const res = await callTool("get_subnet_movers", { sort: "liquidity" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /sort/);
+  });
+
+  test("get_subnet_movers degrades to an empty leaderboard on cold D1", async () => {
+    const res = await callTool("get_subnet_movers", { window: "7d" });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "7d");
+    assert.deepEqual(out.movers, []);
+    assert.equal(out.subnet_count, 0);
+  });
+
+  test("stake-flow and movers payloads validate against outputSchemas", async () => {
+    const ajv = new Ajv2020({ strict: false });
+    const validatorFor = (name) =>
+      ajv.compile(
+        listToolDefinitions().find((t) => t.name === name).outputSchema,
+      );
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
+    try {
+      const subnetStake = await callTool(
+        "get_subnet_stake_flow",
+        { netuid: 7, window: "30d" },
+        {
+          env: stakeFlowD1([
+            {
+              event_kind: "StakeAdded",
+              total_tao: 1,
+              event_count: 1,
+              last_observed: 1,
+            },
+          ]),
+        },
+      );
+      assert.ok(
+        validatorFor("get_subnet_stake_flow")(
+          subnetStake.body.result.structuredContent,
+        ),
+      );
+      const accountStake = await callTool(
+        "get_account_stake_flow",
+        { ss58: SS58 },
+        { env: stakeFlowD1([]) },
+      );
+      assert.ok(
+        validatorFor("get_account_stake_flow")(
+          accountStake.body.result.structuredContent,
+        ),
+      );
+      const movers = await callTool(
+        "get_subnet_movers",
+        { limit: 3 },
+        {
+          env: moversD1({
+            bounds: [{ start_date: "2026-06-01", end_date: "2026-06-30" }],
+            aggregateRows: [],
+          }),
+        },
+      );
+      assert.ok(
+        validatorFor("get_subnet_movers")(movers.body.result.structuredContent),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -4,7 +4,7 @@
 // payloads without routing through workers/api.mjs.
 
 import assert from "node:assert/strict";
-import { afterEach, describe, test } from "vitest";
+import { afterEach, describe, test, vi } from "vitest";
 import {
   configureAnalytics,
   withEdgeCache,
@@ -897,19 +897,25 @@ describe("handleBulkHealthTrends", () => {
   });
 
   test("happy path includes surface_uptime_daily aggregates per window", async () => {
-    globalThis.caches = undefined;
-    const { env } = dbWith();
-    env.__healthMeta = { last_run_at: LAST_RUN_AT };
-    const body = await json(
-      await handleBulkHealthTrends(
-        req("/api/v1/health/trends"),
-        env,
-        url("/api/v1/health/trends"),
-      ),
-    );
-    assert.equal(body.data.observed_at, LAST_RUN_AT);
-    assert.ok(body.data.windows["7d"].subnets.length > 0);
-    assert.equal(body.data.windows["7d"].subnets[0].netuid, NETUID);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-25T00:00:00.000Z"));
+    try {
+      globalThis.caches = undefined;
+      const { env } = dbWith();
+      env.__healthMeta = { last_run_at: LAST_RUN_AT };
+      const body = await json(
+        await handleBulkHealthTrends(
+          req("/api/v1/health/trends"),
+          env,
+          url("/api/v1/health/trends"),
+        ),
+      );
+      assert.equal(body.data.observed_at, LAST_RUN_AT);
+      assert.ok(body.data.windows["7d"].subnets.length > 0);
+      assert.equal(body.data.windows["7d"].subnets[0].netuid, NETUID);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("meta block carries bulk trends artifact path", async () => {


### PR DESCRIPTION
## Summary

Adds a **capital-movement economics MCP bundle** — three REST-backed analytics tools wired through existing D1 loaders with full outputSchema parity. No overlap with open PRs for chain concentration (#2656), subnet-events block range (#2653), chain yield API (#2648), or all-events explorer (#2660).

| REST | MCP tool | Notes |
|------|----------|-------|
| `GET /api/v1/subnets/{netuid}/stake-flow?window=` | `get_subnet_stake_flow` | Net StakeAdded vs StakeRemoved capital flow for one subnet (7d/30d/90d) |
| `GET /api/v1/accounts/{ss58}/stake-flow?window=` | `get_account_stake_flow` | Per-subnet staking flow + direction/HHI concentration scorecard |
| `GET /api/v1/subnets/movers?window=&sort=&limit=` | `get_subnet_movers` | Cross-subnet stake/emission/validator momentum leaderboard |

### Implementation

- **`src/mcp-server.mjs`** — register 3 tools; reuse `loadSubnetStakeFlow`, `loadAccountStakeFlow`, `loadSubnetMovers`; MCP SemVer **1.16.0 → 1.17.0**.
- **`scripts/validate-mcp.mjs`** — cold-D1 smoke for all three tools + outputSchema validation.
- **`tests/mcp-server.test.mjs`** — happy-path, validation-error, cold-degrade, and outputSchema contract tests (pinned clocks for window cutoffs).

Loaders (`src/stake-flow.mjs`, `src/account-stake-flow.mjs`, `src/movers.mjs`) and REST handlers are unchanged — MCP is thin wiring only.

## Conflict avoidance

Does **not** touch `entities.mjs`, stake-flow/movers REST routes, or tools claimed by other open MCP PRs. If #2660 lands first, only shared `mcp-server.mjs` / `server.json` version lines may need a trivial rebase bump to 1.18.0.

## Registry Safety

- Read-only D1 queries only; cold store degrades to schema-stable zeros/empty lists (never throws).

## Test plan

- [x] `node scripts/validate-mcp.mjs` (71 tools)
- [x] `vitest run tests/mcp-server.test.mjs -t "stake-flow and movers"`
- [x] eslint + prettier on touched files
- [ ] CI green (unit + validate-mcp + Codecov patch ≥ 80%)
