### PR TITLE
feat(registry): add SN36 Eirel openapi + subnet-api surfaces

### DIFF
--- a/registry/subnets/sn-36.json
+++ b/registry/subnets/sn-36.json
@@ -57,6 +57,72 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Official Eirel whitepaper (application/pdf), linked as \"Whitepaper\" from the homepage and footer."
+    },
+    {
+      "id": "sn-36-eirel-openapi",
+      "name": "Eirel owner-api OpenAPI spec",
+      "kind": "openapi",
+      "url": "https://api.eirel.ai/openapi.json",
+      "provider": "eirel",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "schema_url": "https://api.eirel.ai/openapi.json",
+      "schema_status": "machine-readable",
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "codevector96"
+      },
+      "notes": "Machine-readable OpenAPI 3.1 spec (owner-api, 121 paths) served on the project's own api.eirel.ai host; documents the public dashboard and metagraph read endpoints registered below."
+    },
+    {
+      "id": "sn-36-eirel-dashboard-overview",
+      "name": "Eirel network overview",
+      "kind": "subnet-api",
+      "url": "https://api.eirel.ai/api/v1/dashboard/overview",
+      "provider": "eirel",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "codevector96"
+      },
+      "notes": "Public dashboard summary (miner/validator/family counts, current run) that self-reports \"netuid\": 36 and \"network\": \"finney\"; GET /api/v1/dashboard/overview in the OpenAPI spec."
+    },
+    {
+      "id": "sn-36-eirel-dashboard-runs",
+      "name": "Eirel evaluation runs",
+      "kind": "subnet-api",
+      "url": "https://api.eirel.ai/api/v1/dashboard/runs",
+      "provider": "eirel",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "codevector96"
+      },
+      "notes": "Public feed of Eirel evaluation runs (id, sequence, status, schedule window); GET /api/v1/dashboard/runs in the OpenAPI spec."
+    },
+    {
+      "id": "sn-36-eirel-metagraph-status",
+      "name": "Eirel metagraph status",
+      "kind": "subnet-api",
+      "url": "https://api.eirel.ai/v1/metagraph/status",
+      "provider": "eirel",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "codevector96"
+      },
+      "notes": "Public metagraph status for netuid 36 on finney (validator/miner counts, timestamp); GET /v1/metagraph/status in the OpenAPI spec."
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

Appends five callable surfaces to the one manifest `registry/subnets/sn-36.json` (SN36 Eirel). Append-only — no other file touched. All URLs live on the subnet's own `api.eirel.ai` host (a subdomain of the registered official site `eirel.ai`), and two of them self-report `"netuid": 36` / `"network": "finney"`, so ownership is self-proving. Generated with `npm run surface:add`.

## Surface

- **Netuid:** 36 (Eirel)
- **Provider slug:** `eirel`
- **Kinds / Public URLs (all GET, no auth, verified 200):**
  - `openapi` — https://api.eirel.ai/openapi.json (machine-readable OpenAPI 3.1, 121 paths)
  - `subnet-api` — https://api.eirel.ai/healthz (liveness: db/redis checks)
  - `subnet-api` — https://api.eirel.ai/api/v1/dashboard/overview (network summary, self-reports netuid 36)
  - `subnet-api` — https://api.eirel.ai/api/v1/dashboard/runs (evaluation-runs feed)
  - `subnet-api` — https://api.eirel.ai/v1/metagraph/status (metagraph status, netuid 36)
- **Source URL (proves the claim):** https://api.eirel.ai/openapi.json (the spec on the subnet's own host lists each path) + https://eirel.ai/ (registered official site; `api.` subdomain)

## Checklist

- [x] Changes exactly one `registry/subnets/sn-36.json` — append-only.
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] Each `url` is public and read-only-probe safe; `source_url` independently proves the subnet publishes it (spec on `api.eirel.ai` + `eirel.ai` official site).
- [x] Public-safe: no auth-only flows, secrets, wallet/PAT data, private URLs, or generated artifacts. (Auth-gated `/v1/*`, `/api-json`, and admin/operator routes were deliberately excluded — only endpoints that return public 200 JSON are registered.)
- [x] Does not duplicate an existing Metagraphed surface (SN36 had no callable surface; `validate:surface` confirms no native-chain collision).
- [ ] No tracked enrichment issue linked — judged on its own merit (linking is optional per CONTRIBUTING).

## Validation

- [x] `npm run validate:surface -- registry/subnets/sn-36.json` — "Surface validation passed: 8 surface(s) across 1 subnet file(s)."
- [x] `npm run scan:public-safety` — passed.