### PR TITLE
fix(test): freeze the clock in the chain-fees COALESCE test to stop date drift

### DIFF
--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import {
   buildChainActivity,
   buildChainCalls,
@@ -996,66 +996,78 @@ test("buildChainFees reports malformed median rows as null, not JSON numbers", (
 });
 
 test("GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL fees", async () => {
-  const captured = [];
-  const env = {
-    ...createLocalArtifactEnv(),
-    METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        return {
-          bind(...params) {
-            captured.push({ sql, params });
-            const rows = /ROW_NUMBER\(\) OVER/.test(sql)
-              ? [
-                  {
-                    day: "2026-06-25",
-                    median_fee_tao: 0.006,
-                    median_tip_tao: 0,
-                  },
-                ]
-              : /GROUP BY day/.test(sql)
+  // loadChainFees's day-safety window is computed from the real Date.now() at
+  // request time (handleRequest doesn't thread a `now` override through from
+  // the HTTP layer), so a hardcoded mock day drifts out of the 7d window as
+  // real time passes and the day-boundary loop silently stops matching it.
+  // Freeze the clock to a fixed instant one day after the mocked day so this
+  // test never goes stale.
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-06-26T12:00:00.000Z"));
+  try {
+    const captured = [];
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              captured.push({ sql, params });
+              const rows = /ROW_NUMBER\(\) OVER/.test(sql)
                 ? [
                     {
                       day: "2026-06-25",
-                      extrinsic_count: 50,
-                      total_fee_tao: 0.5,
-                      total_tip_tao: 0,
+                      median_fee_tao: 0.006,
+                      median_tip_tao: 0,
                     },
                   ]
-                : /GROUP BY signer/.test(sql)
+                : /GROUP BY day/.test(sql)
                   ? [
                       {
-                        signer: "5Pay",
+                        day: "2026-06-25",
+                        extrinsic_count: 50,
                         total_fee_tao: 0.5,
                         total_tip_tao: 0,
-                        extrinsic_count: 50,
                       },
                     ]
-                  : [];
-            return { all: () => Promise.resolve({ results: rows }) };
-          },
-        };
+                  : /GROUP BY signer/.test(sql)
+                    ? [
+                        {
+                          signer: "5Pay",
+                          total_fee_tao: 0.5,
+                          total_tip_tao: 0,
+                          extrinsic_count: 50,
+                        },
+                      ]
+                    : [];
+              return { all: () => Promise.resolve({ results: rows }) };
+            },
+          };
+        },
       },
-    },
-  };
-  const res = await handleRequest(
-    new Request("https://api.metagraph.sh/api/v1/chain/fees?window=7d"),
-    env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.daily[0].avg_fee_tao, 0.01); // 0.5/50
-  assert.equal(body.data.daily[0].median_fee_tao, 0.006);
-  assert.equal(body.data.daily[0].median_tip_tao, 0);
-  assert.equal(body.data.top_fee_payers[0].signer, "5Pay");
-  const daily = captured.find(
-    (q) => /GROUP BY day/.test(q.sql) && !/ROW_NUMBER\(\) OVER/.test(q.sql),
-  );
-  assert.match(daily.sql, /COALESCE\(fee_tao, 0\)/);
-  const median = captured.find((q) => /ROW_NUMBER\(\) OVER/.test(q.sql));
-  assert.match(median.sql, /PARTITION BY day ORDER BY fee_tao/);
-  assert.match(median.sql, /PARTITION BY day ORDER BY tip_tao/);
-  assert.doesNotMatch(median.sql, /GROUP BY day,\s*fee_tao,\s*tip_tao/);
+    };
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/chain/fees?window=7d"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.daily[0].avg_fee_tao, 0.01); // 0.5/50
+    assert.equal(body.data.daily[0].median_fee_tao, 0.006);
+    assert.equal(body.data.daily[0].median_tip_tao, 0);
+    assert.equal(body.data.top_fee_payers[0].signer, "5Pay");
+    const daily = captured.find(
+      (q) => /GROUP BY day/.test(q.sql) && !/ROW_NUMBER\(\) OVER/.test(q.sql),
+    );
+    assert.match(daily.sql, /COALESCE\(fee_tao, 0\)/);
+    const median = captured.find((q) => /ROW_NUMBER\(\) OVER/.test(q.sql));
+    assert.match(median.sql, /PARTITION BY day ORDER BY fee_tao/);
+    assert.match(median.sql, /PARTITION BY day ORDER BY tip_tao/);
+    assert.doesNotMatch(median.sql, /GROUP BY day,\s*fee_tao,\s*tip_tao/);
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test("GET /api/v1/chain/fees rejects non-canonical limits", async () => {


### PR DESCRIPTION
## Summary

`tests/chain-analytics.test.mjs > GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL fees` was failing deterministically on a clean checkout of `main` (confirmed 3/3 runs), independent of any other PR — discovered while validating an unrelated new PR whose only failing check turned out to be this pre-existing issue.

## Root cause

`loadChainFees`'s day-safety window (which days get an exact per-day median vs. `null`) is computed from the real `Date.now()` at request time — `handleRequest` doesn't thread an injectable `now` override through from the HTTP layer. This test's mocked D1 response hardcodes `day: "2026-06-25"`, which was within the `window=7d` range when written but has since drifted outside it as real wall-clock time passed — so the day-boundary loop stopped matching it, silently nulling `median_fee_tao` instead of returning the mocked `0.006`.

This is the same failure *class* as an earlier-diagnosed (but at the time out-of-scope) flaky test elsewhere in the suite: a hardcoded absolute date going stale relative to `Date.now()`-based window filtering.

## Fix

Freeze the clock for this one test via `vi.useFakeTimers()` / `vi.setSystemTime(new Date("2026-06-26T12:00:00.000Z"))` (one day after the mocked day, well inside a 7-day window regardless of real wall-clock time), restored via `vi.useRealTimers()` in a `finally` block.

## Validation

- `npx vitest run tests/chain-analytics.test.mjs` — 38/38 pass (was 1 failed / 37 skipped before the fix)
- `npm run lint` / `npx prettier --check` — clean
- `git diff --check` — clean

## Note for follow-up (not addressed here, out of scope for this fix)

A quick grep found **101 other hardcoded near-date literals** (`"2026-06-2x"`) across 14 other test files (`account-history`, `account-events`, `analytics-live`, `analytics-edge-cache`, `api-coverage`, `artifact-tiering-explicit`, `concentration`, `economics-history`, `mcp-server`, `metagraph-neurons`, `neuron-history`, `request-params`, `request-handlers-entities`, `smoke-route-substitution`). Most are probably inert fixture values with no live window-relative filtering applied against them, but auditing which (if any) combine with `Date.now()`-relative logic the way this one did is a separate, larger task worth doing at some point.