### PR TITLE
fix(neuron-history): coerce string-typed aggregate counts in buildSubnetHistory

### DIFF
--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -55,6 +55,17 @@ function toIso(ms) {
   return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
 }
 
+// Coerce a non-negative integer cell, or null when missing, non-finite, or
+// negative. D1 can return COUNT/SUM aggregates as numeric strings, so a bare
+// `r.neuron_count ?? null` would leak the string into the subnet-history
+// payload (breaking the ["integer","null"] contract). Mirrors toBlockNumber in
+// blocks.mjs / account-events.mjs.
+function toNonNegativeInt(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 0 ? n : null;
+}
+
 /**
  * Daily rollup: snapshot the current `neurons` table into `neuron_daily` for the
  * captured UTC day. A single atomic INSERT...SELECT in the health DB:
@@ -446,8 +457,8 @@ export function buildSubnetHistory(rows, netuid, { window } = {}) {
     .filter((r) => r && typeof r === "object")
     .map((r) => ({
       snapshot_date: r.snapshot_date,
-      neuron_count: r.neuron_count ?? null,
-      validator_count: r.validator_count ?? null,
+      neuron_count: toNonNegativeInt(r.neuron_count),
+      validator_count: toNonNegativeInt(r.validator_count),
       // Round the per-day SUM(stake_tao)/SUM(emission_tao) to stop accumulated
       // float noise from leaking, matching buildEconomicsTrends above.
       total_stake_tao: roundTaoOrNull(r.total_stake_tao),

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -246,6 +246,43 @@ describe("history builders", () => {
     assert.equal(out.points[0].total_emission_tao, null);
   });
 
+  test("buildSubnetHistory coerces string-typed aggregate counts to integers", () => {
+    const out = buildSubnetHistory(
+      [
+        {
+          snapshot_date: "2026-06-20",
+          neuron_count: "256",
+          validator_count: "64",
+        },
+      ],
+      7,
+    );
+    assert.equal(out.points[0].neuron_count, 256);
+    assert.equal(out.points[0].validator_count, 64);
+  });
+
+  test("buildSubnetHistory rejects invalid aggregate counts to null", () => {
+    const out = buildSubnetHistory(
+      [
+        {
+          snapshot_date: "2026-06-20",
+          neuron_count: -1,
+          validator_count: 1.5,
+        },
+        {
+          snapshot_date: "2026-06-19",
+          neuron_count: "abc",
+          validator_count: null,
+        },
+      ],
+      7,
+    );
+    assert.equal(out.points[0].neuron_count, null);
+    assert.equal(out.points[0].validator_count, null);
+    assert.equal(out.points[1].neuron_count, null);
+    assert.equal(out.points[1].validator_count, null);
+  });
+
   test("buildEconomicsTrends rolls per-subnet rows up to one network point per day", () => {
     const out = buildEconomicsTrends(
       [


### PR DESCRIPTION
## Summary

- Harden `buildSubnetHistory` so each point's `neuron_count` and `validator_count` are coerced to non-negative integers (or `null`) instead of leaking D1 numeric strings into the payload.
- Add focused unit tests for string coercion and invalid-cell rejection.

## Problem

The subnet history handler aggregates `neuron_daily` with `COUNT(*)` / `SUM(validator_permit)`. D1 can return those aggregates as numeric strings. `buildSubnetHistory` used `r.neuron_count ?? null`, so `/api/v1/subnets/{netuid}/history` could expose count fields as strings — breaking the `[integer,null]` contract. The per-day TAO sums were already coerced via `roundTaoOrNull`; the count fields were missed.

## Scope / risk

Two files only (`src/neuron-history.mjs`, `tests/neuron-history.test.mjs`). No schema or handler changes. Valid integer counts unchanged; missing values stay `null`.

## Test plan

- [x] `buildSubnetHistory coerces string-typed aggregate counts to integers`
- [x] `buildSubnetHistory rejects invalid aggregate counts to null`
- [x] Existing neuron-history tests pass (`npm test -- tests/neuron-history.test.mjs`)