### PR TITLE
feat(mcp): add direction filter to get_subnet_stake_flow (REST parity)

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -398,6 +398,15 @@ assert.equal(
   0,
   "get_subnet_stake_flow must degrade to zeros on cold D1",
 );
+const stakeFlowIn = await callOk("get_subnet_stake_flow", {
+  netuid: 7,
+  direction: "in",
+});
+assert.equal(
+  stakeFlowIn.netuid,
+  7,
+  "get_subnet_stake_flow must accept the direction filter",
+);
 const moversCold = await callOk("get_subnet_movers", {
   window: "30d",
   sort: "stake",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -117,6 +117,8 @@ import {
   loadSubnetStakeFlow,
   STAKE_FLOW_WINDOWS,
   DEFAULT_STAKE_FLOW_WINDOW,
+  STAKE_FLOW_DIRECTIONS,
+  DEFAULT_STAKE_FLOW_DIRECTION,
 } from "./stake-flow.mjs";
 import { loadAccountStakeFlow } from "./account-stake-flow.mjs";
 import {
@@ -163,7 +165,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.18.0";
+export const MCP_SERVER_VERSION = "1.19.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -1897,7 +1899,8 @@ export const MCP_TOOLS = [
       "(7d, 30d, or 90d; default 30d): TAO staked (StakeAdded) vs unstaked " +
       "(StakeRemoved), the net capital flow, and event counts, summed live " +
       "from the account_events stream. Use it to see whether capital is " +
-      "entering or leaving a subnet. Mirrors " +
+      "entering or leaving a subnet. ?direction narrows to inflow (in) or " +
+      "outflow (out) only; all (default) reports both sides. Mirrors " +
       "GET /api/v1/subnets/{netuid}/stake-flow.",
     inputSchema: {
       type: "object",
@@ -1907,6 +1910,11 @@ export const MCP_TOOLS = [
           type: "string",
           enum: STAKE_FLOW_WINDOW_KEYS,
           description: `Lookback window (default ${DEFAULT_STAKE_FLOW_WINDOW}).`,
+        },
+        direction: {
+          type: "string",
+          enum: STAKE_FLOW_DIRECTIONS,
+          description: `Flow side to report: in | out | all (default ${DEFAULT_STAKE_FLOW_DIRECTION}).`,
         },
       },
       required: ["netuid"],
@@ -1922,8 +1930,17 @@ export const MCP_TOOLS = [
           `window must be one of: ${STAKE_FLOW_WINDOW_KEYS.join(", ")}.`,
         );
       }
+      const direction =
+        optionalString(args, "direction") ?? DEFAULT_STAKE_FLOW_DIRECTION;
+      if (!STAKE_FLOW_DIRECTIONS.includes(direction)) {
+        throw toolError(
+          "invalid_params",
+          `direction must be one of: ${STAKE_FLOW_DIRECTIONS.join(", ")}.`,
+        );
+      }
       const { data } = await loadSubnetStakeFlow(mcpD1Runner(ctx), netuid, {
         windowLabel: window,
+        direction,
       });
       return data;
     },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -2503,6 +2503,42 @@ describe("MCP stake-flow and movers economics tools", () => {
     }
   });
 
+  test("get_subnet_stake_flow narrows to one side with direction=in", async () => {
+    const capture = [];
+    const res = await callTool(
+      "get_subnet_stake_flow",
+      { netuid: 7, window: "30d", direction: "in" },
+      {
+        env: stakeFlowD1(
+          [
+            {
+              event_kind: "StakeAdded",
+              total_tao: 200,
+              event_count: 4,
+              last_observed: 1_717_000_000_000,
+            },
+          ],
+          capture,
+        ),
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total_staked_tao, 200);
+    assert.equal(out.total_unstaked_tao, 0);
+    // direction=in binds only the StakeAdded kind, not StakeRemoved.
+    assert.ok(capture[0].params.includes("StakeAdded"));
+    assert.ok(!capture[0].params.includes("StakeRemoved"));
+  });
+
+  test("get_subnet_stake_flow rejects an unsupported direction", async () => {
+    const res = await callTool("get_subnet_stake_flow", {
+      netuid: 7,
+      direction: "sideways",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /direction must be one of/);
+  });
+
   test("get_subnet_stake_flow rejects an unsupported window", async () => {
     const res = await callTool("get_subnet_stake_flow", {
       netuid: 7,


### PR DESCRIPTION
## Summary

- The REST subnet stake-flow route gained a `?direction=all|in|out` filter in #2694, but the `get_subnet_stake_flow` MCP tool still forwarded only `window` — so AI agents couldn't narrow to inflow (`StakeAdded`) or outflow (`StakeRemoved`) the way REST callers can. This restores MCP↔REST parity (same class as the #2661 MCP parity bundle).

## What Changed

- `src/mcp-server.mjs`: add a `direction` input to `get_subnet_stake_flow` (enum from `STAKE_FLOW_DIRECTIONS` = `all|in|out`, default `all`), validated like `window`, and threaded into the shared `loadSubnetStakeFlow` loader (`in` → `StakeAdded` only, `out` → `StakeRemoved` only). No new loader logic — the loader already accepts `direction`.
- `MCP_SERVER_VERSION` + `server.json`: **1.18.0 → 1.19.0** (MINOR) — adding an input changes the advertised MCP surface, matching the version bump #2661/#2626 made for their MCP surface changes.
- `scripts/validate-mcp.mjs`: smoke check exercising `direction: "in"`.
- `tests/mcp-server.test.mjs`: tests for the `direction=in` narrowing (binds `StakeAdded` only, not `StakeRemoved`) and the invalid-direction reject.

MCP tool changes need no server-card regen (worker-computed) and MCP is not part of the OpenAPI contract — no generated-artifact / contract-drift change.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — MCP tool input only; mirrors an existing REST filter.)

## Validation

- [x] `npm run validate:mcp` — passes ("73 tools, lifecycle + all tools/call")
- [x] `npx vitest run tests/mcp-server.test.mjs` — 362 pass (incl. the 2 new direction tests)
- [x] `npx eslint` + `npx prettier --check` clean · `git diff --check`
