### PR TITLE
fix(metagraph-neurons): coerce string-typed captured_at cells in toIso

### DIFF
--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -50,7 +50,9 @@ const GLOBAL_VALIDATOR_SUBNET_LIMIT = 10;
 const RAO_PER_TAO = 1e9;
 
 function toIso(ms) {
-  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+  if (ms == null) return null;
+  const n = Number(ms);
+  return Number.isFinite(n) && n > 0 ? new Date(n).toISOString() : null;
 }
 
 function numberOrZero(value) {

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -260,6 +260,20 @@ describe("metagraph-neurons builders", () => {
     );
   });
 
+  test("coerces string-typed captured_at cells in snapshot stamp and neuron detail", () => {
+    const captured = "1750000000000";
+    const meta = buildSubnetMetagraph([{ ...ROW, captured_at: captured }], 7);
+    assert.equal(meta.captured_at, new Date(Number(captured)).toISOString());
+    const vals = buildSubnetValidators([{ ...ROW, captured_at: captured }], 7);
+    assert.equal(vals.captured_at, new Date(Number(captured)).toISOString());
+    const detail = buildNeuronDetail({ ...ROW, captured_at: captured }, 7);
+    assert.equal(detail.captured_at, new Date(Number(captured)).toISOString());
+    assert.equal(
+      buildNeuronDetail({ ...ROW, captured_at: "not-a-date" }, 7).captured_at,
+      null,
+    );
+  });
+
   test("buildGlobalValidators groups validator identities across subnets", () => {
     const data = buildGlobalValidators(
       [


### PR DESCRIPTION
## Summary

D1 can return \captured_at\ as a numeric string; \	oIso\ treated that as non-finite and emitted \
ull\ on metagraph/validators/neuron-detail responses.

## What Changed

- \src/metagraph-neurons.mjs\: coerce via \Number()\ before the finite check (same pattern as \locks.mjs\ / \ccount-events.mjs\).
- \	ests/metagraph-neurons.test.mjs\: regression for string \captured_at\ on snapshot stamp + neuron detail.

## Validation

- [ ] \
pm run worker:test\ / \
px vitest run tests/metagraph-neurons.test.mjs\ (CI)
