### PR TITLE
fix(extrinsics): coerce string-typed observed_at cells in formatExtrinsic

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -37,7 +37,13 @@ export const EXTRINSIC_INSERT_COLUMNS = [
 ];
 
 function toIso(ms) {
-  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+  // D1 can return the INTEGER observed_at as a numeric string; a bare
+  // Number.isFinite(ms) is false for a string, so the old form dropped a real
+  // timestamp to null. Coerce first, and require n > 0 so a null/blank/invalid
+  // cell stays null instead of epoch 1970. Mirrors the blocks toIso fix (#2708).
+  if (ms == null) return null;
+  const n = Number(ms);
+  return Number.isFinite(n) && n > 0 ? new Date(n).toISOString() : null;
 }
 
 // Coerce a chain-position cell (block_number / extrinsic_index) to a

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -180,6 +180,38 @@ test("formatExtrinsic maps a non-numeric fee_tao/tip_tao to null (not NaN)", () 
   assert.equal(out.tip_tao, null);
 });
 
+test("formatExtrinsic coerces a string-typed observed_at cell to an ISO timestamp", () => {
+  // D1 can return the INTEGER observed_at as a numeric string; the old
+  // Number.isFinite(string) guard dropped a real timestamp to null. Mirrors #2708.
+  const out = formatExtrinsic({
+    block_number: 10,
+    extrinsic_index: 0,
+    observed_at: "1750000000000",
+  });
+  assert.equal(out.observed_at, new Date(1750000000000).toISOString());
+});
+
+test("formatExtrinsic keeps a null/blank/invalid observed_at as null (not epoch 1970)", () => {
+  assert.equal(
+    formatExtrinsic({ block_number: 10, extrinsic_index: 0, observed_at: null })
+      .observed_at,
+    null,
+  );
+  assert.equal(
+    formatExtrinsic({ block_number: 10, extrinsic_index: 0, observed_at: "" })
+      .observed_at,
+    null,
+  );
+  assert.equal(
+    formatExtrinsic({
+      block_number: 10,
+      extrinsic_index: 0,
+      observed_at: "not-a-timestamp",
+    }).observed_at,
+    null,
+  );
+});
+
 test("formatExtrinsic parses call_args (array, object, parse-failure->null)", () => {
   // Substrate call args are canonically a LIST of {name,value} descriptors.
   const arr = formatExtrinsic({


### PR DESCRIPTION
## Summary

`formatExtrinsic`'s `observed_at` dropped a real timestamp to `null` when D1 returned the `observed_at` INTEGER as a numeric string. The module's `toIso` used `Number.isFinite(ms)`, which is `false` for a string — so `toIso("1750000000000")` returned `null` instead of the ISO timestamp.

This is the identical bug just fixed in the sibling formatters: `blocks.mjs` `toIso` (#2708) and `account-events.mjs` (#2704). `extrinsics.mjs` and `account-stake-flow.mjs` were the remaining holdouts still on the old `toIso`; this PR fixes the extrinsics one (the served `formatExtrinsic.observed_at` path).

## What Changed

- `src/extrinsics.mjs` — harden `toIso` to coerce with `Number()` first and require `n > 0`, so a numeric-string epoch-ms becomes an ISO timestamp while `null`/blank/invalid cells stay `null` (never epoch 1970). Byte-identical to the `blocks.mjs` fix in #2708.
- `tests/extrinsics.test.mjs` — regression tests mirroring #2708: a string `observed_at` coerces to ISO, and null/blank/invalid stay null.

Contract: the extrinsic object's `observed_at` is `{"type":["string","null"],"format":"date-time"}`. No schema change — this aligns runtime output with the contract.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (no contract change)

## Validation

- [x] `npx vitest run tests/extrinsics.test.mjs` — 53 passed (incl. the new cases)
- [x] Confirmed the coercion test **fails on the pre-fix tree** (`observed_at` was `null`) and **passes after** the fix
- [x] `npx eslint` + `npx prettier --check --end-of-line auto` on both files — clean
- [x] `git diff --check` — clean
