### PR TITLE
feat(events): ingest subtensor lifecycle events

### DIFF
--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -251,6 +251,16 @@ def _burn_set(a):  # BurnSet: (netuid, burn_rao) — a subnet's registration cos
     return {"netuid": _idx(netuid), "amount_tao": _tao(amount)}
 
 
+def _subnet_owner_hotkey(a):  # SubnetOwnerHotkeySet: (netuid, new_hotkey)
+    if isinstance(a, dict):
+        netuid = a.get("netuid")
+        hotkey = a.get("new_hotkey", a.get("hotkey"))
+    else:
+        netuid = a[0] if len(a) > 0 else None
+        hotkey = a[1] if len(a) > 1 else None
+    return {"netuid": _idx(netuid), "hotkey": _ss58(hotkey)}
+
+
 def _delegate_added(a):  # DelegateAdded: {coldkey, hotkey, take} or [coldkey, hotkey, ...]
     if isinstance(a, dict):
         ck, hk = a.get("coldkey"), a.get("hotkey")
@@ -293,6 +303,7 @@ def _coldkey_swap(a):  # ColdkeySwapped: {old_coldkey, new_coldkey} or [old_cold
 
 EXTRACTORS = {
     "NeuronRegistered": _registered,
+    "NeuronDeregistered": _registered,  # same [netuid, uid, hotkey] shape
     "StakeAdded": _stake,
     "StakeRemoved": _stake,
     "StakeMoved": _moved,
@@ -303,7 +314,10 @@ EXTRACTORS = {
     # Subnet lifecycle (#1816, #2561)
     "NetworkAdded": _net,
     "NetworkRemoved": _net,
+    "RegistrationAllowed": _net,
+    "PowRegistrationAllowed": _net,
     "BurnSet": _burn_set,  # registration cost/burn (netuid, recycled TAO)
+    "SubnetOwnerHotkeySet": _subnet_owner_hotkey,
     # Delegation (#1816)
     "DelegateAdded": _delegate_added,
     "TakeDecreased": _take_changed,

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -337,6 +337,36 @@ class TransferExtractorTest(unittest.TestCase):
         self.assertIsNone(result["amount_tao"])
 
 
+class NeuronDeregisteredExtractorTest(unittest.TestCase):
+    """Tests for SubtensorModule.NeuronDeregistered (#2553).
+
+    Attribute order confirmed against finney spec 424:
+    (netuid, uid, hotkey), identical to NeuronRegistered.
+    """
+
+    def test_positional_netuid_uid_hotkey(self):
+        result = _extract("NeuronDeregistered", [7, 42, _SS58_A])
+        self.assertEqual(result["netuid"], 7)
+        self.assertEqual(result["uid"], 42)
+        self.assertEqual(result["hotkey"], _SS58_A)
+        self.assertIsNone(result["coldkey"])
+
+    def test_invalid_hotkey_gives_null(self):
+        result = _extract("NeuronDeregistered", [7, 42, "not-an-address"])
+        self.assertEqual(result["netuid"], 7)
+        self.assertEqual(result["uid"], 42)
+        self.assertIsNone(result["hotkey"])
+
+    def test_out_of_range_uid_gives_null(self):
+        result = _extract("NeuronDeregistered", [7, 70000, _SS58_A])
+        self.assertEqual(result["netuid"], 7)
+        self.assertIsNone(result["uid"])
+        self.assertEqual(result["hotkey"], _SS58_A)
+
+    def test_empty_shape_drift_is_skipped(self):
+        self.assertIsNone(_extract("NeuronDeregistered", []))
+
+
 class PrometheusServedExtractorTest(unittest.TestCase):
     """Tests for the SubtensorModule.PrometheusServed extractor (#2554)."""
 
@@ -499,6 +529,69 @@ class ColdkeySwapExtractorTest(unittest.TestCase):
     def test_nonexistent_scheduled_event_is_not_mapped(self):
         # The phantom name must no longer resolve to an extractor.
         self.assertIsNone(_extract("ColdkeySwapScheduled", [_SS58_A, _SS58_B]))
+
+
+class RegistrationAllowedExtractorTest(unittest.TestCase):
+    """Tests for SubtensorModule registration toggles (#2557).
+
+    Attribute order confirmed against finney spec 424:
+    (netuid, allowed). The boolean is display-only for the current row contract.
+    """
+
+    def test_registration_allowed_positional_netuid(self):
+        result = _extract("RegistrationAllowed", [7, True])
+        self.assertEqual(result["netuid"], 7)
+        self.assertIsNone(result["hotkey"])
+
+    def test_pow_registration_allowed_positional_netuid(self):
+        result = _extract("PowRegistrationAllowed", [8, False])
+        self.assertEqual(result["netuid"], 8)
+        self.assertIsNone(result["uid"])
+
+    def test_dict_form_named_netuid(self):
+        result = _extract("RegistrationAllowed", {"netuid": 9, "allowed": True})
+        self.assertEqual(result["netuid"], 9)
+
+    def test_invalid_netuid_gives_null(self):
+        result = _extract("PowRegistrationAllowed", [70000, True])
+        self.assertIsNone(result["netuid"])
+
+    def test_empty_shape_drift_never_raises(self):
+        result = _extract("RegistrationAllowed", [])
+        self.assertIsNotNone(result)
+        self.assertIsNone(result["netuid"])
+
+
+class SubnetOwnerHotkeySetExtractorTest(unittest.TestCase):
+    """Tests for SubtensorModule.SubnetOwnerHotkeySet (#2558).
+
+    Attribute order confirmed against finney spec 424: (netuid, new_hotkey).
+    """
+
+    def test_positional_netuid_new_hotkey(self):
+        result = _extract("SubnetOwnerHotkeySet", [7, _SS58_A])
+        self.assertEqual(result["netuid"], 7)
+        self.assertEqual(result["hotkey"], _SS58_A)
+        self.assertIsNone(result["coldkey"])
+
+    def test_dict_form_named_fields(self):
+        result = _extract(
+            "SubnetOwnerHotkeySet",
+            {"netuid": 8, "new_hotkey": _SS58_B},
+        )
+        self.assertEqual(result["netuid"], 8)
+        self.assertEqual(result["hotkey"], _SS58_B)
+
+    def test_invalid_netuid_or_hotkey_gives_nulls(self):
+        result = _extract("SubnetOwnerHotkeySet", [70000, "not-an-address"])
+        self.assertIsNone(result["netuid"])
+        self.assertIsNone(result["hotkey"])
+
+    def test_empty_shape_drift_never_raises(self):
+        result = _extract("SubnetOwnerHotkeySet", [])
+        self.assertIsNotNone(result)
+        self.assertIsNone(result["netuid"])
+        self.assertIsNone(result["hotkey"])
 
 
 class BurnSetExtractorTest(unittest.TestCase):

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -63,9 +63,13 @@ export const INDEXED_EVENT_KINDS = [
 // scoping validation to INDEXED_EVENT_KINDS alone would wrongly reject valid kinds.
 export const INGESTED_EVENT_KINDS = [
   ...INDEXED_EVENT_KINDS,
+  "NeuronDeregistered",
   "NetworkAdded",
   "NetworkRemoved",
+  "RegistrationAllowed",
+  "PowRegistrationAllowed",
   "BurnSet",
+  "SubnetOwnerHotkeySet",
   "DelegateAdded",
   "TakeDecreased",
   "TakeIncreased",

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -117,6 +117,17 @@ test("INGESTED_EVENT_KINDS accepts BurnSet (subnet registration cost) for kind f
   assert.ok(INGESTED_EVENT_KINDS.includes("BurnSet"));
 });
 
+test("INGESTED_EVENT_KINDS accepts expanded Subtensor lifecycle event filters", () => {
+  for (const kind of [
+    "NeuronDeregistered",
+    "RegistrationAllowed",
+    "PowRegistrationAllowed",
+    "SubnetOwnerHotkeySet",
+  ]) {
+    assert.ok(INGESTED_EVENT_KINDS.includes(kind), `missing ${kind}`);
+  }
+});
+
 test("formatAccountEvent maps a D1 row to an API event (ISO time)", () => {
   const out = formatAccountEvent({
     block_number: 1000,


### PR DESCRIPTION
## Summary

Expands first-party SubtensorModule event ingest coverage for deregistration and subnet lifecycle signals.

Closes #2553
Closes #2557
Closes #2558

## What changed

- Added `NeuronDeregistered` using the existing registered-neuron extractor shape.
- Wired `RegistrationAllowed` and `PowRegistrationAllowed` through the existing netuid-only lifecycle extractor.
- Added `SubnetOwnerHotkeySet` extraction for subnet owner hotkey updates.
- Added the new event kinds to the public `?kind=` validation allow-list.
- Added Python extractor regression coverage and JS kind-filter coverage.

## Why

These events are emitted by current finney metadata but were not included in the first-party event poller, leaving deregistration, registration-toggle, and subnet-owner-hotkey activity invisible in the event feeds.

## Validation

- Verified current finney metadata event names and field order against spec 424.
- `python3 scripts/test_fetch_events.py`
- `npx vitest run tests/account-events.test.mjs`
- `git diff --check`
- `npm run lint`
- `npm run format:check`
- `npm run validate`
- `npm run build`
- `npm run validate:contract-drift`
- `npm run validate:api`
- `npm run validate:types`
- `npm run validate:openapi`
- `npm run scan:public-safety`
- `npm run test:coverage`

## Notes

No D1 migration or schema regeneration is needed; the new events reuse the existing `account_events` columns and response shape. The stake-transfer event is intentionally out of scope because it carries origin and destination netuids and needs a separate contract-aware representation.
