### PR TITLE
feat(mcp): add get_extrinsic_chain_events and extrinsic detail events embed

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -505,6 +505,22 @@ assert.equal(
   true,
   "get_chain_activity must isError without the DATA_API binding",
 );
+const blockChainEventsCold = await call("get_block_chain_events", {
+  block_number: 4200000,
+});
+assert.equal(
+  blockChainEventsCold.isError,
+  true,
+  "get_block_chain_events must isError without the DATA_API binding",
+);
+const extrinsicChainEventsCold = await call("get_extrinsic_chain_events", {
+  ref: "4200000-3",
+});
+assert.equal(
+  extrinsicChainEventsCold.isError,
+  true,
+  "get_extrinsic_chain_events must isError without the DATA_API binding",
+);
 const signersCold = await callOk("get_chain_signers", {
   window: "7d",
   limit: 5,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/data-api-mcp.mjs
+++ b/src/data-api-mcp.mjs
@@ -1,0 +1,154 @@
+// MCP helpers for the Postgres-backed all-events tier (ADR 0013), reached through
+// the DATA_API service binding — the same path REST proxy routes use. Keeps the
+// postgres.js driver out of the main Worker bundle.
+
+function throwToolError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  throw error;
+}
+
+const CHAIN_EVENTS_LIMIT_DEFAULT = 50;
+const CHAIN_EVENTS_LIMIT_MAX = 200;
+
+function clampChainEventsLimit(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return CHAIN_EVENTS_LIMIT_DEFAULT;
+  return Math.min(Math.max(Math.floor(n), 1), CHAIN_EVENTS_LIMIT_MAX);
+}
+
+// The data Worker returns `{ error: "..." }` on 400; some envelopes use
+// `{ error: { message } }` or a top-level `message` instead.
+function dataApiErrorMessage(body) {
+  if (typeof body?.error === "string" && body.error) return body.error;
+  if (typeof body?.error?.message === "string" && body.error.message)
+    return body.error.message;
+  if (typeof body?.message === "string" && body.message) return body.message;
+  return null;
+}
+
+// REST all-events routes use `count`; tolerate legacy/alternate `event_count`.
+function eventCountFromDataApi(data) {
+  if (data?.count != null) return data.count;
+  if (data?.event_count != null) return data.event_count;
+  return Array.isArray(data?.events) ? data.events.length : 0;
+}
+
+export async function dataApiFetchJson(ctx, pathAndQuery) {
+  if (ctx.env?.DATA_RATE_LIMITER?.limit) {
+    const { success } = await ctx.env.DATA_RATE_LIMITER.limit({
+      key: `data:${ctx.clientIp}`,
+    });
+    if (!success) {
+      throwToolError(
+        "data_rate_limited",
+        "Too many data API requests from this client; slow down.",
+      );
+    }
+  }
+
+  const dataApi = ctx.env?.DATA_API;
+  if (!dataApi?.fetch) {
+    throwToolError(
+      "tier_unavailable",
+      "The all-events data tier is unavailable (the data Worker is not bound to " +
+        "this deployment). Try again against the production endpoint.",
+    );
+  }
+
+  let response;
+  try {
+    response = await dataApi.fetch(new Request(`https://d${pathAndQuery}`));
+  } catch {
+    throwToolError(
+      "tier_unavailable",
+      "The all-events data tier could not be reached. Try again shortly.",
+    );
+  }
+
+  if (response.status === 400) {
+    let message = "Invalid request to the all-events data tier.";
+    try {
+      const body = await response.json();
+      message = dataApiErrorMessage(body) ?? message;
+    } catch {
+      /* ignore */
+    }
+    throwToolError("invalid_params", message);
+  }
+
+  if (!response.ok) {
+    throwToolError(
+      "tier_unavailable",
+      `The all-events data tier returned an error (status ${response.status}). ` +
+        "Try again shortly.",
+    );
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    throwToolError(
+      "tier_unavailable",
+      "The all-events data tier returned a malformed response. Try again shortly.",
+    );
+  }
+}
+
+export async function loadBlockChainEvents(ctx, blockNumber) {
+  if (!Number.isSafeInteger(blockNumber) || blockNumber < 0) {
+    throwToolError(
+      "invalid_params",
+      "block_number must be a non-negative integer.",
+    );
+  }
+  const data = await dataApiFetchJson(
+    ctx,
+    `/api/v1/blocks/${blockNumber}/chain-events`,
+  );
+  return {
+    schema_version: 1,
+    block_number: data?.block_number ?? blockNumber,
+    event_count: eventCountFromDataApi(data),
+    events: Array.isArray(data?.events) ? data.events : [],
+  };
+}
+
+const COMPOSITE_REF_RE = /^(\d+)-(\d+)$/;
+
+export async function loadExtrinsicChainEvents(
+  ctx,
+  ref,
+  { limit, cursor } = {},
+) {
+  const composite = COMPOSITE_REF_RE.exec(String(ref));
+  const blockNumber = composite ? Number(composite[1]) : NaN;
+  const extrinsicIndex = composite ? Number(composite[2]) : NaN;
+  if (
+    !composite ||
+    !Number.isSafeInteger(blockNumber) ||
+    !Number.isSafeInteger(extrinsicIndex)
+  ) {
+    throwToolError(
+      "invalid_params",
+      "ref must be the composite id 'block_number-extrinsic_index' (e.g. '4200000-3').",
+    );
+  }
+  const lim = clampChainEventsLimit(limit);
+  let path =
+    `/api/v1/chain-events?block=${blockNumber}` +
+    `&extrinsic=${extrinsicIndex}&limit=${lim}`;
+  if (cursor) path += `&cursor=${encodeURIComponent(String(cursor))}`;
+  const data = await dataApiFetchJson(ctx, path);
+  return {
+    schema_version: 1,
+    ref,
+    block_number: blockNumber,
+    extrinsic_index: extrinsicIndex,
+    limit: lim,
+    event_count: eventCountFromDataApi(data),
+    next_cursor: data?.next_cursor ?? null,
+    events: Array.isArray(data?.events) ? data.events : [],
+  };
+}

--- a/src/extrinsic-detail.mjs
+++ b/src/extrinsic-detail.mjs
@@ -1,0 +1,52 @@
+// Per-extrinsic detail with embedded account_events (#1849): shared D1 loader for
+// REST GET /extrinsics/{ref} and MCP get_extrinsic. Ref is a 0x hash or composite
+// block_number-extrinsic_index; unknown refs return extrinsic:null + events:[].
+
+import {
+  ACCOUNT_EVENT_COLUMNS,
+  formatAccountEvent,
+} from "./account-events.mjs";
+import { EXTRINSIC_READ_COLUMNS, buildExtrinsic } from "./extrinsics.mjs";
+
+const COMPOSITE_REF_RE = /^(\d+)-(\d+)$/;
+const MAX_EMBEDDED_EVENTS = 50;
+
+export async function loadExtrinsicDetail(d1, ref) {
+  const isHash = /^0x[0-9a-fA-F]{64}$/.test(String(ref));
+  let rows;
+  if (isHash) {
+    rows = await d1(
+      `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE extrinsic_hash = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT 1`,
+      [String(ref).toLowerCase()],
+    );
+  } else {
+    const composite = COMPOSITE_REF_RE.exec(String(ref));
+    const blockNumber = composite ? Number(composite[1]) : NaN;
+    const extrinsicIndex = composite ? Number(composite[2]) : NaN;
+    rows =
+      composite &&
+      Number.isSafeInteger(blockNumber) &&
+      Number.isSafeInteger(extrinsicIndex)
+        ? await d1(
+            `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE block_number = ? AND extrinsic_index = ? LIMIT 1`,
+            [blockNumber, extrinsicIndex],
+          )
+        : [];
+  }
+
+  const resolved = rows[0];
+  let events = [];
+  if (
+    resolved &&
+    resolved.block_number != null &&
+    resolved.extrinsic_index != null
+  ) {
+    const eventRows = await d1(
+      `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE block_number = ? AND extrinsic_index = ? ORDER BY event_index ASC LIMIT ?`,
+      [resolved.block_number, resolved.extrinsic_index, MAX_EMBEDDED_EVENTS],
+    );
+    events = (eventRows || []).map(formatAccountEvent).filter(Boolean);
+  }
+
+  return buildExtrinsic(resolved, ref, events);
+}

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -139,7 +139,13 @@ import {
 import { isFinneySs58Address, loadAccountBalance } from "./account-balance.mjs";
 import { loadBlocks, loadBlock } from "./blocks.mjs";
 import { loadBlockEvents, loadBlockExtrinsics } from "./block-subresources.mjs";
-import { loadExtrinsics, loadExtrinsic } from "./extrinsics.mjs";
+import { loadExtrinsics } from "./extrinsics.mjs";
+import { loadExtrinsicDetail } from "./extrinsic-detail.mjs";
+import {
+  dataApiFetchJson,
+  loadBlockChainEvents,
+  loadExtrinsicChainEvents,
+} from "./data-api-mcp.mjs";
 import {
   aiEnabled,
   askQuestion,
@@ -171,7 +177,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.19.0";
+export const MCP_SERVER_VERSION = "1.20.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -428,50 +434,11 @@ async function loadSubnetEconomics(ctx, netuid) {
 // the dedicated data Worker (ADR 0013) so the postgres.js driver stays out of
 // this Worker's bundle; MCP handlers reach it through the DATA_API service
 // binding, the same binding the REST proxy uses for /api/v1/chain-events/stats.
-// A missing binding (e.g. a preview deploy without the data Worker) or a non-OK
-// upstream response surfaces as a clean tool error, never an exception.
 async function loadChainActivity(ctx, blocks) {
-  // Optional in previews/local runs; production binds this beside DATA_API so
-  // MCP calls pay the same data-tier rate limit as REST proxy calls.
-  if (ctx.env?.DATA_RATE_LIMITER?.limit) {
-    const { success } = await ctx.env.DATA_RATE_LIMITER.limit({
-      key: `data:${ctx.clientIp}`,
-    });
-    if (!success) {
-      throw toolError(
-        "data_rate_limited",
-        "Too many data API requests from this client; slow down.",
-      );
-    }
-  }
-
-  const dataApi = ctx.env?.DATA_API;
-  if (!dataApi?.fetch) {
-    throw toolError(
-      "tier_unavailable",
-      "The chain activity tier is unavailable (the all-events data Worker is " +
-        "not bound to this deployment). Try again against the production endpoint.",
-    );
-  }
-  let response;
-  try {
-    response = await dataApi.fetch(
-      new Request(`https://d/api/v1/chain-events/stats?blocks=${blocks}`),
-    );
-  } catch {
-    throw toolError(
-      "tier_unavailable",
-      "The chain activity tier could not be reached. Try again shortly.",
-    );
-  }
-  if (!response.ok) {
-    throw toolError(
-      "tier_unavailable",
-      `The chain activity tier returned an error (status ${response.status}). ` +
-        "Try again shortly.",
-    );
-  }
-  const data = await response.json();
+  const data = await dataApiFetchJson(
+    ctx,
+    `/api/v1/chain-events/stats?blocks=${blocks}`,
+  );
   return {
     window_blocks: data?.window_blocks ?? blocks,
     groups: data?.groups ?? 0,
@@ -3259,9 +3226,12 @@ export const MCP_TOOLS = [
     title: "Get an extrinsic by hash or composite ref",
     description:
       "Fetch the detail for one extrinsic by its 0x extrinsic hash (e.g. '0xabc...') " +
-      "or composite ref '<block_number>-<extrinsic_index>' (e.g. '4200000-3'). Returns " +
-      "extrinsic:null when the ref is unknown or the store is cold — never errors. " +
-      "Use list_extrinsics to find extrinsic refs.",
+      "or composite ref '<block_number>-<extrinsic_index>' (e.g. '4200000-3'). " +
+      "Includes up to 50 curated account_events the extrinsic emitted (#1849). " +
+      "Returns extrinsic:null when the ref is unknown or the store is cold — never " +
+      "errors. Use list_extrinsics to find extrinsic refs. For every raw pallet.method " +
+      "event an extrinsic emitted, use get_extrinsic_chain_events. Mirrors " +
+      "GET /api/v1/extrinsics/{ref}.",
     inputSchema: {
       type: "object",
       properties: {
@@ -3277,7 +3247,76 @@ export const MCP_TOOLS = [
     },
     async handler(args, ctx) {
       const ref = requireString(args, "ref");
-      return loadExtrinsic(mcpD1Runner(ctx), ref);
+      return loadExtrinsicDetail(mcpD1Runner(ctx), ref);
+    },
+  },
+  {
+    name: "get_block_chain_events",
+    title: "Get every raw chain event in one block",
+    description:
+      "Fetch every raw pallet.method event in one block from the Postgres-backed " +
+      "all-events tier (ADR 0013), in natural read order (event_index ASC). " +
+      "Distinct from get_block_events (the curated account-attributed D1 stream). " +
+      "Returns event_count:0 + events:[] when the tier is empty for that block. " +
+      "Requires the all-events data Worker (tier_unavailable in preview deploys). " +
+      "Mirrors GET /api/v1/blocks/{block_number}/chain-events.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        block_number: {
+          type: "integer",
+          description: "Numeric block height.",
+          minimum: 0,
+        },
+      },
+      required: ["block_number"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const blockNumber = requireNonNegativeInt(args, "block_number");
+      return loadBlockChainEvents(ctx, blockNumber);
+    },
+  },
+  {
+    name: "get_extrinsic_chain_events",
+    title: "Get raw chain events emitted by one extrinsic",
+    description:
+      "Fetch raw pallet.method events one extrinsic emitted from the Postgres-backed " +
+      "all-events tier (newest first). ref must be the composite id " +
+      "'block_number-extrinsic_index' (e.g. '4200000-3'). Page with limit (1-200, " +
+      "default 50) or follow next_cursor for deeper pages. Distinct from the curated " +
+      "account_events embedded in get_extrinsic. Requires the all-events data Worker " +
+      "(tier_unavailable in preview deploys). Mirrors GET /api/v1/chain-events?block=&extrinsic=.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ref: {
+          type: "string",
+          description:
+            "Composite extrinsic id 'block_number-extrinsic_index' (e.g. '4200000-3').",
+        },
+        limit: {
+          type: "integer",
+          description: "Max events to return (1-200, default 50).",
+          minimum: 1,
+          maximum: 200,
+        },
+        cursor: {
+          type: "string",
+          description:
+            "Opaque keyset cursor from a previous response's next_cursor for the next page.",
+        },
+      },
+      required: ["ref"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const ref = requireString(args, "ref");
+      const cursor = optionalString(args, "cursor");
+      return loadExtrinsicChainEvents(ctx, ref, {
+        limit: args?.limit,
+        cursor: cursor ?? undefined,
+      });
     },
   },
   {
@@ -4638,6 +4677,17 @@ const EXTRINSIC_ITEM = {
   tip_tao: ANY,
   observed_at: NULLABLE_STRING,
 };
+// Raw all-events tier item (pallet.method events from Postgres chain_events).
+const CHAIN_EVENT_ITEM = {
+  block_number: NULLABLE_INT,
+  event_index: NULLABLE_INT,
+  pallet: NULLABLE_STRING,
+  method: NULLABLE_STRING,
+  args: ANY,
+  phase: ANY,
+  extrinsic_index: NULLABLE_INT,
+  observed_at: NULLABLE_INT,
+};
 // RpcUsageArtifact item shapes — shared by get_rpc_usage outputSchema (mirrors
 // schemas/api-components.schema.json#/components/schemas/RpcUsageArtifact).
 const RPC_USAGE_LATENCY_MS = {
@@ -5545,6 +5595,39 @@ const TOOL_OUTPUT_SCHEMAS = {
       schema_version: { type: "integer" },
       ref: ANY,
       extrinsic: { type: ["object", "null"], additionalProperties: true },
+      events: objectItems(ACCOUNT_EVENT_ITEM),
+    },
+  },
+  get_block_chain_events: {
+    type: "object",
+    additionalProperties: true,
+    required: ["block_number", "event_count", "events"],
+    properties: {
+      schema_version: { type: "integer" },
+      block_number: NULLABLE_INT,
+      event_count: { type: "integer" },
+      events: objectItems(CHAIN_EVENT_ITEM),
+    },
+  },
+  get_extrinsic_chain_events: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "ref",
+      "block_number",
+      "extrinsic_index",
+      "event_count",
+      "events",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      ref: ANY,
+      block_number: NULLABLE_INT,
+      extrinsic_index: NULLABLE_INT,
+      limit: NULLABLE_INT,
+      event_count: { type: "integer" },
+      next_cursor: NULLABLE_STRING,
+      events: objectItems(CHAIN_EVENT_ITEM),
     },
   },
   get_chain_activity: {

--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -996,6 +996,15 @@ test("buildChainFees reports malformed median rows as null, not JSON numbers", (
 });
 
 test("GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL fees", async () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  // Use yesterday UTC so the mocked day stays inside handleChainFees' 7d window
+  // and the median safe-day scan (utcDayFloor(cutoff)..now). A fixed 2026-06-25
+  // label ages out of that loop and skips the ROW_NUMBER median query entirely.
+  const windowDay = new Date(
+    Math.floor((Date.now() - DAY_MS) / DAY_MS) * DAY_MS,
+  )
+    .toISOString()
+    .slice(0, 10);
   const captured = [];
   const env = {
     ...createLocalArtifactEnv(),
@@ -1007,7 +1016,7 @@ test("GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL f
             const rows = /ROW_NUMBER\(\) OVER/.test(sql)
               ? [
                   {
-                    day: "2026-06-25",
+                    day: windowDay,
                     median_fee_tao: 0.006,
                     median_tip_tao: 0,
                   },
@@ -1015,7 +1024,7 @@ test("GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL f
               : /GROUP BY day/.test(sql)
                 ? [
                     {
-                      day: "2026-06-25",
+                      day: windowDay,
                       extrinsic_count: 50,
                       total_fee_tao: 0.5,
                       total_tip_tao: 0,

--- a/tests/extrinsic-detail.test.mjs
+++ b/tests/extrinsic-detail.test.mjs
@@ -1,0 +1,563 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadExtrinsicDetail } from "../src/extrinsic-detail.mjs";
+import {
+  dataApiFetchJson,
+  loadBlockChainEvents,
+  loadExtrinsicChainEvents,
+} from "../src/data-api-mcp.mjs";
+import { handleExtrinsic } from "../workers/request-handlers/entities.mjs";
+
+function req(path) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+function d1With(fixtures = {}, capture = []) {
+  return async (sql, params) => {
+    capture.push({ sql, params });
+    if (/FROM extrinsics WHERE extrinsic_hash/.test(sql))
+      return fixtures.byHash ?? [];
+    if (/FROM extrinsics WHERE block_number = \? AND extrinsic_index/.test(sql))
+      return fixtures.byComposite ?? [];
+    if (
+      /FROM account_events WHERE block_number = \? AND extrinsic_index/.test(
+        sql,
+      )
+    )
+      return fixtures.events ?? [];
+    return [];
+  };
+}
+
+const EXTRINSIC = {
+  block_number: 4_200_000,
+  extrinsic_index: 3,
+  extrinsic_hash: "0x" + "c".repeat(64),
+  signer: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+  call_module: "SubtensorModule",
+  call_function: "set_weights",
+  call_args: null,
+  success: 1,
+  fee_tao: 0.0005,
+  tip_tao: null,
+  observed_at: 1_750_009_000_000,
+};
+const EVENT = {
+  block_number: 4_200_000,
+  extrinsic_index: 3,
+  event_index: 0,
+  event_kind: "WeightsSet",
+  hotkey: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+  coldkey: null,
+  netuid: 7,
+  uid: 3,
+  amount_tao: null,
+  observed_at: 1_750_009_000_000,
+};
+
+describe("loadExtrinsicDetail", () => {
+  test("embeds account_events for a resolved composite ref", async () => {
+    const capture = [];
+    const d1 = d1With({ byComposite: [EXTRINSIC], events: [EVENT] }, capture);
+    const data = await loadExtrinsicDetail(d1, "4200000-3");
+    assert.equal(data.extrinsic.call_function, "set_weights");
+    assert.equal(data.events.length, 1);
+    assert.equal(data.events[0].event_kind, "WeightsSet");
+    const q = capture.find((c) => /FROM account_events/.test(c.sql));
+    assert.deepEqual(q.params.slice(0, 3), [4_200_000, 3, 50]);
+  });
+
+  test("embeds account_events for a hash ref", async () => {
+    const hash = "0x" + "c".repeat(64);
+    const d1 = d1With({ byHash: [EXTRINSIC], events: [EVENT] });
+    const data = await loadExtrinsicDetail(d1, hash);
+    assert.equal(data.events.length, 1);
+    assert.equal(data.events[0].event_kind, "WeightsSet");
+  });
+
+  test("lowercases hash refs before the extrinsics lookup", async () => {
+    const capture = [];
+    const hash = "0x" + "C".repeat(64);
+    const d1 = d1With({ byHash: [EXTRINSIC], events: [] }, capture);
+    await loadExtrinsicDetail(d1, hash);
+    const q = capture.find((c) => /extrinsic_hash = \?/.test(c.sql));
+    assert.equal(q.params[0], hash.toLowerCase());
+  });
+
+  test("malformed ref yields extrinsic:null without account_events query", async () => {
+    const capture = [];
+    const d1 = d1With({}, capture);
+    const data = await loadExtrinsicDetail(d1, "not-an-extrinsic");
+    assert.equal(data.extrinsic, null);
+    assert.deepEqual(data.events, []);
+    assert.equal(
+      capture.some((c) => /FROM account_events/.test(c.sql)),
+      false,
+    );
+  });
+
+  test("skips account_events when extrinsic row is missing", async () => {
+    const capture = [];
+    const d1 = d1With({ byComposite: [] }, capture);
+    const data = await loadExtrinsicDetail(d1, "4200000-3");
+    assert.equal(data.extrinsic, null);
+    assert.equal(
+      capture.some((c) => /FROM account_events/.test(c.sql)),
+      false,
+    );
+  });
+
+  test("skips account_events when the resolved row lacks block coordinates", async () => {
+    const capture = [];
+    const d1 = d1With(
+      { byComposite: [{ ...EXTRINSIC, block_number: null }] },
+      capture,
+    );
+    const data = await loadExtrinsicDetail(d1, "4200000-3");
+    assert.equal(data.extrinsic.block_number, null);
+    assert.deepEqual(data.events, []);
+    assert.equal(
+      capture.some((c) => /FROM account_events/.test(c.sql)),
+      false,
+    );
+  });
+
+  test("treats a null account_events result as an empty embed", async () => {
+    const d1 = async (sql) => {
+      if (
+        /FROM extrinsics WHERE block_number = \? AND extrinsic_index/.test(sql)
+      )
+        return [EXTRINSIC];
+      if (/FROM account_events/.test(sql)) return null;
+      return [];
+    };
+    const data = await loadExtrinsicDetail(d1, "4200000-3");
+    assert.deepEqual(data.events, []);
+  });
+});
+
+describe("handleExtrinsic via loadExtrinsicDetail", () => {
+  test("returns embedded events through the shared loader", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind() {
+              return {
+                all() {
+                  if (
+                    /FROM extrinsics WHERE block_number = \? AND extrinsic_index/.test(
+                      sql,
+                    )
+                  )
+                    return Promise.resolve({ results: [EXTRINSIC] });
+                  if (/FROM account_events/.test(sql))
+                    return Promise.resolve({ results: [EVENT] });
+                  return Promise.resolve({ results: [] });
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const res = await handleExtrinsic(
+      req("/api/v1/extrinsics/4200000-3"),
+      env,
+      "4200000-3",
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.events.length, 1);
+    assert.equal(body.data.events[0].event_kind, "WeightsSet");
+  });
+});
+
+function dataApiCtx({ fetchImpl, rateLimit = null } = {}) {
+  return {
+    clientIp: "127.0.0.1",
+    env: {
+      DATA_API: fetchImpl ? { fetch: fetchImpl } : undefined,
+      DATA_RATE_LIMITER: rateLimit,
+    },
+  };
+}
+
+describe("data-api-mcp", () => {
+  test("dataApiFetchJson surfaces tier_unavailable without a binding", async () => {
+    await assert.rejects(
+      () => dataApiFetchJson(dataApiCtx(), "/api/v1/chain-events/stats"),
+      (err) => err.code === "tier_unavailable",
+    );
+  });
+
+  test("dataApiFetchJson surfaces data_rate_limited when the limiter rejects", async () => {
+    await assert.rejects(
+      () =>
+        dataApiFetchJson(
+          dataApiCtx({
+            rateLimit: {
+              async limit() {
+                return { success: false };
+              },
+            },
+            fetchImpl: async () => new Response("{}"),
+          }),
+          "/api/v1/chain-events/stats",
+        ),
+      (err) => err.code === "data_rate_limited",
+    );
+  });
+
+  test("dataApiFetchJson proceeds when the data API limiter allows the request", async () => {
+    const ctx = dataApiCtx({
+      rateLimit: {
+        async limit({ key }) {
+          assert.equal(key, "data:127.0.0.1");
+          return { success: true };
+        },
+      },
+      fetchImpl: async () => Response.json({ ok: true }),
+    });
+    const out = await dataApiFetchJson(ctx, "/api/v1/chain-events/stats");
+    assert.equal(out.ok, true);
+  });
+
+  test("dataApiFetchJson surfaces tier_unavailable when fetch throws", async () => {
+    await assert.rejects(
+      () =>
+        dataApiFetchJson(
+          dataApiCtx({
+            fetchImpl: async () => {
+              throw new Error("network down");
+            },
+          }),
+          "/api/v1/chain-events/stats",
+        ),
+      (err) => err.code === "tier_unavailable",
+    );
+  });
+
+  test("dataApiFetchJson maps upstream 400 to invalid_params", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ error: "bad filter" }), { status: 400 }),
+    });
+    await assert.rejects(
+      () => dataApiFetchJson(ctx, "/api/v1/chain-events?method=x"),
+      (err) => err.code === "invalid_params" && /bad filter/.test(err.message),
+    );
+  });
+
+  test("dataApiFetchJson preserves nested error.message on upstream 400", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              message:
+                "method filter requires pallet unless block is specified",
+            },
+          }),
+          { status: 400 },
+        ),
+    });
+    await assert.rejects(
+      () => dataApiFetchJson(ctx, "/api/v1/chain-events?method=x"),
+      (err) =>
+        err.code === "invalid_params" &&
+        /method filter requires pallet/.test(err.message),
+    );
+  });
+
+  test("dataApiFetchJson preserves a top-level message envelope on upstream 400", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({ message: "pallet and method must be valid" }),
+          { status: 400 },
+        ),
+    });
+    await assert.rejects(
+      () => dataApiFetchJson(ctx, "/api/v1/chain-events?pallet=bad"),
+      (err) =>
+        err.code === "invalid_params" &&
+        /pallet and method must be valid/.test(err.message),
+    );
+  });
+
+  test("dataApiFetchJson uses a default 400 message when the body is not JSON", async () => {
+    await assert.rejects(
+      () =>
+        dataApiFetchJson(
+          dataApiCtx({
+            fetchImpl: async () => new Response("not-json", { status: 400 }),
+          }),
+          "/api/v1/chain-events?method=x",
+        ),
+      (err) =>
+        err.code === "invalid_params" &&
+        /Invalid request to the all-events data tier/.test(err.message),
+    );
+  });
+
+  test("dataApiFetchJson keeps the default 400 message when error is absent", async () => {
+    await assert.rejects(
+      () =>
+        dataApiFetchJson(
+          dataApiCtx({
+            fetchImpl: async () =>
+              new Response(JSON.stringify({}), { status: 400 }),
+          }),
+          "/api/v1/chain-events?method=x",
+        ),
+      (err) =>
+        err.code === "invalid_params" &&
+        /Invalid request to the all-events data tier/.test(err.message),
+    );
+  });
+
+  test("dataApiFetchJson surfaces tier_unavailable on a non-OK upstream status", async () => {
+    await assert.rejects(
+      () =>
+        dataApiFetchJson(
+          dataApiCtx({
+            fetchImpl: async () => new Response("err", { status: 502 }),
+          }),
+          "/api/v1/chain-events/stats",
+        ),
+      (err) => err.code === "tier_unavailable" && /502/.test(err.message),
+    );
+  });
+
+  test("dataApiFetchJson surfaces tier_unavailable on malformed 2xx JSON", async () => {
+    await assert.rejects(
+      () =>
+        dataApiFetchJson(
+          dataApiCtx({
+            fetchImpl: async () => new Response("not-json", { status: 200 }),
+          }),
+          "/api/v1/chain-events/stats",
+        ),
+      (err) =>
+        err.code === "tier_unavailable" &&
+        /malformed response/.test(err.message),
+    );
+  });
+
+  test("loadBlockChainEvents rejects a non-integer block_number", async () => {
+    await assert.rejects(
+      () =>
+        loadBlockChainEvents(
+          dataApiCtx({ fetchImpl: async () => new Response("{}") }),
+          -1,
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadBlockChainEvents shapes the block sub-resource payload", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async (request) => {
+        assert.match(request.url, /\/blocks\/4200000\/chain-events$/);
+        return Response.json({
+          block_number: 4200000,
+          count: 1,
+          events: [
+            {
+              event_index: 0,
+              pallet: "Balances",
+              method: "Transfer",
+              observed_at: 1,
+            },
+          ],
+        });
+      },
+    });
+    const out = await loadBlockChainEvents(ctx, 4200000);
+    assert.equal(out.block_number, 4200000);
+    assert.equal(out.event_count, 1);
+    assert.equal(out.events[0].pallet, "Balances");
+  });
+
+  // Exact JSON contract from workers/data-api.mjs GET /blocks/:n/chain-events
+  // (mirrors tests/data-api.test.mjs).
+  test("loadBlockChainEvents round-trips the DATA_API block chain-events contract", async () => {
+    const dataApiPayload = {
+      block_number: 123,
+      count: 1,
+      events: [
+        {
+          event_index: 0,
+          pallet: "System",
+          method: "ExtrinsicSuccess",
+          args: { x: 1 },
+          phase: "ApplyExtrinsic",
+          extrinsic_index: 2,
+          observed_at: 100,
+        },
+      ],
+    };
+    const ctx = dataApiCtx({
+      fetchImpl: async () => Response.json(dataApiPayload),
+    });
+    const out = await loadBlockChainEvents(ctx, 123);
+    assert.deepEqual(out.events, dataApiPayload.events);
+    assert.equal(out.event_count, 1);
+    assert.equal(typeof out.events[0].observed_at, "number");
+  });
+
+  test("loadBlockChainEvents accepts event_count when count is absent", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async () =>
+        Response.json({
+          block_number: 55,
+          event_count: 2,
+          events: [{ event_index: 0 }, { event_index: 1 }],
+        }),
+    });
+    const out = await loadBlockChainEvents(ctx, 55);
+    assert.equal(out.event_count, 2);
+  });
+
+  test("loadBlockChainEvents falls back to the requested block_number", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async () => Response.json({ count: 0, events: [] }),
+    });
+    const out = await loadBlockChainEvents(ctx, 99);
+    assert.equal(out.block_number, 99);
+    assert.equal(out.event_count, 0);
+  });
+
+  test("loadBlockChainEvents falls back when upstream block_number is null", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async () =>
+        Response.json({ block_number: null, count: 0, events: [] }),
+    });
+    const out = await loadBlockChainEvents(ctx, 88);
+    assert.equal(out.block_number, 88);
+  });
+
+  test("loadBlockChainEvents defaults a missing event_count to zero", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async () => Response.json({ block_number: 77, events: [] }),
+    });
+    const out = await loadBlockChainEvents(ctx, 77);
+    assert.equal(out.event_count, 0);
+  });
+
+  test("loadBlockChainEvents tolerates a non-array events field", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async () => Response.json({ count: 2, events: null }),
+    });
+    const out = await loadBlockChainEvents(ctx, 1);
+    assert.equal(out.event_count, 2);
+    assert.deepEqual(out.events, []);
+  });
+
+  test("loadExtrinsicChainEvents rejects a non-composite ref", async () => {
+    await assert.rejects(
+      () =>
+        loadExtrinsicChainEvents(
+          dataApiCtx({ fetchImpl: async () => new Response("{}") }),
+          "0xabc",
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadExtrinsicChainEvents forwards block+extrinsic filters", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async (request) => {
+        const url = new URL(request.url);
+        assert.equal(url.searchParams.get("block"), "4200000");
+        assert.equal(url.searchParams.get("extrinsic"), "3");
+        assert.equal(url.searchParams.get("limit"), "50");
+        return Response.json({ count: 0, events: [] });
+      },
+    });
+    const out = await loadExtrinsicChainEvents(ctx, "4200000-3");
+    assert.equal(out.ref, "4200000-3");
+    assert.equal(out.extrinsic_index, 3);
+    assert.equal(out.limit, 50);
+    assert.deepEqual(out.events, []);
+  });
+
+  // Exact JSON contract from workers/data-api.mjs GET /chain-events?block=&extrinsic=
+  test("loadExtrinsicChainEvents round-trips the DATA_API chain-events feed contract", async () => {
+    const dataApiPayload = {
+      count: 1,
+      next_before: 123,
+      next_cursor: "123.0",
+      events: [
+        {
+          block_number: 123,
+          event_index: 0,
+          pallet: "System",
+          method: "ExtrinsicSuccess",
+          args: { x: 1 },
+          phase: "ApplyExtrinsic",
+          extrinsic_index: 2,
+          observed_at: 100,
+        },
+      ],
+    };
+    const ctx = dataApiCtx({
+      fetchImpl: async () => Response.json(dataApiPayload),
+    });
+    const out = await loadExtrinsicChainEvents(ctx, "5870000-3");
+    assert.equal(out.event_count, 1);
+    assert.equal(out.next_cursor, "123.0");
+    assert.deepEqual(out.events, dataApiPayload.events);
+    assert.equal(typeof out.events[0].observed_at, "number");
+  });
+
+  test("loadExtrinsicChainEvents forwards limit and cursor", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async (request) => {
+        const url = new URL(request.url);
+        assert.equal(url.searchParams.get("limit"), "25");
+        assert.equal(url.searchParams.get("cursor"), "4200000.9");
+        return Response.json({
+          count: 1,
+          next_cursor: "4200000.8",
+          events: [{ pallet: "System", method: "ExtrinsicSuccess" }],
+        });
+      },
+    });
+    const out = await loadExtrinsicChainEvents(ctx, "4200000-3", {
+      limit: 25,
+      cursor: "4200000.9",
+    });
+    assert.equal(out.limit, 25);
+    assert.equal(out.next_cursor, "4200000.8");
+    assert.equal(out.events[0].method, "ExtrinsicSuccess");
+  });
+
+  test("loadExtrinsicChainEvents clamps an oversized limit and tolerates sparse payloads", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async (request) => {
+        assert.equal(new URL(request.url).searchParams.get("limit"), "200");
+        return Response.json({ events: null });
+      },
+    });
+    const out = await loadExtrinsicChainEvents(ctx, "4200000-3", {
+      limit: 999,
+    });
+    assert.equal(out.limit, 200);
+    assert.equal(out.event_count, 0);
+    assert.deepEqual(out.events, []);
+    assert.equal(out.next_cursor, null);
+  });
+
+  test("loadExtrinsicChainEvents defaults invalid limits to 50", async () => {
+    const ctx = dataApiCtx({
+      fetchImpl: async (request) => {
+        assert.equal(new URL(request.url).searchParams.get("limit"), "50");
+        return Response.json({ count: 0, events: [] });
+      },
+    });
+    const out = await loadExtrinsicChainEvents(ctx, "4200000-3", { limit: 0 });
+    assert.equal(out.limit, 50);
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1679,7 +1679,7 @@ describe("MCP get_chain_activity (DATA_API binding)", () => {
     const res = await callTool("get_chain_activity", {}, { env: {} });
     assert.equal(res.body.result.isError, true);
     assert.ok(
-      res.body.result.content[0].text.includes("chain activity tier"),
+      res.body.result.content[0].text.includes("all-events data tier"),
       "must surface a clear tier-unavailable message",
     );
   });
@@ -7040,6 +7040,14 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
                       results: fixtures.extrinsic ? [fixtures.extrinsic] : [],
                     });
                   if (
+                    /FROM account_events WHERE block_number = \? AND extrinsic_index = \?/.test(
+                      sql,
+                    )
+                  )
+                    return Promise.resolve({
+                      results: fixtures.extrinsicEvents || [],
+                    });
+                  if (
                     /FROM account_events WHERE block_number = \? ORDER BY event_index/.test(
                       sql,
                     )
@@ -7436,6 +7444,17 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
     assert.ok(q.params.includes(4200000) && q.params.includes(3));
   });
 
