### PR TITLE
feat(api): min_samples filter on the subnet uptime history route

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1643,7 +1643,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). */
+        /** Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). Pass `min_samples` to drop low-sample day rows (daily probe count below the threshold, including zero-sample 'unknown' days) from the history. */
         get: operations["subnetUptime"];
         put?: never;
         post?: never;
@@ -18949,6 +18949,7 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "90d" | "1y";
+                min_samples?: number;
             };
             header?: never;
             path: {

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5525,7 +5525,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/uptime.json",
       "cache": "short",
-      "description": "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup).",
+      "description": "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). Pass `min_samples` to drop low-sample day rows (daily probe count below the threshold, including zero-sample 'unknown' days) from the history.",
       "id": "subnet-uptime",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/uptime",
@@ -5541,6 +5541,13 @@
               "1y"
             ],
             "type": "string"
+          }
+        },
+        {
+          "name": "min_samples",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
           }
         }
       ]

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -35420,6 +35420,15 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "min_samples",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -35560,7 +35569,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup).",
+        "summary": "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). Pass `min_samples` to drop low-sample day rows (daily probe count below the threshold, including zero-sample 'unknown' days) from the history.",
         "tags": [
           "health",
           "subnets",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1643,7 +1643,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). */
+        /** Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). Pass `min_samples` to drop low-sample day rows (daily probe count below the threshold, including zero-sample 'unknown' days) from the history. */
         get: operations["subnetUptime"];
         put?: never;
         post?: never;
