### PR TITLE
feat(api): add dominance shares and a network summary to the subnet movers leaderboard

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1694,7 +1694,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup. */
+        /** Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, validator, and neuron count between the window's start and end neuron_daily snapshots, with start/end values, deltas, percentage changes, and each subnet's share of network stake/emission at the end. A network block totals stake/emission/validators across all subnets with gainer/loser/unchanged counts. Sort by stake (default), emission, validators, or neurons; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup. */
         get: operations["subnetMovers"];
         put?: never;
         post?: never;
@@ -4918,6 +4918,7 @@ export interface components {
                 emission_delta_tao: number;
                 emission_end_tao: number;
                 emission_pct_change: number | null;
+                emission_share_pct: number | null;
                 emission_start_tao: number;
                 netuid: number;
                 neurons_delta: number;
@@ -4926,14 +4927,30 @@ export interface components {
                 stake_delta_tao: number;
                 stake_end_tao: number;
                 stake_pct_change: number | null;
+                stake_share_pct: number | null;
                 stake_start_tao: number;
                 validators_delta: number;
                 validators_end: number;
                 validators_start: number;
             }[];
+            /** @description Network-wide aggregate context: total stake/emission/validator counts at each boundary, their deltas, and how many subnets gained, lost, or held flat on the active sort metric (counted over every subnet, not just the returned page). */
+            network: {
+                gainers: number;
+                losers: number;
+                total_emission_delta_tao: number;
+                total_emission_end_tao: number;
+                total_emission_start_tao: number;
+                total_stake_delta_tao: number;
+                total_stake_end_tao: number;
+                total_stake_start_tao: number;
+                total_validators_delta: number;
+                total_validators_end: number;
+                total_validators_start: number;
+                unchanged: number;
+            };
             schema_version: number;
             /** @enum {string} */
-            sort: "stake" | "emission" | "validators";
+            sort: "stake" | "emission" | "validators" | "neurons";
             start_date: string | null;
             subnet_count: number;
             /** @enum {string|null} */
@@ -19344,7 +19361,7 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
-                sort?: "stake" | "emission" | "validators";
+                sort?: "stake" | "emission" | "validators" | "neurons";
                 limit?: number;
             };
             header?: never;
@@ -19371,6 +19388,7 @@ export interface operations {
                      *             "emission_delta_tao": 0.5,
                      *             "emission_end_tao": 0.5,
                      *             "emission_pct_change": 0.5,
+                     *             "emission_share_pct": 0.5,
                      *             "emission_start_tao": 0.5,
                      *             "netuid": 7,
                      *             "neurons_delta": 1,
@@ -19379,12 +19397,27 @@ export interface operations {
                      *             "stake_delta_tao": 0.5,
                      *             "stake_end_tao": 0.5,
                      *             "stake_pct_change": 0.5,
+                     *             "stake_share_pct": 0.5,
                      *             "stake_start_tao": 0.5,
                      *             "validators_delta": 1,
                      *             "validators_end": 1,
                      *             "validators_start": 1
                      *           }
                      *         ],
+                     *         "network": {
+                     *           "gainers": 1,
+                     *           "losers": 1,
+                     *           "total_emission_delta_tao": 0.5,
+                     *           "total_emission_end_tao": 0.5,
+                     *           "total_emission_start_tao": 0.5,
+                     *           "total_stake_delta_tao": 0.5,
+                     *           "total_stake_end_tao": 0.5,
+                     *           "total_stake_start_tao": 0.5,
+                     *           "total_validators_delta": 1,
+                     *           "total_validators_end": 1,
+                     *           "total_validators_start": 1,
+                     *           "unchanged": 1
+                     *         },
                      *         "schema_version": 1,
                      *         "sort": "stake",
                      *         "start_date": "2026-06-01",

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4406,7 +4406,7 @@
     {
       "artifact_path": "/metagraph/subnets/movers.json",
       "cache": "short",
-      "description": "Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup.",
+      "description": "Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, validator, and neuron count between the window's start and end neuron_daily snapshots, with start/end values, deltas, percentage changes, and each subnet's share of network stake/emission at the end. A network block totals stake/emission/validators across all subnets with gainer/loser/unchanged counts. Sort by stake (default), emission, validators, or neurons; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup.",
       "id": "subnet-movers",
       "method": "GET",
       "path": "/api/v1/subnets/movers",
@@ -4431,7 +4431,8 @@
             "enum": [
               "stake",
               "emission",
-              "validators"
+              "validators",
+              "neurons"
             ],
             "type": "string"
           }

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -507,7 +507,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-01.1",
-      "description": "Cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between a window's start and end snapshots, computed live from the neuron_daily D1 rollup at /api/v1/subnets/movers (no static file).",
+      "description": "Cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, validator, and neuron count between a window's start and end snapshots, with each subnet's share of network stake/emission and a network aggregate summary, computed live from the neuron_daily D1 rollup at /api/v1/subnets/movers (no static file).",
       "id": "subnet-movers",
       "path": "/metagraph/subnets/movers.json",
       "schema_ref": "#/components/schemas/SubnetMoversArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -12955,6 +12955,14 @@
                     "null"
                   ]
                 },
