### PR TITLE
feat(events): decode + ingest SubtensorModule Faucet (testnet TAO mint)

### DIFF
--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -279,6 +279,18 @@ def _coldkey_swap(a):  # ColdkeySwapped: {old_coldkey, new_coldkey} or [old_cold
     return {"coldkey": _ss58(old_ck), "hotkey": _ss58(new_ck)}
 
 
+def _faucet(a):  # Faucet: (account, amount_rao) — testnet TAO mint credited to a
+    # coldkey. Confirmed against subtensor: Event::Faucet(AccountId, u64). Positional
+    # tuple; dict guard mirrors _transfer for named/older decodings.
+    if isinstance(a, dict):
+        account = a.get("account", a.get("who"))
+        amount = a.get("amount")
+    else:
+        account = a[0] if len(a) > 0 else None
+        amount = a[1] if len(a) > 1 else None
+    return {"coldkey": _ss58(account), "amount_tao": _tao(amount)}
+
+
 EXTRACTORS = {
     "NeuronRegistered": _registered,
     "StakeAdded": _stake,
@@ -300,6 +312,8 @@ EXTRACTORS = {
     "ColdkeySwapped": _coldkey_swap,
     # Balances pallet — native TAO transfers between accounts (#1814)
     "Transfer": _transfer,
+    # Testnet faucet mint — test-TAO issuance credited to a coldkey (#2560)
+    "Faucet": _faucet,
 }
 
 

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -501,5 +501,42 @@ class ColdkeySwapExtractorTest(unittest.TestCase):
         self.assertIsNone(_extract("ColdkeySwapScheduled", [_SS58_A, _SS58_B]))
 
 
+class FaucetExtractorTest(unittest.TestCase):
+    """Tests for the SubtensorModule.Faucet extractor (#2560) — testnet TAO mint
+    credited to a coldkey. Attribute order: (account, amount_rao), confirmed
+    against subtensor: Event::Faucet(AccountId, u64). Not FaucetMinted."""
+
+    def test_list_form_positional(self):
+        result = _extract("Faucet", [_SS58_A, _RAO_100])
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertAlmostEqual(result["amount_tao"], 100.0)
+        self.assertIsNone(result["hotkey"])
+        self.assertIsNone(result["netuid"])
+        self.assertIsNone(result["uid"])
+
+    def test_dict_form_named(self):
+        result = _extract("Faucet", {"account": _SS58_A, "amount": _RAO_100})
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertAlmostEqual(result["amount_tao"], 100.0)
+
+    def test_rao_to_tao_coercion(self):
+        result = _extract("Faucet", [_SS58_A, 500_000_000])
+        self.assertAlmostEqual(result["amount_tao"], 0.5)
+
+    def test_zero_amount(self):
+        result = _extract("Faucet", [_SS58_A, 0])
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertAlmostEqual(result["amount_tao"], 0.0)
+
+    def test_invalid_recipient_gives_null_coldkey(self):
+        result = _extract("Faucet", ["not-an-address", _RAO_100])
+        self.assertIsNone(result["coldkey"])
+        self.assertAlmostEqual(result["amount_tao"], 100.0)
+
+    def test_empty_shape_drift_never_raises(self):
+        result = _extract("Faucet", [])
+        self.assertIsNone(result["coldkey"])
+        self.assertIsNone(result["amount_tao"])
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -71,6 +71,7 @@ export const INGESTED_EVENT_KINDS = [
   "HotkeySwapped",
   "ColdkeySwapped",
   "Transfer",
+  "Faucet",
 ];
 
 function toIso(ms) {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -112,6 +112,10 @@ test("INGESTED_EVENT_KINDS accepts PrometheusServed for kind filters", () => {
   assert.ok(INGESTED_EVENT_KINDS.includes("PrometheusServed"));
 });
 
+test("INGESTED_EVENT_KINDS accepts Faucet (testnet TAO mint) for kind filters", () => {
+  assert.ok(INGESTED_EVENT_KINDS.includes("Faucet"));
+});
+
 test("formatAccountEvent maps a D1 row to an API event (ISO time)", () => {
   const out = formatAccountEvent({
     block_number: 1000,


### PR DESCRIPTION
## What & why

Adds a thin extractor for the **testnet faucet mint** event, filling `{coldkey: recipient, amount_tao}` from the credited account + rao amount, wired into the account-event feed for completeness of testnet activity. Small, additive, deterministic; no migration.

**Closes #2560**

## Event confirmation

Confirmed against `opentensor/subtensor` `pallets/subtensor/src/macros/events.rs`:

```rust
/// the faucet it called on the test net.
Faucet(T::AccountId, u64),
```
- **Event id:** `SubtensorModule.Faucet` (not `FaucetMinted`)
- **Attribute order:** `[account: AccountId, amount: u64 (rao)]`
- Maps to `{coldkey: recipient, amount_tao: amount/1e9}`.

## Changes
- `scripts/fetch-events.py` — `_faucet` extractor (positional tuple + dict guard mirroring `_transfer`), registered as `EXTRACTORS["Faucet"]`.
- `src/account-events.mjs` — `Faucet` added to `INGESTED_EVENT_KINDS`.
- `scripts/test_fetch_events.py` — `FaucetExtractorTest`: list/dict form, rao→tao coercion, zero amount, invalid recipient → null, empty-shape drift.
- `tests/account-events.test.mjs` — asserts `INGESTED_EVENT_KINDS` includes `Faucet`.

## Validation
- `python3 -m unittest scripts.test_fetch_events` → all pass (incl. 6 new)
- JS: `INGESTED_EVENT_KINDS.includes("Faucet") === true`; `node --check` clean
