### PR TITLE
feat(graphql): add account node

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -11,7 +11,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `registry/reviews/maintainer-reviewed.json` stores public-safe maintainer review decisions.
 - `schemas/components/*.schema.json` is canonical for public API/artifact component schemas.
 - `schemas/api-components.schema.json` is a generated bundle and should not be edited by hand.
-- `/metagraph/openapi.json`, `/metagraph/types.d.ts`, `generated/metagraphed-api.d.ts`, and `generated/metagraphed-client.ts` are generated from the canonical schema and route metadata.
+- `/metagraph/openapi.json`, `/metagraph/graphql.graphql`, `/metagraph/types.d.ts`, `generated/metagraphed-api.d.ts`, and `generated/metagraphed-client.ts` are generated from the canonical schema and route metadata.
 - `public/metagraph/*` files are compact generated projections and should not be edited by hand. R2-only artifacts must not be committed there.
 - `dist/metagraph-r2/metagraph/*` is the ignored staging tree for volatile/detail generated projections that are uploaded to R2.
 - Artifact contracts carry `storage_tier`: `dual` for compact Git-plus-R2 artifacts, `r2` for volatile/detail artifacts, and `git` for local-only generated support artifacts.
@@ -27,6 +27,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/providers/{slug}/endpoints.json`: endpoint resources for one provider or operator. R2-backed.
 - `/metagraph/api-index.json`: Worker API route map and response-envelope contract.
 - `/metagraph/openapi.json`: OpenAPI 3.1 contract for backend API consumers.
+- `/metagraph/graphql.graphql`: GraphQL SDL contract for backend API consumers.
 - `/metagraph/types.d.ts`: generated TypeScript definitions for consumers.
 - `/metagraph/changelog.json`: reviewable generated artifact and subnet-change summary.
 - `/metagraph/subnets.json`: compact all-subnet index.

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -44,6 +44,13 @@
     },
     {
       "contract_version": "2026-06-30.14",
+      "id": "graphql-sdl",
+      "path": "/metagraph/graphql.graphql",
+      "schema_ref": null,
+      "storage_tier": "dual"
+    },
+    {
+      "contract_version": "2026-06-30.14",
       "id": "type-definitions",
       "path": "/metagraph/types.d.ts",
       "schema_ref": null,

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -55,6 +55,15 @@
       "storage_tier": "dual"
     },
     {
+      "content_type": "application/graphql; charset=utf-8",
+      "contract_version": "2026-06-30.14",
+      "description": "GraphQL SDL contract for the metagraph.sh backend API.",
+      "id": "graphql-sdl",
+      "path": "/metagraph/graphql.graphql",
+      "schema_ref": null,
+      "storage_tier": "dual"
+    },
+    {
       "content_type": "text/plain; charset=utf-8",
       "contract_version": "2026-06-30.14",
       "description": "Generated TypeScript definitions for metagraph.sh backend consumers.",

--- a/public/metagraph/graphql.graphql
+++ b/public/metagraph/graphql.graphql
@@ -1,0 +1,453 @@
+
+  type Query {
+    "Paginated active-subnet index."
+    subnets(limit: Int, cursor: String): SubnetList!
+    "One subnet with its health, surfaces, endpoints, and economics."
+    subnet(netuid: Int!): Subnet
+    "Paginated provider/source registry."
+    providers(limit: Int, cursor: String): ProviderList!
+    "One provider with its subnets."
+    provider(id: String!): Provider
+    "Paginated per-subnet economic + validator metrics."
+    economics(limit: Int, cursor: String): EconomicsList!
+    "Curated public interface surfaces, optionally scoped to one subnet."
+    surfaces(netuid: Int, limit: Int, cursor: String): SurfaceList!
+    "Endpoint/resource registry, optionally scoped to one subnet."
+    endpoints(netuid: Int, limit: Int, cursor: String): EndpointList!
+    "Global operational health rollup with per-subnet summaries."
+    health: GlobalHealth
+    "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
+    opportunity_boards(limit: Int): OpportunityBoards!
+    "Cross-subnet comparison: registry structure, live economics, and live health placed side by side for the requested netuids, in requested order. Mirrors GET /api/v1/compare."
+    compare(netuids: [Int!]!, dimensions: [String!]): Compare!
+    "One Bittensor account with lazy chain-data relationships. Mirrors the /api/v1/accounts/{ss58} family."
+    account(ss58: String!): Account
+  }
+
+  type SubnetList {
+    items: [Subnet!]!
+    total: Int!
+    next_cursor: String
+  }
+
+  type Subnet {
+    netuid: Int!
+    name: String
+    slug: String
+    description: String
+    categories: [String!]
+    status: String
+    subnet_type: String
+    lifecycle: String
+    coverage_level: String
+    curation_level: String
+    integration_readiness: Int
+    surface_count: Int
+    official_surface_count: Int
+    probed_surface_count: Int
+    gap_count: Int
+    first_party: Boolean
+    symbol: String
+    logo_url: String
+    website_url: String
+    docs_url: String
+    "Live operational health summary for this subnet."
+    health: SubnetHealth
+    "Per-subnet economic + validator metrics."
+    economics: SubnetEconomics
+    "Curated public interface surfaces of this subnet."
+    surfaces: [Surface!]!
+    "Endpoint/resource registry rows for this subnet."
+    endpoints: [Endpoint!]!
+  }
+
+  type ProviderList {
+    items: [Provider!]!
+    total: Int!
+    next_cursor: String
+  }
+
+  type Provider {
+    id: String!
+    name: String
+    kind: String
+    authority: String
+    docs_url: String
+    github_url: String
+    website_url: String
+    contact_url: String
+    logo_url: String
+    notes: String
+    public_notes: String
+    endpoint_count: Int
+    surface_count: Int
+    subnet_count: Int
+    netuids: [Int]!
+    "The subnets this provider operates surfaces on."
+    subnets: [Subnet!]!
+  }
+
+  type Account {
+    ss58: String!
+    "Cross-subnet activity summary for this account."
+    summary: AccountSummary!
+    "Durable per-day activity series for this account."
+    history(netuid: Int, from: String, to: String, limit: Int, offset: Int, cursor: String): AccountHistory!
+    "Native-TAO transfers involving this account."
+    transfers(direction: String, block_start: Int, block_end: Int, limit: Int, offset: Int, cursor: String): AccountTransfers!
+    "Top native-TAO counterparties for this account."
+    counterparties(limit: Int): AccountCounterparties!
+    "Extrinsics signed by this account."
+    extrinsics(block_start: Int, block_end: Int, limit: Int, offset: Int, cursor: String): AccountExtrinsics!
+    "Subnets where this account's hotkey is currently registered."
+    subnets: AccountSubnets!
+    "Live finney TAO balance for this account. Null for non-finney or checksum-invalid SS58 addresses."
+    balance: AccountBalance
+  }
+
+  type AccountSummary {
+    schema_version: Int!
+    ss58: String!
+    event_count: Int!
+    subnet_count: Int!
+    first_block: Int
+    last_block: Int
+    first_seen_at: String
+    last_seen_at: String
+    event_kinds: [AccountEventKindCount!]!
+    registrations: [AccountRegistration!]!
+    recent_events: [AccountEvent!]!
+    activity: AccountActivity!
+  }
+
+  type AccountEventKindCount {
+    kind: String!
+    count: Int!
+  }
+
+  type AccountRegistration {
+    netuid: Int
+    uid: Int
+    stake_tao: Float
+    validator_permit: Boolean
+    active: Boolean
+  }
+
+  type AccountActivity {
+    tx_count: Int!
+    last_tx_block: Int
+    last_tx_at: String
+    total_fee_tao: Float
+    modules_called: [AccountModuleCall!]!
+  }
+
+  type AccountModuleCall {
+    call_module: String
+    count: Int!
+  }
+
+  type AccountEvent {
+    block_number: Int
+    event_index: Int
+    event_kind: String
+    hotkey: String
+    coldkey: String
+    netuid: Int
+    uid: Int
+    amount_tao: Float
+    alpha_amount: Float
+    observed_at: String
+    extrinsic_index: Int
+  }
+
+  type AccountHistory {
+    schema_version: Int!
+    ss58: String!
+    day_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    days: [AccountDay!]!
+  }
+
+  type AccountDay {
+    day: String
+    netuid: Int
+    event_count: Int
+    event_kinds: [String!]!
+    first_block: Int
+    last_block: Int
+  }
+
+  type AccountTransfers {
+    schema_version: Int!
+    ss58: String!
+    transfer_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    transfers: [AccountTransfer!]!
+  }
+
+  type AccountTransfer {
+    block_number: Int
+    event_index: Int
+    from: String
+    to: String
+    amount_tao: Float
+    direction: String
+    observed_at: String
+  }
+
+  type AccountCounterparties {
+    schema_version: Int!
+    ss58: String!
+    counterparty_count: Int!
+    transfers_scanned: Int
+    scan_capped: Boolean
+    total_sent_tao: Float
+    total_received_tao: Float
+    counterparties: [AccountCounterparty!]!
+  }
+
+  type AccountCounterparty {
+    address: String!
+    sent_tao: Float!
+    received_tao: Float!
+    net_tao: Float!
+    transfer_count: Int!
+    last_block: Int
+  }
+
+  type AccountExtrinsics {
+    schema_version: Int!
+    ss58: String!
+    extrinsic_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    extrinsics: [AccountExtrinsic!]!
+  }
+
+  type AccountExtrinsic {
+    block_number: Int
+    extrinsic_index: Int
+    extrinsic_hash: String
+    signer: String
+    call_module: String
+    call_function: String
+    success: Boolean
+    fee_tao: Float
+    tip_tao: Float
+    observed_at: String
+  }
+
+  type AccountSubnets {
+    schema_version: Int!
+    ss58: String!
+    subnet_count: Int!
+    subnets: [AccountRegistration!]!
+  }
+
+  type AccountBalance {
+    schema_version: Int!
+    ss58: String!
+    balance_tao: Float
+    queried_at: String
+  }
+
+  type EconomicsList {
+    subnets: [SubnetEconomics!]!
+    total: Int!
+    next_cursor: String
+  }
+
+  type SubnetEconomics {
+    netuid: Int!
+    name: String
+    slug: String
+    emission_share: Float
+    alpha_price_tao: Float
+    registration_allowed: Boolean
+    registration_cost_tao: Float
+    open_slots: Int
+    max_uids: Int
+    miner_count: Int
+    miner_readiness: Int
+    validator_count: Int
+    max_validators: Int
+    total_stake_tao: Float
+    max_stake_tao: Float
+    subnet_volume_tao: Float
+    tao_in_pool_tao: Float
+    alpha_in_pool: Float
+    alpha_out_pool: Float
+    owner_coldkey: String
+    owner_hotkey: String
+  }
+
+  type SurfaceList {
+    items: [Surface!]!
+    total: Int!
+    next_cursor: String
+  }
+
+  type Surface {
+    id: String!
+    key: String
+    netuid: Int
+    name: String
+    kind: String
+    status: String
+    classification: String
+    authority: String
+    provider: String
+    url: String
+    auth_required: Boolean
+    public_safe: Boolean
+    schema_status: String
+    schema_url: String
+    last_verified_at: String
+    stale: Boolean
+    subnet_name: String
+    subnet_slug: String
+    source_urls: [String!]
+    notes: String
+  }
+
+  type EndpointList {
+    items: [Endpoint!]!
+    total: Int!
+    next_cursor: String
+  }
+
+  type Endpoint {
+    id: String!
+    surface_id: String
+    surface_key: String
+    netuid: Int
+    kind: String
+    layer: String
+    network: String
+    status: String
+    classification: String
+    authority: String
+    provider: String
+    operator: String
+    url: String
+    auth_required: Boolean
+    public_safe: Boolean
+    latency_ms: Int
+    latest_block: Int
+    last_checked: String
+    last_ok: String
+    health_source: String
+    score: Int
+    pool_eligible: Boolean
+    monitoring_status: String
+    subnet_name: String
+    subnet_slug: String
+    source_urls: [String!]
+  }
+
+  type GlobalHealth {
+    status: String
+    surface_count: Int
+    ok_count: Int
+    degraded_count: Int
+    failed_count: Int
+    unknown_count: Int
+    avg_latency_ms: Int
+    latency_sample_count: Int
+    last_checked: String
+    last_ok: String
+    generated_at: String
+    operational_observed_at: String
+    health_source: String
+    scope: String
+    subnets: [SubnetHealth!]!
+  }
+
+  type SubnetHealth {
+    netuid: Int
+    name: String
+    slug: String
+    status: String
+    surface_count: Int
+    ok_count: Int
+    degraded_count: Int
+    failed_count: Int
+    unknown_count: Int
+    avg_latency_ms: Int
+    latency_sample_count: Int
+    last_checked: String
+    last_ok: String
+  }
+
+  type OpportunityBoards {
+    observed_at: String
+    with_economics_count: Int!
+    open_slots: [OpportunityEntry!]!
+    cheapest_registration: [OpportunityEntry!]!
+    highest_emission: [OpportunityEntry!]!
+    validator_headroom: [OpportunityEntry!]!
+  }
+
+  type OpportunityEntry {
+    netuid: Int!
+    slug: String
+    name: String
+    open_slots: Int
+    max_uids: Int
+    registration_cost_tao: Float
+    registration_allowed: Boolean
+    emission_share: Float
+    total_stake_tao: Float
+    validator_count: Int
+    miner_count: Int
+    validator_headroom: Int
+    max_validators: Int
+  }
+
+  type Compare {
+    schema_version: Int!
+    source: String
+    observed_at: String
+    dimensions: [String!]!
+    requested_netuids: [Int!]!
+    subnets: [CompareSubnet!]!
+  }
+
+  type CompareSubnet {
+    netuid: Int!
+    name: String
+    slug: String
+    found: Boolean!
+    structure: CompareStructure
+    economics: CompareEconomics
+    health: CompareHealth
+  }
+
+  type CompareStructure {
+    completeness_score: Float
+    surface_count: Int
+    operational_interface_count: Int
+  }
+
+  type CompareEconomics {
+    registration_cost_tao: Float
+    registration_allowed: Boolean
+    open_slots: Int
+    emission_share: Float
+    alpha_price_tao: Float
+    validator_count: Int
+    miner_count: Int
+    total_stake_tao: Float
+    miner_readiness: Int
+  }
+
+  type CompareHealth {
+    surface_count: Int
+    ok_count: Int
+    avg_latency_ms: Int
+  }

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 7,
-  "artifact_size_bytes": 2281663,
+  "artifact_size_bytes": 2282094,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -52,8 +52,8 @@
       "key": "runs/2026-06-18T00-00-00-000Z/schemas/index.json",
       "latest_key": "latest/schemas/index.json",
       "path": "/metagraph/schemas/index.json",
-      "sha256": "cf46bb7bae1b832a07b9937f4bf4b839a870275b835fe0fd5eaf49b4e1b0da26",
-      "size_bytes": 37277,
+      "sha256": "b9c98797d7e0242b4cf5d51053a19396981e66678de1dc3fb2242c72615add2a",
+      "size_bytes": 37708,
       "storage_tier": "dual"
     },
     {
@@ -70,7 +70,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-30.14",
   "full_artifact_count": 2262,
-  "full_artifact_size_bytes": 40486157,
+  "full_artifact_size_bytes": 40486320,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/2026-06-18T00-00-00-000Z/r2-manifest.json",
   "generated_at": "2026-06-18T00:00:00.000Z",
@@ -92,7 +92,7 @@
     "r2": 2255
   },
   "storage_tier_size_bytes": {
-    "dual": 2281663,
-    "r2": 38204494
+    "dual": 2282094,
+    "r2": 38204226
   }
 }

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,14 +1,14 @@
 {
-  "artifact_count": 6,
-  "artifact_size_bytes": 2270482,
+  "artifact_count": 7,
+  "artifact_size_bytes": 2281663,
   "artifacts": [
     {
       "content_type": "application/json",
       "key": "runs/2026-06-18T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "45a992dc196f54d20b6f5b7cfd36ee158d6379fb08427c9181d8bccd741e3157",
-      "size_bytes": 183186,
+      "sha256": "49709f158e37a9db584ee7070ef5e42d242301417d52826f62486f43e5409a07",
+      "size_bytes": 183368,
       "storage_tier": "dual"
     },
     {
@@ -16,8 +16,17 @@
       "key": "runs/2026-06-18T00-00-00-000Z/contracts.json",
       "latest_key": "latest/contracts.json",
       "path": "/metagraph/contracts.json",
-      "sha256": "d4b69053570b4c30ea60c044c520e0523dc9a7836708d39fa9fb3ee4f4725553",
-      "size_bytes": 50635,
+      "sha256": "bba8b568802045edd082162c7136558c14527f2e6adc50b2fa640ec97a401a0e",
+      "size_bytes": 50956,
+      "storage_tier": "dual"
+    },
+    {
+      "content_type": "application/graphql; charset=utf-8",
+      "key": "runs/2026-06-18T00-00-00-000Z/graphql.graphql",
+      "latest_key": "latest/graphql.graphql",
+      "path": "/metagraph/graphql.graphql",
+      "sha256": "37eb527b83e432d85d0c474b30f52cbc876fc492dba3fc5a0d211632b33459fe",
+      "size_bytes": 10678,
       "storage_tier": "dual"
     },
     {
@@ -60,8 +69,8 @@
   "bucket_binding": "METAGRAPH_ARCHIVE",
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-30.14",
-  "full_artifact_count": 2261,
-  "full_artifact_size_bytes": 40449679,
+  "full_artifact_count": 2262,
+  "full_artifact_size_bytes": 40486157,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/2026-06-18T00-00-00-000Z/r2-manifest.json",
   "generated_at": "2026-06-18T00:00:00.000Z",
@@ -79,11 +88,11 @@
   "run_prefix": "runs/2026-06-18T00-00-00-000Z/",
   "schema_version": 1,
   "storage_tier_counts": {
-    "dual": 6,
+    "dual": 7,
     "r2": 2255
   },
   "storage_tier_size_bytes": {
-    "dual": 2270482,
-    "r2": 38179197
+    "dual": 2281663,
+    "r2": 38204494
   }
 }

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -77,6 +77,7 @@ import {
   buildApiIndexArtifact,
   buildContractsArtifact,
 } from "../src/contracts.mjs";
+import { SDL as GRAPHQL_SDL } from "../src/graphql.mjs";
 import {
   MCP_SERVER_INFO,
   MCP_REGISTRY_META,
@@ -2209,6 +2210,11 @@ await writeJson(
   buildApiIndexArtifact(generatedAt, contracts),
 );
 await writeJson(artifactFile("openapi.json"), openApi);
+await fs.writeFile(
+  artifactFile("graphql.graphql"),
+  `${GRAPHQL_SDL.trimEnd()}\n`,
+  "utf8",
+);
 const searchIndexArtifact = buildSearchIndex(
   mergedSubnets,
   surfaces,

--- a/scripts/r2-manifest.mjs
+++ b/scripts/r2-manifest.mjs
@@ -227,10 +227,17 @@ async function listArtifactFiles(dirPath) {
 }
 
 function isManifestedArtifact(fileName) {
-  return fileName.endsWith(".json") || fileName.endsWith(".d.ts");
+  return (
+    fileName.endsWith(".json") ||
+    fileName.endsWith(".d.ts") ||
+    fileName.endsWith(".graphql")
+  );
 }
 
 function contentTypeFor(relativePath) {
+  if (relativePath.endsWith(".graphql")) {
+    return "application/graphql; charset=utf-8";
+  }
   if (relativePath.endsWith(".d.ts")) {
     return "text/plain; charset=utf-8";
   }

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1335,6 +1335,14 @@ async function validateGeneratedArtifacts(
     "R2 manifest: generated type definitions must be uploaded",
   );
   assert(
+    r2ManifestArtifact.artifacts.some(
+      (artifact) =>
+        artifact.path === "/metagraph/graphql.graphql" &&
+        artifact.content_type === "application/graphql; charset=utf-8",
+    ),
+    "R2 manifest: GraphQL SDL contract must be uploaded",
+  );
+  assert(
     (schemaDriftArtifact.openapi_surface_count ??
       schemaDriftArtifact.summary?.surface_count) ===
       surfacesArtifact.surfaces.filter((surface) => surface.kind === "openapi")

--- a/src/account-balance.mjs
+++ b/src/account-balance.mjs
@@ -74,8 +74,9 @@ export function isFinneySs58Address(value) {
 }
 
 // Query live balance for one finney ss58. Uses METAGRAPH_CONTROL KV (60s TTL) when
-// present; balance_tao is null on RPC failure (schema-stable, never throws).
-export async function loadAccountBalance(env, ss58) {
+// present; balance_tao is null on RPC failure. Callers can pass beforeLiveFetch
+// to meter/block only the post-cache live RPC.
+export async function loadAccountBalance(env, ss58, { beforeLiveFetch } = {}) {
   const cacheKey = `balance:${ss58}`;
   const kv = env?.METAGRAPH_CONTROL;
 
@@ -87,6 +88,8 @@ export async function loadAccountBalance(env, ss58) {
       // KV read failure is non-fatal — fall through to the live RPC.
     }
   }
+
+  if (beforeLiveFetch) await beforeLiveFetch();
 
   const queriedAt = new Date().toISOString();
   let balanceTao = null;

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -225,6 +225,7 @@ export const DUAL_PATTERNS = [
   /^r2-manifest\.json$/,
   /^contracts\.json$/,
   /^openapi\.json$/,
+  /^graphql\.graphql$/,
   /^schemas\/index\.json$/,
   /^types\.d\.ts$/,
   // The cron prober's own input list. It is deterministic (probe-enabled overlay

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -649,6 +649,12 @@ export const PUBLIC_ARTIFACTS = [
     "OpenApiArtifact",
   ),
   artifact(
+    "graphql-sdl",
+    "/metagraph/graphql.graphql",
+    "GraphQL SDL contract for the metagraph.sh backend API.",
+    null,
+  ),
+  artifact(
     "type-definitions",
     "/metagraph/types.d.ts",
     "Generated TypeScript definitions for metagraph.sh backend consumers.",
@@ -2863,6 +2869,9 @@ function artifact(id, pathValue, description, schemaRef) {
 }
 
 function artifactContentType(pathValue) {
+  if (pathValue.endsWith(".graphql")) {
+    return "application/graphql; charset=utf-8";
+  }
   if (pathValue.endsWith(".d.ts")) {
     return "text/plain; charset=utf-8";
   }

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -20,7 +20,17 @@ import {
   parseCompareDimensionList,
   parseCompareNetuidList,
 } from "./analytics-live.mjs";
+import {
+  loadAccountExtrinsics,
+  loadAccountHistory,
+  loadAccountSubnets,
+  loadAccountSummary,
+  loadAccountTransfers,
+} from "./account-events.mjs";
+import { isFinneySs58Address, loadAccountBalance } from "./account-balance.mjs";
+import { loadCounterparties } from "./counterparties.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
+import { SS58_ADDRESS_PATTERN, resolveClientIp } from "../workers/config.mjs";
 
 export const GRAPHQL_MAX_DEPTH = 7;
 export const GRAPHQL_MAX_COMPLEXITY = 50;
@@ -54,6 +64,8 @@ export const SDL = `
     opportunity_boards(limit: Int): OpportunityBoards!
     "Cross-subnet comparison: registry structure, live economics, and live health placed side by side for the requested netuids, in requested order. Mirrors GET /api/v1/compare."
     compare(netuids: [Int!]!, dimensions: [String!]): Compare!
