### PR TITLE
feat(api): netuid filter on the account events route

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -79,7 +79,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
+        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= and ?netuid= (one subnet's slice) filters and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
         get: operations["accountEvents"];
         put?: never;
         post?: never;
@@ -6094,6 +6094,7 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: string;
+                netuid?: number;
                 block_start?: number;
                 block_end?: number;
                 limit?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4689,7 +4689,7 @@
     {
       "artifact_path": "/metagraph/accounts/{ss58}/events.json",
       "cache": "short",
-      "description": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+      "description": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= and ?netuid= (one subnet's slice) filters and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
       "id": "account-events",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/events",
@@ -4701,6 +4701,13 @@
           "name": "kind",
           "schema": {
             "type": "string"
+          }
+        },
+        {
+          "name": "netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
           }
         },
         {

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -606,7 +606,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-01.1",
-      "description": "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events (no static file).",
+      "description": "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events (no static file). Supports kind, netuid, and block-height range filters.",
       "id": "account-events",
       "path": "/metagraph/accounts/{ss58}/events.json",
       "schema_ref": "#/components/schemas/AccountEventsArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -16186,6 +16186,15 @@
           },
           {
             "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
             "name": "block_start",
             "required": false,
             "schema": {
@@ -16348,7 +16357,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+        "summary": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= and ?netuid= (one subnet's slice) filters and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
         "tags": [
           "accounts",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -79,7 +79,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
+        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= and ?netuid= (one subnet's slice) filters and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
         get: operations["accountEvents"];
         put?: never;
         post?: never;
@@ -6094,6 +6094,7 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: string;
+                netuid?: number;
                 block_start?: number;
                 block_end?: number;
                 limit?: number;

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -695,7 +695,7 @@ export async function loadAccountSummary(d1, ss58) {
 export async function loadAccountEvents(
   d1,
   ss58,
-  { limit, offset, kind, cursor, blockStart, blockEnd } = {},
+  { limit, offset, kind, cursor, blockStart, blockEnd, netuid } = {},
 ) {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
@@ -713,6 +713,13 @@ export async function loadAccountEvents(
   if (kind) {
     filterParts.push("AND event_kind = ?");
     filterParams.push(kind);
+  }
+  // Per-subnet scope, parity with the sibling /history route: a bound equality
+  // on the account_events netuid column, applied inside each indexed branch so
+  // the hotkey/coldkey seeks stay index-satisfiable.
+  if (netuid != null) {
+    filterParts.push("AND netuid = ?");
+    filterParams.push(netuid);
   }
   // Block-height range filter, parity with the extrinsics and chain-events
   // feeds: the per-branch hotkey/coldkey indexes both lead block_number, so a

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1019,7 +1019,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "account-events",
     "/metagraph/accounts/{ss58}/events.json",
-    "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events (no static file).",
+    "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events (no static file). Supports kind, netuid, and block-height range filters.",
     "AccountEventsArtifact",
   ),
   artifact(
@@ -2007,11 +2007,12 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/events",
     "/metagraph/accounts/{ss58}/events.json",
-    "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+    "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= and ?netuid= (one subnet's slice) filters and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
     "short",
     ["accounts", "analytics"],
     [
       { name: "kind", schema: { type: "string" } },
+      { name: "netuid", schema: { type: "integer", minimum: 0 } },
       { name: "block_start", schema: { type: "integer", minimum: 0 } },
       { name: "block_end", schema: { type: "integer", minimum: 0 } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -1362,6 +1362,61 @@ test("loadAccountEvents applies the block_start/block_end range as bound params"
   ]);
 });
 
+test("loadAccountEvents applies netuid as a bound predicate in both branches (#2585)", async () => {
+  let captured;
+  await loadAccountEvents(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [];
+    },
+    "5Hk",
+    { netuid: 74, limit: 50, offset: 0 },
+  );
+  // The indexed union has a hotkey and a coldkey branch; the netuid equality
+  // must be bound inside each so both seeks stay scoped to the subnet.
+  assert.equal((captured.sql.match(/AND netuid = \?/g) || []).length, 2);
+  assert.deepEqual(captured.params, ["5Hk", 74, "5Hk", "5Hk", 74, 50, 0]);
+});
+
+test("loadAccountEvents combines netuid with the kind filter", async () => {
+  let captured;
+  await loadAccountEvents(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [];
+    },
+    "5Hk",
+    { netuid: 74, kind: "stake_added", limit: 50, offset: 0 },
+  );
+  assert.equal((captured.sql.match(/AND event_kind = \?/g) || []).length, 2);
+  assert.equal((captured.sql.match(/AND netuid = \?/g) || []).length, 2);
+  assert.deepEqual(captured.params, [
+    "5Hk",
+    "stake_added",
+    74,
+    "5Hk",
+    "5Hk",
+    "stake_added",
+    74,
+    50,
+    0,
+  ]);
+});
+
+test("loadAccountEvents without netuid keeps the unfiltered query shape", async () => {
+  let captured;
+  await loadAccountEvents(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [];
+    },
+    "5Hk",
+    { limit: 50, offset: 0 },
+  );
+  assert.doesNotMatch(captured.sql, /AND netuid = \?/);
+  assert.deepEqual(captured.params, ["5Hk", "5Hk", "5Hk", 50, 0]);
+});
+
 test("loadSubnetEvents short-circuits an inverted block range before D1", async () => {
   let called = false;
   const out = await loadSubnetEvents(

--- a/tests/account-routes.test.mjs
+++ b/tests/account-routes.test.mjs
@@ -156,6 +156,18 @@ test("GET /accounts/{ss58}/events rejects an unsupported query param", async () 
   assert.equal(res.status, 400);
 });
 
+test("GET /accounts/{ss58}/events rejects a malformed netuid with a 400 (#2585)", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/events?netuid=seven`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.error.code, "invalid_query");
+  assert.equal(body.meta.parameter, "netuid");
+});
+
 test("GET /accounts/{ss58}/subnets returns the cross-subnet footprint (#1347)", async () => {
   const env = dbWith({
     registrations: [

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -822,6 +822,7 @@ export async function handleAccount(request, env, ss58) {
 export async function handleAccountEvents(request, env, ss58, url) {
   const validationError = validateQueryParams(url, [
     "kind",
+    "netuid",
     "block_start",
     "block_end",
     "limit",
@@ -829,6 +830,14 @@ export async function handleAccountEvents(request, env, ss58, url) {
     "cursor",
   ]);
   if (validationError) return analyticsQueryError(validationError);
+  // Optional per-subnet scope, parity with the sibling /history route: the
+  // account_events rows carry a netuid column, so a caller can follow one
+  // subnet's slice of an account's event stream.
+  const netuid = parseNonNegativeIntParam(
+    url.searchParams.get("netuid"),
+    "netuid",
+  );
+  if (netuid.error) return analyticsQueryError(netuid.error);
   // Optional block-height range filter, parity with the extrinsics and
   // chain-events feeds. Index-satisfiable via idx_account_events_hotkey and
   // idx_account_events_coldkey (each leads block_number), so a bounded range
@@ -848,6 +857,7 @@ export async function handleAccountEvents(request, env, ss58, url) {
     offset: url.searchParams.get("offset"),
     kind: url.searchParams.get("kind"),
     cursor: url.searchParams.get("cursor"),
+    netuid: netuid.value,
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });


### PR DESCRIPTION
## Summary

Closes #2585. `handleAccountEvents` supports `kind`, `block_start`/`block_end`, and paging, but not `netuid` — even though `account_events` carries a `netuid` column and the sibling `/history` route already scopes by subnet. This adds the requested validated `?netuid=` filter:

- `netuid` added to the `validateQueryParams` allow-list; parsed via `parseNonNegativeIntParam` with a 400 (`invalid_query`, `meta.parameter = netuid`) on malformed input (the exact sibling-route pattern).
- Threaded into `loadAccountEvents` as a **bound** `AND netuid = ?` predicate inside **each** indexed branch of the hotkey/coldkey union, so both `idx_account_events_hotkey`/`_coldkey` seeks stay index-satisfiable and scoped to one subnet. Never-throw / schema-stable-zero behaviour on a cold store is unchanged.
- Route + artifact contract descriptions updated; **all** generated projections regenerated and committed — `openapi.json`, `api-index.json`, **`contracts.json`**, and the type declarations (the prior attempt #2689 was closed for the missing `contracts.json`).

## Tests
- Loader: `netuid` bound in both union branches (SQL + exact bind order); combined `kind` + `netuid`; absent → unfiltered query shape pinned.
- Route: malformed `?netuid=seven` → 400 `invalid_query` with `meta.parameter = "netuid"`.

## Validation
- `npm run lint`, `npm run format:check`, `npm run validate:contract-drift`, `npm run validate:openapi` (102 routes), `npm run validate:api` (102 routes) — green
- `npx vitest run tests/account-events.test.mjs tests/account-routes.test.mjs tests/request-handlers-entities.test.mjs` — 359 passed