### PR TITLE
feat(api): add fixture detail endpoint

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -154,7 +154,8 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/api/v1/registry/summary`: fetch the registry-wide summary (completeness, top subnets, level counts, latest changes).
 - `/api/v1/coverage-depth`: fetch the machine-usable scorecard and ranked enrichment queue for prioritizing schema, fixture, example, provenance, and review work.
 - `/api/v1/lineage`: fetch maintainer-approved cross-network subnet lineage (graduated subnets + the deploying-soon testnet pipeline).
-- `/api/v1/fixtures`: fetch the index of captured live request/response fixtures (per-surface samples are at `/metagraph/fixtures/{surface_id}.json`, also via the `get_fixture` MCP tool).
+- `/api/v1/fixtures`: fetch the index of captured live request/response fixtures (per-surface samples are available through `/api/v1/fixtures/{surface_id}`, `/metagraph/fixtures/{surface_id}.json`, and the `get_fixture` MCP tool).
+- `/api/v1/fixtures/{surface_id}`: fetch one captured, sanitized live request/response fixture by surface id.
 - `/api/v1/agent-resources`: fetch the AI-resources index (the copyable agent at `/agent.md`, the MCP server + tools, the skill, llms.txt, OpenAPI, and the agent-facing APIs).
 - `/api/v1/subnets/{netuid}/health/percentiles`: fetch p50/p95/p99 latency percentiles per operational surface over a 7d/30d window (live from D1).
 - `/api/v1/subnets/{netuid}/health/incidents`: fetch SLA (uptime ratio) + reconstructed downtime incidents per operational surface over a 7d/30d window (live from D1).

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -742,8 +742,25 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the index of captured live request/response fixtures (which surfaces carry a sanitized sample). Fetch one with get_fixture / GET /metagraph/fixtures/{surface_id}.json. */
+        /** Fetch the index of captured live request/response fixtures (which surfaces carry a sanitized sample). Fetch one with GET /api/v1/fixtures/{surface_id}, get_fixture, or GET /metagraph/fixtures/{surface_id}.json. */
         get: operations["fixtures"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/fixtures/{surface_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch one captured, sanitized live request/response fixture by surface id. */
+        get: operations["fixtureDetail"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3143,6 +3160,34 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Captured, sanitized live request/response sample for one no-auth GET surface. */
+        FixtureArtifact: components["schemas"]["ArtifactBase"] & ({
+            /** Format: date-time */
+            captured_at?: string | null;
+            kind: components["schemas"]["SurfaceKind"];
+            netuid: number;
+            request: {
+                /** @constant */
+                method: "GET";
+                /** Format: uri */
+                url: string;
+            } & {
+                [key: string]: unknown;
+            };
+            response: {
+                /** @description Sanitized JSON response body; sensitive fields and private URLs are redacted before publish. */
+                body: components["schemas"]["JsonObject"] | unknown[] | string | number | boolean | null;
+                content_type?: string | null;
+                status: number;
+            } & {
+                [key: string]: unknown;
+            };
+            subnet_name?: string | null;
+            subnet_slug?: string | null;
+            surface_id: string;
+        } & {
+            [key: string]: unknown;
+        });
         FixturesIndexArtifact: components["schemas"]["ArtifactBase"] & ({
             candidate_count?: number;
             coverage?: ({
@@ -11225,6 +11270,111 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["FixturesIndexArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    fixtureDetail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                surface_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "captured_at": "2026-06-16T12:00:00.000Z",
+                     *         "generated_at": "1970-01-01T00:00:00.000Z",
+                     *         "kind": "subnet-api",
+                     *         "netuid": 7,
+                     *         "request": {
+                     *           "method": "GET",
+                     *           "url": "https://api.all-ways.io/health"
+                     *         },
+                     *         "response": {
+                     *           "body": {
+                     *             "ok": true
+                     *           },
+                     *           "content_type": "application/json",
+                     *           "status": 200
+                     *         },
+                     *         "schema_version": 1,
+                     *         "subnet_name": "AllWays",
+                     *         "subnet_slug": "allways",
+                     *         "surface_id": "7:subnet-api:new_v2"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "/metagraph/fixtures/7:subnet-api:new_v2.json",
+                     *         "cache": "standard",
+                     *         "contract_version": "2026-07-02.1",
+                     *         "generated_at": "1970-01-01T00:00:00.000Z",
+                     *         "published_at": null,
+                     *         "source": "r2"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["FixtureArtifact"];
                     };
                 };
             };

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -228,7 +228,7 @@
       "contract_version": "2026-07-02.1",
       "id": "fixture-detail",
       "path": "/metagraph/fixtures/{surface_id}.json",
-      "schema_ref": "#/components/schemas/JsonObject",
+      "schema_ref": "#/components/schemas/FixtureArtifact",
       "storage_tier": "r2"
     },
     {
@@ -2643,10 +2643,22 @@
     {
       "artifact_path": "/metagraph/fixtures.json",
       "cache": "standard",
-      "description": "Fetch the index of captured live request/response fixtures (which surfaces carry a sanitized sample). Fetch one with get_fixture / GET /metagraph/fixtures/{surface_id}.json.",
+      "description": "Fetch the index of captured live request/response fixtures (which surfaces carry a sanitized sample). Fetch one with GET /api/v1/fixtures/{surface_id}, get_fixture, or GET /metagraph/fixtures/{surface_id}.json.",
       "id": "fixtures",
       "method": "GET",
       "path": "/api/v1/fixtures",
+      "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
+      "query_parameters": []
+    },
+    {
+      "artifact_path": "/metagraph/fixtures/{surface_id}.json",
+      "cache": "standard",
+      "description": "Fetch one captured, sanitized live request/response fixture by surface id.",
+      "id": "fixture-detail",
+      "method": "GET",
+      "path": "/api/v1/fixtures/{surface_id}",
       "public": true,
       "query_collection": null,
       "query_filter_names": [],

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -294,7 +294,7 @@
       "description": "A captured, sanitized live request/response sample for one surface.",
       "id": "fixture-detail",
       "path": "/metagraph/fixtures/{surface_id}.json",
-      "schema_ref": "#/components/schemas/JsonObject",
+      "schema_ref": "#/components/schemas/FixtureArtifact",
       "storage_tier": "r2"
     },
     {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -5574,6 +5574,117 @@
         ],
         "type": "object"
       },
+      "FixtureArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "captured_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "kind": {
+                "$ref": "#/components/schemas/SurfaceKind"
+              },
+              "netuid": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "request": {
+                "additionalProperties": true,
+                "properties": {
+                  "method": {
+                    "const": "GET"
+                  },
+                  "url": {
+                    "format": "uri",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "method",
+                  "url"
+                ],
+                "type": "object"
+              },
+              "response": {
+                "additionalProperties": true,
+                "properties": {
+                  "body": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/JsonObject"
+                      },
+                      {
+                        "items": {},
+                        "type": "array"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Sanitized JSON response body; sensitive fields and private URLs are redacted before publish."
+                  },
+                  "content_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "status": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "status",
+                  "body"
+                ],
+                "type": "object"
+              },
+              "subnet_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subnet_slug": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "surface_id": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9:._-]*$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "surface_id",
+              "netuid",
+              "kind",
+              "request",
+              "response"
+            ],
+            "type": "object"
+          }
+        ],
+        "description": "Captured, sanitized live request/response sample for one no-auth GET surface."
+      },
       "FixturesIndexArtifact": {
         "allOf": [
           {
@@ -23726,7 +23837,139 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the index of captured live request/response fixtures (which surfaces carry a sanitized sample). Fetch one with get_fixture / GET /metagraph/fixtures/{surface_id}.json.",
+        "summary": "Fetch the index of captured live request/response fixtures (which surfaces carry a sanitized sample). Fetch one with GET /api/v1/fixtures/{surface_id}, get_fixture, or GET /metagraph/fixtures/{surface_id}.json.",
+        "tags": [
+          "registry",
+          "api-dx"
+        ]
+      }
+    },
+    "/api/v1/fixtures/{surface_id}": {
+      "get": {
+        "operationId": "fixtureDetail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "surface_id",
+            "required": true,
+            "schema": {
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9:._-]*$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "captured_at": "2026-06-16T12:00:00.000Z",
+                    "generated_at": "1970-01-01T00:00:00.000Z",
+                    "kind": "subnet-api",
+                    "netuid": 7,
+                    "request": {
+                      "method": "GET",
+                      "url": "https://api.all-ways.io/health"
+                    },
+                    "response": {
+                      "body": {
+                        "ok": true
+                      },
+                      "content_type": "application/json",
+                      "status": 200
+                    },
+                    "schema_version": 1,
+                    "subnet_name": "AllWays",
+                    "subnet_slug": "allways",
+                    "surface_id": "7:subnet-api:new_v2"
+                  },
+                  "meta": {
+                    "artifact_path": "/metagraph/fixtures/7:subnet-api:new_v2.json",
+                    "cache": "standard",
+                    "contract_version": "2026-07-02.1",
+                    "generated_at": "1970-01-01T00:00:00.000Z",
+                    "published_at": null,
+                    "source": "r2"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/FixtureArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch one captured, sanitized live request/response fixture by surface id.",
         "tags": [
           "registry",
           "api-dx"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -742,8 +742,25 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the index of captured live request/response fixtures (which surfaces carry a sanitized sample). Fetch one with get_fixture / GET /metagraph/fixtures/{surface_id}.json. */
+        /** Fetch the index of captured live request/response fixtures (which surfaces carry a sanitized sample). Fetch one with GET /api/v1/fixtures/{surface_id}, get_fixture, or GET /metagraph/fixtures/{surface_id}.json. */
         get: operations["fixtures"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/fixtures/{surface_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch one captured, sanitized live request/response fixture by surface id. */
+        get: operations["fixtureDetail"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3143,6 +3160,34 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description Captured, sanitized live request/response sample for one no-auth GET surface. */
+        FixtureArtifact: components["schemas"]["ArtifactBase"] & ({
+            /** Format: date-time */
+            captured_at?: string | null;
+            kind: components["schemas"]["SurfaceKind"];
+            netuid: number;
+            request: {
+                /** @constant */
+                method: "GET";
+                /** Format: uri */
+                url: string;
+            } & {
+                [key: string]: unknown;
+            };
+            response: {
+                /** @description Sanitized JSON response body; sensitive fields and private URLs are redacted before publish. */
+                body: components["schemas"]["JsonObject"] | unknown[] | string | number | boolean | null;
+                content_type?: string | null;
+                status: number;
+            } & {
+                [key: string]: unknown;
+            };
+            subnet_name?: string | null;
+            subnet_slug?: string | null;
+            surface_id: string;
+        } & {
+            [key: string]: unknown;
+        });
         FixturesIndexArtifact: components["schemas"]["ArtifactBase"] & ({
             candidate_count?: number;
             coverage?: ({
@@ -11225,6 +11270,111 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["FixturesIndexArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    fixtureDetail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                surface_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "captured_at": "2026-06-16T12:00:00.000Z",
+                     *         "generated_at": "1970-01-01T00:00:00.000Z",
+                     *         "kind": "subnet-api",
+                     *         "netuid": 7,
+                     *         "request": {
+                     *           "method": "GET",
+                     *           "url": "https://api.all-ways.io/health"
+                     *         },
+                     *         "response": {
+                     *           "body": {
+                     *             "ok": true
+                     *           },
+                     *           "content_type": "application/json",
+                     *           "status": 200
+                     *         },
+                     *         "schema_version": 1,
+                     *         "subnet_name": "AllWays",
+                     *         "subnet_slug": "allways",
+                     *         "surface_id": "7:subnet-api:new_v2"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "/metagraph/fixtures/7:subnet-api:new_v2.json",
+                     *         "cache": "standard",
+                     *         "contract_version": "2026-07-02.1",
+                     *         "generated_at": "1970-01-01T00:00:00.000Z",
+                     *         "published_at": null,
+                     *         "source": "r2"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["FixtureArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -5560,6 +5560,117 @@
         ],
         "type": "object"
       },
+      "FixtureArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "captured_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "kind": {
+                "$ref": "#/components/schemas/SurfaceKind"
+              },
+              "netuid": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "request": {
+                "additionalProperties": true,
+                "properties": {
+                  "method": {
+                    "const": "GET"
+                  },
+                  "url": {
+                    "format": "uri",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "method",
+                  "url"
+                ],
+                "type": "object"
+              },
+              "response": {
+                "additionalProperties": true,
+                "properties": {
+                  "body": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/JsonObject"
+                      },
+                      {
+                        "items": {},
+                        "type": "array"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Sanitized JSON response body; sensitive fields and private URLs are redacted before publish."
+                  },
+                  "content_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "status": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "status",
+                  "body"
+                ],
+                "type": "object"
+              },
+              "subnet_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subnet_slug": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "surface_id": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9:._-]*$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "surface_id",
+              "netuid",
+              "kind",
+              "request",
+              "response"
+            ],
+            "type": "object"
+          }
+        ],
+        "description": "Captured, sanitized live request/response sample for one no-auth GET surface."
+      },
       "FixturesIndexArtifact": {
         "allOf": [
           {

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -3613,6 +3613,60 @@
             "additionalProperties": true
           }
         ]
+      },
+      "FixtureArtifact": {
+        "description": "Captured, sanitized live request/response sample for one no-auth GET surface.",
+        "allOf": [
+          { "$ref": "#/components/schemas/ArtifactBase" },
+          {
+            "type": "object",
+            "required": ["surface_id", "netuid", "kind", "request", "response"],
+            "properties": {
+              "surface_id": {
+                "type": "string",
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9:._-]*$"
+              },
+              "netuid": { "type": "integer", "minimum": 0 },
+              "subnet_slug": { "type": ["string", "null"] },
+              "subnet_name": { "type": ["string", "null"] },
+              "kind": { "$ref": "#/components/schemas/SurfaceKind" },
+              "captured_at": {
+                "type": ["string", "null"],
+                "format": "date-time"
+              },
+              "request": {
+                "type": "object",
+                "required": ["method", "url"],
+                "properties": {
+                  "method": { "const": "GET" },
+                  "url": { "type": "string", "format": "uri" }
+                },
+                "additionalProperties": true
+              },
+              "response": {
+                "type": "object",
+                "required": ["status", "body"],
+                "properties": {
+                  "status": { "type": "integer" },
+                  "content_type": { "type": ["string", "null"] },
+                  "body": {
+                    "anyOf": [
+                      { "$ref": "#/components/schemas/JsonObject" },
+                      { "type": "array", "items": {} },
+                      { "type": "string" },
+                      { "type": "number" },
+                      { "type": "boolean" },
+                      { "type": "null" }
+                    ],
+                    "description": "Sanitized JSON response body; sensitive fields and private URLs are redacted before publish."
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          }
+        ]
       }
     }
   }

--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -22,9 +22,12 @@ if (
 
 async function runLiveSmoke() {
   const healthDate = await discoverHealthHistoryDate();
-  const apiChecks = API_ROUTES.map((route) => ({
+  const fixtureSurfaceId =
+    process.env.METAGRAPH_LIVE_FIXTURE_SURFACE_ID ||
+    (await discoverFixtureSurfaceId());
+  const apiChecks = liveSmokeApiRoutes(fixtureSurfaceId).map((route) => ({
     route: route.path,
-    url: apiRouteUrl(route.path, healthDate),
+    url: apiRouteUrl(route.path, healthDate, { surfaceId: fixtureSurfaceId }),
   }));
   const rawArtifactChecks = [
     "/metagraph/openapi.json",
@@ -369,7 +372,7 @@ async function discoverHealthHistoryDate() {
   });
 }
 
-export function apiRouteUrl(routePath, date) {
+export function apiRouteUrl(routePath, date, options = {}) {
   // D1-tier detail routes carry id placeholders beyond {netuid}/{slug}/{date}.
   // Substitute constant, dependency-free sample ids that resolve to a live 200:
   // uid 0 always exists; an all-zero hash / block 0 hit the cold→null wrapper
@@ -384,6 +387,7 @@ export function apiRouteUrl(routePath, date) {
     .replace("{uid}", "0")
     .replace("{hash}", `0x${"0".repeat(64)}`)
     .replace("{ref}", "0")
+    .replace("{surface_id}", options.surfaceId || "7:subnet-api:new_v2")
     .replace("{ss58}", "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM");
   // Guard against the recurring #1682 class: any leftover `{` means a route
   // placeholder was never substituted, which silently 404s against a live URL
@@ -409,6 +413,31 @@ export function apiRouteUrl(routePath, date) {
     url.searchParams.set("limit", "3");
   }
   return url.toString();
+}
+
+export function liveSmokeApiRoutes(fixtureSurfaceId = null) {
+  // Fixture detail is a live, R2-only detail route whose path requires a
+  // currently published surface id. The smoke runner derives that id from the
+  // fixture index when the deployment does not supply an explicit override.
+  return API_ROUTES.filter(
+    (route) => route.id !== "fixture-detail" || fixtureSurfaceId,
+  );
+}
+
+export async function discoverFixtureSurfaceId() {
+  const result = await fetchJson(`${baseUrl}/api/v1/fixtures`);
+  return fixtureSurfaceIdFromIndex(result.body);
+}
+
+export function fixtureSurfaceIdFromIndex(body) {
+  const fixtures = body?.data?.fixtures;
+  if (!Array.isArray(fixtures)) {
+    return null;
+  }
+  return (
+    fixtures.find((fixture) => typeof fixture?.surface_id === "string")
+      ?.surface_id || null
+  );
 }
 
 async function fetchJson(url, options = {}) {

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -26,6 +26,23 @@ const ajv = new Ajv2020({
 });
 addFormats(ajv);
 
+const fixtureDetail = {
+  schema_version: 1,
+  generated_at: "1970-01-01T00:00:00.000Z",
+  surface_id: "7:subnet-api:new_v2",
+  netuid: 7,
+  subnet_slug: "allways",
+  subnet_name: "AllWays",
+  kind: "subnet-api",
+  captured_at: "2026-06-16T12:00:00.000Z",
+  request: { method: "GET", url: "https://api.all-ways.io/health" },
+  response: {
+    status: 200,
+    content_type: "application/json",
+    body: { ok: true },
+  },
+};
+
 // Register the OpenAPI components block ONCE under an absolute id (mirroring
 // validate-schemas.mjs) instead of re-inlining all ~198 schemas into every
 // per-route compile. Response schemas resolve their `#/components/...` refs
@@ -76,6 +93,7 @@ function compileResponseValidator(schema) {
 // service binding). It's a separate Worker not present in this harness, so mock it
 // with the bare response shapes it serves (ADR 0013) — api.mjs rewraps them in the
 // canonical envelope, which is what the checks below assert.
+const baseEnv = createLocalArtifactEnv();
 const env = createLocalArtifactEnv({
   DATA_API: {
     async fetch(request) {
@@ -97,6 +115,18 @@ const env = createLocalArtifactEnv({
         JSON.stringify({ block_number: 100, count: 0, events: [] }),
         { status: 200, headers },
       );
+    },
+  },
+  METAGRAPH_ARCHIVE: {
+    async get(key) {
+      if (key === "latest/fixtures/7:subnet-api:new_v2.json") {
+        return {
+          async json() {
+            return fixtureDetail;
+          },
+        };
+      }
+      return baseEnv.METAGRAPH_ARCHIVE.get(key);
     },
   },
 });
@@ -717,6 +747,14 @@ const checks = [
     (body) => {
       assert.equal(typeof body.data.fixture_count, "number");
       assert.equal(Array.isArray(body.data.fixtures), true);
+    },
+  ],
+  [
+    "/api/v1/fixtures/7:subnet-api:new_v2",
+    (body) => {
+      assert.equal(body.data.surface_id, "7:subnet-api:new_v2");
+      assert.equal(body.data.response.status, 200);
+      assert.deepEqual(body.data.response.body, { ok: true });
     },
   ],
   [

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -812,7 +812,7 @@ export const PUBLIC_ARTIFACTS = [
     "fixture-detail",
     "/metagraph/fixtures/{surface_id}.json",
     "A captured, sanitized live request/response sample for one surface.",
-    "JsonObject",
+    "FixtureArtifact",
   ),
   artifact(
     "curation",
@@ -1572,9 +1572,28 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/fixtures",
     "/metagraph/fixtures.json",
-    "Fetch the index of captured live request/response fixtures (which surfaces carry a sanitized sample). Fetch one with get_fixture / GET /metagraph/fixtures/{surface_id}.json.",
+    "Fetch the index of captured live request/response fixtures (which surfaces carry a sanitized sample). Fetch one with GET /api/v1/fixtures/{surface_id}, get_fixture, or GET /metagraph/fixtures/{surface_id}.json.",
     "standard",
     ["registry", "api-dx"],
+  ),
+  route(
+    "fixture-detail",
+    "GET",
+    "/api/v1/fixtures/{surface_id}",
+    "/metagraph/fixtures/{surface_id}.json",
+    "Fetch one captured, sanitized live request/response fixture by surface id.",
+    "standard",
+    ["registry", "api-dx"],
+    [],
+    [
+      {
+        name: "surface_id",
+        schema: {
+          type: "string",
+          pattern: "^[A-Za-z0-9][A-Za-z0-9:._-]*$",
+        },
+      },
+    ],
   ),
   route(
     "agent-resources",
@@ -2760,7 +2779,11 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
         // Deterministic worked example (schema-valid, no live data) so
         // Swagger UI + agents see a concrete response shape. Generated
         // from the schema; enforced by validate-openapi-examples.
-        example: sampleFromSchema(responseSchema, componentSchemas),
+        example: openApiExampleForRoute(
+          entry,
+          responseSchema,
+          componentSchemas,
+        ),
       },
       ...(entry.csv_response
         ? {
@@ -2894,6 +2917,42 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
   };
 }
 
+const FIXTURE_DETAIL_OPENAPI_EXAMPLE = {
+  schema_version: 1,
+  generated_at: "1970-01-01T00:00:00.000Z",
+  surface_id: "7:subnet-api:new_v2",
+  netuid: 7,
+  subnet_slug: "allways",
+  subnet_name: "AllWays",
+  kind: "subnet-api",
+  captured_at: "2026-06-16T12:00:00.000Z",
+  request: { method: "GET", url: "https://api.all-ways.io/health" },
+  response: {
+    status: 200,
+    content_type: "application/json",
+    body: { ok: true },
+  },
+};
+
+function openApiExampleForRoute(entry, responseSchema, componentSchemas) {
+  const example = sampleFromSchema(responseSchema, componentSchemas);
+  if (entry.id !== "fixture-detail") {
+    return example;
+  }
+  return {
+    ...example,
+    data: FIXTURE_DETAIL_OPENAPI_EXAMPLE,
+    meta: {
+      artifact_path: "/metagraph/fixtures/7:subnet-api:new_v2.json",
+      cache: "standard",
+      contract_version: CONTRACT_VERSION,
+      generated_at: FIXTURE_DETAIL_OPENAPI_EXAMPLE.generated_at,
+      published_at: null,
+      source: "r2",
+    },
+  };
+}
+
 export function artifactPathFromTemplate(template, params = {}) {
   return template
     .replace("{netuid}", String(params.netuid ?? ""))
@@ -2926,7 +2985,10 @@ export function compileRoutePattern(pathTemplate) {
     .replace(/__METAGRAPH_SS58__/g, "(?<ss58>[1-9A-HJ-NP-Za-km-z]{47,48})")
     .replace(/__METAGRAPH_SLUG__/g, "(?<slug>[a-z0-9-]+)")
     .replace(/__METAGRAPH_DATE__/g, "(?<date>\\d{4}-\\d{2}-\\d{2})")
-    .replace(/__METAGRAPH_SURFACE_ID__/g, "(?<surface_id>[a-z0-9-]+)")
+    .replace(
+      /__METAGRAPH_SURFACE_ID__/g,
+      "(?<surface_id>[A-Za-z0-9][A-Za-z0-9:._-]*)",
+    )
     .replace(/__METAGRAPH_REF__/g, "(?<ref>\\d+|0x[0-9a-fA-F]{64})")
     .replace(/__METAGRAPH_HASH__/g, "(?<hash>0x[0-9a-fA-F]{64}|\\d+-\\d+)");
   return new RegExp(`^${pattern}\\/?$`);

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -353,6 +353,44 @@ describe("/health readiness", () => {
 
 // --- raw artifact route -------------------------------------------------------
 describe("raw artifact route", () => {
+  const fixture = {
+    schema_version: 1,
+    generated_at: "1970-01-01T00:00:00.000Z",
+    surface_id: "7:subnet-api:new_v2",
+    netuid: 7,
+    subnet_slug: "allways",
+    subnet_name: "AllWays",
+    kind: "subnet-api",
+    captured_at: "2026-06-16T12:00:00.000Z",
+    request: { method: "GET", url: "https://api.all-ways.io/health" },
+    response: {
+      status: 200,
+      content_type: "application/json",
+      body: { ok: true },
+    },
+  };
+
+  function fixtureEnv() {
+    return createLocalArtifactEnv({
+      METAGRAPH_ARCHIVE: {
+        async get(key) {
+          if (key === "latest/fixtures/7:subnet-api:new_v2.json") {
+            const body = JSON.stringify(fixture);
+            return {
+              async json() {
+                return fixture;
+              },
+              async text() {
+                return body;
+              },
+            };
+          }
+          return null;
+        },
+      },
+    });
+  }
+
   test("serves a raw artifact with source + storage-tier headers", async () => {
     const env = createLocalArtifactEnv();
     const res = await handleRequest(req("/metagraph/subnets.json"), env, {});
@@ -399,6 +437,86 @@ describe("raw artifact route", () => {
     assert.equal(res.status, 404);
     const body = await res.json();
     assert.equal(body.meta.artifact_path, "/metagraph/subnets.json");
+  });
+
+  test("serves R2-only fixture details with rich surface ids", async () => {
+    const res = await handleRequest(
+      req("/metagraph/fixtures/7:subnet-api:new_v2.json"),
+      fixtureEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-storage-tier"), "r2");
+    const body = await res.json();
+    assert.equal(body.surface_id, "7:subnet-api:new_v2");
+    assert.deepEqual(body.response.body, { ok: true });
+  });
+});
+
+// --- fixture detail API --------------------------------------------------------
+describe("fixture detail API", () => {
+  const fixture = {
+    schema_version: 1,
+    generated_at: "1970-01-01T00:00:00.000Z",
+    surface_id: "7:subnet-api:new_v2",
+    netuid: 7,
+    subnet_slug: "allways",
+    subnet_name: "AllWays",
+    kind: "subnet-api",
+    captured_at: "2026-06-16T12:00:00.000Z",
+    request: { method: "GET", url: "https://api.all-ways.io/health" },
+    response: {
+      status: 200,
+      content_type: "application/json",
+      body: { ok: true },
+    },
+  };
+
+  function env() {
+    return createLocalArtifactEnv({
+      METAGRAPH_ARCHIVE: {
+        async get(key) {
+          if (key === "latest/fixtures/7:subnet-api:new_v2.json") {
+            return {
+              async json() {
+                return fixture;
+              },
+            };
+          }
+          return null;
+        },
+      },
+    });
+  }
+
+  test("GET /api/v1/fixtures/{surface_id} returns an enveloped fixture", async () => {
+    const res = await handleRequest(
+      req("/api/v1/fixtures/7:subnet-api:new_v2"),
+      env(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^application\/json/);
+
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.surface_id, "7:subnet-api:new_v2");
+    assert.equal(body.data.request.method, "GET");
+    assert.deepEqual(body.data.response.body, { ok: true });
+    assert.equal(
+      body.meta.artifact_path,
+      "/metagraph/fixtures/7:subnet-api:new_v2.json",
+    );
+  });
+
+  test("fixture detail route rejects traversal-like surface ids", async () => {
+    const res = await handleRequest(
+      req("/api/v1/fixtures/..%2Fsecrets"),
+      env(),
+      {},
+    );
+    assert.equal(res.status, 404);
+    assert.equal((await res.json()).error.code, "not_found");
   });
 });
 

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -88,15 +88,19 @@ describe("public contract registry", () => {
       "/metagraph/schemas/sn-56-gradients-openapi.json",
     );
     assert.equal(schemaMatch.groups.surface_id, "sn-56-gradients-openapi");
+    const aliasMatch = schemaPattern.exec(
+      "/metagraph/schemas/7:subnet-api:new_v2.json",
+    );
+    assert.equal(aliasMatch.groups.surface_id, "7:subnet-api:new_v2");
     assert.equal(
-      schemaPattern.test("/metagraph/schemas/SN-56-gradients-openapi.json"),
+      schemaPattern.test("/metagraph/schemas/../secrets.json"),
       false,
     );
     assert.equal(
       artifactPathFromTemplate("/metagraph/schemas/{surface_id}.json", {
-        surface_id: "sn-56-gradients-openapi",
+        surface_id: "7:subnet-api:new_v2",
       }),
-      "/metagraph/schemas/sn-56-gradients-openapi.json",
+      "/metagraph/schemas/7:subnet-api:new_v2.json",
     );
   });
 
@@ -133,6 +137,36 @@ describe("public contract registry", () => {
     assert.equal(openapi.openapi, "3.1.0");
     assert.equal(openapi.info.version, CONTRACT_VERSION);
     assert.equal(Object.keys(openapi.paths).length, API_ROUTES.length);
+    const fixtureArtifactSchema = openapi.components.schemas.FixtureArtifact;
+    assert.equal(
+      fixtureArtifactSchema.allOf.some(
+        (branch) => branch.$ref === "#/components/schemas/ArtifactBase",
+      ),
+      true,
+    );
+    const fixtureDetailSchema = fixtureArtifactSchema.allOf.find(
+      (branch) => branch.properties?.response,
+    );
+    assert.equal(
+      fixtureDetailSchema.properties.surface_id.pattern,
+      "^[A-Za-z0-9][A-Za-z0-9:._-]*$",
+    );
+    assert.equal(
+      fixtureDetailSchema.properties.request.properties.method.const,
+      "GET",
+    );
+    assert.equal(
+      fixtureDetailSchema.properties.kind.$ref,
+      "#/components/schemas/SurfaceKind",
+    );
+    const fixtureBodySchema =
+      fixtureDetailSchema.properties.response.properties.body;
+    assert.equal(
+      fixtureBodySchema.anyOf.some(
+        (branch) => branch.$ref === "#/components/schemas/JsonObject",
+      ),
+      true,
+    );
     assert.equal(Boolean(openapi.components.schemas.SuccessEnvelope), true);
     assert.equal(Boolean(openapi.components.schemas.ErrorEnvelope), true);
     assert.equal(Boolean(openapi.components.schemas.Surface), true);
@@ -145,6 +179,21 @@ describe("public contract registry", () => {
       true,
     );
     assert.equal(openapi["x-metagraphed"].generated_at, generatedAt);
+
+    const fixtureExample =
+      openapi.paths["/api/v1/fixtures/{surface_id}"].get.responses["200"]
+        .content["application/json"].example;
+    assert.equal(fixtureExample.data.surface_id, "7:subnet-api:new_v2");
+    assert.equal(fixtureExample.data.response.status, 200);
+    assert.deepEqual(fixtureExample.data.response.body, { ok: true });
+    assert.equal(
+      fixtureExample.meta.artifact_path,
+      "/metagraph/fixtures/7:subnet-api:new_v2.json",
+    );
+    assert.equal(fixtureExample.meta.cache, "standard");
+    assert.equal(fixtureExample.meta.source, "r2");
+    assert.equal(fixtureExample.meta.pagination, undefined);
+    assert.equal(fixtureExample.meta.stale_contract, undefined);
 
     const subnetParameters = openapi.paths["/api/v1/subnets"].get.parameters;
     assert.equal(

--- a/tests/invariants-contracts.test.mjs
+++ b/tests/invariants-contracts.test.mjs
@@ -180,11 +180,11 @@ describe("contracts — compileRoutePattern per token type", () => {
       token: "{surface_id}",
       group: "surface_id",
       template: "/metagraph/schemas/{surface_id}.json",
-      validPath: "/metagraph/schemas/sn-56-gradients-openapi.json",
-      captured: "sn-56-gradients-openapi",
+      validPath: "/metagraph/schemas/7:Subnet_API.new-v2.json",
+      captured: "7:Subnet_API.new-v2",
       invalid: [
-        "/metagraph/schemas/SN-56.json", // uppercase
         "/metagraph/schemas/.json", // empty id
+        "/metagraph/schemas/../secrets.json", // traversal-like path
       ],
     },
     {

--- a/tests/smoke-route-substitution.test.mjs
+++ b/tests/smoke-route-substitution.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { API_ROUTES } from "../src/contracts.mjs";
-import { apiRouteUrl } from "../scripts/smoke-live-api.mjs";
+import {
+  apiRouteUrl,
+  fixtureSurfaceIdFromIndex,
+  liveSmokeApiRoutes,
+} from "../scripts/smoke-live-api.mjs";
 
 // PR-time guard for the recurring #1682 class: the live smoke substitutes path
 // placeholders ({netuid}/{slug}/{date}/{uid}/{hash}/{ref}/{ss58}) before
@@ -20,4 +24,39 @@ describe("smoke route substitution", () => {
       );
     });
   }
+
+  test("fixture detail live smoke is included when a surface id is available", () => {
+    assert.equal(
+      liveSmokeApiRoutes(null).some((route) => route.id === "fixture-detail"),
+      false,
+    );
+    assert.equal(
+      liveSmokeApiRoutes("7:subnet-api:new_v2").some(
+        (route) => route.id === "fixture-detail",
+      ),
+      true,
+    );
+  });
+
+  test("fixture detail URL uses the discovered surface id", () => {
+    const url = apiRouteUrl("/api/v1/fixtures/{surface_id}", sampleDate, {
+      surfaceId: "91:subnet-api:live_v1",
+    });
+    assert.equal(
+      new URL(url).pathname,
+      "/api/v1/fixtures/91:subnet-api:live_v1",
+    );
+  });
+
+  test("fixture detail live smoke can derive a surface id from the fixture index", () => {
+    assert.equal(
+      fixtureSurfaceIdFromIndex({
+        data: {
+          fixtures: [{ surface_id: "7:subnet-api:new_v2" }],
+        },
+      }),
+      "7:subnet-api:new_v2",
+    );
+    assert.equal(fixtureSurfaceIdFromIndex({ data: { fixtures: [] } }), null);
+  });
 });


### PR DESCRIPTION
## Summary

Adds a first-class REST endpoint for fetching one captured, sanitized API fixture by `surface_id`, backed by the existing per-surface fixture artifacts.

Refs #748

## What changed

- Added `GET /api/v1/fixtures/{surface_id}` as an enveloped API route for fixture details.
- Added a concrete `FixtureArtifact` schema and regenerated OpenAPI, contract, API index, and generated TypeScript artifacts.
- Tightened `FixtureArtifact` to compose with the standard artifact base metadata, constrain `surface_id`, reuse the `SurfaceKind` enum, and model fixture requests as GET samples.
- Typed fixture response bodies as arbitrary JSON values so generated clients accept normal object payloads such as `{ ok: true }`.
- Added a realistic OpenAPI fixture-detail example with route-faithful metadata and no generic pagination or stale-contract fields.
- Broadened the `surface_id` route token to support rich fixture/schema IDs while preserving empty and traversal-like path rejection.
- Updated local API validation, docs contract coverage, and live-smoke route substitution/selection coverage for the fixture detail path.
- Added raw artifact, REST route, contract, docs contract, route-invariant, and operational-smoke coverage.

## Why

The fixture index already tells clients which surfaces have sanitized request/response examples, but REST clients had to jump to raw artifacts or non-REST tooling to fetch an individual fixture. This makes fixture detail discoverable through the public API contract and generated clients.

## Validation

- `npm run build`
- `npx vitest run tests/contracts.test.mjs tests/api-coverage.test.mjs tests/invariants-contracts.test.mjs tests/smoke-route-substitution.test.mjs --testTimeout=30000`
- `npx vitest run tests/contracts.test.mjs tests/smoke-route-substitution.test.mjs --testTimeout=30000`
- `npx vitest run tests/smoke-route-substitution.test.mjs --testTimeout=30000`
- `npm run validate:contract-drift`
- `npm run validate:openapi`
- `npm run validate:openapi-examples`
- `npm run validate:types`
- `npm run validate:generated-client`
- `npm run validate:api`
- `npm run validate:schemas`
- `npm run validate:docs`
- `npm run format:check`
- `npm run lint`
- `npm run scan:public-safety`
- `git diff --check`
- `npm run test:coverage -- --testTimeout=30000` — 161 test files and 4,284 tests passed; statements 99.12%, branches 96.31%, lines 99.43%.

## Notes

Issue context: #748 is the fixture-surfacing roadmap item and is already closed; this PR is a scoped REST API/contract follow-up over already-published fixture artifacts, so there is no open issue for this exact endpoint.

Scope/risk: one new read-only route backed by existing R2 fixture artifacts; no registry data, D1 schema, write path, probing behavior, or MCP surface changes.
