### PR TITLE
feat(api): add CSV export for registry leaderboards

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -963,7 +963,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch registry leaderboards computed live from D1 + registry projections + the economics tier. Operational boards: healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable. Economic opportunity boards (for miners/validators): open-slots, cheapest-registration, highest-emission, validator-headroom. Omit `board` for all boards. */
+        /** Fetch registry leaderboards computed live from D1 + registry projections + the economics tier. Operational boards: healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable. Economic opportunity boards (for miners/validators): open-slots, cheapest-registration, highest-emission, validator-headroom. Omit `board` for all boards. Pass `format=csv` with a selected `board` to export that board's rows as CSV. */
         get: operations["registryLeaderboards"];
         put?: never;
         post?: never;
@@ -12905,6 +12905,7 @@ export interface operations {
             query?: {
                 board?: "healthiest" | "fastest-rpc" | "most-complete" | "most-enriched" | "fastest-growing" | "most-reliable" | "open-slots" | "cheapest-registration" | "highest-emission" | "validator-headroom";
                 limit?: number;
+                format?: "csv";
             };
             header?: never;
             path?: never;
@@ -12963,6 +12964,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RegistryLeaderboardsArtifact"];
                     };
+                    /**
+                     * @example netuid,slug,name,open_slots,max_uids,registration_cost_tao,registration_allowed
+                     *     1,example,Example,10,256,0.1,true
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/generated/metagraphed-client.ts
+++ b/generated/metagraphed-client.ts
@@ -39,6 +39,14 @@ export type QueryParams<Path extends ApiPath> =
   GetOperation<Path> extends { parameters: { query?: infer Query } }
     ? Query
     : never;
+type JsonCompatibleQuery<Query> = Query extends object
+  ? "format" extends keyof Query
+    ? Omit<Query, "format"> & { format?: Exclude<Query["format"], "csv"> }
+    : Query
+  : Query;
+export type JsonQueryParams<Path extends ApiPath> = JsonCompatibleQuery<
+  QueryParams<Path>
+>;
 export type PathParams<Path extends ApiPath> =
   GetOperation<Path> extends { parameters: { path?: infer Params } }
     ? Params
@@ -60,7 +68,7 @@ export interface MetagraphedFetchOptions<Path extends ApiPath>
   extends Omit<RequestInit, "method" | "body"> {
   baseUrl?: string;
   pathParams?: PathParams<Path>;
-  query?: QueryParams<Path>;
+  query?: JsonQueryParams<Path>;
   /** Abort the request after this many ms (default 30000). Pass 0 to disable. An explicit `signal` takes precedence. */
   timeoutMs?: number;
 }
@@ -185,7 +193,7 @@ export async function* metagraphedPaginate<Path extends ApiPath>(
     }
     const page = await metagraphedFetch(path, {
       ...options,
-      query: baseQuery as unknown as QueryParams<Path>,
+      query: baseQuery as unknown as JsonQueryParams<Path>,
     });
     yield page;
     const next = (
@@ -695,7 +703,7 @@ export function createMetagraphedClient(
       }
       const page = await request(path, {
         ...options,
-        query: baseQuery as unknown as QueryParams<Path>,
+        query: baseQuery as unknown as JsonQueryParams<Path>,
       });
       yield page;
       const next = (

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5571,7 +5571,7 @@
     {
       "artifact_path": "/metagraph/registry/leaderboards.json",
       "cache": "standard",
-      "description": "Fetch registry leaderboards computed live from D1 + registry projections + the economics tier. Operational boards: healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable. Economic opportunity boards (for miners/validators): open-slots, cheapest-registration, highest-emission, validator-headroom. Omit `board` for all boards.",
+      "description": "Fetch registry leaderboards computed live from D1 + registry projections + the economics tier. Operational boards: healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable. Economic opportunity boards (for miners/validators): open-slots, cheapest-registration, highest-emission, validator-headroom. Omit `board` for all boards. Pass `format=csv` with a selected `board` to export that board's rows as CSV.",
       "id": "registry-leaderboards",
       "method": "GET",
       "path": "/api/v1/registry/leaderboards",
@@ -5603,6 +5603,15 @@
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
+          }
+        },
+        {
+          "name": "format",
+          "schema": {
+            "enum": [
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -831,7 +831,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-01.1",
-      "description": "Registry leaderboards — operational (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable) and economic opportunity (open-slots, cheapest-registration, highest-emission, validator-headroom) — computed live from D1 + registry projections + the economics tier at /api/v1/registry/leaderboards (no static file).",
+      "description": "Registry leaderboards — operational (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable) and economic opportunity (open-slots, cheapest-registration, highest-emission, validator-headroom) — computed live from D1 + registry projections + the economics tier at /api/v1/registry/leaderboards (no static file). Selected boards can be exported as CSV with `board=<name>&format=csv`.",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",
       "schema_ref": "#/components/schemas/RegistryLeaderboardsArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -26162,6 +26162,17 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -26219,6 +26230,13 @@
                       "type": "object"
                     }
                   ]
+                }
+              },
+              "text/csv": {
+                "example": "netuid,slug,name,open_slots,max_uids,registration_cost_tao,registration_allowed\n1,example,Example,10,256,0.1,true\n",
+                "schema": {
+                  "description": "CSV rows for the selected leaderboard board. Requires `format=csv` and `board`.",
+                  "type": "string"
                 }
               }
             },
