### PR TITLE
feat(mcp): add min_samples filter to get_subnet_uptime (REST parity)

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -395,6 +395,14 @@ assert.ok(
   "get_subnet_yield must return neurons[]",
 );
 assert.equal(yieldCard.netuid, 7, "get_subnet_yield must echo the netuid");
+const uptimeFiltered = await callOk("get_subnet_uptime", {
+  netuid: 7,
+  min_samples: 5,
+});
+assert.ok(
+  Array.isArray(uptimeFiltered.surfaces),
+  "get_subnet_uptime must accept the min_samples filter",
+);
 const stakeFlowCold = await callOk("get_subnet_stake_flow", {
   netuid: 7,
   window: "30d",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -151,9 +151,14 @@ function compareDimensionsFromTokens(tokens) {
 export async function loadSubnetUptime(
   d1,
   netuid,
-  { window = "90d", observedAt = null, now = null } = {},
+  { window = "90d", observedAt = null, now = null, minSamples = null } = {},
 ) {
   const windowParam = Object.hasOwn(UPTIME_WINDOWS, window) ? window : "90d";
+  // Optional min_samples floor: drop low-sample day rows (daily probe count below
+  // the threshold, incl. zero-sample "unknown" days) via HAVING, mirroring the
+  // REST /uptime route (#2700). Null → no filter.
+  const sampleFloor =
+    Number.isInteger(minSamples) && minSamples >= 0 ? minSamples : null;
   const days = UPTIME_WINDOWS[windowParam];
   const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
     .toISOString()
@@ -181,9 +186,11 @@ export async function loadSubnetUptime(
      FROM surface_uptime_daily
      WHERE netuid = ? AND day >= ?
      GROUP BY COALESCE(surface_key, surface_id), day
-     ORDER BY day DESC
+     ${sampleFloor !== null ? "HAVING SUM(samples) >= ?\n     " : ""}ORDER BY day DESC
      LIMIT ?`,
-    [netuid, cutoff, MAX_UPTIME_ROWS],
+    sampleFloor !== null
+      ? [netuid, cutoff, sampleFloor, MAX_UPTIME_ROWS]
+      : [netuid, cutoff, MAX_UPTIME_ROWS],
   );
   return formatUptime({
     netuid,

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -172,7 +172,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.19.0";
+export const MCP_SERVER_VERSION = "1.20.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -2048,7 +2048,9 @@ export const MCP_TOOLS = [
       "Fetch one subnet's long-term daily uptime history for its operational " +
       "surfaces from the live surface_uptime_daily rollup. Returns per-surface " +
       "day series, window-wide uptime ratios, and reliability scores for the " +
-      "requested window (90d or 1y). Mirrors GET /api/v1/subnets/{netuid}/uptime.",
+      "requested window (90d or 1y). ?min_samples drops low-sample day rows " +
+      "(daily probe count below the threshold, incl. zero-sample 'unknown' days). " +
+      "Mirrors GET /api/v1/subnets/{netuid}/uptime.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2057,6 +2059,12 @@ export const MCP_TOOLS = [
           type: "string",
           enum: ["90d", "1y"],
           description: "History window (default 90d).",
+        },
+        min_samples: {
+          type: "integer",
+          minimum: 0,
+          description:
+            "Drop day rows whose daily probe count is below this threshold.",
         },
       },
       required: ["netuid"],
@@ -2071,6 +2079,7 @@ export const MCP_TOOLS = [
       return loadSubnetUptime(mcpD1Runner(ctx), netuid, {
         window: window || "90d",
         observedAt: await mcpObservedAt(ctx),
+        minSamples: optionalNonNegativeInt(args, "min_samples"),
       });
     },
   },

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -220,6 +220,21 @@ describe("analytics-live loaders", () => {
     assert.equal(data.surfaces[0].days[0].uptime_ratio, 0.9);
   });
 
+  test("loadSubnetUptime applies a min_samples HAVING floor when set", async () => {
+    const captured = [];
+    const runner = async (sql, params) => {
+      captured.push({ sql, params });
+      return [];
+    };
+    await loadSubnetUptime(runner, NETUID, { window: "90d", minSamples: 5 });
+    assert.match(captured[0].sql, /HAVING SUM\(samples\) >= \?/);
+    assert.ok(captured[0].params.includes(5));
+    // omitted (or null) → no HAVING clause, original param list
+    captured.length = 0;
+    await loadSubnetUptime(runner, NETUID, { window: "90d" });
+    assert.ok(!/HAVING/.test(captured[0].sql));
+  });
+
   test("loadSubnetHealthTrends returns schema-stable empty surfaces on cold D1", async () => {
     const data = await loadSubnetHealthTrends(d1(), NETUID, {
       observedAt: OBSERVED_AT,


### PR DESCRIPTION
## Summary

- The REST `/subnets/{netuid}/uptime` route gained a `min_samples` filter in #2700 (drops low-sample day rows — daily probe count below the threshold, including zero-sample "unknown" days). The MCP `get_subnet_uptime` tool reads through `loadSubnetUptime` (a separate path from the REST `handleUptime`) and had no such filter — an MCP↔REST parity gap.

## What Changed

- `src/analytics-live.mjs`: `loadSubnetUptime` gains an optional `minSamples` floor — a `HAVING SUM(samples) >= ?` on the same `(surface_key, day)` grouping the REST route uses, with `null` = no filter (backward-compatible; existing callers unaffected).
- `src/mcp-server.mjs`: `get_subnet_uptime` exposes `min_samples` (integer ≥ 0), parsed with the shared `optionalNonNegativeInt` and forwarded to the loader.
- Both the REST route and the MCP loader shape rows through the same `formatUptime`, so the filtered output matches the REST route exactly (no divergence).
- `MCP_SERVER_VERSION` + `server.json`: **1.18.0 → 1.21.0** (changed tool surface; 1.19.0/1.20.0 are taken by my in-flight #2715 / #2724).

## Tests

- `tests/analytics-live.test.mjs`: SQL-capture test — `HAVING SUM(samples) >= ?` + the param are present when `minSamples` is set, and absent (original param list) when omitted.
- `scripts/validate-mcp.mjs`: smoke check calling `get_subnet_uptime` with `min_samples`.

MCP tools need no server-card regen (worker-computed) and are outside the OpenAPI contract — no generated-artifact / contract-drift change.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — MCP tool input only; mirrors an existing REST filter.)

## Validation

- [x] `npm run validate:mcp` — passes ("73 tools, lifecycle + all tools/call")
- [x] `npx vitest run tests/analytics-live.test.mjs` — 53 pass (incl. the new min_samples SQL test)
- [x] `npx vitest run tests/mcp-server.test.mjs` — 360 pass (no uptime-tool regression)
- [x] `npx eslint` + `npx prettier --check` clean · `git diff --check`