+                "emission_share_pct": {
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
                 "emission_start_tao": {
                   "type": "number"
                 },
@@ -12985,6 +12993,14 @@
                     "null"
                   ]
                 },
+                "stake_share_pct": {
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
                 "stake_start_tao": {
                   "type": "number"
                 },
@@ -13006,10 +13022,12 @@
                 "stake_end_tao",
                 "stake_delta_tao",
                 "stake_pct_change",
+                "stake_share_pct",
                 "emission_start_tao",
                 "emission_end_tao",
                 "emission_delta_tao",
                 "emission_pct_change",
+                "emission_share_pct",
                 "validators_start",
                 "validators_end",
                 "validators_delta",
@@ -13021,6 +13039,68 @@
             },
             "type": "array"
           },
+          "network": {
+            "additionalProperties": false,
+            "description": "Network-wide aggregate context: total stake/emission/validator counts at each boundary, their deltas, and how many subnets gained, lost, or held flat on the active sort metric (counted over every subnet, not just the returned page).",
+            "properties": {
+              "gainers": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "losers": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_emission_delta_tao": {
+                "type": "number"
+              },
+              "total_emission_end_tao": {
+                "type": "number"
+              },
+              "total_emission_start_tao": {
+                "type": "number"
+              },
+              "total_stake_delta_tao": {
+                "type": "number"
+              },
+              "total_stake_end_tao": {
+                "type": "number"
+              },
+              "total_stake_start_tao": {
+                "type": "number"
+              },
+              "total_validators_delta": {
+                "type": "integer"
+              },
+              "total_validators_end": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_validators_start": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "unchanged": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "total_stake_start_tao",
+              "total_stake_end_tao",
+              "total_stake_delta_tao",
+              "total_emission_start_tao",
+              "total_emission_end_tao",
+              "total_emission_delta_tao",
+              "total_validators_start",
+              "total_validators_end",
+              "total_validators_delta",
+              "gainers",
+              "losers",
+              "unchanged"
+            ],
+            "type": "object"
+          },
           "schema_version": {
             "type": "integer"
           },
@@ -13028,7 +13108,8 @@
             "enum": [
               "stake",
               "emission",
-              "validators"
+              "validators",
+              "neurons"
             ],
             "type": "string"
           },
@@ -13063,6 +13144,7 @@
           "end_date",
           "sort",
           "subnet_count",
+          "network",
           "movers"
         ],
         "type": "object"
@@ -35961,7 +36043,8 @@
               "enum": [
                 "stake",
                 "emission",
-                "validators"
+                "validators",
+                "neurons"
               ],
               "type": "string"
             }
@@ -35989,6 +36072,7 @@
                         "emission_delta_tao": 0.5,
                         "emission_end_tao": 0.5,
                         "emission_pct_change": 0.5,
+                        "emission_share_pct": 0.5,
                         "emission_start_tao": 0.5,
                         "netuid": 7,
                         "neurons_delta": 1,
@@ -35997,12 +36081,27 @@
                         "stake_delta_tao": 0.5,
                         "stake_end_tao": 0.5,
                         "stake_pct_change": 0.5,
+                        "stake_share_pct": 0.5,
                         "stake_start_tao": 0.5,
                         "validators_delta": 1,
                         "validators_end": 1,
                         "validators_start": 1
                       }
                     ],
