### PR TITLE
fix(api): reject invalid success filter on extrinsics feed (#2575)

### DIFF
--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -565,7 +565,7 @@ test("GET /extrinsics applies the conjunctive filter set (#1846)", async () => {
   assert.equal(boundParams.at(-1), 0);
 });
 
-test("GET /extrinsics?success=true binds 1; an invalid success is ignored (#1846)", async () => {
+test("GET /extrinsics?success=true binds 1; an invalid success returns 400 (#2575)", async () => {
   let boundSql;
   let boundParams;
   const env = {
@@ -589,10 +589,16 @@ test("GET /extrinsics?success=true binds 1; an invalid success is ignored (#1846
   assert.ok(/success = \?/.test(boundSql));
   assert.ok(boundParams.includes(1));
 
-  // A non-true/false success value adds no condition (no WHERE).
-  await handleRequest(req("/api/v1/extrinsics?success=maybe"), env, {});
-  assert.ok(!/success = \?/.test(boundSql));
-  assert.ok(!/WHERE/.test(boundSql));
+  const bad = await handleRequest(
+    req("/api/v1/extrinsics?success=maybe"),
+    env,
+    {},
+  );
+  assert.equal(bad.status, 400);
+  const body = await bad.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.error.code, "invalid_query");
+  assert.equal(body.meta.parameter, "success");
 });
 
 test("GET /extrinsics/{hash} returns detail by extrinsic_hash (#1345)", async () => {

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -29,6 +29,7 @@ import {
   ANALYTICS_WINDOW_PARAM,
   ANALYTICS_WINDOWS,
   DEFAULT_ANALYTICS_WINDOW,
+  DAY_MS,
 } from "../workers/config.mjs";
 
 configureAnalytics({
@@ -44,12 +45,6 @@ configureAnalytics({
 const NETUID = 7;
 const LAST_RUN_AT = "2026-06-18T00:00:00.000Z";
 const ctx = { waitUntil: (promise) => promise };
-
-function recentUtcDay(daysAgo) {
-  const d = new Date();
-  d.setUTCDate(d.getUTCDate() - daysAgo);
-  return d.toISOString().slice(0, 10);
-}
 
 function req(path, init = {}) {
   return new Request(`https://api.metagraph.sh${path}`, init);
@@ -115,13 +110,15 @@ function rowsForSql(sql) {
     ];
   }
   if (sql.includes("FROM surface_uptime_daily")) {
-    const recent = recentUtcDay(1);
-    const older = recentUtcDay(20);
+    const recentDay = new Date(Date.now() - DAY_MS).toISOString().slice(0, 10);
+    const olderDay = new Date(Date.now() - 20 * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
     return [
       {
         netuid: NETUID,
-        day: recent,
-        date: recent,
+        day: recentDay,
+        date: recentDay,
         total: 100,
         ok_count: 98,
         latency_samples: 96,
@@ -130,8 +127,8 @@ function rowsForSql(sql) {
       },
       {
         netuid: NETUID,
-        day: older,
-        date: older,
+        day: olderDay,
+        date: olderDay,
         total: 50,
         ok_count: 45,
         latency_samples: 48,

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -3491,6 +3491,60 @@ describe("handleExtrinsics", () => {
     assert.ok(captures.params.flat().includes(0));
   });
 
+  test("rejects a non-boolean success value with 400 (#2575)", async () => {
+    const { env, captures } = dbWith({ extrinsics: [] });
+    const res = await handleExtrinsics(
+      req("/api/v1/extrinsics"),
+      env,
+      url("/api/v1/extrinsics?success=1"),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "success");
+    assert.match(body.error.message, /true, false/);
+    assert.equal(
+      captures.sql.filter((s) => /FROM extrinsics/.test(s)).length,
+      0,
+    );
+  });
+
+  test("success=true binds only successful extrinsics (#2575)", async () => {
+    const { env, captures } = dbWith({ extrinsics: [] });
+    await handleExtrinsics(
+      req("/api/v1/extrinsics"),
+      env,
+      url("/api/v1/extrinsics?success=true"),
+    );
+    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
+    assert.ok(/success = \?/.test(sql));
+    assert.ok(captures.params.flat().includes(1));
+  });
+
+  test("success=false binds only failed extrinsics, omitting NULL (#2575)", async () => {
+    const { env, captures } = dbWith({ extrinsics: [] });
+    await handleExtrinsics(
+      req("/api/v1/extrinsics"),
+      env,
+      url("/api/v1/extrinsics?success=false"),
+    );
+    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
+    assert.ok(/success = \?/.test(sql));
+    assert.ok(captures.params.flat().includes(0));
+    assert.ok(!/success IS NULL/.test(sql));
+  });
+
+  test("omitted success leaves the feed unfiltered (#2575)", async () => {
+    const { env, captures } = dbWith({ extrinsics: [] });
+    await handleExtrinsics(
+      req("/api/v1/extrinsics"),
+      env,
+      url("/api/v1/extrinsics"),
+    );
+    const sql = captures.sql.find((s) => /FROM extrinsics/.test(s));
+    assert.ok(sql);
+    assert.ok(!/success = \?/.test(sql));
+  });
+
   test("forces module-index for a module-only feed path (#2082)", async () => {
     const { env, captures } = dbWith({ extrinsics: [] });
     await handleExtrinsics(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1461,6 +1461,16 @@ export async function handleExtrinsics(request, env, url) {
   const fromMs = numericFilters.from ?? null;
   const toMs = numericFilters.to ?? null;
   const successRaw = sp.get("success");
+  if (
+    successRaw !== null &&
+    successRaw !== "true" &&
+    successRaw !== "false"
+  ) {
+    return analyticsQueryError({
+      parameter: "success",
+      message: "success must be one of: true, false.",
+    });
+  }
   const data = await loadExtrinsics(d1Runner(env), {
     block: numericFilters.block ?? undefined,
     signer: sp.get("signer") || undefined,

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1461,11 +1461,7 @@ export async function handleExtrinsics(request, env, url) {
   const fromMs = numericFilters.from ?? null;
   const toMs = numericFilters.to ?? null;
   const successRaw = sp.get("success");
-  if (
-    successRaw !== null &&
-    successRaw !== "true" &&
-    successRaw !== "false"
-  ) {
+  if (successRaw !== null && successRaw !== "true" && successRaw !== "false") {
     return analyticsQueryError({
       parameter: "success",
       message: "success must be one of: true, false.",


### PR DESCRIPTION
## Summary
- Reject `?success=` values other than `true` or `false` on `GET /api/v1/extrinsics` with a `400 invalid_query` envelope instead of silently ignoring the filter and returning an unfiltered feed.
- Add handler tests covering the reject arm, both boolean bind paths, and the unfiltered default when `success` is omitted.

Closes #2575

## Test plan
- [x] `npm test -- tests/request-handlers-entities.test.mjs -t "handleExtrinsics"`
- [ ] `npm run validate` (full gate before push)