### PR TITLE
feat(mcp): add get_economics mirroring REST network economics collection

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -340,6 +340,13 @@ assert.ok(
   econ.economics && Number.isInteger(econ.economics.netuid),
   "get_subnet_economics must return the per-subnet economics row",
 );
+const economics = await callOk("get_economics", { limit: 5 });
+assert.ok(
+  Array.isArray(economics.subnets) &&
+    economics.subnets.length <= 5 &&
+    Number.isInteger(economics.total),
+  "get_economics must return subnets[] with pagination totals",
+);
 
 // The trajectory/metagraph/validators/neuron tiers are D1-backed; this cold env
 // has no neurons DB, so each tool must degrade to its schema-stable empty

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -15,9 +15,14 @@ import {
   resolveClientIp,
   SS58_ADDRESS_PATTERN,
 } from "../workers/config.mjs";
+import { applyQueryFilters } from "../workers/list-query.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { d1TimeoutMs, withTimeout } from "../workers/storage.mjs";
-import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
+import {
+  API_QUERY_COLLECTIONS,
+  CONTRACT_VERSION,
+  PRIMARY_DOMAIN,
+} from "./contracts.mjs";
 import {
   loadChainConcentration,
   loadSubnetConcentration,
@@ -163,7 +168,8 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.18.0";
+export const MCP_SERVER_VERSION = "1.19.0";
+const ECONOMICS_SORT_FIELDS = API_QUERY_COLLECTIONS.economics.sort_fields;
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -225,7 +231,8 @@ export const MCP_INSTRUCTIONS =
   "callable subnets and how_do_i_call returns concrete call instructions " +
   "(base URL, auth, schema, health) for one subnet. For on-chain economics and " +
   "participation, get_subnet_economics returns a subnet's registration cost, " +
-  "open slots, and alpha price, get_economics_trends the network-wide " +
+  "open slots, and alpha price, get_economics the live network-wide economics " +
+  "scorecard (filterable/sortable per-subnet rows), get_economics_trends the network-wide " +
   "per-day economics series (stake, alpha price, validator/miner counts), " +
   "get_subnet_trajectory its week-over-week trend, get_subnet_uptime its " +
   "long-term surface uptime history, get_health_trends the all-subnet 7d/30d " +
@@ -410,6 +417,107 @@ async function loadSubnetEconomics(ctx, netuid) {
     captured_at: blob?.captured_at ?? null,
     summary: blob?.summary ?? null,
     economics: blob?.subnets?.find((row) => row?.netuid === netuid) ?? null,
+  };
+}
+
+function economicsQueryUrl(args) {
+  const url = new URL("https://mcp.internal/economics");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw toolError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const q = optionalString(args, "q");
+  if (q) url.searchParams.set("q", q);
+  const registrationAllowed = optionalEnum(args, "registration_allowed", [
+    "true",
+    "false",
+  ]);
+  if (args?.registration_allowed !== undefined && !registrationAllowed) {
+    throw toolError(
+      "invalid_params",
+      "registration_allowed must be 'true' or 'false'.",
+    );
+  }
+  if (registrationAllowed) {
+    url.searchParams.set("registration_allowed", registrationAllowed);
+  }
+  const sort = optionalEnum(args, "sort", ECONOMICS_SORT_FIELDS);
+  if (args?.sort !== undefined && !sort) {
+    throw toolError(
+      "invalid_params",
+      `sort must be one of: ${ECONOMICS_SORT_FIELDS.join(", ")}.`,
+    );
+  }
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (args?.order !== undefined && !order) {
+    throw toolError("invalid_params", "order must be 'asc' or 'desc'.");
+  }
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 100, 1000)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw toolError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+// Network-wide economics collection: live KV tier (KV-primary), else the
+// committed R2 snapshot — the precedence GET /api/v1/economics uses. Applies
+// the same list-query filters (netuid, registration_allowed, q, sort, cursor).
+async function loadNetworkEconomics(ctx, args) {
+  const live = await resolveLiveEconomics({
+    readHealthKv: ctx.readHealthKv,
+    env: ctx.env,
+    contractVersion: mcpContractVersion(ctx),
+  });
+  let blob = live?.data;
+  let source = live?.source || null;
+  if (!blob) {
+    blob = await loadOptionalArtifact(ctx, "/metagraph/economics.json");
+    source = "r2-fallback";
+  }
+  if (!blob || typeof blob !== "object") {
+    throw toolError("not_found", "Economics snapshot unavailable.");
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    economicsQueryUrl(args),
+    "economics",
+    [],
+  );
+  if (transformed.error) {
+    throw toolError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  return {
+    source: source || "r2-fallback",
+    captured_at: data.captured_at ?? null,
+    network: data.network ?? null,
+    summary: data.summary ?? null,
+    subnets: Array.isArray(data.subnets) ? data.subnets : [],
+    total: page.total ?? data.subnets?.length ?? 0,
+    returned: page.returned ?? data.subnets?.length ?? 0,
+    limit: page.limit ?? data.subnets?.length ?? 0,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
   };
 }
 
@@ -1700,6 +1808,70 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
       return loadSubnetEconomics(ctx, netuid);
+    },
+  },
+  {
+    name: "get_economics",
+    title: "Get network-wide subnet economics",
+    description:
+      "Fetch the live network-wide economics scorecard: per-subnet validator " +
+      "and miner counts, registration cost and whether registration is open, open " +
+      "slots, stake, alpha price, emission share, and summary totals. Served " +
+      "live from the economics tier (~3h), falling back to the latest committed " +
+      "snapshot. Filter by netuid or registration_allowed, search by name/slug " +
+      "(q), sort with sort + order, and page with limit (1-1000) / cursor. " +
+      "Mirrors GET /api/v1/economics.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: {
+          type: "integer",
+          description: "Filter to one subnet netuid.",
+          minimum: 0,
+        },
+        registration_allowed: {
+          type: "string",
+          enum: ["true", "false"],
+          description:
+            "Filter to subnets where registration is open (true) or closed (false).",
+        },
+        q: {
+          type: "string",
+          description: "Search subnet name or slug (case-insensitive).",
+        },
+        sort: {
+          type: "string",
+          enum: ECONOMICS_SORT_FIELDS,
+          description:
+            "Field to sort by (bare name only). Pair with order for direction.",
+        },
+        order: {
+          type: "string",
+          enum: ["asc", "desc"],
+          description: "Sort direction for sort (default asc).",
+        },
+        fields: {
+          type: "string",
+          description:
+            "Comma-separated projection of subnet row fields to return.",
+        },
+        limit: {
+          type: "integer",
+          description:
+            "Max subnet rows to return (1-1000). Enables pagination.",
+          minimum: 1,
+          maximum: 1000,
+        },
+        cursor: {
+          type: "integer",
+          description: "Pagination cursor from a prior response's next_cursor.",
+          minimum: 0,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      return loadNetworkEconomics(ctx, args);
     },
   },
   {
@@ -4869,6 +5041,25 @@ const TOOL_OUTPUT_SCHEMAS = {
       captured_at: NULLABLE_STRING,
       summary: { type: ["object", "null"] },
       economics: { type: ["object", "null"] },
+    },
+  },
+  get_economics: {
+    type: "object",
+    additionalProperties: true,
+    required: ["source", "subnets"],
+    properties: {
+      source: NULLABLE_STRING,
+      captured_at: NULLABLE_STRING,
+      network: NULLABLE_STRING,
+      summary: { type: ["object", "null"] },
+      subnets: { type: "array", items: { type: "object" } },
+      total: { type: "integer" },
+      returned: { type: "integer" },
+      limit: { type: "integer" },
+      cursor: { type: "integer" },
+      next_cursor: NULLABLE_INT,
+      sort: NULLABLE_STRING,
+      order: NULLABLE_STRING,
     },
   },
   get_subnet_trajectory: {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -15,14 +15,15 @@ import {
   resolveClientIp,
   SS58_ADDRESS_PATTERN,
 } from "../workers/config.mjs";
-import { applyQueryFilters } from "../workers/list-query.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { d1TimeoutMs, withTimeout } from "../workers/storage.mjs";
+import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
 import {
-  API_QUERY_COLLECTIONS,
-  CONTRACT_VERSION,
-  PRIMARY_DOMAIN,
-} from "./contracts.mjs";
+  GET_ECONOMICS_INSTRUCTIONS,
+  GET_ECONOMICS_MCP_TOOL,
+  GET_ECONOMICS_OUTPUT_SCHEMA,
+  loadNetworkEconomics,
+} from "./network-economics.mjs";
 import {
   loadChainConcentration,
   loadSubnetConcentration,
@@ -169,7 +170,6 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
 export const MCP_SERVER_VERSION = "1.19.0";
-const ECONOMICS_SORT_FIELDS = API_QUERY_COLLECTIONS.economics.sort_fields;
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -231,8 +231,9 @@ export const MCP_INSTRUCTIONS =
   "callable subnets and how_do_i_call returns concrete call instructions " +
   "(base URL, auth, schema, health) for one subnet. For on-chain economics and " +
   "participation, get_subnet_economics returns a subnet's registration cost, " +
-  "open slots, and alpha price, get_economics the live network-wide economics " +
-  "scorecard (filterable/sortable per-subnet rows), get_economics_trends the network-wide " +
+  "open slots, and alpha price, " +
+  GET_ECONOMICS_INSTRUCTIONS +
+  "get_economics_trends the network-wide " +
   "per-day economics series (stake, alpha price, validator/miner counts), " +
   "get_subnet_trajectory its week-over-week trend, get_subnet_uptime its " +
   "long-term surface uptime history, get_health_trends the all-subnet 7d/30d " +
@@ -417,107 +418,6 @@ async function loadSubnetEconomics(ctx, netuid) {
     captured_at: blob?.captured_at ?? null,
     summary: blob?.summary ?? null,
     economics: blob?.subnets?.find((row) => row?.netuid === netuid) ?? null,
-  };
-}
-
-function economicsQueryUrl(args) {
-  const url = new URL("https://mcp.internal/economics");
-  if (args?.netuid !== undefined) {
-    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
-      throw toolError(
-        "invalid_params",
-        "netuid must be a non-negative integer.",
-      );
-    }
-    url.searchParams.set("netuid", String(args.netuid));
-  }
-  const q = optionalString(args, "q");
-  if (q) url.searchParams.set("q", q);
-  const registrationAllowed = optionalEnum(args, "registration_allowed", [
-    "true",
-    "false",
-  ]);
-  if (args?.registration_allowed !== undefined && !registrationAllowed) {
-    throw toolError(
-      "invalid_params",
-      "registration_allowed must be 'true' or 'false'.",
-    );
-  }
-  if (registrationAllowed) {
-    url.searchParams.set("registration_allowed", registrationAllowed);
-  }
-  const sort = optionalEnum(args, "sort", ECONOMICS_SORT_FIELDS);
-  if (args?.sort !== undefined && !sort) {
-    throw toolError(
-      "invalid_params",
-      `sort must be one of: ${ECONOMICS_SORT_FIELDS.join(", ")}.`,
-    );
-  }
-  if (sort) url.searchParams.set("sort", sort);
-  const order = optionalEnum(args, "order", ["asc", "desc"]);
-  if (args?.order !== undefined && !order) {
-    throw toolError("invalid_params", "order must be 'asc' or 'desc'.");
-  }
-  if (order) url.searchParams.set("order", order);
-  const fields = optionalString(args, "fields");
-  if (fields) url.searchParams.set("fields", fields);
-  if (args?.limit !== undefined) {
-    url.searchParams.set("limit", String(clampLimit(args.limit, 100, 1000)));
-  }
-  if (args?.cursor !== undefined) {
-    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
-      throw toolError(
-        "invalid_params",
-        "cursor must be a non-negative integer.",
-      );
-    }
-    url.searchParams.set("cursor", String(args.cursor));
-  }
-  return url;
-}
-
-// Network-wide economics collection: live KV tier (KV-primary), else the
-// committed R2 snapshot — the precedence GET /api/v1/economics uses. Applies
-// the same list-query filters (netuid, registration_allowed, q, sort, cursor).
-async function loadNetworkEconomics(ctx, args) {
-  const live = await resolveLiveEconomics({
-    readHealthKv: ctx.readHealthKv,
-    env: ctx.env,
-    contractVersion: mcpContractVersion(ctx),
-  });
-  let blob = live?.data;
-  let source = live?.source || null;
-  if (!blob) {
-    blob = await loadOptionalArtifact(ctx, "/metagraph/economics.json");
-    source = "r2-fallback";
-  }
-  if (!blob || typeof blob !== "object") {
-    throw toolError("not_found", "Economics snapshot unavailable.");
-  }
-  const transformed = applyQueryFilters(
-    blob,
-    economicsQueryUrl(args),
-    "economics",
-    [],
-  );
-  if (transformed.error) {
-    throw toolError("invalid_params", transformed.error.message);
-  }
-  const { data, meta } = transformed;
-  const page = meta.pagination || {};
-  return {
-    source: source || "r2-fallback",
-    captured_at: data.captured_at ?? null,
-    network: data.network ?? null,
-    summary: data.summary ?? null,
-    subnets: Array.isArray(data.subnets) ? data.subnets : [],
-    total: page.total ?? data.subnets?.length ?? 0,
-    returned: page.returned ?? data.subnets?.length ?? 0,
-    limit: page.limit ?? data.subnets?.length ?? 0,
-    cursor: page.cursor ?? 0,
-    next_cursor: page.next_cursor ?? null,
-    sort: page.sort ?? null,
-    order: page.order ?? null,
   };
 }
 
