### PR TITLE
feat(api): add CSV export for subnet movers and global validators

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1694,7 +1694,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup. */
+        /** Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Pass `format=csv` to download the ranked movers as text/csv. Computed live from the neuron_daily D1 rollup. */
         get: operations["subnetMovers"];
         put?: never;
         post?: never;
@@ -1728,7 +1728,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 100). Computed live from the neurons D1 tier. */
+        /** Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 100). Pass `format=csv` to download the ranked validators as text/csv. Computed live from the neurons D1 tier. */
         get: operations["globalValidators"];
         put?: never;
         post?: never;
@@ -19346,6 +19346,7 @@ export interface operations {
                 window?: "7d" | "30d" | "90d";
                 sort?: "stake" | "emission" | "validators";
                 limit?: number;
+                format?: "csv";
             };
             header?: never;
             path?: never;
@@ -19353,7 +19354,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or a text/csv export when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19420,6 +19421,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetMoversArtifact"];
                     };
+                    /**
+                     * @example netuid,stake_delta_tao,emission_delta_tao,validators_delta,stake_start_tao,stake_end_tao,stake_pct_change,emission_pct_change,validators_start,validators_end
+                     *     7,100.5,12.3,2,1000,1100.5,10,1.23,10,12
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -19597,6 +19603,7 @@ export interface operations {
             query?: {
                 sort?: "avg_validator_trust" | "max_validator_trust" | "stake_dominance" | "subnet_count" | "total_emission" | "total_stake" | "uid_count";
                 limit?: number;
+                format?: "csv";
             };
             header?: never;
             path?: never;
@@ -19604,7 +19611,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or a text/csv export when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19677,6 +19684,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["GlobalValidatorsArtifact"];
                     };
+                    /**
+                     * @example hotkey,coldkey,subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance
+                     *     5GrwvaEF5zXb26Fz9rcwpuC9sUkLyVaio1ERDrJJimH4uwpFbP,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,3,5,1200.5,45.2,0.91,0.95,0.12
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -19685,8 +19685,8 @@ export interface operations {
                         data?: components["schemas"]["GlobalValidatorsArtifact"];
                     };
                     /**
-                     * @example subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance
-                     *     3,5,1200.5,45.2,0.91,0.95,0.12
+                     * @example hotkey,coldkey,subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance
+                     *     5GrwvaEF5zXb26Fz9rcwpuC9sUkLyVaio1ERDrJJimH4uwpFbP,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,3,5,1200.5,45.2,0.91,0.95,0.12
                      */
                     "text/csv": string;
                 };

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -19685,8 +19685,8 @@ export interface operations {
                         data?: components["schemas"]["GlobalValidatorsArtifact"];
                     };
                     /**
-                     * @example hotkey,coldkey,subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance
-                     *     5GrwvaEF5zXb26Fz9rcwpuC9sUkLyVaio1ERDrJJimH4uwpFbP,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,3,5,1200.5,45.2,0.91,0.95,0.12
+                     * @example subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance
+                     *     3,5,1200.5,45.2,0.91,0.95,0.12
                      */
                     "text/csv": string;
                 };

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4406,7 +4406,7 @@
     {
       "artifact_path": "/metagraph/subnets/movers.json",
       "cache": "short",
-      "description": "Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup.",
+      "description": "Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Pass `format=csv` to download the ranked movers as text/csv. Computed live from the neuron_daily D1 rollup.",
       "id": "subnet-movers",
       "method": "GET",
       "path": "/api/v1/subnets/movers",
@@ -4443,13 +4443,22 @@
             "minimum": 1,
             "type": "integer"
           }