+  test("get_extrinsic embeds emitted account_events (#1849)", async () => {
+    const env = chainD1({
+      extrinsic: EXTRINSIC_ROW,
+      extrinsicEvents: [EVENT_ROW],
+    });
+    const res = await callTool("get_extrinsic", { ref: "4200000-3" }, { env });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.events.length, 1);
+    assert.equal(out.events[0].event_kind, "WeightsSet");
+  });
+
   test("get_extrinsic returns extrinsic:null for an unknown ref (cold store)", async () => {
     const res = await callTool("get_extrinsic", { ref: "0x" + "f".repeat(64) });
     assert.equal(res.body.result.isError, false);
@@ -7473,7 +7492,14 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
         { ref: "4200000" },
       ],
       ["list_extrinsics", chainD1({ extrinsics: [EXTRINSIC_ROW] }), {}],
-      ["get_extrinsic", chainD1({ extrinsic: EXTRINSIC_ROW }), { ref: hash }],
+      [
+        "get_extrinsic",
+        chainD1({
+          extrinsic: EXTRINSIC_ROW,
+          extrinsicEvents: [EVENT_ROW],
+        }),
+        { ref: hash },
+      ],
     ];
     for (const [name, env, args] of cases) {
       const res = await callTool(name, args, { env });
@@ -7483,6 +7509,231 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
         `${name}: ${JSON.stringify(validate.errors)}`,
       );
     }
