### PR TITLE
feat(events): ingest ColdkeySwapScheduled for historical coldkey swap intent (#2559)

### DIFF
--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -291,7 +291,7 @@ def _hotkey_swapped(a):  # HotkeySwapped: {coldkey, old_hotkey, new_hotkey} or [
     return {"coldkey": _ss58(ck), "hotkey": _ss58(hk)}
 
 
-def _coldkey_swap(a):  # ColdkeySwapped: {old_coldkey, new_coldkey} or [old_coldkey, new_coldkey]
+def _coldkey_swap(a):  # ColdkeySwapped / ColdkeySwapScheduled: {old_coldkey, new_coldkey} or [old_coldkey, new_coldkey, ...]
     if isinstance(a, dict):
         old_ck, new_ck = a.get("old_coldkey"), a.get("new_coldkey")
     else:
@@ -325,6 +325,7 @@ EXTRACTORS = {
     # Key rotation (#1816)
     "HotkeySwapped": _hotkey_swapped,
     "ColdkeySwapped": _coldkey_swap,
+    "ColdkeySwapScheduled": _coldkey_swap,  # historical: v161–v377; extra execution_block/swap_cost ignored
     # Balances pallet — native TAO transfers between accounts (#1814)
     "Transfer": _transfer,
 }

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -511,8 +511,7 @@ class TakeDelegateExtractorTest(unittest.TestCase):
 
 class ColdkeySwapExtractorTest(unittest.TestCase):
     # Subtensor emits the completed swap as ColdkeySwapped(old_coldkey,
-    # new_coldkey) -- the event the poller must index. ColdkeySwapScheduled is
-    # not a real event, so it must not be the mapped key.
+    # new_coldkey) -- the event the poller must index.
     def test_coldkey_swapped_positional(self):
         result = _extract("ColdkeySwapped", [_SS58_A, _SS58_B])
         self.assertEqual(result["coldkey"], _SS58_A)  # old_coldkey
@@ -526,9 +525,49 @@ class ColdkeySwapExtractorTest(unittest.TestCase):
         self.assertEqual(result["coldkey"], _SS58_A)
         self.assertEqual(result["hotkey"], _SS58_B)
 
-    def test_nonexistent_scheduled_event_is_not_mapped(self):
-        # The phantom name must no longer resolve to an extractor.
-        self.assertIsNone(_extract("ColdkeySwapScheduled", [_SS58_A, _SS58_B]))
+
+class ColdkeySwapScheduledExtractorTest(unittest.TestCase):
+    """Tests for SubtensorModule.ColdkeySwapScheduled (#2559).
+
+    Attribute order confirmed against finney spec 424 (v233+):
+    (old_coldkey, new_coldkey, execution_block, swap_cost). The first two
+    fields match ColdkeySwapped; extra trailing fields are display-only.
+    Removed from live metadata at v377 but still indexed for historical blocks.
+    """
+
+    def test_positional_old_and_new_coldkey(self):
+        result = _extract("ColdkeySwapScheduled", [_SS58_A, _SS58_B])
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertEqual(result["hotkey"], _SS58_B)
+
+    def test_positional_with_trailing_execution_block_and_swap_cost(self):
+        result = _extract("ColdkeySwapScheduled", [_SS58_A, _SS58_B, 7_430_400, 1_000_000_000])
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertEqual(result["hotkey"], _SS58_B)
+
+    def test_named_dict_form(self):
+        result = _extract(
+            "ColdkeySwapScheduled",
+            {"old_coldkey": _SS58_A, "new_coldkey": _SS58_B},
+        )
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertEqual(result["hotkey"], _SS58_B)
+
+    def test_invalid_old_coldkey_gives_null(self):
+        result = _extract("ColdkeySwapScheduled", ["not-an-address", _SS58_B])
+        self.assertIsNone(result["coldkey"])
+        self.assertEqual(result["hotkey"], _SS58_B)
+
+    def test_invalid_new_coldkey_gives_null(self):
+        result = _extract("ColdkeySwapScheduled", [_SS58_A, "not-an-address"])
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertIsNone(result["hotkey"])
+
+    def test_empty_shape_drift_never_raises(self):
+        result = _extract("ColdkeySwapScheduled", [])
+        self.assertIsNotNone(result)
+        self.assertIsNone(result["coldkey"])
+        self.assertIsNone(result["hotkey"])
 
 
 class RegistrationAllowedExtractorTest(unittest.TestCase):

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -75,6 +75,7 @@ export const INGESTED_EVENT_KINDS = [
   "TakeIncreased",
   "HotkeySwapped",
   "ColdkeySwapped",
+  "ColdkeySwapScheduled",
   "Transfer",
 ];
 

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -129,6 +129,10 @@ test("INGESTED_EVENT_KINDS accepts expanded Subtensor lifecycle event filters", 
   }
 });
 
+test("INGESTED_EVENT_KINDS accepts ColdkeySwapScheduled for kind filters", () => {
+  assert.ok(INGESTED_EVENT_KINDS.includes("ColdkeySwapScheduled"));
+});
+
 test("formatAccountEvent maps a D1 row to an API event (ISO time)", () => {
   const out = formatAccountEvent({
     block_number: 1000,


### PR DESCRIPTION
## Summary

- Index `SubtensorModule.ColdkeySwapScheduled` in the event poller using the existing `_coldkey_swap` extractor (same `old_coldkey` / `new_coldkey` mapping as `ColdkeySwapped`).
- Add `ColdkeySwapScheduled` to `INGESTED_EVENT_KINDS` so `?kind=` filters accept it.
- Add Python + JS regression tests mirroring the `ColdkeySwapped` cases.

Closes #2559

## Metadata confirmation

Confirmed against [SubtensorModule.ColdkeySwapScheduled reference](https://subtensor.com/reference/subtensormodule/events/ColdkeySwapScheduled) and finney spec **424** (v233+ field layout):

| # | Field | Type |
|---|-------|------|
| 0 | `old_coldkey` | AccountId |
| 1 | `new_coldkey` | AccountId |
| 2 | `execution_block` | u32 |
| 3 | `swap_cost` | u64 (RAO) |

Event id is **`ColdkeySwapScheduled`** (not `SwapColdkeyScheduled`). The event was removed from live finney metadata at **v377** (replaced by the announcement-based workflow) but remains in historical blocks and is safe to index via the shared extractor — trailing `execution_block` / `swap_cost` fields are ignored, matching the existing `ColdkeySwapped` column contract (`old_coldkey` → `coldkey`, `new_coldkey` → `hotkey`).

## What Changed

- `scripts/fetch-events.py`: `EXTRACTORS["ColdkeySwapScheduled"] = _coldkey_swap`
- `src/account-events.mjs`: append `"ColdkeySwapScheduled"` under the key-rotation group
- `scripts/test_fetch_events.py`: new `ColdkeySwapScheduledExtractorTest`
- `tests/account-events.test.mjs`: assert `INGESTED_EVENT_KINDS` includes the new kind

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. _(none — ingest-only)_

## Validation

- [x] `py scripts/test_fetch_events.py`
- [x] `npm test -- tests/account-events.test.mjs`
