### PR TITLE
docs(contributing): exclude deploy-owned artifacts from contributor commits

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -239,14 +239,30 @@ test for every bug fix**. **Codecov is the coverage gate** — run it unsharded 
 
 ### Phase B3 — Regenerate what you invalidated (then commit it)
 
-| You changed…                                 | Run             | Commit                                                                     |
-| -------------------------------------------- | --------------- | -------------------------------------------------------------------------- |
-| `schemas/` or `schemas/components/`          | `npm run build` | `openapi.json`, generated types, `contracts.json`, api-index               |
-| A new/edited `/api/v1` route or artifact     | `npm run build` | the derived `public/metagraph/*` it produces                               |
-| A canonical `registry/providers/<slug>.json` | `npm run build` | regenerated artifacts (commit only the provider file + its artifacts)      |
-| MCP tools in `src/mcp-server.mjs`            | —               | **nothing** — the server card is worker-computed, not a committed artifact |
+| You changed…                                 | Run             | Commit                                                                                            |
+| -------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------- |
+| `schemas/` or `schemas/components/`          | `npm run build` | `openapi.json`, generated types, `contracts.json`, api-index                                      |
+| A new/edited `/api/v1` route or artifact     | `npm run build` | the derived `public/metagraph/*` it produces                                                      |
+| A canonical `registry/providers/<slug>.json` | `npm run build` | regenerated artifacts (commit only the provider file + its artifacts)                             |
+| MCP tools in `src/mcp-server.mjs`            | —               | **nothing** — the server card is worker-computed, not a committed artifact                        |
+| _(any of the above)_                         | `npm run build` | **never** `public/metagraph/r2-manifest.json` / `public/metagraph/schemas/index.json` — see below |
 
 Stale committed artifacts fail the **derived-artifact freshness** + **contract-drift** gates.
+
+**Never commit `public/metagraph/r2-manifest.json` or `public/metagraph/schemas/index.json`.**
+`npm run build` always rewrites both to reflect a full local/CI build, but their committed copies on
+`main` are owned by the real deploy/publish pipeline (`r2-manifest.json` is the publish lockfile
+read from its committed path at publish time; `schemas/index.json` is a network-capture cache the
+build reconciles in place) — see the "Verify committed derived artifacts are fresh" step in
+`.github/workflows/validate.yml`, which explicitly excludes both for this reason. A contributor
+build will **always** show them as changed for reasons unrelated to your change. After
+`npm run build`, always run:
+
+```sh
+git checkout origin/main -- public/metagraph/r2-manifest.json public/metagraph/schemas/index.json
+```
+
+before staging/committing — even if they show as modified.
 
 **Client SDK version:** do **not** bump `packages/client/package.json` in your PR. The
 `sync-client-version` workflow auto-opens a `chore/sync-client-version` PR after a contract-changing
@@ -286,6 +302,10 @@ the PR template with the validation commands you actually ran. Sync with `main` 
       `review.state: community-submitted`; `public_safe: true`; no health/`verification`/secrets set by hand.
 - [ ] Not a duplicate of an existing surface or an open PR; not the same surface re-titled by `kind`.
 - [ ] `npm run validate:surface` + `npm run scan:public-safety` clean.
+- [ ] If you ran `npm run build` locally out of caution (not normally required for Path A), your diff
+      still touches only your one subnet file — see the Path B note below on
+      `public/metagraph/r2-manifest.json` / `public/metagraph/schemas/index.json`; the Gittensory Gate's
+      registry-review lane rejects a PR that bundles either in with your surface change.
 - [ ] Conventional Commit (no AI attribution); PR template filled; **`Closes #<issue>`** if an issue tracks it (optional).
 
 **Path B (code/schema):**
@@ -294,6 +314,12 @@ the PR template with the validation commands you actually ran. Sync with `main` 
 - [ ] Regenerated + committed: `npm run build` artifacts (OpenAPI/types/contracts) as applicable. MCP
       tool additions do NOT require server-card regen (worker-computed). Client version bump NOT required
       (auto-sync workflow handles it post-merge).
+- [ ] `public/metagraph/r2-manifest.json` and `public/metagraph/schemas/index.json` are **not** part of
+      your diff — both always change on a local/CI build for reasons unrelated to your PR (they're
+      deploy/publish-pipeline-owned, not contract artifacts). Run
+      `git checkout origin/main -- public/metagraph/r2-manifest.json public/metagraph/schemas/index.json`
+      before committing if `npm run build` touched them. `npm run build` itself warns you if either
+      changed.
 - [ ] `git diff --check` clean · `lint` + `format:check` clean · `npm run validate` green ·
       `npm run test:coverage` green · the focused `validate:*` for what you touched green.
 - [ ] Branch current with `main`; Conventional Commit (no AI attribution); PR template filled; `Closes #<issue>` if an issue tracks it (optional).

