### PR TITLE
fix(scan): flag compound credential names in public-safety token-like assignment rule

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -41,8 +41,11 @@ const patterns = [
   },
   {
     name: "token-like assignment",
+    // Optional multi-segment prefix (client_, db_, google_oauth_client_) before the
+    // keyword group: a leading \b has no boundary after an underscore inside
+    // client_secret, so bare secret/password miss the most common credential names.
     regex:
-      /\b(?:api[_-]?key|access[_-]?token|auth[_-]?token|secret|password)\s*[:=]\s*["']?[A-Za-z0-9_./+=-]{16,}/i,
+      /\b(?:[a-z0-9]+(?:[_-][a-z0-9]+)*_)?(?:api[_-]?key|access[_-]?token|auth[_-]?token|secret|password)\s*[:=]\s*["']?[A-Za-z0-9_./+=-]{16,}/i,
   },
   // `soft` patterns are terminology heuristics (not actual secrets). They are
   // skipped for mirrored third-party OpenAPI specs, where wording like "seed

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -177,6 +177,25 @@ describe("captured-fixture body scan", () => {
     }
   });
 
+  test("flags secrets assigned to compound credential names", async () => {
+    const leaks = [
+      "client_secret=abcdefghijklmnop1234",
+      "db_password=abcdefghijklmnop1234",
+      "google_oauth_client_secret=abcdefghijklmnop1234",
+      "secret=abcdefghijklmnop1234",
+    ];
+    await fs.writeFile(TEST_PUBLIC_PATH, `${leaks.join("\n")}\n`, "utf8");
+    const output = runScanOutput();
+    for (const [index] of leaks.entries()) {
+      assert.ok(
+        output.includes(
+          `${TEST_PUBLIC_FILE}:${index + 1}: token-like assignment`,
+        ),
+        `secret on line ${index + 1} must be flagged; got:\n${output}`,
+      );
+    }
+  });
+
   test("flags a link-local cloud-metadata URL as a private/loopback leak", async () => {
     // 169.254.169.254 is the AWS/GCP metadata endpoint — the canonical SSRF /
     // credential-theft target and unsafe per lib.mjs isUnsafeUrl, so a leaked URL


### PR DESCRIPTION
## Summary

The \	oken-like assignment\ hard-secret rule in \scripts/scan-public-safety.mjs\ matched bare \secret\/\password\ with a leading word boundary. Because \_\ is a word character, compound names like \client_secret\ and \google_oauth_client_secret\ were false negatives while the sibling \pi_key\ / \ccess_token\ alternatives already handled underscore joins.

## What Changed

- \scripts/scan-public-safety.mjs\: add an optional multi-segment prefix (\(?:[a-z0-9]+(?:[_-][a-z0-9]+)*_)?\) before the keyword group so one- and multi-segment compound credential names match; bare \secret=\ / \password=\ keep matching.
- \	ests/public-safety.test.mjs\: regression for \client_secret\, \db_password\, \google_oauth_client_secret\, and bare \secret\.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] \
pm run scan:public-safety\ (regex verified locally; full tree scan runs in CI)
- [ ] \
pm run check\
- [ ] \
pm run validate\
- [ ] \
pm run validate:schemas\
- [ ] \
pm run validate:api\
- [ ] \
pm run validate:openapi\
- [ ] \
pm run validate:types\
- [ ] \
pm run validate:artifact-budgets\
- [ ] \
pm run validate:docs\
- [ ] \
pm run validate:intake\
- [ ] \
pm run validate:workflows\
- [ ] \
pm run worker:test\
- [ ] \
pm run test:coverage\
- [x] \
pm run scan:public-safety\
- [ ] \git diff --check\
