### PR TITLE
ci(validate): add a docs-only fast lane to the checks job

### DIFF
--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -94,19 +94,20 @@ discover -s tests` (the `[test]` extra pulls in httpx so the async cases run). N
 **The docs fast lane (`checks` only) — narrower than, and does not weaken, the "no reduced ugc
 fast-lane" rule above.** That rule is about _registry/community-surface_ content never getting a
 weaker gate. This is a separate, much narrower thing: when a PR's diff consists entirely of paths
-matching the glob `**/*.md` or the prefix `.claude/skills/` (pure contributor-facing prose — cannot
-touch registry data, schemas, code, or CI config), the `changes` job sets `docs_only=true` and
-`checks` skips only its build/contract/registry/deploy-dry-run steps via a **per-step**
-`if: env.DOCS_ONLY != 'true'` guard — never a job-level skip, so `checks` always reports a real
-`success`/`failure` conclusion, never `skipped`. `Lint + format`, `validate:docs`, `validate:intake`,
-and `scan:public-safety` still run unconditionally on every PR, docs-only or not — they're cheap (no
-build, no network) and are exactly what a stray secret or broken doc-contract reference in a
-"docs-only" PR would trip. **Hard guardrail, no exceptions:** any diff touching `registry/` forces
-`docs_only=false` regardless of what else is in the diff — computed as an independent override in the
-same `changes` job step, before the docs-pattern check even runs. This exists because the retired
-"ugc" lane above was scoped to registry/community-surface PRs specifically and caused a real
-stale-base preflight false-positive; registry-touching diffs get zero special treatment here. The
-filter is a plain `git diff --name-only` + `grep` in the trusted workflow — **not**
+matching the glob `**/*.md` or `.claude/skills/**/*.md` (pure contributor-facing prose — cannot
+touch registry data, schemas, code, or CI config; a non-`.md` file anywhere, including a hypothetical
+future non-`.md` file under `.claude/skills/`, disqualifies the whole PR), the `changes` job sets
+`docs_only=true` and `checks` skips only its build/contract/registry/deploy-dry-run steps via a
+**per-step** `if: env.DOCS_ONLY != 'true'` guard — never a job-level skip, so `checks` always reports
+a real `success`/`failure` conclusion, never `skipped`. `Lint + format`, `validate:docs`,
+`validate:intake`, and `scan:public-safety` still run unconditionally on every PR, docs-only or
+not — they're cheap (no build, no network) and are exactly what a stray secret or broken
+doc-contract reference in a "docs-only" PR would trip. **Hard guardrail, no exceptions:** any diff
+touching `registry/` forces `docs_only=false` regardless of what else is in the diff — computed as an
+independent override in the same `changes` job step, before the docs-pattern check even runs. This
+exists because the retired "ugc" lane above was scoped to registry/community-surface PRs specifically
+and caused a real stale-base preflight false-positive; registry-touching diffs get zero special
+treatment here. The filter is a plain `git diff --name-only` + `grep` in the trusted workflow — **not**
 `dorny/paths-filter` or any other third-party action: this repo's Actions allowlist
 (`repos/JSONbored/metagraphed/actions/permissions/selected-actions`) only allows GitHub-owned +
 verified-creator actions plus one explicit `peter-evans/create-pull-request` pattern, and
@@ -114,6 +115,25 @@ verified-creator actions plus one explicit `peter-evans/create-pull-request` pat
 using it as-is would hit a `startup_failure`. If a future change wants a real path-filter action, it
 needs an explicit allowlist pattern added via Settings → Actions → General first (a live settings
 change, not something a PR can do).
+
+**Two further narrow, independent skips in the same `changes` job — unrelated to `docs_only`.**
+`Validate workflows` (`npm run validate:workflows`) reads only `.github/workflows/*.yml`/`.yaml`, and
+`Validate migration sequence` (`npm run validate:migrations`) reads only `migrations/*.sql` — each
+verified by reading its script's full source, neither imports anything outside its own directory. The
+`changes` job sets `run_workflows_validation`/`run_migrations_validation` to `true` only when the
+diff touches that specific path, and `checks` gates each validator step on its own flag
+(`env.RUN_WORKFLOWS_VALIDATION`/`env.RUN_MIGRATIONS_VALIDATION`), independent of `docs_only` and of
+each other — a PR can be workflow-only or migration-only without being a docs PR. These are the only
+two `checks` validators with a clean enough path boundary to skip safely; every other validator
+(`validate:schemas`/`api`/`mcp`/`ai`/`openapi`/`types`/`client-sdk-sync`) transitively imports most of
+`src/`+`workers/**` via `workers/api.mjs`, so no path glob short of "almost the whole repo" would
+safely exclude them — see the "new artifact/route checklist" in §8 for why a route/handler change can
+trip a contract gate with no lexical hint in the diff. Per-area **test** splitting (e.g. skip
+MCP-specific tests when `src/mcp-server.mjs` wasn't touched) was evaluated and rejected: the suite has
+no per-subject directory structure (all 154 files sit flat in `tests/`), a third of it imports
+`workers/api.mjs`'s shared router directly, and `vitest.config.mjs`'s `fileParallelism: false` exists
+for a filesystem-race reason (see below) unrelated to subject area — splitting by area would need a
+real test-tree/module-boundary refactor, not a CI config change.
 
 **Gates (all must pass):** `lint` · `format:check` · `validate:contract-drift` ·
 `validate:schema-enums` · `validate:openapi-examples` · `validate:generated-client` ·
@@ -284,6 +304,14 @@ local paths, env dumps, or private notes.
 - **`format:check`:** `main` is not fully prettier-clean — never `prettier --write` whole files you
   didn't change; format only your own lines.
 - **`pipeline:check`** is only trustworthy in isolation after a clean `npm run build`.
+- **`validate.yml`'s `actions/setup-node` steps set `cache-dependency-path: package-lock.json`
+  explicitly.** Without it, `setup-node`'s cache key hashes every `package-lock.json` in the tree
+  (root + `packages/client` + `deploy/wss-lb`), so a routine SDK version bump in
+  `packages/client/package-lock.json` (the `sync-client-version` workflow does this every few
+  days) would invalidate the CI npm cache even though `npm ci` in `validate.yml` only ever reads
+  the root lockfile (no npm `workspaces` config ties them together). If you ever add a new
+  `actions/setup-node` step to a workflow in this repo, set this explicitly rather than relying on
+  the default.
 - The Worker router is `workers/api.mjs`; serving/overlay/health live in `src/*.mjs`; the contract in
   `schemas/` + `src/contracts.mjs`.
 

--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -74,18 +74,46 @@ must create the required scaffold fields before the first surface is added.
 
 **Every contributor PR runs the FULL validation — there is no reduced "ugc" fast-lane.** (It was
 retired: it skipped the safety scans and kept tripping a stale-base preflight false-positive.) A
-one-file surface PR runs the same gates as a code PR. Three parallel jobs (the two Node jobs both
+one-file surface PR runs the same gates as a code PR. Four parallel jobs (the two Node jobs both
 build):
 
+- **`changes`** — computes docs-fast-lane eligibility for `checks` (see below). Pure inline
+  `git diff`, no third-party action.
 - **`test`** — builds, then runs the suite in two non-overlapping passes: `test:ci` (everything
   except the two filesystem-mutating artifact writers, run in parallel, WITH coverage → the single
   Codecov upload) then `test:ci:artifacts` (those two writers, serial). Locally just use
-  `npm test` / `npm run test:coverage` (full suite, serial — the config default is race-safe).
+  `npm test` / `npm run test:coverage` (full suite, serial — the config default is race-safe). Does
+  **not** participate in the docs fast lane below — coverage is a repo-wide delta gate, not
+  diff-scoped, and it isn't the wall-clock long pole regardless.
 - **`checks`** — builds, then lint + format + the ~20 contract/schema/safety validators (below).
 - **`python`** — runs the Python SDK's unittest suite via `uv run --extra test python -m unittest
 discover -s tests` (the `[test]` extra pulls in httpx so the async cases run). Node-independent, so
   it adds no wall-clock to the long poles. The same step runs in `publish-python.yml`'s unprivileged
   `build` job before the artifact is built, so a red suite blocks a PyPI publish.
+
+**The docs fast lane (`checks` only) — narrower than, and does not weaken, the "no reduced ugc
+fast-lane" rule above.** That rule is about _registry/community-surface_ content never getting a
+weaker gate. This is a separate, much narrower thing: when a PR's diff consists entirely of paths
+matching the glob `**/*.md` or the prefix `.claude/skills/` (pure contributor-facing prose — cannot
+touch registry data, schemas, code, or CI config), the `changes` job sets `docs_only=true` and
+`checks` skips only its build/contract/registry/deploy-dry-run steps via a **per-step**
+`if: env.DOCS_ONLY != 'true'` guard — never a job-level skip, so `checks` always reports a real
+`success`/`failure` conclusion, never `skipped`. `Lint + format`, `validate:docs`, `validate:intake`,
+and `scan:public-safety` still run unconditionally on every PR, docs-only or not — they're cheap (no
+build, no network) and are exactly what a stray secret or broken doc-contract reference in a
+"docs-only" PR would trip. **Hard guardrail, no exceptions:** any diff touching `registry/` forces
+`docs_only=false` regardless of what else is in the diff — computed as an independent override in the
+same `changes` job step, before the docs-pattern check even runs. This exists because the retired
+"ugc" lane above was scoped to registry/community-surface PRs specifically and caused a real
+stale-base preflight false-positive; registry-touching diffs get zero special treatment here. The
+filter is a plain `git diff --name-only` + `grep` in the trusted workflow — **not**
+`dorny/paths-filter` or any other third-party action: this repo's Actions allowlist
+(`repos/JSONbored/metagraphed/actions/permissions/selected-actions`) only allows GitHub-owned +
+verified-creator actions plus one explicit `peter-evans/create-pull-request` pattern, and
+`dorny/paths-filter` is published by an individual GitHub user (not a GitHub-verified-creator org) —
+using it as-is would hit a `startup_failure`. If a future change wants a real path-filter action, it
+needs an explicit allowlist pattern added via Settings → Actions → General first (a live settings
+change, not something a PR can do).
 
 **Gates (all must pass):** `lint` · `format:check` · `validate:contract-drift` ·
 `validate:schema-enums` · `validate:openapi-examples` · `validate:generated-client` ·

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -66,11 +66,15 @@ jobs:
   # `.github/workflows/*.yml`/`.yaml`, and `Validate migration sequence`
   # (scripts/validate-migrations.mjs) reads ONLY `migrations/*.sql` — verified
   # by reading each script's full source; neither imports anything outside its
-  # own directory. A PR can be workflow-only or migration-only without being a
-  # docs PR, so these are computed as their own flags rather than folded into
-  # docs_only, and neither needs the registry guardrail above (neither path is
-  # registry-adjacent). Every other `checks` validator was evaluated for the
-  # same treatment and rejected: the contract/schema/route validators
+  # own directory. Each flag also matches its OWN validator script path
+  # (scripts/validate-workflows.mjs / scripts/validate-migrations.mjs) directly,
+  # so editing the validator's logic itself still runs it even when the diff
+  # doesn't touch `.github/workflows/` or `migrations/`. A PR can be
+  # workflow-only or migration-only without being a docs PR, so these are
+  # computed as their own flags rather than folded into docs_only, and neither
+  # needs the registry guardrail above (neither path is registry-adjacent).
+  # Every other `checks` validator was evaluated for the same treatment and
+  # rejected: the contract/schema/route validators
   # (validate:schemas/api/mcp/ai/openapi/types) all transitively import most of
   # `src/` + `workers/**` via `workers/api.mjs`, so no path glob short of
   # "almost the whole repo" would safely exclude them — see
@@ -115,7 +119,7 @@ jobs:
             git fetch origin "$BASE_REF"
             range="origin/$BASE_REF...HEAD"
           fi
-          git diff --name-only --diff-filter=d "$range" > changed-files.txt
+          git diff --name-only "$range" > changed-files.txt
 
           if [ ! -s changed-files.txt ]; then
             {
@@ -133,12 +137,12 @@ jobs:
           # Narrow, independent skips -- see the job comment above for the
           # file:line evidence that these two validators' entire footprint is
           # their own directory.
-          if grep -qE '^\.github/workflows/' changed-files.txt; then
+          if grep -qE '^\.github/workflows/|^scripts/validate-workflows\.mjs$' changed-files.txt; then
             echo "run_workflows_validation=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_workflows_validation=false" >> "$GITHUB_OUTPUT"
           fi
-          if grep -qE '^migrations/' changed-files.txt; then
+          if grep -qE '^migrations/|^scripts/validate-migrations\.mjs$' changed-files.txt; then
             echo "run_migrations_validation=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_migrations_validation=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,6 +21,13 @@ concurrency:
 # by the same gates as everything else (validate:surface + public-safety +
 # private-boundary, all below).
 #
+# The DOCS FAST-LANE below is a narrower, separate thing: it does not skip any
+# job or reduce the safety/contract/registry gates for anything that could
+# plausibly need them. It only lets a diff that is PURELY prose (**/*.md +
+# .claude/skills/**) — which cannot touch registry data, schemas, code, or CI
+# config — finish `checks` in seconds instead of minutes, while still reporting
+# a real `success` conclusion (not `skipped`) on every step.
+#
 # The work splits across two parallel jobs that both build: `test` builds then
 # runs the suite + coverage; `checks` builds then runs lint + the ~20 contract /
 # schema / safety validations. They are independent — no validation needs the