--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -256,10 +256,12 @@ read from its committed path at publish time; `schemas/index.json` is a network-
 build reconciles in place) — see the "Verify committed derived artifacts are fresh" step in
 `.github/workflows/validate.yml`, which explicitly excludes both for this reason. A contributor
 build will **always** show them as changed for reasons unrelated to your change. After
-`npm run build`, always run:
+`npm run build`, always revert them against your **base** remote — `upstream/main` if you forked
+per Phase A0, or `origin/main` if you cloned this repo directly (no `upstream` configured):
 
 ```sh
-git checkout origin/main -- public/metagraph/r2-manifest.json public/metagraph/schemas/index.json
+git checkout "$(git remote | grep -qx upstream && echo upstream || echo origin)/main" -- \
+  public/metagraph/r2-manifest.json public/metagraph/schemas/index.json
 ```
 
 before staging/committing — even if they show as modified.
@@ -316,10 +318,9 @@ the PR template with the validation commands you actually ran. Sync with `main` 
       (auto-sync workflow handles it post-merge).
 - [ ] `public/metagraph/r2-manifest.json` and `public/metagraph/schemas/index.json` are **not** part of
       your diff — both always change on a local/CI build for reasons unrelated to your PR (they're
-      deploy/publish-pipeline-owned, not contract artifacts). Run
-      `git checkout origin/main -- public/metagraph/r2-manifest.json public/metagraph/schemas/index.json`
-      before committing if `npm run build` touched them. `npm run build` itself warns you if either
-      changed.
+      deploy/publish-pipeline-owned, not contract artifacts). Revert them against your base remote
+      (the Phase B3 command above) before committing if `npm run build` touched them. `npm run build`
+      itself warns you if either changed.
 - [ ] `git diff --check` clean · `lint` + `format:check` clean · `npm run validate` green ·
       `npm run test:coverage` green · the focused `validate:*` for what you touched green.
 - [ ] Branch current with `main`; Conventional Commit (no AI attribution); PR template filled; `Closes #<issue>` if an issue tracks it (optional).

--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -213,6 +213,11 @@ local paths, env dumps, or private notes.
 - Editing the contract by hand without `npm run build` (contract-drift), or stale committed artifacts.
 - Committing generated artifacts — `public/datasets/*` or any `public/metagraph/*` outside the reviewed
   contract (regenerated on build/deploy; `ci-verify-submitted-artifacts` rejects them).
+- Bundling `public/metagraph/r2-manifest.json` or `public/metagraph/schemas/index.json` into the diff —
+  even on a Path A surface PR. `npm run build` always rewrites both locally; they are deploy/publish-
+  pipeline-owned (see §8) and the gate's registry-review lane treats their presence as "bundling other
+  file changes" outside the one subnet file. Revert them before committing:
+  `git checkout origin/main -- public/metagraph/r2-manifest.json public/metagraph/schemas/index.json`.
 
 ---
 
@@ -234,6 +239,18 @@ local paths, env dumps, or private notes.
   fails if a committed `public/metagraph/*` is stale.
 - **Reader tests** serve R2-only artifacts that only exist after `npm run build` — build before the
   suite if a test reads served artifacts.
+- **Never commit `public/metagraph/r2-manifest.json` or `public/metagraph/schemas/index.json`.**
+  `npm run build` fully populates R2 staging (per ADR-0001) and rewrites both to reflect that local/CI
+  build, but their committed copies on `main` reflect the last real deploy/publish — not a local build —
+  for reasons unrelated to your change: `r2-manifest.json` is publish infrastructure read from its
+  committed path by `scripts/kv-publish-pointer.mjs` / `scripts/cloudflare-verify.mjs` /
+  `scripts/sync-summary.mjs` during the actual publish, and its `*_artifact_size_bytes` totals are
+  inherently non-deterministic build-to-build; `schemas/index.json` is a network-capture cache the build
+  "reconciles in place". Both are explicitly excluded from the derived-artifact freshness gate in
+  `.github/workflows/validate.yml` (see the comment above that step) — CI won't catch this, but the
+  Gittensory Gate's registry-review lane will reject a PR that bundles them in. After `npm run build`:
+  `git checkout origin/main -- public/metagraph/r2-manifest.json public/metagraph/schemas/index.json`.
+  `npm run build` itself prints a non-fatal warning if either changed.
 - **`format:check`:** `main` is not fully prettier-clean — never `prettier --write` whole files you
   didn't change; format only your own lines.
 - **`pipeline:check`** is only trustworthy in isolation after a clean `npm run build`.

