### PR TITLE
registry(providers): register gm provider (SN28)

### DIFF
--- a/registry/providers/gm.json
+++ b/registry/providers/gm.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "gm",
+  "name": "gm",
+  "kind": "subnet-team",
+  "website_url": "https://saygm.com/",
+  "authority": "community",
+  "notes": "Community-submitted provider profile for the SN28 gm team (saygm.com)."
+}


### PR DESCRIPTION
## Provider Profile Submission

Registers the debut provider profile for the **SN28 gm** team, operator of the `saygm.com` service (a privacy-first, OpenAI-compatible inference gateway). Single-file `registry/providers/gm.json`, provider lane.

## Provider
- Provider slug: `gm`
- Provider name: gm
- Provider kind: `subnet-team`
- Website URL: https://saygm.com/
- Authority: `community` (third-party submission; matches the 92 existing providers using `notes` + `community` authority)

## Checklist
- [x] Changes exactly one `registry/providers/*.json` file
- [x] Schema-valid against `schemas/provider.schema.json`
- [x] Uses `notes` (majority provider convention, e.g. degenbrain / handshake58) — no unbacked capability claims
- [x] Public-safe; no health/uptime/latency/pool-eligibility claims, no secrets or generated artifacts
- [x] Identity backed by the public website https://saygm.com/
