### PR TITLE
feat(api): add direction filter to subnet stake-flow route

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1575,7 +1575,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch net stake flow for one subnet over a recent window: total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and the stake/unstake event counts, summed live from the account_events stream. Windows (7d/30d/90d) are bounded by the account_events retention. */
+        /** Fetch net stake flow for one subnet over a recent window: total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and the stake/unstake event counts, summed live from the account_events stream. ?direction=all|in|out filters to inflow (StakeAdded) or outflow (StakeRemoved) only; omitted defaults to all. Windows (7d/30d/90d) are bounded by the account_events retention. */
         get: operations["subnetStakeFlow"];
         put?: never;
         post?: never;
@@ -18469,6 +18469,7 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                direction?: "all" | "in" | "out";
             };
             header?: never;
             path: {

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4371,7 +4371,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/stake-flow.json",
       "cache": "short",
-      "description": "Fetch net stake flow for one subnet over a recent window: total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and the stake/unstake event counts, summed live from the account_events stream. Windows (7d/30d/90d) are bounded by the account_events retention.",
+      "description": "Fetch net stake flow for one subnet over a recent window: total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and the stake/unstake event counts, summed live from the account_events stream. ?direction=all|in|out filters to inflow (StakeAdded) or outflow (StakeRemoved) only; omitted defaults to all. Windows (7d/30d/90d) are bounded by the account_events retention.",
       "id": "subnet-stake-flow",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/stake-flow",
@@ -4386,6 +4386,17 @@
               "7d",
               "30d",
               "90d"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "direction",
+          "schema": {
+            "enum": [
+              "all",
+              "in",
+              "out"
             ],
             "type": "string"
           }

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -498,7 +498,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-01.1",
-      "description": "Net stake flow for one subnet over a recent window (7d/30d/90d): total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and event counts, summed live from the account_events stream at /api/v1/subnets/{netuid}/stake-flow (no static file).",
+      "description": "Net stake flow for one subnet over a recent window (7d/30d/90d): total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and event counts, with optional ?direction=all|in|out to filter inflow or outflow only, summed live from the account_events stream at /api/v1/subnets/{netuid}/stake-flow (no static file).",
       "id": "subnet-stake-flow",
       "path": "/metagraph/subnets/{netuid}/stake-flow.json",
       "schema_ref": "#/components/schemas/SubnetStakeFlowArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -34754,6 +34754,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "enum": [
+                "all",
+                "in",
+                "out"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -34870,7 +34883,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch net stake flow for one subnet over a recent window: total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and the stake/unstake event counts, summed live from the account_events stream. Windows (7d/30d/90d) are bounded by the account_events retention.",
+        "summary": "Fetch net stake flow for one subnet over a recent window: total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and the stake/unstake event counts, summed live from the account_events stream. ?direction=all|in|out filters to inflow (StakeAdded) or outflow (StakeRemoved) only; omitted defaults to all. Windows (7d/30d/90d) are bounded by the account_events retention.",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1575,7 +1575,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch net stake flow for one subnet over a recent window: total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and the stake/unstake event counts, summed live from the account_events stream. Windows (7d/30d/90d) are bounded by the account_events retention. */
+        /** Fetch net stake flow for one subnet over a recent window: total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and the stake/unstake event counts, summed live from the account_events stream. ?direction=all|in|out filters to inflow (StakeAdded) or outflow (StakeRemoved) only; omitted defaults to all. Windows (7d/30d/90d) are bounded by the account_events retention. */
         get: operations["subnetStakeFlow"];
         put?: never;
         post?: never;
@@ -18469,6 +18469,7 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                direction?: "all" | "in" | "out";
             };
             header?: never;
             path: {

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -947,7 +947,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "subnet-stake-flow",
     "/metagraph/subnets/{netuid}/stake-flow.json",
-    "Net stake flow for one subnet over a recent window (7d/30d/90d): total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and event counts, summed live from the account_events stream at /api/v1/subnets/{netuid}/stake-flow (no static file).",
+    "Net stake flow for one subnet over a recent window (7d/30d/90d): total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and event counts, with optional ?direction=all|in|out to filter inflow or outflow only, summed live from the account_events stream at /api/v1/subnets/{netuid}/stake-flow (no static file).",
     "SubnetStakeFlowArtifact",
   ),
   artifact(

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1807,13 +1807,17 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/stake-flow",
     "/metagraph/subnets/{netuid}/stake-flow.json",
-    "Fetch net stake flow for one subnet over a recent window: total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and the stake/unstake event counts, summed live from the account_events stream. Windows (7d/30d/90d) are bounded by the account_events retention.",
+    "Fetch net stake flow for one subnet over a recent window: total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and the stake/unstake event counts, summed live from the account_events stream. ?direction=all|in|out filters to inflow (StakeAdded) or outflow (StakeRemoved) only; omitted defaults to all. Windows (7d/30d/90d) are bounded by the account_events retention.",
     "short",
     ["subnets", "analytics"],
     [
       {
         name: "window",
         schema: { type: "string", enum: ["7d", "30d", "90d"] },
+      },
+      {
+        name: "direction",
+        schema: { type: "string", enum: ["all", "in", "out"] },
       },
     ],
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],

