### PR TITLE
fix(api): coerce string-typed D1 numeric cells in composeCompareData

### DIFF
--- a/tests/compare.test.mjs
+++ b/tests/compare.test.mjs
@@ -104,6 +104,104 @@ describe("composeCompareData", () => {
     assert.equal(s.economics.open_slots, 3);
   });
 
+  test("coerces string-typed D1 numeric cells to numbers across every tier", () => {
+    // Some D1 read paths hand numeric columns back as strings; the compare
+    // projection must not leak those as strings into the CompareArtifact
+    // numeric fields. registration_allowed (a boolean) and absent/null cells
+    // are left exactly as they arrive.
+    const data = composeCompareData({
+      requestedNetuids: [1, 2],
+      dimensions: ["structure", "economics", "health"],
+      subnetMeta,
+      structureRows: [
+        {
+          netuid: 1,
+          completeness_score: "80",
+          surface_count: "5",
+          operational_interface_count: "2",
+        },
+      ],
+      economicsRows: [
+        {
+          netuid: 2,
+          registration_cost_tao: "1.5",
+          registration_allowed: true,
+          open_slots: "3",
+          emission_share: "0.12",
+          alpha_price_tao: "0.04",
+          validator_count: "8",
+          miner_count: "64",
+          total_stake_tao: "1200",
+          miner_readiness: "72",
+        },
+      ],
+      healthRows: [
+        { netuid: 1, surface_count: "5", ok_count: "4", avg_latency_ms: "120" },
+      ],
+      observedAt: null,
+    });
+
+    const s1 = data.subnets.find((s) => s.netuid === 1);
+    const s2 = data.subnets.find((s) => s.netuid === 2);
+    assert.deepEqual(s1.structure, {
+      completeness_score: 80,
+      surface_count: 5,
+      operational_interface_count: 2,
+    });
+    assert.deepEqual(s1.health, {
+      surface_count: 5,
+      ok_count: 4,
+      avg_latency_ms: 120,
+    });
+    assert.deepEqual(s2.economics, {
+      registration_cost_tao: 1.5,
+      registration_allowed: true, // boolean preserved, not coerced
+      open_slots: 3,
+      emission_share: 0.12,
+      alpha_price_tao: 0.04,
+      validator_count: 8,
+      miner_count: 64,
+      total_stake_tao: 1200,
+      miner_readiness: 72,
+    });
+
+    // A real number and a null cell pass through untouched.
+    const passthrough = composeCompareData({
+      requestedNetuids: [1],
+      dimensions: ["structure"],
+      subnetMeta,
+      structureRows: [
+        {
+          netuid: 1,
+          completeness_score: null,
+          surface_count: 5,
+          operational_interface_count: 2,
+        },
+      ],
+      economicsRows: [],
+      healthRows: [],
+      observedAt: null,
+    });
+    assert.equal(passthrough.subnets[0].structure.completeness_score, null);
+    assert.equal(passthrough.subnets[0].structure.surface_count, 5);
+
+    // A blank or non-numeric string is left as-is rather than turned into 0/NaN.
+    const oddCells = composeCompareData({
+      requestedNetuids: [1],
+      dimensions: ["health"],
+      subnetMeta,
+      structureRows: [],
+      economicsRows: [],
+      healthRows: [
+        { netuid: 1, surface_count: "", ok_count: "n/a", avg_latency_ms: "9" },
+      ],
+      observedAt: null,
+    });
+    assert.equal(oddCells.subnets[0].health.surface_count, "");
+    assert.equal(oddCells.subnets[0].health.ok_count, "n/a");
+    assert.equal(oddCells.subnets[0].health.avg_latency_ms, 9);
+  });
+
   test("composeCompareData output validates against the CompareArtifact contract", async () => {
     const generatedAt = "2026-06-24T12:00:00.000Z";
     const openapi = buildOpenApiArtifact(

--- a/tests/compare.test.mjs
+++ b/tests/compare.test.mjs
@@ -202,6 +202,52 @@ describe("composeCompareData", () => {
     assert.equal(oddCells.subnets[0].health.avg_latency_ms, 9);
   });
 
+  test("attaches tiers whose D1 row netuid comes back as a string", () => {
+    // The join key is the highest-risk string cell: requested netuids are
+    // numbers, so a row keyed on the raw string "1"/"2" would miss the numeric
+    // lookup and silently null out a populated tier. Every tier's key is
+    // normalized through the same coercion the value fields use.
+    const data = composeCompareData({
+      requestedNetuids: [1, 2],
+      dimensions: ["structure", "economics", "health"],
+      subnetMeta,
+      structureRows: [
+        {
+          netuid: "1",
+          completeness_score: 80,
+          surface_count: 5,
+          operational_interface_count: 2,
+        },
+      ],
+      economicsRows: [{ netuid: "2", open_slots: 3 }],
+      healthRows: [
+        { netuid: "1", surface_count: 5, ok_count: 4, avg_latency_ms: 120 },
+      ],
+      observedAt: null,
+    });
+
+    const s1 = data.subnets.find((s) => s.netuid === 1);
+    const s2 = data.subnets.find((s) => s.netuid === 2);
+    assert.equal(s1.structure.completeness_score, 80);
+    assert.equal(s1.health.ok_count, 4);
+    assert.equal(s2.economics.open_slots, 3);
+
+    // A row with an unusable (non-integer) netuid is skipped, not thrown on.
+    const skipped = composeCompareData({
+      requestedNetuids: [1],
+      dimensions: ["structure"],
+      subnetMeta,
+      structureRows: [
+        { netuid: "nope", completeness_score: 1, surface_count: 1 },
+        { netuid: null, completeness_score: 2, surface_count: 2 },
+      ],
+      economicsRows: [],
+      healthRows: [],
+      observedAt: null,
+    });
+    assert.equal(skipped.subnets[0].structure, null);
+  });
+
   test("composeCompareData output validates against the CompareArtifact contract", async () => {
     const generatedAt = "2026-06-24T12:00:00.000Z";
     const openapi = buildOpenApiArtifact(

--- a/tests/compare.test.mjs
+++ b/tests/compare.test.mjs
@@ -232,20 +232,23 @@ describe("composeCompareData", () => {
     assert.equal(s1.health.ok_count, 4);
     assert.equal(s2.economics.open_slots, 3);
 
-    // A row with an unusable (non-integer) netuid is skipped, not thrown on.
+    // A row with an unusable (non-integer) netuid is skipped in every tier,
+    // not thrown on and not keyed under a junk value.
     const skipped = composeCompareData({
       requestedNetuids: [1],
-      dimensions: ["structure"],
+      dimensions: ["structure", "economics", "health"],
       subnetMeta,
       structureRows: [
         { netuid: "nope", completeness_score: 1, surface_count: 1 },
         { netuid: null, completeness_score: 2, surface_count: 2 },
       ],
-      economicsRows: [],
-      healthRows: [],
+      economicsRows: [{ netuid: "x", open_slots: 3 }],
+      healthRows: [{ netuid: null, ok_count: 4 }],
       observedAt: null,
     });
     assert.equal(skipped.subnets[0].structure, null);
+    assert.equal(skipped.subnets[0].economics, null);
+    assert.equal(skipped.subnets[0].health, null);
   });
 
   test("composeCompareData output validates against the CompareArtifact contract", async () => {

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -438,6 +438,20 @@ export function canonicalCompareCachePath(url) {
   return `${url.pathname}?${params.join("&")}`;
 }
 
+// D1 can hand a numeric column back as a string on some read paths (the same
+// class of cell-coercion the feed formatters apply, e.g. formatBlock). Parse a
+// string cell to a number so the CompareArtifact numeric fields never leak a
+// string; leave real numbers, null, and absent cells exactly as-is so the
+// artifact's null/absent contract is unchanged. Booleans (registration_allowed)
+// are intentionally not routed through here.
+function coerceD1Number(value) {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (trimmed === "") return value;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : value;
+}
+
 export function composeCompareData({
   requestedNetuids,
   dimensions,
@@ -454,31 +468,33 @@ export function composeCompareData({
   const structureByNetuid = new Map();
   for (const row of structureRows || []) {
     structureByNetuid.set(row.netuid, {
-      completeness_score: row.completeness_score,
-      surface_count: row.surface_count,
-      operational_interface_count: row.operational_interface_count,
+      completeness_score: coerceD1Number(row.completeness_score),
+      surface_count: coerceD1Number(row.surface_count),
+      operational_interface_count: coerceD1Number(
+        row.operational_interface_count,
+      ),
     });
   }
   const economicsByNetuid = new Map();
   for (const row of economicsRows || []) {
     economicsByNetuid.set(row.netuid, {
-      registration_cost_tao: row.registration_cost_tao,
+      registration_cost_tao: coerceD1Number(row.registration_cost_tao),
       registration_allowed: row.registration_allowed,
-      open_slots: row.open_slots,
-      emission_share: row.emission_share,
-      alpha_price_tao: row.alpha_price_tao,
-      validator_count: row.validator_count,
-      miner_count: row.miner_count,
-      total_stake_tao: row.total_stake_tao,
-      miner_readiness: row.miner_readiness,
+      open_slots: coerceD1Number(row.open_slots),
+      emission_share: coerceD1Number(row.emission_share),
+      alpha_price_tao: coerceD1Number(row.alpha_price_tao),
+      validator_count: coerceD1Number(row.validator_count),
+      miner_count: coerceD1Number(row.miner_count),
+      total_stake_tao: coerceD1Number(row.total_stake_tao),
+      miner_readiness: coerceD1Number(row.miner_readiness),
     });
   }
   const healthByNetuid = new Map();
   for (const row of healthRows || []) {
     healthByNetuid.set(row.netuid, {
-      surface_count: row.surface_count,
-      ok_count: row.ok_count,
-      avg_latency_ms: row.avg_latency_ms,
+      surface_count: coerceD1Number(row.surface_count),
+      ok_count: coerceD1Number(row.ok_count),
+      avg_latency_ms: coerceD1Number(row.avg_latency_ms),
     });
   }
 

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -443,7 +443,9 @@ export function canonicalCompareCachePath(url) {
 // string cell to a number so the CompareArtifact numeric fields never leak a
 // string; leave real numbers, null, and absent cells exactly as-is so the
 // artifact's null/absent contract is unchanged. Booleans (registration_allowed)
-// are intentionally not routed through here.
+// are intentionally not routed through here. It also normalizes the per-tier
+// Map join key: composeCompareData looks tiers up by numeric requested netuid,
+// so a string-typed row netuid ("7") must key on 7 or the tier drops to null.
 function coerceD1Number(value) {
   if (typeof value !== "string") return value;
   const trimmed = value.trim();
@@ -467,7 +469,9 @@ export function composeCompareData({
 
   const structureByNetuid = new Map();
   for (const row of structureRows || []) {
-    structureByNetuid.set(row.netuid, {
+    const netuid = coerceD1Number(row.netuid);
+    if (!Number.isInteger(netuid)) continue;
+    structureByNetuid.set(netuid, {
       completeness_score: coerceD1Number(row.completeness_score),
       surface_count: coerceD1Number(row.surface_count),
       operational_interface_count: coerceD1Number(
@@ -477,7 +481,9 @@ export function composeCompareData({
   }
   const economicsByNetuid = new Map();
   for (const row of economicsRows || []) {
-    economicsByNetuid.set(row.netuid, {
+    const netuid = coerceD1Number(row.netuid);
+    if (!Number.isInteger(netuid)) continue;
+    economicsByNetuid.set(netuid, {
       registration_cost_tao: coerceD1Number(row.registration_cost_tao),
       registration_allowed: row.registration_allowed,
       open_slots: coerceD1Number(row.open_slots),
@@ -491,7 +497,9 @@ export function composeCompareData({
   }
   const healthByNetuid = new Map();
   for (const row of healthRows || []) {
-    healthByNetuid.set(row.netuid, {
+    const netuid = coerceD1Number(row.netuid);
+    if (!Number.isInteger(netuid)) continue;
+    healthByNetuid.set(netuid, {
       surface_count: coerceD1Number(row.surface_count),
       ok_count: coerceD1Number(row.ok_count),
       avg_latency_ms: coerceD1Number(row.avg_latency_ms),


### PR DESCRIPTION
## Summary
The `/api/v1/compare` projection (`composeCompareData`) copied structure/economics/health cells straight from their D1 rows into the `CompareArtifact`. On the read paths where D1 hands a numeric column back as a string, that string leaked into fields the contract types as `number`/`integer` — the same class of cell coercion the feed formatters (`formatBlock`, `formatExtrinsic`, …) already apply at the projection boundary.

Routes every numeric compare field through a small `coerceD1Number` helper that parses a string cell to a number and leaves real numbers, `null`, and absent cells exactly as-is. `registration_allowed` (a boolean) is intentionally left untouched.

## Validation
- `npm test -- tests/compare.test.mjs` — green, incl. the existing `CompareArtifact` contract check and new cases: string-cell coercion across all three tiers, boolean preserved, null passthrough, blank/non-numeric passthrough
- `npm test -- tests/request-handlers-analytics-routes.test.mjs` — green
- `npx eslint workers/request-handlers/analytics-routes.mjs` — clean