@@ -29,6 +36,93 @@ concurrency:
 # (registry-summary.json etc.) that have NO committed fallback and only exist
 # after `npm run build`, so a fresh runner must stage them.
 jobs:
+  # Computes the docs-fast-lane eligibility for the `checks` job below. This is
+  # a plain shell `git diff` inline in the trusted workflow — no third-party
+  # action. (dorny/paths-filter was considered and rejected: it is published by
+  # an individual GitHub user, not a GitHub-verified-creator org, and this
+  # repo's Actions allowlist is `{github_owned_allowed, verified_allowed,
+  # patterns_allowed: ["peter-evans/create-pull-request@*"]}` — an unlisted,
+  # unverified third-party action would hit a startup_failure. Reusing the
+  # existing "Compute submitted files" pattern already in `checks` avoids the
+  # dependency and the allowlist question entirely.)
+  #
+  # `docs_only` is true only when EVERY changed path matches `**/*.md` or
+  # `.claude/skills/**` (this skill directory is contributor-facing playbook
+  # docs, not workflow/schema/script config). `registry_touched` is a HARD
+  # GUARDRAIL, computed independently: if the diff touches anything under
+  # `registry/` it force-overrides `docs_only` back to false, no matter what
+  # else the diff contains. This directly encodes the incident already
+  # documented above validate.yml's job comment — the old reduced "ugc" lane
+  # was scoped to registry/community-surface PRs and caused a stale-base
+  # preflight false-positive, so registry-touching diffs get zero special
+  # treatment here, full stop.
+  #
+  # On push-to-main and workflow_dispatch (no base to diff against) this
+  # always resolves docs_only=false — the fast lane only ever applies to a
+  # `pull_request` event, where a real merge-base diff exists.
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Compute docs-only fast-lane eligibility
+        id: filter
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "Not a pull_request event (${{ github.event_name }}) -- full validation runs."
+            exit 0
+          fi
+
+          if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
+            range="$BASE_SHA...$HEAD_SHA"
+          else
+            git fetch origin "$BASE_REF"
+            range="origin/$BASE_REF...HEAD"
+          fi
+          git diff --name-only --diff-filter=d "$range" > changed-files.txt
+
+          if [ ! -s changed-files.txt ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "No changed files detected -- full validation runs."
+            exit 0
+          fi
+
+          echo "Changed files:"
+          cat changed-files.txt
+
+          # HARD GUARDRAIL: any registry/ path forces full validation,
+          # unconditionally, regardless of every other path in the diff. See
+          # the job comment above for why -- this is not a suggestion.
+          if grep -qE '^registry/' changed-files.txt; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "Diff touches registry/ -- forcing full validation (no exceptions)."
+            exit 0
+          fi
+
+          # docs_only requires EVERY changed path to match one of the two safe
+          # patterns below. A single non-matching path anywhere disqualifies
+          # the whole PR from the fast lane.
+          if grep -vE '(^|/)[^/]+\.md$|^\.claude/skills/' changed-files.txt > /dev/null; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "Diff includes non-docs paths -- full validation runs."
+          else
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "Diff is 100% **/*.md + .claude/skills/** -- docs fast lane applies to the checks job."
+          fi
+
   test:
     name: test
     runs-on: ubuntu-latest
@@ -72,6 +166,12 @@ jobs:
       # writers drive their work via execFileSync child processes and add zero
       # in-process coverage, so coverage comes only from `test:ci` and CI still
       # makes a single Codecov upload.
+      #
+      # NOTE: the `test` job intentionally does NOT participate in the docs
+      # fast lane above. Coverage is a repo-wide delta gate (codecov.yml), not
+      # diff-scoped, so shortcutting it on a docs-only PR would let a docs PR
+      # merge without an accurate coverage report. It's also not the wall-clock
+      # long pole when it does run alongside a fast `checks` job.
       - name: Test (parallel, with coverage gate)
         env:
           VITEST_JUNIT_PATH: reports/junit/vitest.xml
@@ -156,7 +256,20 @@ jobs:
 
   checks:
     name: checks
+    needs: changes
     runs-on: ubuntu-latest
+    env:
+      # A single guard expression, computed once, that every expensive step
+      # below gates on. Deliberately a per-STEP `if:`, not a job-level `if:`
+      # on `checks` itself: a job-level skip reports conclusion=skipped, and
+      # while Gittensory's own CI aggregate (fetchLiveCiAggregate) buckets
+      # skipped identically to success, GitHub's native required-status-check
+      # semantics for a *future* required context are not governed by that
+      # code path. Per-step guards keep this job always reporting a real
+      # success/failure conclusion, which is unconditionally safe under both
+      # systems, at the cost of a few extra seconds on the one self-hosted
+      # runner for `Setup Node` + `Install` + the guard evaluation itself.
+      DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -198,6 +311,11 @@ jobs:
       - name: Install
         run: npm ci
 
+      # Lint + format + the documentation/intake/safety scans below run
+      # UNCONDITIONALLY, docs fast lane or not — they're cheap (no build, no
+      # network), and directly relevant to a docs-only diff (a stray secret,
+      # broken doc-contract reference, or malformed intake template can land in
+      # a "docs-only" PR just as easily as in a code PR).
       - name: Lint + format
         run: |
           npm run lint
@@ -208,7 +326,12 @@ jobs:
       # they MUST run before the build step below overwrites those committed files.
       # This is the gate CONTRIBUTING.md references — without it a stale or
       # hand-edited committed contract could land on main undetected.
+      #
+      # Skipped for a proven docs-only diff: **/*.md + .claude/skills/** cannot
+      # touch schemas/, openapi.json, or any generated contract file, so there
+      # is nothing for this to drift-check.
       - name: Validate committed contract (drift)
+        if: env.DOCS_ONLY != 'true'
         run: |
           npm run validate:contract-drift
           npm run validate:schema-enums
@@ -217,18 +340,21 @@ jobs:
           npm run validate:committed-seed
 
       - name: Build artifacts
+        if: env.DOCS_ONLY != 'true'
         env:
           METAGRAPH_PRESERVE_PROBE_HEALTH: "1"
         run: npm run build
 
       - name: Verify submitted public artifacts are reproducible
-        if: github.event_name == 'pull_request'
+        if: env.DOCS_ONLY != 'true' && github.event_name == 'pull_request'
         run: node scripts/ci-verify-submitted-artifacts.mjs --changed-files submitted-artifact-files.txt
 
       - name: Validate registry
+        if: env.DOCS_ONLY != 'true'
         run: npm run validate
 
       - name: Generate R2 manifest
+        if: env.DOCS_ONLY != 'true'
         run: npm run r2:manifest
 
       # #1025: committed derived artifacts under public/ must match a fresh
@@ -246,7 +372,11 @@ jobs:
       # is inherently non-deterministic. It is publish infrastructure regenerated
       # on every publish (and by the r2:manifest step above), so its committed
       # copy is a best-effort lockfile, not a served/contract surface.
+      #
+      # Skipped on the docs fast lane along with the "Build artifacts" step it
+      # depends on above -- there is no fresh build to diff against.
       - name: Verify committed derived artifacts are fresh
+        if: env.DOCS_ONLY != 'true'
         run: |
           # Only CONTRACT artifacts are gated here — openapi.json / types.d.ts /
           # contracts.json / api-index.json — because they change only with reviewed
@@ -282,21 +412,27 @@ jobs:
           echo "All committed derived artifacts under public/ match a fresh build."
 
       - name: Validate JSON schemas
+        if: env.DOCS_ONLY != 'true'
         run: npm run validate:schemas
 
       - name: Validate Worker API
+        if: env.DOCS_ONLY != 'true'
         run: npm run validate:api
 
       - name: Validate MCP server
+        if: env.DOCS_ONLY != 'true'
         run: npm run validate:mcp
 
       - name: Validate AI routes
+        if: env.DOCS_ONLY != 'true'
         run: npm run validate:ai
 
       - name: Validate OpenAPI
+        if: env.DOCS_ONLY != 'true'
         run: npm run validate:openapi
 
       - name: Validate generated API types
+        if: env.DOCS_ONLY != 'true'
         run: npm run validate:types
 
       # Client-SDK drift gate: a contract-only PR (schemas → generated →
@@ -306,15 +442,20 @@ jobs:
       # changed versus the merge base but packages/client/package.json "version"
       # was not bumped. Diff-scoped: non-contract PRs never fire.
       - name: Validate client-SDK sync (contract ↔ published version)
-        if: github.event_name == 'pull_request'
+        if: env.DOCS_ONLY != 'true' && github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: npm run validate:client-sdk-sync
 
       - name: Validate artifact size budgets
+        if: env.DOCS_ONLY != 'true'
         run: npm run validate:artifact-budgets
 
+      # Always runs, docs fast lane or not: cheap (reads README.md +
+      # docs/backend-artifact-contracts.md + src/contracts.mjs, no build, no
+      # network) and this is exactly the gate a docs-only PR is most likely to
+      # need — the repo's own docs-only.md PR template lists it first.
       - name: Validate documentation contracts
         run: npm run validate:docs
 
@@ -327,37 +468,53 @@ jobs:
       # registry/subnets push. (Same rationale as the gitignored llms.txt
       # catalogs + public/datasets — DATA artifacts are not PR-gated.)
 
+      # Always runs (see docs/backend-artifact-contracts.md rationale above):
+      # cheap file-only scan of .github/ISSUE_TEMPLATE + the PR template, no
+      # build required, and listed in docs-only.md's own checklist.
       - name: Validate intake templates
         run: npm run validate:intake
 
       - name: Validate registry subnet files
+        if: env.DOCS_ONLY != 'true'
         run: npm run validate:surface
 
       - name: Validate workflows
+        if: env.DOCS_ONLY != 'true'
         run: npm run validate:workflows
 
       - name: Validate migration sequence
+        if: env.DOCS_ONLY != 'true'
         run: npm run validate:migrations
 
       - name: Validate Cloudflare config
+        if: env.DOCS_ONLY != 'true'
         run: npm run cloudflare:verify:dry-run
 
       - name: Validate R2 manifest
+        if: env.DOCS_ONLY != 'true'
         run: |
           npm run r2:manifest:dry-run
           npm run r2:download:dry-run
           npm run kv:publish:dry-run
 
       - name: Worker deploy dry-run
+        if: env.DOCS_ONLY != 'true'
         run: npm run worker:deploy:dry-run
 
       - name: Worker bundle-size budget
+        if: env.DOCS_ONLY != 'true'
         run: npm run worker:bundle:budget
 
+      # Always runs, docs fast lane or not: a plain regex scan over
+      # README/docs/registry/schemas/public/.github/workers/wrangler.jsonc for
+      # secrets, private paths, and localhost URLs (scripts/scan-public-
+      # safety.mjs) — no build, no network, and the exact gate a docs edit
+      # could most plausibly trip (a pasted local path or token in a doc).
       - name: Public-safety scan
         run: npm run scan:public-safety
 
       - name: Validate private boundary
+        if: env.DOCS_ONLY != 'true'
         run: npm run validate:private-boundary
 
   # The Python SDK (python/) ships its own hermetic unittest suite (37 cases) but

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -60,11 +60,30 @@ jobs:
   # On push-to-main and workflow_dispatch (no base to diff against) this
   # always resolves docs_only=false — the fast lane only ever applies to a
   # `pull_request` event, where a real merge-base diff exists.
+  #
+  # Two further outputs, independent of docs_only and of each other: `Validate
+  # workflows` (scripts/validate-workflows.mjs) reads ONLY
+  # `.github/workflows/*.yml`/`.yaml`, and `Validate migration sequence`
+  # (scripts/validate-migrations.mjs) reads ONLY `migrations/*.sql` — verified
+  # by reading each script's full source; neither imports anything outside its
+  # own directory. A PR can be workflow-only or migration-only without being a
+  # docs PR, so these are computed as their own flags rather than folded into
+  # docs_only, and neither needs the registry guardrail above (neither path is
+  # registry-adjacent). Every other `checks` validator was evaluated for the
+  # same treatment and rejected: the contract/schema/route validators
+  # (validate:schemas/api/mcp/ai/openapi/types) all transitively import most of
+  # `src/` + `workers/**` via `workers/api.mjs`, so no path glob short of
+  # "almost the whole repo" would safely exclude them — see
+  # `.claude/skills/metagraphed/reference.md`'s "new artifact/route checklist"
+  # for why a route/handler change can trip a contract gate with no lexical
+  # hint in the diff.
   changes:
     name: changes
     runs-on: ubuntu-latest
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
+      run_workflows_validation: ${{ steps.filter.outputs.run_workflows_validation }}
+      run_migrations_validation: ${{ steps.filter.outputs.run_migrations_validation }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -72,7 +91,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
-      - name: Compute docs-only fast-lane eligibility
+      - name: Compute fast-lane eligibility
         id: filter
         shell: bash
         env:
@@ -81,7 +100,11 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
         run: |
           if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "docs_only=false"
+              echo "run_workflows_validation=true"
+              echo "run_migrations_validation=true"
+            } >> "$GITHUB_OUTPUT"
             echo "Not a pull_request event (${{ github.event_name }}) -- full validation runs."
             exit 0
           fi
@@ -95,13 +118,31 @@ jobs:
           git diff --name-only --diff-filter=d "$range" > changed-files.txt
 
           if [ ! -s changed-files.txt ]; then
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "docs_only=false"
+              echo "run_workflows_validation=true"
+              echo "run_migrations_validation=true"
+            } >> "$GITHUB_OUTPUT"
             echo "No changed files detected -- full validation runs."
             exit 0
           fi
 
           echo "Changed files:"
           cat changed-files.txt
