### PR TITLE
feat: Add CSV export for subnet metagraph and validators routes

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -17515,6 +17515,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetMetagraphArtifact"];
                     };
+                    /**
+                     * @example uid,hotkey
+                     *     0,5Hk1
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -19161,6 +19166,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetValidatorsArtifact"];
                     };
+                    /**
+                     * @example uid,hotkey
+                     *     0,5Hk1
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -17449,6 +17449,7 @@ export interface operations {
         parameters: {
             query?: {
                 validator_permit?: "true";
+                format?: "csv";
             };
             header?: never;
             path: {
@@ -19093,7 +19094,9 @@ export interface operations {
     };
     subnetValidators: {
         parameters: {
-            query?: never;
+            query?: {
+                format?: "csv";
+            };
             header?: never;
             path: {
                 netuid: number;

--- a/generated/metagraphed-client.ts
+++ b/generated/metagraphed-client.ts
@@ -43,12 +43,52 @@ export type PathParams<Path extends ApiPath> =
   GetOperation<Path> extends { parameters: { path?: infer Params } }
     ? Params
     : never;
+export type HasResponseContent<
+  Path extends ApiPath,
+  ContentType extends string,
+> = GetOperation<Path> extends {
+  responses: {
+    200: {
+      content: {
+        [Key in ContentType]: unknown;
+      };
+    };
+  };
+}
+  ? true
+  : false;
+export type JsonPath = {
+  [Path in ApiPath]: HasResponseContent<Path, "application/json"> extends true
+    ? Path
+    : never;
+}[ApiPath];
+export type CsvPath = {
+  [Path in ApiPath]: HasResponseContent<Path, "text/csv"> extends true
+    ? Path
+    : never;
+}[ApiPath];
+export type JsonQueryParams<Path extends JsonPath> =
+  QueryParams<Path> extends object
+    ? Omit<QueryParams<Path>, "format"> & { format?: never }
+    : QueryParams<Path>;
 export type JsonResponse<Path extends ApiPath> =
   GetOperation<Path> extends {
     responses: {
       200: {
         content: {
           "application/json": infer Body;
+        };
+      };
+    };
+  }
+    ? Body
+    : never;
+export type CsvResponse<Path extends ApiPath> =
+  GetOperation<Path> extends {
+    responses: {
+      200: {
+        content: {
+          "text/csv": infer Body;
         };
       };
     };
@@ -122,9 +162,11 @@ function resolveSignal(
  * THROWS a MetagraphedError (carrying status + error code + envelope) on any
  * non-2xx, so a resolved value is always a success.
  */
