### PR TITLE
fix(extrinsics): coerce string-typed fee_tao/tip_tao cells in formatExtrinsic

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -53,6 +53,18 @@ function toChainPosition(value) {
   return Number.isInteger(n) && n >= 0 ? n : null;
 }
 
+// Coerce a TAO amount cell (fee_tao / tip_tao, D1 REAL columns) to a number
+// rounded to rao precision (9 dp), or null when missing/non-finite. D1 can
+// return a REAL column as a numeric string, so a bare `?? null` pass-through
+// would leak the string form into the ["number","null"] contract field and
+// serve unrounded float noise. Mirrors toTaoOrNull in account-events.mjs
+// (#2662) and the coercion in formatRegistration (#2487).
+function toTaoOrNull(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.round(n * 1e9) / 1e9 : null;
+}
+
 // Keep only well-formed extrinsics rows (a valid (block_number, extrinsic_index)
 // primary key + an integer timestamp). Shared by the staged-batch loader so
 // garbage is rejected before it touches D1.
@@ -146,8 +158,11 @@ export function formatExtrinsic(row) {
     // successful extrinsic mislabeled false. Number()-coerce first, mirroring
     // toD1Flag in account-events.mjs (#2487).
     success: row.success == null ? null : Number(row.success) === 1,
-    fee_tao: row.fee_tao ?? null,
-    tip_tao: row.tip_tao ?? null,
+    // fee_tao / tip_tao (D1 REAL columns) — coerce through toTaoOrNull so a
+    // numeric string never leaks the string form into the ["number","null"]
+    // payload, matching formatAccountEvent (#2662) and the sibling formatters.
+    fee_tao: toTaoOrNull(row.fee_tao),
+    tip_tao: toTaoOrNull(row.tip_tao),
     observed_at: toIso(row.observed_at),
   };
 }

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -167,6 +167,19 @@ test("formatExtrinsic maps a null/absent fee_tao/tip_tao to null", () => {
   assert.equal(out.tip_tao, null);
 });
 
+test("formatExtrinsic maps a non-numeric fee_tao/tip_tao to null (not NaN)", () => {
+  // A non-finite / non-numeric cell must fall through to null, never leak NaN
+  // into the ["number","null"] contract field.
+  const out = formatExtrinsic({
+    block_number: 10,
+    extrinsic_index: 0,
+    fee_tao: "not-a-number",
+    tip_tao: "abc",
+  });
+  assert.equal(out.fee_tao, null);
+  assert.equal(out.tip_tao, null);
+});
+
 test("formatExtrinsic parses call_args (array, object, parse-failure->null)", () => {
   // Substrate call args are canonically a LIST of {name,value} descriptors.
   const arr = formatExtrinsic({

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -144,6 +144,29 @@ test("formatExtrinsic maps a D1 row to an API extrinsic (ISO time, bool success)
   assert.equal(out.observed_at, new Date(1750000000000).toISOString());
 });
 
+test("formatExtrinsic coerces D1 numeric-string fee_tao/tip_tao and rounds to rao", () => {
+  // D1 can return the REAL fee/tip columns as numeric strings; a bare `?? null`
+  // would leak the string into the ["number","null"] contract field. Coercion
+  // also rounds float noise to rao precision (9 dp). Mirrors #2662.
+  const out = formatExtrinsic({
+    block_number: 10,
+    extrinsic_index: 0,
+    fee_tao: "0.0125",
+    tip_tao: "0.10000000004",
+    observed_at: 1750000000000,
+  });
+  assert.equal(out.fee_tao, 0.0125);
+  assert.equal(typeof out.fee_tao, "number");
+  assert.equal(out.tip_tao, 0.1); // rounded to rao (9 dp)
+  assert.equal(typeof out.tip_tao, "number");
+});
+
+test("formatExtrinsic maps a null/absent fee_tao/tip_tao to null", () => {
+  const out = formatExtrinsic({ block_number: 10, extrinsic_index: 0 });
+  assert.equal(out.fee_tao, null);
+  assert.equal(out.tip_tao, null);
+});
+
 test("formatExtrinsic parses call_args (array, object, parse-failure->null)", () => {
   // Substrate call args are canonically a LIST of {name,value} descriptors.
   const arr = formatExtrinsic({


### PR DESCRIPTION
## Summary

`formatExtrinsic` passed `fee_tao` / `tip_tao` through raw (`row.fee_tao ?? null`), so a D1 numeric-string cell leaked the **string** form into the `["number","null"]` contract fields, and unrounded REAL float noise reached the payload.

This is the same D1-cell coercion class the maintainers have been closing across the row formatters — `block_number`/`extrinsic_index`/`success` are already coerced *in this very function*, and `amount_tao`/`alpha_amount` were just coerced in the sibling `formatAccountEvent` via `toTaoOrNull` (#2662, plus #2487 `formatRegistration`, #2435 `blocks`, #2439/#2641). `fee_tao`/`tip_tao` were the lone tao holdout.

## What Changed

- `src/extrinsics.mjs` — add a local `toTaoOrNull` helper (null-guarded `Number()` + rao rounding to 9 dp, identical shape to `account-events.mjs`), and route `fee_tao`/`tip_tao` through it in `formatExtrinsic`. A numeric string like `"0.0125"` now becomes the number `0.0125`; `null`/absent stays `null`.
- `tests/extrinsics.test.mjs` — regression tests: a numeric-string `fee_tao`/`tip_tao` is coerced to a rao-rounded number (and float noise like `"0.10000000004"` → `0.1`), and a null/absent value maps to `null`.

Contract confirmed: the extrinsic object's `fee_tao`/`tip_tao` are `{"type":["number","null"]}` (`schemas/components/05-subnets.schema.json:2618-2619`). No schema change; this aligns runtime output with the existing contract.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (no contract change; behavior-only coercion fix)

## Validation

- [x] `npx vitest run tests/extrinsics.test.mjs` — 50 passed (incl. the 2 new cases)
- [x] Confirmed the coercion test **fails on the pre-fix tree** (`fee_tao` stayed the string `"0.0125"`) and **passes after** the fix
- [x] `npx eslint src/extrinsics.mjs tests/extrinsics.test.mjs` — clean
- [x] `npx prettier --check --end-of-line auto` on both files — clean
- [x] `git diff --check` — clean
