### PR TITLE
test(artifact-storage): expand tier-classifier branch coverage

### DIFF
--- a/tests/artifact-storage-paths.test.mjs
+++ b/tests/artifact-storage-paths.test.mjs
@@ -1,6 +1,45 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { isGeneratedPublicArtifactRelativePath } from "../src/artifact-storage.mjs";
+import {
+  ARTIFACT_STORAGE_TIERS,
+  artifactRelativePath,
+  artifactStorageTierForPath,
+  artifactStorageTierForRelativePath,
+  isGeneratedPublicArtifactRelativePath,
+  isR2OnlyArtifactPath,
+  isR2PreferredDualArtifactPath,
+  schemaDetailArtifactRelativePath,
+} from "../src/artifact-storage.mjs";
+
+const SS58 = "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM";
+
+describe("artifactRelativePath", () => {
+  test("strips a leading slash and /metagraph/ prefix for absolute paths", () => {
+    assert.equal(artifactRelativePath("/metagraph/openapi.json"), "openapi.json");
+    assert.equal(artifactRelativePath("/openapi.json"), "openapi.json");
+    assert.equal(
+      artifactRelativePath("/metagraph/subnets/7/metagraph.json"),
+      "subnets/7/metagraph.json",
+    );
+  });
+
+  test("leaves relative paths unchanged, including unprefixed metagraph/ segments", () => {
+    assert.equal(artifactRelativePath("contracts.json"), "contracts.json");
+    assert.equal(
+      artifactRelativePath("metagraph/latest.json"),
+      "metagraph/latest.json",
+    );
+    assert.equal(
+      artifactRelativePath("testnet/openapi.json"),
+      "testnet/openapi.json",
+    );
+  });
+
+  test("defaults a missing argument to an empty string", () => {
+    assert.equal(artifactRelativePath(), "");
+    assert.equal(artifactRelativePath(""), "");
+  });
+});
 
 describe("isGeneratedPublicArtifactRelativePath", () => {
   test("matches the committed (dual-tier) public artifacts", () => {
@@ -35,12 +74,12 @@ describe("isGeneratedPublicArtifactRelativePath", () => {
 
   test("does not match partial, suffixed, or differently-scoped paths", () => {
     for (const relativePath of [
-      "xopenapi.json", // not anchored at the start
-      "openapi.jsonx", // not anchored at the end
-      "openapi.json/", // trailing segment
-      "schemas/other.json", // only schemas/index.json is dual
-      "testnet/openapi.json", // secondary-network prefix is not stripped
-      "subnets.json", // an R2/live artifact, not a committed one
+      "xopenapi.json",
+      "openapi.jsonx",
+      "openapi.json/",
+      "schemas/other.json",
+      "testnet/openapi.json",
+      "subnets.json",
       "",
     ]) {
       assert.equal(
@@ -53,5 +92,200 @@ describe("isGeneratedPublicArtifactRelativePath", () => {
 
   test("defaults a missing argument to a non-match", () => {
     assert.equal(isGeneratedPublicArtifactRelativePath(), false);
+  });
+});
+
+describe("artifactStorageTierForRelativePath", () => {
+  test("classifies live-computed artifacts as R2-only", () => {
+    assert.equal(
+      artifactStorageTierForRelativePath(`accounts/${SS58}.json`),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("subnets/7/metagraph.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("subnets.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+  });
+
+  test("classifies committed contract artifacts as dual", () => {
+    assert.equal(
+      artifactStorageTierForRelativePath("contracts.json"),
+      ARTIFACT_STORAGE_TIERS.dual,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("openapi.json"),
+      ARTIFACT_STORAGE_TIERS.dual,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("operational-surfaces.json"),
+      ARTIFACT_STORAGE_TIERS.dual,
+    );
+  });
+
+  test("falls back to git for paths outside both pattern lists", () => {
+    assert.equal(
+      artifactStorageTierForRelativePath("robots.txt"),
+      ARTIFACT_STORAGE_TIERS.git,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("not-a-real-artifact.json"),
+      ARTIFACT_STORAGE_TIERS.git,
+    );
+  });
+
+  test("forces R2 for secondary-network prefixes regardless of mainnet tier", () => {
+    assert.equal(
+      artifactStorageTierForRelativePath("testnet/openapi.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("local/contracts.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("testnet/subnets/7/metagraph.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+  });
+
+  test("defaults a missing argument to git", () => {
+    assert.equal(
+      artifactStorageTierForRelativePath(),
+      ARTIFACT_STORAGE_TIERS.git,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath(""),
+      ARTIFACT_STORAGE_TIERS.git,
+    );
+  });
+});
+
+describe("artifactStorageTierForPath", () => {
+  test("normalizes absolute /metagraph/ paths before tiering", () => {
+    assert.equal(
+      artifactStorageTierForPath("/metagraph/contracts.json"),
+      ARTIFACT_STORAGE_TIERS.dual,
+    );
+    assert.equal(
+      artifactStorageTierForPath("/metagraph/subnets/7/metagraph.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+    assert.equal(
+      artifactStorageTierForPath("/metagraph/robots.txt"),
+      ARTIFACT_STORAGE_TIERS.git,
+    );
+  });
+
+  test("classifies secondary-network absolute paths as R2-only", () => {
+    assert.equal(
+      artifactStorageTierForPath("/metagraph/testnet/openapi.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+  });
+
+  test("defaults a missing argument to git", () => {
+    assert.equal(
+      artifactStorageTierForPath(),
+      ARTIFACT_STORAGE_TIERS.git,
+    );
+  });
+});
+
+describe("isR2OnlyArtifactPath", () => {
+  test("returns true for live-computed artifact paths", () => {
+    assert.equal(isR2OnlyArtifactPath(`/metagraph/accounts/${SS58}.json`), true);
+    assert.equal(
+      isR2OnlyArtifactPath("/metagraph/subnets/7/metagraph.json"),
+      true,
+    );
+    assert.equal(isR2OnlyArtifactPath("subnets.json"), true);
+  });
+
+  test("returns false for committed dual-tier artifacts", () => {
+    assert.equal(isR2OnlyArtifactPath("/metagraph/contracts.json"), false);
+    assert.equal(isR2OnlyArtifactPath("openapi.json"), false);
+    assert.equal(
+      isR2OnlyArtifactPath("/metagraph/operational-surfaces.json"),
+      false,
+    );
+  });
+
+  test("returns false for git-tier paths and the default empty argument", () => {
+    assert.equal(isR2OnlyArtifactPath("/metagraph/robots.txt"), false);
+    assert.equal(isR2OnlyArtifactPath(), false);
+    assert.equal(isR2OnlyArtifactPath(""), false);
+  });
+});
+
+describe("isR2PreferredDualArtifactPath", () => {
+  test("returns false for dual artifacts because the preferred-dual set is empty", () => {
+    assert.equal(
+      isR2PreferredDualArtifactPath("/metagraph/contracts.json"),
+      false,
+    );
+    assert.equal(
+      isR2PreferredDualArtifactPath("/metagraph/openapi.json"),
+      false,
+    );
+  });
+
+  test("returns false for non-dual artifacts", () => {
+    assert.equal(
+      isR2PreferredDualArtifactPath("/metagraph/subnets/7/metagraph.json"),
+      false,
+    );
+    assert.equal(isR2PreferredDualArtifactPath("/metagraph/robots.txt"), false);
+  });
+
+  test("defaults a missing argument to false", () => {
+    assert.equal(isR2PreferredDualArtifactPath(), false);
+    assert.equal(isR2PreferredDualArtifactPath(""), false);
+  });
+});
+
+describe("schemaDetailArtifactRelativePath", () => {
+  test("returns the relative path for a valid schema detail artifact", () => {
+    assert.equal(
+      schemaDetailArtifactRelativePath(
+        "/metagraph/schemas/sn-6-numinous-openapi-schema.json",
+      ),
+      "schemas/sn-6-numinous-openapi-schema.json",
+    );
+    assert.equal(
+      schemaDetailArtifactRelativePath("schemas/allways-swagger.json"),
+      "schemas/allways-swagger.json",
+    );
+  });
+
+  test("rejects the index, non-schema paths, traversal, and malformed segments", () => {
+    assert.equal(
+      schemaDetailArtifactRelativePath("/metagraph/schemas/index.json"),
+      null,
+    );
+    assert.equal(
+      schemaDetailArtifactRelativePath("/metagraph/schema-drift.json"),
+      null,
+    );
+    assert.equal(
+      schemaDetailArtifactRelativePath("/metagraph/../../package.json"),
+      null,
+    );
+    assert.equal(
+      schemaDetailArtifactRelativePath("/metagraph/schemas/../package.json"),
+      null,
+    );
+    assert.equal(
+      schemaDetailArtifactRelativePath("schemas/sn-7\\openapi.json"),
+      null,
+    );
+  });
+
+  test("defaults a missing or empty argument to null", () => {
+    assert.equal(schemaDetailArtifactRelativePath(), null);
+    assert.equal(schemaDetailArtifactRelativePath(""), null);
   });
 });

--- a/tests/artifact-storage-paths.test.mjs
+++ b/tests/artifact-storage-paths.test.mjs
@@ -15,7 +15,10 @@ const SS58 = "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM";
 
 describe("artifactRelativePath", () => {
   test("strips a leading slash and /metagraph/ prefix for absolute paths", () => {
-    assert.equal(artifactRelativePath("/metagraph/openapi.json"), "openapi.json");
+    assert.equal(
+      artifactRelativePath("/metagraph/openapi.json"),
+      "openapi.json",
+    );
     assert.equal(artifactRelativePath("/openapi.json"), "openapi.json");
     assert.equal(
       artifactRelativePath("/metagraph/subnets/7/metagraph.json"),
@@ -188,16 +191,16 @@ describe("artifactStorageTierForPath", () => {
   });
 
   test("defaults a missing argument to git", () => {
-    assert.equal(
-      artifactStorageTierForPath(),
-      ARTIFACT_STORAGE_TIERS.git,
-    );
+    assert.equal(artifactStorageTierForPath(), ARTIFACT_STORAGE_TIERS.git);
   });
 });
 
 describe("isR2OnlyArtifactPath", () => {
   test("returns true for live-computed artifact paths", () => {
-    assert.equal(isR2OnlyArtifactPath(`/metagraph/accounts/${SS58}.json`), true);
+    assert.equal(
+      isR2OnlyArtifactPath(`/metagraph/accounts/${SS58}.json`),
+      true,
+    );
     assert.equal(
       isR2OnlyArtifactPath("/metagraph/subnets/7/metagraph.json"),
       true,


### PR DESCRIPTION
## Summary

- Extend `tests/artifact-storage-paths.test.mjs` with focused branch tests for all tier-classifier helpers in `src/artifact-storage.mjs`.
- Cover live-computed (R2), dual (committed contract), git fallback, and `testnet`/`local` network-prefix paths.
- Exercise match, non-match, and default-empty-argument arms for `artifactRelativePath`, `isGeneratedPublicArtifactRelativePath`, `schemaDetailArtifactRelativePath`, `isR2OnlyArtifactPath`, and `isR2PreferredDualArtifactPath`.

Closes #2569

## Test plan

- [x] `npm test -- tests/artifact-storage-paths.test.mjs` (24 tests pass)
- [x] `npx vitest run --coverage tests/artifact-storage-paths.test.mjs tests/artifact-tiering-explicit.test.mjs` — `src/artifact-storage.mjs` at 100% branch / 100% line coverage
- [x] CI `Validate` workflow green on PR