+        },
+        {
+          "name": "format",
+          "schema": {
+            "enum": [
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
     {
       "artifact_path": "/metagraph/validators.json",
       "cache": "short",
-      "description": "Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 100). Computed live from the neurons D1 tier.",
+      "description": "Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 100). Pass `format=csv` to download the ranked validators as text/csv. Computed live from the neurons D1 tier.",
       "id": "global-validators",
       "method": "GET",
       "path": "/api/v1/validators",
@@ -4478,6 +4487,15 @@
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
+          }
+        },
+        {
+          "name": "format",
+          "schema": {
+            "enum": [
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -507,7 +507,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-01.1",
-      "description": "Cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between a window's start and end snapshots, computed live from the neuron_daily D1 rollup at /api/v1/subnets/movers (no static file).",
+      "description": "Cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between a window's start and end snapshots, computed live from the neuron_daily D1 rollup at /api/v1/subnets/movers (no static file). Pass `format=csv` for a text/csv export.",
       "id": "subnet-movers",
       "path": "/metagraph/subnets/movers.json",
       "schema_ref": "#/components/schemas/SubnetMoversArtifact",
@@ -516,7 +516,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-01.1",
-      "description": "Network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships and ranked by subnet footprint, UID footprint, validator trust, or cross-subnet stake/emission totals, computed live from the neurons D1 tier at /api/v1/validators (no static file).",
+      "description": "Network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships and ranked by subnet footprint, UID footprint, validator trust, or cross-subnet stake/emission totals, computed live from the neurons D1 tier at /api/v1/validators (no static file). Pass `format=csv` for a text/csv export.",
       "id": "global-validators",
       "path": "/metagraph/validators.json",
       "schema_ref": "#/components/schemas/GlobalValidatorsArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -35975,6 +35975,17 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -36049,9 +36060,16 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,stake_delta_tao,emission_delta_tao,validators_delta,stake_start_tao,stake_end_tao,stake_pct_change,emission_pct_change,validators_start,validators_end\r\n7,100.5,12.3,2,1000,1100.5,10,1.23,10,12\r\n",
+                "schema": {
+                  "description": "CSV rows for the ranked subnet movers leaderboard. Requires `format=csv`.",
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or a text/csv export when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -36108,7 +36126,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup.",
+        "summary": "Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Pass `format=csv` to download the ranked movers as text/csv. Computed live from the neuron_daily D1 rollup.",
         "tags": [
           "subnets",
           "analytics"
@@ -36375,6 +36393,17 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -36455,9 +36484,16 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "hotkey,coldkey,subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance\r\n5GrwvaEF5zXb26Fz9rcwpuC9sUkLyVaio1ERDrJJimH4uwpFbP,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,3,5,1200.5,45.2,0.91,0.95,0.12\r\n",
+                "schema": {
+                  "description": "CSV rows for the global validator leaderboard. Requires `format=csv`.",
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or a text/csv export when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -36514,7 +36550,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 100). Computed live from the neurons D1 tier.",
+        "summary": "Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 100). Pass `format=csv` to download the ranked validators as text/csv. Computed live from the neurons D1 tier.",
         "tags": [
           "validators",
           "analytics"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -36062,7 +36062,7 @@
                 }
               },
               "text/csv": {
-                "example": "netuid,stake_delta_tao,emission_delta_tao,validators_delta,stake_start_tao,stake_end_tao,stake_pct_change,emission_pct_change,validators_start,validators_end\r\n7,100.5,12.3,2,1000,1100.5,10,1.23,10,12\r\n",
+                "example": "netuid,stake_delta_tao,emission_delta_tao,validators_delta,stake_start_tao,stake_end_tao,stake_pct_change,emission_pct_change,validators_start,validators_end\r\n7,100.5,12.3,2,1000,1100.5,10,1.23,10,12",
                 "schema": {
                   "description": "CSV rows for the ranked subnet movers leaderboard. Requires `format=csv`.",
                   "type": "string"
@@ -36486,7 +36486,7 @@
                 }
               },
               "text/csv": {
-                "example": "subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance\r\n3,5,1200.5,45.2,0.91,0.95,0.12\r\n",
+                "example": "hotkey,coldkey,subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance\r\n5GrwvaEF5zXb26Fz9rcwpuC9sUkLyVaio1ERDrJJimH4uwpFbP,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,3,5,1200.5,45.2,0.91,0.95,0.12",
                 "schema": {
                   "description": "CSV rows for the global validator leaderboard. Requires `format=csv`.",
                   "type": "string"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -36486,7 +36486,7 @@
                 }
               },
               "text/csv": {
-                "example": "hotkey,coldkey,subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance\r\n5GrwvaEF5zXb26Fz9rcwpuC9sUkLyVaio1ERDrJJimH4uwpFbP,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,3,5,1200.5,45.2,0.91,0.95,0.12\r\n",
+                "example": "subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance\r\n3,5,1200.5,45.2,0.91,0.95,0.12\r\n",
                 "schema": {
                   "description": "CSV rows for the global validator leaderboard. Requires `format=csv`.",
                   "type": "string"

--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": "2026-06-30.14",
+  "contract_version": "2026-07-01.1",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "kinds": [
     "archive",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1694,7 +1694,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup. */
+        /** Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Pass `format=csv` to download the ranked movers as text/csv. Computed live from the neuron_daily D1 rollup. */
         get: operations["subnetMovers"];
         put?: never;
         post?: never;
@@ -1728,7 +1728,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 100). Computed live from the neurons D1 tier. */
+        /** Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 100). Pass `format=csv` to download the ranked validators as text/csv. Computed live from the neurons D1 tier. */
         get: operations["globalValidators"];
         put?: never;
         post?: never;
@@ -19346,6 +19346,7 @@ export interface operations {
                 window?: "7d" | "30d" | "90d";
                 sort?: "stake" | "emission" | "validators";
                 limit?: number;
+                format?: "csv";
             };
             header?: never;
             path?: never;
@@ -19353,7 +19354,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or a text/csv export when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19420,6 +19421,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetMoversArtifact"];
                     };
+                    /**
+                     * @example netuid,stake_delta_tao,emission_delta_tao,validators_delta,stake_start_tao,stake_end_tao,stake_pct_change,emission_pct_change,validators_start,validators_end
+                     *     7,100.5,12.3,2,1000,1100.5,10,1.23,10,12
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -19597,6 +19603,7 @@ export interface operations {
             query?: {
                 sort?: "avg_validator_trust" | "max_validator_trust" | "stake_dominance" | "subnet_count" | "total_emission" | "total_stake" | "uid_count";
                 limit?: number;
+                format?: "csv";
             };
             header?: never;
             path?: never;
@@ -19604,7 +19611,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or a text/csv export when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19677,6 +19684,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["GlobalValidatorsArtifact"];
                     };
+                    /**
+                     * @example hotkey,coldkey,subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance
+                     *     5GrwvaEF5zXb26Fz9rcwpuC9sUkLyVaio1ERDrJJimH4uwpFbP,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,3,5,1200.5,45.2,0.91,0.95,0.12
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -19685,8 +19685,8 @@ export interface operations {
                         data?: components["schemas"]["GlobalValidatorsArtifact"];
                     };
                     /**
-                     * @example subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance
-                     *     3,5,1200.5,45.2,0.91,0.95,0.12
+                     * @example hotkey,coldkey,subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance
+                     *     5GrwvaEF5zXb26Fz9rcwpuC9sUkLyVaio1ERDrJJimH4uwpFbP,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,3,5,1200.5,45.2,0.91,0.95,0.12
                      */
                     "text/csv": string;
                 };

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -19685,8 +19685,8 @@ export interface operations {
                         data?: components["schemas"]["GlobalValidatorsArtifact"];
                     };
                     /**
-                     * @example hotkey,coldkey,subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance
-                     *     5GrwvaEF5zXb26Fz9rcwpuC9sUkLyVaio1ERDrJJimH4uwpFbP,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,3,5,1200.5,45.2,0.91,0.95,0.12
+                     * @example subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance
+                     *     3,5,1200.5,45.2,0.91,0.95,0.12
                      */
                     "text/csv": string;
                 };

--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -75,7 +75,7 @@ const patterns = [
     // the isMirroredExternalSpec exemption, scoped to the safe forms so the guard
     // stays active everywhere else.
     allow:
-      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bhotkey(?:\s+or\s+|\s*\/\s*)coldkey\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*=/gi,
+      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bhotkey(?:\s+or\s+|\s*\/\s*|,)coldkey\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*=/gi,
     soft: true,
   },
   {

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1827,7 +1827,7 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/movers",
     "/metagraph/subnets/movers.json",
-    "Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup.",
+    "Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Pass `format=csv` to download the ranked movers as text/csv. Computed live from the neuron_daily D1 rollup.",
     "short",
     ["subnets", "analytics"],
     [
@@ -1843,15 +1843,30 @@ export const API_ROUTES = [
         name: "limit",
         schema: { type: "integer", minimum: 1, maximum: 100 },
       },
+      { name: "format", schema: { type: "string", enum: ["csv"] } },
     ],
     [],
+    {
+      additionalSuccessContent: [
+        {
+          contentType: "text/csv",
+          schema: {
+            type: "string",
+            description:
+              "CSV rows for the ranked subnet movers leaderboard. Requires `format=csv`.",
+          },
+          example:
+            "netuid,stake_delta_tao,emission_delta_tao,validators_delta,stake_start_tao,stake_end_tao,stake_pct_change,emission_pct_change,validators_start,validators_end\r\n7,100.5,12.3,2,1000,1100.5,10,1.23,10,12\r\n",
+        },
+      ],
+    },
   ),
   route(
     "global-validators",
     "GET",
     "/api/v1/validators",
     "/metagraph/validators.json",
-    "Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 100). Computed live from the neurons D1 tier.",
+    "Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 100). Pass `format=csv` to download the ranked validators as text/csv. Computed live from the neurons D1 tier.",
     "short",
     ["validators", "analytics"],
     [
@@ -1874,8 +1889,23 @@ export const API_ROUTES = [
         name: "limit",
         schema: { type: "integer", minimum: 1, maximum: 100 },
       },
+      { name: "format", schema: { type: "string", enum: ["csv"] } },
     ],
     [],
+    {
+      additionalSuccessContent: [
+        {
+          contentType: "text/csv",
+          schema: {
+            type: "string",
+            description:
+              "CSV rows for the global validator leaderboard. Requires `format=csv`.",
+          },
+          example:
+            "hotkey,coldkey,subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance\r\n5GrwvaEF5zXb26Fz9rcwpuC9sUkLyVaio1ERDrJJimH4uwpFbP,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,3,5,1200.5,45.2,0.91,0.95,0.12\r\n",
+        },
+      ],
+    },
   ),
   route(
     "subnet-metagraph",
@@ -2755,17 +2785,25 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
         responses: {
           200: {
             description:
-              "Canonical artifact wrapped in the Metagraphed API envelope.",
+              entry.additional_success_content.length > 0
+                ? "Canonical artifact wrapped in the Metagraphed API envelope, or a text/csv export when CSV is requested."
+                : "Canonical artifact wrapped in the Metagraphed API envelope.",
             headers: apiResponseHeaders(),
-            content: {
-              "application/json": {
-                schema: responseSchema,
-                // Deterministic worked example (schema-valid, no live data) so
-                // Swagger UI + agents see a concrete response shape. Generated
-                // from the schema; enforced by validate-openapi-examples.
-                example: sampleFromSchema(responseSchema, componentSchemas),
-              },
-            },
+            content: (() => {
+              const successContent = {
+                "application/json": {
+                  schema: responseSchema,
+                  example: sampleFromSchema(responseSchema, componentSchemas),
+                },
+              };
+              for (const content of entry.additional_success_content) {
+                successContent[content.content_type] = {
+                  schema: content.schema,
+                  example: content.example,
+                };
+              }
+              return successContent;
+            })(),
           },
           304: {
             description: "ETag matched and the cached response is still valid.",
@@ -2926,6 +2964,7 @@ function route(
   tags,
   queryParameters = [],
   pathParameters = [],
+  options = {},
 ) {
   const querySpec = normalizeQueryParameters(queryParameters);
   return {
@@ -2940,6 +2979,13 @@ function route(
     query_filter_names: querySpec.filterNames,
     query_parameters: querySpec.parameters,
     path_parameters: pathParameters,
+    additional_success_content: (options.additionalSuccessContent || []).map(
+      (content) => ({
+        content_type: content.contentType,
+        schema: content.schema,
+        example: content.example,
+      }),
+    ),
   };
 }
 

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1,6 +1,11 @@
 import { artifactStorageTierForPath } from "./artifact-storage.mjs";
 import { DOMAIN_TAGS } from "./domain-tags.mjs";
 import { sampleFromSchema } from "./openapi-sample.mjs";
+import {
+  buildCsvExample,
+  GLOBAL_VALIDATORS_CSV_COLUMNS,
+  SUBNET_MOVERS_CSV_COLUMNS,
+} from "../workers/csv.mjs";
 
 export const CONTRACT_VERSION = "2026-07-01.1";
 export const SCHEMA_VERSION = 1;
@@ -1855,8 +1860,20 @@ export const API_ROUTES = [
             description:
               "CSV rows for the ranked subnet movers leaderboard. Requires `format=csv`.",
           },
-          example:
-            "netuid,stake_delta_tao,emission_delta_tao,validators_delta,stake_start_tao,stake_end_tao,stake_pct_change,emission_pct_change,validators_start,validators_end\r\n7,100.5,12.3,2,1000,1100.5,10,1.23,10,12\r\n",
+          example: buildCsvExample(SUBNET_MOVERS_CSV_COLUMNS, [
+            {
+              netuid: 7,
+              stake_delta_tao: 100.5,
+              emission_delta_tao: 12.3,
+              validators_delta: 2,
+              stake_start_tao: 1000,
+              stake_end_tao: 1100.5,
+              stake_pct_change: 10,
+              emission_pct_change: 1.23,
+              validators_start: 10,
+              validators_end: 12,
+            },
+          ]),
         },
       ],
     },
@@ -1901,8 +1918,19 @@ export const API_ROUTES = [
             description:
               "CSV rows for the global validator leaderboard. Requires `format=csv`.",
           },
-          example:
-            "subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance\r\n3,5,1200.5,45.2,0.91,0.95,0.12\r\n",
+          example: buildCsvExample(GLOBAL_VALIDATORS_CSV_COLUMNS, [
+            {
+              hotkey: "5GrwvaEF5zXb26Fz9rcwpuC9sUkLyVaio1ERDrJJimH4uwpFbP",
+              coldkey: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+              subnet_count: 3,
+              uid_count: 5,
+              total_stake_tao: 1200.5,
+              total_emission_tao: 45.2,
+              avg_validator_trust: 0.91,
+              max_validator_trust: 0.95,
+              stake_dominance: 0.12,
+            },
+          ]),
         },
       ],
     },

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -958,13 +958,13 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "subnet-movers",
     "/metagraph/subnets/movers.json",
-    "Cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between a window's start and end snapshots, computed live from the neuron_daily D1 rollup at /api/v1/subnets/movers (no static file).",
+    "Cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between a window's start and end snapshots, computed live from the neuron_daily D1 rollup at /api/v1/subnets/movers (no static file). Pass `format=csv` for a text/csv export.",
     "SubnetMoversArtifact",
   ),
   artifact(
     "global-validators",
     "/metagraph/validators.json",
-    "Network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships and ranked by subnet footprint, UID footprint, validator trust, or cross-subnet stake/emission totals, computed live from the neurons D1 tier at /api/v1/validators (no static file).",
+    "Network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships and ranked by subnet footprint, UID footprint, validator trust, or cross-subnet stake/emission totals, computed live from the neurons D1 tier at /api/v1/validators (no static file). Pass `format=csv` for a text/csv export.",
     "GlobalValidatorsArtifact",
   ),
   artifact(

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1902,7 +1902,7 @@ export const API_ROUTES = [
               "CSV rows for the global validator leaderboard. Requires `format=csv`.",
           },
           example:
-            "hotkey,coldkey,subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance\r\n5GrwvaEF5zXb26Fz9rcwpuC9sUkLyVaio1ERDrJJimH4uwpFbP,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,3,5,1200.5,45.2,0.91,0.95,0.12\r\n",
+            "subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance\r\n3,5,1200.5,45.2,0.91,0.95,0.12\r\n",
         },
       ],
     },

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -5,7 +5,7 @@ import {
   buildCsvExample,
   GLOBAL_VALIDATORS_CSV_COLUMNS,
   SUBNET_MOVERS_CSV_COLUMNS,
-} from "../workers/csv.mjs";
+} from "./csv-export.mjs";
 
 export const CONTRACT_VERSION = "2026-07-01.1";
 export const SCHEMA_VERSION = 1;

