### PR TITLE
fix(api): coerce D1 numeric-string cells in formatTrajectory

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -476,6 +476,11 @@ function round4(value) {
 function roundInt(value) {
   return value == null ? null : Math.round(Number(value));
 }
+function toFiniteOrNull(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
 
 // p50/p95/p99 + avg/min/max latency per surface, computed in SQL (one row per
 // stable surface). `rows`: [{ surface_id, surface_key?, samples, p50, p95, p99,
@@ -1019,9 +1024,9 @@ export function formatTrajectory({ netuid, rows }) {
       // existed / when economics was unavailable that day.
       validator_count: roundInt(row.validator_count),
       miner_count: roundInt(row.miner_count),
-      total_stake_tao: round4(row.total_stake_tao),
-      alpha_price_tao: round4(row.alpha_price_tao),
-      emission_share: round4(row.emission_share),
+      total_stake_tao: toFiniteOrNull(row.total_stake_tao),
+      alpha_price_tao: toFiniteOrNull(row.alpha_price_tao),
+      emission_share: toFiniteOrNull(row.emission_share),
     }))
     .sort((a, b) => String(a.date).localeCompare(String(b.date)));
 

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1009,16 +1009,19 @@ export function formatTrajectory({ netuid, rows }) {
   const points = (rows || [])
     .map((row) => ({
       date: row.snapshot_date,
-      completeness_score: row.completeness_score ?? null,
-      surface_count: row.surface_count ?? null,
-      endpoint_count: row.endpoint_count ?? null,
+      // D1 INTEGER/REAL cells often arrive as numeric strings — coerce through
+      // the same round helpers as the latency formatters so OpenAPI integer/number
+      // types are never violated on the trajectory artifact.
+      completeness_score: roundInt(row.completeness_score),
+      surface_count: roundInt(row.surface_count),
+      endpoint_count: roundInt(row.endpoint_count),
       // Economic time series (#1307) — null on rows captured before the columns
       // existed / when economics was unavailable that day.
-      validator_count: row.validator_count ?? null,
-      miner_count: row.miner_count ?? null,
-      total_stake_tao: row.total_stake_tao ?? null,
-      alpha_price_tao: row.alpha_price_tao ?? null,
-      emission_share: row.emission_share ?? null,
+      validator_count: roundInt(row.validator_count),
+      miner_count: roundInt(row.miner_count),
+      total_stake_tao: round4(row.total_stake_tao),
+      alpha_price_tao: round4(row.alpha_price_tao),
+      emission_share: round4(row.emission_share),
     }))
     .sort((a, b) => String(a.date).localeCompare(String(b.date)));
 

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -5,6 +5,7 @@ import {
   formatIncidents,
   formatLeaderboards,
   formatTrajectory,
+  loadSubnetTrajectory,
   LEADERBOARD_BOARDS,
 } from "../src/health-serving.mjs";
 import { writeSubnetSnapshot } from "../src/health-prober.mjs";
@@ -695,9 +696,59 @@ describe("formatTrajectory", () => {
     assert.equal(typeof point.validator_count, "number");
     assert.equal(typeof point.miner_count, "number");
     assert.equal(typeof point.total_stake_tao, "number");
+    assert.equal(typeof point.alpha_price_tao, "number");
+    assert.equal(typeof point.emission_share, "number");
     assert.equal(point.surface_count, 5);
     assert.equal(point.validator_count, 9);
+    assert.equal(point.miner_count, 247);
     assert.equal(point.total_stake_tao, 2522266);
+    assert.equal(point.alpha_price_tao, 0.04);
+    assert.equal(point.emission_share, 0.01);
+  });
+  test("nulls non-finite D1 economics strings instead of leaking NaN", () => {
+    const out = formatTrajectory({
+      netuid: 5,
+      rows: [
+        {
+          snapshot_date: "2026-06-01",
+          completeness_score: "70",
+          surface_count: "2",
+          endpoint_count: "1",
+          total_stake_tao: "not-a-number",
+          alpha_price_tao: "bad",
+          emission_share: "Infinity",
+        },
+      ],
+    });
+    const point = out.points[0];
+    assert.equal(point.total_stake_tao, null);
+    assert.equal(point.alpha_price_tao, null);
+    assert.equal(point.emission_share, null);
+    assert.equal(point.completeness_score, 70);
+  });
+  test("loadSubnetTrajectory threads D1 string cells through formatTrajectory", async () => {
+    const d1 = async (sql, params) => {
+      assert.ok(sql.includes("FROM subnet_snapshots"));
+      assert.deepEqual(params, [11]);
+      return [
+        {
+          snapshot_date: "2026-06-15",
+          completeness_score: "88",
+          surface_count: "6",
+          endpoint_count: "4",
+          validator_count: "12",
+          miner_count: "300",
+          total_stake_tao: "1000000",
+          alpha_price_tao: "0.055",
+          emission_share: "0.000049",
+        },
+      ];
+    };
+    const out = await loadSubnetTrajectory(d1, 11);
+    const point = out.points[0];
+    assert.equal(point.validator_count, 12);
+    assert.equal(point.alpha_price_tao, 0.055);
+    assert.equal(point.emission_share, 0.000049);
   });
   test("preserves sub-4dp emission_share when coercing D1 strings", () => {
     const out = formatTrajectory({
@@ -968,15 +1019,25 @@ function rowsForSql(sql) {
     return [
       {
         snapshot_date: "2026-06-01",
-        completeness_score: 90,
-        surface_count: 10,
-        endpoint_count: 12,
+        completeness_score: "90",
+        surface_count: "10",
+        endpoint_count: "12",
+        validator_count: "8",
+        miner_count: "200",
+        total_stake_tao: "1500000",
+        alpha_price_tao: "0.03",
+        emission_share: "0.008",
       },
       {
         snapshot_date: "2026-06-10",
-        completeness_score: 97,
-        surface_count: 13,
-        endpoint_count: 15,
+        completeness_score: "97",
+        surface_count: "13",
+        endpoint_count: "15",
+        validator_count: "9",
+        miner_count: "205",
+        total_stake_tao: "1600000",
+        alpha_price_tao: "0.035",
+        emission_share: "0.009",
       },
     ];
   }
@@ -1377,6 +1438,11 @@ describe("analytics routes (fake D1 with data)", () => {
     );
     assert.equal(body.data.point_count, 2);
     assert.equal(body.data.deltas["7d"].completeness_score, 7);
+    const latest = body.data.points[1];
+    assert.equal(typeof latest.total_stake_tao, "number");
+    assert.equal(typeof latest.alpha_price_tao, "number");
+    assert.equal(typeof latest.emission_share, "number");
+    assert.equal(latest.emission_share, 0.009);
   });
   test("leaderboards combines D1 health with registry growth", async () => {
     const { body } = await getJson(

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -671,6 +671,34 @@ describe("formatTrajectory", () => {
     assert.deepEqual(out.points, []);
     assert.equal(out.deltas["7d"], null);
   });
+  test("coerces D1 numeric-string snapshot cells to schema types", () => {
+    const out = formatTrajectory({
+      netuid: 3,
+      rows: [
+        {
+          snapshot_date: "2026-06-01",
+          completeness_score: "80",
+          surface_count: "5",
+          endpoint_count: "3",
+          validator_count: "9",
+          miner_count: "247",
+          total_stake_tao: "2522266",
+          alpha_price_tao: "0.04",
+          emission_share: "0.01",
+        },
+      ],
+    });
+    const point = out.points[0];
+    assert.equal(typeof point.completeness_score, "number");
+    assert.equal(typeof point.surface_count, "number");
+    assert.equal(typeof point.endpoint_count, "number");
+    assert.equal(typeof point.validator_count, "number");
+    assert.equal(typeof point.miner_count, "number");
+    assert.equal(typeof point.total_stake_tao, "number");
+    assert.equal(point.surface_count, 5);
+    assert.equal(point.validator_count, 9);
+    assert.equal(point.total_stake_tao, 2522266);
+  });
 });
 
 // --- writeSubnetSnapshot ----------------------------------------------------

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -699,6 +699,21 @@ describe("formatTrajectory", () => {
     assert.equal(point.validator_count, 9);
     assert.equal(point.total_stake_tao, 2522266);
   });
+  test("preserves sub-4dp emission_share when coercing D1 strings", () => {
+    const out = formatTrajectory({
+      netuid: 4,
+      rows: [
+        {
+          snapshot_date: "2026-06-01",
+          completeness_score: 80,
+          surface_count: 5,
+          endpoint_count: 3,
+          emission_share: "0.000049",
+        },
+      ],
+    });
+    assert.equal(out.points[0].emission_share, 0.000049);
+  });
 });
 
 // --- writeSubnetSnapshot ----------------------------------------------------


### PR DESCRIPTION
## Summary

Coerce D1 numeric-string cells in `formatTrajectory` so subnet trajectory points satisfy OpenAPI integer/number types.

## What Changed

- Run snapshot count/score fields through `roundInt` / `round4` in `formatTrajectory` (mirrors latency formatters in the same module).
- Add a regression test with string-typed D1 row cells.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npx vitest run tests/analytics.test.mjs -t formatTrajectory`

No linked issue — D1 coercion gap found during API artifact audit; trajectory rows from `subnet_snapshots` can surface INTEGER/REAL columns as numeric strings.