### PR TITLE
fix(analytics): canonicalize default window in edge-cache keys

### DIFF
--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -357,6 +357,19 @@ describe("canonicalAnalyticsCacheRoute", () => {
     );
   });
 
+  test("normalizes a missing window to the default window", () => {
+    const bare = url("/api/v1/chain/transfers?limit=25");
+    const explicit = url(`/api/v1/chain/transfers?window=7d&limit=25`);
+    assert.equal(
+      canonicalAnalyticsCacheRoute(bare, ["limit"]),
+      `/api/v1/chain/transfers?window=${DEFAULT_ANALYTICS_WINDOW}&limit=25`,
+    );
+    assert.equal(
+      canonicalAnalyticsCacheRoute(explicit, ["limit"]),
+      canonicalAnalyticsCacheRoute(bare, ["limit"]),
+    );
+  });
+
   test("includes the chain calls grouping and module filter in canonical order", () => {
     const requestUrl = url(
       "/api/v1/chain/calls?call_module=SubtensorModule&limit=10&group_by=module_function&window=30d",

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -99,7 +99,15 @@ function canonicalAnalyticsCacheRoute(url, params = []) {
   const search = new URL("https://cache-key.invalid/").searchParams;
   for (const param of [ANALYTICS_WINDOW_PARAM, ...params]) {
     const value = url.searchParams.get(param);
-    if (value !== null) search.set(param, value);
+    if (value !== null) {
+      search.set(param, value);
+      continue;
+    }
+    // Normalize the default window into the cache key so a bare request and an
+    // explicit ?window=<default> request share one edge-cache entry.
+    if (param === ANALYTICS_WINDOW_PARAM) {
+      search.set(param, DEFAULT_ANALYTICS_WINDOW);
+    }
   }
   const query = search.toString();
   return `${url.pathname}${query ? `?${query}` : ""}`;


### PR DESCRIPTION
## Summary
- Prevent duplicate edge-cache entries for analytics routes by canonicalizing the default `window` into cache keys.
- Ensures bare requests and explicit `?window=7d` requests share the same cache entry.

## Why
Analytics routes default `window` to `7d`, but the cache key previously omitted `window` when not provided. That caused duplicate cache keys (and duplicated cache entries) for identical responses.

## Changes
- Update `canonicalAnalyticsCacheRoute(...)` to always include `window` (defaults to `DEFAULT_ANALYTICS_WINDOW` when absent).
- Add regression test covering missing vs explicit default window normalization.

## Test plan
- `npm test -- tests/request-handlers-analytics.test.mjs`