### PR TITLE
ci(release): batch release-please and client-sync to a 2-day cadence

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,19 +1,30 @@
 name: release-please
 
-# Conventional-commit-driven release automation (#394). On every push to main,
-# release-please maintains a "Release PR" per component (packages/client → npm,
-# python → PyPI, "." → the hosted platform) that bumps the SemVer + regenerates
-# that component's CHANGELOG.md from the conventional commits. Merging a Release
-# PR tags the component (e.g. client-v0.3.0) and creates the GitHub Release with
-# the generated notes. release-please then dispatches the OIDC publish workflows
+# Conventional-commit-driven release automation (#394). release-please maintains a
+# "Release PR" per component (packages/client → npm, python → PyPI, "." → the
+# hosted platform) that bumps the SemVer + regenerates that component's
+# CHANGELOG.md from the conventional commits. Merging a Release PR tags the
+# component (e.g. client-v0.3.0) and creates the GitHub Release with the
+# generated notes. release-please then dispatches the OIDC publish workflows
 # (publish-client / publish-python) via workflow_dispatch — see the Dispatch steps
 # below. A tag-push trigger can't be used: GITHUB_TOKEN-created tags don't fire
 # workflows, and the validate gate requires GITHUB_REF=refs/heads/main. Commits are
 # already Conventional Commits, so the changelog is generated, not hand-maintained.
+#
+# Runs on a schedule rather than every push to main: release-please is idempotent
+# (it recomputes purely from conventional-commit history since the last release
+# tag), so batching to every 2 days has zero functional impact — it only reduces
+# how often the Release PR is refreshed against this repo's push volume.
+# `*/2` on the day-of-month field is "every other calendar day" (e.g. 2nd, 4th,
+# 6th...), not a strict rolling 48h from an arbitrary start — a standard, fine
+# approximation here since release-please just diffs commit history either way.
+# 09:00 UTC is after sync-client-version's 06:00 UTC run (below) so the same day's
+# release-please pass can pick up that day's SDK version-bump commit, if any.
+# workflow_dispatch stays available for an on-demand run.
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: "0 9 */2 * *"
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/sync-client-version.yml
+++ b/.github/workflows/sync-client-version.yml
@@ -6,13 +6,23 @@ name: Sync client SDK version
 # conflicts that occurred when multiple contract PRs were open simultaneously.
 #
 # After this PR merges, dispatch publish-client.yml manually to publish to npm.
+#
+# Runs on a schedule rather than on every push to main: the version-bump logic
+# below is unconditional (it bumps the patch version whenever it runs), so with
+# a push trigger the previous push-path filter was the ONLY thing preventing a
+# needless bump on unrelated pushes. Batching to every 2 days plus the explicit
+# change-detection guard (job below) fixes that at the source. `*/2` on the
+# day-of-month field is "every other calendar day", not a strict rolling 48h —
+# a standard, fine approximation since the guard only cares whether the watched
+# contract files changed since the last bump commit, not exact timing.
+# 06:00 UTC — three hours before release-please.yml's 09:00 UTC run — so a
+# version-bump commit opened/merged here has time to land on main before that
+# same day's release-please pass looks for it. workflow_dispatch stays available
+# for an on-demand run.
 on:
-  push:
-    branches: [main]
-    paths:
-      - "public/metagraph/openapi.json"
-      - "generated/metagraphed-api.d.ts"
-      - "generated/metagraphed-client.ts"
+  schedule:
+    - cron: "0 6 */2 * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -33,13 +43,47 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      # Real change-detection: this job's version bump below is unconditional, so
+      # without this guard a scheduled run would bump the patch version even when
+      # no contract file changed since the last bump. Find the most recent commit
+      # on main whose message starts with "chore(client): bump SDK" (this
+      # workflow's own commit-message convention, see the create-pull-request step
+      # below), then diff that commit against HEAD for the three watched contract
+      # paths. No prior bump commit found (first run ever) or a non-empty diff ⇒
+      # proceed; an empty diff ⇒ skip every subsequent step via its `if:` so the
+      # job still exits cleanly (not a mid-script `exit 0`, which would skip
+      # cleanup/reporting steps a later change might add here).
+      - name: Check for contract changes since the last SDK bump
+        id: contract-diff
+        run: |
+          last_bump="$(git log --grep '^chore(client): bump SDK' --format=%H -n 1 main)"
+          if [ -z "$last_bump" ]; then
+            echo "no prior 'chore(client): bump SDK' commit found; treating as first run"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "last SDK bump commit: ${last_bump}"
+            if git diff --quiet "${last_bump}" HEAD -- \
+              public/metagraph/openapi.json \
+              generated/metagraphed-api.d.ts \
+              generated/metagraphed-client.ts; then
+              echo "no contract changes since ${last_bump}; skipping version bump"
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "contract changes found since ${last_bump}"
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
 
       - name: Setup Node
