### PR TITLE
feat(registry): add SN18 Zeus openapi surface (#581)

### DIFF
--- a/registry/subnets/sn-18.json
+++ b/registry/subnets/sn-18.json
@@ -28,6 +28,27 @@
       },
       "source_urls": ["https://api.zeussubnet.com/openapi.json"],
       "url": "https://api.zeussubnet.com/v1/meta"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-18-zeus-openapi",
+      "kind": "openapi",
+      "name": "Zeus BOREAS Edge API (public)",
+      "notes": "Machine-readable spec for the public BOREAS Edge API documented by Zeus.",
+      "provider": "zeus",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dragunovx16"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.zeussubnet.com/openapi.json",
+      "source_urls": [
+        "https://docs.zeussubnet.com/docs/introduction",
+        "https://api.zeussubnet.com/openapi.json"
+      ],
+      "url": "https://api.zeussubnet.com/openapi.json"
     }
   ],
   "website_url": "https://www.zeussubnet.com/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends the remaining OpenAPI surface to the existing Zeus subnet manifest.

## Surface

- Netuid: 18
- Kind: openapi
- Public URL: https://api.zeussubnet.com/openapi.json
- Source URL (proves the claim): https://docs.zeussubnet.com/docs/introduction
- Provider slug: zeus

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest, or a `subnet:new` scaffold plus surface(s) for a missing manifest (optionally plus one `registry/providers/*.json` for a debut provider).
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #581`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass. Base-layer RPC/WSS/archive, authenticated surfaces, unknown providers, and identity disputes route to manual review.

## Validation

- [x] `npm run validate:surface -- registry/subnets/sn-18.json`
- [x] `npm run scan:public-safety`

Closes #581
