### PR TITLE
fix(api): reject unknown list query parameters

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -7961,6 +7961,7 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9603,6 +9604,7 @@ export interface operations {
                 agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
                 blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9797,6 +9799,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9935,6 +9938,7 @@ export interface operations {
                 netuid?: number;
                 registration_allowed?: "true" | "false";
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10193,6 +10197,7 @@ export interface operations {
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 severity?: "critical" | "warning" | "info";
                 state?: "active" | "resolved";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10345,6 +10350,7 @@ export interface operations {
                 max_eligible_count?: number;
                 min_endpoint_count?: number;
                 max_endpoint_count?: number;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10520,6 +10526,7 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10671,6 +10678,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11297,6 +11305,7 @@ export interface operations {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11429,6 +11438,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11558,6 +11568,7 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12176,6 +12187,7 @@ export interface operations {
                 confidence?: "low" | "medium" | "high";
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12429,6 +12441,7 @@ export interface operations {
                 id?: string;
                 kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
                 authority?: "community" | "official" | "provider-claimed" | "registry-observed";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12682,6 +12695,7 @@ export interface operations {
                 pool_eligible?: "true" | "false";
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13079,6 +13093,7 @@ export interface operations {
                 operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 reason_codes?: string;
                 recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13234,6 +13249,7 @@ export interface operations {
                 missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 netuid?: number;
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13399,6 +13415,7 @@ export interface operations {
                 review_state?: string;
                 manual_review_required?: "true" | "false";
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13609,6 +13626,7 @@ export interface operations {
                 target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 target_type?: "surface-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13819,6 +13837,7 @@ export interface operations {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13952,6 +13971,7 @@ export interface operations {
                 identity_level?: "none" | "directory" | "partial" | "complete";
                 identity_promotion_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 native_name_quality?: "chain" | "placeholder" | "empty";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -14150,6 +14170,7 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -14693,6 +14714,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -14816,6 +14838,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15061,6 +15084,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15213,6 +15237,7 @@ export interface operations {
                 max_surface_count?: number;
                 min_tempo?: number;
                 max_tempo?: number;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15626,6 +15651,7 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -16046,6 +16072,7 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -16320,6 +16347,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -16446,6 +16474,7 @@ export interface operations {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -16654,6 +16683,7 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -18393,6 +18423,7 @@ export interface operations {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -19284,6 +19315,7 @@ export interface operations {
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1047,6 +1047,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1201,6 +1202,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1352,6 +1354,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1442,6 +1445,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1592,6 +1596,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1739,6 +1744,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1857,6 +1863,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -1964,6 +1971,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2060,6 +2068,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2214,6 +2223,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2347,6 +2357,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2434,6 +2445,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2597,6 +2609,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2691,6 +2704,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2781,6 +2795,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -2866,6 +2881,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -3011,6 +3027,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -3169,6 +3186,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -3389,6 +3407,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -3551,6 +3570,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -3798,6 +3818,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -3887,6 +3908,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -4024,6 +4046,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -4153,6 +4176,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -5635,6 +5659,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -5699,6 +5724,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -5775,6 +5801,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -5924,6 +5951,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -6044,6 +6072,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -6177,6 +6206,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -6293,6 +6323,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -6357,6 +6388,7 @@
           }
         },
         {
+          "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
           "name": "fields",
           "schema": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -18659,6 +18659,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -20874,6 +20875,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -21159,6 +21161,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -21389,6 +21392,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -21830,6 +21834,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -22101,6 +22106,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -22432,6 +22438,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -22662,6 +22669,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -23567,6 +23575,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -23787,6 +23796,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -24069,6 +24079,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -24918,6 +24929,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -25278,6 +25290,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -25715,6 +25728,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -26338,6 +26352,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -26655,6 +26670,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -27046,6 +27062,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -27526,6 +27543,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -27843,6 +27861,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -28129,6 +28148,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -28495,6 +28515,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -29184,6 +29205,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -29380,6 +29402,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -29716,6 +29739,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -30142,6 +30166,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -30711,6 +30736,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -31355,6 +31381,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -31782,6 +31809,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -32004,6 +32032,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -32354,6 +32383,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -34559,6 +34589,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,
@@ -35775,6 +35806,7 @@
             }
           },
           {
+            "description": "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
             "in": "query",
             "name": "fields",
             "required": false,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7961,6 +7961,7 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9603,6 +9604,7 @@ export interface operations {
                 agent_status?: "callable" | "base-layer" | "candidate" | "needs-evidence" | "blocked";
                 blocker_level?: "none" | "hard-blocked" | "needs-review" | "missing-data";
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9797,6 +9799,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -9935,6 +9938,7 @@ export interface operations {
                 netuid?: number;
                 registration_allowed?: "true" | "false";
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10193,6 +10197,7 @@ export interface operations {
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 severity?: "critical" | "warning" | "info";
                 state?: "active" | "resolved";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10345,6 +10350,7 @@ export interface operations {
                 max_eligible_count?: number;
                 min_endpoint_count?: number;
                 max_endpoint_count?: number;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10520,6 +10526,7 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -10671,6 +10678,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11297,6 +11305,7 @@ export interface operations {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11429,6 +11438,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -11558,6 +11568,7 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12176,6 +12187,7 @@ export interface operations {
                 confidence?: "low" | "medium" | "high";
                 profile_level?: "directory-only" | "identity-partial" | "identity-complete" | "operational" | "adapter-backed";
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12429,6 +12441,7 @@ export interface operations {
                 id?: string;
                 kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
                 authority?: "community" | "official" | "provider-claimed" | "registry-observed";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -12682,6 +12695,7 @@ export interface operations {
                 pool_eligible?: "true" | "false";
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13079,6 +13093,7 @@ export interface operations {
                 operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 reason_codes?: string;
                 recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13234,6 +13249,7 @@ export interface operations {
                 missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 netuid?: number;
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13399,6 +13415,7 @@ export interface operations {
                 review_state?: string;
                 manual_review_required?: "true" | "false";
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13609,6 +13626,7 @@ export interface operations {
                 target_action?: "submit-new-candidate" | "replace-stale-candidate" | "verify-existing-candidate" | "review-existing-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 target_type?: "surface-candidate" | "adapter-review" | "maintainer-review" | "monitoring-followup";
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13819,6 +13837,7 @@ export interface operations {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -13952,6 +13971,7 @@ export interface operations {
                 identity_level?: "none" | "directory" | "partial" | "complete";
                 identity_promotion_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 native_name_quality?: "chain" | "placeholder" | "empty";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -14150,6 +14170,7 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -14693,6 +14714,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -14816,6 +14838,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15061,6 +15084,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15213,6 +15237,7 @@ export interface operations {
                 max_surface_count?: number;
                 min_tempo?: number;
                 max_tempo?: number;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -15626,6 +15651,7 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -16046,6 +16072,7 @@ export interface operations {
                 provider?: string;
                 publication_state?: "candidate" | "verified" | "monitored" | "pool-eligible" | "disabled" | "rejected";
                 status?: "ok" | "degraded" | "failed" | "unknown";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -16320,6 +16347,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -16446,6 +16474,7 @@ export interface operations {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 review_state?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -16654,6 +16683,7 @@ export interface operations {
                 provider?: string;
                 status?: "ok" | "degraded" | "failed" | "unknown";
                 classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe" | "wrong-chain";
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -18393,6 +18423,7 @@ export interface operations {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -19284,6 +19315,7 @@ export interface operations {
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                /** @description Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored. */
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2961,6 +2961,8 @@ function listQuery(collection, options = {}) {
       ...rangeParameters,
       {
         name: "fields",
+        description:
+          "Optional projection list. Unknown query parameters are rejected with `400 invalid_query` (parameter named in `meta.parameter`) instead of being ignored.",
         schema: fieldListSchema,
       },
       {

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -788,19 +788,17 @@ describe("pagination Link header", () => {
     assert.match(res.headers.get("access-control-expose-headers"), /\blink\b/);
   });
 
-  test("page links drop ignored/tracker query params end-to-end (#1932 cache-key safety)", async () => {
-    // Drive the canonicalization through the real Worker: tracker/attacker params
-    // the edge cache key ignores must not ride along in the cacheable Link header,
-    // while the body-affecting sort/cursor/limit are preserved.
-    const { res, links } = await page(
-      "limit=50&cursor=0&utm_campaign=evil&token=SECRET123",
+  test("unknown tracker params are rejected with invalid_query", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets?limit=50&cursor=0&utm_campaign=evil"),
+      createLocalArtifactEnv(),
+      {},
     );
-    assert.equal(res.status, 200);
-    assert.equal(links.next.searchParams.has("utm_campaign"), false);
-    assert.equal(links.next.searchParams.has("token"), false);
-    assert.equal(links.next.searchParams.get("sort"), "netuid");
-    assert.equal(links.next.searchParams.get("cursor"), "50");
-    assert.equal(links.next.searchParams.get("limit"), "50");
+    assert.equal(res.status, 400);
+    assert.equal(res.headers.get("x-metagraph-error-code"), "invalid_query");
+    const body = await res.json();
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "utm_campaign");
   });
 
   test("middle page advertises all four relations", async () => {

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -709,6 +709,26 @@ describe("list-query unknown query parameters", () => {
       delete API_QUERY_COLLECTIONS.__test_no_filters_list_query;
     }
   });
+
+  test("gracefully handles queryFilterNames when collection has no filters", () => {
+    API_QUERY_COLLECTIONS.__test_no_filters_with_allowlist = {
+      data_key: "rows",
+      search_keys: [],
+      sort_fields: ["netuid"],
+    };
+    try {
+      const result = applyQueryFilters(
+        { rows: [{ netuid: 1, status: "active" }] },
+        query("/api/v1/custom?status=active"),
+        "__test_no_filters_with_allowlist",
+        ["status"],
+      );
+      assert.equal(result.error.parameter, "status");
+      assert.equal(result.error.message, "unknown query parameter.");
+    } finally {
+      delete API_QUERY_COLLECTIONS.__test_no_filters_with_allowlist;
+    }
+  });
 });
 
 describe("list-query pagination Link header", () => {

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
+import { API_QUERY_COLLECTIONS } from "../src/contracts.mjs";
 import {
   applyQueryFilters,
   canonicalListSearch,
@@ -659,6 +660,32 @@ describe("list-query unknown query parameters", () => {
     assert.equal(search.includes("kind=docs"), true);
     assert.equal(search.includes("layer=inference"), false);
     assert.equal(search.includes("junk=1"), false);
+  });
+
+  test("handles sparse collection config without optional filter families", () => {
+    API_QUERY_COLLECTIONS.__test_sparse_list_query = {
+      data_key: "rows",
+      filters: { status: { type: "string" } },
+      search_keys: [],
+      sort_fields: ["netuid"],
+    };
+    try {
+      const result = applyQueryFilters(
+        { rows: [{ netuid: 1, status: "active" }] },
+        query("/api/v1/custom?status=active"),
+        "__test_sparse_list_query",
+      );
+      assert.equal(result.error, undefined);
+      assert.equal(result.data.rows.length, 1);
+      const search = canonicalListSearch(
+        query("/api/v1/custom?status=active&junk=1"),
+        "__test_sparse_list_query",
+      );
+      assert.equal(search.includes("status=active"), true);
+      assert.equal(search.includes("junk=1"), false);
+    } finally {
+      delete API_QUERY_COLLECTIONS.__test_sparse_list_query;
+    }
   });
 });
 

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -705,6 +705,12 @@ describe("list-query unknown query parameters", () => {
         ok.data.rows.map((row) => row.netuid),
         [1, 2],
       );
+      const canonical = canonicalListSearch(
+        query("/api/v1/custom?sort=netuid&junk=1"),
+        "__test_no_filters_list_query",
+      );
+      assert.equal(canonical.includes("sort=netuid"), true);
+      assert.equal(canonical.includes("junk=1"), false);
     } finally {
       delete API_QUERY_COLLECTIONS.__test_no_filters_list_query;
     }

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -565,6 +565,38 @@ describe("list-query endpoint pool count range filters (#2587)", () => {
   }
 });
 
+describe("list-query unknown query parameters", () => {
+  const data = {
+    subnets: [{ netuid: 1, name: "Alpha", status: "active" }],
+  };
+
+  test("unknown params are rejected with an explicit query error", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?statuss=active"),
+      "subnets",
+    );
+    assert.equal(result.error.parameter, "statuss");
+    assert.equal(result.error.message, "unknown query parameter.");
+  });
+
+  test("known params are still accepted", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?status=active&limit=10"),
+      "subnets",
+    );
+    assert.equal(result.error, undefined);
+    assert.equal(result.data.subnets.length, 1);
+  });
+
+  test("empty query params remain valid", () => {
+    const result = applyQueryFilters(data, query("/api/v1/subnets"), "subnets");
+    assert.equal(result.error, undefined);
+    assert.equal(result.data.subnets.length, 1);
+  });
+});
+
 describe("list-query pagination Link header", () => {
   test("first page: next + last only (no earlier page exists)", () => {
     const links = parseLink(pageLink("/api/v1/subnets?sort=netuid&limit=2"));
@@ -665,17 +697,16 @@ describe("list-query pagination Link header", () => {
     }
   });
 
-  test("drops ignored query parameters from cacheable page links", () => {
-    const links = parseLink(
-      pageLink(
-        "/api/v1/subnets?sort=netuid&limit=2&utm_campaign=evil&token=SECRET123",
-      ),
+  test("rejects unknown params instead of emitting page links", () => {
+    const result = applyQueryFilters(
+      {
+        subnets: Array.from({ length: 5 }, (_, i) => ({ netuid: i })),
+      },
+      query("/api/v1/subnets?sort=netuid&limit=2&utm_campaign=evil"),
+      "subnets",
     );
-
-    assert.equal(links.next.searchParams.get("sort"), "netuid");
-    assert.equal(links.next.searchParams.get("limit"), "2");
-    assert.equal(links.next.searchParams.has("utm_campaign"), false);
-    assert.equal(links.next.searchParams.has("token"), false);
+    assert.equal(result.error.parameter, "utm_campaign");
+    assert.equal(result.error.message, "unknown query parameter.");
   });
 
   test("a non-list (no pagination meta) collection yields no header", () => {

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -729,6 +729,40 @@ describe("list-query unknown query parameters", () => {
       delete API_QUERY_COLLECTIONS.__test_no_filters_with_allowlist;
     }
   });
+
+  test("queryFilterNames drops names missing from configured filters", () => {
+    const endpoints = {
+      endpoints: [{ id: "a", kind: "docs", layer: "inference" }],
+    };
+    const result = applyQueryFilters(
+      endpoints,
+      query("/api/v1/endpoints?kind=docs&layer=inference"),
+      "endpoints",
+      ["kind", "not_a_real_filter"],
+    );
+    assert.equal(result.error.parameter, "layer");
+    assert.equal(result.error.message, "unknown query parameter.");
+  });
+
+  test("ignores malformed filter schemas in collection config", () => {
+    API_QUERY_COLLECTIONS.__test_malformed_filter_schema = {
+      data_key: "rows",
+      filters: { status: true },
+      search_keys: [],
+      sort_fields: ["netuid"],
+    };
+    try {
+      const result = applyQueryFilters(
+        { rows: [{ netuid: 1, status: "active" }] },
+        query("/api/v1/custom?status=active"),
+        "__test_malformed_filter_schema",
+      );
+      assert.equal(result.error.parameter, "status");
+      assert.equal(result.error.message, "unknown query parameter.");
+    } finally {
+      delete API_QUERY_COLLECTIONS.__test_malformed_filter_schema;
+    }
+  });
 });
 
 describe("list-query pagination Link header", () => {

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -627,6 +627,39 @@ describe("list-query unknown query parameters", () => {
     assert.equal(result.error, undefined);
     assert.equal(result.data.subnets.length, 1);
   });
+
+  test("queryFilterNames restricts the allowed filter-key set", () => {
+    const endpoints = {
+      endpoints: [{ id: "a", kind: "axon", layer: "inference" }],
+    };
+    const allowed = applyQueryFilters(
+      endpoints,
+      query("/api/v1/endpoints?kind=docs"),
+      "endpoints",
+      ["kind"],
+    );
+    assert.equal(allowed.error, undefined);
+
+    const blocked = applyQueryFilters(
+      endpoints,
+      query("/api/v1/endpoints?layer=inference"),
+      "endpoints",
+      ["kind"],
+    );
+    assert.equal(blocked.error.parameter, "layer");
+    assert.equal(blocked.error.message, "unknown query parameter.");
+  });
+
+  test("canonicalListSearch honors queryFilterNames allow-list", () => {
+    const search = canonicalListSearch(
+      query("/api/v1/endpoints?kind=docs&layer=inference&junk=1"),
+      "endpoints",
+      ["kind"],
+    );
+    assert.equal(search.includes("kind=docs"), true);
+    assert.equal(search.includes("layer=inference"), false);
+    assert.equal(search.includes("junk=1"), false);
+  });
 });
 
 describe("list-query pagination Link header", () => {

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -590,6 +590,38 @@ describe("list-query unknown query parameters", () => {
     assert.equal(result.data.subnets.length, 1);
   });
 
+  test("csv, array, and range params remain accepted", () => {
+    const result = applyQueryFilters(
+      {
+        subnets: [
+          {
+            netuid: 1,
+            status: "active",
+            categories: ["inference"],
+            derived_categories: [],
+            surface_count: 5,
+          },
+          {
+            netuid: 2,
+            status: "inactive",
+            categories: ["training"],
+            derived_categories: [],
+            surface_count: 2,
+          },
+        ],
+      },
+      query(
+        "/api/v1/subnets?netuids=1,2&domain=inference&min_surface_count=1&max_surface_count=10",
+      ),
+      "subnets",
+    );
+    assert.equal(result.error, undefined);
+    assert.deepEqual(
+      result.data.subnets.map((row) => row.netuid),
+      [1],
+    );
+  });
+
   test("empty query params remain valid", () => {
     const result = applyQueryFilters(data, query("/api/v1/subnets"), "subnets");
     assert.equal(result.error, undefined);

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -687,6 +687,28 @@ describe("list-query unknown query parameters", () => {
       delete API_QUERY_COLLECTIONS.__test_sparse_list_query;
     }
   });
+
+  test("handles collection config with no filters object", () => {
+    API_QUERY_COLLECTIONS.__test_no_filters_list_query = {
+      data_key: "rows",
+      search_keys: [],
+      sort_fields: ["netuid"],
+    };
+    try {
+      const ok = applyQueryFilters(
+        { rows: [{ netuid: 2 }, { netuid: 1 }] },
+        query("/api/v1/custom?sort=netuid&order=asc&limit=5"),
+        "__test_no_filters_list_query",
+      );
+      assert.equal(ok.error, undefined);
+      assert.deepEqual(
+        ok.data.rows.map((row) => row.netuid),
+        [1, 2],
+      );
+    } finally {
+      delete API_QUERY_COLLECTIONS.__test_no_filters_list_query;
+    }
+  });
 });
 
 describe("list-query pagination Link header", () => {

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1726,8 +1726,8 @@ describe("Worker runtime", () => {
       assert.equal(secondBody.meta.parameter, "junk");
       assert.equal(
         r2Gets,
-        2,
-        "invalid list query still resolves live overlay before list validation",
+        0,
+        "invalid list query should fail before any overlay artifact read",
       );
       assert.equal(store.size, 0, "invalid list query must not populate cache");
       assert.deepEqual(cachePutKeys, []);

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1644,7 +1644,7 @@ describe("Worker runtime", () => {
     }
   });
 
-  test("canonicalizes overlay cache keys for ignored query parameters", async () => {
+  test("rejects unknown list query parameters on overlay routes", async () => {
     const store = new Map();
     const cachePutKeys = [];
     let r2Gets = 0;
@@ -1716,18 +1716,21 @@ describe("Worker runtime", () => {
         overlayEnv,
         ctx,
       );
-      assert.equal(first.status, 200);
-      assert.equal(second.status, 200);
-      assert.equal(await second.text(), await first.text());
+      assert.equal(first.status, 400);
+      assert.equal(second.status, 400);
+      const firstBody = await first.json();
+      const secondBody = await second.json();
+      assert.equal(firstBody.error.code, "invalid_query");
+      assert.equal(firstBody.meta.parameter, "junk");
+      assert.equal(secondBody.error.code, "invalid_query");
+      assert.equal(secondBody.meta.parameter, "junk");
       assert.equal(
         r2Gets,
-        1,
-        "ignored query params must not bust overlay cache",
+        2,
+        "invalid list query still resolves live overlay before list validation",
       );
-      assert.equal(store.size, 1, "ignored query params share one cache entry");
-      assert.deepEqual(cachePutKeys, [
-        `https://edge-cache.metagraph.sh/overlay/mainnet/${CONTRACT_VERSION}/2026-06-18T00%3A00%3A00.000Z/api/v1/endpoints`,
-      ]);
+      assert.equal(store.size, 0, "invalid list query must not populate cache");
+      assert.deepEqual(cachePutKeys, []);
     } finally {
       globalThis.caches = originalCaches;
     }

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -8,6 +8,7 @@ import {
   applyQueryFilters,
   canonicalListSearch,
   paginationLinkHeader,
+  validateListQueryRequest,
 } from "./list-query.mjs";
 import {
   apiHeaders,
@@ -2310,6 +2311,20 @@ async function handleApiRequest(
   const matched = matchRoute(url.pathname);
   if (!matched) {
     return errorResponse("not_found", "No API route matched this path.", 404);
+  }
+  // Reject invalid list-query params before any artifact fetch/overlay work so
+  // malformed requests cannot force storage reads on live-overlay routes.
+  const queryError = validateListQueryRequest(
+    url,
+    matched.queryCollection,
+    matched.queryFilterNames,
+  );
+  if (queryError) {
+    const artifactPath = artifactPathForNetwork(matched.artifactPath, network);
+    return errorResponse("invalid_query", queryError.message, 400, {
+      artifact_path: artifactPath,
+      parameter: queryError.parameter,
+    });
   }
   // Edge-cache idempotent GETs for pure static-artifact routes (mirrors the
   // RPC-proxy Cache API pattern). Live-overlay routes are excluded by route id,

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -15,30 +15,55 @@ export function applyQueryFilters(
   queryCollection,
   queryFilterNames = [],
 ) {
-  const params = url.searchParams;
   const config = API_QUERY_COLLECTIONS[queryCollection];
   if (!config) {
     return { data, meta: {} };
+  }
+  const normalizedConfig = normalizeListConfig(config, queryFilterNames);
+  const queryError = validateListQuery(
+    url.searchParams,
+    normalizedConfig,
+    queryFilterNames,
+  );
+  if (queryError) {
+    return { error: queryError };
   }
   if (!Array.isArray(data?.[config.data_key])) {
     return { data, meta: {} };
   }
   return applyListTransform(
     data,
-    params,
-    {
-      ...config,
-      filters: Object.fromEntries(
-        (queryFilterNames.length > 0
-          ? queryFilterNames
-          : Object.keys(config.filters ?? {})
-        )
-          .map((name) => [name, config.filters?.[name]])
-          .filter(([, schema]) => schema && typeof schema === "object"),
-      ),
-    },
+    url.searchParams,
+    normalizedConfig,
     queryFilterNames,
   );
+}
+
+export function validateListQueryRequest(
+  url,
+  queryCollection,
+  queryFilterNames = [],
+) {
+  const config = API_QUERY_COLLECTIONS[queryCollection];
+  if (!config) {
+    return null;
+  }
+  const normalizedConfig = normalizeListConfig(config, queryFilterNames);
+  return validateListQuery(url.searchParams, normalizedConfig, queryFilterNames);
+}
+
+function normalizeListConfig(config, queryFilterNames = []) {
+  return {
+    ...config,
+    filters: Object.fromEntries(
+      (queryFilterNames.length > 0
+        ? queryFilterNames
+        : Object.keys(config.filters ?? {})
+      )
+        .map((name) => [name, config.filters?.[name]])
+        .filter(([, schema]) => schema && typeof schema === "object"),
+    ),
+  };
 }
 
 // RFC 8288 Link header for a cursor-paginated response (window from

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -416,7 +416,7 @@ function validateListQuery(params, config, queryFilterNames = []) {
     };
   }
 
-  for (const [key, schema] of Object.entries(config.filters ?? {})) {
+  for (const [key, schema] of Object.entries(config.filters)) {
     if (!params.has(key)) {
       continue;
     }

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -28,8 +28,8 @@ export function applyQueryFilters(
     filters: Object.fromEntries(
       (queryFilterNames.length > 0
         ? queryFilterNames
-        : Object.keys(config.filters)
-      ).map((name) => [name, config.filters[name]]),
+        : Object.keys(config.filters ?? {})
+      ).map((name) => [name, config.filters?.[name]]),
     ),
   });
 }

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -49,7 +49,11 @@ export function validateListQueryRequest(
     return null;
   }
   const normalizedConfig = normalizeListConfig(config, queryFilterNames);
-  return validateListQuery(url.searchParams, normalizedConfig, queryFilterNames);
+  return validateListQuery(
+    url.searchParams,
+    normalizedConfig,
+    queryFilterNames,
+  );
 }
 
 function normalizeListConfig(config, queryFilterNames = []) {

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -29,7 +29,9 @@ export function applyQueryFilters(
       (queryFilterNames.length > 0
         ? queryFilterNames
         : Object.keys(config.filters ?? {})
-      ).map((name) => [name, config.filters?.[name]]),
+      )
+        .map((name) => [name, config.filters?.[name]])
+        .filter(([, schema]) => schema && typeof schema === "object"),
     ),
   });
 }

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -320,6 +320,30 @@ function paginateRows(rows, params) {
 }
 
 function validateListQuery(params, config) {
+  const allowedParams = new Set([
+    "q",
+    "fields",
+    "limit",
+    "cursor",
+    "sort",
+    "order",
+    ...Object.keys(config.filters || {}),
+    ...Object.keys(config.csv_filters || {}),
+    ...Object.keys(config.array_filters || {}),
+    ...(config.range_filters || []).flatMap((field) => [
+      `min_${field}`,
+      `max_${field}`,
+    ]),
+  ]);
+  for (const key of params.keys()) {
+    if (!allowedParams.has(key)) {
+      return {
+        parameter: key,
+        message: "unknown query parameter.",
+      };
+    }
+  }
+
   const limit = params.get("limit");
   if (
     limit !== null &&

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -168,7 +168,7 @@ function filterRows(rows, params, keys, csvFilters = {}, arrayFilters = {}) {
 // F is absent / non-numeric can't satisfy a bound, so it is excluded once any
 // bound on F is set. Validation (validateListQuery) has already confirmed every
 // present min_/max_ param is a finite number, so Number() here is safe.
-function rangeFilterRows(rows, params, rangeFields) {
+function rangeFilterRows(rows, params, rangeFields = []) {
   const bounds = [];
   for (const field of rangeFields) {
     const min = params.get(`min_${field}`);
@@ -375,7 +375,7 @@ function validateListQuery(params, config) {
     };
   }
 
-  for (const [key, schema] of Object.entries(config.filters)) {
+  for (const [key, schema] of Object.entries(config.filters ?? {})) {
     if (!params.has(key)) {
       continue;
     }
@@ -410,7 +410,7 @@ function validateListQuery(params, config) {
     }
   }
 
-  for (const field of config.range_filters) {
+  for (const field of config.range_filters ?? []) {
     for (const bound of ["min", "max"]) {
       const key = `${bound}_${field}`;
       if (params.has(key) && numberParam(params.get(key)) === null) {

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -23,17 +23,22 @@ export function applyQueryFilters(
   if (!Array.isArray(data?.[config.data_key])) {
     return { data, meta: {} };
   }
-  return applyListTransform(data, params, {
-    ...config,
-    filters: Object.fromEntries(
-      (queryFilterNames.length > 0
-        ? queryFilterNames
-        : Object.keys(config.filters ?? {})
-      )
-        .map((name) => [name, config.filters?.[name]])
-        .filter(([, schema]) => schema && typeof schema === "object"),
-    ),
-  });
+  return applyListTransform(
+    data,
+    params,
+    {
+      ...config,
+      filters: Object.fromEntries(
+        (queryFilterNames.length > 0
+          ? queryFilterNames
+          : Object.keys(config.filters ?? {})
+        )
+          .map((name) => [name, config.filters?.[name]])
+          .filter(([, schema]) => schema && typeof schema === "object"),
+      ),
+    },
+    queryFilterNames,
+  );
 }
 
 // RFC 8288 Link header for a cursor-paginated response (window from
@@ -49,10 +54,13 @@ function listQueryParamNames(queryCollection, queryFilterNames = []) {
 }
 
 function listQueryParamNamesFromConfig(config, queryFilterNames = []) {
+  const configuredFilters = config.filters ?? {};
   const filterNames =
     queryFilterNames.length > 0
-      ? queryFilterNames
-      : Object.keys(config.filters);
+      ? queryFilterNames.filter((name) =>
+          Object.hasOwn(configuredFilters, name),
+        )
+      : Object.keys(configuredFilters);
   const rangeNames = (config.range_filters ?? []).flatMap((field) => [
     `min_${field}`,
     `max_${field}`,
@@ -192,8 +200,8 @@ function rangeFilterRows(rows, params, rangeFields = []) {
   );
 }
 
-function applyListTransform(data, params, config) {
-  const queryError = validateListQuery(params, config);
+function applyListTransform(data, params, config, queryFilterNames = []) {
+  const queryError = validateListQuery(params, config, queryFilterNames);
   if (queryError) {
     return { error: queryError };
   }
@@ -325,8 +333,10 @@ function paginateRows(rows, params) {
   };
 }
 
-function validateListQuery(params, config) {
-  const allowedParams = new Set(listQueryParamNamesFromConfig(config));
+function validateListQuery(params, config, queryFilterNames = []) {
+  const allowedParams = new Set(
+    listQueryParamNamesFromConfig(config, queryFilterNames),
+  );
   for (const key of params.keys()) {
     if (!allowedParams.has(key)) {
       return {

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -43,16 +43,20 @@ export function applyQueryFilters(
 function listQueryParamNames(queryCollection, queryFilterNames = []) {
   const config = API_QUERY_COLLECTIONS[queryCollection];
   if (!config) return [];
+  return listQueryParamNamesFromConfig(config, queryFilterNames);
+}
+
+function listQueryParamNamesFromConfig(config, queryFilterNames = []) {
   const filterNames =
     queryFilterNames.length > 0
       ? queryFilterNames
       : Object.keys(config.filters);
-  const rangeNames = (config.range_filters || []).flatMap((field) => [
+  const rangeNames = (config.range_filters ?? []).flatMap((field) => [
     `min_${field}`,
     `max_${field}`,
   ]);
-  const csvNames = Object.keys(config.csv_filters || {});
-  const arrayNames = Object.keys(config.array_filters || {});
+  const csvNames = Object.keys(config.csv_filters ?? {});
+  const arrayNames = Object.keys(config.array_filters ?? {});
   return [
     "q",
     "fields",
@@ -320,21 +324,7 @@ function paginateRows(rows, params) {
 }
 
 function validateListQuery(params, config) {
-  const allowedParams = new Set([
-    "q",
-    "fields",
-    "limit",
-    "cursor",
-    "sort",
-    "order",
-    ...Object.keys(config.filters || {}),
-    ...Object.keys(config.csv_filters || {}),
-    ...Object.keys(config.array_filters || {}),
-    ...(config.range_filters || []).flatMap((field) => [
-      `min_${field}`,
-      `max_${field}`,
-    ]),
-  ]);
+  const allowedParams = new Set(listQueryParamNamesFromConfig(config));
   for (const key of params.keys()) {
     if (!allowedParams.has(key)) {
       return {


### PR DESCRIPTION
## Summary

- Reject unknown query keys on list routes instead of silently ignoring them.
- Return a deterministic invalid-query error (`unknown query parameter.`) naming the offending key.
- Add regression tests for unknown-key rejection, known-key acceptance, and empty-query pass-through.

## What Changed

- Added an allow-list check in `validateListQuery` (`workers/list-query.mjs`) that computes valid keys from standard list params plus configured filters/range/csv/array params.
- Added tests in `tests/list-query.test.mjs` to cover typo rejection and unchanged happy-path behavior.
- Updated pagination test expectations to reflect strict unknown-param rejection.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/list-query.test.mjs`

Fixes #2578

Made with [Cursor](https://cursor.com)