### PR TITLE
feat(registry): add SN93 Bitcast active briefs subnet-api surface

### DIFF
--- a/registry/subnets/bitcast.json
+++ b/registry/subnets/bitcast.json
@@ -97,6 +97,25 @@
         "submitted_by": "glorydavid03023"
       },
       "notes": "Bitcast \"X\" subnet-mechanism repo; README states \"Register a UID on subnet 93\" and \"Subnet ID: 93 (Bittensor mainnet)\". In the team's bitcast-network org."
+    },
+    {
+      "id": "sn-93-bitcast-briefs-api",
+      "name": "Bitcast active briefs API",
+      "kind": "subnet-api",
+      "url": "https://creator.bitcast.network/api/briefs",
+      "provider": "bitcast-network",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/bitcast-network/bitcast",
+        "https://creator.bitcast.network/briefs"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jimcody1995"
+      },
+      "notes": "Public JSON feed of active SN93 content briefs (id_brief, brief_id, brief text, boost, format). Served from the creator portal host; curl-verified 200 application/json with no auth. Distinct from the HTML briefs dashboard at /briefs."
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends **exactly one** new community `subnet-api` surface to one subnet file —
`registry/subnets/bitcast.json` (SN93 Bitcast).

## Surface

- **Netuid:** 93
- **Kind:** subnet-api
- **Public URL:** `https://creator.bitcast.network/api/briefs`
- **Source URLs:** [bitcast-network/bitcast README](https://github.com/bitcast-network/bitcast) (documents the briefs server); [creator briefs portal](https://creator.bitcast.network/briefs) (same host as the API)
- **Provider slug:** `bitcast-network`

Public, no-auth JSON feed of active SN93 content briefs (`id_brief`, `brief_id`, brief text, boost, format). Curl-verified `200 application/json`. Distinct from the registered HTML briefs dashboard at `/briefs`.

`authority: community`, `review.state: community-submitted`; no hand-set health/`verification`/`probe`.

## No linked issue

No open enrichment issue is linked — this is a no-issue surface contribution judged on its own merit: a real public endpoint the registry does not yet list.

## Checklist

- [x] Changes exactly one `registry/subnets/bitcast.json` file (append-only; +19 / -0)
- [x] `authority: community` + `review.state: community-submitted`
- [x] Public-safe: no auth, no secrets, no generated artifacts
- [x] Does not duplicate an existing surface (distinct URL from `/briefs` dashboard)

## Validation

- [x] `npm run validate:surface -- registry/subnets/bitcast.json` → passed (6 surfaces)
- [x] `npm run scan:public-safety` → passed