@@ -26279,7 +26297,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch registry leaderboards computed live from D1 + registry projections + the economics tier. Operational boards: healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable. Economic opportunity boards (for miners/validators): open-slots, cheapest-registration, highest-emission, validator-headroom. Omit `board` for all boards.",
+        "summary": "Fetch registry leaderboards computed live from D1 + registry projections + the economics tier. Operational boards: healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable. Economic opportunity boards (for miners/validators): open-slots, cheapest-registration, highest-emission, validator-headroom. Omit `board` for all boards. Pass `format=csv` with a selected `board` to export that board's rows as CSV.",
         "tags": [
           "registry",
           "analytics",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -963,7 +963,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch registry leaderboards computed live from D1 + registry projections + the economics tier. Operational boards: healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable. Economic opportunity boards (for miners/validators): open-slots, cheapest-registration, highest-emission, validator-headroom. Omit `board` for all boards. */
+        /** Fetch registry leaderboards computed live from D1 + registry projections + the economics tier. Operational boards: healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable. Economic opportunity boards (for miners/validators): open-slots, cheapest-registration, highest-emission, validator-headroom. Omit `board` for all boards. Pass `format=csv` with a selected `board` to export that board's rows as CSV. */
         get: operations["registryLeaderboards"];
         put?: never;
         post?: never;
@@ -12905,6 +12905,7 @@ export interface operations {
             query?: {
                 board?: "healthiest" | "fastest-rpc" | "most-complete" | "most-enriched" | "fastest-growing" | "most-reliable" | "open-slots" | "cheapest-registration" | "highest-emission" | "validator-headroom";
                 limit?: number;
+                format?: "csv";
             };
             header?: never;
             path?: never;
@@ -12963,6 +12964,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RegistryLeaderboardsArtifact"];
                     };
+                    /**
+                     * @example netuid,slug,name,open_slots,max_uids,registration_cost_tao,registration_allowed
+                     *     1,example,Example,10,256,0.1,true
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/scripts/generate-client.mjs
+++ b/scripts/generate-client.mjs
@@ -59,6 +59,14 @@ export type QueryParams<Path extends ApiPath> =
   GetOperation<Path> extends { parameters: { query?: infer Query } }
     ? Query
     : never;
+type JsonCompatibleQuery<Query> = Query extends object
+  ? "format" extends keyof Query
+    ? Omit<Query, "format"> & { format?: Exclude<Query["format"], "csv"> }
+    : Query
+  : Query;
+export type JsonQueryParams<Path extends ApiPath> = JsonCompatibleQuery<
+  QueryParams<Path>
+>;
 export type PathParams<Path extends ApiPath> =
   GetOperation<Path> extends { parameters: { path?: infer Params } }
     ? Params
@@ -80,7 +88,7 @@ export interface MetagraphedFetchOptions<Path extends ApiPath>
   extends Omit<RequestInit, "method" | "body"> {
   baseUrl?: string;
   pathParams?: PathParams<Path>;
-  query?: QueryParams<Path>;
+  query?: JsonQueryParams<Path>;
   /** Abort the request after this many ms (default 30000). Pass 0 to disable. An explicit \`signal\` takes precedence. */
   timeoutMs?: number;
 }
