### PR TITLE
fix(account-events): coerce string-typed observed_at cells in account formatters

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -75,7 +75,9 @@ export const INGESTED_EVENT_KINDS = [
 ];
 
 function toIso(ms) {
-  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+  if (ms == null) return null;
+  const n = Number(ms);
+  return Number.isFinite(n) ? new Date(n).toISOString() : null;
 }
 
 // Coerce a block height or index cell to a non-negative integer, or null when

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -7,6 +7,7 @@ import {
   INGESTED_EVENT_KINDS,
   EVENT_RETENTION_MS,
   formatAccountEvent,
+  formatAccountActivity,
   formatAccountDay,
   formatRegistration,
   buildAccountSummary,
@@ -180,6 +181,19 @@ test("buildAccountTransfers coerces string-typed observed_at cells to ISO timest
     out.transfers[0].observed_at,
     new Date(1750000000000).toISOString(),
   );
+});
+
+test("formatAccountActivity coerces string-typed last_tx_at to ISO timestamps", () => {
+  const out = formatAccountActivity({ last_tx_at: "1750000000000" }, []);
+  assert.equal(out.last_tx_at, new Date(1750000000000).toISOString());
+});
+
+test("buildAccountSummary coerces string-typed first/last seen timestamps", () => {
+  const out = buildAccountSummary("5Hk", {
+    agg: { fo: "1750000000000", lo: "1750009000000" },
+  });
+  assert.equal(out.first_seen_at, new Date(1750000000000).toISOString());
+  assert.equal(out.last_seen_at, new Date(1750009000000).toISOString());
 });
 
 test("formatAccountEvent coerces string-typed netuid and uid cells to Numbers", () => {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -165,6 +165,15 @@ test("formatAccountEvent preserves null observed_at as null (not epoch 1970)", (
   assert.equal(out.observed_at, null);
 });
 
+test("formatAccountEvent drops invalid observed_at strings to null", () => {
+  const out = formatAccountEvent({
+    block_number: 1,
+    event_kind: "Transfer",
+    observed_at: "not-a-timestamp",
+  });
+  assert.equal(out.observed_at, null);
+});
+
 test("buildAccountTransfers coerces string-typed observed_at cells to ISO timestamps", () => {
   const out = buildAccountTransfers(
     [

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -146,6 +146,42 @@ test("formatAccountEvent is null-safe on junk + sparse rows", () => {
   assert.equal(out.observed_at, null);
 });
 
+test("formatAccountEvent coerces string-typed observed_at cells to ISO timestamps", () => {
+  const out = formatAccountEvent({
+    block_number: 1,
+    event_kind: "Transfer",
+    observed_at: "1750000000000",
+  });
+  assert.equal(out.observed_at, new Date(1750000000000).toISOString());
+});
+
+test("formatAccountEvent preserves null observed_at as null (not epoch 1970)", () => {
+  const out = formatAccountEvent({
+    block_number: 1,
+    event_kind: "Transfer",
+    observed_at: null,
+  });
+  assert.equal(out.observed_at, null);
+});
+
+test("buildAccountTransfers coerces string-typed observed_at cells to ISO timestamps", () => {
+  const out = buildAccountTransfers(
+    [
+      {
+        hotkey: "5A",
+        coldkey: "5B",
+        amount_tao: 1,
+        observed_at: "1750000000000",
+      },
+    ],
+    "5A",
+  );
+  assert.equal(
+    out.transfers[0].observed_at,
+    new Date(1750000000000).toISOString(),
+  );
+});
+
 test("formatAccountEvent coerces string-typed netuid and uid cells to Numbers", () => {
   // D1 can return an INTEGER column as a numeric string ("7" not 7); the bare
   // `?? null` pass-through this replaced would have leaked strings into the API


### PR DESCRIPTION
## What

Account event formatters (`formatAccountEvent`, `buildAccountTransfers`, `formatAccountActivity`, `buildAccountSummary`) stamp `observed_at` / `last_*_at` via a local `toIso` helper that only accepted finite numbers. D1 INTEGER/TIMESTAMP columns can return epoch-ms as numeric strings, so those timestamps were silently dropped to `null`.

## How

Harden `toIso` in `account-events.mjs` to `Number()`-coerce epoch-ms cells after an explicit `ms == null` guard (so `null` stays `null`, never epoch 1970). All account-event timestamp fields that already call `toIso` inherit the fix.

## Why no linked issue

Standalone formatter gap found by comparing `toIso` with `subnet-identity-history.mjs`, which already wraps `Number(row.observed_at)`. Merged #2662 covers `formatAccountEvent` TAO cells; open #2682 covers transfer `amount_tao`; this completes **epoch-ms timestamp coercion** on the account-events formatters. No open issue tracks this specific gap.

## Scope / risk

One helper change plus focused unit tests. Valid numeric timestamps unchanged; `null` stays `null`.

## Tests

- `formatAccountEvent coerces string-typed observed_at cells to ISO timestamps`
- `formatAccountEvent preserves null observed_at as null (not epoch 1970)`
- `buildAccountTransfers coerces string-typed observed_at cells to ISO timestamps`

## Test plan

- [x] String and null observed_at cases covered (event + transfer formatters)
- [x] Existing account-events tests continue to pass
- [x] CI vitest + lint/format checks