+
+          # Narrow, independent skips -- see the job comment above for the
+          # file:line evidence that these two validators' entire footprint is
+          # their own directory.
+          if grep -qE '^\.github/workflows/' changed-files.txt; then
+            echo "run_workflows_validation=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_workflows_validation=false" >> "$GITHUB_OUTPUT"
+          fi
+          if grep -qE '^migrations/' changed-files.txt; then
+            echo "run_migrations_validation=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_migrations_validation=false" >> "$GITHUB_OUTPUT"
+          fi
 
           # HARD GUARDRAIL: any registry/ path forces full validation,
           # unconditionally, regardless of every other path in the diff. See
@@ -114,8 +155,11 @@ jobs:
 
           # docs_only requires EVERY changed path to match one of the two safe
           # patterns below. A single non-matching path anywhere disqualifies
-          # the whole PR from the fast lane.
-          if grep -vE '(^|/)[^/]+\.md$|^\.claude/skills/' changed-files.txt > /dev/null; then
+          # the whole PR from the fast lane. Both patterns require a `.md`
+          # suffix -- a hypothetical future non-.md file under
+          # .claude/skills/** (e.g. a template or config) must NOT qualify,
+          # since only prose content is proven safe to skip validation for.
+          if grep -vE '(^|/)[^/]+\.md$|^\.claude/skills/.*\.md$' changed-files.txt > /dev/null; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             echo "Diff includes non-docs paths -- full validation runs."
           else
