### PR TITLE
fix(api): reject unknown list query parameters

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -669,6 +669,19 @@ describe("invalid query handling", () => {
     assert.equal((await res.json()).meta.parameter, "order");
   });
 
+  test("400 invalid_query for an unknown list query parameter", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets?statuss=active"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.error.message, "unknown query parameter.");
+    assert.equal(body.meta.parameter, "statuss");
+  });
+
   test("400 invalid_query for an unsupported projected field", async () => {
     const res = await handleRequest(
       req("/api/v1/subnets?fields=netuid,not_a_field"),
@@ -788,19 +801,15 @@ describe("pagination Link header", () => {
     assert.match(res.headers.get("access-control-expose-headers"), /\blink\b/);
   });
 
-  test("page links drop ignored/tracker query params end-to-end (#1932 cache-key safety)", async () => {
-    // Drive the canonicalization through the real Worker: tracker/attacker params
-    // the edge cache key ignores must not ride along in the cacheable Link header,
-    // while the body-affecting sort/cursor/limit are preserved.
-    const { res, links } = await page(
+  test("page links reject ignored/tracker query params end-to-end", async () => {
+    const { res } = await page(
       "limit=50&cursor=0&utm_campaign=evil&token=SECRET123",
     );
-    assert.equal(res.status, 200);
-    assert.equal(links.next.searchParams.has("utm_campaign"), false);
-    assert.equal(links.next.searchParams.has("token"), false);
-    assert.equal(links.next.searchParams.get("sort"), "netuid");
-    assert.equal(links.next.searchParams.get("cursor"), "50");
-    assert.equal(links.next.searchParams.get("limit"), "50");
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.error.message, "unknown query parameter.");
+    assert.equal(body.meta.parameter, "utm_campaign");
   });
 
   test("middle page advertises all four relations", async () => {

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -473,6 +473,77 @@ describe("list-query numeric range filters", () => {
   });
 });
 
+describe("list-query unknown parameter validation", () => {
+  const data = {
+    subnets: [
+      {
+        netuid: 1,
+        name: "Alpha Inference",
+        slug: "alpha",
+        status: "active",
+        categories: ["inference"],
+        block: 150,
+      },
+      {
+        netuid: 2,
+        name: "Beta Compute",
+        slug: "beta",
+        status: "inactive",
+        categories: ["compute"],
+        block: 50,
+      },
+    ],
+  };
+
+  test("rejects a typoed query parameter before silently returning an unfiltered list", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?statuss=active"),
+      "subnets",
+    );
+
+    assert.equal(result.error.parameter, "statuss");
+    assert.equal(result.error.message, "unknown query parameter.");
+  });
+
+  test("accepts every supported list parameter family", () => {
+    const result = applyQueryFilters(
+      data,
+      query(
+        "/api/v1/subnets?q=alpha&fields=netuid,name&limit=10&cursor=0" +
+          "&sort=netuid&order=asc&status=active&netuids=1" +
+          "&domain=inference&min_block=100&max_block=200",
+      ),
+      "subnets",
+    );
+
+    assert.equal(result.error, undefined);
+    assert.deepEqual(result.data.subnets, [
+      { netuid: 1, name: "Alpha Inference" },
+    ]);
+    assert.equal(result.meta.pagination.total, 1);
+  });
+
+  test("accepts an empty query string", () => {
+    const result = applyQueryFilters(data, query("/api/v1/subnets"), "subnets");
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.data.subnets.length, 2);
+  });
+
+  test("rejects filters excluded by a route-level queryFilterNames allowlist", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?curation_level=native"),
+      "subnets",
+      ["netuid"],
+    );
+
+    assert.equal(result.error.parameter, "curation_level");
+    assert.equal(result.error.message, "unknown query parameter.");
+  });
+});
+
 // #2085: integration_readiness was sortable/filterable via MCP list_subnets but
 // not on the equivalent REST subnets collection. After wiring it into the
 // contract's sort + rangeFilters, the generic list-query engine reads row[key]
