### PR TITLE
fix(blocks): coerce string-typed extrinsic_count/event_count/spec_version in formatBlock

### DIFF
--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -117,9 +117,13 @@ export function formatBlock(row) {
     block_hash: row.block_hash ?? null,
     parent_hash: row.parent_hash ?? null,
     author: row.author ?? null,
-    extrinsic_count: row.extrinsic_count ?? null,
-    event_count: row.event_count ?? null,
-    spec_version: row.spec_version ?? null,
+    // extrinsic_count / event_count / spec_version (D1 INTEGER columns) — coerce
+    // through toBlockNumber like block_number above, so a numeric string never
+    // leaks the string form into these ["integer","null"] contract fields.
+    // Mirrors the count coercion in account-events.mjs and the fix in #2435.
+    extrinsic_count: toBlockNumber(row.extrinsic_count),
+    event_count: toBlockNumber(row.event_count),
+    spec_version: toBlockNumber(row.spec_version),
     observed_at: toIso(row.observed_at),
   };
 }

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -138,6 +138,28 @@ test("formatBlock coerces a string-typed block_number cell to a Number", () => {
   assert.equal(typeof out.block_number, "number");
 });
 
+test("formatBlock coerces string-typed extrinsic_count/event_count/spec_version cells", () => {
+  // Same D1 numeric-string hazard as block_number: these INTEGER columns must
+  // not leak the string form into their ["integer","null"] contract fields.
+  const out = formatBlock({
+    block_number: 1000,
+    extrinsic_count: "4",
+    event_count: "12",
+    spec_version: "201",
+  });
+  assert.equal(out.extrinsic_count, 4);
+  assert.equal(typeof out.extrinsic_count, "number");
+  assert.equal(out.event_count, 12);
+  assert.equal(typeof out.event_count, "number");
+  assert.equal(out.spec_version, 201);
+  assert.equal(typeof out.spec_version, "number");
+  // A missing/invalid count falls through to null, never NaN.
+  const sparse = formatBlock({ block_number: 1, extrinsic_count: "oops" });
+  assert.equal(sparse.extrinsic_count, null);
+  assert.equal(sparse.event_count, null);
+  assert.equal(sparse.spec_version, null);
+});
+
 test("formatBlock rejects a negative or non-integer block_number cell to null", () => {
   // Guard the toBlockNumber helper: negatives and floats are not valid block
   // heights, so the formatter must fall back to null rather than coerce them.


### PR DESCRIPTION
## Summary

`formatBlock` coerced `block_number` through `toBlockNumber`, but passed `extrinsic_count`, `event_count`, and `spec_version` through raw (`row.extrinsic_count ?? null`, …). All three are D1 `INTEGER` columns (see `BLOCK_READ_COLUMNS`), so a numeric-string cell leaks the **string** form into fields the contract declares `["integer","null"]`.

This is the same D1 numeric-string hazard already fixed for `block_number` in this very formatter (#2435), for `netuid`/`uid`/`success` in `formatExtrinsic` (#2439), and for `amount_tao`/`alpha_amount` in `formatAccountEvent` (#2662) — these three block fields were the remaining holdout.

## What Changed

- `src/blocks.mjs` — route `extrinsic_count` / `event_count` / `spec_version` through `toBlockNumber` (null-safe, non-negative-integer coercion), matching `block_number` in the same function and the count coercion in `account-events.mjs`. A numeric string like `"12"` now becomes `12`; a missing/invalid cell stays `null` (never `NaN`).
- `tests/blocks.test.mjs` — regression test: string-typed counts/`spec_version` coerce to numbers, and an invalid cell falls through to `null`.

Contract confirmed: the block object's `extrinsic_count`/`event_count`/`spec_version` are `{"type":["integer","null"]}` (`schemas/components/05-subnets.schema.json:2214-2216`). No schema change — this aligns runtime output with the existing contract.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (no contract change; behavior-only coercion fix)

## Validation

- [x] `npx vitest run tests/blocks.test.mjs` — 61 passed (incl. the new case)
- [x] Confirmed the coercion test **fails on the pre-fix tree** (counts stayed strings) and **passes after** the fix
- [x] `npx eslint src/blocks.mjs tests/blocks.test.mjs` — clean
- [x] `npx prettier --check --end-of-line auto` on both files — clean
- [x] `git diff --check` — clean