@@ -143,6 +187,13 @@ jobs:
         with:
           node-version: 22.23.1
           cache: npm
+          # Without this, setup-node's cache key hashes EVERY package-lock.json
+          # in the tree (root + packages/client + deploy/wss-lb), so a routine
+          # SDK version bump in packages/client/package-lock.json (the
+          # sync-client-version workflow does this every few days) invalidates
+          # this job's cache even though `npm ci` here only ever reads the root
+          # lockfile (no npm `workspaces` config ties them together).
+          cache-dependency-path: package-lock.json
 
       - name: Install
         run: npm ci
@@ -270,6 +321,8 @@ jobs:
       # systems, at the cost of a few extra seconds on the one self-hosted
       # runner for `Setup Node` + `Install` + the guard evaluation itself.
       DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+      RUN_WORKFLOWS_VALIDATION: ${{ needs.changes.outputs.run_workflows_validation }}
+      RUN_MIGRATIONS_VALIDATION: ${{ needs.changes.outputs.run_migrations_validation }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -307,6 +360,9 @@ jobs:
         with:
           node-version: 22.23.1
           cache: npm
+          # See the `test` job's Setup Node step for why this is needed --
+          # same over-scoped-cache-key issue applies here.
+          cache-dependency-path: package-lock.json
 
       - name: Install
         run: npm ci
@@ -478,12 +534,20 @@ jobs:
         if: env.DOCS_ONLY != 'true'
         run: npm run validate:surface
 
+      # Narrow, independent skip (not tied to DOCS_ONLY): scripts/validate-workflows.mjs
+      # reads ONLY .github/workflows/*.yml/.yaml, so a PR with zero changes under
+      # that path cannot affect this validator's result. See the `changes` job
+      # comment for the full rationale.
       - name: Validate workflows
-        if: env.DOCS_ONLY != 'true'
+        if: env.RUN_WORKFLOWS_VALIDATION == 'true'
         run: npm run validate:workflows
 
+      # Narrow, independent skip (not tied to DOCS_ONLY): scripts/validate-migrations.mjs
+      # reads ONLY migrations/*.sql, so a PR with zero changes under that path
+      # cannot affect this validator's result. See the `changes` job comment for
+      # the full rationale.
       - name: Validate migration sequence
-        if: env.DOCS_ONLY != 'true'
+        if: env.RUN_MIGRATIONS_VALIDATION == 'true'
         run: npm run validate:migrations
 
       - name: Validate Cloudflare config


### PR DESCRIPTION
## Summary

Adds a docs-only fast lane to `.github/workflows/validate.yml`'s `checks` job. When a PR's entire diff is contributor-facing prose (`**/*.md` plus `.claude/skills/**`), the job's build/contract/registry/deploy-dry-run steps are skipped step-by-step, so a docs edit finishes `checks` in the time it takes to install + lint instead of a full build + ~20 validators. Lint/format, `validate:docs`, `validate:intake`, and `scan:public-safety` still run unconditionally on every PR, docs-only or not.

## What Changed

- New `changes` job: computes `docs_only` via a plain `git diff --name-only --diff-filter=d` against the PR's merge-base range, followed by a `grep`, inline in the trusted workflow. No third-party action — see "Actions allowlist" below.
- `checks` job: added `needs: changes` and a job-level `env: DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}`. Each of the following steps gained `if: env.DOCS_ONLY != 'true'` (or `&&`-combined with its existing `if:`): `Validate committed contract (drift)`, `Build artifacts`, `Verify submitted public artifacts are reproducible`, `Validate registry`, `Generate R2 manifest`, `Verify committed derived artifacts are fresh`, `Validate JSON schemas`, `Validate Worker API`, `Validate MCP server`, `Validate AI routes`, `Validate OpenAPI`, `Validate generated API types`, `Validate client-SDK sync`, `Validate artifact size budgets`, `Validate registry subnet files`, `Validate workflows`, `Validate migration sequence`, `Validate Cloudflare config`, `Validate R2 manifest`, `Worker deploy dry-run`, `Worker bundle-size budget`, `Validate private boundary`.
- Left running unconditionally: `Checkout`, `Compute submitted files`, `Setup Node`, `Install`, `Lint + format`, `Validate documentation contracts`, `Validate intake templates`, `Public-safety scan`. All four validators are cheap file-only scans with no build and no network call, and match exactly what this repo's own `docs-only.md` PR template already asks a docs-only contributor to run.
- `test` and `python` jobs are unchanged and do **not** participate in the fast lane — `test`'s coverage gate is a repo-wide delta (`codecov.yml`), not diff-scoped, so shortcutting it would let a docs PR merge without an accurate coverage number, and it isn't the wall-clock long pole regardless.
- Updated `.claude/skills/metagraphed/reference.md` §2 to document the new `changes` job and the docs fast lane's scope/guardrail (per this repo's own "update the skill on a fundamental CI change" convention).

