### PR TITLE
feat(events): decode and ingest SubtensorModule StakeTransferred

### DIFF
--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -229,7 +229,10 @@ def _stake_transferred(a):  # StakeTransferred (#2556): stake moved between two 
         ck = a.get("origin_coldkey", a.get("coldkey"))
         hk = a.get("hotkey")
         netuid = a.get("origin_netuid", a.get("netuid"))
-        amount = a.get("amount")
+        # The tuple variant decodes positionally; the dict branch is a defensive
+        # fallback, so accept the raw-rao amount under either "amount" or the
+        # "amount_rao" macro field name a named decoding could surface.
+        amount = a.get("amount", a.get("amount_rao"))
     else:
         ck = a[0] if len(a) > 0 else None
         hk = a[2] if len(a) > 2 else None

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -218,6 +218,31 @@ def _moved(a):  # [coldkey, hotkey, netuid, ...]
     }
 
 
+def _stake_transferred(a):  # StakeTransferred (#2556): stake moved between two coldkeys
+    # Finney 6-tuple: (origin_coldkey, destination_coldkey, hotkey, origin_netuid,
+    # destination_netuid, amount_rao). The shared columns capture the origin leg —
+    # origin_coldkey, hotkey, origin_netuid, and the TAO amount; the destination
+    # coldkey/netuid have no columns and are dropped (no migration, per the issue).
+    # Note the shape differs from _moved: a[1] is a coldkey, not a hotkey, and the
+    # hotkey sits at a[2], so this needs its own extractor.
+    if isinstance(a, dict):
+        ck = a.get("origin_coldkey", a.get("coldkey"))
+        hk = a.get("hotkey")
+        netuid = a.get("origin_netuid", a.get("netuid"))
+        amount = a.get("amount")
+    else:
+        ck = a[0] if len(a) > 0 else None
+        hk = a[2] if len(a) > 2 else None
+        netuid = a[3] if len(a) > 3 else None
+        amount = a[5] if len(a) > 5 else None
+    return {
+        "coldkey": _ss58(ck),
+        "hotkey": _ss58(hk),
+        "netuid": _idx(netuid),
+        "amount_tao": _tao(amount),
+    }
+
+
 def _root(a):  # {coldkey} (named) or [coldkey]
     ck = a.get("coldkey") if isinstance(a, dict) else (a[0] if a else None)
     return {"coldkey": _ss58(ck)}
