### PR TITLE
fix(ci): clarify submitted-artifact mismatch message for deploy-owned files

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,17 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { stableStringify } from "./lib.mjs";
-
-// Deploy/publish-pipeline-owned artifacts: their committed copies reflect the
-// last real publish, not a local/CI validate build, and normal `npm run
-// build` runs are expected to leave them looking "stale" relative to HEAD
-// (see the "Verify committed derived artifacts are fresh" step in
-// .github/workflows/validate.yml for the full reasoning). A production
-// publish run legitimately updates these, so the warning below is skipped
-// in that context.
-const DEPLOY_OWNED_ARTIFACTS = [
-  "public/metagraph/r2-manifest.json",
-  "public/metagraph/schemas/index.json",
-];
+import { DEPLOY_OWNED_ARTIFACTS, stableStringify } from "./lib.mjs";
 
 const productionBuild = isProductionPublishBuild();
 const startedAt = new Date().toISOString();

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,5 +1,9 @@
 import { spawnSync } from "node:child_process";
-import { DEPLOY_OWNED_ARTIFACTS, stableStringify } from "./lib.mjs";
+import {
+  DEPLOY_OWNED_ARTIFACTS,
+  resolveBaseRemote,
+  stableStringify,
+} from "./lib.mjs";
 
 const productionBuild = isProductionPublishBuild();
 const startedAt = new Date().toISOString();