@@ -205,7 +213,7 @@ export async function* metagraphedPaginate<Path extends ApiPath>(
     }
     const page = await metagraphedFetch(path, {
       ...options,
-      query: baseQuery as unknown as QueryParams<Path>,
+      query: baseQuery as unknown as JsonQueryParams<Path>,
     });
     yield page;
     const next = (
@@ -715,7 +723,7 @@ export function createMetagraphedClient(
       }
       const page = await request(path, {
         ...options,
-        query: baseQuery as unknown as QueryParams<Path>,
+        query: baseQuery as unknown as JsonQueryParams<Path>,
       });
       yield page;
       const next = (

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1169,7 +1169,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "registry-leaderboards",
     "/metagraph/registry/leaderboards.json",
-    "Registry leaderboards — operational (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable) and economic opportunity (open-slots, cheapest-registration, highest-emission, validator-headroom) — computed live from D1 + registry projections + the economics tier at /api/v1/registry/leaderboards (no static file).",
+    "Registry leaderboards — operational (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable) and economic opportunity (open-slots, cheapest-registration, highest-emission, validator-headroom) — computed live from D1 + registry projections + the economics tier at /api/v1/registry/leaderboards (no static file). Selected boards can be exported as CSV with `board=<name>&format=csv`.",
     "RegistryLeaderboardsArtifact",
   ),
   artifact(
@@ -2404,7 +2404,7 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/registry/leaderboards",
     "/metagraph/registry/leaderboards.json",
-    "Fetch registry leaderboards computed live from D1 + registry projections + the economics tier. Operational boards: healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable. Economic opportunity boards (for miners/validators): open-slots, cheapest-registration, highest-emission, validator-headroom. Omit `board` for all boards.",
+    "Fetch registry leaderboards computed live from D1 + registry projections + the economics tier. Operational boards: healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable. Economic opportunity boards (for miners/validators): open-slots, cheapest-registration, highest-emission, validator-headroom. Omit `board` for all boards. Pass `format=csv` with a selected `board` to export that board's rows as CSV.",
     "standard",
     ["registry", "analytics", "subnets"],
     [
@@ -2427,8 +2427,23 @@ export const API_ROUTES = [
         },
       },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
+      { name: "format", schema: { type: "string", enum: ["csv"] } },
     ],
     [],
+    {
+      additionalSuccessContent: [
+        {
+          contentType: "text/csv",
+          schema: {
+            type: "string",
+            description:
+              "CSV rows for the selected leaderboard board. Requires `format=csv` and `board`.",
+          },
+          example:
+            "netuid,slug,name,open_slots,max_uids,registration_cost_tao,registration_allowed\n1,example,Example,10,256,0.1,true\n",
+        },
+      ],
+    },
   ),
   route(
     "compare",
@@ -2731,6 +2746,21 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
         },
       ],
     };
