### PR TITLE
fix(blocks): guard invalid observed_at dates

### DIFF
--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -31,7 +31,9 @@ export const BLOCK_INSERT_COLUMNS = [
 function toIso(ms) {
   if (ms == null) return null;
   const n = Number(ms);
-  return Number.isFinite(n) && n > 0 ? new Date(n).toISOString() : null;
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const d = new Date(n);
+  return Number.isFinite(d.getTime()) ? d.toISOString() : null;
 }
 
 // Coerce a block-height cell to a non-negative integer, or null when missing,

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -166,6 +166,15 @@ test("formatBlock drops out-of-range observed_at strings to null", () => {
   assert.equal(out.observed_at, null);
 });
 
+test("formatBlock drops out-of-range observed_at numbers to null", () => {
+  const out = formatBlock({
+    block_number: 1000,
+    block_hash: "0xhash",
+    observed_at: 8640000000000001,
+  });
+  assert.equal(out.observed_at, null);
+});
+
 test("formatBlock is null-safe on junk + sparse rows", () => {
   assert.equal(formatBlock(null), null);
   assert.equal(formatBlock("x"), null);

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -157,6 +157,15 @@ test("formatBlock drops whitespace-only observed_at strings to null", () => {
   assert.equal(out.observed_at, null);
 });
 
+test("formatBlock drops out-of-range observed_at strings to null", () => {
+  const out = formatBlock({
+    block_number: 1000,
+    block_hash: "0xhash",
+    observed_at: "8640000000000001",
+  });
+  assert.equal(out.observed_at, null);
+});
+
 test("formatBlock is null-safe on junk + sparse rows", () => {
   assert.equal(formatBlock(null), null);
   assert.equal(formatBlock("x"), null);


### PR DESCRIPTION
### Motivation

- Fix a robustness regression where `toIso()` coerced numeric strings then passed out-of-range millisecond values to `Date.prototype.toISOString()`, which could throw `RangeError` and crash block formatting paths.

### Description

- Tighten `toIso` in `src/blocks.mjs` to return `null` for non-finite or non-positive inputs, instantiate a `Date` from the number, and only call `toISOString()` when `d.getTime()` is finite.
- Preserve existing behavior for valid numeric strings and null/invalid inputs so valid epoch-ms values still produce ISO timestamps while blanks and malformed strings remain `null`.
- Add a regression test in `tests/blocks.test.mjs` asserting an out-of-range numeric string (`"8640000000000001"`) is dropped to `null` instead of throwing.

### Testing

- Ran `npx vitest run tests/blocks.test.mjs` and the test file passed (all tests green). 
- Ran `npm run lint` and `npm run format:check` and both completed with no lint or formatting failures. 
- Ran `git diff --check` to verify no whitespace issues and it reported clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46d5e0e6c0832caa3fb5cc5ffe928b)