--- a/src/stake-flow.mjs
+++ b/src/stake-flow.mjs
@@ -23,6 +23,11 @@ export const STAKE_REMOVED_KIND = "StakeRemoved";
 export const STAKE_FLOW_WINDOWS = { "7d": 7, "30d": 30, "90d": 90 };
 export const DEFAULT_STAKE_FLOW_WINDOW = "30d";
 
+// direction narrows the stake-flow aggregate to one side: in = StakeAdded only,
+// out = StakeRemoved only, all (or omitted) = both kinds summed as today.
+export const STAKE_FLOW_DIRECTIONS = ["all", "in", "out"];
+export const DEFAULT_STAKE_FLOW_DIRECTION = "all";
+
 // 1 TAO = 1e9 rao. Summing many REAL amount_tao values accumulates IEEE-754 noise
 // below the rao floor; round every TAO output to rao precision, the smallest real
 // unit (the same rounding the turnover/account-summary scorecards apply).
@@ -93,19 +98,29 @@ export function buildStakeFlow(rows, netuid, { window } = {}) {
 export async function loadSubnetStakeFlow(
   d1,
   netuid,
-  { windowLabel = DEFAULT_STAKE_FLOW_WINDOW } = {},
+  {
+    windowLabel = DEFAULT_STAKE_FLOW_WINDOW,
+    direction = DEFAULT_STAKE_FLOW_DIRECTION,
+  } = {},
 ) {
   const days =
     STAKE_FLOW_WINDOWS[windowLabel] ??
     STAKE_FLOW_WINDOWS[DEFAULT_STAKE_FLOW_WINDOW];
   const cutoff = Date.now() - days * DAY_MS;
+  const kinds =
+    direction === "in"
+      ? [STAKE_ADDED_KIND]
+      : direction === "out"
+        ? [STAKE_REMOVED_KIND]
+        : [STAKE_ADDED_KIND, STAKE_REMOVED_KIND];
+  const placeholders = kinds.map(() => "?").join(", ");
   const rows = await d1(
     "SELECT event_kind, COALESCE(SUM(amount_tao), 0) AS total_tao, " +
       "COUNT(*) AS event_count, MAX(observed_at) AS last_observed " +
       "FROM account_events " +
-      "WHERE netuid = ? AND event_kind IN (?, ?) AND observed_at >= ? " +
+      `WHERE netuid = ? AND event_kind IN (${placeholders}) AND observed_at >= ? ` +
       "GROUP BY event_kind",
-    [netuid, STAKE_ADDED_KIND, STAKE_REMOVED_KIND, cutoff],
+    [netuid, ...kinds, cutoff],
   );
   let latestObserved = null;
   for (const row of Array.isArray(rows) ? rows : []) {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1695,7 +1695,9 @@ describe("handleSubnetStakeFlow", () => {
 
     test("canonicalizes omitted and explicit default direction to one cache key", () => {
       const omitted = canonicalSubnetStakeFlowCachePath(
-        new URL("https://api.metagraph.sh/api/v1/subnets/7/stake-flow?window=30d"),
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/7/stake-flow?window=30d",
+        ),
       );
       const explicit = canonicalSubnetStakeFlowCachePath(
         new URL(

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1693,6 +1693,15 @@ describe("handleSubnetStakeFlow", () => {
       assert.equal(path, "/api/v1/subnets/7/stake-flow?bogus=1");
     });
 
+    test("passes an invalid direction through unchanged (the handler rejects it)", () => {
+      const path = canonicalSubnetStakeFlowCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/7/stake-flow?direction=bogus",
+        ),
+      );
+      assert.equal(path, "/api/v1/subnets/7/stake-flow?direction=bogus");
+    });
+
     test("canonicalizes omitted and explicit default direction to one cache key", () => {
       const omitted = canonicalSubnetStakeFlowCachePath(
         new URL(

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -302,11 +302,11 @@ function dbWith({
                   ) {
                     return { results: neuronDailyHistory || [] };
                   }
-                  // Net stake flow: SUM(amount_tao) over the two stake kinds
+                  // Net stake flow: SUM(amount_tao) over stake kinds
                   // (checked before the generic event_kind aggregate below).
                   if (
                     /SUM\(amount_tao\)/.test(sql) &&
-                    /event_kind IN \(\?, \?\)/.test(sql)
+                    /event_kind IN \(/.test(sql)
                   ) {
                     return { results: stakeFlow || [] };
                   }
@@ -1486,6 +1486,18 @@ describe("handleSubnetStakeFlow", () => {
     await errorJson(res);
   });
 
+  test("rejects an unsupported direction enum value with 400", async () => {
+    const res = await handleSubnetStakeFlow(
+      req(`/api/v1/subnets/${NETUID}/stake-flow`),
+      emptyEnv(),
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/stake-flow?direction=invalid`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "direction");
+  });
+
   test("returns schema-stable zeros on cold D1", async () => {
     const body = await assertColdSchema(
       handleSubnetStakeFlow,
@@ -1555,6 +1567,102 @@ describe("handleSubnetStakeFlow", () => {
     assert.equal(body.meta.generated_at, new Date(1717900000000).toISOString());
   });
 
+  test("direction=in binds StakeAdded only", async () => {
+    const { env, captures } = dbWith({
+      stakeFlow: [
+        {
+          event_kind: "StakeAdded",
+          total_tao: 200,
+          event_count: 5,
+          last_observed: 1717000000000,
+        },
+      ],
+    });
+    const body = await json(
+      await handleSubnetStakeFlow(
+        req(`/api/v1/subnets/${NETUID}/stake-flow`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-flow?direction=in`),
+      ),
+    );
+    assert.equal(body.data.total_staked_tao, 200);
+    assert.equal(body.data.total_unstaked_tao, 0);
+    assert.equal(body.data.net_flow_tao, 200);
+    const idx = captures.sql.findIndex((s) =>
+      /FROM account_events WHERE netuid = \? AND event_kind IN/.test(s),
+    );
+    assert.ok(idx !== -1);
+    assert.equal(captures.params[idx][1], "StakeAdded");
+    assert.equal(captures.params[idx].length, 3);
+  });
+
+  test("direction=out binds StakeRemoved only", async () => {
+    const { env, captures } = dbWith({
+      stakeFlow: [
+        {
+          event_kind: "StakeRemoved",
+          total_tao: 50,
+          event_count: 2,
+          last_observed: 1717900000000,
+        },
+      ],
+    });
+    const body = await json(
+      await handleSubnetStakeFlow(
+        req(`/api/v1/subnets/${NETUID}/stake-flow`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/stake-flow?direction=out`),
+      ),
+    );
+    assert.equal(body.data.total_staked_tao, 0);
+    assert.equal(body.data.total_unstaked_tao, 50);
+    assert.equal(body.data.net_flow_tao, -50);
+    const idx = captures.sql.findIndex((s) =>
+      /FROM account_events WHERE netuid = \? AND event_kind IN/.test(s),
+    );
+    assert.ok(idx !== -1);
+    assert.equal(captures.params[idx][1], "StakeRemoved");
+    assert.equal(captures.params[idx].length, 3);
+  });
+
+  test("direction=all and omitted direction both query both kinds", async () => {
+    for (const query of ["", "?direction=all"]) {
+      const { env, captures } = dbWith({
+        stakeFlow: [
+          {
+            event_kind: "StakeAdded",
+            total_tao: 10,
+            event_count: 1,
+            last_observed: 1717000000000,
+          },
+          {
+            event_kind: "StakeRemoved",
+            total_tao: 3,
+            event_count: 1,
+            last_observed: 1717000000000,
+          },
+        ],
+      });
+      const body = await json(
+        await handleSubnetStakeFlow(
+          req(`/api/v1/subnets/${NETUID}/stake-flow`),
+          env,
+          NETUID,
+          url(`/api/v1/subnets/${NETUID}/stake-flow${query}`),
+        ),
+      );
+      assert.equal(body.data.net_flow_tao, 7);
+      const idx = captures.sql.findIndex((s) =>
+        /FROM account_events WHERE netuid = \? AND event_kind IN/.test(s),
+      );
+      assert.ok(idx !== -1);
+      assert.equal(captures.params[idx][1], "StakeAdded");
+      assert.equal(captures.params[idx][2], "StakeRemoved");
+    }
+  });
+
   describe("canonicalSubnetStakeFlowCachePath", () => {
     test("canonicalizes omitted and explicit default window to one cache key", () => {
       const omitted = canonicalSubnetStakeFlowCachePath(
@@ -1583,6 +1691,40 @@ describe("handleSubnetStakeFlow", () => {
         new URL("https://api.metagraph.sh/api/v1/subnets/7/stake-flow?bogus=1"),
       );
       assert.equal(path, "/api/v1/subnets/7/stake-flow?bogus=1");
+    });
+
+    test("canonicalizes omitted and explicit default direction to one cache key", () => {
+      const omitted = canonicalSubnetStakeFlowCachePath(
+        new URL("https://api.metagraph.sh/api/v1/subnets/7/stake-flow?window=30d"),
+      );
+      const explicit = canonicalSubnetStakeFlowCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/7/stake-flow?window=30d&direction=all",
+        ),
+      );
+      assert.equal(omitted, explicit);
+      assert.equal(omitted, "/api/v1/subnets/7/stake-flow?window=30d");
+    });
+
+    test("includes direction=in|out in the cache key", () => {
+      const inPath = canonicalSubnetStakeFlowCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/7/stake-flow?window=7d&direction=in",
+        ),
+      );
+      assert.equal(
+        inPath,
+        "/api/v1/subnets/7/stake-flow?window=7d&direction=in",
+      );
+      const outPath = canonicalSubnetStakeFlowCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/7/stake-flow?window=7d&direction=out",
+        ),
+      );
+      assert.equal(
+        outPath,
+        "/api/v1/subnets/7/stake-flow?window=7d&direction=out",
+      );
     });
   });
 });

--- a/tests/stake-flow.test.mjs
+++ b/tests/stake-flow.test.mjs
@@ -201,4 +201,67 @@ describe("loadSubnetStakeFlow", () => {
     assert.equal(captured[3], Date.now() - STAKE_FLOW_WINDOWS["30d"] * DAY_MS);
     vi.useRealTimers();
   });
+
+  test("direction=in queries StakeAdded only", async () => {
+    const calls = [];
+    const d1 = async (sql, params) => {
+      calls.push({ sql, params });
+      return [
+        {
+          event_kind: STAKE_ADDED_KIND,
+          total_tao: 100,
+          event_count: 3,
+          last_observed: 1717000000000,
+        },
+      ];
+    };
+    const { data } = await loadSubnetStakeFlow(d1, 7, {
+      windowLabel: "7d",
+      direction: "in",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].params[1], STAKE_ADDED_KIND);
+    assert.equal(calls[0].params.length, 3);
+    assert.equal(data.total_staked_tao, 100);
+    assert.equal(data.total_unstaked_tao, 0);
+    assert.equal(data.net_flow_tao, 100);
+  });
+
+  test("direction=out queries StakeRemoved only", async () => {
+    const calls = [];
+    const d1 = async (sql, params) => {
+      calls.push({ sql, params });
+      return [
+        {
+          event_kind: STAKE_REMOVED_KIND,
+          total_tao: 40,
+          event_count: 2,
+          last_observed: 1717000000000,
+        },
+      ];
+    };
+    const { data } = await loadSubnetStakeFlow(d1, 7, {
+      windowLabel: "7d",
+      direction: "out",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].params[1], STAKE_REMOVED_KIND);
+    assert.equal(calls[0].params.length, 3);
+    assert.equal(data.total_staked_tao, 0);
+    assert.equal(data.total_unstaked_tao, 40);
+    assert.equal(data.net_flow_tao, -40);
+  });
+
+  test("direction=all (default) queries both stake kinds", async () => {
+    const calls = [];
+    const d1 = async (_sql, params) => {
+      calls.push(params);
+      return [];
+    };
+    await loadSubnetStakeFlow(d1, 7, { direction: "all" });
+    assert.deepEqual(calls[0].slice(1, 3), [
+      STAKE_ADDED_KIND,
+      STAKE_REMOVED_KIND,
+    ]);
+  });
 });

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -106,6 +106,7 @@ import {
   loadSubnetStakeFlow,
   STAKE_FLOW_WINDOWS,
   DEFAULT_STAKE_FLOW_WINDOW,
+  DEFAULT_STAKE_FLOW_DIRECTION,
 } from "../../src/stake-flow.mjs";
 import { loadAccountStakeFlow } from "../../src/account-stake-flow.mjs";
 import {
@@ -493,18 +494,31 @@ export function canonicalSubnetTurnoverCachePath(url) {
   return `${url.pathname}?window=${encodeURIComponent(label)}${suffix}`;
 }
 
-// Canonical edge-cache key for the subnet-stake-flow route. Only ?window= (one of
-// STAKE_FLOW_WINDOWS) changes the response; an omitted window and the explicit
-// default must share one cache slot, so canonicalize both to ?window=<default>.
+// Canonical edge-cache key for the subnet-stake-flow route. ?window= (one of
+// STAKE_FLOW_WINDOWS) and ?direction= (all|in|out) change the response; omitted
+// window/direction and their explicit defaults must share one cache slot.
 export function canonicalSubnetStakeFlowCachePath(url) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "direction"]);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam =
     url.searchParams.get("window") || DEFAULT_STAKE_FLOW_WINDOW;
   if (!Object.hasOwn(STAKE_FLOW_WINDOWS, windowParam)) {
     return `${url.pathname}${url.search}`;
   }
-  return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
+  const direction = url.searchParams.get("direction");
+  if (
+    direction !== null &&
+    direction !== "all" &&
+    direction !== "in" &&
+    direction !== "out"
+  ) {
+    return `${url.pathname}${url.search}`;
+  }
+  let path = `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
+  if (direction === "in" || direction === "out") {
+    path += `&direction=${encodeURIComponent(direction)}`;
+  }
+  return path;
 }
 
 // Canonical edge-cache key for the cross-subnet movers route: window/sort/limit, each
@@ -623,13 +637,15 @@ export async function handleSubnetTurnover(request, env, netuid, url) {
   );
 }
 
-// GET /api/v1/subnets/{netuid}/stake-flow?window=7d|30d|90d: net stake flow for one
-// subnet over the window — TAO staked (StakeAdded) vs unstaked (StakeRemoved) and
-// the net, summed live from the account_events stream (idx_account_events_netuid_kind).
-// Windows (7d/30d/90d) match the concentration/history route. Cold/absent store →
-// 200 with zeroed totals (schema-stable, never 404), mirroring the sibling routes.
+// GET /api/v1/subnets/{netuid}/stake-flow?window=7d|30d|90d&direction=all|in|out:
+// net stake flow for one subnet over the window — TAO staked (StakeAdded) vs
+// unstaked (StakeRemoved) and the net, summed live from the account_events stream
+// (idx_account_events_netuid_kind). ?direction=in|out narrows to one side;
+// omitted or all sums both. Windows (7d/30d/90d) match the concentration/history
+// route. Cold/absent store → 200 with zeroed totals (schema-stable, never 404),
+// mirroring the sibling routes.
 export async function handleSubnetStakeFlow(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "direction"]);
   if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_STAKE_FLOW_WINDOW;
@@ -639,11 +655,26 @@ export async function handleSubnetStakeFlow(request, env, netuid, url) {
       message: unsupportedWindowMessage(windowParam, STAKE_FLOW_WINDOWS),
     });
   }
+  const direction = url.searchParams.get("direction");
+  if (
+    direction !== null &&
+    direction !== "all" &&
+    direction !== "in" &&
+    direction !== "out"
+  ) {
+    return analyticsQueryError({
+      parameter: "direction",
+      message: `"${direction}" is not a valid direction. Supported: all, in, out.`,
+    });
+  }
+  const normalizedDirection =
+    direction === "in" || direction === "out" ? direction : undefined;
   const { data, generatedAt } = await loadSubnetStakeFlow(
     d1Runner(env),
     netuid,
     {
       windowLabel: windowParam,
+      direction: normalizedDirection ?? DEFAULT_STAKE_FLOW_DIRECTION,
     },
   );
   // account_events-derived, so the meta reports source "chain-events" (via

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -107,6 +107,7 @@ import {
   STAKE_FLOW_WINDOWS,
   DEFAULT_STAKE_FLOW_WINDOW,
   DEFAULT_STAKE_FLOW_DIRECTION,
+  STAKE_FLOW_DIRECTIONS,
 } from "../../src/stake-flow.mjs";
 import { loadAccountStakeFlow } from "../../src/account-stake-flow.mjs";
 import {
@@ -506,12 +507,7 @@ export function canonicalSubnetStakeFlowCachePath(url) {
     return `${url.pathname}${url.search}`;
   }
   const direction = url.searchParams.get("direction");
-  if (
-    direction !== null &&
-    direction !== "all" &&
-    direction !== "in" &&
-    direction !== "out"
-  ) {
+  if (direction !== null && !STAKE_FLOW_DIRECTIONS.includes(direction)) {
     return `${url.pathname}${url.search}`;
   }
   let path = `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
@@ -656,15 +652,10 @@ export async function handleSubnetStakeFlow(request, env, netuid, url) {
     });
   }
   const direction = url.searchParams.get("direction");
-  if (
-    direction !== null &&
-    direction !== "all" &&
-    direction !== "in" &&
-    direction !== "out"
-  ) {
+  if (direction !== null && !STAKE_FLOW_DIRECTIONS.includes(direction)) {
     return analyticsQueryError({
       parameter: "direction",
-      message: `"${direction}" is not a valid direction. Supported: all, in, out.`,
+      message: `"${direction}" is not a valid direction. Supported: ${STAKE_FLOW_DIRECTIONS.join(", ")}.`,
     });
   }
   const normalizedDirection =


### PR DESCRIPTION
## Summary

- Add validated `?direction=all|in|out` to `GET /api/v1/subnets/{netuid}/stake-flow`, mirroring the enum-reject pattern from `handleAccountTransfers`
- Thread direction into `loadSubnetStakeFlow` so `in` restricts to `StakeAdded` and `out` to `StakeRemoved`, while absent/`all` keeps the existing two-sided aggregate
- Update route contract/OpenAPI, regenerate `contracts.json`, and extend edge-cache canonicalization; add handler and loader tests for every enum branch

Supersedes #2664 (closed after merge conflict with `main`).

Closes #2580

## Test plan

- [x] `npm test -- tests/stake-flow.test.mjs tests/request-handlers-entities.test.mjs`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run validate:contract-drift`
- [x] `npm run validate:api`