### PR TITLE
fix(domain-tags): tag 'market making' for the finance rule

### DIFF
--- a/src/domain-tags.mjs
+++ b/src/domain-tags.mjs
@@ -22,7 +22,7 @@ const DOMAIN_TAG_RULES = [
   ],
   [
     "finance",
-    /\b(financ\w*|trading|defi|portfolio|hedge|liquidity|yield farming|price predict\w*)\b/i,
+    /\b(financ\w*|trading|defi|portfolio|hedge|liquidity|yield farming|market[- ]mak\w*|price predict\w*)\b/i,
   ],
   [
     "inference",

--- a/tests/domain-tags.test.mjs
+++ b/tests/domain-tags.test.mjs
@@ -72,6 +72,30 @@ describe("deriveDomainTags", () => {
     );
   });
 
+  test("tags 'market making' / 'market maker' for the finance rule", () => {
+    // Market making is a core DeFi/finance capability, but the finance rule
+    // had no term for it — a "market maker" or "market making" description
+    // dropped the finance tag. Cover both the spaced and hyphenated spellings
+    // and the maker/making inflections with one bounded `market[- ]mak\w*`.
+    for (const description of [
+      "An on-chain market maker",
+      "Automated market making protocol",
+      "A decentralized market-maker for subnet liquidity provisioning",
+    ]) {
+      assert.ok(
+        deriveDomainTags({ description }).includes("finance"),
+        `expected finance tag for ${JSON.stringify(description)}`,
+      );
+    }
+    // "marketplace" must NOT trip the new term (no maker/making sense).
+    assert.equal(
+      deriveDomainTags({ description: "A data marketplace" }).includes(
+        "finance",
+      ),
+      false,
+    );
+  });
+
   test("accepts curated categories that are already in the vocabulary", () => {
     const tags = deriveDomainTags({
       categories: ["Finance", "privacy"],


### PR DESCRIPTION
## Summary
Market making is a core DeFi/finance capability, but the finance domain-tag rule had no keyword for it — a subnet described as a **"market maker"** or doing **"market making"** dropped out of the `?domain=finance` facet.

Adds a bounded `market[- ]mak\w*` alternative (covers "market maker", "market making", and the hyphenated "market-maker" spellings) alongside the existing finance terms. Scoped so "marketplace" does not trip it.

## Validation
- `npm test -- tests/domain-tags.test.mjs` — green (new case incl. a "marketplace" negative)
- `npm test -- tests/discover-candidates-domain.test.mjs tests/contracts.test.mjs` — green