### PR TITLE
feat(registry): add SN37 Aurelius Central API openapi surface

### DIFF
--- a/registry/subnets/sn-37.json
+++ b/registry/subnets/sn-37.json
@@ -27,6 +27,27 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Interactive (Swagger UI) documentation for the mainnet (SN37) Aurelius Central API. The official README documents this production host as the finney/mainnet api_url (the -staging host is testnet SN455)."
+    },
+    {
+      "id": "sn-37-aurelius-openapi",
+      "name": "Aurelius Central API (OpenAPI)",
+      "kind": "openapi",
+      "url": "https://new-collector-api-production.up.railway.app/openapi.json",
+      "schema_url": "https://new-collector-api-production.up.railway.app/openapi.json",
+      "schema_status": "machine-readable",
+      "provider": "aurelius",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/README.md",
+        "https://new-collector-api-production.up.railway.app/docs"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nickmopen"
+      },
+      "notes": "Machine-readable OpenAPI spec for the mainnet (SN37) Aurelius Central API — the same spec the existing /docs Swagger UI renders. The official README documents this production host as the finney/mainnet api_url (the -staging host is testnet SN455)."
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community surface to exactly one subnet manifest —
`registry/subnets/sn-37.json`. Append-only; no other file or field changed.

Closes #582

## Summary

Resolves #582 (Enrich SN37 Aurelius — add OpenAPI/Swagger spec). SN37 (Aurelius)
already registers the Central API's interactive `docs` (Swagger UI) surface but
not the machine-readable spec it renders. This adds the `openapi` surface
pointing at the live `/openapi.json` (title "Aurelius Central API", 58 paths) on
the same production host, so agents and SDKs get the callable contract, not just
the human docs page. The official Aurelius-Protocol README documents this exact
host as the mainnet/finney `api_url`
(`api_url=https://new-collector-api-production.up.railway.app`, plus a
`curl .../health` example), which independently proves the subnet publishes it.

The public artifact for SN37 is the OpenAPI spec (public, no-auth); the API's
functional endpoints are validator-authenticated (challenge / work-token), so
the spec is the correct public, `public_safe` surface to register.

## Surface

- Netuid: 37
- Kind: openapi
- Public URL: https://new-collector-api-production.up.railway.app/openapi.json
- Source URL (proves the claim): https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/README.md
- Provider slug: aurelius

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface (existing surface is `docs`; this is the machine-readable `openapi` spec).
- [x] Links a tracked issue (`Closes #582`).

## Template Used

- surface.md

## Validation

- [x] `npm run validate:surface -- registry/subnets/sn-37.json` → passed (2 surfaces, 1 file)
- [x] `npm run scan:public-safety` → passed