+    const successContent = {
+      "application/json": {
+        schema: responseSchema,
+        // Deterministic worked example (schema-valid, no live data) so
+        // Swagger UI + agents see a concrete response shape. Generated
+        // from the schema; enforced by validate-openapi-examples.
+        example: sampleFromSchema(responseSchema, componentSchemas),
+      },
+    };
+    for (const content of entry.additional_success_content) {
+      successContent[content.content_type] = {
+        schema: content.schema,
+        example: content.example,
+      };
+    }
     paths[openApiPath] = {
       ...(paths[openApiPath] || {}),
       [entry.method.toLowerCase()]: {
@@ -2757,15 +2787,7 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
             description:
               "Canonical artifact wrapped in the Metagraphed API envelope.",
             headers: apiResponseHeaders(),
-            content: {
-              "application/json": {
-                schema: responseSchema,
-                // Deterministic worked example (schema-valid, no live data) so
-                // Swagger UI + agents see a concrete response shape. Generated
-                // from the schema; enforced by validate-openapi-examples.
-                example: sampleFromSchema(responseSchema, componentSchemas),
-              },
-            },
+            content: successContent,
           },
           304: {
             description: "ETag matched and the cached response is still valid.",
@@ -2926,6 +2948,7 @@ function route(
   tags,
   queryParameters = [],
   pathParameters = [],
+  options = {},
 ) {
   const querySpec = normalizeQueryParameters(queryParameters);
   return {
@@ -2940,6 +2963,13 @@ function route(
     query_filter_names: querySpec.filterNames,
     query_parameters: querySpec.parameters,
     path_parameters: pathParameters,
+    additional_success_content: (options.additionalSuccessContent || []).map(
+      (content) => ({
+        content_type: content.contentType,
+        schema: content.schema,
+        example: content.example,
+      }),
+    ),
   };
 }
 

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -1101,6 +1101,33 @@ describe("analytics routes (cold local D1)", () => {
     assert.deepEqual(Object.keys(body.data.boards), ["highest-emission"]);
     assert.ok(body.data.boards["highest-emission"].length <= 5);
   });
+  test("leaderboards exports a selected board as CSV", async () => {
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/registry/leaderboards?board=open-slots&format=csv",
+      ),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    const csv = await res.text();
+    assert.ok(
+      csv.startsWith(
+        "netuid,slug,name,open_slots,max_uids,registration_cost_tao,registration_allowed\n",
+      ),
+    );
+    assert.match(csv, /\n\d+,[^\n]*,\d+,/);
+  });
+  test("leaderboards CSV requires a selected board", async () => {
+    const { status, body } = await getJson(
+      "https://api.metagraph.sh/api/v1/registry/leaderboards?format=csv",
+      env,
+    );
+    assert.equal(status, 400);
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "board");
+  });
   test("leaderboards economic boards prefer the live economics KV blob", async () => {
     // A fresh, on-contract, integrity-valid blob makes resolveLiveEconomics win,
     // so the boards project from KV rather than the committed R2 economics.json.

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -296,6 +296,19 @@ describe("public contract registry", () => {
     }
   });
 
+  test("documents leaderboard CSV exports as text/csv responses", async () => {
+    const generatedAt = "1970-01-01T00:00:00.000Z";
+    const openapi = buildOpenApiArtifact(
+      generatedAt,
+      await loadOpenApiComponentSchemas(generatedAt),
+    );
+    const operation =
+      openapi.paths["/api/v1/registry/leaderboards"].get.responses["200"];
+    assert.ok(operation.content["application/json"].schema);
+    assert.equal(operation.content["text/csv"].schema.type, "string");
+    assert.match(operation.content["text/csv"].example, /^netuid,/);
+  });
+
   test("applies wildcard artifact budgets to dated health history", () => {
     const [result] = evaluateArtifactBudgets([
       {

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -350,6 +350,153 @@ describe("handleLeaderboards", () => {
     assert.ok(Array.isArray(body.data.boards["most-complete"]));
   });
 
+  test("exports the selected board as CSV", async () => {
+    configureAnalyticsRoutes({
+      readHealthMetaKv: async () => ({ last_run_at: OBSERVED_AT }),
+      readEconomicsCurrentKv: async () => ({
+        captured_at: new Date().toISOString(),
+        summary: { with_economics_count: 1 },
+        subnets: [
+          {
+            netuid: 777,
+            slug: "=live",
+            name: 'Quote, "Subnet"\nLine',
+            open_slots: 5,
+            registration_cost_tao: 1.5,
+            registration_allowed: true,
+            emission_share: 1,
+          },
+        ],
+      }),
+    });
+    const env = createLocalArtifactEnv();
+    const request = req(
+      "/api/v1/registry/leaderboards?board=open-slots&format=csv",
+    );
+    const res = await handleLeaderboards(
+      request,
+      env,
+      url("/api/v1/registry/leaderboards?board=open-slots&format=csv"),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    assert.ok(res.headers.get("etag"));
+    const csv = await res.text();
+    assert.ok(
+      csv.startsWith(
+        "netuid,slug,name,open_slots,max_uids,registration_cost_tao,registration_allowed\n",
+      ),
+    );
+    assert.match(csv, /777,'=live,"Quote, ""Subnet""\nLine",5,,1\.5,true\n/);
+
+    const cached = await handleLeaderboards(
+      new Request(request.url, {
+        headers: { "if-none-match": res.headers.get("etag") },
+      }),
+      env,
+      url("/api/v1/registry/leaderboards?board=open-slots&format=csv"),
+    );
+    assert.equal(cached.status, 304);
+    assert.equal(await cached.text(), "");
+  });
+
+  test("exports an empty selected board as header-only CSV", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleLeaderboards(
+      req("/api/v1/registry/leaderboards?board=fastest-rpc&format=csv"),
+      env,
+      url("/api/v1/registry/leaderboards?board=fastest-rpc&format=csv"),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), "netuid,slug,name,latency_ms\n");
+  });
+
+  test("marks CSV responses built from D1 fallback rows", async () => {
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          throw new Error("D1 unavailable");
+        },
+      },
+    };
+    const res = await handleLeaderboards(
+      req("/api/v1/registry/leaderboards?board=fastest-rpc&format=csv"),
+      env,
+      url("/api/v1/registry/leaderboards?board=fastest-rpc&format=csv"),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    assert.equal(await res.text(), "netuid,slug,name,latency_ms\n");
+  });
+
+  test("exports CSV responses built from successful empty D1 rows", async () => {
+    const env = {
+      ...createLocalArtifactEnv(),
+      ...d1Env(),
+    };
+    const res = await handleLeaderboards(
+      req("/api/v1/registry/leaderboards?board=fastest-rpc&format=csv"),
+      env,
+      url("/api/v1/registry/leaderboards?board=fastest-rpc&format=csv"),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    assert.equal(await res.text(), "netuid,slug,name,latency_ms\n");
+  });
+
+  test("exports non-empty operational board rows as CSV", async () => {
+    const env = {
+      ...createLocalArtifactEnv(),
+      ...d1Env({
+        "MIN\\(latency_ms\\)": [{ netuid: 7, min_latency_ms: 42 }],
+      }),
+    };
+    const res = await handleLeaderboards(
+      req("/api/v1/registry/leaderboards?board=fastest-rpc&format=csv"),
+      env,
+      url("/api/v1/registry/leaderboards?board=fastest-rpc&format=csv"),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    const csv = await res.text();
+    assert.equal(csv.split("\n")[0], "netuid,slug,name,latency_ms");
+    assert.match(csv, /\n7,[^\n]*,42\n/);
+  });
+
+  test("suppresses CSV bodies for HEAD requests", async () => {
+    const env = createLocalArtifactEnv();
+    const request = new Request(
+      "https://api.metagraph.sh/api/v1/registry/leaderboards?board=fastest-rpc&format=csv",
+      { method: "HEAD" },
+    );
+    const res = await handleLeaderboards(
+      request,
+      env,
+      url("/api/v1/registry/leaderboards?board=fastest-rpc&format=csv"),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    assert.equal(await res.text(), "");
+  });
+
+  test("requires a board for CSV exports", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleLeaderboards(req("/"), env, url("/?format=csv"));
+    const body = await errorJson(res);
+    assert.equal(body.error.code, "invalid_query");
+    assert.match(body.error.message, /requires a board/);
+    assert.equal(body.meta.parameter, "board");
+  });
+
+  test("rejects unsupported leaderboard formats", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleLeaderboards(req("/"), env, url("/?format=json"));
+    const body = await errorJson(res);
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "format");
+  });
+
   test("uses surface uptime rollups for most-reliable board", async () => {
     const env = d1Env({
       "FROM surface_uptime_daily": [
@@ -630,6 +777,17 @@ describe("canonicalLeaderboardsCachePath", () => {
     );
   });
 
+  test("preserves valid CSV board requests", () => {
+    assert.equal(
+      canonicalLeaderboardsCachePath(
+        url(
+          "/api/v1/registry/leaderboards?format=csv&limit=10&board=open-slots",
+        ),
+      ),
+      "/api/v1/registry/leaderboards?board=open-slots&format=csv&limit=10",
+    );
+  });
+
   test("falls back to raw search on invalid limit", () => {
     const raw = "/api/v1/registry/leaderboards?limit=0";
     assert.equal(canonicalLeaderboardsCachePath(url(raw)), raw);
@@ -638,6 +796,15 @@ describe("canonicalLeaderboardsCachePath", () => {
   test("falls back to raw search on unknown board", () => {
     const raw = "/api/v1/registry/leaderboards?board=not-a-board";
     assert.equal(canonicalLeaderboardsCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on unsupported CSV requests", () => {
+    for (const raw of [
+      "/api/v1/registry/leaderboards?format=json",
+      "/api/v1/registry/leaderboards?format=csv",
+    ]) {
+      assert.equal(canonicalLeaderboardsCachePath(url(raw)), raw);
+    }
   });
 });
 

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -9,7 +9,12 @@
 // injected once at module-init so this file never imports api.mjs back.
 
 import { DAY_MS, MAX_UPTIME_ROWS, UPTIME_WINDOWS } from "../config.mjs";
-import { errorResponse } from "../http.mjs";
+import {
+  apiHeaders,
+  errorResponse,
+  ifNoneMatchSatisfied,
+  weakEtag,
+} from "../http.mjs";
 import { readArtifact } from "../storage.mjs";
 import { contractVersion, envelopeResponse } from "../responses.mjs";
 import {
@@ -56,12 +61,119 @@ let leaderboardProfilesCache = null; // { subnetMeta, mostComplete, builtAt }
 
 const COMPARE_DIMENSIONS = ["structure", "economics", "health"];
 const COMPARE_NETUIDS_PATTERN = /^\d{1,5}(,\d{1,5}){0,127}$/;
+const CSV_SPREADSHEET_FORMULA_PREFIX = /^[=+\-@\t\r\n]/;
+const LEADERBOARD_CSV_COLUMNS = {
+  healthiest: [
+    "netuid",
+    "slug",
+    "name",
+    "uptime_ratio",
+    "surfaces_ok",
+    "surfaces_total",
+    "avg_latency_ms",
+  ],
+  "fastest-rpc": ["netuid", "slug", "name", "latency_ms"],
+  "most-complete": ["netuid", "slug", "name", "completeness_score"],
+  "most-enriched": [
+    "netuid",
+    "slug",
+    "name",
+    "surface_count",
+    "operational_interface_count",
+  ],
+  "fastest-growing": ["netuid", "slug", "name", "completeness_delta"],
+  "most-reliable": [
+    "netuid",
+    "slug",
+    "name",
+    "score",
+    "grade",
+    "uptime_ratio",
+    "avg_latency_ms",
+    "sample_count",
+    "latency_sample_count",
+  ],
+  "open-slots": [
+    "netuid",
+    "slug",
+    "name",
+    "open_slots",
+    "max_uids",
+    "registration_cost_tao",
+    "registration_allowed",
+  ],
+  "cheapest-registration": [
+    "netuid",
+    "slug",
+    "name",
+    "registration_cost_tao",
+    "open_slots",
+    "registration_allowed",
+  ],
+  "highest-emission": [
+    "netuid",
+    "slug",
+    "name",
+    "emission_share",
+    "total_stake_tao",
+    "validator_count",
+    "miner_count",
+  ],
+  "validator-headroom": [
+    "netuid",
+    "slug",
+    "name",
+    "validator_headroom",
+    "validator_count",
+    "max_validators",
+    "emission_share",
+  ],
+};
 
 async function envelopeWithD1Fallback(request, payload, cacheProfile, rowSets) {
   const response = await envelopeResponse(request, payload, cacheProfile);
   return hasD1FallbackRows(...rowSets)
     ? markD1FallbackResponse(response)
     : response;
+}
+
+function csvCell(value) {
+  if (value === null || value === undefined) return "";
+  const text = String(value);
+  const safeText = CSV_SPREADSHEET_FORMULA_PREFIX.test(text)
+    ? `'${text}`
+    : text;
+  return /[",\r\n]/.test(safeText)
+    ? `"${safeText.replace(/"/g, '""')}"`
+    : safeText;
+}
+
+function leaderboardRowsCsv(board, rows) {
+  const columns = LEADERBOARD_CSV_COLUMNS[board];
+  return (
+    [
+      columns.join(","),
+      ...rows.map((row) =>
+        columns.map((column) => csvCell(row[column])).join(","),
+      ),
+    ].join("\n") + "\n"
+  );
+}
+
+async function leaderboardCsvResponse(request, env, board, rows) {
+  const body = leaderboardRowsCsv(board, rows);
+  const headers = apiHeaders("standard");
+  const etag = await weakEtag(body);
+  headers.set("content-type", "text/csv; charset=utf-8");
+  headers.set("etag", etag);
+  headers.set("x-metagraph-contract-version", contractVersion(env));
+  if (ifNoneMatchSatisfied(request, etag)) {
+    return new Response(null, { status: 304, headers });
+  }
+  return new Response(request.method === "HEAD" ? null : body, {
+    status: 200,
+    headers,
+  });
 }
 
 // Week-over-week structural trajectory from daily snapshots.
@@ -226,8 +338,16 @@ export function canonicalEconomicsTrendsCachePath(url) {
 // ?limit=20 request both resolve to the same edge-cache entry — mirrors
 // canonicalCompareCachePath and canonicalUptimeCachePath.
 export function canonicalLeaderboardsCachePath(url) {
-  const validationError = validateQueryParams(url, ["board", "limit"]);
+  const validationError = validateQueryParams(url, [
+    "board",
+    "format",
+    "limit",
+  ]);
   if (validationError) return `${url.pathname}${url.search}`;
+  const format = url.searchParams.get("format");
+  if (format !== null && format !== "csv") {
+    return `${url.pathname}${url.search}`;
+  }
   const limit = url.searchParams.get("limit");
   if (
     limit !== null &&
@@ -239,8 +359,12 @@ export function canonicalLeaderboardsCachePath(url) {
   if (board && !LEADERBOARD_BOARDS.includes(board)) {
     return `${url.pathname}${url.search}`;
   }
+  if (format === "csv" && !board) {
+    return `${url.pathname}${url.search}`;
+  }
   const cap = Math.max(1, Math.min(100, Number(limit) || 20));
   const params = [`limit=${cap}`];
+  if (format === "csv") params.unshift("format=csv");
   if (board) params.unshift(`board=${encodeURIComponent(board)}`);
   return `${url.pathname}?${params.join("&")}`;
 }
@@ -292,14 +416,35 @@ async function resolveEconomicsRows(env) {
 }
 
 export async function handleLeaderboards(request, env, url) {
-  const validationError = validateQueryParams(url, ["board", "limit"]);
+  const validationError = validateQueryParams(url, [
+    "board",
+    "format",
+    "limit",
+  ]);
   if (validationError) return analyticsQueryError(validationError);
   const requestedBoard = url.searchParams.get("board");
+  const requestedFormat = url.searchParams.get("format");
+  if (requestedFormat !== null && requestedFormat !== "csv") {
+    return errorResponse(
+      "invalid_query",
+      'format must be "csv" when provided.',
+      400,
+      { parameter: "format" },
+    );
+  }
   if (requestedBoard && !LEADERBOARD_BOARDS.includes(requestedBoard)) {
     return errorResponse(
       "invalid_query",
       `Unknown board "${requestedBoard}". Valid boards: ${LEADERBOARD_BOARDS.join(", ")}.`,
       400,
+    );
+  }
+  if (requestedFormat === "csv" && !requestedBoard) {
+    return errorResponse(
+      "invalid_query",
+      "format=csv requires a board parameter.",
+      400,
+      { parameter: "board" },
     );
   }
   const limit = url.searchParams.get("limit");
@@ -382,6 +527,22 @@ export async function handleLeaderboards(request, env, url) {
     economicsRows,
     subnetMeta,
   });
+  if (requestedFormat === "csv") {
+    const response = await leaderboardCsvResponse(
+      request,
+      env,
+      requestedBoard,
+      data.boards[requestedBoard],
+    );
+    return hasD1FallbackRows(
+      healthRows,
+      rpcRows,
+      growthSamples,
+      reliabilityRows,
+    )
+      ? markD1FallbackResponse(response)
+      : response;
+  }
   return envelopeWithD1Fallback(
     request,
     {


### PR DESCRIPTION
## Summary

- Add `format=csv` support to `GET /api/v1/registry/leaderboards` for selected leaderboard boards.
- Require `board` when CSV is requested, returning `400 invalid_query` for `?format=csv` without a board.
- Emit stable CSV headers for each board, including header-only CSV for empty boards.
- Preserve cache safety by including `format=csv` in canonical leaderboard cache keys.
- Update the registry leaderboards contract and regenerated OpenAPI/types.
- Add regression coverage for CSV export, missing-board errors, empty-board CSV, HEAD/ETag behavior, routed Worker behavior, and cache canonicalization.

Closes #2537

## Template Used

- Backend/code change
