### PR TITLE
fix(scan): flag a bare Google API key in public-safety scan

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -25,6 +25,10 @@ const patterns = [
     regex:
       /[?&](?:X-Amz-(?:Credential|Signature|Security-Token)|X-Goog-(?:Credential|Signature|Security-Token|SignedHeaders|Expires)|X-Oss-(?:Credential|Signature))=/i,
   },
+  // Google API key: the fixed "AIza" prefix + 35 URL-safe chars. A distinctive,
+  // unambiguous format that a leaked Maps/Cloud key takes; none of the URL/token
+  // rules above catch a bare key value.
+  { name: "google api key", regex: /AIza[0-9A-Za-z_-]{35}/ },
   {
     name: "private or loopback URL",
     // Includes link-local 169.254.0.0/16 — the cloud-metadata endpoint

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -257,6 +257,18 @@ describe("captured-fixture body scan", () => {
     );
   });
 
+  test("flags a bare Google API key", async () => {
+    // The AIza-prefixed 39-char key is a distinctive, unambiguous credential
+    // format that none of the URL/token rules caught.
+    const key = `AIza${"b".repeat(35)}`;
+    await fs.writeFile(TEST_PUBLIC_PATH, `${key}\n`, "utf8");
+    const output = runScanOutput();
+    assert.ok(
+      output.includes(`${TEST_PUBLIC_FILE}:1: google api key`),
+      `Google API key must be flagged; got:\n${output}`,
+    );
+  });
+
   test("still flags a hard secret hidden in a fixture body value", async () => {
     await writeTestFixture({
       note: "token=ghp_abcdefghijklmnopqrstuvwxyz0123456789",


### PR DESCRIPTION
## Summary
A Google API key has a fixed, distinctive shape — the `AIza` prefix plus 35 URL-safe characters — but none of the existing URL or token rules caught a bare key value pasted into a doc, config, or fixture.

Add a `google api key` pattern.

## Validation
- `npm run scan:public-safety` — passes clean on the current tree (no new false positives)
- `npm test -- tests/public-safety.test.mjs` — green, incl. a new detection test