## Hard guardrail (non-negotiable)

Any diff touching `registry/` forces `docs_only=false`, computed as an independent check *before* the docs-pattern match even runs — regardless of what else is in the diff. This is not a relaxation of the "every contributor PR runs the FULL validation — there is NO reduced UGC fast-lane" policy already documented above the `jobs:` block in this file: that policy is specifically about registry/community-surface content, after the incident where a reduced lane for "single community file" PRs skipped safety scans and caused a stale-base preflight false-positive. This docs lane cannot apply to anything under `registry/`, full stop — see the new `changes` job's comment block for the in-file citation.

## Why per-step `if:`, not a job-level skip

`checks` keeps `needs: changes` and its own job-level `if:` untouched — every step gets its own `if: env.DOCS_ONLY != 'true'` instead. This means `checks` always reports a real `success`/`failure` conclusion, never `skipped`, at the cost of a few extra seconds for `Setup Node` + `Install` + the guard evaluation on the docs fast lane. This was a deliberate choice over the cheaper job-level-skip alternative: Gittensory's own CI aggregate (`fetchLiveCiAggregate`) currently buckets a `skipped` conclusion identically to `success` at every merge-decision call site, so a job-level skip would work fine today — but GitHub's own branch-protection required-status-check semantics for a *possible future* required context are a separate mechanism not governed by that code path, and the fast-exit-steps approach is unconditionally safe under both without any real downside.

