### PR TITLE
fix(domain-tags): tag 'distributed computing' for the compute rule

### DIFF
--- a/src/domain-tags.mjs
+++ b/src/domain-tags.mjs
@@ -14,7 +14,7 @@ const DOMAIN_TAG_RULES = [
   ],
   [
     "compute",
-    /\b(gpu|cuda|compute (?:network|layer|subnet)|decentrali[sz]ed comput\w*|hpc|parallel comput\w*|render(?:ing)? farm)\b/i,
+    /\b(gpu|cuda|compute (?:network|layer|subnet)|decentrali[sz]ed comput\w*|hpc|parallel comput\w*|distributed comput\w*|render(?:ing)? farm)\b/i,
   ],
   [
     "data",

--- a/tests/domain-tags.test.mjs
+++ b/tests/domain-tags.test.mjs
@@ -72,6 +72,22 @@ describe("deriveDomainTags", () => {
     );
   });
 
+  test("tags 'distributed computing' for the compute rule", () => {
+    // "distributed computing" is the canonical way a compute subnet describes
+    // itself, yet the compute rule only anchored the "decentralized" and
+    // "parallel" adjective variants — a description that used "distributed"
+    // silently dropped the compute tag. Mirrors the sibling `... comput\w*`
+    // alternatives already in the rule.
+    assert.deepEqual(
+      deriveDomainTags({ description: "A distributed computing network" }),
+      ["compute"],
+    );
+    assert.deepEqual(
+      deriveDomainTags({ description: "Distributed compute for AI workloads" }),
+      ["compute"],
+    );
+  });
+
   test("accepts curated categories that are already in the vocabulary", () => {
     const tags = deriveDomainTags({
       categories: ["Finance", "privacy"],


### PR DESCRIPTION
## Summary
The compute domain-tag rule anchored only the "decentralized" and "parallel" compute-adjective variants, so a subnet that described itself as **"distributed computing"** — the most common phrasing for this class of subnet — silently dropped the `compute` tag and fell out of the `?domain=compute` facet.

Adds a `distributed comput\w*` alternative next to the existing `decentrali[sz]ed comput\w*` / `parallel comput\w*` siblings (same ReDoS-safe, bounded-`\w*` shape). No change to the tag vocabulary, so no generated artifacts move.

## Validation
- `npm test -- tests/domain-tags.test.mjs` — green (new case + no regressions)
- `npm test -- tests/discover-candidates-domain.test.mjs tests/contracts.test.mjs` — green