+  });
+});
+
+describe("MCP all-events tier tools (get_block_chain_events, get_extrinsic_chain_events)", () => {
+  // Exact upstream JSON from workers/data-api.mjs (see tests/data-api.test.mjs).
+  const DATA_API_BLOCK_CHAIN_EVENTS_PAYLOAD = {
+    block_number: 123,
+    count: 1,
+    events: [
+      {
+        event_index: 0,
+        pallet: "System",
+        method: "ExtrinsicSuccess",
+        args: { x: 1 },
+        phase: "ApplyExtrinsic",
+        extrinsic_index: 2,
+        observed_at: 100,
+      },
+    ],
+  };
+  const DATA_API_EXTRINSIC_CHAIN_EVENTS_PAYLOAD = {
+    count: 1,
+    next_before: 123,
+    next_cursor: "123.0",
+    events: [
+      {
+        block_number: 123,
+        event_index: 0,
+        pallet: "System",
+        method: "ExtrinsicSuccess",
+        args: { x: 1 },
+        phase: "ApplyExtrinsic",
+        extrinsic_index: 2,
+        observed_at: 100,
+      },
+    ],
+  };
+
+  function makeDataApi({ payload, status = 200 } = {}) {
+    const calls = [];
+    return {
+      calls,
+      fetch(request) {
+        calls.push(new URL(request.url));
+        return Promise.resolve(
+          new Response(status === 200 ? JSON.stringify(payload) : "err", {
+            status,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      },
+    };
+  }
+
+  test("get_block_chain_events returns raw events for a block", async () => {
+    const dataApi = makeDataApi({
+      payload: {
+        block_number: 4200000,
+        count: 1,
+        events: [
+          {
+            event_index: 0,
+            pallet: "Balances",
+            method: "Transfer",
+            observed_at: 1,
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "get_block_chain_events",
+      { block_number: 4200000 },
+      { env: { DATA_API: dataApi } },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.event_count, 1);
+    assert.equal(out.events[0].pallet, "Balances");
+    assert.match(dataApi.calls[0].pathname, /\/blocks\/4200000\/chain-events$/);
+  });
+
+  test("get_block_chain_events round-trips the DATA_API block chain-events contract", async () => {
+    const dataApi = makeDataApi({
+      payload: DATA_API_BLOCK_CHAIN_EVENTS_PAYLOAD,
+    });
+    const res = await callTool(
+      "get_block_chain_events",
+      { block_number: 123 },
+      { env: { DATA_API: dataApi } },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.block_number, 123);
+    assert.equal(out.event_count, 1);
+    assert.deepEqual(out.events, DATA_API_BLOCK_CHAIN_EVENTS_PAYLOAD.events);
+    assert.equal(typeof out.events[0].observed_at, "number");
+  });
+
+  test("get_extrinsic_chain_events forwards block+extrinsic filters", async () => {
+    const dataApi = makeDataApi({ payload: { count: 0, events: [] } });
+    const res = await callTool(
+      "get_extrinsic_chain_events",
+      { ref: "4200000-3" },
+      { env: { DATA_API: dataApi } },
+    );
+    assert.equal(res.body.result.isError, false);
+    assert.equal(dataApi.calls[0].searchParams.get("block"), "4200000");
+    assert.equal(dataApi.calls[0].searchParams.get("extrinsic"), "3");
+    assert.equal(dataApi.calls[0].searchParams.get("limit"), "50");
+    assert.deepEqual(res.body.result.structuredContent.events, []);
+  });
+
+  test("get_extrinsic_chain_events round-trips the DATA_API chain-events feed contract", async () => {
+    const dataApi = makeDataApi({
+      payload: DATA_API_EXTRINSIC_CHAIN_EVENTS_PAYLOAD,
+    });
+    const res = await callTool(
+      "get_extrinsic_chain_events",
+      { ref: "5870000-3" },
+      { env: { DATA_API: dataApi } },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.event_count, 1);
+    assert.equal(out.next_cursor, "123.0");
+    assert.deepEqual(
+      out.events,
+      DATA_API_EXTRINSIC_CHAIN_EVENTS_PAYLOAD.events,
+    );
+    assert.equal(typeof out.events[0].observed_at, "number");
+    assert.equal(dataApi.calls[0].searchParams.get("block"), "5870000");
+    assert.equal(dataApi.calls[0].searchParams.get("extrinsic"), "3");
+  });
+
+  test("get_extrinsic_chain_events follows next_cursor on a follow-up page", async () => {
+    const calls = [];
+    const dataApi = {
+      calls,
+      fetch(request) {
+        calls.push(new URL(request.url));
+        const cursor = new URL(request.url).searchParams.get("cursor");
+        const payload = cursor
+          ? {
+              count: 1,
+              events: [{ pallet: "System", method: "ExtrinsicSuccess" }],
+            }
+          : { count: 0, next_cursor: "4200000.9", events: [] };
+        return Promise.resolve(
+          new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      },
+    };
+    const first = await callTool(
+      "get_extrinsic_chain_events",
+      { ref: "4200000-3", limit: 10 },
+      { env: { DATA_API: dataApi } },
+    );
+    assert.equal(first.body.result.isError, false);
+    assert.equal(first.body.result.structuredContent.next_cursor, "4200000.9");
+    const second = await callTool(
+      "get_extrinsic_chain_events",
+      { ref: "4200000-3", cursor: "4200000.9" },
+      { env: { DATA_API: dataApi } },
+    );
+    assert.equal(second.body.result.isError, false);
+    assert.equal(calls[1].searchParams.get("cursor"), "4200000.9");
+    assert.equal(
+      second.body.result.structuredContent.events[0].method,
+      "ExtrinsicSuccess",
+    );
+  });
+
+  test("get_extrinsic_chain_events rejects a hash ref", async () => {
+    const res = await callTool(
+      "get_extrinsic_chain_events",
+      { ref: "0x" + "a".repeat(64) },
+      { env: { DATA_API: makeDataApi({ payload: {} }) } },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /composite/i);
+  });
+
+  test("tier_unavailable when DATA_API is absent", async () => {
+    for (const [name, args] of [
+      ["get_block_chain_events", { block_number: 1 }],
+      ["get_extrinsic_chain_events", { ref: "1-0" }],
+    ]) {
+      const res = await callTool(name, args, { env: {} });
+      assert.equal(res.body.result.isError, true, name);
+      assert.match(res.body.result.content[0].text, /unavailable/i);
+    }
+  });
+
+  test("all-events tool payloads validate against their declared outputSchemas", async () => {
+    const ajv = new Ajv2020({ strict: false });
+    const validatorFor = (name) =>
+      ajv.compile(
+        listToolDefinitions().find((t) => t.name === name).outputSchema,
+      );
+    const dataApi = makeDataApi({
+      payload: DATA_API_BLOCK_CHAIN_EVENTS_PAYLOAD,
+    });
+    const blockRes = await callTool(
+      "get_block_chain_events",
+      { block_number: 123 },
+      { env: { DATA_API: dataApi } },
+    );
+    assert.ok(
+      validatorFor("get_block_chain_events")(
+        blockRes.body.result.structuredContent,
+      ),
+    );
+    const extrinsicDataApi = makeDataApi({
+      payload: DATA_API_EXTRINSIC_CHAIN_EVENTS_PAYLOAD,
+    });
+    const extrinsicRes = await callTool(
+      "get_extrinsic_chain_events",
+      { ref: "5870000-3", limit: 10 },
+      { env: { DATA_API: extrinsicDataApi } },
+    );
+    assert.ok(
+      validatorFor("get_extrinsic_chain_events")(
+        extrinsicRes.body.result.structuredContent,
+      ),
+    );
   });
 });
 

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -59,10 +59,8 @@ import {
   MAX_HISTORY_POINTS,
 } from "../../src/neuron-history.mjs";
 import {
-  ACCOUNT_EVENT_COLUMNS,
   INGESTED_EVENT_KINDS,
   buildAccountHistory,
-  formatAccountEvent,
   loadAccountSummary,
   loadAccountEvents,
   loadSubnetEvents,
@@ -80,15 +78,12 @@ import {
   buildBlock,
   loadBlocks,
 } from "../../src/blocks.mjs";
-import {
-  EXTRINSIC_READ_COLUMNS,
-  buildExtrinsic,
-  loadExtrinsics,
-} from "../../src/extrinsics.mjs";
+import { loadExtrinsics } from "../../src/extrinsics.mjs";
 import {
   loadBlockEvents,
   loadBlockExtrinsics,
 } from "../../src/block-subresources.mjs";
+import { loadExtrinsicDetail } from "../../src/extrinsic-detail.mjs";
 import {
   CONCENTRATION_HISTORY_ROW_CAP,
   CONCENTRATION_READ_COLUMNS,
@@ -148,7 +143,6 @@ function parseBoundedIntParam(url, parameter, { def, min, max }) {
 // 1e3, empty/extra halves) into a wrong-but-valid lookup; require bare decimal
 // segments + Number.isSafeInteger (same convention as parseBoundedIntParam).
 const STRICT_UINT_RE = /^\d+$/;
-const COMPOSITE_REF_RE = /^(\d+)-(\d+)$/;
 
 // A strict non-negative block_number, or null for a non-decimal ref (so the
 // caller skips the lookup and serves the schema-stable miss).
@@ -1603,50 +1597,7 @@ export async function handleExtrinsics(request, env, url) {
 // embedded via a second lookup on (block_number, extrinsic_index) — bounded to 50.
 // Empty for pre-migration rows, non-ApplyExtrinsic events, or a cold store.
 export async function handleExtrinsic(request, env, ref) {
-  const isHash = /^0x[0-9a-fA-F]{64}$/.test(ref);
-  let rows;
-  if (isHash) {
-    rows = await d1All(
-      env,
-      `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE extrinsic_hash = ? ORDER BY block_number DESC, extrinsic_index DESC LIMIT 1`,
-      [ref.toLowerCase()],
-    );
-  } else {
-    // Composite "<block>-<index>": exactly two strict decimal halves, so a
-    // malformed ref (extra segment, empty half, hex, sci-notation) is a clean
-    // miss (extrinsic:null) rather than a coerced wrong-but-valid row.
-    const composite = COMPOSITE_REF_RE.exec(ref);
-    const blockNumber = composite ? Number(composite[1]) : NaN;
-    const extrinsicIndex = composite ? Number(composite[2]) : NaN;
-    rows =
-      composite &&
-      Number.isSafeInteger(blockNumber) &&
-      Number.isSafeInteger(extrinsicIndex)
-        ? await d1All(
-            env,
-            `SELECT ${EXTRINSIC_READ_COLUMNS} FROM extrinsics WHERE block_number = ? AND extrinsic_index = ? LIMIT 1`,
-            [blockNumber, extrinsicIndex],
-          )
-        : [];
-  }
-  // Embed the emitted events once we have the resolved (block_number,
-  // extrinsic_index). A second sequential read; d1All swallows a missing-column
-  // error pre-migration → [] (the embed is additive, never breaks the detail).
-  let events = [];
-  const resolved = rows[0];
-  if (
-    resolved &&
-    resolved.block_number != null &&
-    resolved.extrinsic_index != null
-  ) {
-    const eventRows = await d1All(
-      env,
-      `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE block_number = ? AND extrinsic_index = ? ORDER BY event_index ASC LIMIT 50`,
-      [resolved.block_number, resolved.extrinsic_index],
-    );
-    events = eventRows.map(formatAccountEvent).filter(Boolean);
-  }
-  const data = buildExtrinsic(resolved, ref, events);
+  const data = await loadExtrinsicDetail(d1Runner(env), ref);
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

Adds MCP explorer parity for extrinsic-scoped chain events and enriches `get_extrinsic` responses:

- **`get_extrinsic_chain_events`** — exposes `GET /api/v1/chain-events?block=&extrinsic=` so agents can list events emitted by a specific extrinsic without scanning full block feeds.
- **`get_extrinsic` embed** — attaches curated `account_events` on extrinsic detail via shared `extrinsic-detail.mjs` loader.
- **Shared loaders** — new `data-api-mcp.mjs` helpers; `workers/request-handlers/entities.mjs` refactored to reuse the same paths as MCP.
- **MCP SemVer** — `1.19.0` → `1.20.0` (`server.json` + validate-mcp).

8 files, +1174/−104. Unit tests in `tests/extrinsic-detail.test.mjs` and extended MCP server coverage.

## Distinct from other open/merged MCP work

| PR | Relationship |
|----|----------------|
| **#2735** (merged) | `get_economics` — no overlap |
| **#2737** | `ConcentrationMetrics` outputSchema  |
| **#2739** | Event-kind validation on feeds — adjacent but different scope |
| **#2747** | Turnover `changes` filter — no overlap |
| **#2764** | `list_global_validators` — no overlap |

## Test plan

- [x] `npm run lint` / `format:check`
- [x] `vitest run tests/extrinsic-detail.test.mjs`
- [x] MCP tests for `get_extrinsic_chain_events` / `get_extrinsic` embed
- [x] `node scripts/validate-mcp.mjs` (76 tools)