### PR TITLE
fix(account-events): coerce string-typed amount_tao in buildAccountTransfers

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -529,7 +529,7 @@ export function buildAccountTransfers(
       event_index: toBlockNumber(r.event_index),
       from: r.hotkey ?? null,
       to: r.coldkey ?? null,
-      amount_tao: r.amount_tao ?? null,
+      amount_tao: toTaoOrNull(r.amount_tao),
       direction:
         fixedDirection ??
         (r.hotkey === ss58 ? "sent" : r.coldkey === ss58 ? "received" : null),

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -547,6 +547,55 @@ test("buildAccountTransfers labels a self-transfer by the requested side (#2362)
   }
 });
 
+test("buildAccountTransfers coerces string-typed amount_tao cells to Numbers", () => {
+  const out = buildAccountTransfers(
+    [
+      {
+        block_number: 1,
+        event_index: 0,
+        hotkey: "5A",
+        coldkey: "5B",
+        amount_tao: "4.2",
+        observed_at: null,
+      },
+    ],
+    "5A",
+  );
+  assert.equal(typeof out.transfers[0].amount_tao, "number");
+  assert.equal(out.transfers[0].amount_tao, 4.2);
+});
+
+test("buildAccountTransfers preserves null amount_tao as null (not 0)", () => {
+  const out = buildAccountTransfers(
+    [{ hotkey: "5A", coldkey: "5B", amount_tao: null }],
+    "5A",
+  );
+  assert.equal(out.transfers[0].amount_tao, null);
+});
+
+test("buildAccountTransfers rounds amount_tao to rao precision", () => {
+  const out = buildAccountTransfers(
+    [
+      {
+        hotkey: "5A",
+        coldkey: "5B",
+        amount_tao: "1.0000000004",
+        observed_at: null,
+      },
+    ],
+    "5A",
+  );
+  assert.equal(out.transfers[0].amount_tao, 1);
+});
+
+test("buildAccountTransfers drops invalid amount_tao strings", () => {
+  const out = buildAccountTransfers(
+    [{ hotkey: "5A", coldkey: "5B", amount_tao: "not-a-number" }],
+    "5A",
+  );
+  assert.equal(out.transfers[0].amount_tao, null);
+});
+
 test("buildAccountTransfers explicit side never flips a normal row (#2362)", () => {
   // For a non-self transfer the requested side already matches the per-row
   // derivation, so forcing the label is a no-op — the fix only changes the


### PR DESCRIPTION
## What

`GET /api/v1/accounts/{ss58}/transfers` reshapes Transfer rows through `buildAccountTransfers`, which projected `amount_tao` with a bare `?? null` pass-through. D1 can return REAL columns as numeric strings, so the transfer feed could leak string-typed amounts into the JSON payload.

## How

Route `amount_tao` through the existing `toTaoOrNull` helper (same coercion as `formatRegistration` stake_tao in #2487 and `formatAccountActivity` total_fee_tao). REST and MCP account transfer tools share `buildAccountTransfers` — no handler change needed.

## Why no linked issue

Standalone formatter gap found by comparing `buildAccountTransfers` with sibling TAO coercions already applied in `formatRegistration` / `formatAccountActivity`. Open PR #2662 covers `formatAccountEvent` amount_tao/alpha_amount; this completes the **account transfers** ledger path, which does not call `formatAccountEvent`. No open issue tracks this specific gap.

## Scope / risk

One field coercion in `buildAccountTransfers` plus focused unit tests. Valid numeric amounts unchanged; null stays null (not 0).

## Tests

- `buildAccountTransfers coerces string-typed amount_tao cells to Numbers`
- `buildAccountTransfers preserves null amount_tao as null (not 0)`
- `buildAccountTransfers rounds amount_tao to rao precision`
- `buildAccountTransfers drops invalid amount_tao strings`

## Test plan

- [x] String, null, invalid, and rao-rounding amount_tao cases covered
- [x] Existing buildAccountTransfers tests continue to pass
- [x] CI vitest + lint/format checks
