### PR TITLE
feat(economics): add alpha market cap metric

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -606,7 +606,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share, registration block height). Default order is emission share descending. Filter by netuid/registration_allowed, search by name/slug, and sort with `sort=<field>&order=asc|desc` — the two are separate parameters (e.g. `?sort=block&order=asc` or `?sort=total_stake_tao&order=desc`), NOT a combined `field:desc` token. */
+        /** List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, alpha market-cap proxy, emission share, and registration block height). Default order is emission share descending. Filter by netuid/registration_allowed, search by name/slug, and sort with `sort=<field>&order=asc|desc` — the two are separate parameters (e.g. `?sort=alpha_market_cap_tao&order=desc` or `?sort=block&order=asc`), NOT a combined `field:desc` token. */
         get: operations["economics"];
         put?: never;
         post?: never;
@@ -4719,6 +4719,8 @@ export interface components {
         /** @description Per-subnet validator and economic metrics derived from the chain metagraph (#1009). TAO-denominated fields are floats; emission_share is the subnet's alpha price as a fraction of the network total (the dTAO emission weight). Owner keys are public on-chain SS58 addresses. */
         SubnetEconomics: {
             alpha_in_pool: number | null;
+            /** @description Derived market-cap proxy: alpha_price_tao multiplied by total_stake_tao, where total_stake_tao is the circulating-alpha proxy. Null when either input is missing. */
+            alpha_market_cap_tao: number | null;
             alpha_out_pool: number | null;
             alpha_price_tao: number | null;
             /** @description Block height at which this subnet was registered on-chain — the same field the subnets collection exposes for sorting and range filters. */
@@ -9999,7 +10001,7 @@ export interface operations {
                 limit?: number;
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
-                sort?: "alpha_price_tao" | "block" | "emission_share" | "max_stake_tao" | "max_uids" | "max_validators" | "miner_count" | "miner_readiness" | "name" | "netuid" | "open_slots" | "registration_cost_tao" | "subnet_volume_tao" | "total_stake_tao" | "validator_count";
+                sort?: "alpha_market_cap_tao" | "alpha_price_tao" | "block" | "emission_share" | "max_stake_tao" | "max_uids" | "max_validators" | "miner_count" | "miner_readiness" | "name" | "netuid" | "open_slots" | "registration_cost_tao" | "subnet_volume_tao" | "total_stake_tao" | "validator_count";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
             };
@@ -10030,6 +10032,7 @@ export interface operations {
                      *         "subnets": [
                      *           {
                      *             "alpha_in_pool": 0.5,
+                     *             "alpha_market_cap_tao": 0.5,
                      *             "alpha_out_pool": 0.5,
                      *             "alpha_price_tao": 0.5,
                      *             "emission_share": 0.5,
@@ -15457,6 +15460,7 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "economics": {
                      *           "alpha_in_pool": 0.5,
+                     *           "alpha_market_cap_tao": 0.5,
                      *           "alpha_out_pool": 0.5,
                      *           "alpha_price_tao": 0.5,
                      *           "block": 5000000,

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1,819 +1,819 @@
 {
   "artifact_contracts": [
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "contracts",
       "path": "/metagraph/contracts.json",
       "schema_ref": "#/components/schemas/ContractsArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "providers",
       "path": "/metagraph/providers.json",
       "schema_ref": "#/components/schemas/ProvidersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "provider-detail",
       "path": "/metagraph/providers/{slug}.json",
       "schema_ref": "#/components/schemas/ProviderArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",
       "schema_ref": "#/components/schemas/ProviderEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "api-index",
       "path": "/metagraph/api-index.json",
       "schema_ref": "#/components/schemas/ApiIndexArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "openapi",
       "path": "/metagraph/openapi.json",
       "schema_ref": "#/components/schemas/OpenApiArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "type-definitions",
       "path": "/metagraph/types.d.ts",
       "schema_ref": null,
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "changelog",
       "path": "/metagraph/changelog.json",
       "schema_ref": "#/components/schemas/ChangelogArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnets",
       "path": "/metagraph/subnets.json",
       "schema_ref": "#/components/schemas/SubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "metagraph-latest",
       "path": "/metagraph/metagraph/latest.json",
       "schema_ref": "#/components/schemas/SubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-detail",
       "path": "/metagraph/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-overview",
       "path": "/metagraph/overview/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetOverviewArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "profiles",
       "path": "/metagraph/profiles.json",
       "schema_ref": "#/components/schemas/SubnetProfilesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "profile-detail",
       "path": "/metagraph/profiles/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetProfileArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "surfaces",
       "path": "/metagraph/surfaces.json",
       "schema_ref": "#/components/schemas/SurfacesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "surface-aliases",
       "path": "/metagraph/surface-aliases.json",
       "schema_ref": "#/components/schemas/SurfaceAliasesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "surfaces-subnet",
       "path": "/metagraph/surfaces/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetSurfacesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "endpoints",
       "path": "/metagraph/endpoints.json",
       "schema_ref": "#/components/schemas/EndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "endpoints-subnet",
       "path": "/metagraph/endpoints/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "candidates",
       "path": "/metagraph/candidates.json",
       "schema_ref": "#/components/schemas/CandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "candidates-subnet",
       "path": "/metagraph/candidates/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetCandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "review-queue",
       "path": "/metagraph/review-queue.json",
       "schema_ref": "#/components/schemas/ReviewQueueArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "search",
       "path": "/metagraph/search.json",
       "schema_ref": "#/components/schemas/SearchArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "search-index",
       "path": "/metagraph/search-index.json",
       "schema_ref": "#/components/schemas/SearchIndexArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "coverage",
       "path": "/metagraph/coverage.json",
       "schema_ref": "#/components/schemas/CoverageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "coverage-depth",
       "path": "/metagraph/coverage-depth.json",
       "schema_ref": "#/components/schemas/CoverageDepthArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "economics",
       "path": "/metagraph/economics.json",
       "schema_ref": "#/components/schemas/EconomicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "economics-trends",
       "path": "/metagraph/economics/trends.json",
       "schema_ref": "#/components/schemas/EconomicsTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "registry-summary",
       "path": "/metagraph/registry-summary.json",
       "schema_ref": "#/components/schemas/RegistrySummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "lineage",
       "path": "/metagraph/lineage.json",
       "schema_ref": "#/components/schemas/LineageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "fixtures-index",
       "path": "/metagraph/fixtures.json",
       "schema_ref": "#/components/schemas/FixturesIndexArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "agent-resources",
       "path": "/metagraph/agent-resources.json",
       "schema_ref": "#/components/schemas/AgentResourcesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "fixture-detail",
       "path": "/metagraph/fixtures/{surface_id}.json",
       "schema_ref": "#/components/schemas/JsonObject",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "curation",
       "path": "/metagraph/curation.json",
       "schema_ref": "#/components/schemas/CurationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "gaps",
       "path": "/metagraph/gaps.json",
       "schema_ref": "#/components/schemas/GapsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "verification",
       "path": "/metagraph/verification/latest.json",
       "schema_ref": "#/components/schemas/VerificationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "verification-subnet",
       "path": "/metagraph/verification/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetVerificationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "freshness",
       "path": "/metagraph/freshness.json",
       "schema_ref": "#/components/schemas/FreshnessArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "source-health",
       "path": "/metagraph/source-health.json",
       "schema_ref": "#/components/schemas/SourceHealthArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "source-snapshots",
       "path": "/metagraph/source-snapshots.json",
       "schema_ref": "#/components/schemas/SourceSnapshotsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "evidence-ledger",
       "path": "/metagraph/evidence-ledger.json",
       "schema_ref": "#/components/schemas/EvidenceLedgerArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "evidence-subnet",
       "path": "/metagraph/evidence/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetEvidenceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "health-latest",
       "path": "/metagraph/health/latest.json",
       "schema_ref": "#/components/schemas/HealthLatestArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "health-summary",
       "path": "/metagraph/health/summary.json",
       "schema_ref": "#/components/schemas/HealthSummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "health-history",
       "path": "/metagraph/health/history/{date}.json",
       "schema_ref": "#/components/schemas/HealthHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "health-subnet",
       "path": "/metagraph/health/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthSubnetArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "health-badge",
       "path": "/metagraph/health/badges/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthBadgeArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "health-trends",
       "path": "/metagraph/health/trends/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "health-trends-bulk",
       "path": "/metagraph/health/trends.json",
       "schema_ref": "#/components/schemas/BulkHealthTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "health-percentiles",
       "path": "/metagraph/health/percentiles/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthPercentilesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "health-incidents",
       "path": "/metagraph/health/incidents/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-trajectory",
       "path": "/metagraph/subnets/{netuid}/trajectory.json",
       "schema_ref": "#/components/schemas/SubnetTrajectoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-concentration",
       "path": "/metagraph/subnets/{netuid}/concentration.json",
       "schema_ref": "#/components/schemas/SubnetConcentrationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-concentration-history",
       "path": "/metagraph/subnets/{netuid}/concentration/history.json",
       "schema_ref": "#/components/schemas/SubnetConcentrationHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-turnover",
       "path": "/metagraph/subnets/{netuid}/turnover.json",
       "schema_ref": "#/components/schemas/SubnetTurnoverArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-stake-flow",
       "path": "/metagraph/subnets/{netuid}/stake-flow.json",
       "schema_ref": "#/components/schemas/SubnetStakeFlowArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-movers",
       "path": "/metagraph/subnets/movers.json",
       "schema_ref": "#/components/schemas/SubnetMoversArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "global-validators",
       "path": "/metagraph/validators.json",
       "schema_ref": "#/components/schemas/GlobalValidatorsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-metagraph",
       "path": "/metagraph/subnets/{netuid}/metagraph.json",
       "schema_ref": "#/components/schemas/SubnetMetagraphArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-neuron",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}.json",
       "schema_ref": "#/components/schemas/NeuronDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-validators",
       "path": "/metagraph/subnets/{netuid}/validators.json",
       "schema_ref": "#/components/schemas/SubnetValidatorsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-yield",
       "path": "/metagraph/subnets/{netuid}/yield.json",
       "schema_ref": "#/components/schemas/SubnetYieldArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-events",
       "path": "/metagraph/subnets/{netuid}/events.json",
       "schema_ref": "#/components/schemas/SubnetEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-neuron-history",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}/history.json",
       "schema_ref": "#/components/schemas/NeuronHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-history",
       "path": "/metagraph/subnets/{netuid}/history.json",
       "schema_ref": "#/components/schemas/SubnetHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-identity-history",
       "path": "/metagraph/subnets/{netuid}/identity-history.json",
       "schema_ref": "#/components/schemas/SubnetIdentityHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "account-summary",
       "path": "/metagraph/accounts/{ss58}.json",
       "schema_ref": "#/components/schemas/AccountSummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "account-events",
       "path": "/metagraph/accounts/{ss58}/events.json",
       "schema_ref": "#/components/schemas/AccountEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "account-history",
       "path": "/metagraph/accounts/{ss58}/history.json",
       "schema_ref": "#/components/schemas/AccountHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "account-extrinsics",
       "path": "/metagraph/accounts/{ss58}/extrinsics.json",
       "schema_ref": "#/components/schemas/AccountExtrinsicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "account-transfers",
       "path": "/metagraph/accounts/{ss58}/transfers.json",
       "schema_ref": "#/components/schemas/AccountTransfersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "account-counterparties",
       "path": "/metagraph/accounts/{ss58}/counterparties.json",
       "schema_ref": "#/components/schemas/AccountCounterpartiesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "account-stake-flow",
       "path": "/metagraph/accounts/{ss58}/stake-flow.json",
       "schema_ref": "#/components/schemas/AccountStakeFlowArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "account-subnets",
       "path": "/metagraph/accounts/{ss58}/subnets.json",
       "schema_ref": "#/components/schemas/AccountSubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "account-balance",
       "path": "/metagraph/accounts/{ss58}/balance.json",
       "schema_ref": "#/components/schemas/AccountBalanceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "blocks-feed",
       "path": "/metagraph/blocks.json",
       "schema_ref": "#/components/schemas/BlocksFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "block-detail",
       "path": "/metagraph/blocks/{ref}.json",
       "schema_ref": "#/components/schemas/BlockDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "block-extrinsics",
       "path": "/metagraph/blocks/{ref}/extrinsics.json",
       "schema_ref": "#/components/schemas/BlockExtrinsicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "block-events",
       "path": "/metagraph/blocks/{ref}/events.json",
       "schema_ref": "#/components/schemas/BlockEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "chain-events-feed",
       "path": "/metagraph/chain-events.json",
       "schema_ref": "#/components/schemas/ChainEventsFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "block-chain-events",
       "path": "/metagraph/blocks/{ref}/chain-events.json",
       "schema_ref": "#/components/schemas/BlockChainEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "chain-events-stats",
       "path": "/metagraph/chain-events/stats.json",
       "schema_ref": "#/components/schemas/ChainEventsStatsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "extrinsics-feed",
       "path": "/metagraph/extrinsics.json",
       "schema_ref": "#/components/schemas/ExtrinsicsFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "extrinsic-detail",
       "path": "/metagraph/extrinsics/{hash}.json",
       "schema_ref": "#/components/schemas/ExtrinsicDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "chain-activity",
       "path": "/metagraph/chain/activity.json",
       "schema_ref": "#/components/schemas/ChainActivityArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "chain-calls",
       "path": "/metagraph/chain/calls.json",
       "schema_ref": "#/components/schemas/ChainCallsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "chain-signers",
       "path": "/metagraph/chain/signers.json",
       "schema_ref": "#/components/schemas/ChainSignersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "chain-transfers",
       "path": "/metagraph/chain/transfers.json",
       "schema_ref": "#/components/schemas/ChainTransfersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "chain-fees",
       "path": "/metagraph/chain/fees.json",
       "schema_ref": "#/components/schemas/ChainFeesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "chain-concentration",
       "path": "/metagraph/chain/concentration.json",
       "schema_ref": "#/components/schemas/ChainConcentrationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-uptime",
       "path": "/metagraph/subnets/{netuid}/uptime.json",
       "schema_ref": "#/components/schemas/UptimeArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "global-incidents",
       "path": "/metagraph/incidents.json",
       "schema_ref": "#/components/schemas/GlobalIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",
       "schema_ref": "#/components/schemas/RegistryLeaderboardsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "compare",
       "path": "/metagraph/compare.json",
       "schema_ref": "#/components/schemas/CompareArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "rpc-usage",
       "path": "/metagraph/rpc/usage.json",
       "schema_ref": "#/components/schemas/RpcUsageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
       "schema_ref": "#/components/schemas/RpcEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "rpc-pools",
       "path": "/metagraph/rpc/pools.json",
       "schema_ref": "#/components/schemas/RpcPoolsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "endpoint-pools",
       "path": "/metagraph/endpoint-pools.json",
       "schema_ref": "#/components/schemas/EndpointPoolsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "endpoint-incidents",
       "path": "/metagraph/endpoint-incidents.json",
       "schema_ref": "#/components/schemas/EndpointIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "operational-surfaces",
       "path": "/metagraph/operational-surfaces.json",
       "schema_ref": "#/components/schemas/OperationalSurfacesArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "agent-catalog",
       "path": "/metagraph/agent-catalog.json",
       "schema_ref": "#/components/schemas/AgentCatalogArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "agent-catalog-subnet",
       "path": "/metagraph/agent-catalog/{netuid}.json",
       "schema_ref": "#/components/schemas/AgentCatalogSubnetArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",
       "schema_ref": "#/components/schemas/SchemaDriftArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "schema-index",
       "path": "/metagraph/schemas/index.json",
       "schema_ref": "#/components/schemas/SchemaIndexArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "schema-snapshot",
       "path": "/metagraph/schemas/{surface_id}.json",
       "schema_ref": "#/components/schemas/JsonObject",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",
       "schema_ref": "#/components/schemas/AdapterArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "r2-manifest",
       "path": "/metagraph/r2-manifest.json",
       "schema_ref": "#/components/schemas/R2ManifestArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "review-curation",
       "path": "/metagraph/review/curation.json",
       "schema_ref": "#/components/schemas/ReviewCurationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "review-gap-priorities",
       "path": "/metagraph/review/gap-priorities.json",
       "schema_ref": "#/components/schemas/ReviewGapPrioritiesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "subnet-gaps",
       "path": "/metagraph/review/gaps/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetGapsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "review-profile-completeness",
       "path": "/metagraph/review/profile-completeness.json",
       "schema_ref": "#/components/schemas/ReviewProfileCompletenessArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "review-adapter-candidates",
       "path": "/metagraph/review/adapter-candidates.json",
       "schema_ref": "#/components/schemas/ReviewAdapterCandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "review-enrichment-queue",
       "path": "/metagraph/review/enrichment-queue.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentQueueArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "review-enrichment-evidence",
       "path": "/metagraph/review/enrichment-evidence.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentEvidenceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "review-enrichment-targets",
       "path": "/metagraph/review/enrichment-targets.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentTargetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
       "schema_ref": "#/components/schemas/ReviewDecisionsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "id": "build-summary",
       "path": "/metagraph/build-summary.json",
       "schema_ref": "#/components/schemas/BuildSummaryArtifact",
@@ -821,7 +821,7 @@
     }
   ],
   "base_path": "/api/v1",
-  "contract_version": "2026-06-30.14",
+  "contract_version": "2026-07-01.1",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "openapi_url": "/api/v1/openapi.json",
   "primary_domain": "api.metagraph.sh",
@@ -2406,7 +2406,7 @@
     {
       "artifact_path": "/metagraph/economics.json",
       "cache": "standard",
-      "description": "List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share, registration block height). Default order is emission share descending. Filter by netuid/registration_allowed, search by name/slug, and sort with `sort=<field>&order=asc|desc` — the two are separate parameters (e.g. `?sort=block&order=asc` or `?sort=total_stake_tao&order=desc`), NOT a combined `field:desc` token.",
+      "description": "List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, alpha market-cap proxy, emission share, and registration block height). Default order is emission share descending. Filter by netuid/registration_allowed, search by name/slug, and sort with `sort=<field>&order=asc|desc` — the two are separate parameters (e.g. `?sort=alpha_market_cap_tao&order=desc` or `?sort=block&order=asc`), NOT a combined `field:desc` token.",
       "id": "economics",
       "method": "GET",
       "path": "/api/v1/economics",
@@ -2467,6 +2467,7 @@
           "name": "sort",
           "schema": {
             "enum": [
+              "alpha_market_cap_tao",
               "alpha_price_tao",
               "block",
               "emission_share",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -2,7 +2,7 @@
   "artifacts": [
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Public artifact contract metadata for metagraph.sh consumers.",
       "id": "contracts",
       "path": "/metagraph/contracts.json",
@@ -11,7 +11,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Provider/source registry.",
       "id": "providers",
       "path": "/metagraph/providers.json",
@@ -20,7 +20,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-provider detail payload.",
       "id": "provider-detail",
       "path": "/metagraph/providers/{slug}.json",
@@ -29,7 +29,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Endpoint resources for one provider or operator.",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",
@@ -38,7 +38,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Clean API route index for metagraph.sh consumers.",
       "id": "api-index",
       "path": "/metagraph/api-index.json",
@@ -47,7 +47,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "OpenAPI 3.1 contract for the metagraph.sh backend API.",
       "id": "openapi",
       "path": "/metagraph/openapi.json",
@@ -56,7 +56,7 @@
     },
     {
       "content_type": "text/plain; charset=utf-8",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Generated TypeScript definitions for metagraph.sh backend consumers.",
       "id": "type-definitions",
       "path": "/metagraph/types.d.ts",
@@ -65,7 +65,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Reviewable generated artifact and subnet-change summary.",
       "id": "changelog",
       "path": "/metagraph/changelog.json",
@@ -74,7 +74,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "All active Finney subnets with compact registry metadata.",
       "id": "subnets",
       "path": "/metagraph/subnets.json",
@@ -83,7 +83,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Latest normalized all-subnet metagraph index with chain-native state and registry coverage metadata.",
       "id": "metagraph-latest",
       "path": "/metagraph/metagraph/latest.json",
@@ -92,7 +92,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-subnet detail payload.",
       "id": "subnet-detail",
       "path": "/metagraph/subnets/{netuid}.json",
@@ -101,7 +101,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Composed per-subnet overview: profile + health + curation + gaps + counts.",
       "id": "subnet-overview",
       "path": "/metagraph/overview/{netuid}.json",
@@ -110,7 +110,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Public-safe subnet identity and completeness profiles.",
       "id": "profiles",
       "path": "/metagraph/profiles.json",
@@ -119,7 +119,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-subnet public-safe profile detail.",
       "id": "profile-detail",
       "path": "/metagraph/profiles/{netuid}.json",
@@ -128,7 +128,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Curated public interface surfaces only.",
       "id": "surfaces",
       "path": "/metagraph/surfaces.json",
@@ -137,7 +137,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Deprecated surface display-id aliases mapped to stable surface keys for renamed surfaces.",
       "id": "surface-aliases",
       "path": "/metagraph/surface-aliases.json",
@@ -146,7 +146,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Curated public interface surfaces for one subnet.",
       "id": "surfaces-subnet",
       "path": "/metagraph/surfaces/{netuid}.json",
@@ -155,7 +155,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Generalized endpoint/resource registry derived from curated surfaces and probe observations.",
       "id": "endpoints",
       "path": "/metagraph/endpoints.json",
@@ -164,7 +164,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Generalized endpoint/resource registry for one subnet.",
       "id": "endpoints-subnet",
       "path": "/metagraph/endpoints/{netuid}.json",
@@ -173,7 +173,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Unpromoted candidate surfaces from public discovery.",
       "id": "candidates",
       "path": "/metagraph/candidates.json",
@@ -182,7 +182,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Unpromoted candidate surfaces for one subnet.",
       "id": "candidates-subnet",
       "path": "/metagraph/candidates/{netuid}.json",
@@ -191,7 +191,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Candidate surfaces queued for maintainer review.",
       "id": "review-queue",
       "path": "/metagraph/review-queue.json",
@@ -200,7 +200,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Compact search index for subnets, surfaces, and providers.",
       "id": "search",
       "path": "/metagraph/search.json",
@@ -209,7 +209,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Slim search index (the same documents as search.json without the per-document token blobs) for fast browser typeahead and listing.",
       "id": "search-index",
       "path": "/metagraph/search-index.json",
@@ -218,7 +218,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Registry coverage counts and source precedence.",
       "id": "coverage",
       "path": "/metagraph/coverage.json",
@@ -227,7 +227,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Machine-usable coverage depth scorecard with per-subnet readiness dimensions and a ranked enrichment queue.",
       "id": "coverage-depth",
       "path": "/metagraph/coverage-depth.json",
@@ -236,7 +236,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-subnet validator and economic metrics from the chain: validator/miner counts, total + max stake, registration cost, alpha price, derived price-weighted emission share, and on-chain registration block height.",
       "id": "economics",
       "path": "/metagraph/economics.json",
@@ -245,7 +245,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Network-wide economics time series (#1307) aggregated per UTC day across all subnets from the daily subnet_snapshots D1 rollup (the same source the per-subnet trajectory reads), served live at /api/v1/economics/trends (no static file).",
       "id": "economics-trends",
       "path": "/metagraph/economics/trends.json",
@@ -254,7 +254,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Registry-wide summary: completeness rollup, top subnets, level counts, latest changes.",
       "id": "registry-summary",
       "path": "/metagraph/registry-summary.json",
@@ -263,7 +263,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Cross-network subnet lineage: maintainer-approved mainnet ↔ testnet pairs with reviewed match evidence.",
       "id": "lineage",
       "path": "/metagraph/lineage.json",
@@ -272,7 +272,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Index of captured live request/response fixtures (which surfaces carry a sanitized sample).",
       "id": "fixtures-index",
       "path": "/metagraph/fixtures.json",
@@ -281,7 +281,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Machine index of every AI resource: the copyable agent, the MCP server + tools, the skill, llms.txt, OpenAPI, and the agent-facing APIs.",
       "id": "agent-resources",
       "path": "/metagraph/agent-resources.json",
@@ -290,7 +290,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "A captured, sanitized live request/response sample for one surface.",
       "id": "fixture-detail",
       "path": "/metagraph/fixtures/{surface_id}.json",
@@ -299,7 +299,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Curation state and gaps for every active subnet.",
       "id": "curation",
       "path": "/metagraph/curation.json",
@@ -308,7 +308,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Missing public interface facets by subnet.",
       "id": "gaps",
       "path": "/metagraph/gaps.json",
@@ -317,7 +317,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Latest candidate verification snapshot.",
       "id": "verification",
       "path": "/metagraph/verification/latest.json",
@@ -326,7 +326,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Latest candidate verification snapshot for one subnet.",
       "id": "verification-subnet",
       "path": "/metagraph/verification/subnets/{netuid}.json",
@@ -335,7 +335,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Freshness and staleness summary for generated backend data.",
       "id": "freshness",
       "path": "/metagraph/freshness.json",
@@ -344,7 +344,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Upstream source and provider health summary.",
       "id": "source-health",
       "path": "/metagraph/source-health.json",
@@ -353,7 +353,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Compact hashes and counts for canonical source inputs.",
       "id": "source-snapshots",
       "path": "/metagraph/source-snapshots.json",
@@ -362,7 +362,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Public evidence ledger for subnet and surface claims.",
       "id": "evidence-ledger",
       "path": "/metagraph/evidence-ledger.json",
@@ -371,7 +371,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Public evidence ledger claims for one subnet.",
       "id": "evidence-subnet",
       "path": "/metagraph/evidence/{netuid}.json",
@@ -380,7 +380,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Latest surface health snapshot.",
       "id": "health-latest",
       "path": "/metagraph/health/latest.json",
@@ -389,7 +389,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Global and per-subnet health rollup.",
       "id": "health-summary",
       "path": "/metagraph/health/summary.json",
@@ -398,7 +398,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Compact daily health-history snapshot.",
       "id": "health-history",
       "path": "/metagraph/health/history/{date}.json",
@@ -407,7 +407,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-subnet health payload for metagraph.sh consumers.",
       "id": "health-subnet",
       "path": "/metagraph/health/subnets/{netuid}.json",
@@ -416,7 +416,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Badge data contract for status rendering.",
       "id": "health-badge",
       "path": "/metagraph/health/badges/{netuid}.json",
@@ -425,7 +425,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Computed 7d/30d uptime + success-only latency trends (mean, p50/p95/p99 tail, and healthy-sample count) for one subnet's operational surfaces. Served live from D1 at /api/v1/subnets/{netuid}/health/trends (no static file).",
       "id": "health-trends",
       "path": "/metagraph/health/trends/{netuid}.json",
@@ -434,7 +434,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Compact all-subnet 7d/30d daily uptime + success-only latency trend matrix (mean + healthy-sample count). Served live from D1 at /api/v1/health/trends (no static file).",
       "id": "health-trends-bulk",
       "path": "/metagraph/health/trends.json",
@@ -443,7 +443,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Latency percentiles (p50/p95/p99 + avg/min/max) per operational surface for one subnet, computed live from D1 at /api/v1/subnets/{netuid}/health/percentiles (no static file).",
       "id": "health-percentiles",
       "path": "/metagraph/health/percentiles/{netuid}.json",
@@ -452,7 +452,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "SLA (uptime ratio) and reconstructed downtime incidents per operational surface for one subnet, computed live from D1 at /api/v1/subnets/{netuid}/health/incidents (no static file).",
       "id": "health-incidents",
       "path": "/metagraph/health/incidents/{netuid}.json",
@@ -461,7 +461,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Week-over-week structural trajectory (completeness + surface/endpoint counts) for one subnet from daily snapshots, served live from D1 at /api/v1/subnets/{netuid}/trajectory (no static file).",
       "id": "subnet-trajectory",
       "path": "/metagraph/subnets/{netuid}/trajectory.json",
@@ -470,7 +470,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Stake & emission concentration metrics (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) for one subnet across three lenses — per-UID, per-entity (coldkeys collapsed to the true control distribution), and validator-only consensus power — served live from the neurons D1 tier at /api/v1/subnets/{netuid}/concentration (no static file).",
       "id": "subnet-concentration",
       "path": "/metagraph/subnets/{netuid}/concentration.json",
@@ -479,7 +479,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/concentration/history (no static file).",
       "id": "subnet-concentration-history",
       "path": "/metagraph/subnets/{netuid}/concentration/history.json",
@@ -488,7 +488,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + Jaccard retention, UID deregistrations, and a 0-100 stability score — served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/turnover (no static file).",
       "id": "subnet-turnover",
       "path": "/metagraph/subnets/{netuid}/turnover.json",
@@ -497,7 +497,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Net stake flow for one subnet over a recent window (7d/30d/90d): total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and event counts, summed live from the account_events stream at /api/v1/subnets/{netuid}/stake-flow (no static file).",
       "id": "subnet-stake-flow",
       "path": "/metagraph/subnets/{netuid}/stake-flow.json",
@@ -506,7 +506,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between a window's start and end snapshots, computed live from the neuron_daily D1 rollup at /api/v1/subnets/movers (no static file).",
       "id": "subnet-movers",
       "path": "/metagraph/subnets/movers.json",
@@ -515,7 +515,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships and ranked by subnet footprint, UID footprint, validator trust, or cross-subnet stake/emission totals, computed live from the neurons D1 tier at /api/v1/validators (no static file).",
       "id": "global-validators",
       "path": "/metagraph/validators.json",
@@ -524,7 +524,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-UID metagraph (stake, trust, consensus, incentive, dividends, emission, validator_permit, rank, axon) for one subnet, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/metagraph (no static file).",
       "id": "subnet-metagraph",
       "path": "/metagraph/subnets/{netuid}/metagraph.json",
@@ -533,7 +533,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "A single neuron's metagraph state by UID, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/neurons/{uid} (no static file).",
       "id": "subnet-neuron",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}.json",
@@ -542,7 +542,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Validators (validator_permit) of one subnet ranked by stake, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/validators (no static file).",
       "id": "subnet-validators",
       "path": "/metagraph/subnets/{netuid}/validators.json",
@@ -551,7 +551,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-UID emission yield (emission/stake return rate) for one subnet over the current metagraph snapshot, ranked high to low with a distribution summary (subnet aggregate yield, mean, p25/median/p75/p90 percentiles), a validator/miner split, and a per-UID above/below-median label, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/yield (no static file).",
       "id": "subnet-yield",
       "path": "/metagraph/subnets/{netuid}/yield.json",
@@ -560,7 +560,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "First-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, served live from the account_events D1 tier filtered by netuid at /api/v1/subnets/{netuid}/events (no static file).",
       "id": "subnet-events",
       "path": "/metagraph/subnets/{netuid}/events.json",
@@ -569,7 +569,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-UID daily metagraph history (stake/trust/emission/rank over time) for one UID, served live from the neuron_daily D1 rollup tier at /api/v1/subnets/{netuid}/neurons/{uid}/history (no static file).",
       "id": "subnet-neuron-history",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}/history.json",
@@ -578,7 +578,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-subnet daily aggregate history (neuron/validator counts + stake/emission totals) for one subnet, served live from the neuron_daily D1 rollup tier at /api/v1/subnets/{netuid}/history (no static file).",
       "id": "subnet-history",
       "path": "/metagraph/subnets/{netuid}/history.json",
@@ -587,7 +587,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Append-only on-chain identity timeline for one subnet (SubnetIdentitiesV3 field snapshots on change), served live from the subnet_identity_history D1 tier at /api/v1/subnets/{netuid}/identity-history (no static file).",
       "id": "subnet-identity-history",
       "path": "/metagraph/subnets/{netuid}/identity-history.json",
@@ -596,7 +596,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Cross-subnet activity summary for one account (hotkey or coldkey): chain-event aggregates joined to current registrations, served live from D1 at /api/v1/accounts/{ss58} (no static file).",
       "id": "account-summary",
       "path": "/metagraph/accounts/{ss58}.json",
@@ -605,7 +605,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events (no static file).",
       "id": "account-events",
       "path": "/metagraph/accounts/{ss58}/events.json",
@@ -614,7 +614,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Durable per-day activity series for one account (hotkey-keyed, newest day first), served live from the account_events_daily rollup at /api/v1/accounts/{ss58}/history (no static file).",
       "id": "account-history",
       "path": "/metagraph/accounts/{ss58}/history.json",
@@ -623,7 +623,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Paginated extrinsics this account signed (by signer), newest first, served live from the extrinsics D1 tier at /api/v1/accounts/{ss58}/extrinsics (no static file).",
       "id": "account-extrinsics",
       "path": "/metagraph/accounts/{ss58}/extrinsics.json",
@@ -632,7 +632,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers (no static file).",
       "id": "account-transfers",
       "path": "/metagraph/accounts/{ss58}/transfers.json",
@@ -641,7 +641,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-counterparty fund-flow rollup for one account, with optional ?counterparty=<ss58> relationship evidence — native-TAO transfers from the account_events D1 tier at /api/v1/accounts/{ss58}/counterparties (no static file).",
       "id": "account-counterparties",
       "path": "/metagraph/accounts/{ss58}/counterparties.json",
@@ -650,7 +650,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "One account's StakeAdded vs StakeRemoved flow per subnet over a recent window (7d/30d/90d): per-subnet net and gross flow with a direction label, plus account totals, an HHI concentration of where the flow is focused, and the dominant subnet — summed live from the account_events D1 tier at /api/v1/accounts/{ss58}/stake-flow (no static file).",
       "id": "account-stake-flow",
       "path": "/metagraph/accounts/{ss58}/stake-flow.json",
@@ -659,7 +659,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "The subnets where an account's hotkey is currently registered, served live from the neurons D1 tier at /api/v1/accounts/{ss58}/subnets (no static file).",
       "id": "account-subnets",
       "path": "/metagraph/accounts/{ss58}/subnets.json",
@@ -668,7 +668,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Live TAO balance (free+reserved, in TAO) for a finney account, queried from the RPC at request time with 60s KV cache. balance_tao is null on RPC failure. (#1818)",
       "id": "account-balance",
       "path": "/metagraph/accounts/{ss58}/balance.json",
@@ -677,7 +677,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "The recent-block feed (newest first) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks (no static file).",
       "id": "blocks-feed",
       "path": "/metagraph/blocks.json",
@@ -686,7 +686,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks/{ref} (no static file).",
       "id": "block-detail",
       "path": "/metagraph/blocks/{ref}.json",
@@ -695,7 +695,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "The extrinsics in one block (by numeric block_number or 0x block_hash), in natural order, served live from the first-party extrinsics D1 tier at /api/v1/blocks/{ref}/extrinsics (no static file).",
       "id": "block-extrinsics",
       "path": "/metagraph/blocks/{ref}/extrinsics.json",
@@ -704,7 +704,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "The decoded chain events in one block (by numeric block_number or 0x block_hash), in natural order, served live from the first-party account_events D1 tier filtered by block_number at /api/v1/blocks/{ref}/events (no static file).",
       "id": "block-events",
       "path": "/metagraph/blocks/{ref}/events.json",
@@ -713,7 +713,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events (no static file). Distinct from the curated account-attributed event stream; empty before the all-events backfill runs.",
       "id": "chain-events-feed",
       "path": "/metagraph/chain-events.json",
@@ -722,7 +722,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Every raw pallet-level event in one block (event_index ascending) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/blocks/{ref}/chain-events (no static file). Distinct from /blocks/{ref}/events (the curated account-attributed D1 stream).",
       "id": "block-chain-events",
       "path": "/metagraph/blocks/{ref}/chain-events.json",
@@ -731,7 +731,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Chain-activity aggregate (pallet.method event distribution over the most recent N blocks) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events/stats (no static file) and consumed by the get_chain_activity MCP tool.",
       "id": "chain-events-stats",
       "path": "/metagraph/chain-events/stats.json",
@@ -740,7 +740,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "The recent-extrinsic feed (newest first) for the block explorer (#1345), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics (no static file).",
       "id": "extrinsics-feed",
       "path": "/metagraph/extrinsics.json",
@@ -749,7 +749,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics/{hash} (no static file).",
       "id": "extrinsic-detail",
       "path": "/metagraph/extrinsics/{hash}.json",
@@ -758,7 +758,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Daily network-activity aggregates (extrinsic/event/block counts, success rate, unique signers) over a 7d or 30d window for the block explorer (#1987), computed live from the first-party chain D1 tiers at /api/v1/chain/activity (no static file).",
       "id": "chain-activity",
       "path": "/metagraph/chain/activity.json",
@@ -767,7 +767,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Extrinsic call-mix breakdown (count + share per call_module / call_function) over a 7d or 30d window for the block explorer (#1989), computed live from the first-party extrinsics D1 tier at /api/v1/chain/calls (no static file).",
       "id": "chain-calls",
       "path": "/metagraph/chain/calls.json",
@@ -776,7 +776,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Windowed most-active-account leaderboard (signers ranked by tx_count or total_fee_tao, with fees/tips + newest block) over a 7d or 30d window for the block explorer (#1990), computed live from the first-party extrinsics D1 tier at /api/v1/chain/signers (no static file).",
       "id": "chain-signers",
       "path": "/metagraph/chain/signers.json",
@@ -785,7 +785,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Network-wide native-TAO transfer analytics over a 7d or 30d window: total Balances.Transfer volume + count, distinct senders/receivers, the top senders and receivers ranked by volume, and the top senders' share of total volume (a concentration signal), computed live from the account_events Transfer feed at /api/v1/chain/transfers (no static file).",
       "id": "chain-transfers",
       "path": "/metagraph/chain/transfers.json",
@@ -794,7 +794,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Fee/tip market analytics (daily totals, averages, exact medians, and a top-fee-payer list) over a 7d or 30d window for the block explorer (#1988), computed live from the first-party extrinsics D1 tier at /api/v1/chain/fees (no static file).",
       "id": "chain-fees",
       "path": "/metagraph/chain/fees.json",
@@ -803,7 +803,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Network-wide stake and emission concentration metrics (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) aggregated across all subnets' neurons over three lenses (per-UID, per-entity with coldkeys collapsed across subnets into the network control distribution, and validator-only consensus power), computed live from the neurons D1 tier at /api/v1/chain/concentration (no static file).",
       "id": "chain-concentration",
       "path": "/metagraph/chain/concentration.json",
@@ -812,7 +812,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Long-term daily uptime history per operational surface for one subnet (90d/1y window), served live from the surface_uptime_daily D1 rollup (no static file).",
       "id": "subnet-uptime",
       "path": "/metagraph/subnets/{netuid}/uptime.json",
@@ -821,7 +821,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window, served live from D1 at /api/v1/incidents (no static file).",
       "id": "global-incidents",
       "path": "/metagraph/incidents.json",
@@ -830,7 +830,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Registry leaderboards — operational (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable) and economic opportunity (open-slots, cheapest-registration, highest-emission, validator-headroom) — computed live from D1 + registry projections + the economics tier at /api/v1/registry/leaderboards (no static file).",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",
@@ -839,7 +839,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Cross-subnet comparison — registry structure (completeness + surface counts), the live economics tier, and the live per-subnet health rollup placed side by side for the requested netuids in requested order — computed live from registry projections + the economics tier + D1 at /api/v1/compare (no static file).",
       "id": "compare",
       "path": "/metagraph/compare.json",
@@ -848,7 +848,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets) over a 7d/30d window, computed live from the rpc_proxy_events telemetry at /api/v1/rpc/usage (no static file).",
       "id": "rpc-usage",
       "path": "/metagraph/rpc/usage.json",
@@ -857,7 +857,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Bittensor base-layer RPC endpoint registry and probe status.",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
@@ -866,7 +866,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Endpoint pool scoring for future read-only RPC routing.",
       "id": "rpc-pools",
       "path": "/metagraph/rpc/pools.json",
@@ -875,7 +875,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Generalized endpoint pool scoring for future read-only routing.",
       "id": "endpoint-pools",
       "path": "/metagraph/endpoint-pools.json",
@@ -884,7 +884,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Probe-derived endpoint incident summary and active endpoint failures.",
       "id": "endpoint-incidents",
       "path": "/metagraph/endpoint-incidents.json",
@@ -893,7 +893,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Operational surfaces (RPC/WSS/subnet-api/SSE/data-artifact) probed live by the cron health prober; input list for the 15-minute scheduled prober.",
       "id": "operational-surfaces",
       "path": "/metagraph/operational-surfaces.json",
@@ -902,7 +902,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Compact index of subnets exposing callable services (subnet-api/openapi/sse/data-artifact) — the machine-readable 'which subnet does X + how to call it' index for AI agents.",
       "id": "agent-catalog",
       "path": "/metagraph/agent-catalog.json",
@@ -911,7 +911,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Per-subnet agent capability catalog: each callable service with its base URL, auth, machine-readable schema, and live-build health/eligibility.",
       "id": "agent-catalog-subnet",
       "path": "/metagraph/agent-catalog/{netuid}.json",
@@ -920,7 +920,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "OpenAPI schema snapshot/drift status.",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",
@@ -929,7 +929,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Index of captured machine-readable schemas.",
       "id": "schema-index",
       "path": "/metagraph/schemas/index.json",
@@ -938,7 +938,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Captured machine-readable OpenAPI/Swagger schema snapshot detail.",
       "id": "schema-snapshot",
       "path": "/metagraph/schemas/{surface_id}.json",
@@ -947,7 +947,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Adapter-backed public metrics by subnet slug.",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",
@@ -956,7 +956,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "R2 upload manifest for generated artifact history.",
       "id": "r2-manifest",
       "path": "/metagraph/r2-manifest.json",
@@ -965,7 +965,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Maintainer curation and adapter candidate report.",
       "id": "review-curation",
       "path": "/metagraph/review/curation.json",
@@ -974,7 +974,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Subnet interface gap priorities.",
       "id": "review-gap-priorities",
       "path": "/metagraph/review/gap-priorities.json",
@@ -983,7 +983,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Interface gap priorities and enrichment queue for one subnet.",
       "id": "subnet-gaps",
       "path": "/metagraph/review/gaps/{netuid}.json",
@@ -992,7 +992,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Profile completeness and contributor targeting report.",
       "id": "review-profile-completeness",
       "path": "/metagraph/review/profile-completeness.json",
@@ -1001,7 +1001,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Subnets worth deeper adapter work.",
       "id": "review-adapter-candidates",
       "path": "/metagraph/review/adapter-candidates.json",
@@ -1010,7 +1010,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Prioritized all-subnet enrichment work queue for contributor-safe registry improvements.",
       "id": "review-enrichment-queue",
       "path": "/metagraph/review/enrichment-queue.json",
@@ -1019,7 +1019,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Detailed candidate evidence by missing or contributor-target surface kind for enrichment work.",
       "id": "review-enrichment-evidence",
       "path": "/metagraph/review/enrichment-evidence.json",
@@ -1028,7 +1028,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Contributor-oriented enrichment target pack grouped by submission kind, review route, and evidence action.",
       "id": "review-enrichment-targets",
       "path": "/metagraph/review/enrichment-targets.json",
@@ -1037,7 +1037,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Public-safe maintainer review decision ledger.",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
@@ -1046,7 +1046,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-06-30.14",
+      "contract_version": "2026-07-01.1",
       "description": "Generated build summary.",
       "id": "build-summary",
       "path": "/metagraph/build-summary.json",
@@ -1055,7 +1055,7 @@
     }
   ],
   "base_path": "/metagraph",
-  "contract_version": "2026-06-30.14",
+  "contract_version": "2026-07-01.1",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "name": "Metagraphed public backend artifact contract",
   "notes": [

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -12167,6 +12167,13 @@
               "null"
             ]
           },
+          "alpha_market_cap_tao": {
+            "description": "Derived market-cap proxy: alpha_price_tao multiplied by total_stake_tao, where total_stake_tao is the circulating-alpha proxy. Null when either input is missing.",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "alpha_out_pool": {
             "type": [
               "number",
@@ -12296,6 +12303,7 @@
           "registration_allowed",
           "registration_cost_tao",
           "alpha_price_tao",
+          "alpha_market_cap_tao",
           "total_stake_tao",
           "max_stake_tao",
           "tao_in_pool_tao",
@@ -15508,7 +15516,7 @@
   "info": {
     "description": "Public, read-only API over canonical Metagraphed registry artifacts for Bittensor subnet interfaces. **No authentication** — every operation is an unauthenticated GET. Responses use a stable JSON envelope `{ ok, schema_version, data, meta }` (errors: `{ ok: false, error }`) and carry `ETag` + `Cache-Control` for conditional caching. Rate-limited per client. Multi-network: insert a `/{network}/` segment after `/api/v1/` (mainnet is the default — omit it) to read testnet data, e.g. `/api/v1/testnet/subnets`. Testnet exposes the subset of routes that have data; `/api/v1/lineage` tracks which testnet subnets have graduated.",
     "title": "Metagraphed API",
-    "version": "2026-06-30.14"
+    "version": "2026-07-01.1"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -21602,6 +21610,7 @@
             "required": false,
             "schema": {
               "enum": [
+                "alpha_market_cap_tao",
                 "alpha_price_tao",
                 "block",
                 "emission_share",
@@ -21649,6 +21658,7 @@
                     "subnets": [
                       {
                         "alpha_in_pool": 0.5,
+                        "alpha_market_cap_tao": 0.5,
                         "alpha_out_pool": 0.5,
                         "alpha_price_tao": 0.5,
                         "emission_share": 0.5,
@@ -21777,7 +21787,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share, registration block height). Default order is emission share descending. Filter by netuid/registration_allowed, search by name/slug, and sort with `sort=<field>&order=asc|desc` — the two are separate parameters (e.g. `?sort=block&order=asc` or `?sort=total_stake_tao&order=desc`), NOT a combined `field:desc` token.",
+        "summary": "List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, alpha market-cap proxy, emission share, and registration block height). Default order is emission share descending. Filter by netuid/registration_allowed, search by name/slug, and sort with `sort=<field>&order=asc|desc` — the two are separate parameters (e.g. `?sort=alpha_market_cap_tao&order=desc` or `?sort=block&order=asc`), NOT a combined `field:desc` token.",
         "tags": [
           "subnets"
         ]
@@ -30577,6 +30587,7 @@
                     "contract_version": "2026-06-29.1",
                     "economics": {
                       "alpha_in_pool": 0.5,
+                      "alpha_market_cap_tao": 0.5,
                       "alpha_out_pool": 0.5,
                       "alpha_price_tao": 0.5,
                       "block": 5000000,
@@ -36498,7 +36509,7 @@
   ],
   "x-metagraphed": {
     "canonical_artifact_base_path": "/metagraph",
-    "contract_version": "2026-06-30.14",
+    "contract_version": "2026-07-01.1",
     "generated_at": "1970-01-01T00:00:00.000Z",
     "notes": "OpenAPI describes Worker response envelopes and canonical artifact payloads. Raw /metagraph JSON remains the reviewed source contract.",
     "schema_version": 1

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -606,7 +606,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share, registration block height). Default order is emission share descending. Filter by netuid/registration_allowed, search by name/slug, and sort with `sort=<field>&order=asc|desc` — the two are separate parameters (e.g. `?sort=block&order=asc` or `?sort=total_stake_tao&order=desc`), NOT a combined `field:desc` token. */
+        /** List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, alpha market-cap proxy, emission share, and registration block height). Default order is emission share descending. Filter by netuid/registration_allowed, search by name/slug, and sort with `sort=<field>&order=asc|desc` — the two are separate parameters (e.g. `?sort=alpha_market_cap_tao&order=desc` or `?sort=block&order=asc`), NOT a combined `field:desc` token. */
         get: operations["economics"];
         put?: never;
         post?: never;
@@ -4719,6 +4719,8 @@ export interface components {
         /** @description Per-subnet validator and economic metrics derived from the chain metagraph (#1009). TAO-denominated fields are floats; emission_share is the subnet's alpha price as a fraction of the network total (the dTAO emission weight). Owner keys are public on-chain SS58 addresses. */
         SubnetEconomics: {
             alpha_in_pool: number | null;
+            /** @description Derived market-cap proxy: alpha_price_tao multiplied by total_stake_tao, where total_stake_tao is the circulating-alpha proxy. Null when either input is missing. */
+            alpha_market_cap_tao: number | null;
             alpha_out_pool: number | null;
             alpha_price_tao: number | null;
             /** @description Block height at which this subnet was registered on-chain — the same field the subnets collection exposes for sorting and range filters. */
@@ -9999,7 +10001,7 @@ export interface operations {
                 limit?: number;
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
-                sort?: "alpha_price_tao" | "block" | "emission_share" | "max_stake_tao" | "max_uids" | "max_validators" | "miner_count" | "miner_readiness" | "name" | "netuid" | "open_slots" | "registration_cost_tao" | "subnet_volume_tao" | "total_stake_tao" | "validator_count";
+                sort?: "alpha_market_cap_tao" | "alpha_price_tao" | "block" | "emission_share" | "max_stake_tao" | "max_uids" | "max_validators" | "miner_count" | "miner_readiness" | "name" | "netuid" | "open_slots" | "registration_cost_tao" | "subnet_volume_tao" | "total_stake_tao" | "validator_count";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
             };
@@ -10030,6 +10032,7 @@ export interface operations {
                      *         "subnets": [
                      *           {
                      *             "alpha_in_pool": 0.5,
+                     *             "alpha_market_cap_tao": 0.5,
                      *             "alpha_out_pool": 0.5,
                      *             "alpha_price_tao": 0.5,
                      *             "emission_share": 0.5,
@@ -15457,6 +15460,7 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "economics": {
                      *           "alpha_in_pool": 0.5,
+                     *           "alpha_market_cap_tao": 0.5,
                      *           "alpha_out_pool": 0.5,
                      *           "alpha_price_tao": 0.5,
                      *           "block": 5000000,

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -12145,6 +12145,13 @@
               "null"
             ]
           },
+          "alpha_market_cap_tao": {
+            "description": "Derived market-cap proxy: alpha_price_tao multiplied by total_stake_tao, where total_stake_tao is the circulating-alpha proxy. Null when either input is missing.",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "alpha_out_pool": {
             "type": [
               "number",
@@ -12274,6 +12281,7 @@
           "registration_allowed",
           "registration_cost_tao",
           "alpha_price_tao",
+          "alpha_market_cap_tao",
           "total_stake_tao",
           "max_stake_tao",
           "tao_in_pool_tao",

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1257,6 +1257,7 @@
           "registration_allowed",
           "registration_cost_tao",
           "alpha_price_tao",
+          "alpha_market_cap_tao",
           "total_stake_tao",
           "max_stake_tao",
           "tao_in_pool_tao",
@@ -1283,6 +1284,10 @@
           "registration_allowed": { "type": "boolean" },
           "registration_cost_tao": { "type": ["number", "null"] },
           "alpha_price_tao": { "type": ["number", "null"] },
+          "alpha_market_cap_tao": {
+            "type": ["number", "null"],
+            "description": "Derived market-cap proxy: alpha_price_tao multiplied by total_stake_tao, where total_stake_tao is the circulating-alpha proxy. Null when either input is missing."
+          },
           "total_stake_tao": { "type": ["number", "null"] },
           "max_stake_tao": { "type": ["number", "null"] },
           "tao_in_pool_tao": { "type": ["number", "null"] },

--- a/scripts/lib/economics-artifacts.mjs
+++ b/scripts/lib/economics-artifacts.mjs
@@ -40,6 +40,15 @@ export function computeMinerReadiness(economics, openSlots, emissionShare) {
   return Math.max(0, Math.min(100, score));
 }
 
+export function computeAlphaMarketCapTao(alphaPriceTao, totalStakeTao) {
+  if (!Number.isFinite(alphaPriceTao) || !Number.isFinite(totalStakeTao)) {
+    return null;
+  }
+  // total_stake_tao is the on-chain circulating-alpha proxy for this display
+  // metric until a dedicated circulating-alpha supply field is available.
+  return alphaPriceTao * totalStakeTao;
+}
+
 export function buildEconomicsArtifact({
   subnets,
   economicsByNetuid,
@@ -76,12 +85,17 @@ export function buildEconomicsArtifact({
       numericOrZero(economics.miner_count);
     const maxUids = numericOrZero(economics.max_uids);
     const openSlots = maxUids > 0 ? Math.max(0, maxUids - participants) : null;
+    const alphaMarketCapTao = computeAlphaMarketCapTao(
+      price,
+      economics.total_stake_tao,
+    );
     return {
       netuid: subnet.netuid,
       slug: subnet.slug,
       name: subnet.name,
       block: subnet.block ?? null,
       ...economics,
+      alpha_market_cap_tao: alphaMarketCapTao,
       emission_share: emissionShare,
       open_slots: openSlots,
       miner_readiness: computeMinerReadiness(

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2,7 +2,7 @@ import { artifactStorageTierForPath } from "./artifact-storage.mjs";
 import { DOMAIN_TAGS } from "./domain-tags.mjs";
 import { sampleFromSchema } from "./openapi-sample.mjs";
 
-export const CONTRACT_VERSION = "2026-06-30.14";
+export const CONTRACT_VERSION = "2026-07-01.1";
 export const SCHEMA_VERSION = 1;
 // The API + artifacts are served from the api subdomain; the bare apex
 // (metagraph.sh) is the metagraphed-ui UI. PRIMARY_DOMAIN drives the OpenAPI
@@ -193,6 +193,7 @@ export const API_QUERY_COLLECTIONS = {
     },
     search: ["name", "slug"],
     sort: [
+      "alpha_market_cap_tao",
       "alpha_price_tao",
       "block",
       "emission_share",
@@ -1519,7 +1520,7 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/economics",
     "/metagraph/economics.json",
-    "List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, emission share, registration block height). Default order is emission share descending. Filter by netuid/registration_allowed, search by name/slug, and sort with `sort=<field>&order=asc|desc` — the two are separate parameters (e.g. `?sort=block&order=asc` or `?sort=total_stake_tao&order=desc`), NOT a combined `field:desc` token.",
+    "List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, alpha market-cap proxy, emission share, and registration block height). Default order is emission share descending. Filter by netuid/registration_allowed, search by name/slug, and sort with `sort=<field>&order=asc|desc` — the two are separate parameters (e.g. `?sort=alpha_market_cap_tao&order=desc` or `?sort=block&order=asc`), NOT a combined `field:desc` token.",
     "standard",
     ["subnets"],
     listQuery("economics"),

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -131,6 +131,7 @@ export const SDL = `
     slug: String
     emission_share: Float
     alpha_price_tao: Float
+    alpha_market_cap_tao: Float
     registration_allowed: Boolean
     registration_cost_tao: Float
     open_slots: Int

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -19,7 +19,7 @@ import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
 
 describe("public contract registry", () => {
   test("keeps API routes and artifacts unique", () => {
-    assert.equal(CONTRACT_VERSION, "2026-06-30.14");
+    assert.equal(CONTRACT_VERSION, "2026-07-01.1");
     assert.equal(CACHE_SECONDS.short, 60);
     assert.equal(
       new Set(API_ROUTES.map((route) => route.id)).size,

--- a/tests/economics-artifacts.test.mjs
+++ b/tests/economics-artifacts.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  computeAlphaMarketCapTao,
   computeMinerReadiness,
   buildEconomicsArtifact,
 } from "../scripts/lib/economics-artifacts.mjs";
@@ -116,6 +117,34 @@ describe("computeMinerReadiness", () => {
   });
 });
 
+// --- computeAlphaMarketCapTao ----------------------------------------------
+
+describe("computeAlphaMarketCapTao", () => {
+  test("multiplies finite alpha price by the total-stake supply proxy", () => {
+    assert.equal(computeAlphaMarketCapTao(0.04, 1000), 40);
+  });
+
+  test("returns null when alpha price is missing", () => {
+    assert.equal(computeAlphaMarketCapTao(null, 1000), null);
+  });
+
+  test("returns null when total stake is missing", () => {
+    assert.equal(computeAlphaMarketCapTao(0.04, null), null);
+  });
+
+  test("returns null when both inputs are missing", () => {
+    assert.equal(computeAlphaMarketCapTao(undefined, undefined), null);
+  });
+
+  test("returns null for non-finite inputs", () => {
+    assert.equal(computeAlphaMarketCapTao(Number.NaN, 1000), null);
+    assert.equal(
+      computeAlphaMarketCapTao(0.04, Number.POSITIVE_INFINITY),
+      null,
+    );
+  });
+});
+
 // --- buildEconomicsArtifact -------------------------------------------------
 
 function econSubnet(netuid, overrides = {}) {
@@ -171,6 +200,7 @@ describe("buildEconomicsArtifact", () => {
     const row = artifact.subnets[0];
     assert.equal(row.block, 1_234_567);
     assert.equal(row.emission_share, 1); // only priced subnet → 100% of total
+    assert.equal(row.alpha_market_cap_tao, 40);
     assert.equal(row.open_slots, 47); // 256 − 9 − 200
     // 40 registration + 30 open slots + 20 cost≤1 + 10 active.
     assert.equal(row.miner_readiness, 100);
@@ -194,6 +224,7 @@ describe("buildEconomicsArtifact", () => {
     });
     assert.equal(artifact.subnets.length, 1);
     assert.equal(artifact.subnets[0].netuid, 1);
+    assert.equal(artifact.subnets[0].alpha_market_cap_tao, 0.2);
     assert.equal(artifact.summary.subnet_count, 2);
     assert.equal(artifact.summary.with_economics_count, 1);
   });
@@ -262,6 +293,7 @@ describe("buildEconomicsArtifact", () => {
       generatedAt: "2026-06-25T00:00:00.000Z",
     });
     assert.equal(artifact.subnets[0].emission_share, null);
+    assert.equal(artifact.subnets[0].alpha_market_cap_tao, null);
   });
 
   test("open_slots is null without max_uids and clamps to zero when oversubscribed", () => {

--- a/tests/economics-query.test.mjs
+++ b/tests/economics-query.test.mjs
@@ -9,18 +9,21 @@ const blob = {
       netuid: 1,
       name: "apex",
       validator_count: 50,
+      alpha_market_cap_tao: 25,
       registration_allowed: true,
     },
     {
       netuid: 2,
       name: "beta",
       validator_count: 10,
+      alpha_market_cap_tao: null,
       registration_allowed: false,
     },
     {
       netuid: 3,
       name: "gamma",
       validator_count: 90,
+      alpha_market_cap_tao: 100,
       registration_allowed: true,
     },
   ],
@@ -41,6 +44,17 @@ test("economics collection filters by registration_allowed (boolean as string)",
   const url = new URL("https://x/api/v1/economics?registration_allowed=true");
   const { data } = applyQueryFilters(blob, url, "economics", []);
   assert.deepEqual(data.subnets.map((s) => s.netuid).sort(), [1, 3]);
+});
+
+test("economics collection sorts by alpha_market_cap_tao with nulls last", () => {
+  const url = new URL(
+    "https://x/api/v1/economics?sort=alpha_market_cap_tao&order=desc",
+  );
+  const { data } = applyQueryFilters(blob, url, "economics", []);
+  assert.deepEqual(
+    data.subnets.map((s) => s.netuid),
+    [3, 1, 2],
+  );
 });
 
 test("economics collection searches by name", () => {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1168,14 +1168,14 @@ describe("graphql — economics pagination", () => {
             captured_at: new Date().toISOString(),
             subnets: [
               { netuid: 1, emission_share: 0.6 },
-              { netuid: 2, emission_share: 0.4 },
+              { netuid: 2, emission_share: 0.4, alpha_market_cap_tao: 80 },
             ],
           },
         },
       },
     );
     const { status, body } = await gql(
-      "{ economics { subnets { netuid } total } }",
+      "{ economics { subnets { netuid alpha_market_cap_tao } total } }",
       env,
     );
     assert.equal(status, 200);
@@ -1184,6 +1184,8 @@ describe("graphql — economics pagination", () => {
       body.data.economics.subnets.map((s) => s.netuid),
       [1, 2],
     );
+    assert.equal(body.data.economics.subnets[0].alpha_market_cap_tao, null);
+    assert.equal(body.data.economics.subnets[1].alpha_market_cap_tao, 80);
   });
 });
 
@@ -1321,10 +1323,10 @@ describe("graphql — complexity weights keep the guard meaningful", () => {
 
   test("greedily pulling many fields of several relationships across the list exceeds the budget", async () => {
     // subnets(5) items(1) + four relationship containers (5 each = 20) + 28 leaf
-    // fields = 54 > 50.
+    // fields = 55 > 50.
     const { status, body } = await gql(
       `{ subnets { items {
-          economics { netuid emission_share open_slots max_uids miner_count validator_count total_stake_tao }
+          economics { netuid emission_share alpha_market_cap_tao open_slots max_uids miner_count validator_count total_stake_tao }
           endpoints { id status kind url latency_ms last_ok score }
           health { status ok_count failed_count degraded_count unknown_count surface_count avg_latency_ms }
           surfaces { id key kind status url provider name }


### PR DESCRIPTION
## Summary
Adds `alpha_market_cap_tao` to the per-subnet economics artifact as `alpha_price_tao * total_stake_tao` when both inputs are finite.

Closes #2546

## What changed
- Added a pure economics artifact derivation with explicit null handling and a comment documenting `total_stake_tao` as the circulating-alpha proxy.
- Added the field to the canonical `SubnetEconomics` schema, economics sort enum, GraphQL economics row, generated OpenAPI, generated TypeScript definitions, contracts, and API index.
- Added regression coverage for present/null/non-finite inputs, list sorting with nulls last, GraphQL exposure, and the contract version sentinel.

## Why
Consumers can rank and display subnet market-cap context without recomputing or guessing the proxy used by the registry.

## Validation
- `npm run build`
- `npm run validate`
- `npm run lint`
- `npm run format:check`
- `npm run validate:api`
- `npm run validate:contract-drift`
- `npm run validate:openapi-examples`
- `npm run validate:types`
- `npm run validate:schema-enums`
- `npm run validate:generated-client`
- `npm run validate:client-sdk-sync`
- `npm run validate:docs`
- `npx vitest run tests/contracts.test.mjs tests/economics-artifacts.test.mjs tests/economics-query.test.mjs tests/graphql.test.mjs`
- `npm run test:coverage` (151 files, 3911 tests passed; line coverage 99.36%)
- `git diff --check`