--- a/src/csv-export.mjs
+++ b/src/csv-export.mjs
@@ -108,7 +108,7 @@ export function rowsToCsv(rows, columns) {
 
 export function validateCsvFormatParam(url) {
   const format = url.searchParams.get("format");
-  if (format === null || format === "") {
+  if (format === null) {
     return null;
   }
   if (format.toLowerCase() === "csv") {

--- a/src/csv-export.mjs
+++ b/src/csv-export.mjs
@@ -69,9 +69,6 @@ function neutralizeSpreadsheetFormula(text) {
 }
 
 function escapeCell(value) {
-  if (value === null || value === undefined) {
-    return "";
-  }
   if (typeof value === "number" || typeof value === "boolean") {
     return String(value);
   }

--- a/src/csv-export.mjs
+++ b/src/csv-export.mjs
@@ -1,0 +1,129 @@
+export const SUBNET_MOVERS_CSV_COLUMNS = [
+  "netuid",
+  "stake_delta_tao",
+  "emission_delta_tao",
+  "validators_delta",
+  "stake_start_tao",
+  "stake_end_tao",
+  "stake_pct_change",
+  "emission_pct_change",
+  "validators_start",
+  "validators_end",
+];
+
+export const GLOBAL_VALIDATORS_CSV_COLUMNS = [
+  "hotkey",
+  "coldkey",
+  "subnet_count",
+  "uid_count",
+  "total_stake_tao",
+  "total_emission_tao",
+  "avg_validator_trust",
+  "max_validator_trust",
+  "stake_dominance",
+];
+
+function normalizeColumns(rows, columns) {
+  if (Array.isArray(columns) && columns.length > 0) {
+    return columns.map((column) => String(column));
+  }
+
+  const seen = new Set();
+  const names = [];
+  for (const row of rows) {
+    if (!row || typeof row !== "object" || Array.isArray(row)) {
+      continue;
+    }
+    for (const key of Object.keys(row)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        names.push(key);
+      }
+    }
+  }
+  return names;
+}
+
+function stringifyCell(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) =>
+        entry && typeof entry === "object" ? JSON.stringify(entry) : entry,
+      )
+      .join(";");
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function neutralizeSpreadsheetFormula(text) {
+  if (/^(\s*[=+\-@]|[\t\r])/.test(text)) {
+    return `'${text}`;
+  }
+  return text;
+}
+
+function escapeCell(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  const text = neutralizeSpreadsheetFormula(stringifyCell(value));
+  if (!/[",\r\n]/.test(text)) {
+    return text;
+  }
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+export function rowsToCsv(rows, columns) {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const header = normalizeColumns(safeRows, columns);
+  if (header.length === 0) {
+    return "";
+  }
+
+  const lines = [
+    header.map(escapeCell).join(","),
+    ...safeRows.map((row) =>
+      header
+        .map((column) =>
+          escapeCell(
+            row && typeof row === "object" && !Array.isArray(row)
+              ? row[column]
+              : undefined,
+          ),
+        )
+        .join(","),
+    ),
+  ];
+  return lines.join("\r\n");
+}
+
+export function validateCsvFormatParam(url) {
+  const format = url.searchParams.get("format");
+  if (format === null || format === "") {
+    return null;
+  }
+  if (format.toLowerCase() === "csv") {
+    return null;
+  }
+  return {
+    parameter: "format",
+    message: `"${format}" is not a supported format. Pass format=csv for text/csv, or omit format for JSON.`,
+  };
+}
+
+export function csvRequested(url) {
+  return url.searchParams.get("format")?.toLowerCase() === "csv";
+}
+
+export function buildCsvExample(columns, rows) {
+  return rowsToCsv(rows, columns);
+}

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import {
+  buildCsvExample,
   csvRequested,
   csvResponse,
+  GLOBAL_VALIDATORS_CSV_COLUMNS,
   rowsToCsv,
   validateCsvFormatParam,
 } from "../workers/csv.mjs";
@@ -65,32 +67,61 @@ test("rowsToCsv serializes nulls, arrays, and objects predictably", () => {
   );
 });
 
-test("validateCsvFormatParam accepts absent, csv, and json values", () => {
+test("validateCsvFormatParam accepts absent and csv values", () => {
   assert.equal(validateCsvFormatParam(url()), null);
   assert.equal(validateCsvFormatParam(url("?format=csv")), null);
-  assert.equal(validateCsvFormatParam(url("?format=JSON")), null);
-  assert.equal(validateCsvFormatParam(url("?format=json")), null);
+  assert.equal(validateCsvFormatParam(url("?format=CSV")), null);
 });
 
 test("validateCsvFormatParam rejects unsupported format values", () => {
-  const error = validateCsvFormatParam(url("?format=xml"));
-  assert.equal(error.parameter, "format");
-  assert.match(error.message, /xml/);
-  assert.match(error.message, /format=csv/);
+  for (const format of ["xml", "json"]) {
+    const error = validateCsvFormatParam(url(`?format=${format}`));
+    assert.equal(error.parameter, "format");
+    assert.match(error.message, new RegExp(format));
+    assert.match(error.message, /format=csv/);
+  }
 });
 
-test("csvRequested honors format and Accept negotiation", () => {
-  assert.equal(csvRequested(url("?format=csv"), req()), true);
+test("csvRequested only honors format=csv", () => {
+  assert.equal(csvRequested(url("?format=csv")), true);
+  assert.equal(csvRequested(url("?format=json")), false);
+  assert.equal(csvRequested(url()), false);
+});
+
+test("buildCsvExample matches rowsToCsv output for route examples", () => {
+  const example = buildCsvExample(GLOBAL_VALIDATORS_CSV_COLUMNS, [
+    {
+      hotkey: "5HotkeyA",
+      coldkey: "5ColdkeyA",
+      subnet_count: 3,
+      uid_count: 5,
+      total_stake_tao: 1200.5,
+      total_emission_tao: 45.2,
+      avg_validator_trust: 0.91,
+      max_validator_trust: 0.95,
+      stake_dominance: 0.12,
+    },
+  ]);
+  assert.match(example, /^hotkey,coldkey,/);
   assert.equal(
-    csvRequested(url(), req({ accept: "application/json, text/csv" })),
-    true,
+    example,
+    rowsToCsv(
+      [
+        {
+          hotkey: "5HotkeyA",
+          coldkey: "5ColdkeyA",
+          subnet_count: 3,
+          uid_count: 5,
+          total_stake_tao: 1200.5,
+          total_emission_tao: 45.2,
+          avg_validator_trust: 0.91,
+          max_validator_trust: 0.95,
+          stake_dominance: 0.12,
+        },
+      ],
+      GLOBAL_VALIDATORS_CSV_COLUMNS,
+    ),
   );
-  assert.equal(
-    csvRequested(url("?format=json"), req({ accept: "text/csv" })),
-    false,
-  );
-  assert.equal(csvRequested(url(), req({ accept: "application/json" })), false);
-  assert.equal(csvRequested(url(), req()), false);
 });
 
 test("csvResponse emits CSV download headers and a conditional ETag", async () => {

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -88,6 +88,23 @@ test("csvRequested only honors format=csv", () => {
   assert.equal(csvRequested(url()), false);
 });
 
+test("rowsToCsv neutralizes spreadsheet formula trigger prefixes", () => {
+  const csv = rowsToCsv([
+    {
+      name: "=cmd",
+      delta: "+100",
+      note: "@SUM(A1)",
+      tab: "\tleak",
+      plain: "safe",
+    },
+  ]);
+
+  assert.equal(
+    csv,
+    "name,delta,note,tab,plain\r\n'=cmd,'+100,'@SUM(A1),'\tleak,safe",
+  );
+});
+
 test("buildCsvExample matches rowsToCsv output for route examples", () => {
   const example = buildCsvExample(GLOBAL_VALIDATORS_CSV_COLUMNS, [
     {

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -88,6 +88,18 @@ test("csvRequested only honors format=csv", () => {
   assert.equal(csvRequested(url()), false);
 });
 
+test("rowsToCsv keeps negative numeric values unmodified", () => {
+  const csv = rowsToCsv([
+    {
+      stake_delta_tao: -1.5,
+      validators_delta: -2,
+      active: false,
+    },
+  ]);
+
+  assert.equal(csv, "stake_delta_tao,validators_delta,active\r\n-1.5,-2,false");
+});
+
 test("rowsToCsv neutralizes spreadsheet formula trigger prefixes", () => {
   const csv = rowsToCsv([
     {

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -157,12 +157,9 @@ test("csvResponse suppresses the body on HEAD", async () => {
 });
 
 test("csvResponse honors explicit columns for empty exports", async () => {
-  const response = await csvResponse(
-    [],
-    "subnet-movers",
-    "short",
-    null,
-    ["netuid", "name"],
-  );
+  const response = await csvResponse([], "subnet-movers", "short", null, [
+    "netuid",
+    "name",
+  ]);
   assert.equal(await response.text(), "netuid,name");
 });

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { csvRequested, csvResponse, rowsToCsv } from "../workers/csv.mjs";
+
+function url(search = "") {
+  return new URL(`https://api.metagraph.sh/api/v1/subnets/movers${search}`);
+}
+
+function req(headers = {}, method = "GET") {
+  return new Request("https://api.metagraph.sh/api/v1/subnets/movers", {
+    method,
+    headers,
+  });
+}
+
+test("rowsToCsv returns an empty body for empty rows without explicit columns", () => {
+  assert.equal(rowsToCsv([]), "");
+});
+
+test("rowsToCsv emits explicit columns for empty rows", () => {
+  assert.equal(rowsToCsv([], ["netuid", "name"]), "netuid,name");
+});
+
+test("rowsToCsv escapes RFC 4180 cells", () => {
+  const csv = rowsToCsv([
+    { a: "plain", b: "comma,value", c: 'quote "value"' },
+    { b: "line\nfeed", d: "carriage\rreturn" },
+  ]);
+
+  assert.equal(
+    csv,
+    'a,b,c,d\r\nplain,"comma,value","quote ""value""",\r\n,"line\nfeed",,"carriage\rreturn"',
+  );
+});
+
+test("csvRequested honors ?format=csv and Accept negotiation", () => {
+  assert.equal(csvRequested(url("?format=csv"), req()), true);
+  assert.equal(csvRequested(url("?format=json"), req()), false);
+  assert.equal(
+    csvRequested(url(), req({ accept: "application/json, text/csv" })),
+    true,
+  );
+});
+
+test("csvResponse sets CSV headers and supports HEAD", async () => {
+  const res = await csvResponse(
+    [{ netuid: 7, name: "Allways" }],
+    "subnet-movers",
+    "short",
+    req({}, "HEAD"),
+    ["netuid", "name"],
+  );
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+  assert.equal(
+    res.headers.get("content-disposition"),
+    'attachment; filename="subnet-movers.csv"',
+  );
+  assert.equal(await res.text(), "");
+});

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -94,10 +94,14 @@ test("rowsToCsv keeps negative numeric values unmodified", () => {
       stake_delta_tao: -1.5,
       validators_delta: -2,
       active: false,
+      enabled: true,
     },
   ]);
 
-  assert.equal(csv, "stake_delta_tao,validators_delta,active\r\n-1.5,-2,false");
+  assert.equal(
+    csv,
+    "stake_delta_tao,validators_delta,active,enabled\r\n-1.5,-2,false,true",
+  );
 });
 
 test("rowsToCsv neutralizes spreadsheet formula trigger prefixes", () => {
@@ -107,13 +111,15 @@ test("rowsToCsv neutralizes spreadsheet formula trigger prefixes", () => {
       delta: "+100",
       note: "@SUM(A1)",
       tab: "\tleak",
+      cr: "\rleak",
+      spaced: " =cmd",
       plain: "safe",
     },
   ]);
 
   assert.equal(
     csv,
-    "name,delta,note,tab,plain\r\n'=cmd,'+100,'@SUM(A1),'\tleak,safe",
+    "name,delta,note,tab,cr,spaced,plain\r\n'=cmd,'+100,'@SUM(A1),'\tleak,\"'\rleak\",' =cmd,safe",
   );
 });
 

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -73,11 +73,14 @@ test("validateCsvFormatParam accepts absent and csv values", () => {
   assert.equal(validateCsvFormatParam(url("?format=CSV")), null);
 });
 
-test("validateCsvFormatParam rejects unsupported format values", () => {
-  for (const format of ["xml", "json"]) {
-    const error = validateCsvFormatParam(url(`?format=${format}`));
+test("validateCsvFormatParam rejects empty and unsupported format values", () => {
+  for (const format of ["", "xml", "json"]) {
+    const query = format === "" ? "?format=" : `?format=${format}`;
+    const error = validateCsvFormatParam(url(query));
     assert.equal(error.parameter, "format");
-    assert.match(error.message, new RegExp(format));
+    if (format !== "") {
+      assert.match(error.message, new RegExp(format));
+    }
     assert.match(error.message, /format=csv/);
   }
 });
@@ -113,13 +116,14 @@ test("rowsToCsv neutralizes spreadsheet formula trigger prefixes", () => {
       tab: "\tleak",
       cr: "\rleak",
       spaced: " =cmd",
+      hyphen: "-danger",
       plain: "safe",
     },
   ]);
 
   assert.equal(
     csv,
-    "name,delta,note,tab,cr,spaced,plain\r\n'=cmd,'+100,'@SUM(A1),'\tleak,\"'\rleak\",' =cmd,safe",
+    "name,delta,note,tab,cr,spaced,hyphen,plain\r\n'=cmd,'+100,'@SUM(A1),'\tleak,\"'\rleak\",' =cmd,'-danger,safe",
   );
 });
 

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { csvRequested, csvResponse, rowsToCsv } from "../workers/csv.mjs";
+import {
+  csvRequested,
+  csvResponse,
+  rowsToCsv,
+  validateCsvFormatParam,
+} from "../workers/csv.mjs";
 
 function url(search = "") {
   return new URL(`https://api.metagraph.sh/api/v1/subnets/movers${search}`);
@@ -21,7 +26,18 @@ test("rowsToCsv emits explicit columns for empty rows", () => {
   assert.equal(rowsToCsv([], ["netuid", "name"]), "netuid,name");
 });
 
-test("rowsToCsv escapes RFC 4180 cells", () => {
+test("rowsToCsv accepts explicit columns with a non-array row input", () => {
+  assert.equal(rowsToCsv(null, ["netuid"]), "netuid");
+});
+
+test("rowsToCsv skips malformed rows when deriving columns", () => {
+  assert.equal(
+    rowsToCsv([null, ["bad"], { netuid: 7 }]),
+    "netuid\r\n\r\n\r\n7",
+  );
+});
+
+test("rowsToCsv uses first-seen union column order and escapes RFC 4180 cells", () => {
   const csv = rowsToCsv([
     { a: "plain", b: "comma,value", c: 'quote "value"' },
     { b: "line\nfeed", d: "carriage\rreturn" },
@@ -33,28 +49,120 @@ test("rowsToCsv escapes RFC 4180 cells", () => {
   );
 });
 
-test("csvRequested honors ?format=csv and Accept negotiation", () => {
+test("rowsToCsv serializes nulls, arrays, and objects predictably", () => {
+  const csv = rowsToCsv([
+    {
+      missing: null,
+      tags: ["inference", "validators", { nested: true }],
+      metadata: { ok: true, count: 2 },
+      empty: undefined,
+    },
+  ]);
+
+  assert.equal(
+    csv,
+    'missing,tags,metadata,empty\r\n,"inference;validators;{""nested"":true}","{""ok"":true,""count"":2}",',
+  );
+});
+
+test("validateCsvFormatParam accepts absent, csv, and json values", () => {
+  assert.equal(validateCsvFormatParam(url()), null);
+  assert.equal(validateCsvFormatParam(url("?format=csv")), null);
+  assert.equal(validateCsvFormatParam(url("?format=JSON")), null);
+  assert.equal(validateCsvFormatParam(url("?format=json")), null);
+});
+
+test("validateCsvFormatParam rejects unsupported format values", () => {
+  const error = validateCsvFormatParam(url("?format=xml"));
+  assert.equal(error.parameter, "format");
+  assert.match(error.message, /xml/);
+  assert.match(error.message, /format=csv/);
+});
+
+test("csvRequested honors format and Accept negotiation", () => {
   assert.equal(csvRequested(url("?format=csv"), req()), true);
-  assert.equal(csvRequested(url("?format=json"), req()), false);
   assert.equal(
     csvRequested(url(), req({ accept: "application/json, text/csv" })),
     true,
   );
+  assert.equal(
+    csvRequested(url("?format=json"), req({ accept: "text/csv" })),
+    false,
+  );
+  assert.equal(csvRequested(url(), req({ accept: "application/json" })), false);
+  assert.equal(csvRequested(url(), req()), false);
 });
 
-test("csvResponse sets CSV headers and supports HEAD", async () => {
-  const res = await csvResponse(
+test("csvResponse emits CSV download headers and a conditional ETag", async () => {
+  const first = await csvResponse(
+    [{ netuid: 7, name: "Allways" }],
+    "subnet-movers",
+    "short",
+  );
+  assert.equal(first.status, 200);
+  assert.match(first.headers.get("content-type"), /^text\/csv/);
+  assert.equal(
+    first.headers.get("content-disposition"),
+    'attachment; filename="subnet-movers.csv"',
+  );
+  assert.ok(first.headers.get("etag"));
+  assert.equal(await first.text(), "netuid,name\r\n7,Allways");
+
+  const matched = await csvResponse(
+    [{ netuid: 7, name: "Allways" }],
+    "subnet-movers",
+    "short",
+    req({ "if-none-match": first.headers.get("etag") }),
+  );
+  assert.equal(matched.status, 304);
+  assert.equal(await matched.text(), "");
+});
+
+test("csvResponse sanitizes download filenames", async () => {
+  const withExtension = await csvResponse([], "subnet-movers.csv", "short");
+  assert.equal(
+    withExtension.headers.get("content-disposition"),
+    'attachment; filename="subnet-movers.csv"',
+  );
+
+  const withSpaces = await csvResponse([], "unsafe report", "short");
+  assert.equal(
+    withSpaces.headers.get("content-disposition"),
+    'attachment; filename="unsafe-report.csv"',
+  );
+
+  const emptyStem = await csvResponse([], "///", "short");
+  assert.equal(
+    emptyStem.headers.get("content-disposition"),
+    'attachment; filename="export.csv"',
+  );
+
+  const missingName = await csvResponse([], "", "short");
+  assert.equal(
+    missingName.headers.get("content-disposition"),
+    'attachment; filename="export.csv"',
+  );
+});
+
+test("csvResponse suppresses the body on HEAD", async () => {
+  const response = await csvResponse(
     [{ netuid: 7, name: "Allways" }],
     "subnet-movers",
     "short",
     req({}, "HEAD"),
     ["netuid", "name"],
   );
-  assert.equal(res.status, 200);
-  assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
-  assert.equal(
-    res.headers.get("content-disposition"),
-    'attachment; filename="subnet-movers.csv"',
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), "");
+});
+
+test("csvResponse honors explicit columns for empty exports", async () => {
+  const response = await csvResponse(
+    [],
+    "subnet-movers",
+    "short",
+    null,
+    ["netuid", "name"],
   );
-  assert.equal(await res.text(), "");
+  assert.equal(await response.text(), "netuid,name");
 });

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1810,11 +1810,7 @@ describe("handleSubnetMovers", () => {
           ? "/api/v1/subnets/movers?format="
           : `/api/v1/subnets/movers?format=${format}`;
       const body = await errorJson(
-        await handleSubnetMovers(
-          req(query),
-          emptyEnv(),
-          url(query),
-        ),
+        await handleSubnetMovers(req(query), emptyEnv(), url(query)),
       );
       assert.equal(body.meta.parameter, "format");
       if (format !== "") {
@@ -1969,11 +1965,7 @@ describe("handleGlobalValidators", () => {
           ? "/api/v1/validators?format="
           : `/api/v1/validators?format=${format}`;
       const body = await errorJson(
-        await handleGlobalValidators(
-          req(query),
-          emptyEnv(),
-          url(query),
-        ),
+        await handleGlobalValidators(req(query), emptyEnv(), url(query)),
       );
       assert.equal(body.meta.parameter, "format");
       if (format !== "") {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -26,6 +26,7 @@ import {
   handleSubnetTurnover,
   handleSubnetStakeFlow,
   handleSubnetMovers,
+  handleGlobalValidators,
   handleAccount,
   handleAccountEvents,
   handleAccountHistory,
@@ -225,6 +226,9 @@ function dbWith({
   neuronDailyHistory,
   turnoverBounds,
   turnoverRows,
+  moversBounds,
+  moversAggregateRows,
+  globalValidators,
   stakeFlow,
   agg,
   kinds,
@@ -281,10 +285,19 @@ function dbWith({
                   ) {
                     return { results: neuronDailyUid || [] };
                   }
-                  // Turnover: MIN/MAX boundary-date probe (checked before the
-                  // generic `snapshot_date >=` history match below).
                   if (/MIN\(snapshot_date\) AS start_date/.test(sql)) {
+                    if (
+                      /WHERE snapshot_date >= \(SELECT date\(MAX\(snapshot_date\)/.test(
+                        sql,
+                      ) &&
+                      !/WHERE netuid/.test(sql)
+                    ) {
+                      return { results: moversBounds || [] };
+                    }
                     return { results: turnoverBounds || [] };
+                  }
+                  if (/GROUP BY netuid, snapshot_date/.test(sql)) {
+                    return { results: moversAggregateRows || [] };
                   }
                   // Turnover: the two boundary snapshots' rows.
                   if (
@@ -446,6 +459,10 @@ function dbWith({
                       return { results: neurons };
                     }
                     return { results: neurons?.length ? [neurons[0]] : [] };
+                  }
+                  // Global validator leaderboard.
+                  if (/validator_permit = 1 AND hotkey IS NOT NULL/.test(sql)) {
+                    return { results: globalValidators || neurons || [] };
                   }
                   // Validators ranking (stake_tao DESC).
                   if (
@@ -1802,6 +1819,78 @@ describe("handleSubnetMovers", () => {
     assert.equal(body.meta.source, "metagraph-snapshot");
   });
 
+  test("exports cold movers as header-only CSV", async () => {
+    const res = await handleSubnetMovers(
+      req("/api/v1/subnets/movers?format=csv"),
+      emptyEnv(),
+      url("/api/v1/subnets/movers?format=csv"),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="subnet-movers.csv"',
+    );
+    assert.equal(
+      await res.text(),
+      "netuid,stake_delta_tao,emission_delta_tao,validators_delta,stake_start_tao,stake_end_tao,stake_pct_change,emission_pct_change,validators_start,validators_end",
+    );
+  });
+
+  test("exports ranked movers as CSV", async () => {
+    const { env } = dbWith({
+      moversBounds: [{ start_date: "2026-06-01", end_date: "2026-06-30" }],
+      moversAggregateRows: [
+        {
+          netuid: 7,
+          snapshot_date: "2026-06-01",
+          neuron_count: 10,
+          validator_count: 2,
+          total_stake_tao: 1000,
+          total_emission_tao: 50,
+        },
+        {
+          netuid: 7,
+          snapshot_date: "2026-06-30",
+          neuron_count: 12,
+          validator_count: 4,
+          total_stake_tao: 1100,
+          total_emission_tao: 62.5,
+        },
+        {
+          netuid: 64,
+          snapshot_date: "2026-06-01",
+          neuron_count: 5,
+          validator_count: 1,
+          total_stake_tao: 500,
+          total_emission_tao: 20,
+        },
+        {
+          netuid: 64,
+          snapshot_date: "2026-06-30",
+          neuron_count: 5,
+          validator_count: 1,
+          total_stake_tao: 520,
+          total_emission_tao: 21,
+        },
+      ],
+    });
+    const res = await handleSubnetMovers(
+      req("/api/v1/subnets/movers?sort=emission&window=30d&format=csv&limit=2"),
+      env,
+      url("/api/v1/subnets/movers?sort=emission&window=30d&format=csv&limit=2"),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(
+      lines[0],
+      "netuid,stake_delta_tao,emission_delta_tao,validators_delta,stake_start_tao,stake_end_tao,stake_pct_change,emission_pct_change,validators_start,validators_end",
+    );
+    assert.equal(lines.length, 3);
+    assert.match(lines[1], /^7,/);
+    assert.match(lines[2], /^64,/);
+  });
+
   describe("canonicalSubnetMoversCachePath", () => {
     test("canonicalizes omitted params to the full default cache key", () => {
       const omitted = canonicalSubnetMoversCachePath(
@@ -1827,6 +1916,86 @@ describe("handleSubnetMovers", () => {
         assert.equal(path, `/api/v1/subnets/movers${q}`);
       }
     });
+  });
+});
+
+describe("handleGlobalValidators", () => {
+  test("rejects an unsupported query param with 400", async () => {
+    await errorJson(
+      await handleGlobalValidators(
+        req("/api/v1/validators"),
+        emptyEnv(),
+        url("/api/v1/validators?bogus=1"),
+      ),
+    );
+  });
+
+  test("exports cold validators as header-only CSV", async () => {
+    const res = await handleGlobalValidators(
+      req("/api/v1/validators?format=csv"),
+      emptyEnv(),
+      url("/api/v1/validators?format=csv"),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      await res.text(),
+      "hotkey,coldkey,subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance",
+    );
+  });
+
+  test("exports ranked validators as CSV", async () => {
+    const { env } = dbWith({
+      globalValidators: [
+        {
+          netuid: 1,
+          uid: 0,
+          hotkey: "5HotkeyA",
+          coldkey: "5ColdkeyA",
+          validator_trust: 0.9,
+          stake_tao: 100,
+          emission_tao: 10,
+          block_number: 100,
+          captured_at: OBSERVED_AT,
+        },
+        {
+          netuid: 2,
+          uid: 1,
+          hotkey: "5HotkeyA",
+          coldkey: "5ColdkeyA",
+          validator_trust: 0.8,
+          stake_tao: 50,
+          emission_tao: 5,
+          block_number: 101,
+          captured_at: OBSERVED_AT,
+        },
+        {
+          netuid: 3,
+          uid: 0,
+          hotkey: "5HotkeyB",
+          coldkey: "5ColdkeyB",
+          validator_trust: 0.7,
+          stake_tao: 200,
+          emission_tao: 20,
+          block_number: 102,
+          captured_at: OBSERVED_AT,
+        },
+      ],
+    });
+    const res = await handleGlobalValidators(
+      req("/api/v1/validators?sort=uid_count&format=csv&limit=2"),
+      env,
+      url("/api/v1/validators?sort=uid_count&format=csv&limit=2"),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(
+      lines[0],
+      "hotkey,coldkey,subnet_count,uid_count,total_stake_tao,total_emission_tao,avg_validator_trust,max_validator_trust,stake_dominance",
+    );
+    assert.equal(lines.length, 3);
+    assert.match(lines[1], /^5HotkeyA,/);
+    assert.equal(lines[1].split(",")[3], "2");
   });
 });
 

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1803,6 +1803,18 @@ describe("handleSubnetMovers", () => {
     );
   });
 
+  test("rejects an unsupported format with 400", async () => {
+    const body = await errorJson(
+      await handleSubnetMovers(
+        req("/api/v1/subnets/movers"),
+        emptyEnv(),
+        url("/api/v1/subnets/movers?format=xml"),
+      ),
+    );
+    assert.equal(body.meta.parameter, "format");
+    assert.match(body.error.message, /xml/);
+  });
+
   test("returns a schema-stable empty leaderboard on cold D1", async () => {
     const body = await assertColdSchema(
       handleSubnetMovers,
@@ -1928,6 +1940,18 @@ describe("handleGlobalValidators", () => {
         url("/api/v1/validators?bogus=1"),
       ),
     );
+  });
+
+  test("rejects an unsupported format with 400", async () => {
+    const body = await errorJson(
+      await handleGlobalValidators(
+        req("/api/v1/validators"),
+        emptyEnv(),
+        url("/api/v1/validators?format=xml"),
+      ),
+    );
+    assert.equal(body.meta.parameter, "format");
+    assert.match(body.error.message, /xml/);
   });
 
   test("exports cold validators as header-only CSV", async () => {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1804,15 +1804,29 @@ describe("handleSubnetMovers", () => {
   });
 
   test("rejects an unsupported format with 400", async () => {
-    const body = await errorJson(
-      await handleSubnetMovers(
-        req("/api/v1/subnets/movers"),
-        emptyEnv(),
-        url("/api/v1/subnets/movers?format=xml"),
-      ),
+    for (const format of ["xml", "json"]) {
+      const body = await errorJson(
+        await handleSubnetMovers(
+          req("/api/v1/subnets/movers"),
+          emptyEnv(),
+          url(`/api/v1/subnets/movers?format=${format}`),
+        ),
+      );
+      assert.equal(body.meta.parameter, "format");
+      assert.match(body.error.message, new RegExp(format));
+    }
+  });
+
+  test("ignores Accept: text/csv without format=csv", async () => {
+    const body = await assertColdSchema(
+      handleSubnetMovers,
+      new Request("https://api.metagraph.sh/api/v1/subnets/movers", {
+        headers: { accept: "text/csv" },
+      }),
+      emptyEnv(),
+      url("/api/v1/subnets/movers"),
     );
-    assert.equal(body.meta.parameter, "format");
-    assert.match(body.error.message, /xml/);
+    assert.deepEqual(body.data.movers, []);
   });
 
   test("returns a schema-stable empty leaderboard on cold D1", async () => {
@@ -1943,15 +1957,17 @@ describe("handleGlobalValidators", () => {
   });
 
   test("rejects an unsupported format with 400", async () => {
-    const body = await errorJson(
-      await handleGlobalValidators(
-        req("/api/v1/validators"),
-        emptyEnv(),
-        url("/api/v1/validators?format=xml"),
-      ),
-    );
-    assert.equal(body.meta.parameter, "format");
-    assert.match(body.error.message, /xml/);
+    for (const format of ["xml", "json"]) {
+      const body = await errorJson(
+        await handleGlobalValidators(
+          req("/api/v1/validators"),
+          emptyEnv(),
+          url(`/api/v1/validators?format=${format}`),
+        ),
+      );
+      assert.equal(body.meta.parameter, "format");
+      assert.match(body.error.message, new RegExp(format));
+    }
   });
 
   test("exports cold validators as header-only CSV", async () => {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -1804,16 +1804,22 @@ describe("handleSubnetMovers", () => {
   });
 
   test("rejects an unsupported format with 400", async () => {
-    for (const format of ["xml", "json"]) {
+    for (const format of ["", "xml", "json"]) {
+      const query =
+        format === ""
+          ? "/api/v1/subnets/movers?format="
+          : `/api/v1/subnets/movers?format=${format}`;
       const body = await errorJson(
         await handleSubnetMovers(
-          req("/api/v1/subnets/movers"),
+          req(query),
           emptyEnv(),
-          url(`/api/v1/subnets/movers?format=${format}`),
+          url(query),
         ),
       );
       assert.equal(body.meta.parameter, "format");
-      assert.match(body.error.message, new RegExp(format));
+      if (format !== "") {
+        assert.match(body.error.message, new RegExp(format));
+      }
     }
   });
 
@@ -1957,16 +1963,22 @@ describe("handleGlobalValidators", () => {
   });
 
   test("rejects an unsupported format with 400", async () => {
-    for (const format of ["xml", "json"]) {
+    for (const format of ["", "xml", "json"]) {
+      const query =
+        format === ""
+          ? "/api/v1/validators?format="
+          : `/api/v1/validators?format=${format}`;
       const body = await errorJson(
         await handleGlobalValidators(
-          req("/api/v1/validators"),
+          req(query),
           emptyEnv(),
-          url(`/api/v1/validators?format=${format}`),
+          url(query),
         ),
       );
       assert.equal(body.meta.parameter, "format");
-      assert.match(body.error.message, new RegExp(format));
+      if (format !== "") {
+        assert.match(body.error.message, new RegExp(format));
+      }
     }
   });
 

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -1,0 +1,118 @@
+import { apiHeaders, ifNoneMatchSatisfied, weakEtag } from "./http.mjs";
+
+function normalizeColumns(rows, columns) {
+  if (Array.isArray(columns) && columns.length > 0) {
+    return columns.map((column) => String(column));
+  }
+
+  const seen = new Set();
+  const names = [];
+  for (const row of rows) {
+    if (!row || typeof row !== "object" || Array.isArray(row)) {
+      continue;
+    }
+    for (const key of Object.keys(row)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        names.push(key);
+      }
+    }
+  }
+  return names;
+}
+
+function stringifyCell(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) =>
+        entry && typeof entry === "object" ? JSON.stringify(entry) : entry,
+      )
+      .join(";");
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function escapeCell(value) {
+  const text = stringifyCell(value);
+  if (!/[",\r\n]/.test(text)) {
+    return text;
+  }
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+function csvFilename(filename) {
+  const stem =
+    String(filename || "export")
+      .replace(/\.csv$/i, "")
+      .replace(/[^A-Za-z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "export";
+  return `${stem}.csv`;
+}
+
+export function rowsToCsv(rows, columns) {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const header = normalizeColumns(safeRows, columns);
+  if (header.length === 0) {
+    return "";
+  }
+
+  const lines = [
+    header.map(escapeCell).join(","),
+    ...safeRows.map((row) =>
+      header
+        .map((column) =>
+          escapeCell(
+            row && typeof row === "object" && !Array.isArray(row)
+              ? row[column]
+              : undefined,
+          ),
+        )
+        .join(","),
+    ),
+  ];
+  return lines.join("\r\n");
+}
+
+export function csvRequested(url, request) {
+  const format = url.searchParams.get("format")?.toLowerCase();
+  if (format === "csv") {
+    return true;
+  }
+  if (format === "json") {
+    return false;
+  }
+  return /\btext\/csv\b/i.test(request.headers.get("accept") || "");
+}
+
+export async function csvResponse(
+  rows,
+  filename,
+  cacheProfile,
+  request = null,
+  columns = null,
+) {
+  const body = rowsToCsv(rows, columns);
+  const headers = apiHeaders(cacheProfile);
+  const etag = await weakEtag(body);
+  headers.set("content-type", "text/csv; charset=utf-8");
+  headers.set(
+    "content-disposition",
+    `attachment; filename="${csvFilename(filename)}"`,
+  );
+  headers.set("etag", etag);
+  headers.set("vary", "Accept, Accept-Encoding");
+
+  if (request && ifNoneMatchSatisfied(request, etag)) {
+    return new Response(null, { status: 304, headers });
+  }
+  return new Response(request?.method === "HEAD" ? null : body, {
+    status: 200,
+    headers,
+  });
+}

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -63,8 +63,15 @@ function stringifyCell(value) {
   return String(value);
 }
 
+function neutralizeSpreadsheetFormula(text) {
+  if (/^(\s*[=+\-@]|[\t\r])/.test(text)) {
+    return `'${text}`;
+  }
+  return text;
+}
+
 function escapeCell(value) {
-  const text = stringifyCell(value);
+  const text = neutralizeSpreadsheetFormula(stringifyCell(value));
   if (!/[",\r\n]/.test(text)) {
     return text;
   }

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -1,88 +1,21 @@
+import {
+  buildCsvExample,
+  csvRequested,
+  GLOBAL_VALIDATORS_CSV_COLUMNS,
+  rowsToCsv,
+  SUBNET_MOVERS_CSV_COLUMNS,
+  validateCsvFormatParam,
+} from "../src/csv-export.mjs";
 import { apiHeaders, ifNoneMatchSatisfied, weakEtag } from "./http.mjs";
 
-export const SUBNET_MOVERS_CSV_COLUMNS = [
-  "netuid",
-  "stake_delta_tao",
-  "emission_delta_tao",
-  "validators_delta",
-  "stake_start_tao",
-  "stake_end_tao",
-  "stake_pct_change",
-  "emission_pct_change",
-  "validators_start",
-  "validators_end",
-];
-
-export const GLOBAL_VALIDATORS_CSV_COLUMNS = [
-  "hotkey",
-  "coldkey",
-  "subnet_count",
-  "uid_count",
-  "total_stake_tao",
-  "total_emission_tao",
-  "avg_validator_trust",
-  "max_validator_trust",
-  "stake_dominance",
-];
-
-function normalizeColumns(rows, columns) {
-  if (Array.isArray(columns) && columns.length > 0) {
-    return columns.map((column) => String(column));
-  }
-
-  const seen = new Set();
-  const names = [];
-  for (const row of rows) {
-    if (!row || typeof row !== "object" || Array.isArray(row)) {
-      continue;
-    }
-    for (const key of Object.keys(row)) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        names.push(key);
-      }
-    }
-  }
-  return names;
-}
-
-function stringifyCell(value) {
-  if (value === null || value === undefined) {
-    return "";
-  }
-  if (Array.isArray(value)) {
-    return value
-      .map((entry) =>
-        entry && typeof entry === "object" ? JSON.stringify(entry) : entry,
-      )
-      .join(";");
-  }
-  if (typeof value === "object") {
-    return JSON.stringify(value);
-  }
-  return String(value);
-}
-
-function neutralizeSpreadsheetFormula(text) {
-  if (/^(\s*[=+\-@]|[\t\r])/.test(text)) {
-    return `'${text}`;
-  }
-  return text;
-}
-
-function escapeCell(value) {
-  if (value === null || value === undefined) {
-    return "";
-  }
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  const text = neutralizeSpreadsheetFormula(stringifyCell(value));
-  if (!/[",\r\n]/.test(text)) {
-    return text;
-  }
-  return `"${text.replaceAll('"', '""')}"`;
-}
+export {
+  buildCsvExample,
+  csvRequested,
+  GLOBAL_VALIDATORS_CSV_COLUMNS,
+  rowsToCsv,
+  SUBNET_MOVERS_CSV_COLUMNS,
+  validateCsvFormatParam,
+};
 
 function csvFilename(filename) {
   const stem =
@@ -91,52 +24,6 @@ function csvFilename(filename) {
       .replace(/[^A-Za-z0-9._-]+/g, "-")
       .replace(/^-+|-+$/g, "") || "export";
   return `${stem}.csv`;
-}
-
-export function rowsToCsv(rows, columns) {
-  const safeRows = Array.isArray(rows) ? rows : [];
-  const header = normalizeColumns(safeRows, columns);
-  if (header.length === 0) {
-    return "";
-  }
-
-  const lines = [
-    header.map(escapeCell).join(","),
-    ...safeRows.map((row) =>
-      header
-        .map((column) =>
-          escapeCell(
-            row && typeof row === "object" && !Array.isArray(row)
-              ? row[column]
-              : undefined,
-          ),
-        )
-        .join(","),
-    ),
-  ];
-  return lines.join("\r\n");
-}
-
-export function validateCsvFormatParam(url) {
-  const format = url.searchParams.get("format");
-  if (format === null || format === "") {
-    return null;
-  }
-  if (format.toLowerCase() === "csv") {
-    return null;
-  }
-  return {
-    parameter: "format",
-    message: `"${format}" is not a supported format. Pass format=csv for text/csv, or omit format for JSON.`,
-  };
-}
-
-export function csvRequested(url) {
-  return url.searchParams.get("format")?.toLowerCase() === "csv";
-}
-
-export function buildCsvExample(columns, rows) {
-  return rowsToCsv(rows, columns);
 }
 
 export async function csvResponse(

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -1,5 +1,30 @@
 import { apiHeaders, ifNoneMatchSatisfied, weakEtag } from "./http.mjs";
 
+export const SUBNET_MOVERS_CSV_COLUMNS = [
+  "netuid",
+  "stake_delta_tao",
+  "emission_delta_tao",
+  "validators_delta",
+  "stake_start_tao",
+  "stake_end_tao",
+  "stake_pct_change",
+  "emission_pct_change",
+  "validators_start",
+  "validators_end",
+];
+
+export const GLOBAL_VALIDATORS_CSV_COLUMNS = [
+  "hotkey",
+  "coldkey",
+  "subnet_count",
+  "uid_count",
+  "total_stake_tao",
+  "total_emission_tao",
+  "avg_validator_trust",
+  "max_validator_trust",
+  "stake_dominance",
+];
+
 function normalizeColumns(rows, columns) {
   if (Array.isArray(columns) && columns.length > 0) {
     return columns.map((column) => String(column));
@@ -84,8 +109,7 @@ export function validateCsvFormatParam(url) {
   if (format === null || format === "") {
     return null;
   }
-  const normalized = format.toLowerCase();
-  if (normalized === "csv" || normalized === "json") {
+  if (format.toLowerCase() === "csv") {
     return null;
   }
   return {
@@ -94,15 +118,12 @@ export function validateCsvFormatParam(url) {
   };
 }
 
-export function csvRequested(url, request) {
-  const format = url.searchParams.get("format")?.toLowerCase();
-  if (format === "csv") {
-    return true;
-  }
-  if (format === "json") {
-    return false;
-  }
-  return /\btext\/csv\b/i.test(request.headers.get("accept") || "");
+export function csvRequested(url) {
+  return url.searchParams.get("format")?.toLowerCase() === "csv";
+}
+
+export function buildCsvExample(columns, rows) {
+  return rowsToCsv(rows, columns);
 }
 
 export async function csvResponse(
@@ -121,7 +142,7 @@ export async function csvResponse(
     `attachment; filename="${csvFilename(filename)}"`,
   );
   headers.set("etag", etag);
-  headers.set("vary", "Accept, Accept-Encoding");
+  headers.set("vary", "Accept-Encoding");
 
   if (request && ifNoneMatchSatisfied(request, etag)) {
     return new Response(null, { status: 304, headers });

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -71,6 +71,12 @@ function neutralizeSpreadsheetFormula(text) {
 }
 
 function escapeCell(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
   const text = neutralizeSpreadsheetFormula(stringifyCell(value));
   if (!/[",\r\n]/.test(text)) {
     return text;

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -79,6 +79,21 @@ export function rowsToCsv(rows, columns) {
   return lines.join("\r\n");
 }
 
+export function validateCsvFormatParam(url) {
+  const format = url.searchParams.get("format");
+  if (format === null || format === "") {
+    return null;
+  }
+  const normalized = format.toLowerCase();
+  if (normalized === "csv" || normalized === "json") {
+    return null;
+  }
+  return {
+    parameter: "format",
+    message: `"${format}" is not a supported format. Pass format=csv for text/csv, or omit format for JSON.`,
+  };
+}
+
 export function csvRequested(url, request) {
   const format = url.searchParams.get("format")?.toLowerCase();
   if (format === "csv") {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -28,7 +28,7 @@ import {
 } from "../request-params.mjs";
 
 import { errorResponse, X_METAGRAPH_ARTIFACT_SOURCE_HEADER } from "../http.mjs";
-import { csvRequested, csvResponse } from "../csv.mjs";
+import { csvRequested, csvResponse, validateCsvFormatParam } from "../csv.mjs";
 import {
   contractVersion,
   envelopeResponse,
@@ -303,6 +303,8 @@ export async function handleGlobalValidators(request, env, url) {
     max: GLOBAL_VALIDATOR_LIMIT_MAX,
   });
   if (limit.error) return analyticsQueryError(limit.error);
+  const formatError = validateCsvFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const data = await loadGlobalValidators(d1Runner(env), {
     sort: sortParam,
     limit: limit.value,
@@ -756,6 +758,8 @@ export async function handleSubnetMovers(request, env, url) {
     max: MOVERS_LIMIT_MAX,
   });
   if (limit.error) return analyticsQueryError(limit.error);
+  const formatError = validateCsvFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const data = await loadSubnetMovers(d1Runner(env), {
     windowLabel: windowParam,
     sort: sortParam,

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -28,7 +28,13 @@ import {
 } from "../request-params.mjs";
 
 import { errorResponse, X_METAGRAPH_ARTIFACT_SOURCE_HEADER } from "../http.mjs";
-import { csvRequested, csvResponse, validateCsvFormatParam } from "../csv.mjs";
+import {
+  csvRequested,
+  csvResponse,
+  GLOBAL_VALIDATORS_CSV_COLUMNS,
+  SUBNET_MOVERS_CSV_COLUMNS,
+  validateCsvFormatParam,
+} from "../csv.mjs";
 import {
   contractVersion,
   envelopeResponse,
@@ -121,31 +127,6 @@ import {
   MOVERS_LIMIT_MAX,
 } from "../../src/movers.mjs";
 import { loadSubnetIdentityHistory } from "../../src/subnet-identity-history.mjs";
-
-const SUBNET_MOVERS_CSV_COLUMNS = [
-  "netuid",
-  "stake_delta_tao",
-  "emission_delta_tao",
-  "validators_delta",
-  "stake_start_tao",
-  "stake_end_tao",
-  "stake_pct_change",
-  "emission_pct_change",
-  "validators_start",
-  "validators_end",
-];
-
-const GLOBAL_VALIDATORS_CSV_COLUMNS = [
-  "hotkey",
-  "coldkey",
-  "subnet_count",
-  "uid_count",
-  "total_stake_tao",
-  "total_emission_tao",
-  "avg_validator_trust",
-  "max_validator_trust",
-  "stake_dominance",
-];
 
 function parseBoundedIntParam(url, parameter, { def, min, max }) {
   const raw = url.searchParams.get(parameter);
@@ -309,7 +290,7 @@ export async function handleGlobalValidators(request, env, url) {
     sort: sortParam,
     limit: limit.value,
   });
-  if (csvRequested(url, request)) {
+  if (csvRequested(url)) {
     return csvResponse(
       data.validators,
       "validators",
@@ -765,7 +746,7 @@ export async function handleSubnetMovers(request, env, url) {
     sort: sortParam,
     limit: limit.value,
   });
-  if (csvRequested(url, request)) {
+  if (csvRequested(url)) {
     return csvResponse(
       data.movers,
       "subnet-movers",

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -28,6 +28,7 @@ import {
 } from "../request-params.mjs";
 
 import { errorResponse, X_METAGRAPH_ARTIFACT_SOURCE_HEADER } from "../http.mjs";
+import { csvRequested, csvResponse } from "../csv.mjs";
 import {
   contractVersion,
   envelopeResponse,
@@ -120,6 +121,31 @@ import {
   MOVERS_LIMIT_MAX,
 } from "../../src/movers.mjs";
 import { loadSubnetIdentityHistory } from "../../src/subnet-identity-history.mjs";
+
+const SUBNET_MOVERS_CSV_COLUMNS = [
+  "netuid",
+  "stake_delta_tao",
+  "emission_delta_tao",
+  "validators_delta",
+  "stake_start_tao",
+  "stake_end_tao",
+  "stake_pct_change",
+  "emission_pct_change",
+  "validators_start",
+  "validators_end",
+];
+
+const GLOBAL_VALIDATORS_CSV_COLUMNS = [
+  "hotkey",
+  "coldkey",
+  "subnet_count",
+  "uid_count",
+  "total_stake_tao",
+  "total_emission_tao",
+  "avg_validator_trust",
+  "max_validator_trust",
+  "stake_dominance",
+];
 
 function parseBoundedIntParam(url, parameter, { def, min, max }) {
   const raw = url.searchParams.get(parameter);
@@ -259,7 +285,7 @@ export async function handleSubnetValidators(request, env, netuid, url) {
 // scoped to each membership row because those source units are not globally aggregated.
 // Cold/absent D1 returns a schema-stable empty list.
 export async function handleGlobalValidators(request, env, url) {
-  const validationError = validateQueryParams(url, ["sort", "limit"]);
+  const validationError = validateQueryParams(url, ["sort", "limit", "format"]);
   if (validationError) return analyticsQueryError(validationError);
   const sortParam =
     url.searchParams.get("sort") || DEFAULT_GLOBAL_VALIDATOR_SORT;
@@ -281,6 +307,15 @@ export async function handleGlobalValidators(request, env, url) {
     sort: sortParam,
     limit: limit.value,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.validators,
+      "validators",
+      "short",
+      request,
+      GLOBAL_VALIDATORS_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {
@@ -692,7 +727,12 @@ export async function handleSubnetStakeFlow(request, env, netuid, url) {
 // snapshot_date read). Cold/absent or single-snapshot store → 200 with movers:[]
 // (schema-stable, never 404), mirroring the sibling history/turnover routes.
 export async function handleSubnetMovers(request, env, url) {
-  const validationError = validateQueryParams(url, ["window", "sort", "limit"]);
+  const validationError = validateQueryParams(url, [
+    "window",
+    "sort",
+    "limit",
+    "format",
+  ]);
   if (validationError) return analyticsQueryError(validationError);
   const windowParam = url.searchParams.get("window") || DEFAULT_MOVERS_WINDOW;
   if (!Object.hasOwn(MOVERS_WINDOWS, windowParam)) {
@@ -721,6 +761,15 @@ export async function handleSubnetMovers(request, env, url) {
     sort: sortParam,
     limit: limit.value,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.movers,
+      "subnet-movers",
+      "short",
+      request,
+      SUBNET_MOVERS_CSV_COLUMNS,
+    );
+  }
   // neuron_daily-derived, so the meta reports the metagraph-snapshot source; generated_at
   // is the end snapshot date (string), matching the turnover/history routes.
   return envelopeResponse(


### PR DESCRIPTION
## Summary

- Add a shared `workers/csv.mjs` helper (`rowsToCsv`, `csvRequested`, `csvResponse`) for tabular API exports
- Wire `format=csv` onto `/api/v1/subnets/movers` and `/api/v1/validators`, returning ranked leaderboard rows as `text/csv` with stable column headers
- Extend schema-first contracts, regenerated OpenAPI/types/contracts artifacts, and handler tests for cold and warm CSV paths

## No linked issue

Self-contained API export feature: explicit `format=csv` on two existing analytics leaderboards, with no registry or data-model changes. Overlaps with open CSV groundwork PRs (#2718, #2748) are limited to the shared `workers/csv.mjs` helper pattern; this PR only touches movers + validators handlers.

## Test plan

- [x] `npm test -- tests/csv.test.mjs tests/request-handlers-entities.test.mjs`
- [x] `npm run build`
- [x] `npm run validate:contract-drift`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run scan:public-safety`