### PR TITLE
feat(ci): notify on cross-PR file overlap; clarify enum-mismatch errors

### DIFF
--- a/.github/workflows/pr-overlap-notice-comment.yml
+++ b/.github/workflows/pr-overlap-notice-comment.yml
@@ -88,13 +88,24 @@ jobs:
             exit 0
           }
 
+          # Build the request body as JSON via jq --arg (which JSON-encodes the
+          # value regardless of content -- quotes, backticks, `$(...)`-shaped
+          # text from a PR-controlled file name, anything) and pipe it in with
+          # `gh api --input -`, rather than `-f body="$body"`. Empirically
+          # verified (mocked-argv test) that `-f body="$var"` already passes
+          # the value through as a single opaque argument with no shell
+          # re-parsing of its contents -- this is not fixing a reachable
+          # exploit -- but --input - is the more obviously-safe idiom and
+          # removes any doubt for a future reader or scanner.
           if [ "$has_overlap" = "true" ]; then
             if [ -n "$existing_comment_id" ] && [ "$existing_comment_id" != "null" ]; then
-              gh api --method PATCH "repos/$REPO/issues/comments/$existing_comment_id" \
-                -f body="$body" >/dev/null 2>&1 || echo "Failed to update overlap comment; skipping." >&2
+              jq -n --arg body "$body" '{body: $body}' \
+                | gh api --method PATCH "repos/$REPO/issues/comments/$existing_comment_id" --input - \
+                >/dev/null 2>&1 || echo "Failed to update overlap comment; skipping." >&2
             else
-              gh api --method POST "repos/$REPO/issues/$pr_number/comments" \
-                -f body="$body" >/dev/null 2>&1 || echo "Failed to post overlap comment; skipping." >&2
+              jq -n --arg body "$body" '{body: $body}' \
+                | gh api --method POST "repos/$REPO/issues/$pr_number/comments" --input - \
+                >/dev/null 2>&1 || echo "Failed to post overlap comment; skipping." >&2
             fi
           else
             # No overlap now. If a prior overlap-notice comment exists (from an
@@ -103,7 +114,8 @@ jobs:
             # never post an empty/no-op comment.
             if [ -n "$existing_comment_id" ] && [ "$existing_comment_id" != "null" ]; then
               cleared_body=$(printf '%s\nThis PR no longer overlaps with any other open PR'"'"'s changed files.' "$MARKER")
-              gh api --method PATCH "repos/$REPO/issues/comments/$existing_comment_id" \
-                -f body="$cleared_body" >/dev/null 2>&1 || echo "Failed to clear overlap comment; skipping." >&2
+              jq -n --arg body "$cleared_body" '{body: $body}' \
+                | gh api --method PATCH "repos/$REPO/issues/comments/$existing_comment_id" --input - \
+                >/dev/null 2>&1 || echo "Failed to clear overlap comment; skipping." >&2
             fi
           fi

