### PR TITLE
feat(mcp): add get_chain_concentration mirroring the network concentration route

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -350,6 +350,12 @@ assert.ok(
   Array.isArray(chainCalls.calls),
   "get_chain_calls must return calls[]",
 );
+const chainConc = await callOk("get_chain_concentration", {});
+assert.equal(
+  typeof chainConc.subnet_count,
+  "number",
+  "get_chain_concentration must return a numeric subnet_count",
+);
 const meta = await callOk("get_subnet_metagraph", { netuid: 7 });
 assert.ok(
   Array.isArray(meta.neurons),

--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -351,10 +351,9 @@ assert.ok(
   "get_chain_calls must return calls[]",
 );
 const chainConc = await callOk("get_chain_concentration", {});
-assert.equal(
-  typeof chainConc.subnet_count,
-  "number",
-  "get_chain_concentration must return a numeric subnet_count",
+assert.ok(
+  Number.isInteger(chainConc.subnet_count),
+  "get_chain_concentration must return an integer subnet_count",
 );
 const meta = await callOk("get_subnet_metagraph", { netuid: 7 });
 assert.ok(

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -163,7 +163,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.17.0";
+export const MCP_SERVER_VERSION = "1.18.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -19,6 +19,7 @@ import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { d1TimeoutMs, withTimeout } from "../workers/storage.mjs";
 import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
 import {
+  loadChainConcentration,
   loadSubnetConcentration,
   loadSubnetConcentrationHistory,
   parseConcentrationHistoryWindow,
@@ -259,7 +260,9 @@ export const MCP_INSTRUCTIONS =
   "activity analytics, get_chain_calls returns the extrinsic call-mix " +
   "(count + share per pallet/module) over a 7d/30d window, get_chain_fees the " +
   "fee/tip market series plus top payers, get_chain_transfers network-wide " +
-  "native-TAO transfer volume plus top senders/receivers, get_network_activity the daily " +
+  "native-TAO transfer volume plus top senders/receivers, get_chain_concentration " +
+  "the network-wide stake/emission decentralization scorecard across all subnets, " +
+  "get_network_activity the daily " +
   "network-activity time series (blocks/extrinsics/events/signers), and " +
   "get_chain_activity the recent pallet.method event distribution, and " +
   "list_chain_events the raw recent decoded event feed (filterable by " +
@@ -1748,6 +1751,26 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
       return loadSubnetConcentration(mcpD1Runner(ctx), netuid);
+    },
+  },
+  {
+    name: "get_chain_concentration",
+    title: "Get network-wide stake/emission concentration",
+    description:
+      "Fetch the network-wide stake and emission decentralization scorecard: " +
+      "Gini, HHI, Nakamoto coefficient, top-percentile shares, and entropy over " +
+      "per-UID, per-entity (coldkeys collapsed ACROSS subnets into the true " +
+      "network control distribution — one operator running validators in ten " +
+      "subnets counts once), and validator-only distributions, plus the " +
+      "subnet_count the snapshot spans. The network-level companion of " +
+      "get_subnet_concentration. Mirrors GET /api/v1/chain/concentration.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadChainConcentration(mcpD1Runner(ctx));
     },
   },
   {
@@ -4861,6 +4884,24 @@ const TOOL_OUTPUT_SCHEMAS = {
     properties: {
       schema_version: { type: "integer" },
       netuid: { type: "integer" },
+      neuron_count: { type: "integer" },
+      entity_count: { type: "integer" },
+      uids_per_entity: { type: ["number", "null"] },
+      captured_at: NULLABLE_STRING,
+      stake: { type: ["object", "null"] },
+      emission: { type: ["object", "null"] },
+      entity_stake: { type: ["object", "null"] },
+      entity_emission: { type: ["object", "null"] },
+      validator_stake: { type: ["object", "null"] },
+    },
+  },
+  get_chain_concentration: {
+    type: "object",
+    additionalProperties: true,
+    required: ["subnet_count", "neuron_count"],
+    properties: {
+      schema_version: { type: "integer" },
+      subnet_count: { type: "integer" },
       neuron_count: { type: "integer" },
       entity_count: { type: "integer" },
       uids_per_entity: { type: ["number", "null"] },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5054,6 +5054,50 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.stake.holders, 2);
   });
 
+  test("get_chain_concentration returns schema-stable null blocks on cold D1", async () => {
+    const res = await callTool("get_chain_concentration", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(out.subnet_count, 0);
+    assert.equal(out.neuron_count, 0);
+    assert.equal(out.stake, null);
+    assert.equal(out.emission, null);
+  });
+
+  test("get_chain_concentration collapses entities across subnets network-wide", async () => {
+    const res = await callTool(
+      "get_chain_concentration",
+      {},
+      {
+        env: {
+          METAGRAPH_HEALTH_DB: metagraphD1({
+            neurons: [
+              {
+                ...ROW,
+                netuid: 1,
+                stake_tao: 100,
+                emission_tao: 2,
+                coldkey: "ck-a",
+              },
+              {
+                ...MINER,
+                netuid: 2,
+                stake_tao: 50,
+                emission_tao: 1,
+                coldkey: "ck-a",
+              },
+            ],
+          }),
+        },
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.subnet_count, 2); // spans netuids 1 and 2
+    assert.equal(out.neuron_count, 2);
+    assert.equal(out.entity_count, 1); // both rows share coldkey ck-a
+    assert.equal(out.entity_stake.total, 150);
+    assert.equal(out.stake.holders, 2);
+  });
+
   test("get_subnet_concentration_history defaults to 30d and returns points", async () => {
     const res = await callTool(
       "get_subnet_concentration_history",


### PR DESCRIPTION
## Summary

- The network-wide stake/emission concentration endpoint (added in #2606, `GET /api/v1/chain/concentration`) had **no MCP tool**, even though its per-subnet sibling `get_subnet_concentration` does — and the two other recently-added network-level analytics endpoints both got MCP mirrors (`get_chain_transfers` #2626, `get_subnet_yield` #2612). This closes that parity gap so AI agents get the network-level decentralization scorecard they can already fetch over REST.

## What Changed

- `src/mcp-server.mjs`:
  - New `get_chain_concentration` tool — no input params (network-wide snapshot), a thin wrapper over the existing shared `loadChainConcentration` loader (no new D1/aggregation logic).
  - A declared `outputSchema` (mirrors `get_subnet_concentration` with `subnet_count` in place of `netuid`) so `structuredContent` can never drift.
  - A one-line mention in `MCP_INSTRUCTIONS`.
- `scripts/validate-mcp.mjs`: a `callOk("get_chain_concentration", {})` smoke check asserting a numeric `subnet_count` (parity with how #2612 added a `get_subnet_yield` check).
- `tests/mcp-server.test.mjs`: tool tests for the cold-D1 path (schema-stable null blocks, `subnet_count: 0`) and the populated path (entities collapsed across subnets — `subnet_count: 2`, `entity_count: 1`).

Per the repo's contribution rules, MCP tool additions do **not** require a server-card regen (it's worker-computed), and MCP tools are not part of the OpenAPI contract — so there is no generated-artifact / contract-drift change.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None touched — MCP server card is worker-computed.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — MCP tool only; mirrors an existing REST route.)

## Validation

- [x] `npm run validate:mcp` — passes ("73 tools, lifecycle + all tools/call")
- [x] `npx vitest run tests/mcp-server.test.mjs` — 355 pass (incl. the 2 new tests)
- [x] `npx vitest run tests/agent-tool-specs.test.mjs` — tool-count parity holds
- [x] `npx eslint` + `npx prettier --check` clean · `git diff --check`
