### PR TITLE
fix(badge): provider reliability n/a when uptime rows cover only some subnets

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1240,7 +1240,8 @@ export async function loadReliabilityAggregate({
   try {
     const row = await db
       .prepare(
-        `SELECT SUM(samples) AS samples,
+        `SELECT COUNT(DISTINCT netuid) AS covered_netuids,
+                SUM(samples) AS samples,
                 SUM(ok_count) AS ok_count,
                 ${dailyLatencyColumns({ roundedAvg: true })}
          FROM surface_uptime_daily
@@ -1248,6 +1249,13 @@ export async function loadReliabilityAggregate({
       )
       .bind(...ids, cutoff)
       .first();
+    const covered = Number(row?.covered_netuids) || 0;
+    // Multi-subnet rollups (provider badges) require every netuid to have at
+    // least one in-window daily row. Summing only the subnets that happened to
+    // report would headline a partial provider as if it were fully covered.
+    if (ids.length > 1 && covered !== ids.length) {
+      return null;
+    }
     return scoreFromStats({
       samples: Number(row?.samples) || 0,
       okCount: Number(row?.ok_count) || 0,

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -440,7 +440,7 @@ describe("badge — uptime / reliability metric", () => {
       "https://api.metagraph.sh/api/v1/providers/partial/badge.svg?metric=uptime",
     );
     const db = {
-      prepare(sql) {
+      prepare(_sql) {
         return {
           bind() {
             return this;

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -435,6 +435,41 @@ describe("badge — uptime / reliability metric", () => {
     assert.match(text, /n\/a/);
   });
 
+  test("provider uptime is n/a when only some subnets have in-window uptime rows", async () => {
+    const url = new URL(
+      "https://api.metagraph.sh/api/v1/providers/partial/badge.svg?metric=uptime",
+    );
+    const db = {
+      prepare(sql) {
+        return {
+          bind() {
+            return this;
+          },
+          async first() {
+            // Only netuid 7 has rows in-window; netuid 9 is absent from DISTINCT.
+            return {
+              covered_netuids: 1,
+              samples: 100,
+              ok_count: 90,
+              avg_latency_ms: 500,
+              latency_samples: 90,
+            };
+          },
+        };
+      },
+    };
+    const res = await handleBadgeRequest(new Request(url), {}, url, {
+      readArtifact: makeReadArtifact({
+        "/metagraph/providers.json": {
+          providers: [{ slug: "partial", netuids: [7, 9] }],
+        },
+      }),
+      db,
+    });
+    assert.equal(res.status, 200);
+    assert.match(await res.text(), /n\/a/);
+  });
+
   test("label override applies to the uptime variant too", async () => {
     const { text } = await badge(
       "/api/v1/subnets/7/badge.svg?metric=uptime&label=uptime",

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -2800,7 +2800,12 @@ describe("loadReliabilityAggregate (D1-backed, one query for many subnets)", () 
     const sink = {};
     const out = await loadReliabilityAggregate({
       db: aggregateDb(
-        { samples: 1440, ok_count: 1080, avg_latency_ms: 600 },
+        {
+          covered_netuids: 2,
+          samples: 1440,
+          ok_count: 1080,
+          avg_latency_ms: 600,
+        },
         sink,
       ),
       netuids: [7, 12],
@@ -2813,8 +2818,24 @@ describe("loadReliabilityAggregate (D1-backed, one query for many subnets)", () 
     );
     assert.equal(out.uptime_ratio, 0.75);
     // One IN-list query over a deduped, sorted netuid set + the day cutoff.
+    assert.match(sink.sql, /COUNT\(DISTINCT netuid\)/);
     assert.match(sink.sql, /netuid IN \(\?,\?\)/);
     assert.deepEqual(sink.params, [7, 12, "2026-05-14"]);
+  });
+
+  test("returns null for a multi-subnet rollup when any netuid lacks in-window rows", async () => {
+    assert.equal(
+      await loadReliabilityAggregate({
+        db: aggregateDb({
+          covered_netuids: 1,
+          samples: 720,
+          ok_count: 700,
+          avg_latency_ms: 400,
+        }),
+        netuids: [7, 12],
+      }),
+      null,
+    );
   });
 
   test("weights the latency mean by healthy readings, not total probes", async () => {

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -28,6 +28,7 @@ import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import {
   ANALYTICS_WINDOW_PARAM,
   ANALYTICS_WINDOWS,
+  DAY_MS,
   DEFAULT_ANALYTICS_WINDOW,
 } from "../workers/config.mjs";
 
@@ -71,6 +72,37 @@ function emptyEnv() {
   return {};
 }
 
+// Bulk-trends fixtures must track Date.now(): loadBulkHealthTrends filters rows
+// against a rolling 7d/30d cutoff, so pinned June 2026 dates eventually fall
+// outside the 7d window and the happy-path assertion sees zero subnets.
+function bulkTrendDailyRows() {
+  const now = Date.now();
+  const recentDay = new Date(now - 2 * DAY_MS).toISOString().slice(0, 10);
+  const olderDay = new Date(now - 20 * DAY_MS).toISOString().slice(0, 10);
+  return [
+    {
+      netuid: NETUID,
+      day: recentDay,
+      date: recentDay,
+      total: 100,
+      ok_count: 98,
+      latency_samples: 96,
+      p50: 120,
+      p95: 400,
+    },
+    {
+      netuid: NETUID,
+      day: olderDay,
+      date: olderDay,
+      total: 50,
+      ok_count: 45,
+      latency_samples: 48,
+      p50: 200,
+      p95: 500,
+    },
+  ];
+}
+
 // One row backs every shape the analytics SQL returns (shared ok-latency CTE,
 // SLA aggregates, gap-island incidents, bulk daily uptime).
 function rowsForSql(sql) {
@@ -109,28 +141,7 @@ function rowsForSql(sql) {
     ];
   }
   if (sql.includes("FROM surface_uptime_daily")) {
-    return [
-      {
-        netuid: NETUID,
-        day: "2026-06-24",
-        date: "2026-06-24",
-        total: 100,
-        ok_count: 98,
-        latency_samples: 96,
-        p50: 120,
-        p95: 400,
-      },
-      {
-        netuid: NETUID,
-        day: "2026-06-01",
-        date: "2026-06-01",
-        total: 50,
-        ok_count: 45,
-        latency_samples: 48,
-        p50: 200,
-        p95: 500,
-      },
-    ];
+    return bulkTrendDailyRows();
   }
   return [];
 }


### PR DESCRIPTION
## Summary
- `loadReliabilityAggregate` counts distinct netuids with in-window `surface_uptime_daily` rows and returns null for multi-subnet rollups when any requested netuid is absent.
- Provider uptime/grade badges therefore show n/a instead of scoring only the subnets that happened to report.

## Test plan
- [x] `loadReliabilityAggregate` unit test for covered_netuids < ids.length
- [x] Badge integration test with a partial D1 aggregate renders n/a