### PR TITLE
fix(icon-proxy): treat 403/408/429 as transient in the icon negative cache

### DIFF
--- a/src/icon-proxy.mjs
+++ b/src/icon-proxy.mjs
@@ -290,7 +290,19 @@ export async function handleIconProxy(request, env, url, options = {}) {
         signal: controller.signal,
       }).finally(() => clearTimeout(timeout));
       if (!res.ok) {
-        if (res.status >= 500) transient = true; // upstream blip, not a real "no"
+        // Transient (retry soon), not a stable "no": 5xx upstream blips, the
+        // retryable 4xx (408 timeout, 429 rate-limit), and 403 — the anti-bot
+        // block these aggregators return to non-browser UAs, which is the exact
+        // prod failure this module works around (see the BROWSER_UA note above).
+        // Blackholing any of these as a 24h stable negative would drop a real,
+        // resolvable icon for a full day.
+        if (
+          res.status >= 500 ||
+          res.status === 429 ||
+          res.status === 408 ||
+          res.status === 403
+        )
+          transient = true;
         continue;
       }
       const ct = res.headers.get("content-type") || "image/png";

--- a/tests/icon-proxy.test.mjs
+++ b/tests/icon-proxy.test.mjs
@@ -609,6 +609,50 @@ test("allowlisted host, 5xx from an aggregator -> short transient negative cache
   assert.match(res.headers.get("cache-control"), /max-age=600/);
 });
 
+test("allowlisted host, 429 rate-limit from an aggregator -> short transient negative cache", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async () => new Response("", { status: 429 }),
+  });
+  assert.equal(res.status, 404);
+  // 429 is a retryable upstream blip, not a stable "no" — a real icon must
+  // retry in 10m, not be blackholed for 24h.
+  assert.match(res.headers.get("cache-control"), /max-age=600/);
+});
+
+test("allowlisted host, 403 bot-block from an aggregator -> short transient negative cache", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async () => new Response("", { status: 403 }),
+  });
+  assert.equal(res.status, 404);
+  // 403 is the aggregators' anti-bot block (the failure this module exists to
+  // survive), so it must take the short retry window, not the 24h stable one.
+  assert.match(res.headers.get("cache-control"), /max-age=600/);
+});
+
+test("allowlisted host, genuine 404 from an aggregator -> stable 24h negative cache", async () => {
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: { get: async () => null, put: async () => {} },
+  };
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async () => new Response("", { status: 404 }),
+  });
+  assert.equal(res.status, 404);
+  // A clean 404 is a real "no icon" — it keeps the long stable window.
+  assert.match(res.headers.get("cache-control"), /max-age=86400/);
+});
+
 test("aborts a hung upstream fetch via the timeout controller", async () => {
   vi.useFakeTimers();
   try {


### PR DESCRIPTION
# fix(icon-proxy): treat 403/408/429 as transient in the icon negative cache

## Summary

The favicon resolver in `src/icon-proxy.mjs` tries each aggregator and, when a
host resolves to no icon, negative-caches the 404 for one of two windows:

```js
const NEGATIVE_CACHE_STABLE = "public, max-age=86400"; // 24h — won't resolve
const NEGATIVE_CACHE_TRANSIENT = "public, max-age=600"; // 10m — retry soon
```

The choice hinges on a `transient` flag — "an allowlisted host that only saw
transient failures must be retried soon; a clean negative is a stable 'no' and
keeps 24h." But that flag was only set for `5xx`:

```js
if (!res.ok) {
  if (res.status >= 500) transient = true; // upstream blip, not a real "no"
  continue;
}
```

So a **403** or **429** fell into the clean-negative branch and was cached as a
**stable 24h "no icon"**:

- **403** is the anti-bot block these aggregators return to non-browser user
  agents — the *exact* prod failure this module was written to work around (its
  own comments note "the services bot-block the default Worker UA").
- **429** is a rate-limit — the textbook retryable response.

Because both aggregators are fetched with the same UA, a bot-block or rate-limit
tends to hit them together, so a single bad minute **blackholes a real, resolvable
icon for a full day** — precisely the outcome the 10-minute transient window
exists to prevent.

## Fix

Classify the retryable statuses (`403`, `408`, `429`) alongside `5xx` as
transient, so they take the short retry window; a genuine `404` still keeps the
24h stable window:

```js
if (!res.ok) {
  // Transient (retry soon), not a stable "no": 5xx upstream blips, the
  // retryable 4xx (408 timeout, 429 rate-limit), and 403 — the anti-bot
  // block these aggregators return to non-browser UAs, which is the exact
  // prod failure this module works around (see the BROWSER_UA note above).
  if (
    res.status >= 500 ||
    res.status === 429 ||
    res.status === 408 ||
    res.status === 403
  )
    transient = true;
  continue;
}
```

No behavior change for the success path or for genuine negatives — only the
negative-cache TTL for these upstream failure modes.

## Tests

Added regression coverage in `tests/icon-proxy.test.mjs` (matching the existing
5xx / thrown-error transient tests):

- `429` from an aggregator → `max-age=600` (transient)
- `403` from an aggregator → `max-age=600` (transient)
- genuine `404` from an aggregator → `max-age=86400` (stable, unchanged)

## Validation

- `npx vitest run tests/icon-proxy.test.mjs` — 30 passed (+3 new)
- `npm run lint` — clean
- Prettier: changed lines conform (verified line-ending-normalized; repo `main`
  is not fully prettier-clean, so any whole-file `--check` noise is pre-existing)
- No merge conflicts against latest `main`