+    "One Bittensor account with lazy chain-data relationships. Mirrors the /api/v1/accounts/{ss58} family."
+    account(ss58: String!): Account
   }
 
   type SubnetList {
@@ -117,6 +129,175 @@ export const SDL = `
     netuids: [Int]!
     "The subnets this provider operates surfaces on."
     subnets: [Subnet!]!
+  }
+
+  type Account {
+    ss58: String!
+    "Cross-subnet activity summary for this account."
+    summary: AccountSummary!
+    "Durable per-day activity series for this account."
+    history(netuid: Int, from: String, to: String, limit: Int, offset: Int, cursor: String): AccountHistory!
+    "Native-TAO transfers involving this account."
+    transfers(direction: String, block_start: Int, block_end: Int, limit: Int, offset: Int, cursor: String): AccountTransfers!
+    "Top native-TAO counterparties for this account."
+    counterparties(limit: Int): AccountCounterparties!
+    "Extrinsics signed by this account."
+    extrinsics(block_start: Int, block_end: Int, limit: Int, offset: Int, cursor: String): AccountExtrinsics!
+    "Subnets where this account's hotkey is currently registered."
+    subnets: AccountSubnets!
+    "Live finney TAO balance for this account. Null for non-finney or checksum-invalid SS58 addresses."
+    balance: AccountBalance
+  }
+
+  type AccountSummary {
+    schema_version: Int!
+    ss58: String!
+    event_count: Int!
+    subnet_count: Int!
+    first_block: Int
+    last_block: Int
+    first_seen_at: String
+    last_seen_at: String
+    event_kinds: [AccountEventKindCount!]!
+    registrations: [AccountRegistration!]!
+    recent_events: [AccountEvent!]!
+    activity: AccountActivity!
+  }
+
+  type AccountEventKindCount {
+    kind: String!
+    count: Int!
+  }
+
+  type AccountRegistration {
+    netuid: Int
+    uid: Int
+    stake_tao: Float
+    validator_permit: Boolean
+    active: Boolean
+  }
+
+  type AccountActivity {
+    tx_count: Int!
+    last_tx_block: Int
+    last_tx_at: String
+    total_fee_tao: Float
+    modules_called: [AccountModuleCall!]!
+  }
+
+  type AccountModuleCall {
+    call_module: String
+    count: Int!
+  }
+
+  type AccountEvent {
+    block_number: Int
+    event_index: Int
+    event_kind: String
+    hotkey: String
+    coldkey: String
+    netuid: Int
+    uid: Int
+    amount_tao: Float
+    alpha_amount: Float
+    observed_at: String
+    extrinsic_index: Int
+  }
+
+  type AccountHistory {
+    schema_version: Int!
+    ss58: String!
+    day_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    days: [AccountDay!]!
+  }
+
+  type AccountDay {
+    day: String
+    netuid: Int
+    event_count: Int
+    event_kinds: [String!]!
+    first_block: Int
+    last_block: Int
+  }
+
+  type AccountTransfers {
+    schema_version: Int!
+    ss58: String!
+    transfer_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    transfers: [AccountTransfer!]!
+  }
+
+  type AccountTransfer {
+    block_number: Int
+    event_index: Int
+    from: String
+    to: String
+    amount_tao: Float
+    direction: String
+    observed_at: String
+  }
+
+  type AccountCounterparties {
+    schema_version: Int!
+    ss58: String!
+    counterparty_count: Int!
+    transfers_scanned: Int
+    scan_capped: Boolean
+    total_sent_tao: Float
+    total_received_tao: Float
+    counterparties: [AccountCounterparty!]!
+  }
+
+  type AccountCounterparty {
+    address: String!
+    sent_tao: Float!
+    received_tao: Float!
+    net_tao: Float!
+    transfer_count: Int!
+    last_block: Int
+  }
+
+  type AccountExtrinsics {
+    schema_version: Int!
+    ss58: String!
+    extrinsic_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    extrinsics: [AccountExtrinsic!]!
+  }
+
+  type AccountExtrinsic {
+    block_number: Int
+    extrinsic_index: Int
+    extrinsic_hash: String
+    signer: String
+    call_module: String
+    call_function: String
+    success: Boolean
+    fee_tao: Float
+    tip_tao: Float
+    observed_at: String
+  }
+
+  type AccountSubnets {
+    schema_version: Int!
+    ss58: String!
+    subnet_count: Int!
+    subnets: [AccountRegistration!]!
+  }
+
+  type AccountBalance {
+    schema_version: Int!
+    ss58: String!
+    balance_tao: Float
+    queried_at: String
   }
 
   type EconomicsList {
@@ -327,6 +508,7 @@ const schema = buildSchema(SDL);
 export const DEFAULT_FIELD_COMPLEXITY = 1;
 const RELATIONSHIP_FIELD_COMPLEXITY = 5;
 export const FIELD_COMPLEXITY = {
+  account: RELATIONSHIP_FIELD_COMPLEXITY,
   subnets: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet: RELATIONSHIP_FIELD_COMPLEXITY,
   providers: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -337,6 +519,12 @@ export const FIELD_COMPLEXITY = {
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
+  summary: RELATIONSHIP_FIELD_COMPLEXITY,
+  history: RELATIONSHIP_FIELD_COMPLEXITY,
+  transfers: RELATIONSHIP_FIELD_COMPLEXITY,
+  counterparties: RELATIONSHIP_FIELD_COMPLEXITY,
+  extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
+  balance: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -686,6 +874,39 @@ function providerNode(provider) {
   };
 }
 
+function accountNode(ss58) {
+  return {
+    ss58,
+    summary: (_args, context) =>
+      once(context, `account:${ss58}:summary`, () =>
+        loadAccountSummary(graphqlD1(context), ss58),
+      ),
+    history: (args, context) =>
+      loadAccountHistory(graphqlD1(context), ss58, accountHistoryArgs(args)),
+    transfers: (args, context) =>
+      loadAccountTransfers(
+        graphqlD1(context),
+        ss58,
+        accountTransfersArgs(args),
+      ),
+    counterparties: (args, context) =>
+      loadCounterparties(graphqlD1(context), ss58, {
+        limit: args?.limit,
+      }),
+    extrinsics: (args, context) =>
+      loadAccountExtrinsics(
+        graphqlD1(context),
+        ss58,
+        accountExtrinsicsArgs(args),
+      ),
+    subnets: (_args, context) =>
+      once(context, `account:${ss58}:subnets`, () =>
+        loadAccountSubnets(graphqlD1(context), ss58),
+      ),
+    balance: (_args, context) => loadGraphqlAccountBalance(context, ss58),
+  };
+}
+
 async function loadSubnetHealth(context, netuid) {
   return subnetBadgeStatus(await loadLiveHealth(context), netuid);
 }
@@ -711,6 +932,87 @@ async function loadProviderSubnets(context, netuids) {
     .map((netuid) => byNetuid.get(netuid))
     .filter(Boolean)
     .map((row) => subnetNode(row));
+}
+
+function requireNonNegativeInt(value, name) {
+  if (value == null) return null;
+  if (!Number.isInteger(value) || value < 0) {
+    throw new GraphQLError(`${name} must be a non-negative integer.`, {
+      extensions: { code: "BAD_USER_INPUT" },
+    });
+  }
+  return value;
+}
+
+const GRAPHQL_ACCOUNT_DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+function requireDay(value, name) {
+  if (value == null) return null;
+  if (typeof value !== "string" || !GRAPHQL_ACCOUNT_DAY.test(value)) {
+    throw new GraphQLError(`${name} must be a YYYY-MM-DD date.`, {
+      extensions: { code: "BAD_USER_INPUT" },
+    });
+  }
+  return value;
+}
+
+function accountHistoryArgs(args = {}) {
+  return {
+    netuid: requireNonNegativeInt(args.netuid, "netuid"),
+    from: requireDay(args.from, "from"),
+    to: requireDay(args.to, "to"),
+    limit: args.limit,
+    offset: requireNonNegativeInt(args.offset, "offset"),
+    cursor: args.cursor,
+  };
+}
+
+function accountTransfersArgs(args = {}) {
+  const direction = args.direction ?? null;
+  if (
+    direction !== null &&
+    direction !== "all" &&
+    direction !== "sent" &&
+    direction !== "received"
+  ) {
+    throw new GraphQLError("direction must be one of all, sent, or received.", {
+      extensions: { code: "BAD_USER_INPUT" },
+    });
+  }
+  return {
+    direction: direction === "all" ? null : direction,
+    blockStart: requireNonNegativeInt(args.block_start, "block_start"),
+    blockEnd: requireNonNegativeInt(args.block_end, "block_end"),
+    limit: args.limit,
+    offset: requireNonNegativeInt(args.offset, "offset"),
+    cursor: args.cursor,
+  };
+}
+
+function accountExtrinsicsArgs(args = {}) {
+  return {
+    blockStart: requireNonNegativeInt(args.block_start, "block_start"),
+    blockEnd: requireNonNegativeInt(args.block_end, "block_end"),
+    limit: args.limit,
+    offset: requireNonNegativeInt(args.offset, "offset"),
+    cursor: args.cursor,
+  };
+}
+
+async function loadGraphqlAccountBalance(context, ss58) {
+  if (!isFinneySs58Address(ss58)) return null;
+  if (context.env?.RPC_RATE_LIMITER?.limit) {
+    const { success } = await context.env.RPC_RATE_LIMITER.limit({
+      key: `balance:${resolveClientIp(context.request)}`,
+    });
+    if (!success) {
+      throw new GraphQLError(
+        "Too many live balance requests from this client; slow down.",
+        { extensions: { code: "RATE_LIMITED" } },
+      );
+    }
+  }
+  return loadAccountBalance(context.env, ss58);
 }
 
 // --- Resolvers ---
@@ -788,6 +1090,13 @@ const rootValue = {
     const data = await loadArtifact(context, `/metagraph/providers/${id}.json`);
     if (!data) return null;
     return providerNode(data.provider ?? data);
+  },
+
+  account({ ss58 }) {
+    if (typeof ss58 !== "string" || !SS58_ADDRESS_PATTERN.test(ss58)) {
+      return null;
+    }
+    return accountNode(ss58);
   },
 
   async economics({ limit, cursor }, context) {
@@ -1053,7 +1362,7 @@ export async function handleGraphQLRequest(request, env) {
     schema,
     document,
     rootValue,
-    contextValue: { env, cache: new Map() },
+    contextValue: { env, request, cache: new Map() },
     variableValues: variables ?? undefined,
     operationName: operationName ?? undefined,
   });

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -891,7 +891,7 @@ function accountNode(ss58) {
       ),
     counterparties: (args, context) =>
       loadCounterparties(graphqlD1(context), ss58, {
-        limit: args?.limit,
+        limit: requireOptionalNonNegativeInt(args?.limit, "limit"),
       }),
     extrinsics: (args, context) =>
       loadAccountExtrinsics(
@@ -944,6 +944,10 @@ function requireNonNegativeInt(value, name) {
   return value;
 }
 
+function requireOptionalNonNegativeInt(value, name) {
+  return value == null ? undefined : requireNonNegativeInt(value, name);
+}
+
 const GRAPHQL_ACCOUNT_DAY = /^\d{4}-\d{2}-\d{2}$/;
 
 function requireDay(value, name) {
@@ -961,7 +965,7 @@ function accountHistoryArgs(args = {}) {
     netuid: requireNonNegativeInt(args.netuid, "netuid"),
     from: requireDay(args.from, "from"),
     to: requireDay(args.to, "to"),
-    limit: args.limit,
+    limit: requireOptionalNonNegativeInt(args.limit, "limit"),
     offset: requireNonNegativeInt(args.offset, "offset"),
     cursor: args.cursor,
   };
@@ -983,7 +987,7 @@ function accountTransfersArgs(args = {}) {
     direction: direction === "all" ? null : direction,
     blockStart: requireNonNegativeInt(args.block_start, "block_start"),
     blockEnd: requireNonNegativeInt(args.block_end, "block_end"),
-    limit: args.limit,
+    limit: requireOptionalNonNegativeInt(args.limit, "limit"),
     offset: requireNonNegativeInt(args.offset, "offset"),
     cursor: args.cursor,
   };
@@ -993,7 +997,7 @@ function accountExtrinsicsArgs(args = {}) {
   return {
     blockStart: requireNonNegativeInt(args.block_start, "block_start"),
     blockEnd: requireNonNegativeInt(args.block_end, "block_end"),
-    limit: args.limit,
+    limit: requireOptionalNonNegativeInt(args.limit, "limit"),
     offset: requireNonNegativeInt(args.offset, "offset"),
     cursor: args.cursor,
   };
@@ -1001,18 +1005,20 @@ function accountExtrinsicsArgs(args = {}) {
 
 async function loadGraphqlAccountBalance(context, ss58) {
   if (!isFinneySs58Address(ss58)) return null;
-  if (context.env?.RPC_RATE_LIMITER?.limit) {
-    const { success } = await context.env.RPC_RATE_LIMITER.limit({
-      key: `balance:${resolveClientIp(context.request)}`,
-    });
-    if (!success) {
-      throw new GraphQLError(
-        "Too many live balance requests from this client; slow down.",
-        { extensions: { code: "RATE_LIMITED" } },
-      );
-    }
-  }
-  return loadAccountBalance(context.env, ss58);
+  return loadAccountBalance(context.env, ss58, {
+    beforeLiveFetch: async () => {
+      if (!context.env?.RPC_RATE_LIMITER?.limit) return;
+      const { success } = await context.env.RPC_RATE_LIMITER.limit({
+        key: `balance:${resolveClientIp(context.request)}`,
+      });
+      if (!success) {
+        throw new GraphQLError(
+          "Too many live balance requests from this client; slow down.",
+          { extensions: { code: "RATE_LIMITED" } },
+        );
+      }
+    },
+  });
 }
 
 // --- Resolvers ---

--- a/tests/artifact-storage-paths.test.mjs
+++ b/tests/artifact-storage-paths.test.mjs
@@ -9,6 +9,7 @@ describe("isGeneratedPublicArtifactRelativePath", () => {
       "r2-manifest.json",
       "contracts.json",
       "openapi.json",
+      "graphql.graphql",
       "schemas/index.json",
       "types.d.ts",
       "operational-surfaces.json",
@@ -28,6 +29,10 @@ describe("isGeneratedPublicArtifactRelativePath", () => {
       true,
     );
     assert.equal(
+      isGeneratedPublicArtifactRelativePath("/metagraph/graphql.graphql"),
+      true,
+    );
+    assert.equal(
       isGeneratedPublicArtifactRelativePath("/metagraph/contracts.json"),
       true,
     );
@@ -38,6 +43,7 @@ describe("isGeneratedPublicArtifactRelativePath", () => {
       "xopenapi.json", // not anchored at the start
       "openapi.jsonx", // not anchored at the end
       "openapi.json/", // trailing segment
+      "graphql.graphql.json", // extension must match exactly
       "schemas/other.json", // only schemas/index.json is dual
       "testnet/openapi.json", // secondary-network prefix is not stripped
       "subnets.json", // an R2/live artifact, not a committed one

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -112,7 +112,31 @@ describe("public contract registry", () => {
     assert.equal(contracts.primary_domain, "api.metagraph.sh");
     assert.equal(contracts.openapi_url, "/metagraph/openapi.json");
     assert.equal(contracts.type_definitions_url, "/metagraph/types.d.ts");
+    assert.deepEqual(
+      contracts.artifacts.find((artifact) => artifact.id === "graphql-sdl"),
+      {
+        content_type: "application/graphql; charset=utf-8",
+        contract_version: CONTRACT_VERSION,
+        description: "GraphQL SDL contract for the metagraph.sh backend API.",
+        id: "graphql-sdl",
+        path: "/metagraph/graphql.graphql",
+        schema_ref: null,
+        storage_tier: "dual",
+      },
+    );
     assert.equal(apiIndex.openapi_url, "/api/v1/openapi.json");
+    assert.deepEqual(
+      apiIndex.artifact_contracts.find(
+        (artifact) => artifact.id === "graphql-sdl",
+      ),
+      {
+        contract_version: CONTRACT_VERSION,
+        id: "graphql-sdl",
+        path: "/metagraph/graphql.graphql",
+        schema_ref: null,
+        storage_tier: "dual",
+      },
+    );
     assert.equal(apiIndex.routes.length, API_ROUTES.length);
     assert.equal(
       apiIndex.routes.find((route) => route.id === "subnets").query_collection,

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -23,6 +23,8 @@ import {
 
 // Minimal fake env — no R2 or ASSETS, so readArtifact always returns ok:false.
 const emptyEnv = {};
+const ACCOUNT_SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+const COUNTERPARTY_SS58 = "5F3sa2TJAWMqDhXG6jhV4N8ko9SxwGy8TpaNS1repoXhD3v8";
 
 async function gql(query, env = emptyEnv, extras = {}) {
   const req = new Request("https://api.metagraph.sh/api/v1/graphql", {
@@ -65,6 +67,69 @@ function fixtureEnv(fixtures = {}, { reads, kv, kvReads } = {}) {
       },
     };
   }
+  return env;
+}
+
+function asRows(value) {
+  if (Array.isArray(value)) return value;
+  return value ? [value] : [];
+}
+
+function accountRowsForSql(sql, rows) {
+  if (sql.includes("COUNT(DISTINCT netuid) AS sc")) {
+    return asRows(rows.agg);
+  }
+  if (sql.includes("GROUP BY event_kind")) return rows.kinds || [];
+  if (sql.includes("ORDER BY stake_tao DESC")) {
+    return rows.registrations || [];
+  }
+  if (sql.includes("LIMIT 10") && sql.includes("FROM account_events")) {
+    return rows.recent || [];
+  }
+  if (sql.includes("COUNT(*) AS tx_count")) {
+    return asRows(rows.activity);
+  }
+  if (sql.includes("SELECT call_module, COUNT(*) AS count")) {
+    return rows.modules || [];
+  }
+  if (sql.includes("FROM account_events_daily")) return rows.days || [];
+  if (sql.includes("ORDER BY netuid") && sql.includes("FROM neurons")) {
+    return rows.subnets || [];
+  }
+  if (
+    sql.includes("SELECT hotkey, coldkey, amount_tao, block_number FROM") &&
+    sql.includes("UNION ALL")
+  ) {
+    return rows.counterpartyTransfers || [];
+  }
+  if (
+    sql.includes("FROM extrinsics WHERE signer = ?") &&
+    sql.includes("extrinsic_hash")
+  ) {
+    return rows.extrinsics || [];
+  }
+  if (sql.includes("event_kind = 'Transfer'")) return rows.transfers || [];
+  return [];
+}
+
+function accountD1Env(rows = {}, { calls = [] } = {}) {
+  const env = fixtureEnv();
+  env.METAGRAPH_HEALTH_DB = {
+    prepare(sql) {
+      const call = { sql, params: [] };
+      calls.push(call);
+      return {
+        bind(...params) {
+          call.params = params;
+          return {
+            async all() {
+              return { results: accountRowsForSql(sql, rows) };
+            },
+          };
+        },
+      };
+    },
+  };
   return env;
 }
 
@@ -1022,6 +1087,408 @@ describe("graphql — broadened Subnet + nested relationships", () => {
   });
 });
 
+describe("graphql — account node + lazy account relationships", () => {
+  test("SDL advertises account(ss58) and the account relationship node", () => {
+    assert.match(SDL, /account\(ss58: String!\): Account/);
+    assert.match(SDL, /type Account \{/);
+    assert.match(SDL, /summary: AccountSummary!/);
+    assert.match(SDL, /balance: AccountBalance/);
+  });
+
+  test("invalid account ids return null before touching live account stores", async () => {
+    const calls = [];
+    const env = accountD1Env({}, { calls });
+    const { status, body } = await gql(
+      '{ account(ss58: "not-an-address") { ss58 } }',
+      env,
+    );
+
+    assert.equal(status, 200);
+    assert.equal(body.data.account, null);
+    assert.equal(calls.length, 0);
+  });
+
+  test("account identity is lazy and does not read D1 until a relationship is selected", async () => {
+    const env = fixtureEnv();
+    env.METAGRAPH_HEALTH_DB = {
+      prepare() {
+        throw new Error("account identity should not read D1");
+      },
+    };
+
+    const { status, body } = await gql(
+      `{ account(ss58: "${ACCOUNT_SS58}") { ss58 } }`,
+      env,
+    );
+
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account, { ss58: ACCOUNT_SS58 });
+  });
+
+  test("summary and subnets reuse the existing account summary/subnet loaders", async () => {
+    const firstSeen = Date.UTC(2026, 5, 1);
+    const lastSeen = Date.UTC(2026, 5, 3);
+    const calls = [];
+    const env = accountD1Env(
+      {
+        agg: { c: 3, sc: 2, fb: 10, lb: 30, fo: firstSeen, lo: lastSeen },
+        kinds: [
+          { kind: "StakeAdded", count: 2 },
+          { kind: "Transfer", count: 1 },
+        ],
+        registrations: [
+          {
+            netuid: 7,
+            uid: 12,
+            stake_tao: 123.45,
+            validator_permit: 1,
+            active: 1,
+          },
+        ],
+        recent: [
+          {
+            block_number: 30,
+            event_index: 4,
+            event_kind: "StakeAdded",
+            hotkey: ACCOUNT_SS58,
+            coldkey: null,
+            netuid: 7,
+            uid: 12,
+            amount_tao: 2,
+            alpha_amount: 0.5,
+            observed_at: lastSeen,
+            extrinsic_index: 2,
+          },
+        ],
+        activity: {
+          tx_count: 4,
+          last_tx_block: 31,
+          last_tx_at: lastSeen,
+          total_fee_tao: 0.123456789,
+        },
+        modules: [{ call_module: "SubtensorModule", count: 3 }],
+        subnets: [
+          {
+            netuid: 7,
+            uid: 12,
+            stake_tao: 123.45,
+            validator_permit: 1,
+            active: 1,
+          },
+          {
+            netuid: 8,
+            uid: 2,
+            stake_tao: 10,
+            validator_permit: 0,
+            active: 0,
+          },
+        ],
+      },
+      { calls },
+    );
+
+    const { status, body } = await gql(
+      `{ account(ss58: "${ACCOUNT_SS58}") {
+          summary {
+            event_count subnet_count first_block last_block first_seen_at last_seen_at
+            event_kinds { kind count }
+            registrations { netuid uid stake_tao validator_permit active }
+            recent_events { event_kind block_number observed_at }
+            activity { tx_count last_tx_block last_tx_at total_fee_tao modules_called { call_module count } }
+          }
+        } }`,
+      env,
+    );
+    const subnetsResult = await gql(
+      `{ account(ss58: "${ACCOUNT_SS58}") {
+          subnets { subnet_count subnets { netuid uid stake_tao active } }
+        } }`,
+      env,
+    );
+
+    assert.equal(status, 200);
+    assert.equal(subnetsResult.status, 200);
+    const account = body.data.account;
+    assert.equal(account.summary.event_count, 3);
+    assert.equal(account.summary.subnet_count, 2);
+    assert.equal(
+      account.summary.first_seen_at,
+      new Date(firstSeen).toISOString(),
+    );
+    assert.equal(
+      account.summary.last_seen_at,
+      new Date(lastSeen).toISOString(),
+    );
+    assert.deepEqual(account.summary.event_kinds, [
+      { kind: "StakeAdded", count: 2 },
+      { kind: "Transfer", count: 1 },
+    ]);
+    assert.deepEqual(account.summary.registrations[0], {
+      netuid: 7,
+      uid: 12,
+      stake_tao: 123.45,
+      validator_permit: true,
+      active: true,
+    });
+    assert.equal(account.summary.recent_events[0].event_kind, "StakeAdded");
+    assert.equal(account.summary.activity.tx_count, 4);
+    assert.equal(
+      account.summary.activity.modules_called[0].call_module,
+      "SubtensorModule",
+    );
+    assert.equal(subnetsResult.body.data.account.subnets.subnet_count, 2);
+    assert.equal(
+      subnetsResult.body.data.account.subnets.subnets[1].active,
+      false,
+    );
+    assert.ok(
+      calls.some((call) => call.sql.includes("ORDER BY stake_tao DESC")),
+    );
+    assert.ok(calls.some((call) => call.sql.includes("ORDER BY netuid")));
+  });
+
+  test("history, transfers, and counterparties resolve through shared account loaders", async () => {
+    const observedAt = Date.UTC(2026, 5, 30);
+    const env = accountD1Env({
+      days: [
+        {
+          day: "2026-06-30",
+          netuid: 7,
+          event_count: 5,
+          event_kinds: "StakeAdded,WeightsSet",
+          first_block: 10,
+          last_block: 20,
+        },
+      ],
+      transfers: [
+        {
+          block_number: 20,
+          event_index: 1,
+          event_kind: "Transfer",
+          hotkey: ACCOUNT_SS58,
+          coldkey: COUNTERPARTY_SS58,
+          amount_tao: 1.25,
+          observed_at: observedAt,
+        },
+      ],
+      counterpartyTransfers: [
+        {
+          hotkey: ACCOUNT_SS58,
+          coldkey: COUNTERPARTY_SS58,
+          amount_tao: 1.25,
+          block_number: 20,
+        },
+        {
+          hotkey: COUNTERPARTY_SS58,
+          coldkey: ACCOUNT_SS58,
+          amount_tao: 0.75,
+          block_number: 21,
+        },
+      ],
+    });
+
+    const { status, body } = await gql(
+      `{ account(ss58: "${ACCOUNT_SS58}") {
+          history(netuid: 7, from: "2026-06-01", to: "2026-06-30", limit: 1) {
+            day_count next_cursor days { day netuid event_count event_kinds }
+          }
+          transfers(direction: "sent", block_start: 10, block_end: 20, limit: 1) {
+            transfer_count next_cursor transfers { direction amount_tao from to observed_at }
+          }
+        } }`,
+      env,
+    );
+    const counterpartiesResult = await gql(
+      `{ account(ss58: "${ACCOUNT_SS58}") {
+          counterparties(limit: 1) {
+            counterparty_count total_sent_tao total_received_tao
+            counterparties { address sent_tao received_tao net_tao transfer_count last_block }
+          }
+        } }`,
+      env,
+    );
+
+    assert.equal(status, 200);
+    assert.equal(counterpartiesResult.status, 200);
+    const account = body.data.account;
+    assert.equal(account.history.day_count, 1);
+    assert.equal(account.history.next_cursor, "20260630.7");
+    assert.deepEqual(account.history.days[0], {
+      day: "2026-06-30",
+      netuid: 7,
+      event_count: 5,
+      event_kinds: ["StakeAdded", "WeightsSet"],
+    });
+    assert.equal(account.transfers.transfer_count, 1);
+    assert.equal(account.transfers.next_cursor, "20.1");
+    assert.equal(account.transfers.transfers[0].direction, "sent");
+    assert.equal(account.transfers.transfers[0].amount_tao, 1.25);
+    assert.equal(
+      account.transfers.transfers[0].observed_at,
+      new Date(observedAt).toISOString(),
+    );
+    const counterparties =
+      counterpartiesResult.body.data.account.counterparties;
+    assert.equal(counterparties.counterparty_count, 1);
+    assert.equal(counterparties.total_sent_tao, 1.25);
+    assert.equal(counterparties.total_received_tao, 0.75);
+    assert.deepEqual(counterparties.counterparties[0], {
+      address: COUNTERPARTY_SS58,
+      sent_tao: 1.25,
+      received_tao: 0.75,
+      net_tao: -0.5,
+      transfer_count: 2,
+      last_block: 21,
+    });
+  });
+
+  test("extrinsics resolves the account signer feed", async () => {
+    const observedAt = Date.UTC(2026, 5, 29);
+    const env = accountD1Env({
+      extrinsics: [
+        {
+          block_number: 30,
+          extrinsic_index: 2,
+          extrinsic_hash: "0xabc",
+          signer: ACCOUNT_SS58,
+          call_module: "Balances",
+          call_function: "transfer_keep_alive",
+          call_args: "{}",
+          success: 1,
+          fee_tao: 0.002,
+          tip_tao: 0,
+          observed_at: observedAt,
+        },
+      ],
+    });
+
+    const { status, body } = await gql(
+      `{ account(ss58: "${ACCOUNT_SS58}") {
+          extrinsics(block_start: 10, block_end: 30, limit: 1) {
+            extrinsic_count next_cursor
+            extrinsics { block_number extrinsic_index extrinsic_hash signer call_module success fee_tao observed_at }
+          }
+        } }`,
+      env,
+    );
+
+    assert.equal(status, 200);
+    assert.equal(body.data.account.extrinsics.extrinsic_count, 1);
+    assert.equal(body.data.account.extrinsics.next_cursor, "30.2");
+    assert.deepEqual(body.data.account.extrinsics.extrinsics[0], {
+      block_number: 30,
+      extrinsic_index: 2,
+      extrinsic_hash: "0xabc",
+      signer: ACCOUNT_SS58,
+      call_module: "Balances",
+      success: true,
+      fee_tao: 0.002,
+      observed_at: new Date(observedAt).toISOString(),
+    });
+  });
+
+  test("balance uses the live balance limiter and KV-backed account balance loader", async () => {
+    const kvReads = new Map();
+    let limiterKey = null;
+    const env = fixtureEnv(
+      {},
+      {
+        kvReads,
+        kv: {
+          [`balance:${ACCOUNT_SS58}`]: {
+            schema_version: 1,
+            ss58: ACCOUNT_SS58,
+            balance_tao: 12.5,
+            queried_at: "2026-06-30T00:00:00.000Z",
+          },
+        },
+      },
+    );
+    env.RPC_RATE_LIMITER = {
+      async limit({ key }) {
+        limiterKey = key;
+        return { success: true };
+      },
+    };
+
+    const { status, body } = await gql(
+      `{ account(ss58: "${ACCOUNT_SS58}") { balance { ss58 balance_tao queried_at } } }`,
+      env,
+    );
+
+    assert.equal(status, 200);
+    assert.equal(limiterKey, "balance:anonymous");
+    assert.equal(kvReads.get(`balance:${ACCOUNT_SS58}`), 1);
+    assert.deepEqual(body.data.account.balance, {
+      ss58: ACCOUNT_SS58,
+      balance_tao: 12.5,
+      queried_at: "2026-06-30T00:00:00.000Z",
+    });
+  });
+
+  test("balance rate-limit failures surface as GraphQL field errors", async () => {
+    const env = fixtureEnv();
+    env.RPC_RATE_LIMITER = {
+      async limit() {
+        return { success: false };
+      },
+    };
+
+    const { status, body } = await gql(
+      `{ account(ss58: "${ACCOUNT_SS58}") { balance { balance_tao } } }`,
+      env,
+    );
+
+    assert.equal(status, 200);
+    assert.equal(body.data.account.balance, null);
+    assert.equal(body.errors[0].extensions.code, "RATE_LIMITED");
+  });
+
+  test("balance is null for a well-formed but non-finney ss58, before the limiter runs", async () => {
+    // Checksum-broken sibling of ACCOUNT_SS58: passes the loose SS58_ADDRESS_PATTERN
+    // (so the account node still resolves) but fails isFinneySs58Address, so balance
+    // short-circuits to null without consuming the live-RPC rate limiter or KV.
+    const NON_FINNEY_SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc6";
+    let limiterCalled = false;
+    const env = fixtureEnv();
+    env.RPC_RATE_LIMITER = {
+      async limit() {
+        limiterCalled = true;
+        return { success: true };
+      },
+    };
+
+    const { status, body } = await gql(
+      `{ account(ss58: "${NON_FINNEY_SS58}") { ss58 balance { balance_tao } } }`,
+      env,
+    );
+
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.account.ss58, NON_FINNEY_SS58);
+    assert.equal(body.data.account.balance, null);
+    assert.equal(limiterCalled, false);
+  });
+
+  test("relationship argument validation returns BAD_USER_INPUT", async () => {
+    const badHistory = await gql(
+      `{ account(ss58: "${ACCOUNT_SS58}") { history(netuid: -1) { day_count } } }`,
+      accountD1Env(),
+    );
+    assert.equal(badHistory.status, 200);
+    assert.equal(badHistory.body.data.account, null);
+    assert.equal(badHistory.body.errors[0].extensions.code, "BAD_USER_INPUT");
+
+    const badDirection = await gql(
+      `{ account(ss58: "${ACCOUNT_SS58}") { transfers(direction: "sideways") { transfer_count } } }`,
+      accountD1Env(),
+    );
+    assert.equal(badDirection.status, 200);
+    assert.equal(badDirection.body.data.account, null);
+    assert.equal(badDirection.body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+});
+
 describe("graphql — surfaces / endpoints / health roots", () => {
   test("surfaces filters by netuid and paginates", async () => {
     const env = fixtureEnv({
@@ -1279,6 +1746,7 @@ describe("graphql — opportunity boards (reuse the leaderboard ranking)", () =>
 describe("graphql — complexity weights keep the guard meaningful", () => {
   test("FIELD_COMPLEXITY weights the read/fan-out fields above scalars", () => {
     for (const field of [
+      "account",
       "subnets",
       "subnet",
       "providers",
@@ -1288,6 +1756,12 @@ describe("graphql — complexity weights keep the guard meaningful", () => {
       "endpoints",
       "health",
       "opportunity_boards",
+      "summary",
+      "history",
+      "transfers",
+      "counterparties",
+      "extrinsics",
+      "balance",
     ]) {
       assert.equal(FIELD_COMPLEXITY[field], 5, `${field} should be weighted`);
     }

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1387,9 +1387,9 @@ describe("graphql — account node + lazy account relationships", () => {
     });
   });
 
-  test("balance uses the live balance limiter and KV-backed account balance loader", async () => {
+  test("balance serves KV hits before the live balance limiter", async () => {
     const kvReads = new Map();
-    let limiterKey = null;
+    let limiterCalled = false;
     const env = fixtureEnv(
       {},
       {
@@ -1405,9 +1405,9 @@ describe("graphql — account node + lazy account relationships", () => {
       },
     );
     env.RPC_RATE_LIMITER = {
-      async limit({ key }) {
-        limiterKey = key;
-        return { success: true };
+      async limit() {
+        limiterCalled = true;
+        return { success: false };
       },
     };
 
@@ -1417,13 +1417,43 @@ describe("graphql — account node + lazy account relationships", () => {
     );
 
     assert.equal(status, 200);
-    assert.equal(limiterKey, "balance:anonymous");
+    assert.equal(body.errors, undefined);
+    assert.equal(limiterCalled, false);
     assert.equal(kvReads.get(`balance:${ACCOUNT_SS58}`), 1);
     assert.deepEqual(body.data.account.balance, {
       ss58: ACCOUNT_SS58,
       balance_tao: 12.5,
       queried_at: "2026-06-30T00:00:00.000Z",
     });
+  });
+
+  test("balance applies the live limiter before a live RPC fallback", async () => {
+    const origFetch = globalThis.fetch;
+    let limiterKey = null;
+    globalThis.fetch = async () => ({ ok: false });
+    try {
+      const env = fixtureEnv();
+      env.RPC_RATE_LIMITER = {
+        async limit({ key }) {
+          limiterKey = key;
+          return { success: true };
+        },
+      };
+
+      const { status, body } = await gql(
+        `{ account(ss58: "${ACCOUNT_SS58}") { balance { ss58 balance_tao queried_at } } }`,
+        env,
+      );
+
+      assert.equal(status, 200);
+      assert.equal(body.errors, undefined);
+      assert.equal(limiterKey, "balance:anonymous");
+      assert.equal(body.data.account.balance.ss58, ACCOUNT_SS58);
+      assert.equal(body.data.account.balance.balance_tao, null);
+      assert.ok(body.data.account.balance.queried_at);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
   });
 
   test("balance rate-limit failures surface as GraphQL field errors", async () => {
@@ -1486,6 +1516,23 @@ describe("graphql — account node + lazy account relationships", () => {
     assert.equal(badDirection.status, 200);
     assert.equal(badDirection.body.data.account, null);
     assert.equal(badDirection.body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("account relationship limits reject negative values", async () => {
+    const queries = [
+      `{ account(ss58: "${ACCOUNT_SS58}") { history(limit: -1) { day_count } } }`,
+      `{ account(ss58: "${ACCOUNT_SS58}") { transfers(limit: -1) { transfer_count } } }`,
+      `{ account(ss58: "${ACCOUNT_SS58}") { counterparties(limit: -1) { counterparty_count } } }`,
+      `{ account(ss58: "${ACCOUNT_SS58}") { extrinsics(limit: -1) { extrinsic_count } } }`,
+    ];
+
+    for (const query of queries) {
+      const { status, body } = await gql(query, accountD1Env());
+      assert.equal(status, 200);
+      assert.equal(body.data.account, null);
+      assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+      assert.match(body.errors[0].message, /limit/);
+    }
   });
 });
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { Blob } from "node:buffer";
+import { readFileSync } from "node:fs";
 import { buildSchema, getIntrospectionQuery, parse, validate } from "graphql";
 import { describe, test } from "vitest";
 import {
@@ -1093,6 +1094,15 @@ describe("graphql — account node + lazy account relationships", () => {
     assert.match(SDL, /type Account \{/);
     assert.match(SDL, /summary: AccountSummary!/);
     assert.match(SDL, /balance: AccountBalance/);
+  });
+
+  test("committed GraphQL SDL artifact matches the Worker SDL", () => {
+    const artifact = readFileSync(
+      new URL("../public/metagraph/graphql.graphql", import.meta.url),
+      "utf8",
+    );
+
+    assert.equal(artifact, `${SDL.trimEnd()}\n`);
   });
 
   test("invalid account ids return null before touching live account stores", async () => {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1456,6 +1456,30 @@ describe("graphql — account node + lazy account relationships", () => {
     }
   });
 
+  test("balance live fallback works when the limiter binding is absent", async () => {
+    const origFetch = globalThis.fetch;
+    let rpcCalled = false;
+    globalThis.fetch = async () => {
+      rpcCalled = true;
+      return { ok: false };
+    };
+    try {
+      const { status, body } = await gql(
+        `{ account(ss58: "${ACCOUNT_SS58}") { balance { ss58 balance_tao queried_at } } }`,
+        fixtureEnv(),
+      );
+
+      assert.equal(status, 200);
+      assert.equal(body.errors, undefined);
+      assert.equal(rpcCalled, true);
+      assert.equal(body.data.account.balance.ss58, ACCOUNT_SS58);
+      assert.equal(body.data.account.balance.balance_tao, null);
+      assert.ok(body.data.account.balance.queried_at);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
   test("balance rate-limit failures surface as GraphQL field errors", async () => {
     const env = fixtureEnv();
     env.RPC_RATE_LIMITER = {
@@ -1509,6 +1533,14 @@ describe("graphql — account node + lazy account relationships", () => {
     assert.equal(badHistory.body.data.account, null);
     assert.equal(badHistory.body.errors[0].extensions.code, "BAD_USER_INPUT");
 
+    const badDate = await gql(
+      `{ account(ss58: "${ACCOUNT_SS58}") { history(from: "not-a-day") { day_count } } }`,
+      accountD1Env(),
+    );
+    assert.equal(badDate.status, 200);
+    assert.equal(badDate.body.data.account, null);
+    assert.equal(badDate.body.errors[0].extensions.code, "BAD_USER_INPUT");
+
     const badDirection = await gql(
       `{ account(ss58: "${ACCOUNT_SS58}") { transfers(direction: "sideways") { transfer_count } } }`,
       accountD1Env(),
@@ -1533,6 +1565,25 @@ describe("graphql — account node + lazy account relationships", () => {
       assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
       assert.match(body.errors[0].message, /limit/);
     }
+  });
+
+  test("account relationships accept omitted limits and all-direction transfers", async () => {
+    const { status, body } = await gql(
+      `{ account(ss58: "${ACCOUNT_SS58}") {
+          history { day_count }
+          transfers(direction: "all") { transfer_count }
+          counterparties { counterparty_count }
+          extrinsics { extrinsic_count }
+        } }`,
+      accountD1Env(),
+    );
+
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.account.history.day_count, 0);
+    assert.equal(body.data.account.transfers.transfer_count, 0);
+    assert.equal(body.data.account.counterparties.counterparty_count, 0);
+    assert.equal(body.data.account.extrinsics.extrinsic_count, 0);
   });
 });
 

--- a/tests/invariants-contracts.test.mjs
+++ b/tests/invariants-contracts.test.mjs
@@ -86,8 +86,8 @@ describe("contracts — route ⇄ artifact mapping invariants", () => {
         `${artifact.id} is not under /metagraph/`,
       );
       assert.ok(artifact.storage_tier, `${artifact.id} has no storage_tier`);
-      // Every JSON payload must be typed; the generated .d.ts text artifact is
-      // the documented exception (it carries TS types, not a JSON schema).
+      // Every JSON payload must be typed; generated text contract artifacts
+      // carry their own syntax instead of a JSON schema.
       if (artifact.path.endsWith(".json")) {
         assert.ok(
           typeof artifact.schema_ref === "string" && artifact.schema_ref,
@@ -95,8 +95,8 @@ describe("contracts — route ⇄ artifact mapping invariants", () => {
         );
       } else {
         assert.ok(
-          artifact.path.endsWith(".d.ts"),
-          `non-JSON artifact ${artifact.id} must be the .d.ts exception`,
+          artifact.path.endsWith(".d.ts") || artifact.path.endsWith(".graphql"),
+          `non-JSON artifact ${artifact.id} must be a known text contract`,
         );
         assert.equal(artifact.schema_ref, null);
       }

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -28,6 +28,7 @@ import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import {
   ANALYTICS_WINDOW_PARAM,
   ANALYTICS_WINDOWS,
+  DAY_MS,
   DEFAULT_ANALYTICS_WINDOW,
 } from "../workers/config.mjs";
 
@@ -43,6 +44,12 @@ configureAnalytics({
 
 const NETUID = 7;
 const LAST_RUN_AT = "2026-06-18T00:00:00.000Z";
+const RECENT_DAILY_DAY = new Date(Date.now() - 2 * DAY_MS)
+  .toISOString()
+  .slice(0, 10);
+const OLDER_DAILY_DAY = new Date(Date.now() - 20 * DAY_MS)
+  .toISOString()
+  .slice(0, 10);
 const ctx = { waitUntil: (promise) => promise };
 
 function req(path, init = {}) {
@@ -112,8 +119,8 @@ function rowsForSql(sql) {
     return [
       {
         netuid: NETUID,
-        day: "2026-06-24",
-        date: "2026-06-24",
+        day: RECENT_DAILY_DAY,
+        date: RECENT_DAILY_DAY,
         total: 100,
         ok_count: 98,
         latency_samples: 96,
@@ -122,8 +129,8 @@ function rowsForSql(sql) {
       },
       {
         netuid: NETUID,
-        day: "2026-06-01",
-        date: "2026-06-01",
+        day: OLDER_DAILY_DAY,
+        date: OLDER_DAILY_DAY,
         total: 50,
         ok_count: 45,
         latency_samples: 48,

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -682,6 +682,10 @@ describe("script utility contracts", () => {
       ARTIFACT_STORAGE_TIERS.dual,
     );
     assert.equal(
+      artifactStorageTierForRelativePath("graphql.graphql"),
+      ARTIFACT_STORAGE_TIERS.dual,
+    );
+    assert.equal(
       artifactStorageTierForRelativePath("schemas/allways-swagger.json"),
       ARTIFACT_STORAGE_TIERS.r2,
     );


### PR DESCRIPTION
## Summary

Add an account-centric GraphQL node so clients can query one Bittensor account and its account data relationships from `/api/v1/graphql`.

No matching backend feature issue form is available in this repository; the public issue forms are for subnet surfaces, provider profiles, and endpoint/status reports.

## What Changed

- Added `account(ss58: String!): Account` to the GraphQL SDL.
- Added lazy account relationships for `summary`, `history`, `transfers`, `counterparties`, `extrinsics`, `subnets`, and `balance`.
- Reused the existing shared account loaders instead of duplicating REST/MCP account analytics logic.
- Applied the existing finney SS58 checksum validator and RPC balance limiter before live balance reads.
- Added complexity weights for the new account fan-out fields.
- Added focused GraphQL tests for account identity, lazy D1 access, all account relationships, cursor propagation, balance limiter/cache behavior, invalid balance SS58 handling, and bad relationship arguments.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [x] `git diff --check`

Additional focused validation:

- [x] `npm exec vitest -- run tests/graphql.test.mjs`
- [x] `npm exec prettier -- --check src/graphql.mjs tests/graphql.test.mjs`
- [x] `npm exec eslint -- src/graphql.mjs tests/graphql.test.mjs`
