### PR TITLE
feat(mcp): add list_global_validators mirroring the global validator leaderboard

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -382,6 +382,13 @@ assert.ok(
   Array.isArray(vals.validators),
   "list_subnet_validators must return validators[]",
 );
+const globalVals = await callOk("list_global_validators", {
+  sort: "total_stake",
+});
+assert.ok(
+  Array.isArray(globalVals.validators),
+  "list_global_validators must return validators[]",
+);
 const yieldCard = await callOk("get_subnet_yield", { netuid: 7 });
 assert.ok(
   Array.isArray(yieldCard.neurons),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.18.0",
+  "version": "1.20.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -93,6 +93,11 @@ import {
   loadNeuron,
   loadSubnetMetagraph,
   loadSubnetValidators,
+  loadGlobalValidators,
+  GLOBAL_VALIDATOR_SORTS,
+  DEFAULT_GLOBAL_VALIDATOR_SORT,
+  GLOBAL_VALIDATOR_LIMIT_DEFAULT,
+  GLOBAL_VALIDATOR_LIMIT_MAX,
 } from "./metagraph-neurons.mjs";
 import {
   loadAccountSummary,
@@ -163,7 +168,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.18.0";
+export const MCP_SERVER_VERSION = "1.20.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -250,7 +255,9 @@ export const MCP_INSTRUCTIONS =
   "usage analytics (request volume, latency, failover, cache hits, per-endpoint " +
   "distribution) over a 7d/30d window, get_subnet_metagraph the " +
   "per-UID neuron snapshot (validator_permit filters to validators), " +
-  "list_subnet_validators its validators ranked by stake, and get_neuron one " +
+  "list_subnet_validators its validators ranked by stake, list_global_validators " +
+  "the network-wide validator/operator leaderboard grouped by identity across " +
+  "subnets, and get_neuron one " +
   "UID — use these to decide where to mine or validate. For wallet lookup, " +
   "get_account summarizes what one hotkey or coldkey does across the network, " +
   "get_account_balance its live native-TAO balance (free+reserved) from finney RPC, " +
@@ -2196,6 +2203,50 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
       return loadSubnetValidators(mcpD1Runner(ctx), netuid);
+    },
+  },
+  {
+    name: "list_global_validators",
+    title: "List the network-wide validator leaderboard",
+    description:
+      "List the network-wide validator/operator leaderboard from the current " +
+      "neurons snapshot: permit-holding UIDs grouped by hotkey identity across " +
+      "ALL subnets, so you see an operator's cross-subnet footprint (subnet " +
+      "count, uid count, aggregate stake/emission, avg/max validator trust, and " +
+      "stake dominance) rather than one subnet at a time. The network-level " +
+      "companion of list_subnet_validators. Mirrors GET /api/v1/validators.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sort: {
+          type: "string",
+          enum: GLOBAL_VALIDATOR_SORTS,
+          description: `Ranking field (default ${DEFAULT_GLOBAL_VALIDATOR_SORT}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max operators to return (1-${GLOBAL_VALIDATOR_LIMIT_MAX}, default ${GLOBAL_VALIDATOR_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: GLOBAL_VALIDATOR_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const sort =
+        optionalString(args, "sort") ?? DEFAULT_GLOBAL_VALIDATOR_SORT;
+      if (!GLOBAL_VALIDATOR_SORTS.includes(sort)) {
+        throw toolError(
+          "invalid_params",
+          `sort must be one of: ${GLOBAL_VALIDATOR_SORTS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        GLOBAL_VALIDATOR_LIMIT_DEFAULT,
+        GLOBAL_VALIDATOR_LIMIT_MAX,
+      );
+      return loadGlobalValidators(mcpD1Runner(ctx), { sort, limit });
     },
   },
   {
@@ -5140,6 +5191,20 @@ const TOOL_OUTPUT_SCHEMAS = {
       validator_count: { type: "integer" },
       captured_at: NULLABLE_STRING,
       block_number: NULLABLE_INT,
+      validators: { type: "array", items: { type: "object" } },
+    },
+  },
+  list_global_validators: {
+    type: "object",
+    additionalProperties: true,
+    required: ["validator_count", "validators"],
+    properties: {
+      schema_version: { type: "integer" },
+      sort: NULLABLE_STRING,
+      limit: { type: "integer" },
+      captured_at: NULLABLE_STRING,
+      block_number: NULLABLE_INT,
+      validator_count: { type: "integer" },
       validators: { type: "array", items: { type: "object" } },
     },
   },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5035,6 +5035,40 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.validators[0].validator_permit, true);
   });
 
+  test("list_global_validators groups a permit-holder across subnets", async () => {
+    const res = await callTool(
+      "list_global_validators",
+      { sort: "subnet_count" },
+      {
+        env: {
+          METAGRAPH_HEALTH_DB: metagraphD1({
+            neurons: [
+              { ...ROW, netuid: 1, hotkey: "hk-a", coldkey: "ck-a" },
+              { ...ROW, netuid: 2, hotkey: "hk-a", coldkey: "ck-a" },
+            ],
+          }),
+        },
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.sort, "subnet_count");
+    assert.equal(out.validator_count, 1); // one hotkey identity across 2 subnets
+    assert.equal(out.validators[0].subnet_count, 2);
+  });
+
+  test("list_global_validators rejects an unsupported sort", async () => {
+    const res = await callTool("list_global_validators", { sort: "bogus" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /sort must be one of/);
+  });
+
+  test("list_global_validators degrades to an empty list on cold D1", async () => {
+    const res = await callTool("list_global_validators", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(out.validator_count, 0);
+    assert.deepEqual(out.validators, []);
+  });
+
   test("get_neuron returns one UID, neuron:null for an absent UID", async () => {
     const present = await callTool(
       "get_neuron",


### PR DESCRIPTION
## Summary

- The network-wide validator/operator leaderboard (`GET /api/v1/validators`, added in #2493 and extended with sorting/dominance in #2685) had **no MCP tool**, unlike its per-subnet sibling `list_subnet_validators`. This adds `list_global_validators` so AI agents can rank operators by cross-subnet footprint — the same network-level parity pattern as `get_chain_concentration` / `get_chain_transfers`.

## What Changed

- `src/mcp-server.mjs`: new `list_global_validators` tool — `sort` (enum `GLOBAL_VALIDATOR_SORTS`: `subnet_count` (default), `uid_count`, `total_stake`, `total_emission`, `avg_validator_trust`, `max_validator_trust`, `stake_dominance`) + `limit` (1–100, default 20), validated like the REST route, forwarded to the shared `loadGlobalValidators` loader (no new query logic). Declared `outputSchema` so `structuredContent` can't drift; `MCP_INSTRUCTIONS` entry.
- `MCP_SERVER_VERSION` + `server.json`: **1.18.0 → 1.20.0** (new tool surface; 1.19.0 is taken by my in-flight stake-flow-direction PR #2715).
- `scripts/validate-mcp.mjs`: smoke check (`sort: "total_stake"`).
- `tests/mcp-server.test.mjs`: tests for cross-subnet identity grouping (`subnet_count: 2` for one hotkey across two subnets), invalid-sort reject, and cold-D1 empty list.

MCP tools need no server-card regen (worker-computed) and are outside the OpenAPI contract — no generated-artifact / contract-drift change.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — MCP tool only; mirrors an existing REST route.)

## Validation

- [x] `npm run validate:mcp` — passes ("74 tools, lifecycle + all tools/call")
- [x] `npx vitest run tests/mcp-server.test.mjs` — 363 pass (incl. the 3 new tests)
- [x] `npx eslint` + `npx prettier --check` clean · `git diff --check`