--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -216,8 +216,8 @@ local paths, env dumps, or private notes.
 - Bundling `public/metagraph/r2-manifest.json` or `public/metagraph/schemas/index.json` into the diff —
   even on a Path A surface PR. `npm run build` always rewrites both locally; they are deploy/publish-
   pipeline-owned (see §8) and the gate's registry-review lane treats their presence as "bundling other
-  file changes" outside the one subnet file. Revert them before committing:
-  `git checkout origin/main -- public/metagraph/r2-manifest.json public/metagraph/schemas/index.json`.
+  file changes" outside the one subnet file. Revert them before committing — see §8 for the exact
+  command.
 
 ---
 
@@ -248,9 +248,11 @@ local paths, env dumps, or private notes.
   inherently non-deterministic build-to-build; `schemas/index.json` is a network-capture cache the build
   "reconciles in place". Both are explicitly excluded from the derived-artifact freshness gate in
   `.github/workflows/validate.yml` (see the comment above that step) — CI won't catch this, but the
-  Gittensory Gate's registry-review lane will reject a PR that bundles them in. After `npm run build`:
-  `git checkout origin/main -- public/metagraph/r2-manifest.json public/metagraph/schemas/index.json`.
-  `npm run build` itself prints a non-fatal warning if either changed.
+  Gittensory Gate's registry-review lane will reject a PR that bundles them in. After `npm run build`,
+  revert them against your **base** remote — `upstream/main` if you forked per Phase A0, or
+  `origin/main` if you cloned this repo directly (no `upstream` configured):
+  `git checkout "$(git remote | grep -qx upstream && echo upstream || echo origin)/main" -- public/metagraph/r2-manifest.json public/metagraph/schemas/index.json`.
+  `npm run build` itself prints a non-fatal warning if either changed, with the same command.
 - **`format:check`:** `main` is not fully prettier-clean — never `prettier --write` whole files you
   didn't change; format only your own lines.
 - **`pipeline:check`** is only trustworthy in isolation after a clean `npm run build`.

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,18 @@
 import { spawnSync } from "node:child_process";
 import { stableStringify } from "./lib.mjs";
 
+// Deploy/publish-pipeline-owned artifacts: their committed copies reflect the
+// last real publish, not a local/CI validate build, and normal `npm run
+// build` runs are expected to leave them looking "stale" relative to HEAD
+// (see the "Verify committed derived artifacts are fresh" step in
+// .github/workflows/validate.yml for the full reasoning). A production
+// publish run legitimately updates these, so the warning below is skipped
+// in that context.
+const DEPLOY_OWNED_ARTIFACTS = [
+  "public/metagraph/r2-manifest.json",
+  "public/metagraph/schemas/index.json",
+];
+
 const productionBuild = isProductionPublishBuild();
 const startedAt = new Date().toISOString();
 const effectiveBuildTimestamp =
@@ -53,6 +65,39 @@ console.log(
     results,
   }),
 );
