### PR TITLE
fix(api): coerce D1 string cells for block neighbor numbers

### DIFF
--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -142,8 +142,10 @@ export function buildBlock(row, ref, { prev, next } = {}) {
     schema_version: 1,
     ref: ref ?? null,
     block,
-    prev_block_number: block ? (prev ?? null) : null,
-    next_block_number: block ? (next ?? null) : null,
+    // MAX/MIN neighbor cells are INTEGER in D1 but can surface as numeric strings;
+    // coerce like formatBlock's block_number so nav fields stay schema-typed.
+    prev_block_number: block ? toBlockNumber(prev) : null,
+    next_block_number: block ? toBlockNumber(next) : null,
   };
 }
 

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -226,7 +226,7 @@ test("loadBlock resolves neighbors when D1 returns a string-typed block_number (
     if (/MAX\(block_number\)/.test(sql)) {
       // The anchor must be bound as a Number, not the raw "1234" string.
       assert.deepEqual(params, [1234, 1234]);
-      return [{ prev: 1230, next: 1240 }];
+      return [{ prev: "1230", next: "1240" }];
     }
     return [];
   };
@@ -234,6 +234,17 @@ test("loadBlock resolves neighbors when D1 returns a string-typed block_number (
   assert.equal(out.block.block_number, 1234);
   assert.equal(out.prev_block_number, 1230);
   assert.equal(out.next_block_number, 1240);
+  assert.equal(typeof out.prev_block_number, "number");
+  assert.equal(typeof out.next_block_number, "number");
+});
+
+test("buildBlock coerces string-typed neighbor block numbers (#1853)", () => {
+  const row = { block_number: 1234, block_hash: "0xabc", observed_at: 1 };
+  const out = buildBlock(row, "1234", { prev: "1230", next: "1240" });
+  assert.equal(out.prev_block_number, 1230);
+  assert.equal(out.next_block_number, 1240);
+  assert.equal(typeof out.prev_block_number, "number");
+  assert.equal(typeof out.next_block_number, "number");
 });
 
 test("buildBlock defaults a null/absent ref to null (regression)", () => {


### PR DESCRIPTION
## Summary

Coerce D1 string cells for `prev_block_number` / `next_block_number` in `buildBlock`.

## What Changed

- Run neighbor MAX/MIN results through `toBlockNumber` in `buildBlock` (sibling fix to the anchor `block_number` coercion from #2489 / #2708).
- Extend neighbor regression tests to assert string-typed D1 cells become numbers.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npx vitest run tests/blocks.test.mjs -t "buildBlock|loadBlock resolves neighbors"`

No linked issue — D1 neighbor cells can arrive as numeric strings while the anchor block is already coerced.