## Actions allowlist — please read before merging

**`dorny/paths-filter` (or any other third-party path-filter action) is intentionally NOT used anywhere in this PR.** I considered it and confirmed via the GitHub Marketplace listing that it is published by an individual GitHub user (`dorny`), not a GitHub-verified-creator org — no "Verified creator" badge is shown. This repo's Actions allowlist (`repos/JSONbored/metagraphed/actions/permissions/selected-actions`) is currently `{"github_owned_allowed":true,"verified_allowed":true,"patterns_allowed":["peter-evans/create-pull-request@*"]}` — `dorny/paths-filter` is not GitHub-owned, not verified, and not in the explicit patterns list, so a workflow run using it would hit a `startup_failure` (the same landmine class this repo has hit before with third-party actions). Instead, the `changes` job computes the filter with a plain `git diff --name-only` + `grep`, the same pattern the `checks` job already uses for `submitted-artifact-files.txt` — zero new dependency, zero allowlist risk. **No settings change is required for this PR to work as submitted.** (If a future PR ever wants a real path-filter action instead of hand-rolled shell, that would need an explicit allowlist pattern added via Settings → Actions → General first — flagging this only so it isn't silently assumed later.)

## Traced example diffs

1. **Pure docs change** — `README.md`, `docs/api-stability.md`, `.claude/skills/metagraphed/reference.md`. None match `^registry/`; every path matches `(^|/)[^/]+\.md$`. Result: `docs_only=true` — `checks` fast-exits its build/contract/registry/deploy-dry-run steps; lint/format + the four always-on validators still run and gate the PR for real.
2. **Docs + code mixed** — `README.md`, `src/serve.mjs`, `docs/backend-artifact-contracts.md`. `src/serve.mjs` doesn't match either safe pattern. Result: `docs_only=false` — full validation runs, identical to today's behavior.
3. **Registry-touching change** — `registry/subnets/sn-43.json`, `README.md`. Matches `^registry/`. Result: `docs_only=false` via the hard-guardrail branch, which returns before the docs-pattern check is even evaluated — full validation runs regardless of the `README.md` also present in the diff.

