### PR TITLE
fix(neuron-history): coerce string-typed captured_at cells in buildNeuronHistory

### DIFF
--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -52,7 +52,9 @@ export function isValidSnapshotDate(value) {
 }
 
 function toIso(ms) {
-  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+  if (ms == null) return null;
+  const n = Number(ms);
+  return Number.isFinite(n) && n > 0 ? new Date(n).toISOString() : null;
 }
 
 /**

--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -54,7 +54,9 @@ export function isValidSnapshotDate(value) {
 function toIso(ms) {
   if (ms == null) return null;
   const n = Number(ms);
-  return Number.isFinite(n) && n > 0 ? new Date(n).toISOString() : null;
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const date = new Date(n);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
 }
 
 /**

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -237,6 +237,37 @@ describe("history builders", () => {
     assert.equal(sparse.points[0].block_number, null);
   });
 
+  test("buildNeuronHistory coerces string-typed captured_at cells to ISO timestamps", () => {
+    const out = buildNeuronHistory(
+      [dailyRow({ captured_at: "1780000000000" })],
+      7,
+      3,
+    );
+    assert.equal(
+      out.points[0].captured_at,
+      new Date(1780000000000).toISOString(),
+    );
+  });
+
+  test("buildNeuronHistory preserves null captured_at as null (not epoch 1970)", () => {
+    const out = buildNeuronHistory([dailyRow({ captured_at: null })], 7, 3);
+    assert.equal(out.points[0].captured_at, null);
+  });
+
+  test("buildNeuronHistory drops invalid captured_at strings to null", () => {
+    const out = buildNeuronHistory(
+      [dailyRow({ captured_at: "not-a-timestamp" })],
+      7,
+      3,
+    );
+    assert.equal(out.points[0].captured_at, null);
+  });
+
+  test("buildNeuronHistory drops blank captured_at strings to null (not epoch 1970)", () => {
+    const out = buildNeuronHistory([dailyRow({ captured_at: "" })], 7, 3);
+    assert.equal(out.points[0].captured_at, null);
+  });
+
   test("buildSubnetHistory defaults window + every aggregate to null on sparse rows", () => {
     const out = buildSubnetHistory([{ snapshot_date: "2026-06-20" }], 7);
     assert.equal(out.window, null);

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -268,6 +268,15 @@ describe("history builders", () => {
     assert.equal(out.points[0].captured_at, null);
   });
 
+  test("buildNeuronHistory drops out-of-range captured_at strings to null", () => {
+    const out = buildNeuronHistory(
+      [dailyRow({ captured_at: "8640000000000001" })],
+      7,
+      3,
+    );
+    assert.equal(out.points[0].captured_at, null);
+  });
+
   test("buildSubnetHistory defaults window + every aggregate to null on sparse rows", () => {
     const out = buildSubnetHistory([{ snapshot_date: "2026-06-20" }], 7);
     assert.equal(out.window, null);


### PR DESCRIPTION
## What

`buildNeuronHistory` (`src/neuron-history.mjs`) stamps each history point's `captured_at` via a local `toIso` helper that only accepted finite numbers. D1 can return epoch-ms as numeric strings, so per-UID neuron history payloads could silently drop snapshot timestamps to `null`.

## How

Harden `toIso` with an explicit `ms == null` guard (so `null` stays `null`, never epoch 1970) plus `Number()` coercion and an `n > 0` check (blank strings coerce to `0`). `buildNeuronHistory` is shared by the neuron history route and MCP history tools — no handler changes needed.

## Why no linked issue

Standalone formatter gap found by comparing `neuron-history.mjs` `toIso` with the merged `blocks.mjs` hardening (#2708) and `subnet-identity-history.mjs` (`Number(row.observed_at)`). Merged #2671 covered `formatNeuron` score cells only; live neuron `captured_at` was hardened on `metagraph-neurons.mjs` separately. No open issue tracks this history-builder gap.

## Scope / risk

One helper change plus focused `buildNeuronHistory` unit tests. Valid numeric timestamps unchanged; `null` stays `null`.

## Tests

- `buildNeuronHistory coerces string-typed captured_at cells to ISO timestamps`
- `buildNeuronHistory preserves null captured_at as null (not epoch 1970)`
- `buildNeuronHistory drops invalid captured_at strings to null`
- `buildNeuronHistory drops blank captured_at strings to null (not epoch 1970)`

## Test plan

- [x] String, null, invalid, and blank captured_at cases covered on buildNeuronHistory
- [x] Existing neuron-history tests continue to pass
- [x] CI vitest + lint/format checks