@@ -307,6 +332,7 @@ EXTRACTORS = {
     "StakeAdded": _stake,
     "StakeRemoved": _stake,
     "StakeMoved": _moved,
+    "StakeTransferred": _stake_transferred,  # (#2556) stake moved between two coldkeys
     "AxonServed": _axon,
     "PrometheusServed": _axon,  # [netuid, hotkey]
     "WeightsSet": _weights,

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -520,6 +520,20 @@ class StakeTransferredExtractorTest(unittest.TestCase):
         self.assertEqual(result["netuid"], 9)
         self.assertAlmostEqual(result["amount_tao"], 100.0)
 
+    def test_dict_form_accepts_amount_rao_macro_field_name(self):
+        # A named decoding could surface the TaoBalance leg under the macro field
+        # name "amount_rao" instead of "amount"; the dict fallback accepts both.
+        result = _extract(
+            "StakeTransferred",
+            {
+                "origin_coldkey": _SS58_A,
+                "hotkey": _SS58_C,
+                "origin_netuid": 9,
+                "amount_rao": _RAO_100,
+            },
+        )
+        self.assertAlmostEqual(result["amount_tao"], 100.0)
+
     def test_invalid_keys_give_null(self):
         result = _extract(
             "StakeTransferred",

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -246,6 +246,29 @@ class EventRowBatchCapTest(unittest.TestCase):
         self.assertAlmostEqual(rows[0]["amount_tao"], 100.0)
         self.assertEqual(rows[0]["observed_at"], 456)
 
+    def test_event_rows_for_events_builds_stake_transferred_row(self):
+        # Exercises the full poller staging path (module dispatch -> extract ->
+        # built row), not just _extract, so a registry/row-building regression for
+        # the new StakeTransferred kind is caught, not only the pure extractor.
+        rows = event_rows_for_events(
+            100,
+            [
+                self.Event(
+                    "SubtensorModule",
+                    "StakeTransferred",
+                    [_SS58_A, _SS58_B, _SS58_C, 7, 8, _RAO_100],
+                )
+            ],
+            200,
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["event_kind"], "StakeTransferred")
+        self.assertEqual(rows[0]["coldkey"], _SS58_A)  # origin_coldkey
+        self.assertEqual(rows[0]["hotkey"], _SS58_C)  # hotkey at a[2], not dest ck
+        self.assertEqual(rows[0]["netuid"], 7)  # origin_netuid
+        self.assertAlmostEqual(rows[0]["amount_tao"], 100.0)
+        self.assertEqual(rows[0]["observed_at"], 200)
+
     def test_can_append_event_block_keeps_batches_under_cap(self):
         existing = [{}] * 3
         self.assertTrue(_can_append_event_block(existing, [{}] * 2, max_rows=5))

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -283,6 +283,7 @@ class LagAlertNeededTest(unittest.TestCase):
 _extract = _fe.extract
 _SS58_A = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
 _SS58_B = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+_SS58_C = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
 _RAO_100 = 100_000_000_000  # 100 TAO in rao
 
 
@@ -480,6 +481,85 @@ class StakeAlphaExtractorTest(unittest.TestCase):
         # Transfer carries no alpha leg → null (extract() defaults the key).
         result = _extract("Transfer", [_SS58_A, _SS58_B, _RAO_100])
         self.assertIsNone(result["alpha_amount"])
+
+
+class StakeTransferredExtractorTest(unittest.TestCase):
+    """Tests for SubtensorModule.StakeTransferred (#2556) — stake moved between two
+    coldkeys. Attribute order confirmed against the subtensor events macro:
+    (origin_coldkey, destination_coldkey, hotkey, origin_netuid, destination_netuid,
+    amount_rao). The origin leg maps to the shared coldkey/hotkey/netuid/amount
+    columns; the shape differs from StakeMoved, so it uses its own extractor.
+    """
+
+    def test_positional_maps_origin_leg_and_amount(self):
+        result = _extract(
+            "StakeTransferred",
+            [_SS58_A, _SS58_B, _SS58_C, 7, 8, _RAO_100],
+        )
+        # origin_coldkey -> coldkey, hotkey read from a[2] (NOT the destination
+        # coldkey at a[1]), origin_netuid -> netuid (NOT the hotkey at a[2]).
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertEqual(result["hotkey"], _SS58_C)
+        self.assertEqual(result["netuid"], 7)
+        self.assertAlmostEqual(result["amount_tao"], 100.0)
+
+    def test_dict_form_named_fields(self):
+        result = _extract(
+            "StakeTransferred",
+            {
+                "origin_coldkey": _SS58_A,
+                "destination_coldkey": _SS58_B,
+                "hotkey": _SS58_C,
+                "origin_netuid": 9,
+                "destination_netuid": 3,
+                "amount": _RAO_100,
+            },
+        )
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertEqual(result["hotkey"], _SS58_C)
+        self.assertEqual(result["netuid"], 9)
+        self.assertAlmostEqual(result["amount_tao"], 100.0)
+
+    def test_invalid_keys_give_null(self):
+        result = _extract(
+            "StakeTransferred",
+            ["not-an-address", _SS58_B, "not-a-hotkey", 7, 8, _RAO_100],
+        )
+        self.assertIsNone(result["coldkey"])
+        self.assertIsNone(result["hotkey"])
+        self.assertEqual(result["netuid"], 7)
+
+    def test_out_of_range_netuid_gives_null(self):
+        result = _extract(
+            "StakeTransferred",
+            [_SS58_A, _SS58_B, _SS58_C, 70000, 8, _RAO_100],
+        )
+        self.assertIsNone(result["netuid"])
+        self.assertEqual(result["coldkey"], _SS58_A)
+
+    def test_negative_amount_gives_null(self):
+        result = _extract(
+            "StakeTransferred",
+            [_SS58_A, _SS58_B, _SS58_C, 7, 8, -5],
+        )
+        self.assertIsNone(result["amount_tao"])
+
+    def test_short_payload_nulls_missing_legs(self):
+        # A truncated tuple (only the two coldkeys) → hotkey/netuid/amount null,
+        # never raises.
+        result = _extract("StakeTransferred", [_SS58_A, _SS58_B])
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertIsNone(result["hotkey"])
+        self.assertIsNone(result["netuid"])
+        self.assertIsNone(result["amount_tao"])
+
+    def test_empty_shape_drift_never_raises(self):
+        result = _extract("StakeTransferred", [])
+        self.assertIsNotNone(result)
+        self.assertIsNone(result["coldkey"])
+        self.assertIsNone(result["hotkey"])
+        self.assertIsNone(result["netuid"])
+        self.assertIsNone(result["amount_tao"])
 
 
 class TakeDelegateExtractorTest(unittest.TestCase):

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -63,6 +63,8 @@ export const INDEXED_EVENT_KINDS = [
 // scoping validation to INDEXED_EVENT_KINDS alone would wrongly reject valid kinds.
 export const INGESTED_EVENT_KINDS = [
   ...INDEXED_EVENT_KINDS,
+  // Stake moved between two coldkeys (#2556) — a stake event beyond the indexed core.
+  "StakeTransferred",
   "NeuronDeregistered",
   "NetworkAdded",
   "NetworkRemoved",

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -63,7 +63,10 @@ export const INDEXED_EVENT_KINDS = [
 // scoping validation to INDEXED_EVENT_KINDS alone would wrongly reject valid kinds.
 export const INGESTED_EVENT_KINDS = [
   ...INDEXED_EVENT_KINDS,
-  // Stake moved between two coldkeys (#2556) — a stake event beyond the indexed core.
+  // Stake moved between two coldkeys (#2556). Ingestible for the kind filter but
+  // deliberately NOT in INDEXED_EVENT_KINDS: only the origin leg (origin_coldkey,
+  // hotkey, origin_netuid, amount) fits the shared account_events columns, so it
+  // is not part of the minimal indexed core the way StakeAdded/Removed/Moved are.
   "StakeTransferred",
   "NeuronDeregistered",
   "NetworkAdded",

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -129,6 +129,10 @@ test("INGESTED_EVENT_KINDS accepts expanded Subtensor lifecycle event filters", 
   }
 });
 
+test("INGESTED_EVENT_KINDS accepts StakeTransferred (cross-coldkey stake move) for kind filters", () => {
+  assert.ok(INGESTED_EVENT_KINDS.includes("StakeTransferred"));
+});
+
 test("formatAccountEvent maps a D1 row to an API event (ISO time)", () => {
   const out = formatAccountEvent({
     block_number: 1000,


### PR DESCRIPTION
Closes #2556.

Decodes and ingests SubtensorModule StakeTransferred, stake moved between two coldkeys, into the account_events stream. The attribute tuple was confirmed against the subtensor events macro as (origin_coldkey, destination_coldkey, hotkey, origin_netuid, destination_netuid, amount_rao), which differs from StakeMoved, so it uses its own extractor rather than reusing _moved whose a[1] is a hotkey and a[2] a netuid. The origin leg maps to the shared coldkey, hotkey, netuid and TAO amount columns with no migration, and the kind is added to INGESTED_EVENT_KINDS so the public kind filter accepts it.