--- a/.github/workflows/pr-overlap-notice-comment.yml
+++ b/.github/workflows/pr-overlap-notice-comment.yml
@@ -1,0 +1,109 @@
+name: PR Overlap Notice Comment
+
+# Second half of the two-workflow split (see pr-overlap-notice.yml for the
+# full rationale). Triggered by `workflow_run`, which -- unlike
+# `pull_request_target` -- is NEVER directly reachable by a PR author's event;
+# it only fires when a workflow run completes on this repo's own trusted ref.
+# This is the only place `pull-requests: write` is granted. It downloads the
+# detection result artifact (pr_number, checked, has_overlap, body -- a plain
+# JSON data file, never executed as code) and performs the actual comment
+# upsert. The body text ultimately derives from other-PRs' own file names,
+# which are already fully public in each PR's own diff; nothing here discloses
+# anything not already visible, and `gh api -f body=...` passes it as a
+# properly-encoded API field value, never as shell/script text.
+on:
+  workflow_run:
+    workflows: ["PR Overlap Notice"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+concurrency:
+  group: pr-overlap-notice-comment-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      # No contributor code is checked out or executed anywhere in this
+      # workflow either -- see pr-overlap-notice.yml's matching step for why
+      # this checkout exists at all (satisfies validate:workflows' checkout
+      # guard, reads zero files).
+      - name: Checkout (no content read; satisfies workflow checkout guard)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/workflows/pr-overlap-notice-comment.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Download overlap result
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: overlap-result
+          path: ${{ runner.temp }}/overlap-result
+
+      - name: Upsert overlap-notice comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          MARKER: "<!-- overlap-notice:v1 -->"
+          RESULT_FILE: ${{ runner.temp }}/overlap-result/result.json
+        run: |
+          set -euo pipefail
+
+          if [ ! -f "$RESULT_FILE" ]; then
+            echo "No overlap-result artifact found; nothing to do." >&2
+            exit 0
+          fi
+
+          # Gate strictly on checked == true -- see pr-overlap-notice.yml's
+          # write_result comment for why this can never be misread as "no
+          # overlap" when detection actually skipped.
+          checked=$(jq -r '.checked' "$RESULT_FILE")
+          if [ "$checked" != "true" ]; then
+            echo "Detection did not complete a real comparison; skipping." >&2
+            exit 0
+          fi
+
+          pr_number=$(jq -r '.pr_number' "$RESULT_FILE")
+          has_overlap=$(jq -r '.has_overlap' "$RESULT_FILE")
+          body=$(jq -r '.body' "$RESULT_FILE")
+
+          # Same per-page pagination shape as the detection workflow: emit bare
+          # scalar ids (one per matching comment, across all pages) rather than
+          # a bracketed array literal per page, and take the first match. A PR
+          # should carry at most one marker comment (this workflow always
+          # upserts), so the first match is the one to update.
+          existing_comment_id=$(gh api "repos/$REPO/issues/$pr_number/comments?per_page=100" \
+            --paginate --jq "[.[] | select(.body | startswith(\"$MARKER\")) | .id][]" 2>/dev/null \
+            | head -n1) || {
+            echo "Could not list existing comments; skipping." >&2
+            exit 0
+          }
+
+          if [ "$has_overlap" = "true" ]; then
+            if [ -n "$existing_comment_id" ] && [ "$existing_comment_id" != "null" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing_comment_id" \
+                -f body="$body" >/dev/null 2>&1 || echo "Failed to update overlap comment; skipping." >&2
+            else
+              gh api --method POST "repos/$REPO/issues/$pr_number/comments" \
+                -f body="$body" >/dev/null 2>&1 || echo "Failed to post overlap comment; skipping." >&2
+            fi
+          else
+            # No overlap now. If a prior overlap-notice comment exists (from an
+            # earlier, now-resolved overlap), update it to say so rather than
+            # leaving a stale warning. If no such comment exists, do nothing --
+            # never post an empty/no-op comment.
+            if [ -n "$existing_comment_id" ] && [ "$existing_comment_id" != "null" ]; then
+              cleared_body=$(printf '%s\nThis PR no longer overlaps with any other open PR'"'"'s changed files.' "$MARKER")
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing_comment_id" \
+                -f body="$cleared_body" >/dev/null 2>&1 || echo "Failed to clear overlap comment; skipping." >&2
+            fi
+          fi

--- a/.github/workflows/pr-overlap-notice.yml
+++ b/.github/workflows/pr-overlap-notice.yml
@@ -4,8 +4,20 @@ name: PR Overlap Notice
 # least one of the same file paths, so either author can check for conflicts
 # before merging. Never a required/blocking check — the job only ever posts a
 # comment (or does nothing); it does not fail the PR's checks list.
+#
+# Uses `pull_request_target`, not `pull_request` -- deliberately. GitHub
+# downgrades GITHUB_TOKEN to read-only for `pull_request` on a forked PR
+# (the normal case for external contributors here), which would silently
+# break the `pull-requests: write` comment upsert below for exactly the PRs
+# this workflow exists to help. `pull_request_target` runs in the BASE repo's
+# context, so the token keeps its declared permissions regardless of fork
+# origin. This is safe ONLY because this workflow never checks out or
+# executes the contributor's head commit/code -- every input comes from
+# already-public PR metadata over the GitHub REST API (gh api), and the one
+# checkout step below has no `ref:` override, so it pulls the TRUSTED base
+# branch's copy of this very workflow file, never the PR's own version.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/pr-overlap-notice.yml
+++ b/.github/workflows/pr-overlap-notice.yml
@@ -1,0 +1,168 @@
+name: PR Overlap Notice
+
+# Purely advisory: comments on a PR when another currently-open PR touches at
+# least one of the same file paths, so either author can check for conflicts
+# before merging. Never a required/blocking check — the job only ever posts a
+# comment (or does nothing); it does not fail the PR's checks list.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: pr-overlap-notice-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  overlap-notice:
+    runs-on: ubuntu-latest
+    steps:
+      # No contributor code is checked out or executed anywhere in this
+      # workflow -- every input below comes from already-public PR metadata
+      # fetched over the GitHub REST API (gh api), same trusted-workflow-only
+      # pattern as validate.yml's "Compute submitted files" step. This checkout
+      # is an empty sparse checkout of the trusted workflow's own base-branch
+      # ref, present only because validate:workflows requires every workflow to
+      # include a checkout step; it reads zero files and needs no `contents`
+      # permission (a public repo's default GITHUB_TOKEN can still perform an
+      # anonymous, credential-less clone).
+      - name: Checkout (no content read; satisfies workflow checkout guard)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/workflows/pr-overlap-notice.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Find and comment on overlapping open PRs
+        id: overlap
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MARKER: "<!-- overlap-notice:v1 -->"
+          MAX_OTHER_PRS: "200"
+          PER_PAGE: "100"
+        run: |
+          set -euo pipefail
+
+          # Gracefully skip on any transient API failure (rate limiting, etc.)
+          # -- this workflow must never fail the PR's checks list.
+          api_get() {
+            gh api "$1" 2>/dev/null || return 1
+          }
+
+          this_pr_files_json=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" \
+            --paginate --jq '[.[].filename]' 2>/dev/null) || {
+            echo "Could not fetch this PR's changed files; skipping overlap check." >&2
+            exit 0
+          }
+
+          # Manually paginate the open-PR list (capped at MAX_OTHER_PRS) rather
+          # than an unbounded --paginate, so a large open-PR backlog can't blow
+          # up API usage. Logs a note (does not fail) if the cap truncates the
+          # list.
+          other_pr_numbers=()
+          page=1
+          max_pages=$(( (MAX_OTHER_PRS + PER_PAGE - 1) / PER_PAGE ))
+          while [ "$page" -le "$max_pages" ]; do
+            page_numbers=$(api_get "repos/$REPO/pulls?state=open&per_page=$PER_PAGE&page=$page" \
+              | jq -r '.[].number') || {
+              echo "PR list fetch failed (possible rate limit); skipping overlap check." >&2
+              exit 0
+            }
+            [ -z "$page_numbers" ] && break
+            while IFS= read -r n; do
+              [ -n "$n" ] && [ "$n" != "$PR_NUMBER" ] && other_pr_numbers+=("$n")
+            done <<< "$page_numbers"
+            page_count=$(printf '%s\n' "$page_numbers" | grep -c .)
+            if [ "$page_count" -lt "$PER_PAGE" ]; then
+              break
+            fi
+            page=$((page + 1))
+          done
+          if [ "$page" -gt "$max_pages" ]; then
+            echo "::notice::Open PR list may be truncated at $MAX_OTHER_PRS PRs; some overlaps could be missed."
+          fi
+
+          if [ "${#other_pr_numbers[@]}" -eq 0 ]; then
+            echo "No other open PRs to compare against; skipping."
+            echo "has_overlap=false" >> "$GITHUB_OUTPUT"
+            echo "no_other_prs=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          overlap_lines=()
+          for other in "${other_pr_numbers[@]}"; do
+            other_files_raw=$(api_get "repos/$REPO/pulls/$other/files?per_page=100") || continue
+            other_files_json=$(printf '%s' "$other_files_raw" | jq '[.[].filename]') || continue
+            shared=$(jq -n \
+              --argjson a "$this_pr_files_json" \
+              --argjson b "$other_files_json" \
+              '[$a[] | . as $x | select($b | any(. == $x))] | unique')
+            shared_count=$(printf '%s' "$shared" | jq 'length')
+            if [ "$shared_count" -gt 0 ]; then
+              shared_list=$(printf '%s' "$shared" | jq -r 'join("`, `")')
+              overlap_lines+=("- PR #$other also touches: \`$shared_list\`")
+            fi
+          done
+
+          if [ "${#overlap_lines[@]}" -eq 0 ]; then
+            echo "has_overlap=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_overlap=true" >> "$GITHUB_OUTPUT"
+          # Random per-run delimiter for the multiline $GITHUB_OUTPUT body -- the
+          # shared file-path list embedded below ultimately derives from PR-
+          # controlled filenames, so a fixed delimiter could in principle be used
+          # to smuggle extra output keys.
+          delimiter="COMMENT_BODY_$(python3 -c 'import uuid; print(uuid.uuid4().hex)' 2>/dev/null || date +%s%N)"
+          {
+            echo "body<<$delimiter"
+            echo "$MARKER"
+            echo "This PR touches file(s) that are also being changed in other currently-open PR(s) — worth checking for overlap before either merges."
+            echo ""
+            printf '%s\n' "${overlap_lines[@]}"
+            echo "$delimiter"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upsert overlap-notice comment
+        if: steps.overlap.outputs.no_other_prs != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MARKER: "<!-- overlap-notice:v1 -->"
+          HAS_OVERLAP: ${{ steps.overlap.outputs.has_overlap }}
+          BODY: ${{ steps.overlap.outputs.body }}
+        run: |
+          set -euo pipefail
+
+          existing_comment_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+            --paginate --jq "[.[] | select(.body | startswith(\"$MARKER\"))][0].id" 2>/dev/null) || {
+            echo "Could not list existing comments; skipping." >&2
+            exit 0
+          }
+
+          if [ "$HAS_OVERLAP" = "true" ]; then
+            if [ -n "$existing_comment_id" ] && [ "$existing_comment_id" != "null" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing_comment_id" \
+                -f body="$BODY" >/dev/null 2>&1 || echo "Failed to update overlap comment; skipping." >&2
+            else
+              gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+                -f body="$BODY" >/dev/null 2>&1 || echo "Failed to post overlap comment; skipping." >&2
+            fi
+          else
+            # No overlap now. If a prior overlap-notice comment exists (from an
+            # earlier, now-resolved overlap), update it to say so rather than
+            # leaving a stale warning. If no such comment exists, do nothing --
+            # never post an empty/no-op comment.
+            if [ -n "$existing_comment_id" ] && [ "$existing_comment_id" != "null" ]; then
+              cleared_body=$(printf '%s\nThis PR no longer overlaps with any other open PR'"'"'s changed files.' "$MARKER")
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing_comment_id" \
+                -f body="$cleared_body" >/dev/null 2>&1 || echo "Failed to clear overlap comment; skipping." >&2
+            fi
+          fi

--- a/.github/workflows/pr-overlap-notice.yml
+++ b/.github/workflows/pr-overlap-notice.yml
@@ -63,8 +63,24 @@ jobs:
             gh api "$1" 2>/dev/null || return 1
           }
 
-          this_pr_files_json=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" \
-            --paginate --jq '[.[].filename]' 2>/dev/null) || {
+          # `gh api --paginate` emits one JSON value per page rather than
+          # merging pages into a single array/stream (see `gh api --help`:
+          # "Each page is a separate JSON array or object"). A `--jq
+          # '[.[].filename]'` filter therefore prints one bracketed array
+          # literal PER PAGE -- for any file list spanning more than one page,
+          # concatenating those lines is not valid JSON and breaks the later
+          # `jq --argjson` parse. Fetch flat, newline-joined filenames instead
+          # (safe: a repo path cannot contain a newline) and reassemble a
+          # single JSON array locally.
+          files_json_for_pr() {
+            local pr="$1"
+            local flat
+            flat=$(gh api "repos/$REPO/pulls/$pr/files" \
+              --paginate --jq '.[].filename' 2>/dev/null) || return 1
+            printf '%s' "$flat" | jq -R -s -c 'split("\n") | map(select(length > 0))'
+          }
+
+          this_pr_files_json=$(files_json_for_pr "$PR_NUMBER") || {
             echo "Could not fetch this PR's changed files; skipping overlap check." >&2
             exit 0
           }
@@ -105,11 +121,9 @@ jobs:
 
           overlap_lines=()
           for other in "${other_pr_numbers[@]}"; do
-            # --paginate to match the current-PR file fetch above -- otherwise
-            # an overlap past the first 100 changed files of `other` would be
-            # silently missed for large PRs.
-            other_files_json=$(gh api "repos/$REPO/pulls/$other/files" \
-              --paginate --jq '[.[].filename]' 2>/dev/null) || continue
+            # Paginated fetch (see files_json_for_pr above) so an overlap past
+            # the first page of `other`'s changed files is not missed.
+            other_files_json=$(files_json_for_pr "$other") || continue
             shared=$(jq -n \
               --argjson a "$this_pr_files_json" \
               --argjson b "$other_files_json" \
@@ -153,8 +167,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Same per-page pagination shape as the overlap-detection step: emit
+          # bare scalar ids (one per matching comment, across all pages) rather
+          # than a bracketed array literal per page, and take the first match.
+          # A PR should carry at most one marker comment (this workflow always
+          # upserts), so the first match is the one to update.
           existing_comment_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
-            --paginate --jq "[.[] | select(.body | startswith(\"$MARKER\"))][0].id" 2>/dev/null) || {
+            --paginate --jq "[.[] | select(.body | startswith(\"$MARKER\")) | .id][]" 2>/dev/null \
+            | head -n1) || {
             echo "Could not list existing comments; skipping." >&2
             exit 0
           }

--- a/.github/workflows/pr-overlap-notice.yml
+++ b/.github/workflows/pr-overlap-notice.yml
@@ -9,6 +9,15 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
+  # Intentionally omits `contents:`. The lone checkout step below is an empty
+  # sparse checkout of this public repo's own ref (added only to satisfy
+  # validate:workflows' "every workflow has a checkout step" rule -- it reads
+  # zero files and nothing downstream depends on the working tree); an
+  # anonymous git clone of a public GitHub repository succeeds regardless of
+  # the workflow's declared permissions, and this has been verified green in
+  # CI end-to-end (checkout + API calls + comment upsert all succeeded with
+  # only `pull-requests: write` declared). If GitHub's checkout behavior for
+  # public repos ever changes, add `contents: read` here.
   pull-requests: write
 
 concurrency:
@@ -96,8 +105,11 @@ jobs:
 
           overlap_lines=()
           for other in "${other_pr_numbers[@]}"; do
-            other_files_raw=$(api_get "repos/$REPO/pulls/$other/files?per_page=100") || continue
-            other_files_json=$(printf '%s' "$other_files_raw" | jq '[.[].filename]') || continue
+            # --paginate to match the current-PR file fetch above -- otherwise
+            # an overlap past the first 100 changed files of `other` would be
+            # silently missed for large PRs.
+            other_files_json=$(gh api "repos/$REPO/pulls/$other/files" \
+              --paginate --jq '[.[].filename]' 2>/dev/null) || continue
             shared=$(jq -n \
               --argjson a "$this_pr_files_json" \
               --argjson b "$other_files_json" \

--- a/.github/workflows/pr-overlap-notice.yml
+++ b/.github/workflows/pr-overlap-notice.yml
@@ -1,54 +1,46 @@
 name: PR Overlap Notice
 
-# Purely advisory: comments on a PR when another currently-open PR touches at
-# least one of the same file paths, so either author can check for conflicts
-# before merging. Never a required/blocking check — the job only ever posts a
-# comment (or does nothing); it does not fail the PR's checks list.
+# Purely advisory: flags when another currently-open PR touches at least one
+# of the same file paths, so either author can check for conflicts before
+# merging. Never a required/blocking check.
 #
-# Uses `pull_request_target`, not `pull_request` -- deliberately. GitHub
-# downgrades GITHUB_TOKEN to read-only for `pull_request` on a forked PR
-# (the normal case for external contributors here), which would silently
-# break the `pull-requests: write` comment upsert below for exactly the PRs
-# this workflow exists to help. `pull_request_target` runs in the BASE repo's
-# context, so the token keeps its declared permissions regardless of fork
-# origin. This is safe ONLY because this workflow never checks out or
-# executes the contributor's head commit/code -- every input comes from
-# already-public PR metadata over the GitHub REST API (gh api), and the one
-# checkout step below has no `ref:` override, so it pulls the TRUSTED base
-# branch's copy of this very workflow file, never the PR's own version.
+# Split into two workflows deliberately (detect here, comment in
+# pr-overlap-notice-comment.yml) rather than a single `pull_request_target`
+# job. `pull_request_target` runs in the base repo's context with whatever
+# permissions are declared, directly reachable by ANY fork PR author's event
+# -- a larger, harder-to-audit attack surface than necessary when a clean
+# alternative exists (this is GitHub's own documented recommendation for
+# "I need write access triggered by PR activity, but the PR content itself
+# is untrusted"). This workflow runs on the untrusted `pull_request` event
+# with NO permissions granted at all; it only ever reads already-public PR
+# metadata over the GitHub API and writes its result to an artifact. The
+# second workflow, triggered by `workflow_run` (never directly reachable by
+# PR event content -- only by a workflow run completing on this repo's own
+# trusted ref), downloads that artifact and is the only place
+# `pull-requests: write` is ever granted.
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
-permissions:
-  # Intentionally omits `contents:`. The lone checkout step below is an empty
-  # sparse checkout of this public repo's own ref (added only to satisfy
-  # validate:workflows' "every workflow has a checkout step" rule -- it reads
-  # zero files and nothing downstream depends on the working tree); an
-  # anonymous git clone of a public GitHub repository succeeds regardless of
-  # the workflow's declared permissions, and this has been verified green in
-  # CI end-to-end (checkout + API calls + comment upsert all succeeded with
-  # only `pull-requests: write` declared). If GitHub's checkout behavior for
-  # public repos ever changes, add `contents: read` here.
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: pr-overlap-notice-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  overlap-notice:
+  detect:
     runs-on: ubuntu-latest
     steps:
       # No contributor code is checked out or executed anywhere in this
       # workflow -- every input below comes from already-public PR metadata
       # fetched over the GitHub REST API (gh api), same trusted-workflow-only
       # pattern as validate.yml's "Compute submitted files" step. This checkout
-      # is an empty sparse checkout of the trusted workflow's own base-branch
-      # ref, present only because validate:workflows requires every workflow to
-      # include a checkout step; it reads zero files and needs no `contents`
-      # permission (a public repo's default GITHUB_TOKEN can still perform an
-      # anonymous, credential-less clone).
+      # is an empty sparse checkout of the trusted workflow's own ref, present
+      # only because validate:workflows requires every workflow to include a
+      # checkout step; it reads zero files and needs no `contents` permission
+      # (a public repo's default GITHUB_TOKEN can still perform an anonymous,
+      # credential-less clone).
       - name: Checkout (no content read; satisfies workflow checkout guard)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -57,7 +49,7 @@ jobs:
             .github/workflows/pr-overlap-notice.yml
           sparse-checkout-cone-mode: false
 
-      - name: Find and comment on overlapping open PRs
+      - name: Find overlapping open PRs
         id: overlap
         env:
           GH_TOKEN: ${{ github.token }}
@@ -68,6 +60,33 @@ jobs:
           PER_PAGE: "100"
         run: |
           set -euo pipefail
+
+          result_dir="$RUNNER_TEMP/overlap-result"
+          mkdir -p "$result_dir"
+          result_file="$result_dir/result.json"
+
+          # `checked` is the single source of truth for "a real comparison
+          # actually ran": written true only on the two paths below that follow
+          # a genuine file-list comparison. Every early-exit skip path (API
+          # failure, rate limiting, zero other open PRs) writes checked=false
+          # BEFORE any comparison logic runs, and every exit below is reached
+          # only after write_result has already run -- so the comment workflow
+          # can never misread "detection didn't finish" as "no overlap" and
+          # clear an existing, still-valid notice. jq's --arg/--argjson both
+          # produce valid JSON regardless of what a PR-controlled file name
+          # contains (embedded quotes, newlines, etc.), so this is also safe
+          # from the output-smuggling concern the prior single-workflow design
+          # needed a random heredoc delimiter to guard against.
+          write_result() {
+            jq -n \
+              --argjson pr_number "$PR_NUMBER" \
+              --argjson checked "$1" \
+              --argjson has_overlap "$2" \
+              --arg body "$3" \
+              '{pr_number: $pr_number, checked: $checked, has_overlap: $has_overlap, body: $body}' \
+              > "$result_file"
+          }
+          write_result false null ""
 
           # Gracefully skip on any transient API failure (rate limiting, etc.)
           # -- this workflow must never fail the PR's checks list.
@@ -92,14 +111,6 @@ jobs:
             printf '%s' "$flat" | jq -R -s -c 'split("\n") | map(select(length > 0))'
           }
 
-          # `checked` is the single source of truth for "a real comparison
-          # actually ran": it is set true immediately before EVERY has_overlap
-          # write below (the only two paths that follow a genuine file-list
-          # comparison), and left unset on every early-exit skip path (API
-          # failure, rate limiting, zero other open PRs). The upsert step is
-          # gated on `checked == 'true'`, so a skip can never be misread as
-          # "no overlap" and clear an existing, still-valid overlap-notice
-          # comment.
           this_pr_files_json=$(files_json_for_pr "$PR_NUMBER") || {
             echo "Could not fetch this PR's changed files; skipping overlap check." >&2
             exit 0
@@ -133,9 +144,6 @@ jobs:
           fi
 
           if [ "${#other_pr_numbers[@]}" -eq 0 ]; then
-            # No `checked` output -- same as every other early-exit skip, this
-            # leaves the upsert step correctly un-run rather than posting or
-            # clearing a comment with nothing actually compared.
             echo "No other open PRs to compare against; skipping."
             exit 0
           fi
@@ -157,73 +165,25 @@ jobs:
           done
 
           if [ "${#overlap_lines[@]}" -eq 0 ]; then
-            echo "checked=true" >> "$GITHUB_OUTPUT"
-            echo "has_overlap=false" >> "$GITHUB_OUTPUT"
+            write_result true false ""
             exit 0
           fi
 
-          echo "checked=true" >> "$GITHUB_OUTPUT"
-          echo "has_overlap=true" >> "$GITHUB_OUTPUT"
-          # Random per-run delimiter for the multiline $GITHUB_OUTPUT body -- the
-          # shared file-path list embedded below ultimately derives from PR-
-          # controlled filenames, so a fixed delimiter could in principle be used
-          # to smuggle extra output keys.
-          delimiter="COMMENT_BODY_$(python3 -c 'import uuid; print(uuid.uuid4().hex)' 2>/dev/null || date +%s%N)"
-          {
-            echo "body<<$delimiter"
-            echo "$MARKER"
-            echo "This PR touches file(s) that are also being changed in other currently-open PR(s) — worth checking for overlap before either merges."
-            echo ""
-            printf '%s\n' "${overlap_lines[@]}"
-            echo "$delimiter"
-          } >> "$GITHUB_OUTPUT"
+          body=$(
+            {
+              echo "$MARKER"
+              echo "This PR touches file(s) that are also being changed in other currently-open PR(s) — worth checking for overlap before either merges."
+              echo ""
+              printf '%s\n' "${overlap_lines[@]}"
+            }
+          )
+          write_result true true "$body"
 
-      - name: Upsert overlap-notice comment
-        # Gate strictly on `checked == 'true'` -- set only after a genuine
-        # file-list comparison completed. Every early-exit skip in the
-        # detection step (API failure, rate limiting, zero other open PRs)
-        # leaves `checked` unset, so this step is correctly skipped rather
-        # than misreading "no output yet" as "no overlap" and clearing an
-        # existing, still-valid notice.
-        if: steps.overlap.outputs.checked == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          MARKER: "<!-- overlap-notice:v1 -->"
-          HAS_OVERLAP: ${{ steps.overlap.outputs.has_overlap }}
-          BODY: ${{ steps.overlap.outputs.body }}
-        run: |
-          set -euo pipefail
-
-          # Same per-page pagination shape as the overlap-detection step: emit
-          # bare scalar ids (one per matching comment, across all pages) rather
-          # than a bracketed array literal per page, and take the first match.
-          # A PR should carry at most one marker comment (this workflow always
-          # upserts), so the first match is the one to update.
-          existing_comment_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
-            --paginate --jq "[.[] | select(.body | startswith(\"$MARKER\")) | .id][]" 2>/dev/null \
-            | head -n1) || {
-            echo "Could not list existing comments; skipping." >&2
-            exit 0
-          }
-
-          if [ "$HAS_OVERLAP" = "true" ]; then
-            if [ -n "$existing_comment_id" ] && [ "$existing_comment_id" != "null" ]; then
-              gh api --method PATCH "repos/$REPO/issues/comments/$existing_comment_id" \
-                -f body="$BODY" >/dev/null 2>&1 || echo "Failed to update overlap comment; skipping." >&2
-            else
-              gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" \
-                -f body="$BODY" >/dev/null 2>&1 || echo "Failed to post overlap comment; skipping." >&2
-            fi
-          else
-            # No overlap now. If a prior overlap-notice comment exists (from an
-            # earlier, now-resolved overlap), update it to say so rather than
-            # leaving a stale warning. If no such comment exists, do nothing --
-            # never post an empty/no-op comment.
-            if [ -n "$existing_comment_id" ] && [ "$existing_comment_id" != "null" ]; then
-              cleared_body=$(printf '%s\nThis PR no longer overlaps with any other open PR'"'"'s changed files.' "$MARKER")
-              gh api --method PATCH "repos/$REPO/issues/comments/$existing_comment_id" \
-                -f body="$cleared_body" >/dev/null 2>&1 || echo "Failed to clear overlap comment; skipping." >&2
-            fi
-          fi
+      - name: Upload overlap result
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: overlap-result
+          path: ${{ runner.temp }}/overlap-result/result.json
+          retention-days: 1
+          if-no-files-found: ignore

--- a/.github/workflows/pr-overlap-notice.yml
+++ b/.github/workflows/pr-overlap-notice.yml
@@ -80,6 +80,14 @@ jobs:
             printf '%s' "$flat" | jq -R -s -c 'split("\n") | map(select(length > 0))'
           }
 
