### PR TITLE
fix(api): coerce string-typed REAL score cells in formatNeuron

### DIFF
--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -136,6 +136,49 @@ describe("metagraph-neurons builders", () => {
     assert.equal(n.validator_trust, null);
   });
 
+  test("formatNeuron coerces string-typed REAL score cells (rank/trust/consensus/…)", () => {
+    // rank/trust/validator_trust/consensus/incentive/dividends are nullable REAL
+    // columns that D1 can surface as numeric strings ("0.5" not 0.5). #2493 left
+    // them on a bare `?? null` pass-through while coercing the other numeric
+    // fields, so a string cell leaked straight into the number-typed API payload.
+    const n = formatNeuron({
+      rank: "0.75",
+      trust: "0.5",
+      validator_trust: "0.99",
+      consensus: "0.4",
+      incentive: "0.1",
+      dividends: "0.2",
+    });
+    assert.equal(n.rank, 0.75);
+    assert.equal(typeof n.rank, "number");
+    assert.equal(n.trust, 0.5);
+    assert.equal(n.validator_trust, 0.99);
+    assert.equal(n.consensus, 0.4);
+    assert.equal(n.incentive, 0.1);
+    assert.equal(n.dividends, 0.2);
+    assert.equal(typeof n.dividends, "number");
+  });
+
+  test("formatNeuron keeps null contract for explicit null score cells", () => {
+    // nullableNumber(null) === 0 (Number(null) is 0, which is finite), so the
+    // score fields need the same `== null` guard as uid/stake/emission — an
+    // explicit null REAL cell must serialize as null, not 0.
+    const n = formatNeuron({
+      rank: null,
+      trust: null,
+      validator_trust: null,
+      consensus: null,
+      incentive: null,
+      dividends: null,
+    });
+    assert.equal(n.rank, null);
+    assert.equal(n.trust, null);
+    assert.equal(n.validator_trust, null);
+    assert.equal(n.consensus, null);
+    assert.equal(n.incentive, null);
+    assert.equal(n.dividends, null);
+  });
+
   test("formatNeuron rounds stake_tao / emission_tao to rao precision (no IEEE-754 leak)", () => {
     // Regression for the Gittensory Orb follow-up blocker on #2503: stake_tao /
     // emission_tao must be rounded to 1e-9 (rao) precision so a noisy REAL


### PR DESCRIPTION
# Summary

This PR fixes type coercion for the six neuron score fields returned by the API.

Previously, `formatNeuron()` passed the following nullable `REAL` columns directly from D1 into the response:

- `rank`
- `trust`
- `validator_trust`
- `consensus`
- `incentive`
- `dividends`

When D1 returned these values as numeric strings (for example, `"0.5"`), the API serialized them as strings instead of numbers, despite the schema defining them as numeric fields.

This change normalizes all score fields using the existing numeric coercion helper while preserving `null` values for missing data.

## Root Cause

`formatNeuron()` normalized several numeric fields in a previous fix but continued to pass the six score fields through without type conversion.

Since D1 may return `REAL` columns as strings, these values could be exposed directly in the API response, resulting in responses that did not match the documented schema.

Additionally, the existing `nullableNumber()` helper converts `null` to `0`, so explicit `null` checks are required before coercion to preserve the API's null contract.

## Changes

### Source

**`src/metagraph-neurons.mjs`**

Updated the following fields to use `nullableNumber()` behind a null check:

- `rank`
- `trust`
- `validator_trust`
- `consensus`
- `incentive`
- `dividends`

The implementation preserves existing behavior by:

- Converting numeric strings to numbers.
- Preserving explicit `null` values.
- Leaving response structure unchanged.

### Tests

**`tests/metagraph-neurons.test.mjs`**

Added regression tests verifying:

- String-typed score values are serialized as numbers.
- Explicit `null` values remain `null` instead of becoming `0`.
- Existing neuron formatting behavior remains unchanged.

## Impact

- ✅ Score fields always serialize as numbers when values are present.
- ✅ Explicit `null` values are preserved.
- ✅ API responses remain consistent with the documented schema.
- ✅ No changes to SQL queries, database schema, or response structure.

## Validation

- [x] `npx vitest run tests/metagraph-neurons.test.mjs`
- [x] `npm run lint`
- [x] Verified the new regression tests fail on `main` and pass with this fix.
- [x] No merge conflicts against the latest `main`.