@@ -18949,6 +18949,7 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "90d" | "1y";
+                min_samples?: number;
             };
             header?: never;
             path: {

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2381,10 +2381,13 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/uptime",
     "/metagraph/subnets/{netuid}/uptime.json",
-    "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup).",
+    "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). Pass `min_samples` to drop low-sample day rows (daily probe count below the threshold, including zero-sample 'unknown' days) from the history.",
     "short",
     ["health", "subnets", "analytics"],
-    [{ name: "window", schema: { type: "string", enum: ["90d", "1y"] } }],
+    [
+      { name: "window", schema: { type: "string", enum: ["90d", "1y"] } },
+      { name: "min_samples", schema: { type: "integer", minimum: 0 } },
+    ],
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -1210,6 +1210,56 @@ describe("analytics routes (fake D1 with data)", () => {
     assert.equal(incidentQuery.params.at(-2), 2);
   });
 
+  test("uptime ?min_samples adds a bound HAVING sample floor (#2582)", async () => {
+    const queries = [];
+    const envWithCapture = captureD1Env(queries);
+    const { status } = await getJson(
+      "https://api.metagraph.sh/api/v1/subnets/7/uptime?min_samples=3",
+      envWithCapture,
+    );
+    assert.equal(status, 200);
+    const uptimeQuery = queries.find((query) =>
+      query.sql.includes("FROM surface_uptime_daily"),
+    );
+    // The floor is a bound HAVING predicate between GROUP BY and ORDER BY, so
+    // sparse day rows (including SUM(samples)=0 'unknown' days) drop in SQL.
+    assert.match(
+      uptimeQuery.sql,
+      /GROUP BY COALESCE\(surface_key, surface_id\), day\s+HAVING SUM\(samples\) >= \?\s+ORDER BY day DESC/,
+    );
+    assert.equal(uptimeQuery.params[0], 7); // netuid
+    assert.equal(uptimeQuery.params[2], 3); // the bound HAVING floor
+    assert.equal(uptimeQuery.params.length, 4); // netuid, cutoff, floor, LIMIT
+  });
+
+  test("uptime without min_samples keeps the unfiltered query shape", async () => {
+    const queries = [];
+    const envWithCapture = captureD1Env(queries);
+    const { status } = await getJson(
+      "https://api.metagraph.sh/api/v1/subnets/7/uptime",
+      envWithCapture,
+    );
+    assert.equal(status, 200);
+    const uptimeQuery = queries.find((query) =>
+      query.sql.includes("FROM surface_uptime_daily"),
+    );
+    assert.doesNotMatch(uptimeQuery.sql, /HAVING/);
+    assert.equal(uptimeQuery.params.length, 3); // netuid, cutoff, LIMIT only
+  });
+
+  test("uptime rejects a malformed min_samples with a 400", async () => {
+    const queries = [];
+    const envWithCapture = captureD1Env(queries);
+    const { status, body } = await getJson(
+      "https://api.metagraph.sh/api/v1/subnets/7/uptime?min_samples=lots",
+      envWithCapture,
+    );
+    assert.equal(status, 400);
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "min_samples");
+    assert.equal(queries.length, 0, "malformed input must not reach D1");
+  });
+
   test("trends and uptime SQL group by stable surface key", async () => {
     const queries = [];
     const envWithCapture = captureD1Env(queries);

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -24,6 +24,7 @@ import {
   dailyLatencyColumns,
   surfaceStatusAvgLatencySql,
 } from "../../src/health-sql.mjs";
+import { parseNonNegativeIntParam } from "../request-params.mjs";
 import {
   parseHistoryWindow,
   unsupportedWindowMessage,
@@ -123,7 +124,7 @@ export async function handleEconomicsTrends(request, env, url) {
 
 // Long-term daily uptime history for one subnet's operational surfaces.
 export async function handleUptime(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "min_samples"]);
   if (validationError) return analyticsQueryError(validationError);
   const windowParam = url.searchParams.get("window") || "90d";
   if (!Object.hasOwn(UPTIME_WINDOWS, windowParam)) {
@@ -132,6 +133,14 @@ export async function handleUptime(request, env, netuid, url) {
       message: unsupportedWindowMessage(windowParam, UPTIME_WINDOWS),
     });
   }
+  // Optional low-sample noise floor: drop day rows whose aggregated probe count
+  // is below the threshold (a HAVING bound param), so sparse days (including
+  // the SUM(samples)=0 'unknown' rows) can be excluded from availability charts.
+  const minSamples = parseNonNegativeIntParam(
+    url.searchParams.get("min_samples"),
+    "min_samples",
+  );
+  if (minSamples.error) return analyticsQueryError(minSamples.error);
   const days = UPTIME_WINDOWS[windowParam];
   const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
     .toISOString()
@@ -160,9 +169,11 @@ export async function handleUptime(request, env, netuid, url) {
      FROM surface_uptime_daily
      WHERE netuid = ? AND day >= ?
      GROUP BY COALESCE(surface_key, surface_id), day
-     ORDER BY day DESC
+     ${minSamples.value !== null ? "HAVING SUM(samples) >= ?\n     " : ""}ORDER BY day DESC
      LIMIT ?`,
-    [netuid, cutoff, MAX_UPTIME_ROWS],
+    minSamples.value !== null
+      ? [netuid, cutoff, minSamples.value, MAX_UPTIME_ROWS]
+      : [netuid, cutoff, MAX_UPTIME_ROWS],
   );
   const healthMeta = await readHealthMetaKv(env);
   const data = formatUptime({


### PR DESCRIPTION
## Summary

Closes #2582. `handleUptime` returns every day row, including `SUM(samples)=0` `'unknown'` days, so a caller charting real availability has to drop low-sample noise client-side. This adds the requested validated `?min_samples=N` filter:

- `min_samples` added to the `validateQueryParams` allow-list; parsed via `parseNonNegativeIntParam` with a 400 (`invalid_query`, `meta.parameter = min_samples`) on malformed input, which never reaches D1.
- Applied as a **bound** `HAVING SUM(samples) >= ?` between the `GROUP BY` and `ORDER BY`, only when the parameter is present — absent keeps the exact prior query shape and bind order.
- Route contract description + `min_samples` query parameter added; OpenAPI/API-index/type projections regenerated (+91/−9 total).

## Tests
Follow the house pattern the incidents floor uses (assert the captured SQL + bound params, not a stub that pretends to filter):
- `?min_samples=3` → the uptime query matches `GROUP BY … HAVING SUM(samples) >= ? … ORDER BY day DESC` with `3` bound in position and 4 binds total.
- absent → no `HAVING`, 3 binds (prior shape pinned).
- malformed → 400 `invalid_query` with `meta.parameter = "min_samples"`, and zero D1 queries issued.

## Validation
- `npm run lint`, `npm run format:check`, `npm run validate:contract-drift`, `npm run validate:openapi` (102 routes), `npm run validate:api` (102 routes) — green
- `npx vitest run tests/analytics.test.mjs` (58) + api-coverage/openapi-sample/invariants/health-serving (324) — all passing