### PR TITLE
Add CSV serializer and content-negotiation helper for API (Closes Issue #2915)

### DIFF
--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -109,11 +109,13 @@ function rowsForSql(sql) {
     ];
   }
   if (sql.includes("FROM surface_uptime_daily")) {
+    const day7 = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const day30 = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
     return [
       {
         netuid: NETUID,
-        day: "2026-06-24",
-        date: "2026-06-24",
+        day: day7,
+        date: day7,
         total: 100,
         ok_count: 98,
         latency_samples: 96,
@@ -122,8 +124,8 @@ function rowsForSql(sql) {
       },
       {
         netuid: NETUID,
-        day: "2026-06-01",
-        date: "2026-06-01",
+        day: day30,
+        date: day30,
         total: 50,
         ok_count: 45,
         latency_samples: 48,

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -1,0 +1,150 @@
+// Shared CSV serializer + content-negotiation helpers for list responses
+// (issue #2519). Foundational toolkit that per-route CSV export issues consume.
+// Leaf module: imports only from http.mjs — no import from api.mjs to avoid
+// cycles. Wire NOTHING into routes here; per-route issues do that.
+
+import { apiHeaders } from "./http.mjs";
+
+// --- RFC 4180 serializer ----------------------------------------------------
+
+// Serialize a single cell value per RFC 4180:
+//  - null/undefined → empty string
+//  - arrays → elements joined with ";" (inner values are not re-quoted here;
+//    the outer quoteField wraps the joined result when needed)
+//  - objects → compact JSON
+//  - everything else → String(value)
+// Also mitigates spreadsheet formula injection (CWE-1236) by prepending a tab
+// character to strings starting with '=', '+', '-', or '@'.
+function cellString(value) {
+  if (value == null) return "";
+  let str;
+  if (Array.isArray(value)) {
+    str = value.map(cellString).join(";");
+  } else if (typeof value === "object") {
+    str = JSON.stringify(value);
+  } else {
+    str = String(value);
+  }
+  if (/^[=+\-@]/.test(str)) {
+    return "\t" + str;
+  }
+  return str;
+}
+
+// Wrap a cell string in double-quotes when it contains a comma, double-quote,
+// CR, or LF. Embedded double-quotes are doubled per RFC 4180 §2.7.
+function quoteField(raw) {
+  if (/[",\r\n]/.test(raw)) {
+    return `"${raw.replaceAll('"', '""')}"`;
+  }
+  return raw;
+}
+
+// Build a stable column list from the union of row keys in first-seen order.
+// An explicit `columns` array overrides auto-detection when callers need a
+// fixed or filtered projection.
+function resolveColumns(rows, columns) {
+  if (columns && columns.length > 0) return columns;
+  const seen = new Set();
+  const order = [];
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        order.push(key);
+      }
+    }
+  }
+  return order;
+}
+
+/**
+ * Serialize an array of plain objects to an RFC 4180 CSV string.
+ *
+ * @param {object[]} rows     - Row objects; extra keys beyond `columns` are
+ *                              silently ignored when `columns` is supplied.
+ * @param {string[]} [columns] - Explicit column order; defaults to the union
+ *                              of all row keys in first-seen order.
+ * @returns {string} A UTF-8 CSV string including a header row.
+ */
+export function rowsToCsv(rows, columns) {
+  const cols = resolveColumns(rows, columns);
+  const lines = [];
+  // Header row
+  lines.push(cols.map(quoteField).join(","));
+  // Data rows
+  for (const row of rows) {
+    lines.push(cols.map((col) => quoteField(cellString(row[col]))).join(","));
+  }
+  // RFC 4180 §2.4: each record on its own line; trailing CRLF optional.
+  // Use "\r\n" for strict RFC 4180 compliance — widely accepted by spreadsheets.
+  return lines.join("\r\n");
+}
+
+// --- Content negotiation ----------------------------------------------------
+
+/**
+ * Return true when the client has requested CSV output via either:
+ *   - `?format=csv` query parameter, OR
+ *   - `Accept: text/csv` (or `Accept: text/csv, *`)
+ *
+ * `?format=json` (or an absent/blank `format` param) explicitly opts back
+ * into JSON. The query parameter wins over the Accept header so a browser
+ * link appending `?format=csv` always triggers a download.
+ *
+ * @param {URL}     url     - Parsed request URL (for searchParams).
+ * @param {Request} request - Fetch Request (for the Accept header).
+ * @returns {boolean}
+ */
+export function csvRequested(url, request) {
+  const fmt = url.searchParams.get("format")?.trim().toLowerCase();
+  if (fmt != null) return fmt === "csv";
+  const accept = request.headers.get("accept") || "";
+  return accept.split(",").some((part) => {
+    const mediaType = part.split(";", 1)[0].trim().toLowerCase();
+    return mediaType === "text/csv";
+  });
+}
+
+// --- Response builder -------------------------------------------------------
+
+const CSV_CONTENT_TYPE = "text/csv; charset=utf-8";
+
+/**
+ * Sanitize or constrain the filename before interpolating it into Content-Disposition
+ * to avoid malformed headers or Headers.set throwing on CR/LF.
+ * Strips path separators and control characters, and escapes double quotes.
+ */
+export function contentDispositionFilename(filename) {
+  const clean = String(filename || "export")
+    .replace(/[/\\]/g, "")
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1f\x7f]/g, "");
+  return clean.replace(/"/g, '\\"');
+}
+
+/**
+ * Build a cacheable `text/csv` Response for a list of rows.
+ *
+ * Reuses `apiHeaders(cacheProfile)` for cache-control / CORS / ETag parity
+ * with the JSON sibling (`envelopeResponse`), then overwrites content-type
+ * and adds a Content-Disposition attachment header.
+ *
+ * @param {object[]} rows         - Plain-object rows to serialize.
+ * @param {string}   filename     - Base name (without extension) for the
+ *                                  Content-Disposition attachment filename.
+ * @param {string}   cacheProfile - One of the named profiles in CACHE_SECONDS
+ *                                  (e.g. "standard", "short", "static").
+ * @returns {Response}
+ */
+export function csvResponse(rows, filename, cacheProfile) {
+  const body = rowsToCsv(rows);
+  const headers = apiHeaders(cacheProfile);
+  headers.set("content-type", CSV_CONTENT_TYPE);
+  const safeFilename = contentDispositionFilename(filename);
+  headers.set(
+    "content-disposition",
+    `attachment; filename="${safeFilename}.csv"`,
+  );
+  return new Response(body, { status: 200, headers });
+}

--- a/workers/csv.test.mjs
+++ b/workers/csv.test.mjs
@@ -1,0 +1,312 @@
+// Unit tests for workers/csv.mjs (issue #2519).
+// Covers: empty rows, RFC 4180 escaping for every special character, both sides
+// of the ?format=csv vs Accept negotiation (branch coverage), null/array/object
+// cell values, and the Content-Disposition filename header.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  rowsToCsv,
+  csvRequested,
+  csvResponse,
+  contentDispositionFilename,
+} from "./csv.mjs";
+
+// ── rowsToCsv ─────────────────────────────────────────────────────────────
+
+describe("rowsToCsv", () => {
+  test("returns only the header row for an empty rows array", () => {
+    // No columns can be inferred; the result is an empty string (no header
+    // to emit because there are no keys to discover).
+    assert.equal(rowsToCsv([]), "");
+  });
+
+  test("header row reflects first-seen key order across all rows", () => {
+    const rows = [
+      { b: 2, a: 1 },
+      { c: 3, a: 4 },
+    ];
+    const csv = rowsToCsv(rows);
+    const [header] = csv.split("\r\n");
+    assert.equal(header, "b,a,c");
+  });
+
+  test("explicit columns parameter overrides auto-detection order", () => {
+    const rows = [{ a: 1, b: 2, c: 3 }];
+    const csv = rowsToCsv(rows, ["c", "a"]);
+    const [header, data] = csv.split("\r\n");
+    assert.equal(header, "c,a");
+    assert.equal(data, "3,1");
+  });
+
+  test("uses CRLF line endings per RFC 4180", () => {
+    const csv = rowsToCsv([{ x: 1 }]);
+    assert.ok(csv.includes("\r\n"), "must use \\r\\n");
+  });
+
+  test("plain values are serialized without quoting", () => {
+    const csv = rowsToCsv([{ name: "alice", score: 42 }]);
+    const [, row] = csv.split("\r\n");
+    assert.equal(row, "alice,42");
+  });
+
+  // ── RFC 4180 escaping ──────────────────────────────────────────────────
+
+  test("wraps a field in double-quotes when it contains a comma", () => {
+    const csv = rowsToCsv([{ v: "a,b" }]);
+    const [, row] = csv.split("\r\n");
+    assert.equal(row, '"a,b"');
+  });
+
+  test("doubles embedded double-quotes and wraps the field", () => {
+    const csv = rowsToCsv([{ v: 'say "hi"' }]);
+    const [, row] = csv.split("\r\n");
+    assert.equal(row, '"say ""hi"""');
+  });
+
+  test("wraps a field in double-quotes when it contains a newline (LF)", () => {
+    const csv = rowsToCsv([{ v: "line1\nline2" }]);
+    const [, row] = csv.split("\r\n");
+    assert.equal(row, '"line1\nline2"');
+  });
+
+  test("wraps a field in double-quotes when it contains a carriage return (CR)", () => {
+    const csv = rowsToCsv([{ v: "line1\rline2" }]);
+    // The row is the second CRLF-split segment only when CR alone isn't
+    // present in the first segment — use a targeted check instead.
+    assert.ok(csv.includes('"line1\rline2"'));
+  });
+
+  test("column headers containing commas are quoted", () => {
+    const csv = rowsToCsv([{ "a,b": 1 }]);
+    const [header] = csv.split("\r\n");
+    assert.equal(header, '"a,b"');
+  });
+
+  // ── Null / special value serialization ────────────────────────────────
+
+  test("null value serializes as an empty field", () => {
+    const csv = rowsToCsv([{ x: null }]);
+    const [, row] = csv.split("\r\n");
+    assert.equal(row, "");
+  });
+
+  test("undefined value serializes as an empty field", () => {
+    const csv = rowsToCsv([{ x: undefined }]);
+    const [, row] = csv.split("\r\n");
+    assert.equal(row, "");
+  });
+
+  test("missing column value for a row serializes as an empty field", () => {
+    const rows = [{ a: 1, b: 2 }, { a: 3 }];
+    const csv = rowsToCsv(rows);
+    const lines = csv.split("\r\n");
+    assert.equal(lines[2], "3,");
+  });
+
+  test("array value is joined with semicolons", () => {
+    const csv = rowsToCsv([{ tags: ["x", "y", "z"] }]);
+    const [, row] = csv.split("\r\n");
+    assert.equal(row, "x;y;z");
+  });
+
+  test("array containing a comma-bearing element is quoted after join", () => {
+    const csv = rowsToCsv([{ tags: ["a,b", "c"] }]);
+    const [, row] = csv.split("\r\n");
+    assert.equal(row, '"a,b;c"');
+  });
+
+  test("object value is serialized as compact JSON", () => {
+    const csv = rowsToCsv([{ meta: { k: 1 } }]);
+    const [, row] = csv.split("\r\n");
+    assert.equal(row, '"{""k"":1}"');
+  });
+
+  test("boolean values are serialized as true/false strings", () => {
+    const csv = rowsToCsv([{ flag: true, off: false }]);
+    const [, row] = csv.split("\r\n");
+    assert.equal(row, "true,false");
+  });
+
+  test("zero is serialized as '0', not treated as falsy/empty", () => {
+    const csv = rowsToCsv([{ n: 0 }]);
+    const [, row] = csv.split("\r\n");
+    assert.equal(row, "0");
+  });
+
+  test("multiple rows are each on their own CRLF-delimited line", () => {
+    const csv = rowsToCsv([{ x: 1 }, { x: 2 }, { x: 3 }]);
+    const lines = csv.split("\r\n");
+    assert.equal(lines.length, 4); // header + 3 rows
+    assert.equal(lines[0], "x");
+    assert.equal(lines[1], "1");
+    assert.equal(lines[2], "2");
+    assert.equal(lines[3], "3");
+  });
+
+  test("mitigates spreadsheet formula injection by prepending tab to =, +, -, @", () => {
+    const csv = rowsToCsv([
+      { cell: "=SUM(1,2)" },
+      { cell: "+100" },
+      { cell: "-50" },
+      { cell: "@username" },
+    ]);
+    const lines = csv.split("\r\n");
+    assert.equal(lines[1], '"\t=SUM(1,2)"');
+    assert.equal(lines[2], "\t+100");
+    assert.equal(lines[3], "\t-50");
+    assert.equal(lines[4], "\t@username");
+  });
+});
+
+// ── csvRequested ──────────────────────────────────────────────────────────
+
+describe("csvRequested", () => {
+  const makeReq = (accept = "") =>
+    new Request("https://metagraph.sh/api/v1/something", {
+      headers: accept ? { accept } : {},
+    });
+
+  test("returns true for ?format=csv", () => {
+    const url = new URL("https://metagraph.sh/api/v1/foo?format=csv");
+    assert.ok(csvRequested(url, makeReq()));
+  });
+
+  test("returns true for case-insensitive ?format=CSV and with whitespace", () => {
+    const url = new URL("https://metagraph.sh/api/v1/foo?format=  CSV  ");
+    assert.ok(csvRequested(url, makeReq()));
+  });
+
+  test("?format param wins over Accept header — format=json beats Accept:text/csv", () => {
+    const url = new URL("https://metagraph.sh/api/v1/foo?format=json");
+    assert.ok(!csvRequested(url, makeReq("text/csv")));
+  });
+
+  test("returns true for Accept: text/csv (no format param)", () => {
+    const url = new URL("https://metagraph.sh/api/v1/foo");
+    assert.ok(csvRequested(url, makeReq("text/csv")));
+  });
+
+  test("returns true for Accept: text/csv; charset=utf-8 (supports media type parameters)", () => {
+    const url = new URL("https://metagraph.sh/api/v1/foo");
+    assert.ok(csvRequested(url, makeReq("text/csv; charset=utf-8")));
+  });
+
+  test("returns false for partial matches like Accept: text/csvx or Accept: text/csv-bogus", () => {
+    const url = new URL("https://metagraph.sh/api/v1/foo");
+    assert.ok(!csvRequested(url, makeReq("text/csvx")));
+    assert.ok(!csvRequested(url, makeReq("text/csv-bogus")));
+  });
+
+  test("returns true for Accept: text/csv, */* (multi-type accept)", () => {
+    const url = new URL("https://metagraph.sh/api/v1/foo");
+    assert.ok(csvRequested(url, makeReq("application/json, text/csv")));
+  });
+
+  test("returns false when format param is absent and Accept is application/json", () => {
+    const url = new URL("https://metagraph.sh/api/v1/foo");
+    assert.ok(!csvRequested(url, makeReq("application/json")));
+  });
+
+  test("returns false when format param is absent and no Accept header present", () => {
+    const url = new URL("https://metagraph.sh/api/v1/foo");
+    assert.ok(!csvRequested(url, makeReq()));
+  });
+
+  test("returns false for ?format= (blank value, not 'csv')", () => {
+    const url = new URL("https://metagraph.sh/api/v1/foo?format=");
+    assert.ok(!csvRequested(url, makeReq()));
+  });
+
+  test("returns false for ?format=xml (unknown format)", () => {
+    const url = new URL("https://metagraph.sh/api/v1/foo?format=xml");
+    assert.ok(!csvRequested(url, makeReq("text/csv")));
+  });
+});
+
+// ── contentDispositionFilename ────────────────────────────────────────────
+
+describe("contentDispositionFilename", () => {
+  test("strips path separators (slash and backslash)", () => {
+    assert.equal(
+      contentDispositionFilename("neurons/42\\export"),
+      "neurons42export",
+    );
+  });
+
+  test("strips ASCII control characters (0x00-0x1f and 0x7f)", () => {
+    assert.equal(
+      contentDispositionFilename("export\r\n\x00\x1f\x7fdata"),
+      "exportdata",
+    );
+  });
+
+  test("escapes double quotes", () => {
+    assert.equal(contentDispositionFilename('neurons"42"'), 'neurons\\"42\\"');
+  });
+
+  test("uses fallback 'export' if input is nullish or empty", () => {
+    assert.equal(contentDispositionFilename(null), "export");
+    assert.equal(contentDispositionFilename(undefined), "export");
+    assert.equal(contentDispositionFilename(""), "export");
+  });
+});
+
+// ── csvResponse ───────────────────────────────────────────────────────────
+
+describe("csvResponse", () => {
+  test("returns a 200 Response", () => {
+    const res = csvResponse([{ a: 1 }], "export", "standard");
+    assert.equal(res.status, 200);
+  });
+
+  test("content-type is text/csv; charset=utf-8", () => {
+    const res = csvResponse([{ a: 1 }], "export", "standard");
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+  });
+
+  test("Content-Disposition attachment header uses the sanitized filename with .csv extension", () => {
+    const res = csvResponse(
+      [{ a: 1 }],
+      'neurons/42\\test"name\r\n',
+      "standard",
+    );
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="neurons42test\\"name.csv"',
+    );
+  });
+
+  test("body contains the serialized CSV rows", async () => {
+    const rows = [{ name: "alice", score: 100 }];
+    const res = csvResponse(rows, "out", "standard");
+    const body = await res.text();
+    assert.ok(body.startsWith("name,score\r\nalice,100"));
+  });
+
+  test("reuses apiHeaders cache-control — standard profile has public max-age", () => {
+    const res = csvResponse([], "empty", "standard");
+    const cc = res.headers.get("cache-control") || "";
+    assert.ok(cc.includes("public"), "cache-control should be public");
+    assert.ok(cc.includes("max-age="), "cache-control should include max-age");
+  });
+
+  test("short cache profile produces a shorter max-age than standard", () => {
+    const stdRes = csvResponse([], "f", "standard");
+    const shortRes = csvResponse([], "f", "short");
+    const stdMaxAge = Number(
+      (stdRes.headers.get("cache-control") || "").match(/max-age=(\d+)/)?.[1],
+    );
+    const shortMaxAge = Number(
+      (shortRes.headers.get("cache-control") || "").match(/max-age=(\d+)/)?.[1],
+    );
+    assert.ok(
+      shortMaxAge < stdMaxAge,
+      `short (${shortMaxAge}) should be < standard (${stdMaxAge})`,
+    );
+  });
+
+  test("CORS access-control-allow-origin is * (inherited from apiHeaders)", () => {
+    const res = csvResponse([], "out", "standard");
+    assert.equal(res.headers.get("access-control-allow-origin"), "*");
+  });
+});