+
+warnIfDeployOwnedArtifactsChanged();
+
+function warnIfDeployOwnedArtifactsChanged() {
+  // A real publish run (productionBuild) is expected to update these files —
+  // don't warn in that context. Everywhere else (plain local/CI validate
+  // build), a diff here is the footgun this warning exists to catch.
+  if (productionBuild) {
+    return;
+  }
+  const diff = spawnSync(
+    "git",
+    ["status", "--porcelain", "--", ...DEPLOY_OWNED_ARTIFACTS],
+    { cwd: process.cwd(), encoding: "utf8" },
+  );
+  if (diff.status !== 0 || !diff.stdout.trim()) {
+    return;
+  }
+  console.warn(
+    [
+      "",
+      "warning: build modified deploy-owned artifact(s):",
+      ...DEPLOY_OWNED_ARTIFACTS.map((file) => `  - ${file}`),
+      "These reflect the last real publish, not this local/CI build, and will",
+      "always differ for reasons unrelated to your change (see the",
+      '"Verify committed derived artifacts are fresh" step in',
+      ".github/workflows/validate.yml). Revert them before committing:",
+      "",
+      `  git checkout origin/main -- ${DEPLOY_OWNED_ARTIFACTS.join(" ")}`,
+      "",
+    ].join("\n"),
+  );
+}
 
 function localSteps() {
   return [

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -83,6 +83,7 @@ function warnIfDeployOwnedArtifactsChanged() {
   if (diff.status !== 0 || !diff.stdout.trim()) {
     return;
   }
+  const baseRemote = resolveBaseRemote();
   console.warn(
     [
       "",
@@ -93,10 +94,23 @@ function warnIfDeployOwnedArtifactsChanged() {
       '"Verify committed derived artifacts are fresh" step in',
       ".github/workflows/validate.yml). Revert them before committing:",
       "",
-      `  git checkout origin/main -- ${DEPLOY_OWNED_ARTIFACTS.join(" ")}`,
+      `  git checkout ${baseRemote}/main -- ${DEPLOY_OWNED_ARTIFACTS.join(" ")}`,
       "",
     ].join("\n"),
   );
+}
+
+// Forks (Phase A0) set up `upstream` pointing at the canonical repo, with
+// `origin` as the contributor's own fork — possibly stale relative to it. A
+// direct clone of the canonical repo has no `upstream` remote at all, so
+// `origin` there IS canonical. Prefer `upstream` when present.
+function resolveBaseRemote() {
+  const result = spawnSync("git", ["remote"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  const remotes = (result.stdout || "").split("\n").map((line) => line.trim());
+  return remotes.includes("upstream") ? "upstream" : "origin";
 }
 
 function localSteps() {


### PR DESCRIPTION
## Summary

- `npm run build` always rewrites `public/metagraph/r2-manifest.json` and `public/metagraph/schemas/index.json` to reflect a full local/CI build (populating R2 staging per ADR-0001), but the committed copies on `main` reflect the last real deploy/publish, not a local build. Neither file was previously mentioned in `.claude/skills/metagraphed/SKILL.md` or `reference.md`, so contributors following the Path B "run `npm run build`, commit what changed" instructions had no way to know to revert these two files first.
- Cost: (1) a giant, irrelevant diff on any contributor PR that ran `npm run build`, and (2) on Path A surface PRs specifically, the extra file makes the Gittensory Gate's registry-review lane reject the PR for "bundling other file changes" even though the contributor only meant to touch their one `registry/subnets/<slug>.json`.
- `.github/workflows/validate.yml`'s "Verify committed derived artifacts are fresh" step already excludes both files from its freshness check, with a comment explaining why: `r2-manifest.json` is publish infrastructure read from its committed path by `scripts/kv-publish-pointer.mjs` / `scripts/cloudflare-verify.mjs` / `scripts/sync-summary.mjs` during the actual publish (its committed copy is a best-effort lockfile, not a served contract surface, and its `*_artifact_size_bytes` totals are inherently non-deterministic build-to-build); `schemas/index.json` is a network-capture cache the build "reconciles in place". CI does not hard-fail on this — the gap was purely in contributor guidance.

## What Changed

- `.claude/skills/metagraphed/SKILL.md`: Phase B3's regeneration table gets a row calling out the two files as "never commit"; a new paragraph after the table explains why and gives the exact `git checkout origin/main -- ...` revert command; the Final pre-push checklist gets a Path B bullet for this plus a cross-reference from the Path A checklist (for a Path A contributor who runs `npm run build` out of caution).
- `.claude/skills/metagraphed/reference.md`: added a bullet to §7 ("What gets a PR closed / routed to manual") calling out bundling either file as a gate-rejection cause, and a bullet to §8 ("Code/schema gotchas") with the full reasoning and the load-bearing consumer scripts cited.
- `scripts/build.mjs`: added a small, non-fatal `warnIfDeployOwnedArtifactsChanged()` check at the end of the pipeline. It runs `git status --porcelain` on the two files and prints a warning with the exact revert command if either changed. It's skipped when `isProductionPublishBuild()` is true (a real publish run legitimately needs to update these), so it only fires for plain local/CI validate builds. Never fails the build.

This is docs + a warning, not artifact removal — `r2-manifest.json` stays committed and tracked (it's genuinely load-bearing publish infrastructure served at a public URL); `scripts/ci-verify-submitted-artifacts.mjs`, `.github/workflows/validate.yml`'s exclusion list, and `scripts/r2-manifest.mjs`'s generation logic are all untouched.

## Validation

- `npm run format:check` — clean (had to reformat the two touched skill files with `npx prettier --write --no-cache` after the edits; no other files touched)
- `npm run lint` — clean
- `npm run build` — ran once to confirm the new warning fires correctly and doesn't throw/fail the pipeline; confirmed via `git status` that both files changed as expected, then reverted them with `git checkout origin/main -- public/metagraph/r2-manifest.json public/metagraph/schemas/index.json` per the guidance in this PR before committing
- `npx vitest run` — full suite, 155 files / 4029 tests passed