-export async function metagraphedFetch<Path extends ApiPath>(
+export async function metagraphedFetch<Path extends JsonPath>(
   path: Path,
-  options: MetagraphedFetchOptions<Path> = {},
+  options: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+    query?: JsonQueryParams<Path>;
+  } = {},
 ): Promise<JsonResponse<Path>> {
   const {
     baseUrl = "https://api.metagraph.sh",
@@ -167,13 +209,64 @@ export async function metagraphedFetch<Path extends ApiPath>(
   return body as JsonResponse<Path>;
 }
 
+export async function metagraphedFetchCsv<Path extends CsvPath>(
+  path: Path,
+  options: MetagraphedFetchOptions<Path> = {},
+): Promise<CsvResponse<Path>> {
+  const {
+    baseUrl = "https://api.metagraph.sh",
+    pathParams,
+    query,
+    timeoutMs = 30000,
+    signal,
+    ...init
+  } = options;
+  const resolvedPath = interpolatePath(
+    String(path),
+    pathParams as Record<string, string | number> | undefined,
+  );
+  const url = new URL(resolvedPath, baseUrl);
+  const csvQuery = {
+    ...(query as Record<string, unknown> | undefined),
+    format: "csv",
+  };
+  for (const [key, value] of Object.entries(csvQuery)) {
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  const response = await fetch(url, {
+    ...init,
+    method: "GET",
+    headers: {
+      accept: "text/csv",
+      ...(init.headers || {}),
+    },
+    signal: resolveSignal(signal, timeoutMs),
+  });
+  if (!response.ok) {
+    const body = await readJsonBody(response);
+    const envelope = isErrorEnvelope(body) ? body : undefined;
+    throw new MetagraphedError(
+      envelope?.error?.message ??
+        `GET ${url.pathname} failed with status ${response.status}`,
+      response.status,
+      envelope?.error?.code,
+      envelope,
+    );
+  }
+  return (await response.text()) as CsvResponse<Path>;
+}
+
 /**
  * Follow cursor pagination for a list endpoint, yielding each page's success
  * envelope until meta.pagination.next_cursor is exhausted.
  */
-export async function* metagraphedPaginate<Path extends ApiPath>(
+export async function* metagraphedPaginate<Path extends JsonPath>(
   path: Path,
-  options: MetagraphedFetchOptions<Path> = {},
+  options: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+    query?: JsonQueryParams<Path>;
+  } = {},
 ): AsyncGenerator<JsonResponse<Path>, void, unknown> {
   const baseQuery: Record<string, unknown> = {
     ...(options.query as Record<string, unknown> | undefined),
@@ -511,17 +604,27 @@ function buildEtagCacheKey(
  * createMetagraphedClient.
  */
 export interface MetagraphedClient {
-  request<Path extends ApiPath>(
+  request<Path extends JsonPath>(
     path: Path,
-    options?: MetagraphedFetchOptions<Path>,
+    options?: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+      query?: JsonQueryParams<Path>;
+    },
   ): Promise<JsonResponse<Path>>;
-  paginate<Path extends ApiPath>(
+  requestCsv<Path extends CsvPath>(
     path: Path,
     options?: MetagraphedFetchOptions<Path>,
+  ): Promise<CsvResponse<Path>>;
+  paginate<Path extends JsonPath>(
+    path: Path,
+    options?: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+      query?: JsonQueryParams<Path>;
+    },
   ): AsyncGenerator<JsonResponse<Path>, void, unknown>;
-  fetchAll<Item = unknown, Path extends ApiPath = ApiPath>(
+  fetchAll<Item = unknown, Path extends JsonPath = JsonPath>(
     path: Path,
-    options?: MetagraphedFetchOptions<Path>,
+    options?: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+      query?: JsonQueryParams<Path>;
+    },
   ): Promise<Item[]>;
   rpc<Result = unknown>(
     network: string,
@@ -582,9 +685,11 @@ export function createMetagraphedClient(
       : clientOptions.cache
     : null;
 
-  async function request<Path extends ApiPath>(
+  async function request<Path extends JsonPath>(
     path: Path,
-    options: MetagraphedFetchOptions<Path> = {},
+    options: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+      query?: JsonQueryParams<Path>;
+    } = {},
   ): Promise<JsonResponse<Path>> {
     const {
       baseUrl: requestBaseUrl,
@@ -681,9 +786,23 @@ export function createMetagraphedClient(
     }
   }
 
-  async function* paginate<Path extends ApiPath>(
+  async function requestCsv<Path extends CsvPath>(
     path: Path,
     options: MetagraphedFetchOptions<Path> = {},
+  ): Promise<CsvResponse<Path>> {
+    return metagraphedFetchCsv(path, {
+      ...options,
+      baseUrl: options.baseUrl ?? baseUrl,
+      headers: mergeRequestHeaders(clientOptions.headers, options.headers),
+      timeoutMs: options.timeoutMs ?? clientOptions.timeoutMs ?? 30000,
+    });
+  }
+
+  async function* paginate<Path extends JsonPath>(
+    path: Path,
+    options: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+      query?: JsonQueryParams<Path>;
+    } = {},
   ): AsyncGenerator<JsonResponse<Path>, void, unknown> {
     const baseQuery: Record<string, unknown> = {
       ...(options.query as Record<string, unknown> | undefined),
@@ -708,9 +827,11 @@ export function createMetagraphedClient(
     }
   }
 
-  async function fetchAll<Item = unknown, Path extends ApiPath = ApiPath>(
+  async function fetchAll<Item = unknown, Path extends JsonPath = JsonPath>(
     path: Path,
-    options: MetagraphedFetchOptions<Path> = {},
+    options: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+      query?: JsonQueryParams<Path>;
+    } = {},
   ): Promise<Item[]> {
     const items: Item[] = [];
     for await (const page of paginate(path, options)) {
@@ -753,6 +874,7 @@ export function createMetagraphedClient(
 
   return {
     request,
+    requestCsv,
     paginate,
     fetchAll,
     rpc,

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4501,6 +4501,15 @@
             ],
             "type": "string"
           }
+        },
+        {
+          "name": "format",
+          "schema": {
+            "enum": [
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -4526,7 +4535,17 @@
       "public": true,
       "query_collection": null,
       "query_filter_names": [],
-      "query_parameters": []
+      "query_parameters": [
+        {
+          "name": "format",
+          "schema": {
+            "enum": [
+              "csv"
+            ],
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/subnets/{netuid}/yield.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -33558,6 +33558,17 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -35644,6 +35655,17 @@
             "schema": {
               "minimum": 0,
               "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "csv"
+              ],
+              "type": "string"
             }
           }
         ],

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -33632,6 +33632,12 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "uid,hotkey\n0,5Hk1",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
             "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
@@ -35729,6 +35735,12 @@
                       "type": "object"
                     }
                   ]
+                }
+              },
+              "text/csv": {
+                "example": "uid,hotkey\n0,5Hk1",
+                "schema": {
+                  "type": "string"
                 }
               }
             },

--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": "2026-06-30.14",
+  "contract_version": "2026-07-01.1",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "kinds": [
     "archive",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -17515,6 +17515,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetMetagraphArtifact"];
                     };
+                    /**
+                     * @example uid,hotkey
+                     *     0,5Hk1
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -19161,6 +19166,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetValidatorsArtifact"];
                     };
+                    /**
+                     * @example uid,hotkey
+                     *     0,5Hk1
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -17449,6 +17449,7 @@ export interface operations {
         parameters: {
             query?: {
                 validator_permit?: "true";
+                format?: "csv";
             };
             header?: never;
             path: {
@@ -19093,7 +19094,9 @@ export interface operations {
     };
     subnetValidators: {
         parameters: {
-            query?: never;
+            query?: {
+                format?: "csv";
+            };
             header?: never;
             path: {
                 netuid: number;

--- a/scripts/generate-client.mjs
+++ b/scripts/generate-client.mjs
@@ -63,12 +63,52 @@ export type PathParams<Path extends ApiPath> =
   GetOperation<Path> extends { parameters: { path?: infer Params } }
     ? Params
     : never;
+export type HasResponseContent<
+  Path extends ApiPath,
+  ContentType extends string,
+> = GetOperation<Path> extends {
+  responses: {
+    200: {
+      content: {
+        [Key in ContentType]: unknown;
+      };
+    };
+  };
+}
+  ? true
+  : false;
+export type JsonPath = {
+  [Path in ApiPath]: HasResponseContent<Path, "application/json"> extends true
+    ? Path
+    : never;
+}[ApiPath];
+export type CsvPath = {
+  [Path in ApiPath]: HasResponseContent<Path, "text/csv"> extends true
+    ? Path
+    : never;
+}[ApiPath];
+export type JsonQueryParams<Path extends JsonPath> =
+  QueryParams<Path> extends object
+    ? Omit<QueryParams<Path>, "format"> & { format?: never }
+    : QueryParams<Path>;
 export type JsonResponse<Path extends ApiPath> =
   GetOperation<Path> extends {
     responses: {
       200: {
         content: {
           "application/json": infer Body;
+        };
+      };
+    };
+  }
+    ? Body
+    : never;
+export type CsvResponse<Path extends ApiPath> =
+  GetOperation<Path> extends {
+    responses: {
+      200: {
+        content: {
+          "text/csv": infer Body;
         };
       };
     };
@@ -142,9 +182,11 @@ function resolveSignal(
  * THROWS a MetagraphedError (carrying status + error code + envelope) on any
  * non-2xx, so a resolved value is always a success.
  */
-export async function metagraphedFetch<Path extends ApiPath>(
+export async function metagraphedFetch<Path extends JsonPath>(
   path: Path,
-  options: MetagraphedFetchOptions<Path> = {},
+  options: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+    query?: JsonQueryParams<Path>;
+  } = {},
 ): Promise<JsonResponse<Path>> {
   const {
     baseUrl = "https://api.metagraph.sh",
@@ -187,13 +229,64 @@ export async function metagraphedFetch<Path extends ApiPath>(
   return body as JsonResponse<Path>;
 }
 
+export async function metagraphedFetchCsv<Path extends CsvPath>(
+  path: Path,
+  options: MetagraphedFetchOptions<Path> = {},
+): Promise<CsvResponse<Path>> {
+  const {
+    baseUrl = "https://api.metagraph.sh",
+    pathParams,
+    query,
+    timeoutMs = 30000,
+    signal,
+    ...init
+  } = options;
+  const resolvedPath = interpolatePath(
+    String(path),
+    pathParams as Record<string, string | number> | undefined,
+  );
+  const url = new URL(resolvedPath, baseUrl);
+  const csvQuery = {
+    ...(query as Record<string, unknown> | undefined),
+    format: "csv",
+  };
+  for (const [key, value] of Object.entries(csvQuery)) {
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  const response = await fetch(url, {
+    ...init,
+    method: "GET",
+    headers: {
+      accept: "text/csv",
+      ...(init.headers || {}),
+    },
+    signal: resolveSignal(signal, timeoutMs),
+  });
+  if (!response.ok) {
+    const body = await readJsonBody(response);
+    const envelope = isErrorEnvelope(body) ? body : undefined;
+    throw new MetagraphedError(
+      envelope?.error?.message ??
+        \`GET \${url.pathname} failed with status \${response.status}\`,
+      response.status,
+      envelope?.error?.code,
+      envelope,
+    );
+  }
+  return (await response.text()) as CsvResponse<Path>;
+}
+
 /**
  * Follow cursor pagination for a list endpoint, yielding each page's success
  * envelope until meta.pagination.next_cursor is exhausted.
  */
-export async function* metagraphedPaginate<Path extends ApiPath>(
+export async function* metagraphedPaginate<Path extends JsonPath>(
   path: Path,
-  options: MetagraphedFetchOptions<Path> = {},
+  options: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+    query?: JsonQueryParams<Path>;
+  } = {},
 ): AsyncGenerator<JsonResponse<Path>, void, unknown> {
   const baseQuery: Record<string, unknown> = {
     ...(options.query as Record<string, unknown> | undefined),
@@ -531,17 +624,27 @@ function buildEtagCacheKey(
  * createMetagraphedClient.
  */
 export interface MetagraphedClient {
-  request<Path extends ApiPath>(
+  request<Path extends JsonPath>(
     path: Path,
-    options?: MetagraphedFetchOptions<Path>,
+    options?: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+      query?: JsonQueryParams<Path>;
+    },
   ): Promise<JsonResponse<Path>>;
-  paginate<Path extends ApiPath>(
+  requestCsv<Path extends CsvPath>(
     path: Path,
     options?: MetagraphedFetchOptions<Path>,
+  ): Promise<CsvResponse<Path>>;
+  paginate<Path extends JsonPath>(
+    path: Path,
+    options?: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+      query?: JsonQueryParams<Path>;
+    },
   ): AsyncGenerator<JsonResponse<Path>, void, unknown>;
-  fetchAll<Item = unknown, Path extends ApiPath = ApiPath>(
+  fetchAll<Item = unknown, Path extends JsonPath = JsonPath>(
     path: Path,
-    options?: MetagraphedFetchOptions<Path>,
+    options?: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+      query?: JsonQueryParams<Path>;
+    },
   ): Promise<Item[]>;
   rpc<Result = unknown>(
     network: string,
@@ -602,9 +705,11 @@ export function createMetagraphedClient(
       : clientOptions.cache
     : null;
 
-  async function request<Path extends ApiPath>(
+  async function request<Path extends JsonPath>(
     path: Path,
-    options: MetagraphedFetchOptions<Path> = {},
+    options: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+      query?: JsonQueryParams<Path>;
+    } = {},
   ): Promise<JsonResponse<Path>> {
     const {
       baseUrl: requestBaseUrl,
@@ -701,9 +806,23 @@ export function createMetagraphedClient(
     }
   }
 
-  async function* paginate<Path extends ApiPath>(
+  async function requestCsv<Path extends CsvPath>(
     path: Path,
     options: MetagraphedFetchOptions<Path> = {},
+  ): Promise<CsvResponse<Path>> {
+    return metagraphedFetchCsv(path, {
+      ...options,
+      baseUrl: options.baseUrl ?? baseUrl,
+      headers: mergeRequestHeaders(clientOptions.headers, options.headers),
+      timeoutMs: options.timeoutMs ?? clientOptions.timeoutMs ?? 30000,
+    });
+  }
+
+  async function* paginate<Path extends JsonPath>(
+    path: Path,
+    options: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+      query?: JsonQueryParams<Path>;
+    } = {},
   ): AsyncGenerator<JsonResponse<Path>, void, unknown> {
     const baseQuery: Record<string, unknown> = {
       ...(options.query as Record<string, unknown> | undefined),
@@ -728,9 +847,11 @@ export function createMetagraphedClient(
     }
   }
 
-  async function fetchAll<Item = unknown, Path extends ApiPath = ApiPath>(
+  async function fetchAll<Item = unknown, Path extends JsonPath = JsonPath>(
     path: Path,
-    options: MetagraphedFetchOptions<Path> = {},
+    options: Omit<MetagraphedFetchOptions<Path>, "query"> & {
+      query?: JsonQueryParams<Path>;
+    } = {},
   ): Promise<Item[]> {
     const items: Item[] = [];
     for await (const page of paginate(path, options)) {
@@ -773,6 +894,7 @@ export function createMetagraphedClient(
 
   return {
     request,
+    requestCsv,
     paginate,
     fetchAll,
     rpc,

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1885,7 +1885,10 @@ export const API_ROUTES = [
     "Fetch the per-UID metagraph (stake, trust, consensus, incentive, dividends, emission, validator_permit, rank, axon) for one subnet, computed live from the neurons D1 tier. Add ?validator_permit=true for validators only.",
     "short",
     ["subnets", "analytics"],
-    [{ name: "validator_permit", schema: { type: "string", enum: ["true"] } }],
+    [
+      { name: "validator_permit", schema: { type: "string", enum: ["true"] } },
+      { name: "format", schema: { type: "string", enum: ["csv"] } },
+    ],
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(
@@ -1910,7 +1913,7 @@ export const API_ROUTES = [
     "Fetch the validators (validator_permit) of one subnet ranked by stake, computed live from the neurons D1 tier.",
     "short",
     ["subnets", "analytics"],
-    [],
+    [{ name: "format", schema: { type: "string", enum: ["csv"] } }],
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1890,6 +1890,7 @@ export const API_ROUTES = [
       { name: "format", schema: { type: "string", enum: ["csv"] } },
     ],
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
+    ["application/json", "text/csv"],
   ),
   route(
     "subnet-neuron",
@@ -1915,6 +1916,7 @@ export const API_ROUTES = [
     ["subnets", "analytics"],
     [{ name: "format", schema: { type: "string", enum: ["csv"] } }],
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
+    ["application/json", "text/csv"],
   ),
   route(
     "subnet-yield",
@@ -2734,6 +2736,27 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
         },
       ],
     };
+    const successContent = {};
+    for (const contentType of entry.response_content_types || [
+      "application/json",
+    ]) {
+      if (contentType === "application/json") {
+        successContent["application/json"] = {
+          schema: responseSchema,
+          // Deterministic worked example (schema-valid, no live data) so
+          // Swagger UI + agents see a concrete response shape. Generated
+          // from the schema; enforced by validate-openapi-examples.
+          example: sampleFromSchema(responseSchema, componentSchemas),
+        };
+        continue;
+      }
+      if (contentType === "text/csv") {
+        successContent["text/csv"] = {
+          schema: { type: "string" },
+          example: "uid,hotkey\n0,5Hk1",
+        };
+      }
+    }
     paths[openApiPath] = {
       ...(paths[openApiPath] || {}),
       [entry.method.toLowerCase()]: {
@@ -2760,15 +2783,7 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
             description:
               "Canonical artifact wrapped in the Metagraphed API envelope.",
             headers: apiResponseHeaders(),
-            content: {
-              "application/json": {
-                schema: responseSchema,
-                // Deterministic worked example (schema-valid, no live data) so
-                // Swagger UI + agents see a concrete response shape. Generated
-                // from the schema; enforced by validate-openapi-examples.
-                example: sampleFromSchema(responseSchema, componentSchemas),
-              },
-            },
+            content: successContent,
           },
           304: {
             description: "ETag matched and the cached response is still valid.",
@@ -2929,6 +2944,7 @@ function route(
   tags,
   queryParameters = [],
   pathParameters = [],
+  responseContentTypes = ["application/json"],
 ) {
   const querySpec = normalizeQueryParameters(queryParameters);
   return {
@@ -2943,6 +2959,7 @@ function route(
     query_filter_names: querySpec.filterNames,
     query_parameters: querySpec.parameters,
     path_parameters: pathParameters,
+    response_content_types: responseContentTypes,
   };
 }
 

--- a/tests/client-sdk.test.ts
+++ b/tests/client-sdk.test.ts
@@ -7,6 +7,7 @@ import {
   createMetagraphedClient,
   MetagraphedError,
   metagraphedFetch,
+  metagraphedFetchCsv,
   metagraphedPaginate,
   metagraphedRpc,
 } from "../generated/metagraphed-client";
@@ -133,6 +134,28 @@ describe("metagraphedFetch", () => {
     );
     await metagraphedFetch("/api/v1/health" as never, { timeoutMs: 0 });
     expect((fetchMock.mock.calls[1][1] as RequestInit).signal).toBeUndefined();
+  });
+
+  test("metagraphedFetchCsv requests CSV and forces format=csv", async () => {
+    const fetchMock = stubFetch(
+      async () =>
+        new Response("uid,hotkey\n0,5Hk1", {
+          status: 200,
+          headers: { "content-type": "text/csv; charset=utf-8" },
+        }),
+    );
+    const out = await metagraphedFetchCsv(
+      "/api/v1/subnets/{netuid}/metagraph" as never,
+      {
+        pathParams: { netuid: 7 } as never,
+        query: { validator_permit: "true" } as never,
+      },
+    );
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.searchParams.get("format")).toBe("csv");
+    expect(url.searchParams.get("validator_permit")).toBe("true");
+    expect((init.headers as Record<string, string>).accept).toBe("text/csv");
+    expect(out).toBe("uid,hotkey\n0,5Hk1");
   });
 });
 

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -288,11 +288,19 @@ describe("public contract registry", () => {
     assert.deepEqual(genericAliases, []);
 
     for (const route of API_ROUTES) {
-      const dataRef =
+      const content =
         openapi.paths[route.path][route.method.toLowerCase()].responses["200"]
-          .content["application/json"].schema.allOf[1].properties.data.$ref;
+          .content;
+      const dataRef =
+        content["application/json"].schema.allOf[1].properties.data.$ref;
       assert.notEqual(dataRef, "#/components/schemas/JsonObject");
       assert.notEqual(dataRef, "#/components/schemas/GenericArtifact");
+      if (route.id === "subnet-metagraph" || route.id === "subnet-validators") {
+        assert.deepEqual(Object.keys(content).sort(), [
+          "application/json",
+          "text/csv",
+        ]);
+      }
     }
   });
 

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -760,6 +760,22 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
     assert.equal(body.data.neurons[0].uid, 0);
   });
 
+  test("GET /subnets/{n}/metagraph?format=csv serves CSV through the Worker route", async () => {
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/metagraph?format=csv",
+      ),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    const lines = (await res.text()).split("\n");
+    assert.match(lines[0], /^uid,hotkey,/);
+    assert.match(lines[1], /^0,/);
+    assert.match(lines[2], /^5,/);
+  });
+
   test("GET /subnets/{n}/yield routes to the emission-yield handler", async () => {
     const { res, body } = await getJson("/api/v1/subnets/7/yield", env);
     assert.equal(res.status, 200);

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -533,6 +533,17 @@ describe("handleSubnetMetagraph", () => {
     assert.match(body.error.message, /bogus/);
   });
 
+  test("rejects unsupported metagraph CSV format with 400", async () => {
+    const res = await handleSubnetMetagraph(
+      req(`/api/v1/subnets/${NETUID}/metagraph?format=json`),
+      emptyEnv(),
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/metagraph?format=json`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
   test("returns schema-stable empty payload on cold/unbound D1", async () => {
     const body = await assertColdSchema(
       handleSubnetMetagraph,
@@ -642,6 +653,49 @@ describe("handleSubnetMetagraph", () => {
     );
     assert.equal(res.status, 200);
     assert.equal((await res.text()).split("\n").length, 1);
+  });
+
+  test("format=csv HEAD returns headers without a body", async () => {
+    const { env } = dbWith({ neurons: [neuronRow()] });
+    const res = await handleSubnetMetagraph(
+      new Request(
+        `https://api.metagraph.sh/api/v1/subnets/${NETUID}/metagraph?format=csv`,
+        {
+          method: "HEAD",
+        },
+      ),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/metagraph?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    assert.equal(await res.text(), "");
+  });
+
+  test("format=csv honors If-None-Match with 304", async () => {
+    const { env } = dbWith({ neurons: [neuronRow()] });
+    const first = await handleSubnetMetagraph(
+      req(`/api/v1/subnets/${NETUID}/metagraph?format=csv`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/metagraph?format=csv`),
+    );
+    const etag = first.headers.get("etag");
+    assert.ok(etag);
+    const second = await handleSubnetMetagraph(
+      new Request(
+        `https://api.metagraph.sh/api/v1/subnets/${NETUID}/metagraph?format=csv`,
+        {
+          headers: { "if-none-match": etag },
+        },
+      ),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/metagraph?format=csv`),
+    );
+    assert.equal(second.status, 304);
+    assert.equal(await second.text(), "");
   });
 
   test("validator_permit=true filters to validators only", async () => {
@@ -1595,6 +1649,14 @@ describe("handleSubnetTurnover", () => {
 
     test("returns raw search on an unsupported query parameter", () => {
       const raw = "/api/v1/subnets/1/metagraph?unknown=1";
+      const key = canonicalSubnetMetagraphCachePath(
+        new URL(`https://api.metagraph.sh${raw}`),
+      );
+      assert.equal(key, raw);
+    });
+
+    test("returns raw search on an unsupported format value", () => {
+      const raw = "/api/v1/subnets/1/metagraph?format=json";
       const key = canonicalSubnetMetagraphCachePath(
         new URL(`https://api.metagraph.sh${raw}`),
       );

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -567,6 +567,83 @@ describe("handleSubnetMetagraph", () => {
     );
   });
 
+  test("format=csv returns metagraph neurons as CSV", async () => {
+    const { env } = dbWith({
+      neurons: [
+        neuronRow({ uid: 1, validator_permit: 1, axon: "1.2.3.4:9000" }),
+        neuronRow({ uid: 2, validator_permit: 0, axon: null }),
+      ],
+    });
+    const res = await handleSubnetMetagraph(
+      req(`/api/v1/subnets/${NETUID}/metagraph?format=csv`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/metagraph?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    const lines = (await res.text()).split("\n");
+    assert.equal(
+      lines[0],
+      [
+        "uid",
+        "hotkey",
+        "coldkey",
+        "active",
+        "validator_permit",
+        "rank",
+        "trust",
+        "validator_trust",
+        "consensus",
+        "incentive",
+        "dividends",
+        "emission_tao",
+        "stake_tao",
+        "registered_at_block",
+        "is_immunity_period",
+        "axon",
+      ].join(","),
+    );
+    assert.match(lines[1], /^1,/);
+    assert.match(lines[1], /,true,/);
+    assert.match(lines[2], /^2,/);
+    assert.match(lines[2], /,false,/);
+  });
+
+  test("format=csv with validator_permit=true only exports validators", async () => {
+    const { env, captures } = dbWith({
+      neurons: [neuronRow({ uid: 1, validator_permit: 1 })],
+    });
+    const res = await handleSubnetMetagraph(
+      req(
+        `/api/v1/subnets/${NETUID}/metagraph?validator_permit=true&format=csv`,
+      ),
+      env,
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/metagraph?validator_permit=true&format=csv`,
+      ),
+    );
+    assert.equal(res.status, 200);
+    assert.ok(
+      captures.sql.some((s) => /validator_permit = 1/.test(s)),
+      "expected validator_permit filter in SQL",
+    );
+    assert.match(await res.text(), /^uid,hotkey,/);
+  });
+
+  test("format=csv returns header-only CSV for an empty metagraph", async () => {
+    const { env } = dbWith({ neurons: [] });
+    const res = await handleSubnetMetagraph(
+      req(`/api/v1/subnets/${NETUID}/metagraph?format=csv`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/metagraph?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    assert.equal((await res.text()).split("\n").length, 1);
+  });
+
   test("validator_permit=true filters to validators only", async () => {
     const { env, captures } = dbWith({
       neurons: [neuronRow({ validator_permit: 1 })],
@@ -730,6 +807,17 @@ describe("handleSubnetValidators", () => {
     await errorJson(res);
   });
 
+  test("rejects unsupported validator CSV format with 400", async () => {
+    const res = await handleSubnetValidators(
+      req(`/api/v1/subnets/${NETUID}/validators?format=json`),
+      emptyEnv(),
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/validators?format=json`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
   test("returns schema-stable empty validators on cold D1", async () => {
     const body = await assertColdSchema(
       handleSubnetValidators,
@@ -740,6 +828,35 @@ describe("handleSubnetValidators", () => {
     );
     assert.equal(body.data.validator_count, 0);
     assert.deepEqual(body.data.validators, []);
+  });
+
+  test("format=csv returns validators as CSV", async () => {
+    const { env } = dbWith({
+      neurons: [neuronRow({ uid: 8, stake_tao: 500 })],
+    });
+    const res = await handleSubnetValidators(
+      req(`/api/v1/subnets/${NETUID}/validators?format=csv`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/validators?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    const lines = (await res.text()).split("\n");
+    assert.match(lines[0], /^uid,hotkey,/);
+    assert.match(lines[1], /^8,/);
+  });
+
+  test("format=csv returns header-only CSV for empty validators", async () => {
+    const { env } = dbWith({ neurons: [] });
+    const res = await handleSubnetValidators(
+      req(`/api/v1/subnets/${NETUID}/validators?format=csv`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/validators?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    assert.equal((await res.text()).split("\n").length, 1);
   });
 
   test("happy path returns validator rows ranked by stake", async () => {
@@ -1453,6 +1570,27 @@ describe("handleSubnetTurnover", () => {
         ),
       );
       assert.equal(key, "/api/v1/subnets/1/metagraph?validator_permit=true");
+    });
+
+    test("preserves csv format in the cache key", () => {
+      const key = canonicalSubnetMetagraphCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/1/metagraph?format=csv",
+        ),
+      );
+      assert.equal(key, "/api/v1/subnets/1/metagraph?format=csv");
+    });
+
+    test("preserves validator filter before csv format in the cache key", () => {
+      const key = canonicalSubnetMetagraphCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/1/metagraph?format=csv&validator_permit=true",
+        ),
+      );
+      assert.equal(
+        key,
+        "/api/v1/subnets/1/metagraph?validator_permit=true&format=csv",
+      );
     });
 
     test("returns raw search on an unsupported query parameter", () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -30,6 +30,7 @@ import {
 import { errorResponse, X_METAGRAPH_ARTIFACT_SOURCE_HEADER } from "../http.mjs";
 import {
   contractVersion,
+  csvResponse,
   envelopeResponse,
   publishedAt,
 } from "../responses.mjs";
@@ -173,22 +174,75 @@ async function metagraphMeta(env, artifactPath, generatedAt) {
   };
 }
 
+const NEURON_CSV_COLUMNS = [
+  "uid",
+  "hotkey",
+  "coldkey",
+  "active",
+  "validator_permit",
+  "rank",
+  "trust",
+  "validator_trust",
+  "consensus",
+  "incentive",
+  "dividends",
+  "emission_tao",
+  "stake_tao",
+  "registered_at_block",
+  "is_immunity_period",
+  "axon",
+];
+
+function validateCsvFormat(url) {
+  const format = url.searchParams.get("format");
+  if (format === null || format === "csv") return null;
+  return {
+    parameter: "format",
+    message: "format must be one of: csv.",
+  };
+}
+
+function csvValue(value) {
+  if (value == null) return "";
+  const text = String(value);
+  const safe = /^[=+\-@\t\r]/.test(text) ? `'${text}` : text;
+  return /[",\n\r]/.test(safe) ? `"${safe.replaceAll('"', '""')}"` : safe;
+}
+
+function neuronsCsv(rows) {
+  return [
+    NEURON_CSV_COLUMNS.join(","),
+    ...rows.map((row) =>
+      NEURON_CSV_COLUMNS.map((column) => csvValue(row[column])).join(","),
+    ),
+  ].join("\n");
+}
+
 export async function handleSubnetMetagraph(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, ["validator_permit"]);
+  const validationError = validateQueryParams(url, [
+    "validator_permit",
+    "format",
+  ]);
   if (validationError) return analyticsQueryError(validationError);
+  const formatError = validateCsvFormat(url);
+  if (formatError) return analyticsQueryError(formatError);
   const validatorsOnly = url.searchParams.get("validator_permit") === "true";
   const data = await loadSubnetMetagraph(d1Runner(env), netuid, {
     validatorsOnly,
   });
+  const meta = await metagraphMeta(
+    env,
+    `/metagraph/subnets/${netuid}/metagraph.json`,
+    data.captured_at,
+  );
+  if (url.searchParams.get("format") === "csv") {
+    return csvResponse(request, neuronsCsv(data.neurons), meta, "short");
+  }
   return envelopeResponse(
     request,
     {
       data,
-      meta: await metagraphMeta(
-        env,
-        `/metagraph/subnets/${netuid}/metagraph.json`,
-        data.captured_at,
-      ),
+      meta,
     },
     "short",
   );
@@ -235,18 +289,24 @@ export async function handleNeuron(request, env, netuid, uid) {
 }
 
 export async function handleSubnetValidators(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, []);
+  const validationError = validateQueryParams(url, ["format"]);
   if (validationError) return analyticsQueryError(validationError);
+  const formatError = validateCsvFormat(url);
+  if (formatError) return analyticsQueryError(formatError);
   const data = await loadSubnetValidators(d1Runner(env), netuid);
+  const meta = await metagraphMeta(
+    env,
+    `/metagraph/subnets/${netuid}/validators.json`,
+    data.captured_at,
+  );
+  if (url.searchParams.get("format") === "csv") {
+    return csvResponse(request, neuronsCsv(data.validators), meta, "short");
+  }
   return envelopeResponse(
     request,
     {
       data,
-      meta: await metagraphMeta(
-        env,
-        `/metagraph/subnets/${netuid}/validators.json`,
-        data.captured_at,
-      ),
+      meta,
     },
     "short",
   );
@@ -543,12 +603,19 @@ export function canonicalSubnetMoversCachePath(url) {
 // ?validator_permit=true changes the response; omission and =false both serve
 // the full metagraph and must share one cache slot.
 export function canonicalSubnetMetagraphCachePath(url) {
-  const validationError = validateQueryParams(url, ["validator_permit"]);
+  const validationError = validateQueryParams(url, [
+    "validator_permit",
+    "format",
+  ]);
   if (validationError) return `${url.pathname}${url.search}`;
+  if (validateCsvFormat(url)) return `${url.pathname}${url.search}`;
   const validatorsOnly = url.searchParams.get("validator_permit") === "true";
-  return validatorsOnly
-    ? `${url.pathname}?validator_permit=true`
-    : url.pathname;
+  const format = url.searchParams.get("format");
+  const search = new URL("https://cache-key.invalid/").searchParams;
+  if (validatorsOnly) search.set("validator_permit", "true");
+  if (format === "csv") search.set("format", "csv");
+  const query = search.toString();
+  return `${url.pathname}${query ? `?${query}` : ""}`;
 }
 
 // GET /api/v1/subnets/{netuid}/concentration/history?window=7d|30d|90d: the per-day

--- a/workers/responses.mjs
+++ b/workers/responses.mjs
@@ -109,3 +109,36 @@ export async function envelopeResponse(
     headers,
   });
 }
+
+export async function csvResponse(
+  request,
+  csv,
+  meta,
+  cacheProfile,
+  extraHeaders = {},
+) {
+  const body = String(csv);
+  const headers = apiHeaders(cacheProfile);
+  headers.set("content-type", "text/csv; charset=utf-8");
+  const etag = await weakEtag(body);
+  headers.set("etag", etag);
+  headers.set(
+    "x-metagraph-contract-version",
+    meta.contract_version || CONTRACT_VERSION,
+  );
+  for (const [key, value] of Object.entries(extraHeaders)) {
+    if (value != null) {
+      headers.set(key, value);
+    }
+  }
+  if (ifNoneMatchSatisfied(request, etag)) {
+    return new Response(null, {
+      status: 304,
+      headers,
+    });
+  }
+  return new Response(request.method === "HEAD" ? null : body, {
+    status: 200,
+    headers,
+  });
+}


### PR DESCRIPTION
## Summary
Implements `?format=csv` for:
- `GET /api/v1/subnets/{netuid}/metagraph`
- `GET /api/v1/subnets/{netuid}/validators`

The CSV output uses the existing neuron response fields, supports `validator_permit=true` on the metagraph route, returns header-only CSV for empty results, and updates generated API/OpenAPI artifacts.
## Related Issue
Closes: #2535
## Change Type
- [x] Feature
- [x] API contract update
- [x] Tests
- [x] Generated artifacts
- [ ] Bug fix
- [ ] Documentation only
- [ ] Refactor only
## Real Behavior Proof
- `GET /api/v1/subnets/7/metagraph?format=csv` returns `text/csv`
- `GET /api/v1/subnets/7/metagraph?validator_permit=true&format=csv` exports only validators
- `GET /api/v1/subnets/7/validators?format=csv` returns validator rows as CSV
- Empty metagraph/validator results return a header-only CSV response
- Invalid format values return `400 invalid_query`
## Validation
- [x] `npm run build`
- [x] `npm test -- tests/request-handlers-entities.test.mjs`
- [x] `npm run lint && npm run format:check`
- [x] `npm run validate`
- [x] `npm run validate:openapi && npm run validate:types && npm run validate:contract-drift`
- [x] `npm run test:ci`
## Checklist
- [x] Focused change for issue `#2535`
- [x] No unrelated registry or data changes
- [x] Contracts updated in `src/contracts.mjs`
- [x] Generated OpenAPI/types artifacts committed
- [x] CSV behavior covered by tests
- [x] CI-style test command passes