@@ -665,10 +736,14 @@ describe("list-query pagination Link header", () => {
     }
   });
 
-  test("drops ignored query parameters from cacheable page links", () => {
+  test("canonical page links drop ignored query parameters", () => {
     const links = parseLink(
-      pageLink(
-        "/api/v1/subnets?sort=netuid&limit=2&utm_campaign=evil&token=SECRET123",
+      paginationLinkHeader(
+        query(
+          "/api/v1/subnets?sort=netuid&limit=2&utm_campaign=evil&token=SECRET123",
+        ),
+        { cursor: 0, limit: 2, next_cursor: 2, total: 5 },
+        { queryCollection: "subnets" },
       ),
     );
 

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
+import { API_QUERY_COLLECTIONS } from "../src/contracts.mjs";
 import {
   applyQueryFilters,
   canonicalListSearch,
   paginationLinkHeader,
+  validateListQueryParams,
 } from "../workers/list-query.mjs";
 
 function query(path) {
@@ -541,6 +543,66 @@ describe("list-query unknown parameter validation", () => {
 
     assert.equal(result.error.parameter, "curation_level");
     assert.equal(result.error.message, "unknown query parameter.");
+  });
+
+  test("rejects all filters when a route allowlist has no configured filter names", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?status=active"),
+      "subnets",
+      ["not_a_configured_filter"],
+    );
+
+    assert.equal(result.error.parameter, "status");
+    assert.equal(result.error.message, "unknown query parameter.");
+  });
+
+  test("preflight skips routes without list-query contracts", () => {
+    assert.equal(
+      validateListQueryParams(
+        query("/api/v1/not-a-list?anything=1"),
+        undefined,
+      ),
+      null,
+    );
+  });
+
+  test("transform stays a no-op when the artifact data key is not a list", () => {
+    const result = applyQueryFilters(
+      { subnets: null },
+      query("/api/v1/subnets?statuss=active"),
+      "subnets",
+    );
+
+    assert.deepEqual(result, { data: { subnets: null }, meta: {} });
+  });
+
+  test("handles sparse collection configs without optional filter families", () => {
+    const collection = "__test_sparse_rows";
+    API_QUERY_COLLECTIONS[collection] = { data_key: "rows" };
+    try {
+      assert.equal(
+        validateListQueryParams(query("/api/v1/sparse?limit=1"), collection),
+        null,
+      );
+
+      const sortError = validateListQueryParams(
+        query("/api/v1/sparse?sort=name"),
+        collection,
+      );
+      assert.equal(sortError.parameter, "sort");
+      assert.equal(sortError.message, "sort is not supported for rows.");
+
+      const result = applyQueryFilters(
+        { rows: [] },
+        query("/api/v1/sparse?surprise=1"),
+        collection,
+      );
+      assert.equal(result.error.parameter, "surprise");
+      assert.equal(result.error.message, "unknown query parameter.");
+    } finally {
+      delete API_QUERY_COLLECTIONS[collection];
+    }
   });
 });
 

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1644,7 +1644,7 @@ describe("Worker runtime", () => {
     }
   });
 
-  test("canonicalizes overlay cache keys for ignored query parameters", async () => {
+  test("rejects unknown list query parameters before overlay cache reads", async () => {
     const store = new Map();
     const cachePutKeys = [];
     let r2Gets = 0;
@@ -1716,18 +1716,13 @@ describe("Worker runtime", () => {
         overlayEnv,
         ctx,
       );
-      assert.equal(first.status, 200);
-      assert.equal(second.status, 200);
-      assert.equal(await second.text(), await first.text());
-      assert.equal(
-        r2Gets,
-        1,
-        "ignored query params must not bust overlay cache",
-      );
-      assert.equal(store.size, 1, "ignored query params share one cache entry");
-      assert.deepEqual(cachePutKeys, [
-        `https://edge-cache.metagraph.sh/overlay/mainnet/${CONTRACT_VERSION}/2026-06-18T00%3A00%3A00.000Z/api/v1/endpoints`,
-      ]);
+      assert.equal(first.status, 400);
+      assert.equal(second.status, 400);
+      assert.equal((await first.json()).meta.parameter, "junk");
+      assert.equal((await second.json()).meta.parameter, "junk");
+      assert.equal(r2Gets, 0, "invalid list queries do not read R2 overlays");
+      assert.equal(store.size, 0, "invalid list queries are not cached");
+      assert.deepEqual(cachePutKeys, []);
     } finally {
       globalThis.caches = originalCaches;
     }

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -782,6 +782,7 @@ describe("Worker runtime", () => {
       ["/api/v1/subnets?fields=netuid,nope", "fields"],
       ["/api/v1/subnets?netuid=nope", "netuid"],
       ["/api/v1/subnets?subnet_type=nope", "subnet_type"],
+      ["/api/v1/subnets/7/endpoints?netuid=7", "netuid"],
     ];
 
     for (const [path, parameter] of invalidCases) {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -8,6 +8,7 @@ import {
   applyQueryFilters,
   canonicalListSearch,
   paginationLinkHeader,
+  validateListQueryParams,
 } from "./list-query.mjs";
 import {
   apiHeaders,
@@ -2330,6 +2331,18 @@ async function handleApiRequest(
   if (!matched) {
     return errorResponse("not_found", "No API route matched this path.", 404);
   }
+  const artifactPath = artifactPathForNetwork(matched.artifactPath, network);
+  const queryError = validateListQueryParams(
+    url,
+    matched.queryCollection,
+    matched.queryFilterNames,
+  );
+  if (queryError) {
+    return errorResponse("invalid_query", queryError.message, 400, {
+      artifact_path: artifactPath,
+      parameter: queryError.parameter,
+    });
+  }
   // Edge-cache idempotent GETs for pure static-artifact routes (mirrors the
   // RPC-proxy Cache API pattern). Live-overlay routes are excluded by route id,
   // not by whether live data happened to be available for this request, so cold
@@ -2396,8 +2409,6 @@ async function handleApiRequest(
   }
   // Mainnet (default) reads the unprefixed artifact (no-op); non-default networks
   // read metagraph/{prefix}/… — see artifactPathForNetwork.
-  const artifactPath = artifactPathForNetwork(matched.artifactPath, network);
-
   // Live operational-health overlay (Phase 3): current health is live-only.
   // Static current-health artifacts are not read for mainnet health routes, so
   // stale R2 objects left behind by earlier publishes cannot affect responses.

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -81,7 +81,7 @@ function listQueryParamNamesForConfig(config, queryFilterNames = []) {
   const filterNames =
     queryFilterNames.length > 0
       ? effectiveFilterNames(config, queryFilterNames)
-      : Object.keys(config.filters || {});
+      : Object.keys(config.filters);
   const rangeNames = (config.range_filters || []).flatMap((field) => [
     `min_${field}`,
     `max_${field}`,
@@ -406,7 +406,7 @@ function validateListQuery(params, config) {
     };
   }
 
-  for (const [key, schema] of Object.entries(config.filters || {})) {
+  for (const [key, schema] of Object.entries(config.filters)) {
     if (!params.has(key)) {
       continue;
     }

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -2,7 +2,8 @@
 // and cursor pagination over in-memory artifact collections. Extracted from
 // workers/api.mjs (issue #510, de-monolith) as a leaf module: it imports only
 // the query-collection contract and nothing from api.mjs, so there is no cycle.
-// `applyQueryFilters` is the single public entry; the rest are internal helpers.
+// `applyQueryFilters` is the main public entry; route preflight uses the same
+// validator before artifact/cache reads.
 import { API_QUERY_COLLECTIONS } from "../src/contracts.mjs";
 import { linkHeader } from "./http.mjs";
 import { DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT } from "./request-params.mjs";
@@ -23,15 +24,38 @@ export function applyQueryFilters(
   if (!Array.isArray(data?.[config.data_key])) {
     return { data, meta: {} };
   }
-  return applyListTransform(data, params, {
+  return applyListTransform(
+    data,
+    params,
+    listQueryConfig(config, queryFilterNames),
+  );
+}
+
+export function validateListQueryParams(
+  url,
+  queryCollection,
+  queryFilterNames = [],
+) {
+  const config = API_QUERY_COLLECTIONS[queryCollection];
+  if (!config) {
+    return null;
+  }
+  return validateListQuery(
+    url.searchParams,
+    listQueryConfig(config, queryFilterNames),
+  );
+}
+
+function listQueryConfig(config, queryFilterNames = []) {
+  return {
     ...config,
     filters: Object.fromEntries(
-      (queryFilterNames.length > 0
-        ? queryFilterNames
-        : Object.keys(config.filters)
-      ).map((name) => [name, config.filters[name]]),
+      effectiveFilterNames(config, queryFilterNames).map((name) => [
+        name,
+        config.filters[name],
+      ]),
     ),
-  });
+  };
 }
 
 // RFC 8288 Link header for a cursor-paginated response (window from
@@ -43,10 +67,21 @@ export function applyQueryFilters(
 function listQueryParamNames(queryCollection, queryFilterNames = []) {
   const config = API_QUERY_COLLECTIONS[queryCollection];
   if (!config) return [];
+  return listQueryParamNamesForConfig(config, queryFilterNames);
+}
+
+function effectiveFilterNames(config, queryFilterNames = []) {
+  const filters = config.filters || {};
+  return queryFilterNames.length > 0
+    ? queryFilterNames.filter((name) => Object.hasOwn(filters, name))
+    : Object.keys(filters);
+}
+
+function listQueryParamNamesForConfig(config, queryFilterNames = []) {
   const filterNames =
     queryFilterNames.length > 0
-      ? queryFilterNames
-      : Object.keys(config.filters);
+      ? effectiveFilterNames(config, queryFilterNames)
+      : Object.keys(config.filters || {});
   const rangeNames = (config.range_filters || []).flatMap((field) => [
     `min_${field}`,
     `max_${field}`,
@@ -320,6 +355,16 @@ function paginateRows(rows, params) {
 }
 
 function validateListQuery(params, config) {
+  const allowedParams = new Set(listQueryParamNamesForConfig(config));
+  for (const key of params.keys()) {
+    if (!allowedParams.has(key)) {
+      return {
+        parameter: key,
+        message: "unknown query parameter.",
+      };
+    }
+  }
+
   const limit = params.get("limit");
   if (
     limit !== null &&
@@ -354,14 +399,14 @@ function validateListQuery(params, config) {
   }
 
   const sort = params.get("sort");
-  if (sort !== null && !config.sort_fields.includes(sort)) {
+  if (sort !== null && !(config.sort_fields || []).includes(sort)) {
     return {
       parameter: "sort",
       message: `sort is not supported for ${config.data_key}.`,
     };
   }
 
-  for (const [key, schema] of Object.entries(config.filters)) {
+  for (const [key, schema] of Object.entries(config.filters || {})) {
     if (!params.has(key)) {
       continue;
     }
@@ -396,7 +441,7 @@ function validateListQuery(params, config) {
     }
   }
 
-  for (const field of config.range_filters) {
+  for (const field of config.range_filters || []) {
     for (const bound of ["min", "max"]) {
       const key = `${bound}_${field}`;
       if (params.has(key) && numberParam(params.get(key)) === null) {


### PR DESCRIPTION
## Summary

- Reject unknown query parameters on list API routes with `400 invalid_query` instead of silently ignoring typoed keys.
- Share the list-query allow-list between Worker preflight validation and the existing transform validation.
- Preserve valid list-query behavior for search, projection, pagination, sort/order, filters, CSV/array filters, and range filters.
- Add regression coverage for unknown params, valid params, empty queries, route-scoped filter allow-lists, and overlay-cache preflight behavior.

## Template Used

- Backend/code change

Closes #2578
