### PR TITLE
fix(api): canonicalize validators edge cache key

### DIFF
--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -1071,6 +1071,67 @@ describe("neurons-tier edge cache", () => {
     }
   });
 
+  test("global validators rejects invalid queries before reading the neuron cache stamp", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = neuronsEnv(queries);
+
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/validators?bogus=1"),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+
+    assert.equal(res.status, 400);
+    assert.equal(queries.length, 0, "invalid queries must not read D1 stamp");
+    assert.deepEqual(cache.putKeys, []);
+    assert.equal(cache.store.size, 0);
+  });
+
+  test("global validators canonicalizes equivalent query variants before caching", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = neuronsEnv(queries);
+
+    const first = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/validators?limit=1"),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(first.status, 200);
+    const queriesAfterMiss = queries.length;
+
+    const hit = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/validators?limit=01&sort=subnet_count",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(hit.status, 200);
+    assert.equal(
+      queries.length,
+      queriesAfterMiss + 1,
+      "a cache HIT reads only the stamp and skips validator data queries",
+    );
+    assert.match(queries.at(-1).sql, /MAX\(captured_at\)/);
+    assert.deepEqual(cache.putKeys, [
+      expectedStampKey(
+        NEURON_CAPTURED_AT,
+        "global-validators",
+        "/api/v1/validators",
+        "?sort=subnet_count&limit=1",
+      ),
+    ]);
+    assert.equal(cache.store.size, 1);
+  });
+
   test("a new neuron captured_at busts cache while health last_run_at is unchanged", async () => {
     originalCaches = globalThis.caches;
     const cache = mockCaches();

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -18,6 +18,7 @@ import {
   handleSubnetYield,
   handleNeuron,
   handleSubnetValidators,
+  handleGlobalValidators,
   handleNeuronHistory,
   handleSubnetHistory,
   handleSubnetIdentityHistory,
@@ -47,6 +48,7 @@ import {
   canonicalSubnetStakeFlowCachePath,
   canonicalSubnetMoversCachePath,
   canonicalSubnetMetagraphCachePath,
+  canonicalGlobalValidatorsCachePath,
 } from "../workers/request-handlers/entities.mjs";
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
@@ -763,6 +765,62 @@ describe("handleSubnetValidators", () => {
       body.meta.artifact_path,
       `/metagraph/subnets/${NETUID}/validators.json`,
     );
+  });
+});
+
+describe("handleGlobalValidators", () => {
+  // workers/api.mjs always resolves canonicalGlobalValidatorsCachePath(url)
+  // first and short-circuits on its { response } before handleGlobalValidators
+  // ever runs, so the router never reaches this guard with an invalid query.
+  // It stays as defense in depth for any direct/non-cached caller, so cover it
+  // directly here rather than only through the edge-cache route.
+  test("rejects an unsupported query param with 400", async () => {
+    const res = await handleGlobalValidators(
+      req("/api/v1/validators"),
+      emptyEnv(),
+      url("/api/v1/validators?bogus=1"),
+    );
+    await errorJson(res);
+  });
+
+  test("returns schema-stable empty leaderboard on cold D1", async () => {
+    const body = await assertColdSchema(
+      handleGlobalValidators,
+      req("/api/v1/validators"),
+      emptyEnv(),
+      url("/api/v1/validators"),
+    );
+    assert.deepEqual(body.data.validators, []);
+  });
+});
+
+describe("canonicalGlobalValidatorsCachePath", () => {
+  test("returns a response short-circuit for an unsupported query param", () => {
+    const result = canonicalGlobalValidatorsCachePath(
+      url("/api/v1/validators?bogus=1"),
+    );
+    assert.equal(result.cachePathAndSearch, undefined);
+    assert.ok(result.response instanceof Response);
+    assert.equal(result.response.status, 400);
+  });
+
+  test("returns a response short-circuit for an unsupported sort value", () => {
+    const result = canonicalGlobalValidatorsCachePath(
+      url("/api/v1/validators?sort=bogus"),
+    );
+    assert.equal(result.cachePathAndSearch, undefined);
+    assert.equal(result.response.status, 400);
+  });
+
+  test("omitted sort/limit and their explicit defaults produce the same cache key", () => {
+    const omitted = canonicalGlobalValidatorsCachePath(
+      url("/api/v1/validators"),
+    );
+    const explicit = canonicalGlobalValidatorsCachePath(
+      url("/api/v1/validators?sort=subnet_count&limit=20"),
+    );
+    assert.equal(omitted.response, undefined);
+    assert.equal(omitted.cachePathAndSearch, explicit.cachePathAndSearch);
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -86,6 +86,7 @@ import {
   handleSubnetMovers,
   canonicalSubnetMoversCachePath,
   handleGlobalValidators,
+  canonicalGlobalValidatorsCachePath,
   canonicalSubnetMetagraphCachePath,
   handleAccount,
   handleAccountHistory,
@@ -1186,13 +1187,15 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // validator's permit=1 row wouldn't touch a filtered MAX(captured_at), leaving this
   // leaderboard's edge cache stale for that change.
   if (url.pathname === "/api/v1/validators") {
+    const validatorsCache = canonicalGlobalValidatorsCachePath(url);
+    if (validatorsCache.response) return validatorsCache.response;
     return withEdgeCache(
       request,
       ctx,
       env,
       "global-validators",
       () => handleGlobalValidators(request, env, url),
-      null,
+      validatorsCache.cachePathAndSearch,
       (edgeEnv) => readNeuronsCacheStamp(edgeEnv),
     );
   }

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -258,28 +258,47 @@ export async function handleSubnetValidators(request, env, netuid, url) {
 // operator footprint rather than only one subnet at a time. Stake/emission values stay
 // scoped to each membership row because those source units are not globally aggregated.
 // Cold/absent D1 returns a schema-stable empty list.
-export async function handleGlobalValidators(request, env, url) {
+function parseGlobalValidatorsQuery(url) {
   const validationError = validateQueryParams(url, ["sort", "limit"]);
-  if (validationError) return analyticsQueryError(validationError);
-  const sortParam =
-    url.searchParams.get("sort") || DEFAULT_GLOBAL_VALIDATOR_SORT;
-  if (!GLOBAL_VALIDATOR_SORTS.includes(sortParam)) {
-    return analyticsQueryError({
-      parameter: "sort",
-      message: `"${sortParam}" is not a supported sort. Supported: ${GLOBAL_VALIDATOR_SORTS.join(
-        ", ",
-      )}.`,
-    });
+  if (validationError) return { error: validationError };
+
+  const sort = url.searchParams.get("sort") || DEFAULT_GLOBAL_VALIDATOR_SORT;
+  if (!GLOBAL_VALIDATOR_SORTS.includes(sort)) {
+    return {
+      error: {
+        parameter: "sort",
+        message: `"${sort}" is not a supported sort. Supported: ${GLOBAL_VALIDATOR_SORTS.join(
+          ", ",
+        )}.`,
+      },
+    };
   }
+
   const limit = parseBoundedIntParam(url, "limit", {
     def: GLOBAL_VALIDATOR_LIMIT_DEFAULT,
     min: 1,
     max: GLOBAL_VALIDATOR_LIMIT_MAX,
   });
-  if (limit.error) return analyticsQueryError(limit.error);
+  if (limit.error) return { error: limit.error };
+
+  return { sort, limit: limit.value };
+}
+
+export function canonicalGlobalValidatorsCachePath(url) {
+  const parsed = parseGlobalValidatorsQuery(url);
+  if (parsed.error) {
+    return { response: analyticsQueryError(parsed.error) };
+  }
+  const search = `sort=${encodeURIComponent(parsed.sort)}&limit=${parsed.limit}`;
+  return { cachePathAndSearch: `${url.pathname}?${search}` };
+}
+
+export async function handleGlobalValidators(request, env, url) {
+  const parsed = parseGlobalValidatorsQuery(url);
+  if (parsed.error) return analyticsQueryError(parsed.error);
   const data = await loadGlobalValidators(d1Runner(env), {
-    sort: sortParam,
-    limit: limit.value,
+    sort: parsed.sort,
+    limit: parsed.limit,
   });
   return envelopeResponse(
     request,


### PR DESCRIPTION
### Motivation
- The `/api/v1/validators` route was wrapped with `withEdgeCache` using a raw pathname+search key, which allowed invalid or non-canonical query variants to trigger the neuron cache-stamp D1 read and to populate many distinct edge-cache entries for the same logical leaderboard.
- This weakens cache coalescing and can amplify availability/cost by letting unauthenticated callers force extra D1 work or many cache slots for equivalent queries.

### Description
- Add a shared parser/validator `parseGlobalValidatorsQuery(url)` that enforces and normalizes `sort` and `limit` for the global validators handler.
- Add `canonicalGlobalValidatorsCachePath(url)` which returns a canonical `cachePathAndSearch` (normalized `sort` + numeric `limit`) or an early `response` for invalid queries. 
- Update `handleGlobalValidators` to consume the parsed/normalized values and keep its validation logic centralized. 
- Update the router in `workers/api.mjs` to call `canonicalGlobalValidatorsCachePath(url)` and reject invalid queries before calling `withEdgeCache`, and pass the canonical cache path into `withEdgeCache` so the cache key is normalized. 
- Add regression tests in `tests/analytics-edge-cache.test.mjs` that assert invalid queries do not read the neuron stamp and that equivalent query variants coalesce to a single cache entry.

### Testing
- Ran the focused edge-cache suite with `npm test -- tests/analytics-edge-cache.test.mjs` and all tests passed (including the new regressions). 
- Ran lint and formatting checks with `npm run lint` and `npm run format:check`, both passed. 
- Rebuilt artifacts with `npm run build` and validated the API with `npm run validate:api`, which completed successfully. 
- Ran the full `npm run validate` suite and it completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45eca2e004832c8125381698737fb7)