### PR TITLE
fix(api): reject unknown kind on account events before D1

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2021,6 +2021,35 @@ describe("handleAccountEvents", () => {
     );
   });
 
+  test("rejects an unknown event kind with 400", async () => {
+    const { env, captures } = dbWith({
+      accountEvents: [accountEventRow()],
+    });
+    const res = await handleAccountEvents(
+      req(`/api/v1/accounts/${SS58}/events`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events?kind=Nonexistent`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "kind");
+    assert.match(body.error.message, /not a supported event kind/);
+    assert.equal(captures.sql.length, 0);
+  });
+
+  test("accepts a non-SubtensorModule ingested kind (Transfer), not just INDEXED_EVENT_KINDS", async () => {
+    const { env, captures } = dbWith({
+      accountEvents: [accountEventRow({ event_kind: "Transfer" })],
+    });
+    await handleAccountEvents(
+      req(`/api/v1/accounts/${SS58}/events`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events?kind=Transfer`),
+    );
+    assert.ok(captures.sql.some((s) => /event_kind = \?/.test(s)));
+  });
+
   test("cursor uses keyset seek instead of offset", async () => {
     const { env, captures } = dbWith({
       accountEvents: [accountEventRow({ block_number: 150, event_index: 2 })],

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -843,10 +843,22 @@ export async function handleAccountEvents(request, env, ss58, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
+  const kind = url.searchParams.get("kind");
+  // Reject an unknown ?kind= up front, validated against the FULL ingested set
+  // (not just INDEXED_EVENT_KINDS, which would wrongly reject Transfer/NetworkAdded
+  // etc.). A typo/nonexistent kind otherwise matches nothing and forces a full
+  // index walk on this public, ~60s-cached route — parity with handleSubnetEvents
+  // (#2081).
+  if (kind != null && !INGESTED_EVENT_KINDS.includes(kind)) {
+    return analyticsQueryError({
+      parameter: "kind",
+      message: `"${kind}" is not a supported event kind. Supported: ${INGESTED_EVENT_KINDS.join(", ")}.`,
+    });
+  }
   const data = await loadAccountEvents(d1Runner(env), ss58, {
     limit: url.searchParams.get("limit"),
     offset: url.searchParams.get("offset"),
-    kind: url.searchParams.get("kind"),
+    kind,
     cursor: url.searchParams.get("cursor"),
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,


### PR DESCRIPTION
## Summary

- Reject unknown `?kind=` on `GET /api/v1/accounts/{ss58}/events` before querying D1, matching `handleSubnetEvents` (#2081).
- A typo or unsupported kind otherwise matches nothing and forces a full index walk on this public, ~60s-cached route.

## Test plan

- [x] `npm test -- tests/request-handlers-entities.test.mjs` (unknown kind returns 400 with no SQL; Transfer ingested kind still accepted)