@@ -1811,67 +1711,19 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "get_economics",
-    title: "Get network-wide subnet economics",
-    description:
-      "Fetch the live network-wide economics scorecard: per-subnet validator " +
-      "and miner counts, registration cost and whether registration is open, open " +
-      "slots, stake, alpha price, emission share, and summary totals. Served " +
-      "live from the economics tier (~3h), falling back to the latest committed " +
-      "snapshot. Filter by netuid or registration_allowed, search by name/slug " +
-      "(q), sort with sort + order, and page with limit (1-1000) / cursor. " +
-      "Mirrors GET /api/v1/economics.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        netuid: {
-          type: "integer",
-          description: "Filter to one subnet netuid.",
-          minimum: 0,
-        },
-        registration_allowed: {
-          type: "string",
-          enum: ["true", "false"],
-          description:
-            "Filter to subnets where registration is open (true) or closed (false).",
-        },
-        q: {
-          type: "string",
-          description: "Search subnet name or slug (case-insensitive).",
-        },
-        sort: {
-          type: "string",
-          enum: ECONOMICS_SORT_FIELDS,
-          description:
-            "Field to sort by (bare name only). Pair with order for direction.",
-        },
-        order: {
-          type: "string",
-          enum: ["asc", "desc"],
-          description: "Sort direction for sort (default asc).",
-        },
-        fields: {
-          type: "string",
-          description:
-            "Comma-separated projection of subnet row fields to return.",
-        },
-        limit: {
-          type: "integer",
-          description:
-            "Max subnet rows to return (1-1000). Enables pagination.",
-          minimum: 1,
-          maximum: 1000,
-        },
-        cursor: {
-          type: "integer",
-          description: "Pagination cursor from a prior response's next_cursor.",
-          minimum: 0,
-        },
-      },
-      additionalProperties: false,
-    },
+    ...GET_ECONOMICS_MCP_TOOL,
     async handler(args, ctx) {
-      return loadNetworkEconomics(ctx, args);
+      try {
+        return await loadNetworkEconomics(ctx, args, {
+          contractVersion: mcpContractVersion,
+          readOptionalArtifact: loadOptionalArtifact,
+        });
+      } catch (err) {
+        if (err?.networkEconomics) {
+          throw toolError(err.code, err.message);
+        }
+        throw err;
+      }
     },
   },
   {
@@ -5043,25 +4895,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       economics: { type: ["object", "null"] },
     },
   },