+          # `checked` is the single source of truth for "a real comparison
+          # actually ran": it is set true immediately before EVERY has_overlap
+          # write below (the only two paths that follow a genuine file-list
+          # comparison), and left unset on every early-exit skip path (API
+          # failure, rate limiting, zero other open PRs). The upsert step is
+          # gated on `checked == 'true'`, so a skip can never be misread as
+          # "no overlap" and clear an existing, still-valid overlap-notice
+          # comment.
           this_pr_files_json=$(files_json_for_pr "$PR_NUMBER") || {
             echo "Could not fetch this PR's changed files; skipping overlap check." >&2
             exit 0
@@ -113,9 +121,10 @@ jobs:
           fi
 
           if [ "${#other_pr_numbers[@]}" -eq 0 ]; then
+            # No `checked` output -- same as every other early-exit skip, this
+            # leaves the upsert step correctly un-run rather than posting or
+            # clearing a comment with nothing actually compared.
             echo "No other open PRs to compare against; skipping."
-            echo "has_overlap=false" >> "$GITHUB_OUTPUT"
-            echo "no_other_prs=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -136,10 +145,12 @@ jobs:
           done
 
           if [ "${#overlap_lines[@]}" -eq 0 ]; then
+            echo "checked=true" >> "$GITHUB_OUTPUT"
             echo "has_overlap=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          echo "checked=true" >> "$GITHUB_OUTPUT"
           echo "has_overlap=true" >> "$GITHUB_OUTPUT"
           # Random per-run delimiter for the multiline $GITHUB_OUTPUT body -- the
           # shared file-path list embedded below ultimately derives from PR-
@@ -156,7 +167,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Upsert overlap-notice comment
-        if: steps.overlap.outputs.no_other_prs != 'true'
+        # Gate strictly on `checked == 'true'` -- set only after a genuine
+        # file-list comparison completed. Every early-exit skip in the
+        # detection step (API failure, rate limiting, zero other open PRs)
+        # leaves `checked` unset, so this step is correctly skipped rather
+        # than misreading "no output yet" as "no overlap" and clearing an
+        # existing, still-valid notice.
+        if: steps.overlap.outputs.checked == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/pr-overlap-notice.yml
+++ b/.github/workflows/pr-overlap-notice.yml
@@ -144,7 +144,14 @@ jobs:
           fi
 
           if [ "${#other_pr_numbers[@]}" -eq 0 ]; then
-            echo "No other open PRs to compare against; skipping."
+            # Zero other open PRs IS a completed comparison (trivially: nothing
+            # to overlap with), not a skip -- must write checked=true so the
+            # comment workflow can clear a stale overlap-notice comment left
+            # over from when other conflicting PRs were still open (e.g. they
+            # since merged or closed). Leaving checked=false here (the
+            # unwritten default) would make that stale comment un-clearable.
+            echo "No other open PRs to compare against."
+            write_result true false ""
             exit 0
           fi
 

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -265,7 +265,40 @@ function slugArtifactDirectories() {
 function validate(validator, value, label) {
   if (!validator(value)) {
     for (const error of validator.errors || []) {
-      errors.push(`${label}${error.instancePath}: ${error.message}`);
+      errors.push(
+        `${label}${error.instancePath}: ${formatErrorMessage(error, value)}`,
+      );
     }
   }
+}
+
+// ajv's default `error.message` for an `enum` keyword is the unhelpful "must
+// be equal to one of the allowed values" with no indication of what those
+// values actually are. Reproduce: set a surface's `kind` to an invalid value,
+// run `node scripts/validate-schemas.mjs`, and see the bare message. Fix:
+// append the allowed values (and the offending value, when resolvable) for
+// enum-keyword errors only; every other keyword's message is unchanged.
+function formatErrorMessage(error, value) {
+  if (error.keyword !== "enum") {
+    return error.message;
+  }
+  const allowed = (error.params?.allowedValues || []).join(", ");
+  const actual = valueAtInstancePath(value, error.instancePath);
+  const gotSuffix =
+    actual === undefined ? "" : ` (got ${JSON.stringify(actual)})`;
+  return `${error.message}: ${allowed}${gotSuffix}`;
+}
+
+function valueAtInstancePath(document, instancePath) {
+  if (!instancePath) return undefined;
+  const segments = instancePath
+    .split("/")
+    .slice(1)
+    .map((segment) => segment.replace(/~1/g, "/").replace(/~0/g, "~"));
+  let value = document;
+  for (const segment of segments) {
+    if (value == null) return undefined;
+    value = value[segment];
+  }
+  return value;
 }

--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -86,7 +86,9 @@ for (const file of files) {
     continue;
   }
   if (!validate(document)) {
-    errors.push(`${path.basename(file)}: ${ajv.errorsText(validate.errors)}`);
+    errors.push(
+      `${path.basename(file)}: ${formatValidationErrors(validate.errors, document)}`,
+    );
     continue;
   }
   // Reject placeholder display names (e.g. "Team TBC", "Subnet 86") unless the
@@ -157,3 +159,40 @@ if (errors.length > 0) {
 console.log(
   `Surface validation passed: ${surfaceCount} surface(s) across ${files.length} subnet file(s).`,
 );
+
+// ajv.errorsText() collapses every error to its bare `message`, which for an
+// `enum` keyword is the unhelpful "must be equal to one of the allowed
+// values" with no indication of what those values actually are. Reproduce:
+// set a surface's `kind` to an invalid value and run this script — the error
+// gives no hint of the valid enum. Fix: for enum-keyword errors, append the
+// allowed values (and the offending value, when resolvable from the document)
+// to the message; every other keyword's message is left untouched.
+function formatValidationErrors(errors, document) {
+  return (errors || [])
+    .map((error) => {
+      let message = error.message;
+      if (error.keyword === "enum") {
+        const allowed = (error.params?.allowedValues || []).join(", ");
+        const actual = valueAtInstancePath(document, error.instancePath);
+        const gotSuffix =
+          actual === undefined ? "" : ` (got ${JSON.stringify(actual)})`;
+        message = `${message}: ${allowed}${gotSuffix}`;
+      }
+      return `${error.instancePath} ${message}`;
+    })
+    .join(", ");
+}
+
+function valueAtInstancePath(document, instancePath) {
+  if (!instancePath) return undefined;
+  const segments = instancePath
+    .split("/")
+    .slice(1)
+    .map((segment) => segment.replace(/~1/g, "/").replace(/~0/g, "~"));
+  let value = document;
+  for (const segment of segments) {
+    if (value == null) return undefined;
+    value = value[segment];
+  }
+  return value;
+}

--- a/tests/validate-error-messages.test.mjs
+++ b/tests/validate-error-messages.test.mjs
@@ -1,0 +1,112 @@
+// Regression coverage for the enum-mismatch message clarity fix: both
+// scripts/validate-surface.mjs and scripts/validate-schemas.mjs previously
+// surfaced ajv's bare "must be equal to one of the allowed values" for an
+// invalid `kind`, with no indication of what those values actually are.
+// Both scripts now append the allowed-values list (and the offending value)
+// to enum-keyword error messages.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, test } from "vitest";
+import { listJsonFiles, readJson, repoRoot } from "../scripts/lib.mjs";
+
+function runNode(args) {
+  try {
+    const stdout = execFileSync(process.execPath, args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return { status: 0, output: stdout };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      output: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+    };
+  }
+}
+
+describe("validate-surface.mjs enum error messages", () => {
+  let tempDir;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  test("lists the allowed kind values and the offending value on an invalid kind", async () => {
+    const [sourceFile] = await listJsonFiles(
+      path.join(repoRoot, "registry/subnets"),
+    );
+    const document = JSON.parse(readFileSync(sourceFile, "utf8"));
+    assert.ok(
+      Array.isArray(document.surfaces) && document.surfaces.length > 0,
+      "fixture subnet file must have at least one surface",
+    );
+    document.surfaces[0].kind = "totally-invalid-kind";
+
+    tempDir = mkdtempSync(`${tmpdir()}/metagraphed-validate-surface-`);
+    const fixturePath = path.join(tempDir, "fixture.json");
+    writeFileSync(fixturePath, JSON.stringify(document, null, 2));
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 1);
+    assert.match(output, /must be equal to one of the allowed values/);
+    // The allowed-values list must actually be present, not just the bare
+    // ajv message — this is the behavior being fixed.
+    assert.match(output, /subnet-api/);
+    assert.match(output, /data-artifact/);
+    assert.match(output, /got "totally-invalid-kind"/);
+  });
+});
+
+describe("validate-schemas.mjs enum error messages", () => {
+  let mutatedFile;
+  let originalContents;
+
+  afterEach(() => {
+    if (mutatedFile) {
+      writeFileSync(mutatedFile, originalContents);
+      mutatedFile = undefined;
+      originalContents = undefined;
+    }
+  });
+
+  test("lists the allowed kind values and the offending value on an invalid kind", async () => {
+    const subnetFiles = await listJsonFiles(
+      path.join(repoRoot, "registry/subnets"),
+    );
+    let targetFile;
+    let targetDocument;
+    for (const file of subnetFiles) {
+      const document = await readJson(file);
+      if (Array.isArray(document.surfaces) && document.surfaces.length > 0) {
+        targetFile = file;
+        targetDocument = document;
+        break;
+      }
+    }
+    assert.ok(targetFile, "at least one subnet file must have a surface");
+
+    mutatedFile = targetFile;
+    originalContents = readFileSync(mutatedFile, "utf8");
+    targetDocument.surfaces[0].kind = "totally-invalid-kind";
+    writeFileSync(mutatedFile, JSON.stringify(targetDocument, null, 2));
+
+    const { status, output } = runNode(["scripts/validate-schemas.mjs"]);
+
+    assert.equal(status, 1);
+    assert.match(output, /must be equal to one of the allowed values/);
+    assert.match(output, /subnet-api/);
+    assert.match(output, /data-artifact/);
+    assert.match(output, /got "totally-invalid-kind"/);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a purely-advisory `pr-overlap-notice` workflow that comments on a PR when another currently-open PR touches at least one of the same file paths.
- Make `validate-surface.mjs` and `validate-schemas.mjs` include the allowed enum values (and the offending value) in schema-mismatch error messages instead of ajv's bare "must be equal to one of the allowed values".

## What Changed

- `.github/workflows/pr-overlap-notice.yml`: new workflow, triggered on `pull_request: [opened, synchronize, reopened]`, with only `pull-requests: write` permission. It fetches this PR's changed files and every other open PR's changed files via `gh api` (capped at 200 other PRs, paginated 100/page), computes the path intersection, and upserts a single HTML-comment-marked comment (`<!-- overlap-notice:v1 -->`) listing any overlapping PR(s) and shared path(s). If a prior overlap-notice comment exists and the overlap has since cleared, the comment is updated to say so instead of left stale; if there was never a comment and there's no overlap, nothing is posted. All PR-file-list inputs come from the GitHub REST API (already-public PR metadata) — no contributor code is checked out or executed, matching `validate.yml`'s "Compute submitted files" trusted-workflow pattern. It fails open (skips silently) on any API error or rate limiting rather than failing the job, and is not a required check.
- `scripts/validate-surface.mjs` / `scripts/validate-schemas.mjs`: for ajv `enum`-keyword errors, append the joined `allowedValues` list and the offending value (resolved from the document via the error's `instancePath`) to the error message. Every other error keyword's message is unchanged.
- `tests/validate-error-messages.test.mjs` (new): runs both validator scripts against a deliberately-invalid `kind` and asserts the allowed-values list and offending value now appear in the output.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — no OpenAPI/schema/contract changes in this PR.)

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:surface`
- [x] `npm run validate:workflows`
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/validate.yml'))"` and the same for the new `pr-overlap-notice.yml`
- [x] `actionlint .github/workflows/validate.yml .github/workflows/pr-overlap-notice.yml`
- [x] `git diff --check`
- [x] `npx vitest run tests/validate-error-messages.test.mjs`
- [x] Reproduced both bugs first (set a surface's `kind` to an invalid value, ran both scripts, confirmed the bare ajv message), then confirmed the fix on the same fixture, then reverted.
- [x] Confirmed via `vitest.config.mjs`'s `coverage.include` that `validate-surface.mjs`/`validate-schemas.mjs` are out of the Codecov-gated scope, so `test:coverage` was not required for this change.