+                    "network": {
+                      "gainers": 1,
+                      "losers": 1,
+                      "total_emission_delta_tao": 0.5,
+                      "total_emission_end_tao": 0.5,
+                      "total_emission_start_tao": 0.5,
+                      "total_stake_delta_tao": 0.5,
+                      "total_stake_end_tao": 0.5,
+                      "total_stake_start_tao": 0.5,
+                      "total_validators_delta": 1,
+                      "total_validators_end": 1,
+                      "total_validators_start": 1,
+                      "unchanged": 1
+                    },
                     "schema_version": 1,
                     "sort": "stake",
                     "start_date": "2026-06-01",
@@ -36108,7 +36207,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup.",
+        "summary": "Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, validator, and neuron count between the window's start and end neuron_daily snapshots, with start/end values, deltas, percentage changes, and each subnet's share of network stake/emission at the end. A network block totals stake/emission/validators across all subnets with gainer/loser/unchanged counts. Sort by stake (default), emission, validators, or neurons; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup.",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1694,7 +1694,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup. */
+        /** Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, validator, and neuron count between the window's start and end neuron_daily snapshots, with start/end values, deltas, percentage changes, and each subnet's share of network stake/emission at the end. A network block totals stake/emission/validators across all subnets with gainer/loser/unchanged counts. Sort by stake (default), emission, validators, or neurons; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup. */
         get: operations["subnetMovers"];
         put?: never;
         post?: never;
@@ -4918,6 +4918,7 @@ export interface components {
                 emission_delta_tao: number;
                 emission_end_tao: number;
                 emission_pct_change: number | null;
+                emission_share_pct: number | null;
                 emission_start_tao: number;
                 netuid: number;
                 neurons_delta: number;
@@ -4926,14 +4927,30 @@ export interface components {
                 stake_delta_tao: number;
                 stake_end_tao: number;
                 stake_pct_change: number | null;
+                stake_share_pct: number | null;
                 stake_start_tao: number;
                 validators_delta: number;
                 validators_end: number;
                 validators_start: number;
             }[];
+            /** @description Network-wide aggregate context: total stake/emission/validator counts at each boundary, their deltas, and how many subnets gained, lost, or held flat on the active sort metric (counted over every subnet, not just the returned page). */
+            network: {
+                gainers: number;
+                losers: number;
+                total_emission_delta_tao: number;
+                total_emission_end_tao: number;
+                total_emission_start_tao: number;
+                total_stake_delta_tao: number;
+                total_stake_end_tao: number;
+                total_stake_start_tao: number;
+                total_validators_delta: number;
+                total_validators_end: number;
+                total_validators_start: number;
+                unchanged: number;
+            };
             schema_version: number;
             /** @enum {string} */
-            sort: "stake" | "emission" | "validators";
+            sort: "stake" | "emission" | "validators" | "neurons";
             start_date: string | null;
             subnet_count: number;
             /** @enum {string|null} */
@@ -19344,7 +19361,7 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
-                sort?: "stake" | "emission" | "validators";
+                sort?: "stake" | "emission" | "validators" | "neurons";
                 limit?: number;
             };
             header?: never;
@@ -19371,6 +19388,7 @@ export interface operations {
                      *             "emission_delta_tao": 0.5,
                      *             "emission_end_tao": 0.5,
                      *             "emission_pct_change": 0.5,
+                     *             "emission_share_pct": 0.5,
                      *             "emission_start_tao": 0.5,
                      *             "netuid": 7,
                      *             "neurons_delta": 1,
@@ -19379,12 +19397,27 @@ export interface operations {
                      *             "stake_delta_tao": 0.5,
                      *             "stake_end_tao": 0.5,
                      *             "stake_pct_change": 0.5,
+                     *             "stake_share_pct": 0.5,
                      *             "stake_start_tao": 0.5,
                      *             "validators_delta": 1,
                      *             "validators_end": 1,
                      *             "validators_start": 1
                      *           }
                      *         ],
+                     *         "network": {
+                     *           "gainers": 1,
+                     *           "losers": 1,
+                     *           "total_emission_delta_tao": 0.5,
+                     *           "total_emission_end_tao": 0.5,
+                     *           "total_emission_start_tao": 0.5,
+                     *           "total_stake_delta_tao": 0.5,
+                     *           "total_stake_end_tao": 0.5,
+                     *           "total_stake_start_tao": 0.5,
+                     *           "total_validators_delta": 1,
+                     *           "total_validators_end": 1,
+                     *           "total_validators_start": 1,
+                     *           "unchanged": 1
+                     *         },
                      *         "schema_version": 1,
                      *         "sort": "stake",
                      *         "start_date": "2026-06-01",

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -12933,6 +12933,14 @@
                     "null"
                   ]
                 },