-  get_economics: {
-    type: "object",
-    additionalProperties: true,
-    required: ["source", "subnets"],
-    properties: {
-      source: NULLABLE_STRING,
-      captured_at: NULLABLE_STRING,
-      network: NULLABLE_STRING,
-      summary: { type: ["object", "null"] },
-      subnets: { type: "array", items: { type: "object" } },
-      total: { type: "integer" },
-      returned: { type: "integer" },
-      limit: { type: "integer" },
-      cursor: { type: "integer" },
-      next_cursor: NULLABLE_INT,
-      sort: NULLABLE_STRING,
-      order: NULLABLE_STRING,
-    },
-  },
+  get_economics: GET_ECONOMICS_OUTPUT_SCHEMA,
   get_subnet_trajectory: {
     type: "object",
     additionalProperties: true,

--- a/src/network-economics.mjs
+++ b/src/network-economics.mjs
@@ -89,6 +89,9 @@ export function economicsQueryUrl(args) {
 }
 
 export async function loadNetworkEconomics(ctx, args, deps) {
+  // Validate/build the list-query URL before any tier I/O so invalid_params
+  // (netuid, cursor, sort, …) never triggers live-KV or R2 reads.
+  const queryUrl = economicsQueryUrl(args);
   const live = await resolveLiveEconomics({
     readHealthKv: ctx.readHealthKv,
     env: ctx.env,
@@ -103,12 +106,7 @@ export async function loadNetworkEconomics(ctx, args, deps) {
   if (!blob || typeof blob !== "object") {
     throw networkEconomicsError("not_found", "Economics snapshot unavailable.");
   }
-  const transformed = applyQueryFilters(
-    blob,
-    economicsQueryUrl(args),
-    "economics",
-    [],
-  );
+  const transformed = applyQueryFilters(blob, queryUrl, "economics", []);
   if (transformed.error) {
     throw networkEconomicsError("invalid_params", transformed.error.message);
   }

--- a/src/network-economics.mjs
+++ b/src/network-economics.mjs
@@ -1,0 +1,218 @@
+// Network-wide economics collection loader for REST + MCP parity.
+// Pure orchestration over resolveLiveEconomics + applyQueryFilters; MCP/REST
+// handlers keep tier precedence and envelope wiring.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+import { resolveLiveEconomics } from "./health-serving.mjs";
+
+const ECONOMICS_SORT_FIELDS = API_QUERY_COLLECTIONS.economics.sort_fields;
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export function networkEconomicsError(code, message) {
+  const err = new Error(message);
+  err.code = code;
+  err.networkEconomics = true;
+  return err;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw networkEconomicsError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw networkEconomicsError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function economicsQueryUrl(args) {
+  const url = new URL("https://mcp.internal/economics");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw networkEconomicsError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const q = optionalString(args, "q");
+  if (q) url.searchParams.set("q", q);
+  const registrationAllowed = optionalEnum(args, "registration_allowed", [
+    "true",
+    "false",
+  ]);
+  if (registrationAllowed) {
+    url.searchParams.set("registration_allowed", registrationAllowed);
+  }
+  const sort = optionalEnum(args, "sort", ECONOMICS_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 100, 1000)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw networkEconomicsError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadNetworkEconomics(ctx, args, deps) {
+  const live = await resolveLiveEconomics({
+    readHealthKv: ctx.readHealthKv,
+    env: ctx.env,
+    contractVersion: deps.contractVersion(ctx),
+  });
+  let blob = live?.data;
+  let source = live?.source ?? null;
+  if (!blob) {
+    blob = await deps.readOptionalArtifact(ctx, "/metagraph/economics.json");
+    source = "r2-fallback";
+  }
+  if (!blob || typeof blob !== "object") {
+    throw networkEconomicsError("not_found", "Economics snapshot unavailable.");
+  }
+  const transformed = applyQueryFilters(
+    blob,
+    economicsQueryUrl(args),
+    "economics",
+    [],
+  );
+  if (transformed.error) {
+    throw networkEconomicsError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const subnets = Array.isArray(data.subnets) ? data.subnets : [];
+  const subnetLen = subnets.length;
+  return {
+    source: source || "r2-fallback",
+    captured_at: data.captured_at ?? null,
+    network: data.network ?? null,
+    summary: data.summary ?? null,
+    subnets,
+    total: page.total ?? subnetLen,
+    returned: page.returned ?? subnetLen,
+    limit: page.limit ?? subnetLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const GET_ECONOMICS_INSTRUCTIONS =
+  "get_economics the live network-wide economics " +
+  "scorecard (filterable/sortable per-subnet rows), ";
+
+export const GET_ECONOMICS_MCP_TOOL = {
+  name: "get_economics",
+  title: "Get network-wide subnet economics",
+  description:
+    "Fetch the live network-wide economics scorecard: per-subnet validator " +
+    "and miner counts, registration cost and whether registration is open, open " +
+    "slots, stake, alpha price, emission share, and summary totals. Served " +
+    "live from the economics tier (~3h), falling back to the latest committed " +
+    "snapshot. Filter by netuid or registration_allowed, search by name/slug " +
+    "(q), sort with sort + order, and page with limit (1-1000) / cursor. " +
+    "Mirrors GET /api/v1/economics.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter to one subnet netuid.",
+        minimum: 0,
+      },
+      registration_allowed: {
+        type: "string",
+        enum: ["true", "false"],
+        description:
+          "Filter to subnets where registration is open (true) or closed (false).",
+      },
+      q: {
+        type: "string",
+        description: "Search subnet name or slug (case-insensitive).",
+      },
+      sort: {
+        type: "string",
+        enum: ECONOMICS_SORT_FIELDS,
+        description:
+          "Field to sort by (bare name only). Pair with order for direction.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of subnet row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max subnet rows to return (1-1000). Enables pagination.",
+        minimum: 1,
+        maximum: 1000,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+export const GET_ECONOMICS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["source", "subnets"],
+  properties: {
+    source: NULLABLE_STRING,
+    captured_at: NULLABLE_STRING,
+    network: NULLABLE_STRING,
+    summary: { type: ["object", "null"] },
+    subnets: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -532,6 +532,54 @@ describe("find_subnet_opportunities + leaderboards — economics R2 fallback", (
   });
 });
 
+// ── get_economics — list-query + tier fallbacks ─────────────────────────
+describe("get_economics — branch coverage", () => {
+  const ECON_ROW = {
+    netuid: 7,
+    name: "Allways",
+    slug: "allways",
+    emission_share: 1,
+    registration_allowed: true,
+  };
+  const ECON_BLOB = {
+    contract_version: "test-contract",
+    captured_at: FRESH_RUN,
+    schema_version: 1,
+    summary: { with_economics_count: 1, subnet_count: 1 },
+    subnets: [ECON_ROW],
+  };
+
+  test("tolerates economics blob with no subnets array", async () => {
+    const deps = makeDeps(
+      {
+        "/metagraph/economics.json": { captured_at: FRESH_RUN, summary: null },
+      },
+      {},
+    );
+    const res = await callTool("get_economics", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.source, "r2-fallback");
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.summary, null);
+  });
+
+  test("rejects malformed fields list from list-query validation", async () => {
+    const res = await callTool(
+      "get_economics",
+      { fields: "netuid,9invalid" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": ECON_BLOB }, {}),
+        env: {},
+      },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /fields must be a comma-separated/,
+    );
+  });
+});
+
 // ── list_subnet_apis fallbacks ────────────────────────────
 describe("list_subnet_apis — detail fallback fields", () => {
   test("falls back to the requested netuid + empty services when detail is bare", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4901,6 +4901,139 @@ describe("MCP economics + metagraph data tools", () => {
     assert.match(res.body.result.content[0].text, /invalid_params/);
   });
 
+  test("get_economics rejects invalid netuid and cursor before loading data", async () => {
+    const deps = makeDeps({ "/metagraph/economics.json": ECON_BLOB }, {});
+    for (const [args, pattern] of [
+      [{ netuid: -1 }, /netuid must be a non-negative integer/],
+      [{ cursor: -1 }, /cursor must be a non-negative integer/],
+    ]) {
+      const res = await callTool("get_economics", args, { deps, env: {} });
+      assert.equal(res.body.result.isError, true, JSON.stringify(args));
+      assert.match(res.body.result.content[0].text, pattern);
+    }
+  });
+
+  test("get_economics supports q search, fields projection, and netuid filter", async () => {
+    const blob = {
+      ...ECON_BLOB,
+      network: "finney",
+      subnets: [
+        ECON_ROW,
+        { ...ECON_ROW, netuid: 8, name: "Other", slug: "other" },
+      ],
+    };
+    const res = await callTool(
+      "get_economics",
+      { q: "allways", fields: "netuid,name,emission_share" },
+      { deps: makeDeps({ "/metagraph/economics.json": blob }, {}), env: {} },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.network, "finney");
+    assert.equal(out.subnets.length, 1);
+    assert.deepEqual(Object.keys(out.subnets[0]).sort(), [
+      "emission_share",
+      "name",
+      "netuid",
+    ]);
+
+    const byNetuid = await callTool(
+      "get_economics",
+      { netuid: 8 },
+      { deps: makeDeps({ "/metagraph/economics.json": blob }, {}), env: {} },
+    );
+    assert.equal(byNetuid.body.result.structuredContent.subnets[0].netuid, 8);
+  });
+
+  test("get_economics rejects unsupported fields projection", async () => {
+    const res = await callTool(
+      "get_economics",
+      { fields: "netuid,not_a_field" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": ECON_BLOB }, {}),
+        env: {},
+      },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /fields includes unsupported/,
+    );
+  });
+
+  test("get_economics returns next_cursor when more pages remain", async () => {
+    const blob = {
+      ...ECON_BLOB,
+      subnets: [
+        ECON_ROW,
+        { ...ECON_ROW, netuid: 8 },
+        { ...ECON_ROW, netuid: 9 },
+      ],
+    };
+    const res = await callTool(
+      "get_economics",
+      { limit: 1, sort: "netuid", order: "asc" },
+      { deps: makeDeps({ "/metagraph/economics.json": blob }, {}), env: {} },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.next_cursor, 1);
+    assert.equal(out.subnets[0].netuid, 7);
+  });
+
+  test("get_economics defaults pagination when limit and cursor are omitted", async () => {
+    const res = await callTool(
+      "get_economics",
+      {},
+      {
+        deps: makeDeps({ "/metagraph/economics.json": ECON_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.source, "r2-fallback");
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.total, 1);
+    assert.equal(out.returned, 1);
+    assert.equal(out.cursor, 0);
+    assert.equal(out.next_cursor, null);
+    assert.equal(out.captured_at, FRESH_RUN);
+  });
+
+  test("get_economics handler rethrows unexpected loader failures", async () => {
+    const tool = MCP_TOOLS.find((t) => t.name === "get_economics");
+    await assert.rejects(
+      () =>
+        tool.handler(
+          {},
+          {
+            env: {},
+            readHealthKv: async () => null,
+            readArtifact: async () => {
+              throw new Error("kaboom");
+            },
+          },
+        ),
+      /kaboom/,
+    );
+  });
+
+  test("get_economics payload validates against its declared outputSchema", async () => {
+    const ajv = new Ajv2020({ strict: false });
+    const validate = ajv.compile(
+      listToolDefinitions().find((t) => t.name === "get_economics")
+        .outputSchema,
+    );
+    const res = await callTool(
+      "get_economics",
+      { sort: "netuid", order: "asc" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": ECON_BLOB }, {}),
+        env: {},
+      },
+    );
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("get_economics surfaces not_found when neither tier has data", async () => {
     const res = await callTool(
       "get_economics",

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4827,6 +4827,90 @@ describe("MCP economics + metagraph data tools", () => {
     assert.match(res.body.result.content[0].text, /not_found/);
   });
 
+  test("get_economics serves the live KV economics tier with REST list-query filters", async () => {
+    const blob = {
+      ...ECON_BLOB,
+      subnets: [
+        ECON_ROW,
+        {
+          ...ECON_ROW,
+          netuid: 9,
+          name: "Beta",
+          slug: "beta",
+          registration_allowed: false,
+          emission_share: 0,
+        },
+      ],
+      summary: {
+        ...ECON_BLOB.summary,
+        subnet_count: 2,
+        with_economics_count: 2,
+      },
+    };
+    const res = await callTool(
+      "get_economics",
+      { registration_allowed: "true", sort: "emission_share", order: "desc" },
+      {
+        deps: makeDeps({}, { "economics:current": blob }),
+        env: { METAGRAPH_CONTRACT_VERSION: "test-contract" },
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.source, "live-kv");
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.subnets[0].netuid, 7);
+    assert.equal(out.total, 1);
+  });
+
+  test("get_economics falls back to R2 and pages with limit/cursor", async () => {
+    const blob = {
+      ...ECON_BLOB,
+      subnets: [
+        ECON_ROW,
+        { ...ECON_ROW, netuid: 8, emission_share: 0.5 },
+        { ...ECON_ROW, netuid: 9, emission_share: 0.1 },
+      ],
+    };
+    const res = await callTool(
+      "get_economics",
+      { limit: 2, cursor: 1, sort: "netuid", order: "asc" },
+      { deps: makeDeps({ "/metagraph/economics.json": blob }, {}), env: {} },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.source, "r2-fallback");
+    assert.equal(out.total, 3);
+    assert.equal(out.returned, 2);
+    assert.equal(out.cursor, 1);
+    assert.equal(out.next_cursor, null);
+    assert.deepEqual(
+      out.subnets.map((row) => row.netuid),
+      [8, 9],
+    );
+  });
+
+  test("get_economics rejects an invalid sort field", async () => {
+    const res = await callTool(
+      "get_economics",
+      { sort: "not_a_field" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": ECON_BLOB }, {}),
+        env: {},
+      },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /invalid_params/);
+  });
+
+  test("get_economics surfaces not_found when neither tier has data", async () => {
+    const res = await callTool(
+      "get_economics",
+      {},
+      { deps: makeDeps({}, {}), env: {} },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /not_found/);
+  });
+
   // A D1 `neurons` row (booleans as 0/1 INTEGER, stake/emission already TAO floats),
   // mirroring the metagraph-neurons unit-test fixtures.
   const ROW = {

--- a/tests/network-economics.test.mjs
+++ b/tests/network-economics.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { describe, test, vi } from "vitest";
 import Ajv2020 from "ajv/dist/2020.js";
+import * as healthServing from "../src/health-serving.mjs";
 import {
   economicsQueryUrl,
   GET_ECONOMICS_MCP_TOOL,
@@ -100,6 +101,11 @@ describe("network-economics — economicsQueryUrl", () => {
     const url = economicsQueryUrl({ limit: 0 });
     assert.equal(url.searchParams.get("limit"), "100");
   });
+
+  test("falls back when limit is not a number", () => {
+    const url = economicsQueryUrl({ limit: "50" });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
 });
 
 describe("network-economics — loadNetworkEconomics", () => {
@@ -165,6 +171,27 @@ describe("network-economics — loadNetworkEconomics", () => {
     assert.equal(out.summary, null);
     assert.equal(out.network, null);
     assert.equal(out.captured_at, FRESH_RUN);
+  });
+
+  test("null-fills captured_at when the snapshot omits it", async () => {
+    const out = await loadNetworkEconomics(
+      makeCtx(),
+      {},
+      makeDeps({ subnets: [ECON_ROW], summary: ECON_BLOB.summary }),
+    );
+    assert.equal(out.captured_at, null);
+  });
+
+  test("defaults source when the live tier returns data without a source label", async () => {
+    const spy = vi
+      .spyOn(healthServing, "resolveLiveEconomics")
+      .mockResolvedValue({ data: ECON_BLOB, source: null });
+    try {
+      const out = await loadNetworkEconomics(makeCtx(), {}, makeDeps(null));
+      assert.equal(out.source, "r2-fallback");
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   test("surfaces not_found when neither tier has data", async () => {

--- a/tests/network-economics.test.mjs
+++ b/tests/network-economics.test.mjs
@@ -194,6 +194,29 @@ describe("network-economics — loadNetworkEconomics", () => {
     }
   });
 
+  test("validates list-query args before live-KV or R2 reads", async () => {
+    let tierReads = 0;
+    const deps = {
+      contractVersion: () => "test-contract",
+      readOptionalArtifact: async () => {
+        tierReads += 1;
+        return ECON_BLOB;
+      },
+    };
+    const ctx = {
+      readHealthKv: async () => {
+        tierReads += 1;
+        return ECON_BLOB;
+      },
+      env: { METAGRAPH_CONTRACT_VERSION: "test-contract" },
+    };
+    await assert.rejects(
+      () => loadNetworkEconomics(ctx, { netuid: -1 }, deps),
+      /netuid must be a non-negative integer/,
+    );
+    assert.equal(tierReads, 0);
+  });
+
   test("surfaces not_found when neither tier has data", async () => {
     await assert.rejects(
       () => loadNetworkEconomics(makeCtx(), {}, makeDeps(null)),

--- a/tests/network-economics.test.mjs
+++ b/tests/network-economics.test.mjs
@@ -1,0 +1,267 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import {
+  economicsQueryUrl,
+  GET_ECONOMICS_MCP_TOOL,
+  GET_ECONOMICS_OUTPUT_SCHEMA,
+  loadNetworkEconomics,
+  networkEconomicsError,
+} from "../src/network-economics.mjs";
+
+const FRESH_RUN = new Date(Date.now() - 60_000).toISOString();
+
+const ECON_ROW = {
+  netuid: 7,
+  name: "Allways",
+  slug: "allways",
+  emission_share: 1,
+  registration_allowed: true,
+};
+
+const ECON_BLOB = {
+  contract_version: "test-contract",
+  captured_at: FRESH_RUN,
+  schema_version: 1,
+  summary: { with_economics_count: 1, subnet_count: 1 },
+  subnets: [ECON_ROW],
+};
+
+function makeCtx({ kv = null } = {}) {
+  return {
+    readHealthKv(_env, key) {
+      if (kv && Object.prototype.hasOwnProperty.call(kv, key)) {
+        return Promise.resolve(kv[key]);
+      }
+      return Promise.resolve(null);
+    },
+    env: { METAGRAPH_CONTRACT_VERSION: "test-contract" },
+  };
+}
+
+function makeDeps(artifactData) {
+  return {
+    contractVersion: () => "test-contract",
+    readOptionalArtifact: async () => artifactData,
+  };
+}
+
+describe("network-economics — economicsQueryUrl", () => {
+  test("maps every list-query arg onto the internal URL", () => {
+    const url = economicsQueryUrl({
+      netuid: 7,
+      q: "allways",
+      registration_allowed: "true",
+      sort: "emission_share",
+      order: "desc",
+      fields: "netuid,name",
+      limit: 50,
+      cursor: 2,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("q"), "allways");
+    assert.equal(url.searchParams.get("registration_allowed"), "true");
+    assert.equal(url.searchParams.get("sort"), "emission_share");
+    assert.equal(url.searchParams.get("order"), "desc");
+    assert.equal(url.searchParams.get("fields"), "netuid,name");
+    assert.equal(url.searchParams.get("limit"), "50");
+    assert.equal(url.searchParams.get("cursor"), "2");
+  });
+
+  test("rejects invalid netuid and cursor", () => {
+    for (const [args, pattern] of [
+      [{ netuid: -1 }, /netuid must be a non-negative integer/],
+      [{ cursor: -1 }, /cursor must be a non-negative integer/],
+    ]) {
+      assert.throws(
+        () => economicsQueryUrl(args),
+        (err) => {
+          assert.equal(err.networkEconomics, true);
+          assert.equal(err.code, "invalid_params");
+          assert.match(err.message, pattern);
+          return true;
+        },
+      );
+    }
+  });
+
+  test("rejects blank optional strings and invalid enums", () => {
+    assert.throws(
+      () => economicsQueryUrl({ q: "   " }),
+      /must be a non-empty string/,
+    );
+    assert.throws(
+      () => economicsQueryUrl({ sort: "not_a_field" }),
+      /must be one of:/,
+    );
+  });
+
+  test("clamps limit fallback when limit is below 1", () => {
+    const url = economicsQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+});
+
+describe("network-economics — loadNetworkEconomics", () => {
+  test("serves the live KV tier with list-query filters applied", async () => {
+    const blob = {
+      ...ECON_BLOB,
+      subnets: [
+        ECON_ROW,
+        {
+          ...ECON_ROW,
+          netuid: 9,
+          registration_allowed: false,
+          emission_share: 0,
+        },
+      ],
+      summary: {
+        ...ECON_BLOB.summary,
+        subnet_count: 2,
+        with_economics_count: 2,
+      },
+    };
+    const out = await loadNetworkEconomics(
+      makeCtx({ kv: { "economics:current": blob } }),
+      { registration_allowed: "true", sort: "emission_share", order: "desc" },
+      makeDeps(null),
+    );
+    assert.equal(out.source, "live-kv");
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.subnets[0].netuid, 7);
+  });
+
+  test("falls back to R2 and pages with limit/cursor", async () => {
+    const blob = {
+      ...ECON_BLOB,
+      subnets: [
+        ECON_ROW,
+        { ...ECON_ROW, netuid: 8, emission_share: 0.5 },
+        { ...ECON_ROW, netuid: 9, emission_share: 0.1 },
+      ],
+    };
+    const out = await loadNetworkEconomics(
+      makeCtx(),
+      { limit: 2, cursor: 1, sort: "netuid", order: "asc" },
+      makeDeps(blob),
+    );
+    assert.equal(out.source, "r2-fallback");
+    assert.equal(out.total, 3);
+    assert.equal(out.returned, 2);
+    assert.deepEqual(
+      out.subnets.map((row) => row.netuid),
+      [8, 9],
+    );
+  });
+
+  test("null-fills optional envelope fields and tolerates missing subnets[]", async () => {
+    const out = await loadNetworkEconomics(
+      makeCtx(),
+      {},
+      makeDeps({ captured_at: FRESH_RUN, summary: null }),
+    );
+    assert.equal(out.source, "r2-fallback");
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.summary, null);
+    assert.equal(out.network, null);
+    assert.equal(out.captured_at, FRESH_RUN);
+  });
+
+  test("surfaces not_found when neither tier has data", async () => {
+    await assert.rejects(
+      () => loadNetworkEconomics(makeCtx(), {}, makeDeps(null)),
+      (err) => {
+        assert.equal(err.code, "not_found");
+        assert.match(err.message, /unavailable/);
+        return true;
+      },
+    );
+  });
+
+  test("surfaces invalid_params from list-query validation", async () => {
+    await assert.rejects(
+      () =>
+        loadNetworkEconomics(
+          makeCtx(),
+          { sort: "not_a_field" },
+          makeDeps(ECON_BLOB),
+        ),
+      (err) => {
+        assert.equal(err.code, "invalid_params");
+        return true;
+      },
+    );
+  });
+
+  test("supports q search, fields projection, netuid filter, and next_cursor", async () => {
+    const blob = {
+      ...ECON_BLOB,
+      network: "finney",
+      subnets: [
+        ECON_ROW,
+        { ...ECON_ROW, netuid: 8, name: "Other", slug: "other" },
+        { ...ECON_ROW, netuid: 9, name: "Third", slug: "third" },
+      ],
+    };
+    const searched = await loadNetworkEconomics(
+      makeCtx(),
+      { q: "allways", fields: "netuid,name,emission_share" },
+      makeDeps(blob),
+    );
+    assert.equal(searched.network, "finney");
+    assert.equal(searched.subnets.length, 1);
+
+    const byNetuid = await loadNetworkEconomics(
+      makeCtx(),
+      { netuid: 8 },
+      makeDeps(blob),
+    );
+    assert.equal(byNetuid.subnets[0].netuid, 8);
+
+    const paged = await loadNetworkEconomics(
+      makeCtx(),
+      { limit: 1, sort: "netuid", order: "asc" },
+      makeDeps(blob),
+    );
+    assert.equal(paged.next_cursor, 1);
+    assert.equal(paged.returned, 1);
+  });
+
+  test("rejects unsupported and malformed fields projection", async () => {
+    await assert.rejects(
+      () =>
+        loadNetworkEconomics(
+          makeCtx(),
+          { fields: "netuid,not_a_field" },
+          makeDeps(ECON_BLOB),
+        ),
+      /unsupported field/,
+    );
+    await assert.rejects(
+      () =>
+        loadNetworkEconomics(
+          makeCtx(),
+          { fields: "netuid,9invalid" },
+          makeDeps(ECON_BLOB),
+        ),
+      /fields must be a comma-separated/,
+    );
+  });
+});
+
+describe("network-economics — MCP surface exports", () => {
+  test("declares a compilable tool + output schema", () => {
+    assert.equal(GET_ECONOMICS_MCP_TOOL.name, "get_economics");
+    assert.ok(
+      GET_ECONOMICS_MCP_TOOL.inputSchema.properties.sort.enum.length > 0,
+    );
+    const ajv = new Ajv2020({ strict: false });
+    assert.ok(ajv.compile(GET_ECONOMICS_OUTPUT_SCHEMA));
+  });
+
+  test("networkEconomicsError tags typed loader failures", () => {
+    const err = networkEconomicsError("invalid_params", "bad");
+    assert.equal(err.networkEconomics, true);
+    assert.equal(err.code, "invalid_params");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `get_economics`, an MCP tool mirroring `GET /api/v1/economics`: the live network-wide per-subnet economics scorecard (validator/miner counts, registration cost, open slots, stake, alpha price, emission share, and summary totals). Served live from the economics KV tier (~3h) with committed-R2 fallback, using the same list-query filters as REST (`netuid`, `registration_allowed`, `q`, `sort`, `order`, `fields`, `limit`, `cursor`).

**Unrelated to #2737**, which hardens `ConcentrationMetrics` outputSchema parity for the existing `get_chain_concentration` / `get_subnet_concentration` tools (#2693 feedback atop merged #2710) on branch `feat/mcp-get-chain-concentration`. These PRs touch different regions of `mcp-server.mjs`, address different issues, and do not supersede one another.

## What changed

- **`src/mcp-server.mjs`** — register `get_economics` with `loadNetworkEconomics()` (`resolveLiveEconomics` + `applyQueryFilters`); bump MCP SemVer **1.18.0 → 1.19.0**.
- **`server.json`** — MCP Registry listing version **1.19.0**.
- **`scripts/validate-mcp.mjs`** — cold-path smoke for `get_economics` (**74 tools**).
- **`tests/mcp-server.test.mjs`** — live-KV filter/sort, R2 pagination, `q` + `fields` projection, invalid-param guards, and `not_found` when both tiers are cold.

No new REST routes, D1 loaders, or `entities.mjs` changes.

## Overlap avoidance

Touches the economics tool region (~1700 in `mcp-server.mjs`). Does not overlap with open MCP PRs for concentration schema parity (#2737), global validators (#2724), or subnet-events block range (#2736).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `node scripts/validate-mcp.mjs` (74 tools)
- [x] `npx vitest run tests/mcp-server.test.mjs -t get_economics`
- [x] `checks` + `test` CI jobs green
- [ ] `codecov/patch` — in progress (additional branch-coverage tests landing)
