### PR TITLE
fix(streamer): fail fast on ingest auth errors

### DIFF
--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -197,6 +197,13 @@ def push(url, payload):
             resp.read()
         return True
     except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            log.error(
+                "ingest push rejected (HTTP %s) — auth/token misconfiguration; "
+                "exiting so this does not silently retry forever",
+                e.code,
+            )
+            sys.exit(1)
         log.warning(
             "ingest push rejected (HTTP %s) — poller backstop will cover this gap",
             e.code,


### PR DESCRIPTION
## Summary
- Fail fast in scripts/stream-events.py when ingest returns HTTP 401/403.
- Keep existing retry/backstop behavior for transient network and non-auth HTTP errors.
- Prevent silent degraded realtime ingestion when ingest token is wrong or rotated.

## Test plan
- [ ] Validate streamer exits non-zero when ingest endpoint returns 401.
- [ ] Validate streamer exits non-zero when ingest endpoint returns 403.
- [ ] Validate non-auth HTTP errors still log warning and continue.

## Notes
- Tried to open a matching upstream issue first, but the available account tokens do not have CreateIssue permission on JSONbored/metagraphed.