### PR TITLE
fix(scan): flag all GitHub token prefixes in public-safety scan

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -17,7 +17,13 @@ const targetRoots = [
 const patterns = [
   { name: "local absolute path", regex: /\/Users\/|\/home\/|C:\\Users\\/ },
   { name: "private key marker", regex: /BEGIN [A-Z ]*PRIVATE KEY/ },
-  { name: "github token", regex: /ghp_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+/ },
+  // Covers every GitHub token prefix, not just the personal-access ghp_: gho_
+  // (OAuth), ghu_ (user-to-server), ghs_ (server-to-server / App installation),
+  // and ghr_ (refresh) are all real, leakable credentials in the same family.
+  {
+    name: "github token",
+    regex: /gh[opsur]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+/,
+  },
   { name: "openai-style token", regex: /sk-[A-Za-z0-9]{20,}/ },
   { name: "slack-style token", regex: /xox[baprs]-[A-Za-z0-9-]+/ },
   {

--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -22,7 +22,7 @@ const patterns = [
   // and ghr_ (refresh) are all real, leakable credentials in the same family.
   {
     name: "github token",
-    regex: /gh[opsur]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+/,
+    regex: /(?:gh[opsur]|github_pat)_[A-Za-z0-9_]+/,
   },
   { name: "openai-style token", regex: /sk-[A-Za-z0-9]{20,}/ },
   { name: "slack-style token", regex: /xox[baprs]-[A-Za-z0-9-]+/ },

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -199,13 +199,13 @@ describe("captured-fixture body scan", () => {
   test("flags every GitHub token prefix, not just ghp_", async () => {
     // ghp_ is the personal-access prefix, but gho_/ghu_/ghs_/ghr_ (OAuth,
     // user-to-server, App installation, refresh) are the same leakable family.
-    const leaks = [
-      "ghp_abcdefghijklmnopqrstuvwxyz0123456789",
-      "gho_abcdefghijklmnopqrstuvwxyz0123456789",
-      "ghu_abcdefghijklmnopqrstuvwxyz0123456789",
-      "ghs_abcdefghijklmnopqrstuvwxyz0123456789",
-      "ghr_abcdefghijklmnopqrstuvwxyz0123456789",
-    ];
+    // Assemble each token from a prefix + shared body at runtime so the source
+    // never commits a contiguous token-shaped literal (which secret scanners
+    // would flag as a leaked credential in the diff).
+    const body = "abcdefghijklmnopqrstuvwxyz0123456789";
+    const leaks = ["ghp", "gho", "ghu", "ghs", "ghr"].map(
+      (prefix) => `${prefix}_${body}`,
+    );
     await fs.writeFile(TEST_PUBLIC_PATH, `${leaks.join("\n")}\n`, "utf8");
     const output = runScanOutput();
     for (const [index] of leaks.entries()) {

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -196,6 +196,26 @@ describe("captured-fixture body scan", () => {
     }
   });
 
+  test("flags every GitHub token prefix, not just ghp_", async () => {
+    // ghp_ is the personal-access prefix, but gho_/ghu_/ghs_/ghr_ (OAuth,
+    // user-to-server, App installation, refresh) are the same leakable family.
+    const leaks = [
+      "ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+      "gho_abcdefghijklmnopqrstuvwxyz0123456789",
+      "ghu_abcdefghijklmnopqrstuvwxyz0123456789",
+      "ghs_abcdefghijklmnopqrstuvwxyz0123456789",
+      "ghr_abcdefghijklmnopqrstuvwxyz0123456789",
+    ];
+    await fs.writeFile(TEST_PUBLIC_PATH, `${leaks.join("\n")}\n`, "utf8");
+    const output = runScanOutput();
+    for (const [index] of leaks.entries()) {
+      assert.ok(
+        output.includes(`${TEST_PUBLIC_FILE}:${index + 1}: github token`),
+        `github token on line ${index + 1} must be flagged; got:\n${output}`,
+      );
+    }
+  });
+
   test("flags a link-local cloud-metadata URL as a private/loopback leak", async () => {
     // 169.254.169.254 is the AWS/GCP metadata endpoint — the canonical SSRF /
     // credential-theft target and unsafe per lib.mjs isUnsafeUrl, so a leaked URL


### PR DESCRIPTION
## Summary
The github-token rule only matched the personal-access `ghp_` prefix (and `github_pat_`). GitHub issues the same class of leakable credential under `gho_` (OAuth), `ghu_` (user-to-server), `ghs_` (App installation / server-to-server), and `ghr_` (refresh) — none of which the scanner caught.

Widen the prefix character class to `gh[opsur]_` so every GitHub token family is flagged.

## Validation
- `npm run scan:public-safety` — passes clean on the current tree (no new false positives)
- `npm test -- tests/public-safety.test.mjs` — green, incl. a new test covering all five prefixes