### PR TITLE
feat(mcp): add block_start/block_end to get_subnet_events

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -2338,6 +2338,7 @@ export const MCP_TOOLS = [
       "amount, and timestamp. Optionally filter by event kind (e.g. StakeAdded, " +
       "NeuronRegistered, AxonServed, WeightsSet) and page with limit (1-1000, " +
       "default 100) / offset, or follow next_cursor for stable keyset pagination. " +
+      "Optionally constrain block height with block_start/block_end (inclusive). " +
       "Use it to watch what is happening on one subnet right now. Events are " +
       "decoded directly from the chain. Mirrors GET /api/v1/subnets/{netuid}/events.",
     inputSchema: {
@@ -2349,6 +2350,18 @@ export const MCP_TOOLS = [
           description:
             "Optional event-kind filter, e.g. 'StakeAdded' or 'WeightsSet'. " +
             "Omit for all kinds; an unknown kind simply matches nothing.",
+        },
+        block_start: {
+          type: "integer",
+          description:
+            "Optional inclusive lower block bound; omit for no lower limit.",
+          minimum: 0,
+        },
+        block_end: {
+          type: "integer",
+          description:
+            "Optional inclusive upper block bound; omit for no upper limit.",
+          minimum: 0,
         },
         limit: {
           type: "integer",
@@ -2377,6 +2390,8 @@ export const MCP_TOOLS = [
       const cursor = optionalString(args, "cursor");
       return loadSubnetEvents(mcpD1Runner(ctx), netuid, {
         kind,
+        blockStart: optionalNonNegativeInt(args, "block_start"),
+        blockEnd: optionalNonNegativeInt(args, "block_end"),
         limit: args?.limit,
         offset: args?.offset,
         cursor,

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -7572,6 +7572,60 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
     assert.ok(q.params.includes("WeightsSet"));
   });
 
+  test("get_subnet_events applies block_start/block_end and cursor pagination", async () => {
+    const capture = [];
+    const env = parityD1(
+      {
+        events: [
+          {
+            block_number: 150,
+            event_index: 4,
+            event_kind: "StakeAdded",
+            hotkey: "5Hk",
+            coldkey: null,
+            netuid: 1,
+            uid: 3,
+            amount_tao: 1.5,
+            observed_at: 1750009000000,
+            extrinsic_index: null,
+          },
+        ],
+      },
+      capture,
+    );
+    const res = await callTool(
+      "get_subnet_events",
+      {
+        netuid: 1,
+        block_start: 100,
+        block_end: 900,
+        cursor: "200.2",
+        limit: 1,
+        offset: 99,
+      },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.event_count, 1);
+    assert.equal(out.next_cursor, "150.4");
+    const q = capture.find((c) => /FROM account_events/.test(c.sql));
+    assert.ok(/block_number >= \?/.test(q.sql));
+    assert.ok(/block_number <= \?/.test(q.sql));
+    assert.ok(/\(block_number, event_index\) < \(\?, \?\)/.test(q.sql));
+    assert.ok(!/OFFSET/.test(q.sql));
+    assert.deepEqual(q.params, [1, 100, 900, 200, 2, 1]);
+  });
+
+  test("get_subnet_events rejects a non-integer block_start", async () => {
+    const res = await callTool(
+      "get_subnet_events",
+      { netuid: 1, block_start: "bad" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /block_start/i);
+  });
+
   test("get_subnet_events clamps an over-range limit like the REST route", async () => {
     const capture = [];
     const env = parityD1({ events: [] }, capture);


### PR DESCRIPTION
## Summary

- Add optional `block_start` and `block_end` parameters to the MCP `get_subnet_events` tool, matching the existing REST `GET /api/v1/subnets/{netuid}/events` query filters.
- Wire the parameters through to the shared `loadSubnetEvents` loader (already used by REST), so pagination with `cursor` and block bounds composes the same way as `get_account_events` and the extrinsics/transfers feeds.
- Add MCP integration tests for block-range + cursor pagination and invalid `block_start` validation.

Follow-up to closed #2653 (merge conflicts only). No MCP version bump — additive optional params on an existing tool.

## Test plan

- [x] `npx vitest run tests/mcp-server.test.mjs -t "get_subnet_events"`
- [x] `npm run validate:mcp` — 73 tools, lifecycle + all tools/call
- [x] `npm run lint`
- [x] `npm run format:check`