### PR TITLE
fix(neuron-history): coerce string-typed block_number cells in buildNeuronHistory

### DIFF
--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -58,12 +58,22 @@ function toIso(ms) {
 // Coerce a block-height cell to a non-negative integer, or null when missing,
 // non-finite, or negative. D1 can return an INTEGER column as a numeric string,
 // so a bare `r.block_number ?? null` would silently leak the string into the
-// history payload (and break downstream arithmetic/comparisons). Mirrors the
-// `toBlockNumber` already applied in blocks.mjs / account-events.mjs.
+// history payload (and break downstream arithmetic/comparisons). Only finite
+// numbers and all-digit strings are accepted — blank/whitespace strings and
+// booleans must not survive `Number()` coercion as 0/1.
 function toBlockNumber(value) {
   if (value == null) return null;
-  const n = Number(value);
-  return Number.isInteger(n) && n >= 0 ? n : null;
+  if (typeof value === "boolean") return null;
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value === "string") {
+    const digits = value.trim();
+    if (digits === "" || !/^\d+$/.test(digits)) return null;
+    const n = Number(digits);
+    return Number.isSafeInteger(n) && n >= 0 ? n : null;
+  }
+  return null;
 }
 
 /**

--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -55,6 +55,17 @@ function toIso(ms) {
   return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
 }
 
+// Coerce a block-height cell to a non-negative integer, or null when missing,
+// non-finite, or negative. D1 can return an INTEGER column as a numeric string,
+// so a bare `r.block_number ?? null` would silently leak the string into the
+// history payload (and break downstream arithmetic/comparisons). Mirrors the
+// `toBlockNumber` already applied in blocks.mjs / account-events.mjs.
+function toBlockNumber(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 0 ? n : null;
+}
+
 /**
  * Daily rollup: snapshot the current `neurons` table into `neuron_daily` for the
  * captured UTC day. A single atomic INSERT...SELECT in the health DB:
@@ -303,7 +314,7 @@ export function buildNeuronHistory(rows, netuid, uid, { window } = {}) {
       return {
         snapshot_date: r.snapshot_date,
         captured_at: toIso(r.captured_at),
-        block_number: r.block_number ?? null,
+        block_number: toBlockNumber(r.block_number),
         ...neuron,
       };
     })

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -277,6 +277,25 @@ describe("history builders", () => {
     }
   });
 
+  test("buildNeuronHistory rejects unsupported block_number types and unsafe integer strings", () => {
+    const out = buildNeuronHistory(
+      [
+        dailyRow({ block_number: 5_000_000 }),
+        dailyRow({ block_number: " 5000000 " }),
+        dailyRow({ block_number: "99999999999999999999" }),
+        dailyRow({ block_number: {} }),
+        dailyRow({ block_number: ["1"] }),
+      ],
+      7,
+      3,
+    );
+    assert.equal(out.points[0].block_number, 5_000_000);
+    assert.equal(out.points[1].block_number, 5_000_000);
+    assert.equal(out.points[2].block_number, null);
+    assert.equal(out.points[3].block_number, null);
+    assert.equal(out.points[4].block_number, null);
+  });
+
   test("buildSubnetHistory defaults window + every aggregate to null on sparse rows", () => {
     const out = buildSubnetHistory([{ snapshot_date: "2026-06-20" }], 7);
     assert.equal(out.window, null);

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -261,6 +261,22 @@ describe("history builders", () => {
     assert.equal(out.points[2].block_number, null);
   });
 
+  test("buildNeuronHistory rejects Number-coercible junk block_number cells to null", () => {
+    const out = buildNeuronHistory(
+      [
+        dailyRow({ block_number: "" }),
+        dailyRow({ block_number: "   " }),
+        dailyRow({ block_number: false }),
+        dailyRow({ block_number: true }),
+      ],
+      7,
+      3,
+    );
+    for (const point of out.points) {
+      assert.equal(point.block_number, null);
+    }
+  });
+
   test("buildSubnetHistory defaults window + every aggregate to null on sparse rows", () => {
     const out = buildSubnetHistory([{ snapshot_date: "2026-06-20" }], 7);
     assert.equal(out.window, null);

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -237,6 +237,30 @@ describe("history builders", () => {
     assert.equal(sparse.points[0].block_number, null);
   });
 
+  test("buildNeuronHistory coerces string-typed block_number cells to integers", () => {
+    const out = buildNeuronHistory(
+      [dailyRow({ block_number: "5000000" })],
+      7,
+      3,
+    );
+    assert.equal(out.points[0].block_number, 5_000_000);
+  });
+
+  test("buildNeuronHistory rejects invalid block_number cells to null", () => {
+    const out = buildNeuronHistory(
+      [
+        dailyRow({ block_number: -1 }),
+        dailyRow({ block_number: 1.5 }),
+        dailyRow({ block_number: "abc" }),
+      ],
+      7,
+      3,
+    );
+    assert.equal(out.points[0].block_number, null);
+    assert.equal(out.points[1].block_number, null);
+    assert.equal(out.points[2].block_number, null);
+  });
+
   test("buildSubnetHistory defaults window + every aggregate to null on sparse rows", () => {
     const out = buildSubnetHistory([{ snapshot_date: "2026-06-20" }], 7);
     assert.equal(out.window, null);


### PR DESCRIPTION
## Summary

- Harden `buildNeuronHistory` so each history point's `block_number` is coerced to a non-negative integer (or `null`) instead of leaking D1 numeric strings into the payload.
- Add focused unit tests for string coercion and invalid-cell rejection.

## Problem

D1 can return INTEGER columns as numeric strings. `buildNeuronHistory` used `r.block_number ?? null`, so per-UID neuron history points could expose `block_number` as a string — breaking the `["integer","null"]` contract and downstream comparisons. The sibling `blocks.mjs` / `account-events.mjs` formatters already coerce block heights; this path was missed.

## Scope / risk

Two files only (`src/neuron-history.mjs`, `tests/neuron-history.test.mjs`). No schema or handler changes. Valid integer block numbers unchanged; missing values stay `null`.

## Test plan

- [x] `buildNeuronHistory coerces string-typed block_number cells to integers`
- [x] `buildNeuronHistory rejects invalid block_number cells to null`
- [x] Existing neuron-history tests pass (`npm test -- tests/neuron-history.test.mjs`)