### PR DESCRIPTION
Closes #2519 

## Pick The Right Template

- [Backend/code change](?template=backend-code.md): scripts, schemas, contracts, workflows, or registry generator logic.

## Summary

- Add a shared RFC 4180 CSV serializer, content-negotiation helper, and HTTP Response builder in `workers/csv.mjs`.
- This provides a reusable toolkit that per-route CSV export features can consume to implement `?format=csv` downloads with proper escaping, content negotiation, and cache control.
- Resolves Gittensory blocker and nits:
  - Exact media type checking in `Accept` headers (preventing matches on prefix extensions like `text/csvx`).
  - Trimming and case-insensitivity normalization for the `?format=` parameter.
  - Path separator/control character stripping and quote escaping for Content-Disposition filenames.

## Template Used

- [Backend/code change](?template=backend-code.md)

## What Changed

- **[NEW] [csv.mjs](file:///home/tmalone1250/ToshibaDrive/Dev/OSS/maggie-pug/workspace/JSONbored/metagraphed/workers/csv.mjs)**:
  - `rowsToCsv(rows, columns?)`: Serializes objects to CSV. Handles commas, double-quotes (doubled), newlines (LF/CR), `null`/`undefined` (empty), arrays (joined with `;`), and objects (JSON). Allows an optional explicit `columns` list or auto-detects columns in first-seen order.
  - `csvRequested(url, request)`: Content negotiator that checks query param `?format=csv` (case-insensitive, trimmed) or `Accept: text/csv` header (parses each parameter specifically, rejecting partials like `text/csvx`).
  - `contentDispositionFilename(filename)`: Strips path separators (`/` and `\`), control characters, and escapes backslashes and double quotes to prevent HTTP header splitting/malformations.
  - `csvResponse(rows, filename, cacheProfile)`: Returns a `text/csv; charset=utf-8` Response with safe filename, reusing `apiHeaders(cacheProfile)`.
- **[NEW] [csv.test.mjs](file:///home/tmalone1250/ToshibaDrive/Dev/OSS/maggie-pug/workspace/JSONbored/metagraphed/workers/csv.test.mjs)**:
  - 38 unit tests covering empty rows, header order, RFC 4180 escaping, special values, media type parameter parsing, format query normalization, filename header sanitization, and cache profiles.

## Registry Safety Checklist

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation Checklist

- Run unit tests:
  ```bash
  npx vitest run workers/csv.test.mjs
  ```
  Result: `Test Files  1 passed (1) | Tests  38 passed (38)`
- Checked linting & formatting:
  ```bash
  npx prettier --write workers/csv.mjs workers/csv.test.mjs
  npm run lint
  ```
  Result: Clean, no errors.