### PR TITLE
fix(scan): catch secrets under multi-segment credential names in public-safety scan

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -41,8 +41,16 @@ const patterns = [
   },
   {
     name: "token-like assignment",
+    // The optional `(?:[a-z0-9]+[_-])*` prefix matches underscore/hyphen-joined
+    // credential names of ANY depth (client_secret, google_oauth_client_secret,
+    // database_user_password): a leading `\b` has no boundary after the
+    // underscore in a compound name, so the bare `secret`/`password` alternatives
+    // would otherwise miss the most common real key names while still matching
+    // bare `secret=`/`password=`. The `+[_-]` segment can't match empty and the
+    // separator is disjoint from `[a-z0-9]`, so there is no catastrophic
+    // backtracking.
     regex:
-      /\b(?:api[_-]?key|access[_-]?token|auth[_-]?token|secret|password)\s*[:=]\s*["']?[A-Za-z0-9_./+=-]{16,}/i,
+      /\b(?:[a-z0-9]+[_-])*(?:api[_-]?key|access[_-]?token|auth[_-]?token|secret|password)\s*[:=]\s*["']?[A-Za-z0-9_./+=-]{16,}/i,
   },
   // `soft` patterns are terminology heuristics (not actual secrets). They are
   // skipped for mirrored third-party OpenAPI specs, where wording like "seed

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -198,6 +198,30 @@ describe("captured-fixture body scan", () => {
     }
   });
 
+  test("flags secrets under compound (multi-segment) credential names", async () => {
+    // The token-like assignment rule must catch underscore/hyphen-joined key
+    // names of any depth — a leading \b has no boundary after the underscore in a
+    // compound name, so client_secret / google_oauth_client_secret /
+    // database_user_password would otherwise slip past. Bare secret=/password=
+    // must keep matching; a short value must not.
+    const leaks = [
+      "client_secret=abcdefghijklmnop1234",
+      "google_oauth_client_secret=abcdefghijklmnop1234",
+      "database_user_password=abcdefghijklmnop1234",
+      "secret=abcdefghijklmnop1234",
+    ];
+    await fs.writeFile(TEST_PUBLIC_PATH, `${leaks.join("\n")}\n`, "utf8");
+    const output = runScanOutput();
+    for (const [index] of leaks.entries()) {
+      assert.ok(
+        output.includes(
+          `${TEST_PUBLIC_FILE}:${index + 1}: token-like assignment`,
+        ),
+        `secret on line ${index + 1} must be flagged; got:\n${output}`,
+      );
+    }
+  });
+
   test("does not flag soft Bittensor terminology in a mirrored fixture body", async () => {
     // Regression for the publish-wedging false positive: upstream API docs
     // legitimately say "miner hotkey" / "validator hotkey path".


### PR DESCRIPTION
## Summary

- The `token-like assignment` hard-secret rule in `scripts/scan-public-safety.mjs` anchored the bare `secret`/`password` keywords with a leading `\b`. Because `_` is a word character, there's no boundary after the underscore in a compound key name, so `client_secret=…`, `google_oauth_client_secret=…`, `database_user_password=…` — the most common real credential variable names — **did not match**, and a genuine leaked value under them slipped past `scan:public-safety`.
- The rule already encodes underscore/hyphen joins for its sibling alternatives (`api[_-]?key`, `access[_-]?token`, `auth[_-]?token`), so the gap for `secret`/`password` was an inconsistency.

> This supersedes #2645, which added a **single**-segment prefix (`(?:[a-z0-9]+[_-])?`) — the review correctly noted that left multi-segment names like `google_oauth_client_secret` still uncovered. This uses `*` so a compound name of **any depth** matches.

## What Changed

- `scripts/scan-public-safety.mjs`: add a `(?:[a-z0-9]+[_-])*` prefix before the keyword group. The `[a-z0-9]+[_-]` segment cannot match empty and the separator is disjoint from `[a-z0-9]`, so there is no catastrophic backtracking (a 100k-char no-match input scans in ~1ms; a 40k-segment input in ~3ms). Bare `secret=`/`password=` and the 16+ char value floor still apply.
- `tests/public-safety.test.mjs`: regression covering one-, two-, and three-segment key names (`client_secret`, `google_oauth_client_secret`, `database_user_password`) plus the bare `secret=` form. Fails without the fix.

Verified the scanner still reports `Public-safety scan passed.` on the whole tree — no new false positives.

### Reproduction (before)

`google_oauth_client_secret=abcdefghijklmnop1234` committed anywhere in the scanned tree was **not** flagged by `npm run scan:public-safety`, even though bare `secret=abcdefghijklmnop1234` was.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state. (Regression uses obvious placeholders; scanner still passes.)
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — scanner rule only.)

## Validation

- [x] `npx vitest run tests/public-safety.test.mjs` — the new regression passes; it fails without the fix
- [x] `npm run scan:public-safety` — `Public-safety scan passed.` (no new false positives)
- [x] ReDoS-checked: 100k-char / 40k-segment inputs scan in ~1–3ms
- [x] `npx eslint` + `npx prettier --check` clean · `git diff --check`