@@ -71,7 +75,7 @@ function warnIfDeployOwnedArtifactsChanged() {
   if (diff.status !== 0 || !diff.stdout.trim()) {
     return;
   }
-  const baseRemote = resolveBaseRemote();
+  const baseRemote = resolveBaseRemote(process.cwd());
   console.warn(
     [
       "",
@@ -86,19 +90,6 @@ function warnIfDeployOwnedArtifactsChanged() {
       "",
     ].join("\n"),
   );
-}
-
-// Forks (Phase A0) set up `upstream` pointing at the canonical repo, with
-// `origin` as the contributor's own fork — possibly stale relative to it. A
-// direct clone of the canonical repo has no `upstream` remote at all, so
-// `origin` there IS canonical. Prefer `upstream` when present.
-function resolveBaseRemote() {
-  const result = spawnSync("git", ["remote"], {
-    cwd: process.cwd(),
-    encoding: "utf8",
-  });
-  const remotes = (result.stdout || "").split("\n").map((line) => line.trim());
-  return remotes.includes("upstream") ? "upstream" : "origin";
 }
 
 function localSteps() {

--- a/scripts/ci-verify-submitted-artifacts.mjs
+++ b/scripts/ci-verify-submitted-artifacts.mjs
@@ -6,7 +6,7 @@ import {
   artifactRelativePath,
   isGeneratedPublicArtifactRelativePath,
 } from "../src/artifact-storage.mjs";
-import { artifactFilePath } from "./lib.mjs";
+import { artifactFilePath, DEPLOY_OWNED_ARTIFACTS } from "./lib.mjs";
 
 // Generated artifacts like openapi.json now exceed Node's default 1 MB
 // execFileSync buffer, so git reads must allow plenty of headroom or the
@@ -108,13 +108,33 @@ function main() {
   }
 
   if (mismatches.length > 0) {
-    console.error(
-      [
-        "Submitted public artifacts do not match a fresh build (content differs, not just formatting):",
-        ...mismatches.map((file) => `- ${file}`),
-        "Run `npm run build` and commit the regenerated public artifacts.",
-      ].join("\n"),
-    );
+    const { deployOwned: deployOwnedMismatches, other: otherMismatches } =
+      partitionMismatches(mismatches);
+
+    if (deployOwnedMismatches.length > 0) {
+      console.error(
+        [
+          "Deploy/publish-pipeline-owned artifact(s) in your diff don't match a fresh build --",
+          "this is EXPECTED and not something to fix by rebuilding again. These files are not",
+          "reviewed contract surfaces; their committed copies on main reflect the last real",
+          "publish, not your local build, and constantly drift for reasons unrelated to your PR",
+          "(see .claude/skills/metagraphed/reference.md §8):",
+          ...deployOwnedMismatches.map((file) => `- ${file}`),
+          "",
+          "Revert them and re-commit -- do not try to make them match:",
+          `  git checkout origin/main -- ${DEPLOY_OWNED_ARTIFACTS.join(" ")}`,
+        ].join("\n"),
+      );
+    }
+    if (otherMismatches.length > 0) {
+      console.error(
+        [
+          "Submitted public artifacts do not match a fresh build (content differs, not just formatting):",
+          ...otherMismatches.map((file) => `- ${file}`),
+          "Run `npm run build` and commit the regenerated public artifacts.",
+        ].join("\n"),
+      );
+    }
     process.exit(1);
   }
   console.log(
@@ -133,6 +153,20 @@ export function isSubmittedPublicArtifactPath(file) {
   return (
     file.startsWith("public/metagraph/") || file.startsWith("public/datasets/")
   );
+}
+
+/**
+ * Splits mismatch entries (e.g. "public/metagraph/r2-manifest.json (content
+ * differs from a fresh build)") into deploy-owned-artifact entries, which get
+ * a distinct "revert, don't rebuild" message, versus everything else, which
+ * keeps the generic "run npm run build and commit" message.
+ */
+export function partitionMismatches(mismatches) {
+  const deployOwned = mismatches.filter((entry) =>
+    DEPLOY_OWNED_ARTIFACTS.some((file) => entry.startsWith(file)),
+  );
+  const other = mismatches.filter((entry) => !deployOwned.includes(entry));
+  return { deployOwned, other };
 }
 
 /** Stable JSON: recursively sort object keys while preserving semantic array order. */

--- a/scripts/ci-verify-submitted-artifacts.mjs
+++ b/scripts/ci-verify-submitted-artifacts.mjs
@@ -6,7 +6,11 @@ import {
   artifactRelativePath,
   isGeneratedPublicArtifactRelativePath,
 } from "../src/artifact-storage.mjs";
-import { artifactFilePath, DEPLOY_OWNED_ARTIFACTS } from "./lib.mjs";
+import {
+  artifactFilePath,
+  DEPLOY_OWNED_ARTIFACTS,
+  resolveBaseRemote,
+} from "./lib.mjs";
 
 // Generated artifacts like openapi.json now exceed Node's default 1 MB
 // execFileSync buffer, so git reads must allow plenty of headroom or the
@@ -112,19 +116,7 @@ function main() {
       partitionMismatches(mismatches);
 
     if (deployOwnedMismatches.length > 0) {
-      console.error(
-        [
-          "Deploy/publish-pipeline-owned artifact(s) in your diff don't match a fresh build --",
-          "this is EXPECTED and not something to fix by rebuilding again. These files are not",
-          "reviewed contract surfaces; their committed copies on main reflect the last real",
-          "publish, not your local build, and constantly drift for reasons unrelated to your PR",
-          "(see .claude/skills/metagraphed/reference.md §8):",
-          ...deployOwnedMismatches.map((file) => `- ${file}`),
-          "",
-          "Revert them and re-commit -- do not try to make them match:",
-          `  git checkout origin/main -- ${DEPLOY_OWNED_ARTIFACTS.join(" ")}`,
-        ].join("\n"),
-      );
+      console.error(buildDeployOwnedMismatchMessage(deployOwnedMismatches));
     }
     if (otherMismatches.length > 0) {
       console.error(
@@ -162,11 +154,37 @@ export function isSubmittedPublicArtifactPath(file) {
  * keeps the generic "run npm run build and commit" message.
  */
 export function partitionMismatches(mismatches) {
+  // Match the exact "<path> (<reason>)" format this script's own mismatch
+  // entries use, not a bare path-prefix `startsWith`, so a differently-named
+  // file that happens to share a prefix (e.g. an unrelated
+  // "public/metagraph/r2-manifest.json.bak (...)") can't be misclassified if
+  // this helper is ever reused against a different string shape.
   const deployOwned = mismatches.filter((entry) =>
-    DEPLOY_OWNED_ARTIFACTS.some((file) => entry.startsWith(file)),
+    DEPLOY_OWNED_ARTIFACTS.some((file) => entry.startsWith(`${file} (`)),
   );
   const other = mismatches.filter((entry) => !deployOwned.includes(entry));
   return { deployOwned, other };
+}
+
+/**
+ * Renders the "revert, don't rebuild" message for deploy-owned artifact
+ * mismatches. Resolves the revert command's remote via resolveBaseRemote so
+ * fork contributors (origin = their fork, upstream = canonical) get
+ * `upstream/main`, matching the same recommendation as build.mjs's local
+ * warning -- never a hardcoded `origin/main`, which is wrong on a fork.
+ */
+export function buildDeployOwnedMismatchMessage(deployOwnedMismatches, cwd) {
+  return [
+    "Deploy/publish-pipeline-owned artifact(s) in your diff don't match a fresh build --",
+    "this is EXPECTED and not something to fix by rebuilding again. These files are not",
+    "reviewed contract surfaces; their committed copies on main reflect the last real",
+    "publish, not your local build, and constantly drift for reasons unrelated to your PR",
+    "(see .claude/skills/metagraphed/reference.md §8):",
+    ...deployOwnedMismatches.map((file) => `- ${file}`),
+    "",
+    "Revert them and re-commit -- do not try to make them match:",
+    `  git checkout ${resolveBaseRemote(cwd)}/main -- ${DEPLOY_OWNED_ARTIFACTS.join(" ")}`,
+  ].join("\n");
 }
 
 /** Stable JSON: recursively sort object keys while preserving semantic array order. */

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { lookup } from "node:dns/promises";
 import { BlockList, isIP } from "node:net";
@@ -33,6 +34,19 @@ export const DEPLOY_OWNED_ARTIFACTS = [
   "public/metagraph/r2-manifest.json",
   "public/metagraph/schemas/index.json",
 ];
+
+// Forks (Phase A0 of the contributor skill) set up `upstream` pointing at the
+// canonical repo, with `origin` as the contributor's own fork -- possibly
+// stale relative to it. A direct clone of the canonical repo has no
+// `upstream` remote at all, so `origin` there IS canonical. Prefer `upstream`
+// when present. Single source of truth for build.mjs's local warning and
+// ci-verify-submitted-artifacts.mjs's remediation message, so both always
+// recommend the same, correct remote.
+export function resolveBaseRemote(cwd = process.cwd()) {
+  const result = spawnSync("git", ["remote"], { cwd, encoding: "utf8" });
+  const remotes = (result.stdout || "").split("\n").map((line) => line.trim());
+  return remotes.includes("upstream") ? "upstream" : "origin";
+}
 
 const credentialedUrlParams = new Set([
   "access_key",

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -23,6 +23,17 @@ export const publicMetagraphRoot = path.join(repoRoot, "public/metagraph");
 export const r2StagingRoot = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT);
 export const generatedSourceRoot = path.join(repoRoot, "dist/metagraph-source");
 
+// Deploy/publish-pipeline-owned artifacts: their committed copies on `main`
+// reflect the last real publish, not a local/CI build, so they are EXPECTED
+// to drift on every `npm run build` for reasons unrelated to any given PR.
+// Single source of truth, consumed by build.mjs (post-build local warning)
+// and ci-verify-submitted-artifacts.mjs (submitted-artifact mismatch
+// messaging) so both stay in sync.
+export const DEPLOY_OWNED_ARTIFACTS = [
+  "public/metagraph/r2-manifest.json",
+  "public/metagraph/schemas/index.json",
+];
+
 const credentialedUrlParams = new Set([
   "access_key",
   "access-token",

--- a/tests/ci-artifact-verifier.test.mjs
+++ b/tests/ci-artifact-verifier.test.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { test } from "vitest";
 import {
+  buildDeployOwnedMismatchMessage,
   canonicalArtifactJson,
   canonicalJson,
   isSubmittedPublicArtifactPath,
@@ -104,6 +109,54 @@ test("partitionMismatches puts everything in `other` when nothing is deploy-owne
   const { deployOwned, other } = partitionMismatches(mismatches);
   assert.deepEqual(deployOwned, []);
   assert.deepEqual(other, mismatches);
+});
+
+test("buildDeployOwnedMismatchMessage recommends upstream/main on a fork checkout", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "wj-deploy-owned-msg-"));
+  execFileSync("git", ["init", "-q"], { cwd: dir });
+  execFileSync(
+    "git",
+    [
+      "remote",
+      "add",
+      "origin",
+      "https://github.com/contributor/metagraphed.git",
+    ],
+    { cwd: dir },
+  );
+  execFileSync(
+    "git",
+    [
+      "remote",
+      "add",
+      "upstream",
+      "https://github.com/JSONbored/metagraphed.git",
+    ],
+    { cwd: dir },
+  );
+  const message = buildDeployOwnedMismatchMessage(
+    ["public/metagraph/r2-manifest.json (content differs from a fresh build)"],
+    dir,
+  );
+  assert.match(message, /git checkout upstream\/main --/);
+  assert.doesNotMatch(message, /git checkout origin\/main --/);
+});
+
+test("buildDeployOwnedMismatchMessage falls back to origin/main on a direct clone", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "wj-deploy-owned-msg-"));
+  execFileSync("git", ["init", "-q"], { cwd: dir });
+  execFileSync(
+    "git",
+    ["remote", "add", "origin", "https://github.com/JSONbored/metagraphed.git"],
+    { cwd: dir },
+  );
+  const message = buildDeployOwnedMismatchMessage(
+    [
+      "public/metagraph/schemas/index.json (content differs from a fresh build)",
+    ],
+    dir,
+  );
+  assert.match(message, /git checkout origin\/main --/);
 });
 
 test("R2 manifest comparison rejects invalid ignored byte totals", () => {

--- a/tests/ci-artifact-verifier.test.mjs
+++ b/tests/ci-artifact-verifier.test.mjs
@@ -4,6 +4,7 @@ import {
   canonicalArtifactJson,
   canonicalJson,
   isSubmittedPublicArtifactPath,
+  partitionMismatches,
 } from "../scripts/ci-verify-submitted-artifacts.mjs";
 
 test("submitted artifact verifier includes force-added public datasets", () => {
@@ -74,6 +75,35 @@ test("R2 manifest comparison ignores only R2 aggregate byte drift", () => {
       storage_tier_size_bytes: { dual: 11, r2: 21 },
     }),
   );
+});
+
+test("partitionMismatches routes deploy-owned artifacts to their own bucket, from real PR #2667 data", () => {
+  // PR #2667's actual failure: a count-field drift (registry growth between
+  // the contributor's build and CI's, not tolerated by canonicalArtifactJson)
+  // produced this exact mismatch entry, alongside an unrelated genuine
+  // mismatch to make sure the two buckets don't cross-contaminate.
+  const mismatches = [
+    "public/metagraph/r2-manifest.json (content differs from a fresh build)",
+    "public/metagraph/schemas/index.json (content differs from a fresh build)",
+    "public/metagraph/coverage.json (content differs from a fresh build)",
+  ];
+  const { deployOwned, other } = partitionMismatches(mismatches);
+  assert.deepEqual(deployOwned, [
+    "public/metagraph/r2-manifest.json (content differs from a fresh build)",
+    "public/metagraph/schemas/index.json (content differs from a fresh build)",
+  ]);
+  assert.deepEqual(other, [
+    "public/metagraph/coverage.json (content differs from a fresh build)",
+  ]);
+});
+
+test("partitionMismatches puts everything in `other` when nothing is deploy-owned", () => {
+  const mismatches = [
+    "public/metagraph/openapi.json (content differs from a fresh build)",
+  ];
+  const { deployOwned, other } = partitionMismatches(mismatches);
+  assert.deepEqual(deployOwned, []);
+  assert.deepEqual(other, mismatches);
 });
 
 test("R2 manifest comparison rejects invalid ignored byte totals", () => {

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -1813,4 +1813,12 @@ describe("resolveBaseRemote", () => {
       process.chdir(previousCwd);
     }
   });
+
+  test("falls back to origin when git remote produces no output at all", () => {
+    // A repo with zero configured remotes: `git remote` exits 0 with empty
+    // stdout, exercising the `result.stdout || ""` fallback (falsy empty
+    // string on both sides) rather than a non-empty remote list.
+    const dir = initRepo();
+    assert.equal(resolveBaseRemote(dir), "origin");
+  });
 });

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -1792,4 +1792,25 @@ describe("resolveBaseRemote", () => {
     );
     assert.equal(resolveBaseRemote(dir), "origin");
   });
+
+  test("defaults to process.cwd() when called with no argument", () => {
+    const dir = initRepo();
+    execFileSync(
+      "git",
+      [
+        "remote",
+        "add",
+        "upstream",
+        "https://github.com/JSONbored/metagraphed.git",
+      ],
+      { cwd: dir },
+    );
+    const previousCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      assert.equal(resolveBaseRemote(), "upstream");
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
 });

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -42,7 +42,9 @@ import {
   resolveSurfaceCurationLevel,
   flattenSurfaces,
   withSurfaceFreshness,
+  resolveBaseRemote,
 } from "../scripts/lib.mjs";
+import { execFileSync } from "node:child_process";
 
 describe("buildEconomicsArtifact", () => {
   const base = {
@@ -1741,5 +1743,53 @@ describe("withSurfaceFreshness curation_level re-resolution (#1757)", () => {
     const [row] = withSurfaceFreshness(surfaces, nowMs);
     assert.equal(row.stale, false);
     assert.equal(row.curation_level, "machine-verified");
+  });
+});
+
+describe("resolveBaseRemote", () => {
+  function initRepo() {
+    const dir = mkdtempSync(path.join(tmpdir(), "wj-base-remote-"));
+    execFileSync("git", ["init", "-q"], { cwd: dir });
+    return dir;
+  }
+
+  test("prefers upstream when a fork has both origin and upstream configured", () => {
+    const dir = initRepo();
+    execFileSync(
+      "git",
+      [
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/contributor/metagraphed.git",
+      ],
+      { cwd: dir },
+    );
+    execFileSync(
+      "git",
+      [
+        "remote",
+        "add",
+        "upstream",
+        "https://github.com/JSONbored/metagraphed.git",
+      ],
+      { cwd: dir },
+    );
+    assert.equal(resolveBaseRemote(dir), "upstream");
+  });
+
+  test("falls back to origin for a direct clone with no upstream remote", () => {
+    const dir = initRepo();
+    execFileSync(
+      "git",
+      [
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/JSONbored/metagraphed.git",
+      ],
+      { cwd: dir },
+    );
+    assert.equal(resolveBaseRemote(dir), "origin");
   });
 });


### PR DESCRIPTION
## Summary

PR #2667 (contributor) hit a `checks` failure — `Verify submitted public artifacts are reproducible` reported:

```
- public/metagraph/r2-manifest.json (content differs from a fresh build)
```

Root-caused via a clean-clone rebuild of that PR's branch: the mismatch is a real content difference (`full_artifact_count`/`storage_tier_counts.r2` off by exactly 2, reflecting registry growth on `main` between the contributor's last local build and now), but the message gave zero indication of *why*, or that the fix is always the same regardless of cause: revert the file, don't chase the diff.

This is a message-clarity fix only. It does **not** relax the existing tamper-detection logic in `canonicalArtifactJson` (still covered by its own dedicated tests) — it only changes which message a contributor sees when `r2-manifest.json`/`schemas/index.json` specifically are the files that mismatch, vs. a genuine unexpected/tampered artifact.

## Changes

- **`scripts/lib.mjs`**: extracted `DEPLOY_OWNED_ARTIFACTS` as a shared, exported constant (previously a local `const` duplicated only in `build.mjs`).
- **`scripts/build.mjs`**: now imports `DEPLOY_OWNED_ARTIFACTS` from `lib.mjs` instead of defining its own copy.
- **`scripts/ci-verify-submitted-artifacts.mjs`**: new exported `partitionMismatches()` splits mismatch entries into deploy-owned (gets a distinct "revert, don't rebuild" message with the exact command) vs. everything else (keeps the existing generic message).
- **`tests/ci-artifact-verifier.test.mjs`**: two new regression tests for `partitionMismatches`, one directly modeled on PR #2667's real mismatch data.

## Validation

- `npm run lint` / `npx prettier --check` — clean on all touched files
- `node scripts/validate-workflows.mjs` — 18 workflows validated (unaffected, but touches shared `lib.mjs`)
- `npx vitest run tests/ci-artifact-verifier.test.mjs` — 8/8 passing (6 existing + 2 new)
- `npm run test:coverage` (full suite, after `npm run build`) — 153/155 files passing; the 2 failing files (`network-routing.test.mjs`, `public-safety.test.mjs`) are non-deterministic across repeated full-suite runs (different subtests fail each time) and pass cleanly in isolation both with and without this diff — confirmed unrelated to this change.
- `scripts/build.mjs`/`scripts/ci-verify-submitted-artifacts.mjs` are outside `vitest.config.mjs`'s `coverage.include` scope (only `scripts/lib.mjs` is tracked, and that change is a trivial constant export), so this PR doesn't affect the Codecov patch-coverage gate.