+                "emission_share_pct": {
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
                 "emission_start_tao": {
                   "type": "number"
                 },
@@ -12963,6 +12971,14 @@
                     "null"
                   ]
                 },
+                "stake_share_pct": {
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
                 "stake_start_tao": {
                   "type": "number"
                 },
@@ -12984,10 +13000,12 @@
                 "stake_end_tao",
                 "stake_delta_tao",
                 "stake_pct_change",
+                "stake_share_pct",
                 "emission_start_tao",
                 "emission_end_tao",
                 "emission_delta_tao",
                 "emission_pct_change",
+                "emission_share_pct",
                 "validators_start",
                 "validators_end",
                 "validators_delta",
@@ -12999,6 +13017,68 @@
             },
             "type": "array"
           },
+          "network": {
+            "additionalProperties": false,
+            "description": "Network-wide aggregate context: total stake/emission/validator counts at each boundary, their deltas, and how many subnets gained, lost, or held flat on the active sort metric (counted over every subnet, not just the returned page).",
+            "properties": {
+              "gainers": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "losers": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_emission_delta_tao": {
+                "type": "number"
+              },
+              "total_emission_end_tao": {
+                "type": "number"
+              },
+              "total_emission_start_tao": {
+                "type": "number"
+              },
+              "total_stake_delta_tao": {
+                "type": "number"
+              },
+              "total_stake_end_tao": {
+                "type": "number"
+              },
+              "total_stake_start_tao": {
+                "type": "number"
+              },
+              "total_validators_delta": {
+                "type": "integer"
+              },
+              "total_validators_end": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_validators_start": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "unchanged": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "total_stake_start_tao",
+              "total_stake_end_tao",
+              "total_stake_delta_tao",
+              "total_emission_start_tao",
+              "total_emission_end_tao",
+              "total_emission_delta_tao",
+              "total_validators_start",
+              "total_validators_end",
+              "total_validators_delta",
+              "gainers",
+              "losers",
+              "unchanged"
+            ],
+            "type": "object"
+          },
           "schema_version": {
             "type": "integer"
           },
@@ -13006,7 +13086,8 @@
             "enum": [
               "stake",
               "emission",
-              "validators"
+              "validators",
+              "neurons"
             ],
             "type": "string"
           },
@@ -13041,6 +13122,7 @@
           "end_date",
           "sort",
           "subnet_count",
+          "network",
           "movers"
         ],
         "type": "object"

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -1008,6 +1008,7 @@
           "end_date",
           "sort",
           "subnet_count",
+          "network",
           "movers"
         ],
         "properties": {
@@ -1026,9 +1027,42 @@
           },
           "sort": {
             "type": "string",
-            "enum": ["stake", "emission", "validators"]
+            "enum": ["stake", "emission", "validators", "neurons"]
           },
           "subnet_count": { "type": "integer", "minimum": 0 },
