### PR TITLE
feat(mcp): exclusion filters (not_) on list_subnets categorical args

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -242,6 +242,15 @@ assert.deepEqual(
 
 await callOk("search_subnets", { query: "subnet", limit: 5 });
 await callOk("find_subnets_by_capability", { capability: "data", limit: 5 });
+const excluded = await callOk("list_subnets", {
+  not_status: "inactive",
+  limit: 5,
+});
+assert.ok(
+  Array.isArray(excluded.subnets) &&
+    excluded.subnets.every((s) => s.status !== "inactive"),
+  "list_subnets not_status must exclude matching subnets",
+);
 const overview = await callOk("get_subnet", { netuid: 7 });
 assert.equal(overview.netuid ?? overview.subnet?.netuid ?? 7, 7);
 await callOk("get_subnet_health", { netuid: 7 });

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -162,7 +162,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.17.0";
+export const MCP_SERVER_VERSION = "1.18.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -1068,6 +1068,54 @@ function rangeFilterSubnets(rows, args) {
   );
 }
 
+// Categorical args list_subnets filters on, each available as inclusion (`arg`)
+// and exclusion (`not_arg`).
+const LIST_SUBNETS_CATEGORICAL = ["status", "subnet_type", "domain"];
+
+// Does `subnet` match categorical filter `field` = `value` (already lowercased)?
+// `domain` tests the union of curated + derived categories; the rest are scalar.
+// Shared by inclusion and exclusion so `status=` and `not_status=` stay exact
+// complements.
+function subnetCategoricalMatch(subnet, field, value) {
+  if (field === "domain") {
+    const tags = [
+      ...(Array.isArray(subnet.categories) ? subnet.categories : []),
+      ...(Array.isArray(subnet.derived_categories)
+        ? subnet.derived_categories
+        : []),
+    ].map((tag) => String(tag).toLowerCase());
+    return tags.includes(value);
+  }
+  return String(subnet[field] ?? "").toLowerCase() === value;
+}
+
+// Apply the categorical filters: keep rows matching every `field=v` and matching
+// none of the `not_field=v` exclusions (case-insensitive). A row missing the
+// field never matches, so it survives an exclusion but fails an inclusion.
+function categoricalFilterSubnets(rows, args) {
+  const includes = [];
+  const excludes = [];
+  for (const arg of LIST_SUBNETS_CATEGORICAL) {
+    const inc = typeof args?.[arg] === "string" ? args[arg].trim() : "";
+    if (inc) includes.push({ field: arg, value: inc.toLowerCase() });
+    const exc =
+      typeof args?.[`not_${arg}`] === "string" ? args[`not_${arg}`].trim() : "";
+    if (exc) excludes.push({ field: arg, value: exc.toLowerCase() });
+  }
+  if (includes.length === 0 && excludes.length === 0) {
+    return rows;
+  }
+  return rows.filter(
+    (subnet) =>
+      includes.every(({ field, value }) =>
+        subnetCategoricalMatch(subnet, field, value),
+      ) &&
+      excludes.every(
+        ({ field, value }) => !subnetCategoricalMatch(subnet, field, value),
+      ),
+  );
+}
+
 // A search.json document → keywordScore shape: title/slug are identity; subtitle
 // and tokens (which already fold in categories/service kinds) are recall-only.
 function scoreDocument(doc, terms) {
@@ -1257,6 +1305,18 @@ export const MCP_TOOLS = [
           description:
             "Filter to subnets tagged with this domain/category, e.g. 'inference'.",
         },
+        not_status: {
+          type: "string",
+          description: "Exclude subnets with this lifecycle status.",
+        },
+        not_subnet_type: {
+          type: "string",
+          description: "Exclude subnets of this type (e.g. 'root').",
+        },
+        not_domain: {
+          type: "string",
+          description: "Exclude subnets tagged with this domain/category.",
+        },
         min_readiness: {
           type: "integer",
           description:
@@ -1311,43 +1371,9 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const index = await loadArtifactData(ctx, "/metagraph/subnets.json");
       const all = Array.isArray(index.subnets) ? index.subnets : [];
-      const status =
-        typeof args?.status === "string"
-          ? args.status.trim().toLowerCase()
-          : null;
-      const subnetType =
-        typeof args?.subnet_type === "string"
-          ? args.subnet_type.trim().toLowerCase()
-          : null;
-      const domain =
-        typeof args?.domain === "string"
-          ? args.domain.trim().toLowerCase()
-          : null;
-      const categorical = all.filter((subnet) => {
-        if (status && String(subnet.status || "").toLowerCase() !== status) {
-          return false;
-        }
-        if (
-          subnetType &&
-          String(subnet.subnet_type || "").toLowerCase() !== subnetType
-        ) {
-          return false;
-        }
-        if (domain) {
-          const tags = [
-            ...(Array.isArray(subnet.categories) ? subnet.categories : []),
-            ...(Array.isArray(subnet.derived_categories)
-              ? subnet.derived_categories
-              : []),
-          ].map((tag) => String(tag).toLowerCase());
-          if (!tags.includes(domain)) {
-            return false;
-          }
-        }
-        return true;
-      });
-      // Apply the inclusive numeric range bounds (min_/max_) after the
-      // categorical filters, mirroring the REST list endpoint's filter order.
+      // Categorical inclusion (status/subnet_type/domain) and exclusion
+      // (not_status/not_subnet_type/not_domain), then the numeric range bounds.
+      const categorical = categoricalFilterSubnets(all, args);
       const filtered = rangeFilterSubnets(categorical, args);
       // Sort the filtered list before paging; unscored subnets sort last and
       // equal values tie-break by netuid for a stable page (sortSubnets).

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4296,6 +4296,85 @@ describe("list_subnets", () => {
   const rangeNetuids = (out) =>
     out.subnets.map((s) => s.netuid).sort((a, b) => a - b);
 
+  // Fixture: 0=root/active, 7=application/active/inference,
+  // 8=application/deprecated with derived_categories ["data"].
+  test("not_status / not_subnet_type / not_domain exclude matching subnets", async () => {
+    const notActive = (
+      await callTool("list_subnets", { not_status: "active" }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(notActive), [8]); // only the deprecated one
+
+    const notApp = (
+      await callTool(
+        "list_subnets",
+        { not_subnet_type: "application" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(notApp), [0]); // only the root one
+
+    const notInference = (
+      await callTool("list_subnets", { not_domain: "inference" }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(notInference), [0, 8]); // 7 (inference) dropped
+  });
+
+  test("not_domain also excludes a derived_categories match (union semantics)", async () => {
+    // netuid 8 carries "data" only via derived_categories — the exclusion must
+    // treat curated + derived tags as one domain set, like the inclusion does.
+    const out = (
+      await callTool("list_subnets", { not_domain: "data" }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(out), [0, 7]);
+  });
+
+  test("not_<categorical> is case-insensitive (matches the inclusion form)", async () => {
+    const out = (
+      await callTool("list_subnets", { not_status: "ACTIVE" }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(out), [8]);
+  });
+
+  test("a row missing the field fails inclusion but survives its exclusion (complements)", async () => {
+    const localDeps = makeDeps({
+      "/metagraph/subnets.json": {
+        subnets: [
+          { netuid: 1, slug: "a", name: "A", status: "active" },
+          { netuid: 2, slug: "b", name: "B" }, // status absent
+        ],
+      },
+    });
+    const included = (
+      await callTool("list_subnets", { status: "active" }, { deps: localDeps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(included), [1]); // absent-status row fails inclusion
+
+    const excluded = (
+      await callTool(
+        "list_subnets",
+        { not_status: "active" },
+        { deps: localDeps },
+      )
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(excluded), [2]); // …but survives the exclusion
+    // Together they partition the fixture: inclusion ∪ exclusion = all rows.
+    assert.deepEqual(
+      [...rangeNetuids(included), ...rangeNetuids(excluded)].sort(),
+      [1, 2],
+    );
+  });
+
+  test("inclusion and exclusion compose (status=active AND not_subnet_type=root)", async () => {
+    const out = (
+      await callTool(
+        "list_subnets",
+        { status: "active", not_subnet_type: "root" },
+        { deps },
+      )
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(out), [7]); // active {0,7} minus root {0}
+  });
+
   test("max_readiness keeps rows <= the bound (complement of min_readiness)", async () => {
     const out = (
       await callTool("list_subnets", { max_readiness: 50 }, { deps })


### PR DESCRIPTION
## Summary

Resubmits the `list_subnets` exclusion filters, addressing the #2373 review blocker and nits.

`list_subnets` can filter **to** a `status`/`subnet_type`/`domain` but not **away from** one. This adds `not_status`, `not_subnet_type`, and `not_domain` — the complement of the matching inclusion arg — extending the same parity direction as the merged range filters (#2280). Inclusion and exclusion share one case-insensitive `subnetCategoricalMatch` helper, so `status=active` and `not_status=active` are exact complements; a row missing the field survives an exclusion but fails an inclusion; `not_domain` covers the curated + derived category union. Composes with the `min_/max_` range filters, sort, and pagination.

## Addresses the #2373 review
- **Blocker — version signal:** this is an additive tool input change, so `MCP_SERVER_VERSION` (src/mcp-server.mjs) and `server.json` both move **1.17.0 → 1.18.0** per the file-local SemVer bump policy (#393).
- **Nits:** `subnetCategoricalMatch` uses `?? ""` (falsy-but-valid safe); regression tests added for (a) a row **missing** the categorical field — fails inclusion, survives exclusion, the two partition the fixture; (b) `not_domain` excluding a **derived_categories** match (union semantics); plus case-insensitivity and inclusion+exclusion composition.
- `scripts/validate-mcp.mjs` gains a `not_status` smoke assertion (same pattern as other tool capabilities).

## Changes
- `src/mcp-server.mjs`: `subnetCategoricalMatch` + `categoricalFilterSubnets`; 3 `not_` args in the `list_subnets` inputSchema; version bump.
- `server.json`: 1.17.0 → 1.18.0.
- `scripts/validate-mcp.mjs`: `not_status` smoke.
- `tests/mcp-server.test.mjs`: 5 new cases. No contract/openapi change; no server-card regen (worker-computed).

## Validation
- `node scripts/validate-mcp.mjs` (72 tools, version consistency) — green
- `npx vitest run tests/mcp-server.test.mjs` — 358 passed; new lines fully covered
- `npm run lint`, `npm run format:check` — clean