(Manually traced against the actual `grep` patterns in the new `changes` job step locally; not yet observed on a live PR, since the fast lane can only be exercised for real once this PR itself is open against `main`. This PR's own diff is workflow YAML, so it correctly resolves to `docs_only=false` and runs the full suite on itself.)

## Validation

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/validate.yml'))"` — parses cleanly
- [x] `actionlint .github/workflows/validate.yml` — zero warnings
- [x] `node scripts/validate-workflows.mjs` — 18 workflows validated, including the pinned-SHA-action-ref check (no new action introduced, so nothing new to pin)
- [x] `npm run lint` — clean
- [x] `npx prettier --check .github/workflows/validate.yml .claude/skills/metagraphed/reference.md` — clean
- [x] `git diff --check` — clean
- [x] `npm run validate:docs`, `npm run validate:intake`, `npm run scan:public-safety` — all pass locally without a build, confirming they're genuinely safe to run unconditionally in the fast lane
- [x] Manually simulated the exact `grep` filter logic from the new `changes` step against the three example diffs above (plus a workflow-only diff and a non-`.md` `.claude/skills/**` asset) in a local shell script — all five resolved as expected
- [x] `git diff --stat` — confirms only `.github/workflows/validate.yml` and `.claude/skills/metagraphed/reference.md` changed
