### PR TITLE
fix(mcp): document concentration metric fields in concentration tool outputSchemas

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -361,8 +361,11 @@ assert.ok(
 );
 const chainConc = await callOk("get_chain_concentration", {});
 assert.ok(
-  Number.isInteger(chainConc.subnet_count),
-  "get_chain_concentration must return an integer subnet_count",
+  chainConc.subnet_count === 0 &&
+    chainConc.neuron_count === 0 &&
+    chainConc.stake === null &&
+    chainConc.emission === null,
+  "get_chain_concentration must return schema-stable empties on cold D1",
 );
 const meta = await callOk("get_subnet_metagraph", { netuid: 7 });
 assert.ok(

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -4525,6 +4525,26 @@ const objectItems = (properties = {}) => ({
   type: "array",
   items: { type: "object", additionalProperties: true, properties },
 });
+// One concentration lens (stake, emission, entity_*, validator_stake): mirrors
+// components/schemas/ConcentrationMetrics in the OpenAPI contract.
+const CONCENTRATION_METRICS_BLOCK = {
+  type: ["object", "null"],
+  additionalProperties: true,
+  properties: {
+    holders: { type: "integer" },
+    total: { type: ["number", "null"] },
+    gini: { type: ["number", "null"] },
+    hhi: { type: ["number", "null"] },
+    hhi_normalized: { type: ["number", "null"] },
+    nakamoto_coefficient: NULLABLE_INT,
+    top_1pct_share: { type: ["number", "null"] },
+    top_5pct_share: { type: ["number", "null"] },
+    top_10pct_share: { type: ["number", "null"] },
+    top_20pct_share: { type: ["number", "null"] },
+    entropy: { type: ["number", "null"] },
+    entropy_normalized: { type: ["number", "null"] },
+  },
+};
 // Shared account item shapes: a registration appears in get_account +
 // get_account_subnets, an event in get_account + get_account_events.
 const ACCOUNT_REGISTRATION_ITEM = {
@@ -4914,11 +4934,11 @@ const TOOL_OUTPUT_SCHEMAS = {
       entity_count: { type: "integer" },
       uids_per_entity: { type: ["number", "null"] },
       captured_at: NULLABLE_STRING,
-      stake: { type: ["object", "null"] },
-      emission: { type: ["object", "null"] },
-      entity_stake: { type: ["object", "null"] },
-      entity_emission: { type: ["object", "null"] },
-      validator_stake: { type: ["object", "null"] },
+      stake: CONCENTRATION_METRICS_BLOCK,
+      emission: CONCENTRATION_METRICS_BLOCK,
+      entity_stake: CONCENTRATION_METRICS_BLOCK,
+      entity_emission: CONCENTRATION_METRICS_BLOCK,
+      validator_stake: CONCENTRATION_METRICS_BLOCK,
     },
   },
   get_chain_concentration: {
@@ -4932,11 +4952,11 @@ const TOOL_OUTPUT_SCHEMAS = {
       entity_count: { type: "integer" },
       uids_per_entity: { type: ["number", "null"] },
       captured_at: NULLABLE_STRING,
-      stake: { type: ["object", "null"] },
-      emission: { type: ["object", "null"] },
-      entity_stake: { type: ["object", "null"] },
-      entity_emission: { type: ["object", "null"] },
-      validator_stake: { type: ["object", "null"] },
+      stake: CONCENTRATION_METRICS_BLOCK,
+      emission: CONCENTRATION_METRICS_BLOCK,
+      entity_stake: CONCENTRATION_METRICS_BLOCK,
+      entity_emission: CONCENTRATION_METRICS_BLOCK,
+      validator_stake: CONCENTRATION_METRICS_BLOCK,
     },
   },
   get_subnet_concentration_history: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5131,6 +5131,14 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.entity_count, 1);
     assert.equal(out.entity_stake.total, 150);
     assert.equal(out.stake.holders, 2);
+    assert.equal(out.emission.total, 3);
+    assert.equal(out.emission.holders, 2);
+    assert.equal(out.entity_emission.total, 3);
+    assert.equal(out.entity_emission.holders, 1);
+    assert.equal(out.validator_stake.total, 100);
+    assert.equal(out.validator_stake.holders, 1);
+    assert.ok(out.stake.gini != null);
+    assert.ok(out.emission.gini != null);
   });
 
   test("get_chain_concentration returns schema-stable null blocks on cold D1", async () => {
@@ -5175,6 +5183,15 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.entity_count, 1); // both rows share coldkey ck-a
     assert.equal(out.entity_stake.total, 150);
     assert.equal(out.stake.holders, 2);
+    assert.equal(out.emission.total, 3);
+    assert.equal(out.emission.holders, 2);
+    assert.equal(out.entity_emission.total, 3);
+    assert.equal(out.entity_emission.holders, 1);
+    assert.equal(out.validator_stake.total, 100);
+    assert.equal(out.validator_stake.holders, 1);
+    assert.equal(out.validator_stake.nakamoto_coefficient, 1);
+    assert.ok(out.stake.gini != null);
+    assert.ok(out.emission.gini != null);
   });
 
   test("get_subnet_concentration_history defaults to 30d and returns points", async () => {


### PR DESCRIPTION
## Summary

`get_chain_concentration` landed on `main` via #2710, but its MCP `outputSchema` still advertised opaque `object|null` metric blocks instead of explicit `ConcentrationMetrics` fields. Maintainer feedback on closed #2693 asked for OpenAPI-parity schema plus broader lens coverage in tests. This PR completes that contract so agents can rely on Gini, HHI, Nakamoto, top-percentile shares, and entropy in `structuredContent` validation.

Applies the same `ConcentrationMetrics` block to `get_subnet_concentration` for sibling-tool consistency (same opaque schema pattern, no loader or behavior change).

## What changed

- **`src/mcp-server.mjs`**
  - Add shared `CONCENTRATION_METRICS_BLOCK` mirroring OpenAPI `components/schemas/ConcentrationMetrics`.
  - Wire into `TOOL_OUTPUT_SCHEMAS.get_chain_concentration` and `get_subnet_concentration` (replaces `object|null` for `stake`, `emission`, `entity_stake`, `entity_emission`, `validator_stake`).
- **`scripts/validate-mcp.mjs`**
  - Strengthen cold-D1 smoke check: assert schema-stable empties (`subnet_count`/`neuron_count` zero, `stake`/`emission` null), not only integer `subnet_count`.
- **`tests/mcp-server.test.mjs`**
  - Extend populated-path assertions to cover `emission`, `entity_emission`, and `validator_stake` lenses (totals, holders, Gini, Nakamoto), in addition to existing `stake` / `entity_stake` / cross-subnet entity collapse checks from #2710.

No new routes, loaders, D1 queries, MCP tool additions, or `entities.mjs` changes — schema + validation/test hardening atop merged #2710.

## Overlap avoidance

Touches the concentration `TOOL_OUTPUT_SCHEMAS` region (~4530 in `mcp-server.mjs`). Does not overlap with open MCP PRs for network economics (#2735), global validators (#2724), or subnet-events block range (#2736).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (MCP output schema only; mirrors existing OpenAPI `ConcentrationMetrics`.)

## Validation

- [x] `git diff --check`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `node scripts/validate-mcp.mjs` (73 tools, lifecycle + all tools/call)
- [x] `npx vitest run tests/mcp-server.test.mjs -t "get_chain_concentration|get_subnet_concentration returns"`
- [x] `npx vitest run tests/agent-tool-specs.test.mjs`
- [x] CI green (incl. codecov patch)

Addresses feedback from #2693.