### PR TITLE
fix(badge): provider apis badge n/a when any subnet lacks surfaces

### DIFF
--- a/src/badge.mjs
+++ b/src/badge.mjs
@@ -431,12 +431,15 @@ async function apisContent({ target, readArtifact, env }) {
     );
     const netuids = findProvider(providers, target.slug)?.netuids || [];
     if (netuids.length) {
-      const counts = (
-        await Promise.all(
-          netuids.map((n) => callableApiCount(readArtifact, env, n)),
-        )
-      ).filter((c) => typeof c === "number");
-      if (counts.length) count = counts.reduce((a, b) => a + b, 0);
+      const counts = await Promise.all(
+        netuids.map((n) => callableApiCount(readArtifact, env, n)),
+      );
+      const numeric = counts.filter((c) => typeof c === "number");
+      // Sum only when every subnet resolved a surfaces artifact. A partial sum
+      // would under-report one missing subnet as a lower total instead of n/a.
+      if (numeric.length === netuids.length) {
+        count = numeric.reduce((a, b) => a + b, 0);
+      }
     }
   }
   if (count == null) return NA_CONTENT;

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -500,6 +500,23 @@ describe("badge — apis metric", () => {
     assert.match(text, /#007ec6/);
   });
 
+  test("provider apis is n/a when any subnet lacks a surfaces artifact", async () => {
+    const { text } = await badge(
+      "/api/v1/providers/partial/badge.svg?metric=apis",
+      {
+        fixtures: {
+          "/metagraph/providers.json": {
+            providers: [{ slug: "partial", netuids: [7, 9] }],
+          },
+        },
+      },
+    );
+    // netuid 7 has 2 callable surfaces; netuid 9 has no artifact — must not
+    // headline the partial sum (2) as the provider total.
+    assert.match(text, /n\/a/);
+    assert.match(text, /#9f9f9f/);
+  });
+
   test("a subnet with no surfaces artifact degrades to n/a (still 200)", async () => {
     const { res, text } = await badge(
       "/api/v1/subnets/9/badge.svg?metric=apis",

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -28,6 +28,7 @@ import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import {
   ANALYTICS_WINDOW_PARAM,
   ANALYTICS_WINDOWS,
+  DAY_MS,
   DEFAULT_ANALYTICS_WINDOW,
 } from "../workers/config.mjs";
 
@@ -71,6 +72,37 @@ function emptyEnv() {
   return {};
 }
 
+// Bulk-trends fixtures must track Date.now(): loadBulkHealthTrends filters rows
+// against a rolling 7d/30d cutoff, so pinned June 2026 dates eventually fall
+// outside the 7d window and the happy-path assertion sees zero subnets.
+function bulkTrendDailyRows() {
+  const now = Date.now();
+  const recentDay = new Date(now - 2 * DAY_MS).toISOString().slice(0, 10);
+  const olderDay = new Date(now - 20 * DAY_MS).toISOString().slice(0, 10);
+  return [
+    {
+      netuid: NETUID,
+      day: recentDay,
+      date: recentDay,
+      total: 100,
+      ok_count: 98,
+      latency_samples: 96,
+      p50: 120,
+      p95: 400,
+    },
+    {
+      netuid: NETUID,
+      day: olderDay,
+      date: olderDay,
+      total: 50,
+      ok_count: 45,
+      latency_samples: 48,
+      p50: 200,
+      p95: 500,
+    },
+  ];
+}
+
 // One row backs every shape the analytics SQL returns (shared ok-latency CTE,
 // SLA aggregates, gap-island incidents, bulk daily uptime).
 function rowsForSql(sql) {
@@ -109,28 +141,7 @@ function rowsForSql(sql) {
     ];
   }
   if (sql.includes("FROM surface_uptime_daily")) {
-    return [
-      {
-        netuid: NETUID,
-        day: "2026-06-24",
-        date: "2026-06-24",
-        total: 100,
-        ok_count: 98,
-        latency_samples: 96,
-        p50: 120,
-        p95: 400,
-      },
-      {
-        netuid: NETUID,
-        day: "2026-06-01",
-        date: "2026-06-01",
-        total: 50,
-        ok_count: 45,
-        latency_samples: 48,
-        p50: 200,
-        p95: 500,
-      },
-    ];
+    return bulkTrendDailyRows();
   }
   return [];
 }


### PR DESCRIPTION
## Summary
- Provider `metric=apis` badges now require every listed subnet to resolve a surfaces artifact before summing callable API counts.
- A partial sum (e.g. 2 apis when one of two subnets is missing its artifact) degrades to n/a instead of understating the missing subnet as zero.

## Test plan
- [x] Unit test: provider spanning netuids [7, 9] with only netuid 7 having surfaces renders n/a
- [x] Existing datura provider sum test still passes