### PR TITLE
fix(domain-tags): tag the plural 'language models' for the inference rule

### DIFF
--- a/src/domain-tags.mjs
+++ b/src/domain-tags.mjs
@@ -26,7 +26,7 @@ const DOMAIN_TAG_RULES = [
   ],
   [
     "inference",
-    /\b(inference|llms?|large language model|language model|text[- ]generation|chatbots?|prompt(?:s|ing)?|completion(?:s)?)\b/i,
+    /\b(inference|llms?|large language models?|language models?|text[- ]generation|chatbots?|prompt(?:s|ing)?|completion(?:s)?)\b/i,
   ],
   [
     "media",

--- a/tests/domain-tags.test.mjs
+++ b/tests/domain-tags.test.mjs
@@ -54,6 +54,24 @@ describe("deriveDomainTags", () => {
     );
   });
 
+  test("tags the plural 'language models' / 'large language models'", () => {
+    // "large language models" is the single most natural way to describe an
+    // LLM/inference subnet, yet the inference rule only anchored the singular
+    // ("language model") — the trailing \b failed before the plural "s", so a
+    // plural-only description silently dropped the inference tag. Mirrors the
+    // s? plurals every other alternative in the rule already carries.
+    assert.deepEqual(
+      deriveDomainTags({ description: "A marketplace for language models" }),
+      ["inference"],
+    );
+    assert.deepEqual(
+      deriveDomainTags({
+        description: "A decentralized network of large language models",
+      }),
+      ["inference"],
+    );
+  });
+
   test("accepts curated categories that are already in the vocabulary", () => {
     const tags = deriveDomainTags({
       categories: ["Finance", "privacy"],


### PR DESCRIPTION
## Summary

The `inference` rule in `src/domain-tags.mjs` anchored only the singular forms
`language model` and `large language model`:

```js
/\b(inference|llms?|large language model|language model|…|chatbots?|prompt(?:s|ing)?|completion(?:s)?)\b/i
```

The trailing `\b` fails right before a plural `s`, and no other alternative
catches it, so a description that says **"language models"** or **"large
language models"** — the single most natural way to describe an LLM/inference
subnet — matched nothing and silently dropped the `inference` tag (and the
`?domain=inference` facet filter). The singular worked; the plural didn't.

Every other pluralizable term in the same rule already allows the plural
(`llms?`, `chatbots?`, `prompt(?:s|ing)?`, `completion(?:s)?`), so the two
"language model" alternatives were the inconsistent outliers — an oversight, not
intent (the suite already asserts plural inflections must be tagged).

## Fix

Add the optional plural `s` to both alternatives:

```js
/\b(inference|llms?|large language models?|language models?|…)\b/i
```

## Tests

Added a regression test asserting `deriveDomainTags` tags both
`"...language models"` and `"...large language models"` as `["inference"]`.
Existing coverage (singular match, other plural inflections) stays green.

## Validation

- `npx vitest run tests/domain-tags.test.mjs` — 8 passed
- `npm run lint` — clean
- Prettier: changed lines conform (LF-normalized check)
- No merge conflicts against latest `main`