+        if: steps.contract-diff.outputs.changed == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.23.1
 
       - name: Compute next patch version
+        if: steps.contract-diff.outputs.changed == 'true'
         id: version
         run: |
           current=$(node -p "require('./packages/client/package.json').version")
@@ -49,6 +93,7 @@ jobs:
           echo "next=$next" >> "$GITHUB_OUTPUT"
 
       - name: Bump packages/client/package.json
+        if: steps.contract-diff.outputs.changed == 'true'
         run: |
           node -e "
           const fs = require('fs');
@@ -58,6 +103,7 @@ jobs:
           "
 
       - name: Bump packages/client/package-lock.json
+        if: steps.contract-diff.outputs.changed == 'true'
         run: |
           node -e "
           const fs = require('fs');
@@ -68,6 +114,7 @@ jobs:
           "
 
       - name: Open sync PR (no-op if unchanged)
+        if: steps.contract-diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Reduces release/SDK-sync PR churn. `release-please.yml` and `sync-client-version.yml` both currently trigger on every push to main, which given this repo's commit velocity means merging one PR immediately spawns or refreshes one or both auto-PRs — recurring on nearly every merge.

- **`.github/workflows/release-please.yml`**: switched the trigger from `push: branches: [main]` to `schedule: cron: "0 9 */2 * *"` (every other calendar day at **09:00 UTC**), plus kept/added `workflow_dispatch` for on-demand runs. release-please is idempotent — it recomputes purely from conventional-commit history since the last release tag — so this has zero functional impact, only less frequent Release PR refreshing. Noted in-file that `*/2` on the day-of-month field means "every other calendar day" (2nd, 4th, 6th, ...), not a strict rolling 48h from an arbitrary start.
- **`.github/workflows/sync-client-version.yml`**: switched the trigger to the same 2-day cadence but at **06:00 UTC** — three hours earlier than release-please's 09:00 UTC — so a version-bump commit it opens/merges has time to land on main before that same day's release-please run looks for it. Also kept/added `workflow_dispatch`.

  More importantly, this workflow's patch-version bump was **unconditional** — it had no check for whether the contract actually changed since the last bump, and the push-path filter (`public/metagraph/openapi.json`, `generated/metagraphed-api.d.ts`, `generated/metagraphed-client.ts`) was the *only* thing preventing a needless bump. Added a real change-detection guard as a new first step (`Check for contract changes since the last SDK bump`): it finds the most recent commit on `main` whose message starts with `chore(client): bump SDK` (the workflow's own commit convention), then diffs that commit against `HEAD` for the three watched paths. No prior bump commit (first run ever) or a non-empty diff → proceed; empty diff → every subsequent step is skipped via `if: steps.contract-diff.outputs.changed == 'true'` (not a mid-script `exit 0`), so the job still exits cleanly. The existing version-bump logic, package-lock bump logic, and the `peter-evans/create-pull-request` step are unchanged, just gated behind this new check.

## Why

Every push to main was firing both workflows regardless of whether anything relevant changed, adding constant auto-PR noise on top of this repo's normal PR volume. Neither workflow needs push-triggered immediacy: release-please's Release PR only needs to be current by the time someone wants to cut a release, and the SDK version only needs bumping when the contract itself changed.

## Test plan

- [x] `node scripts/validate-workflows.mjs` (repo's workflow validator) — passes, 18 workflows validated
- [x] `npx prettier --check .github/workflows/release-please.yml .github/workflows/sync-client-version.yml` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `git diff --check` — clean
- [x] Verified both files parse via `js-yaml` and confirmed both cron expressions are valid 5-field GitHub Actions syntax (`0 9 */2 * *`, `0 6 */2 * *`)
- [x] `git diff --stat` confirms only the two intended workflow files changed