### PR TITLE
fix(test): stop chain-fees median test from rotting past its hardcoded day

### DIFF
--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -997,6 +997,12 @@ test("buildChainFees reports malformed median rows as null, not JSON numbers", (
 
 test("GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL fees", async () => {
   const captured = [];
+  // loadChainFees only computes a day's median when that day falls within its
+  // own real Date.now()-anchored safe-day window (src/analytics-live.mjs), so
+  // the mocked row's day must track wall-clock time rather than a fixed
+  // calendar date that ages out of the trailing window.
+  const dayMs = 24 * 60 * 60 * 1000;
+  const day = new Date(Date.now() - 2 * dayMs).toISOString().slice(0, 10);
   const env = {
     ...createLocalArtifactEnv(),
     METAGRAPH_HEALTH_DB: {
@@ -1007,7 +1013,7 @@ test("GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL f
             const rows = /ROW_NUMBER\(\) OVER/.test(sql)
               ? [
                   {
-                    day: "2026-06-25",
+                    day,
                     median_fee_tao: 0.006,
                     median_tip_tao: 0,
                   },
@@ -1015,7 +1021,7 @@ test("GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL f
               : /GROUP BY day/.test(sql)
                 ? [
                     {
-                      day: "2026-06-25",
+                      day,
                       extrinsic_count: 50,
                       total_fee_tao: 0.5,
                       total_tip_tao: 0,


### PR DESCRIPTION
## Summary

- `tests/chain-analytics.test.mjs` — "GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL fees" was failing deterministically on a clean checkout: `median_fee_tao` came back `null` instead of the expected `0.006`.
- Root cause is in the test, not the median computation. `loadChainFees` (`src/analytics-live.mjs`) only issues its per-day median query for days that fall inside a real `Date.now()`-anchored trailing window (the "safe day" cap). The test's fake D1 hardcoded the mocked row's `day` to a fixed calendar date (`"2026-06-25"`). Once wall-clock time advanced far enough that this date fell outside the 7-day window relative to the real clock, the day was never added to `safeDayBoundaries`, the median CTE query was never issued at all, `medianRows` stayed empty, and `buildChainFees` correctly reported `median_fee_tao: null` for a day it received no median data for — exactly the same code path used for a legitimately median-less day.
- This is not the "coerce string-typed D1 numeric cell" bug class from prior fixes (e.g. #2751-ish commits) — `toNullableTao`/`toTao` (`src/chain-analytics.mjs`) already coerce numeric-string D1 cells correctly via `Number(value)`, confirmed by the adjacent `buildChainFees` unit tests that pass a string `median_fee_tao` and already pass.
- Checked [#2675](https://github.com/JSONbored/metagraphed/pull/2675) first per the report — it bounds `call_module`-scoped median scans with a composite index and is unrelated to this failure; it doesn't touch `tests/chain-analytics.test.mjs` and wouldn't fix this test.

## What Changed

- Derive the mocked median/daily row's `day` from the real clock (`Date.now() - 2 days`, formatted the same way `strftime('%Y-%m-%d', ...)` buckets it) instead of a hardcoded absolute date, so the test always exercises a day inside `loadChainFees`'s real safe-day window regardless of when it runs. Matches the pattern already used by the `loadChainFees`-level tests in `tests/analytics-live.test.mjs`, which pass an explicit `now` for the same reason.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none touched — test-only change).
- [x] R2-only/high-churn detail artifacts are not committed.
- [ ] Public API/OpenAPI/schema changes are intentional and documented. (n/a — no API/schema change)

## Validation

- [x] `npx vitest run tests/chain-analytics.test.mjs` — 38/38 passed, including the previously-failing test (re-ran 3x for determinism)
- [x] `npm test` — full suite; the two pre-existing failures (`tests/artifacts.test.mjs` missing `openapi-typescript` binary under this environment's Node version, `tests/mcp-server.test.mjs` artifact-race test) are unrelated to this change and reproduce identically on `origin/main` before this diff
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`