### PR TITLE
fix(analytics): reuse growthRowsFromSamples in REST leaderboards handler

### DIFF
--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -1296,8 +1296,10 @@ describe("analytics routes (fake D1 with data)", () => {
 });
 
 describe("leaderboards growth baseline handles a null window-start score", () => {
-  // A subnet whose earliest in-window snapshot is unscored (null) must NOT
-  // produce a spurious positive delta from a forward-shifted baseline.
+  // A subnet whose earliest in-window snapshot is unscored (null) must latch
+  // the first real completeness score, not pin `first` to null for the whole
+  // window — otherwise REST diverges from MCP and drops genuinely fast-growing
+  // subnets (mirrors growthRowsFromSamples / #2602).
   function growthD1(growthRows) {
     return {
       prepare(sql) {
@@ -1316,7 +1318,7 @@ describe("leaderboards growth baseline handles a null window-start score", () =>
       },
     };
   }
-  test("excludes a subnet that was unscored at the window start", async () => {
+  test("includes a subnet once real scores exist after a leading null", async () => {
     const env = {
       ...createLocalArtifactEnv(),
       METAGRAPH_HEALTH_DB: growthD1([
@@ -1329,11 +1331,11 @@ describe("leaderboards growth baseline handles a null window-start score", () =>
       "https://api.metagraph.sh/api/v1/registry/leaderboards?board=fastest-growing",
       env,
     );
-    assert.equal(
-      body.data.boards["fastest-growing"].some((e) => e.netuid === 9),
-      false,
-      "unscored-at-start subnet must not appear with a spurious delta",
+    const entry = body.data.boards["fastest-growing"].find(
+      (e) => e.netuid === 9,
     );
+    assert.ok(entry, "leading-null subnet must rank once real scores exist");
+    assert.equal(entry.completeness_delta, 5);
   });
 });
 

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -422,6 +422,28 @@ describe("handleLeaderboards", () => {
     assert.match(healthSql, /AVG\(CASE WHEN/);
     assert.doesNotMatch(healthSql, /AVG\(latency_ms\)/);
   });
+
+  test("fastest-growing latches growth from the first non-null completeness score", async () => {
+    const env = d1Env({
+      "WHERE snapshot_date >= \\?": [
+        { netuid: 9, snapshot_date: "2026-06-03", completeness_score: null },
+        { netuid: 9, snapshot_date: "2026-06-06", completeness_score: 80 },
+        { netuid: 9, snapshot_date: "2026-06-10", completeness_score: 85 },
+      ],
+    });
+    const body = await json(
+      await handleLeaderboards(
+        req("/"),
+        env,
+        url("/?board=fastest-growing&limit=5"),
+      ),
+    );
+    const entry = body.data.boards["fastest-growing"].find(
+      (e) => e.netuid === 9,
+    );
+    assert.ok(entry, "leading-null subnet must rank once real scores exist");
+    assert.equal(entry.completeness_delta, 5);
+  });
 });
 
 describe("handleCompare", () => {

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -29,6 +29,7 @@ import {
   unsupportedWindowMessage,
 } from "../../src/neuron-history.mjs";
 import { loadEconomicsTrends } from "../../src/economics-trends.mjs";
+import { growthRowsFromSamples } from "../../src/analytics-live.mjs";
 import {
   formatLeaderboards,
   formatTrajectory,
@@ -355,23 +356,7 @@ export async function handleLeaderboards(request, env, url) {
       ),
     ]);
 
-  const growthByNetuid = new Map();
-  for (const row of growthSamples) {
-    const entry = growthByNetuid.get(row.netuid) || {
-      first: undefined,
-      last: undefined,
-    };
-    if (entry.first === undefined) entry.first = row.completeness_score ?? null;
-    entry.last = row.completeness_score ?? null;
-    growthByNetuid.set(row.netuid, entry);
-  }
-  const growthRows = [...growthByNetuid.entries()].map(([netuid, entry]) => ({
-    netuid,
-    delta:
-      entry.first != null && entry.last != null
-        ? Number(entry.last) - Number(entry.first)
-        : null,
-  }));
+  const growthRows = growthRowsFromSamples(growthSamples);
 
   const meta = await readHealthMetaKv(env);
   const data = formatLeaderboards({


### PR DESCRIPTION
## Summary

`GET /api/v1/registry/leaderboards` (`handleLeaderboards` in `workers/request-handlers/analytics-routes.mjs`) still computes **fastest-growing** deltas with the pre-latch inline loop (`entry.first === undefined` pins the first row even when `completeness_score` is NULL). The MCP tool `get_registry_leaderboards` calls `loadRegistryLeaderboards` → `growthRowsFromSamples()` in `src/analytics-live.mjs`, which already latches the first/last **non-null** scores (fixed in #2602 for the shared loader).

REST and MCP therefore disagree on which subnets appear on the fastest-growing board and what `completeness_delta` they carry.

## Root cause

Duplicated growth logic drifted after #2602 updated only `growthRowsFromSamples()`:

**Fixed (MCP / shared loader)** — `src/analytics-live.mjs`:

```javascript
if (score != null) {
  if (entry.first == null) entry.first = score;
  entry.last = score;
}
```

**Still broken (REST)** — `workers/request-handlers/analytics-routes.mjs` ~355–371:

```javascript
if (entry.first === undefined) entry.first = row.completeness_score ?? null;
entry.last = row.completeness_score ?? null;
```

A subnet whose earliest in-window snapshot has `completeness_score: null` gets `first = null`, `delta = null`, and is filtered out of fastest-growing — even when later snapshots show real growth (e.g. null → 10 → 90 should rank with delta 80).

## Impact

- **REST/MCP parity break**: same D1 data, different fastest-growing board between `/api/v1/registry/leaderboards?board=fastest-growing` and `get_registry_leaderboards`.
- **Silent omission**: genuinely fast-growing subnets disappear from the REST leaderboard when profiling starts mid-window.
- **Agent confusion**: MCP agents see subnets REST consumers (and the UI wired to REST) do not.

## Proposed fix

1. Import `growthRowsFromSamples` from `src/analytics-live.mjs` in `analytics-routes.mjs`.
2. Delete the inline `growthByNetuid` loop; replace with `growthRowsFromSamples(growthSamples)`.
3. Update `tests/analytics.test.mjs` describe block **"leaderboards growth baseline handles a null window-start score"** — it currently asserts the old (broken) exclusion; align with `tests/analytics-live.test.mjs` ("ignores a leading null score when latching first"): subnet 9 with `[null, 80, 85]` should produce `delta: 5` and appear on the board.
4. Add a REST handler test in `tests/request-handlers-analytics-routes.test.mjs` mirroring the MCP/live loader regression.

## Test plan

- [x] `npm test -- tests/analytics.test.mjs tests/analytics-live.test.mjs tests/request-handlers-analytics-routes.test.mjs`
- [x] `npm run lint && npm run validate`
- [ ] Assert REST fastest-growing matches `growthRowsFromSamples` for leading-null fixture

## Notes

- No schema/OpenAPI change.
- Completes the REST side of the #2602 growth-latch fix; no existing issue/PR tracks this missed sibling (GitHub search for `handleLeaderboards growthRowsFromSamples` returns zero hits).
