### PR TITLE
feat(api): add direction filter to account stake-flow route

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -130,7 +130,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch one account's StakeAdded vs StakeRemoved flow per subnet over a recent window (7d/30d/90d): per-subnet net and gross flow with a direction label (accumulating/exiting/churning/idle), plus account totals, an HHI concentration of where the flow is focused, and the dominant subnet — summed live from the account_events D1 tier. */
+        /** Fetch one account's StakeAdded vs StakeRemoved flow per subnet over a recent window (7d/30d/90d): per-subnet net and gross flow with a direction label (accumulating/exiting/churning/idle), plus account totals, an HHI concentration of where the flow is focused, and the dominant subnet — summed live from the account_events D1 tier. ?direction=all|in|out filters to inflow (StakeAdded) or outflow (StakeRemoved) only; omitted defaults to all. */
         get: operations["accountStakeFlow"];
         put?: never;
         post?: never;
@@ -6448,6 +6448,7 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                direction?: "all" | "in" | "out";
             };
             header?: never;
             path: {

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4929,7 +4929,7 @@
     {
       "artifact_path": "/metagraph/accounts/{ss58}/stake-flow.json",
       "cache": "short",
-      "description": "Fetch one account's StakeAdded vs StakeRemoved flow per subnet over a recent window (7d/30d/90d): per-subnet net and gross flow with a direction label (accumulating/exiting/churning/idle), plus account totals, an HHI concentration of where the flow is focused, and the dominant subnet — summed live from the account_events D1 tier.",
+      "description": "Fetch one account's StakeAdded vs StakeRemoved flow per subnet over a recent window (7d/30d/90d): per-subnet net and gross flow with a direction label (accumulating/exiting/churning/idle), plus account totals, an HHI concentration of where the flow is focused, and the dominant subnet — summed live from the account_events D1 tier. ?direction=all|in|out filters to inflow (StakeAdded) or outflow (StakeRemoved) only; omitted defaults to all.",
       "id": "account-stake-flow",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/stake-flow",
@@ -4944,6 +4944,17 @@
               "7d",
               "30d",
               "90d"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "direction",
+          "schema": {
+            "enum": [
+              "all",
+              "in",
+              "out"
             ],
             "type": "string"
           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -16745,6 +16745,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "enum": [
+                "all",
+                "in",
+                "out"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -16880,7 +16893,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch one account's StakeAdded vs StakeRemoved flow per subnet over a recent window (7d/30d/90d): per-subnet net and gross flow with a direction label (accumulating/exiting/churning/idle), plus account totals, an HHI concentration of where the flow is focused, and the dominant subnet — summed live from the account_events D1 tier.",
+        "summary": "Fetch one account's StakeAdded vs StakeRemoved flow per subnet over a recent window (7d/30d/90d): per-subnet net and gross flow with a direction label (accumulating/exiting/churning/idle), plus account totals, an HHI concentration of where the flow is focused, and the dominant subnet — summed live from the account_events D1 tier. ?direction=all|in|out filters to inflow (StakeAdded) or outflow (StakeRemoved) only; omitted defaults to all.",
         "tags": [
           "accounts",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -130,7 +130,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch one account's StakeAdded vs StakeRemoved flow per subnet over a recent window (7d/30d/90d): per-subnet net and gross flow with a direction label (accumulating/exiting/churning/idle), plus account totals, an HHI concentration of where the flow is focused, and the dominant subnet — summed live from the account_events D1 tier. */
+        /** Fetch one account's StakeAdded vs StakeRemoved flow per subnet over a recent window (7d/30d/90d): per-subnet net and gross flow with a direction label (accumulating/exiting/churning/idle), plus account totals, an HHI concentration of where the flow is focused, and the dominant subnet — summed live from the account_events D1 tier. ?direction=all|in|out filters to inflow (StakeAdded) or outflow (StakeRemoved) only; omitted defaults to all. */
         get: operations["accountStakeFlow"];
         put?: never;
         post?: never;
@@ -6448,6 +6448,7 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                direction?: "all" | "in" | "out";
             };
             header?: never;
             path: {

--- a/src/account-stake-flow.mjs
+++ b/src/account-stake-flow.mjs
@@ -177,19 +177,28 @@ export function buildAccountStakeFlow(rows, address, { window } = {}) {
 export async function loadAccountStakeFlow(
   d1,
   address,
-  { windowLabel = DEFAULT_STAKE_FLOW_WINDOW } = {},
+  { windowLabel = DEFAULT_STAKE_FLOW_WINDOW, direction } = {},
 ) {
   const days =
     STAKE_FLOW_WINDOWS[windowLabel] ??
     STAKE_FLOW_WINDOWS[DEFAULT_STAKE_FLOW_WINDOW];
   const cutoff = Date.now() - days * DAY_MS;
+  // direction narrows the flow to one side: in = StakeAdded only, out =
+  // StakeRemoved only, all (or omitted) = both kinds. Mirrors loadSubnetStakeFlow.
+  const kinds =
+    direction === "in"
+      ? [STAKE_ADDED_KIND]
+      : direction === "out"
+        ? [STAKE_REMOVED_KIND]
+        : [STAKE_ADDED_KIND, STAKE_REMOVED_KIND];
+  const placeholders = kinds.map(() => "?").join(", ");
   const rows = await d1(
     "SELECT netuid, event_kind, COALESCE(SUM(amount_tao), 0) AS total_tao, " +
       "COUNT(*) AS event_count, MAX(observed_at) AS last_observed " +
       "FROM account_events INDEXED BY idx_account_events_hotkey " +
-      "WHERE hotkey = ? AND event_kind IN (?, ?) AND observed_at >= ? " +
+      `WHERE hotkey = ? AND event_kind IN (${placeholders}) AND observed_at >= ? ` +
       "GROUP BY netuid, event_kind",
-    [address, STAKE_ADDED_KIND, STAKE_REMOVED_KIND, cutoff],
+    [address, ...kinds, cutoff],
   );
   let latestObserved = null;
   for (const row of Array.isArray(rows) ? rows : []) {

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2111,13 +2111,17 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/stake-flow",
     "/metagraph/accounts/{ss58}/stake-flow.json",
-    "Fetch one account's StakeAdded vs StakeRemoved flow per subnet over a recent window (7d/30d/90d): per-subnet net and gross flow with a direction label (accumulating/exiting/churning/idle), plus account totals, an HHI concentration of where the flow is focused, and the dominant subnet — summed live from the account_events D1 tier.",
+    "Fetch one account's StakeAdded vs StakeRemoved flow per subnet over a recent window (7d/30d/90d): per-subnet net and gross flow with a direction label (accumulating/exiting/churning/idle), plus account totals, an HHI concentration of where the flow is focused, and the dominant subnet — summed live from the account_events D1 tier. ?direction=all|in|out filters to inflow (StakeAdded) or outflow (StakeRemoved) only; omitted defaults to all.",
     "short",
     ["accounts", "analytics"],
     [
       {
         name: "window",
         schema: { type: "string", enum: ["7d", "30d", "90d"] },
+      },
+      {
+        name: "direction",
+        schema: { type: "string", enum: ["all", "in", "out"] },
       },
     ],
     [{ name: "ss58", schema: { type: "string" } }],

--- a/tests/account-stake-flow.test.mjs
+++ b/tests/account-stake-flow.test.mjs
@@ -208,6 +208,54 @@ describe("loadAccountStakeFlow", () => {
     assert.equal(d.data.window, DEFAULT_STAKE_FLOW_WINDOW);
   });
 
+  test("direction=in queries StakeAdded only (#2694 parity)", async () => {
+    const calls = [];
+    const d1 = async (sql, params) => {
+      calls.push({ sql, params });
+      return [added(1, 100, 3, 5000)];
+    };
+    const d = await loadAccountStakeFlow(d1, ADDR, {
+      windowLabel: "7d",
+      direction: "in",
+    });
+    // Only the StakeAdded kind is bound: [address, StakeAdded, cutoff].
+    assert.equal(calls[0].params.length, 3);
+    assert.equal(calls[0].params[1], STAKE_ADDED_KIND);
+    assert.equal(d.data.total_staked_tao, 100);
+    assert.equal(d.data.total_unstaked_tao, 0);
+    assert.equal(d.data.net_flow_tao, 100);
+  });
+
+  test("direction=out queries StakeRemoved only (#2694 parity)", async () => {
+    const calls = [];
+    const d1 = async (sql, params) => {
+      calls.push({ sql, params });
+      return [removed(1, 40, 2, 6000)];
+    };
+    const d = await loadAccountStakeFlow(d1, ADDR, {
+      windowLabel: "7d",
+      direction: "out",
+    });
+    assert.equal(calls[0].params.length, 3);
+    assert.equal(calls[0].params[1], STAKE_REMOVED_KIND);
+    assert.equal(d.data.total_staked_tao, 0);
+    assert.equal(d.data.total_unstaked_tao, 40);
+    assert.equal(d.data.net_flow_tao, -40);
+  });
+
+  test("direction omitted sums both kinds (unchanged default)", async () => {
+    const calls = [];
+    const d1 = async (sql, params) => {
+      calls.push({ sql, params });
+      return [added(1, 100, 2, 5000), removed(1, 30, 1, 6000)];
+    };
+    await loadAccountStakeFlow(d1, ADDR, { windowLabel: "7d" });
+    // [address, StakeAdded, StakeRemoved, cutoff].
+    assert.equal(calls[0].params.length, 4);
+    assert.equal(calls[0].params[1], STAKE_ADDED_KIND);
+    assert.equal(calls[0].params[2], STAKE_REMOVED_KIND);
+  });
+
   test("an unknown window label falls back to the 30d cutoff", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2784,6 +2784,36 @@ describe("handleAccountStakeFlow", () => {
     await errorJson(res);
   });
 
+  test("rejects an unsupported direction enum value with 400 (#2694 parity)", async () => {
+    const res = await handleAccountStakeFlow(
+      req(`/api/v1/accounts/${SS58}/stake-flow`),
+      emptyEnv(),
+      SS58,
+      url(`/api/v1/accounts/${SS58}/stake-flow?direction=invalid`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "direction");
+  });
+
+  test("threads ?direction=in to the loader as StakeAdded only", async () => {
+    const { env, captures } = dbWith({ stakeFlow: [] });
+    await handleAccountStakeFlow(
+      req(`/api/v1/accounts/${SS58}/stake-flow`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/stake-flow?direction=in`),
+    );
+    const bound = captures.params.find(
+      (p) => Array.isArray(p) && p.includes("StakeAdded"),
+    );
+    assert.ok(bound, "expected a bound StakeAdded param");
+    assert.ok(
+      !bound.includes("StakeRemoved"),
+      "direction=in must not bind StakeRemoved",
+    );
+  });
+
   test("returns schema-stable zeros on cold D1", async () => {
     const body = await assertColdSchema(
       handleAccountStakeFlow,

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -767,7 +767,7 @@ async function accountEnvelopeResponse(
 // its flow is focused, and a direction label. account_events-derived (source
 // "chain-events"). Cold/absent store → schema-stable zeros (never 404).
 export async function handleAccountStakeFlow(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "direction"]);
   if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_STAKE_FLOW_WINDOW;
@@ -777,11 +777,23 @@ export async function handleAccountStakeFlow(request, env, ss58, url) {
       message: unsupportedWindowMessage(windowParam, STAKE_FLOW_WINDOWS),
     });
   }
+  // ?direction=all|in|out narrows to inflow/outflow only; omitted sums both.
+  // Mirrors the subnet stake-flow route (#2694).
+  const direction = url.searchParams.get("direction");
+  if (direction !== null && !STAKE_FLOW_DIRECTIONS.includes(direction)) {
+    return analyticsQueryError({
+      parameter: "direction",
+      message: `"${direction}" is not a valid direction. Supported: ${STAKE_FLOW_DIRECTIONS.join(", ")}.`,
+    });
+  }
+  const normalizedDirection =
+    direction === "in" || direction === "out" ? direction : undefined;
   const { data, generatedAt } = await loadAccountStakeFlow(
     d1Runner(env),
     ss58,
     {
       windowLabel: windowParam,
+      direction: normalizedDirection,
     },
   );
   return accountEnvelopeResponse(


### PR DESCRIPTION
## Summary

Adds a `?direction=all|in|out` filter to `GET /api/v1/accounts/{ss58}/stake-flow`, mirroring the subnet stake-flow route which got the same filter in #2694. `in` narrows to inflow (StakeAdded) only, `out` to outflow (StakeRemoved) only, and omitted/`all` sums both as before — completing the parity across the two stake-flow routes.

## What Changed

- `src/account-stake-flow.mjs` — `loadAccountStakeFlow` accepts a `direction` option and binds only the requested `event_kind`(s) (dynamic placeholders), identical to `loadSubnetStakeFlow`.
- `workers/request-handlers/entities.mjs` — `handleAccountStakeFlow` now validates `["window","direction"]`, rejects an unsupported direction with a 400 (`invalid_query`, `meta.parameter: "direction"`), and threads the normalized direction to the loader. (`STAKE_FLOW_DIRECTIONS` was already imported.)
- `src/contracts.mjs` — added the `direction` query param (enum `all|in|out`) and updated the route description.
- Regenerated contract artifacts via `npm run build`: `openapi.json`, `api-index.json`, `contracts.json`, `types.d.ts`, `generated/metagraphed-api.d.ts`, `generated/metagraphed-client.ts`. Deploy-owned/data artifacts (r2-manifest, schemas/index, operational-surfaces, etc.) were reverted per the build's own guidance.
- Tests: `tests/account-stake-flow.test.mjs` (loader: `direction=in` → StakeAdded only, `direction=out` → StakeRemoved only, omitted → both) and `tests/request-handlers-entities.test.mjs` (handler: invalid direction → 400; `direction=in` threaded to bind StakeAdded only).

The account route has no Worker-side canonical cache path (it CDN-caches by full URL), so `?direction=in`/`out`/omitted are naturally distinct cache entries — no cache-collision handling needed (unlike the subnet route).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by `npm run build`, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (a new optional query param mirroring #2694; response shape unchanged).

## Validation

- [x] `npm run validate:contract-drift` — passed
- [x] `npm run validate:openapi` — passed (102 routes) · `validate:api` — 102 routes · `validate:types` — current · `validate:schemas` — passed
- [x] `npx vitest run tests/account-stake-flow.test.mjs tests/request-handlers-entities.test.mjs` — 270 passed (incl. the new direction cases)
- [x] `npx eslint` + `npx prettier --check --end-of-line auto` on all source/test files — clean
- [x] `git diff --check` — clean