+          "network": {
+            "type": "object",
+            "description": "Network-wide aggregate context: total stake/emission/validator counts at each boundary, their deltas, and how many subnets gained, lost, or held flat on the active sort metric (counted over every subnet, not just the returned page).",
+            "required": [
+              "total_stake_start_tao",
+              "total_stake_end_tao",
+              "total_stake_delta_tao",
+              "total_emission_start_tao",
+              "total_emission_end_tao",
+              "total_emission_delta_tao",
+              "total_validators_start",
+              "total_validators_end",
+              "total_validators_delta",
+              "gainers",
+              "losers",
+              "unchanged"
+            ],
+            "properties": {
+              "total_stake_start_tao": { "type": "number" },
+              "total_stake_end_tao": { "type": "number" },
+              "total_stake_delta_tao": { "type": "number" },
+              "total_emission_start_tao": { "type": "number" },
+              "total_emission_end_tao": { "type": "number" },
+              "total_emission_delta_tao": { "type": "number" },
+              "total_validators_start": { "type": "integer", "minimum": 0 },
+              "total_validators_end": { "type": "integer", "minimum": 0 },
+              "total_validators_delta": { "type": "integer" },
+              "gainers": { "type": "integer", "minimum": 0 },
+              "losers": { "type": "integer", "minimum": 0 },
+              "unchanged": { "type": "integer", "minimum": 0 }
+            },
+            "additionalProperties": false
+          },
           "movers": {
             "type": "array",
             "items": {
@@ -1039,10 +1073,12 @@
                 "stake_end_tao",
                 "stake_delta_tao",
                 "stake_pct_change",
+                "stake_share_pct",
                 "emission_start_tao",
                 "emission_end_tao",
                 "emission_delta_tao",
                 "emission_pct_change",
+                "emission_share_pct",
                 "validators_start",
                 "validators_end",
                 "validators_delta",
@@ -1056,10 +1092,20 @@
                 "stake_end_tao": { "type": "number" },
                 "stake_delta_tao": { "type": "number" },
                 "stake_pct_change": { "type": ["number", "null"] },
+                "stake_share_pct": {
+                  "type": ["number", "null"],
+                  "minimum": 0,
+                  "maximum": 100
+                },
                 "emission_start_tao": { "type": "number" },
                 "emission_end_tao": { "type": "number" },
                 "emission_delta_tao": { "type": "number" },
                 "emission_pct_change": { "type": ["number", "null"] },
+                "emission_share_pct": {
+                  "type": ["number", "null"],
+                  "minimum": 0,
+                  "maximum": 100
+                },
                 "validators_start": { "type": "integer", "minimum": 0 },
                 "validators_end": { "type": "integer", "minimum": 0 },
                 "validators_delta": { "type": "integer" },

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -953,7 +953,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "subnet-movers",
     "/metagraph/subnets/movers.json",
-    "Cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between a window's start and end snapshots, computed live from the neuron_daily D1 rollup at /api/v1/subnets/movers (no static file).",
+    "Cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, validator, and neuron count between a window's start and end snapshots, with each subnet's share of network stake/emission and a network aggregate summary, computed live from the neuron_daily D1 rollup at /api/v1/subnets/movers (no static file).",
     "SubnetMoversArtifact",
   ),
   artifact(
@@ -1827,7 +1827,7 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/movers",
     "/metagraph/subnets/movers.json",
-    "Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup.",
+    "Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, validator, and neuron count between the window's start and end neuron_daily snapshots, with start/end values, deltas, percentage changes, and each subnet's share of network stake/emission at the end. A network block totals stake/emission/validators across all subnets with gainer/loser/unchanged counts. Sort by stake (default), emission, validators, or neurons; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup.",
     "short",
     ["subnets", "analytics"],
     [
@@ -1837,7 +1837,10 @@ export const API_ROUTES = [
       },
       {
         name: "sort",
-        schema: { type: "string", enum: ["stake", "emission", "validators"] },
+        schema: {
+          type: "string",
+          enum: ["stake", "emission", "validators", "neurons"],
+        },
       },
       {
         name: "limit",

--- a/src/movers.mjs
+++ b/src/movers.mjs
@@ -13,7 +13,7 @@ export const MOVERS_WINDOWS = { "7d": 7, "30d": 30, "90d": 90 };
 export const DEFAULT_MOVERS_WINDOW = "30d";
 
 // Rankable metrics: the signed delta to sort the leaderboard by.
-export const MOVERS_SORTS = ["stake", "emission", "validators"];
+export const MOVERS_SORTS = ["stake", "emission", "validators", "neurons"];
 export const DEFAULT_MOVERS_SORT = "stake";
 
 export const MOVERS_LIMIT_DEFAULT = 20;
@@ -66,11 +66,35 @@ function indexByNetuid(rows) {
 
 const ZERO = { neurons: 0, validators: 0, stake: 0, emission: 0 };
 
+// Sum a boundary map's stake, emission, and validator counts across every subnet — the
+// single source the dominance-share denominator and the network summary totals derive
+// from, so both stay consistent as more network-level fields are added.
+function sumBoundary(map) {
+  let stake = 0;
+  let emission = 0;
+  let validators = 0;
+  for (const v of map.values()) {
+    stake += v.stake;
+    emission += v.emission;
+    validators += v.validators;
+  }
+  return { stake, emission, validators };
+}
+
 const SORT_KEY = {
   stake: "stake_delta_tao",
   emission: "emission_delta_tao",
   validators: "validators_delta",
+  neurons: "neurons_delta",
 };
+
+// A subnet's share (%) of a network total, rounded to 2dp. Null when the total is
+// 0 or non-finite (share of nothing is undefined) — mirrors pctChange's null contract.
+function pctShare(part, total) {
+  if (!Number.isFinite(part) || !Number.isFinite(total) || total <= 0)
+    return null;
+  return Math.round((part / total) * 100 * 100) / 100;
+}
 
 // Build the per-subnet mover scorecards from the start + end snapshot aggregates and rank
 // them by the chosen metric's signed delta (biggest gainers first, biggest losers last),
@@ -83,6 +107,10 @@ export function computeMovers(
   const startMap = indexByNetuid(startRows);
   const endMap = indexByNetuid(endRows);
   const netuids = new Set([...startMap.keys(), ...endMap.keys()]);
+  // Network end totals for the dominance shares: each subnet's stake/emission as a
+  // percentage of the whole network at the window's end snapshot. Summed over EVERY
+  // subnet (not just the returned page) so the share denominator is the true total.
+  const endTotals = sumBoundary(endMap);
   const movers = [];
   for (const netuid of netuids) {
     const s = startMap.get(netuid) ?? ZERO;
@@ -93,10 +121,13 @@ export function computeMovers(
       stake_end_tao: roundTao(e.stake),
       stake_delta_tao: roundTao(e.stake - s.stake),
       stake_pct_change: pctChange(s.stake, e.stake),
+      // Dominance: this subnet's share of network stake at the end snapshot.
+      stake_share_pct: pctShare(e.stake, endTotals.stake),
       emission_start_tao: roundTao(s.emission),
       emission_end_tao: roundTao(e.emission),
       emission_delta_tao: roundTao(e.emission - s.emission),
       emission_pct_change: pctChange(s.emission, e.emission),
+      emission_share_pct: pctShare(e.emission, endTotals.emission),
       validators_start: s.validators,
       validators_end: e.validators,
       validators_delta: e.validators - s.validators,
@@ -108,6 +139,41 @@ export function computeMovers(
   const key = SORT_KEY[sort] ?? SORT_KEY[DEFAULT_MOVERS_SORT];
   movers.sort((a, b) => b[key] - a[key] || a.netuid - b.netuid);
   return movers;
+}
+
+// Network-wide aggregate context for the leaderboard: total stake/emission/validator
+// counts at each boundary plus their deltas, and how many subnets gained, lost, or held
+// flat on the ACTIVE sort metric. Totals sum the RAW boundary aggregates and round once at
+// the end (not a sum of already-rounded per-subnet fields), so no rao drift accumulates
+// across subnets. Gainer/loser/unchanged counts cover the full ranked set (every subnet),
+// so they stay network-wide even though the response caps `movers` to `limit`. Empty
+// boundaries (cold or single-snapshot store) yield an all-zero summary, never throws.
+function buildNetworkSummary(ranked, sortDeltaKey, startRows, endRows) {
+  const start = sumBoundary(indexByNetuid(startRows));
+  const end = sumBoundary(indexByNetuid(endRows));
+  let gainers = 0;
+  let losers = 0;
+  let unchanged = 0;
+  for (const m of ranked) {
+    const delta = m[sortDeltaKey];
+    if (delta > 0) gainers += 1;
+    else if (delta < 0) losers += 1;
+    else unchanged += 1;
+  }
+  return {
+    total_stake_start_tao: roundTao(start.stake),
+    total_stake_end_tao: roundTao(end.stake),
+    total_stake_delta_tao: roundTao(end.stake - start.stake),
+    total_emission_start_tao: roundTao(start.emission),
+    total_emission_end_tao: roundTao(end.emission),
+    total_emission_delta_tao: roundTao(end.emission - start.emission),
+    total_validators_start: start.validators,
+    total_validators_end: end.validators,
+    total_validators_delta: end.validators - start.validators,
+    gainers,
+    losers,
+    unchanged,
+  };
 }
 
 // Shape the cross-subnet movers leaderboard. Null-safe: missing/equal boundary dates (cold
@@ -154,6 +220,12 @@ export function buildMovers(
     end_date: endDate ?? null,
     sort: normalizedSort,
     subnet_count: ranked.length,
+    network: buildNetworkSummary(
+      ranked,
+      SORT_KEY[normalizedSort],
+      comparable ? startRows : [],
+      comparable ? endRows : [],
+    ),
     movers: ranked.slice(0, normalizedLimit),
   };
 }

--- a/tests/movers.test.mjs
+++ b/tests/movers.test.mjs
@@ -201,6 +201,135 @@ describe("computeMovers", () => {
   });
 });
 
+describe("movers dominance shares", () => {
+  const startRows = [
+    agg(1, "s", { neurons: 10, validators: 3, stake: 100, emission: 5 }),
+    agg(2, "s", { neurons: 8, validators: 2, stake: 50, emission: 4 }),
+  ];
+  const endRows = [
+    agg(1, "e", { neurons: 12, validators: 4, stake: 250, emission: 9 }),
+    agg(2, "e", { neurons: 8, validators: 2, stake: 30, emission: 4 }),
+  ];
+
+  test("each subnet carries its share of network stake/emission at the end", () => {
+    const m = computeMovers(startRows, endRows, { sort: "stake" });
+    const s1 = m.find((x) => x.netuid === 1);
+    const s2 = m.find((x) => x.netuid === 2);
+    // end stake total 280 -> 250/280 = 89.29%, 30/280 = 10.71%.
+    assert.equal(s1.stake_share_pct, 89.29);
+    assert.equal(s2.stake_share_pct, 10.71);
+    // shares are over the whole network, so they sum to ~100.
+    assert.equal(
+      Math.round((s1.stake_share_pct + s2.stake_share_pct) * 100) / 100,
+      100,
+    );
+    // end emission total 13 -> 9/13 = 69.23%, 4/13 = 30.77%.
+    assert.equal(s1.emission_share_pct, 69.23);
+    assert.equal(s2.emission_share_pct, 30.77);
+  });
+
+  test("share is null when the network end total is zero (share of nothing)", () => {
+    // Every subnet removed by the end -> end totals are 0.
+    const m = computeMovers(
+      [agg(9, "s", { neurons: 4, validators: 1, stake: 60, emission: 3 })],
+      [],
+      { sort: "stake" },
+    );
+    assert.equal(m[0].stake_share_pct, null);
+    assert.equal(m[0].emission_share_pct, null);
+  });
+});
+
+describe("movers network summary", () => {
+  const startRows = [
+    agg(1, "s", { neurons: 10, validators: 3, stake: 100, emission: 5 }),
+    agg(2, "s", { neurons: 8, validators: 2, stake: 50, emission: 4 }),
+  ];
+  const endRows = [
+    agg(1, "e", { neurons: 12, validators: 4, stake: 250, emission: 9 }),
+    agg(2, "e", { neurons: 8, validators: 2, stake: 30, emission: 4 }),
+  ];
+  const opts = { window: "30d", startDate: "s", endDate: "e" };
+
+  test("totals stake/emission/validators across all subnets with their deltas", () => {
+    const { network } = buildMovers(startRows, endRows, opts);
+    assert.equal(network.total_stake_start_tao, 150);
+    assert.equal(network.total_stake_end_tao, 280);
+    assert.equal(network.total_stake_delta_tao, 130);
+    assert.equal(network.total_emission_start_tao, 9);
+    assert.equal(network.total_emission_end_tao, 13);
+    assert.equal(network.total_emission_delta_tao, 4);
+    assert.equal(network.total_validators_start, 5);
+    assert.equal(network.total_validators_end, 6);
+    assert.equal(network.total_validators_delta, 1);
+  });
+
+  test("gainer/loser/unchanged counts follow the active sort metric", () => {
+    // By stake: subnet 1 +150 (gainer), subnet 2 -20 (loser).
+    const byStake = buildMovers(startRows, endRows, { ...opts, sort: "stake" });
+    assert.deepEqual(
+      [
+        byStake.network.gainers,
+        byStake.network.losers,
+        byStake.network.unchanged,
+      ],
+      [1, 1, 0],
+    );
+    // By neurons: subnet 1 +2 (gainer), subnet 2 +0 (unchanged).
+    const byNeurons = buildMovers(startRows, endRows, {
+      ...opts,
+      sort: "neurons",
+    });
+    assert.deepEqual(
+      [
+        byNeurons.network.gainers,
+        byNeurons.network.losers,
+        byNeurons.network.unchanged,
+      ],
+      [1, 0, 1],
+    );
+  });
+
+  test("counts every subnet, not just the returned page", () => {
+    // limit 1 returns one mover, but the summary still counts both subnets.
+    const { network } = buildMovers(startRows, endRows, { ...opts, limit: 1 });
+    assert.equal(network.gainers + network.losers + network.unchanged, 2);
+  });
+
+  test("empty / non-comparable inputs yield an all-zero network summary", () => {
+    const { network } = buildMovers([], [], {
+      window: "30d",
+      startDate: null,
+      endDate: null,
+    });
+    assert.equal(network.total_stake_end_tao, 0);
+    assert.equal(network.total_validators_delta, 0);
+    assert.equal(network.gainers, 0);
+    assert.equal(network.losers, 0);
+    assert.equal(network.unchanged, 0);
+  });
+});
+
+describe("movers neurons sort", () => {
+  test("ranks by neuron-count delta, gainers first", () => {
+    const m = computeMovers(
+      [
+        agg(1, "s", { neurons: 10, validators: 0, stake: 0, emission: 0 }),
+        agg(2, "s", { neurons: 8, validators: 0, stake: 0, emission: 0 }),
+      ],
+      [
+        agg(1, "e", { neurons: 11, validators: 0, stake: 0, emission: 0 }), // +1
+        agg(2, "e", { neurons: 20, validators: 0, stake: 0, emission: 0 }), // +12
+      ],
+      { sort: "neurons" },
+    );
+    assert.deepEqual(
+      m.map((x) => x.netuid),
+      [2, 1],
+    );
+  });
+});
+
 describe("loadSubnetMovers", () => {
   test("resolves global boundary dates then reads the cross-subnet aggregate", async () => {
     vi.useFakeTimers();
@@ -242,6 +371,54 @@ describe("loadSubnetMovers", () => {
     assert.equal(data.subnet_count, 1);
     assert.equal(data.movers[0].stake_delta_tao, 150);
     vi.useRealTimers();
+  });
+
+  test("sort=neurons ranks by neuron-count delta through the public loader path", async () => {
+    const d1 = async (sql) => {
+      if (/MIN\(snapshot_date\)/.test(sql)) {
+        return [{ start_date: "2026-05-31", end_date: "2026-06-30" }];
+      }
+      return [
+        agg(1, "2026-05-31", {
+          neurons: 10,
+          validators: 2,
+          stake: 50,
+          emission: 3,
+        }),
+        agg(2, "2026-05-31", {
+          neurons: 8,
+          validators: 2,
+          stake: 50,
+          emission: 3,
+        }),
+        agg(1, "2026-06-30", {
+          neurons: 11, // +1
+          validators: 2,
+          stake: 50,
+          emission: 3,
+        }),
+        agg(2, "2026-06-30", {
+          neurons: 20, // +12
+          validators: 2,
+          stake: 50,
+          emission: 3,
+        }),
+      ];
+    };
+    const data = await loadSubnetMovers(d1, {
+      windowLabel: "30d",
+      sort: "neurons",
+    });
+    assert.equal(data.sort, "neurons"); // the public query value is accepted + echoed
+    assert.deepEqual(
+      data.movers.map((m) => m.netuid),
+      [2, 1], // biggest neuron gainer first
+    );
+    // both subnets gained neurons over the window -> 2 gainers, none lost or flat
+    assert.deepEqual(
+      [data.network.gainers, data.network.losers, data.network.unchanged],
+      [2, 0, 0],
+    );
   });
 
   test("defaults to the 30d window + stake sort", async () => {


### PR DESCRIPTION
Adds cross-subnet dominance context to the movers leaderboard: each subnet now carries its share of network stake and emission at the window end, a network block totals stake, emission, and validators across all subnets with gainer, loser, and unchanged counts on the active sort metric, and a new neurons sort ranks by neuron-count change. Pure additive shaping on the existing neuron_daily-derived route with the schema, contract, artifact description, OpenAPI, and generated types regenerated, plus branch-complete unit tests; network totals are summed from the raw boundary aggregates and rounded once, and the share fields are bounded 0 to 100.

No linked issue: this is a self-directed additive enhancement to an already-published route, judged on its own merit, with no contract-drift and every generated artifact regenerated in the same diff.