### PR TITLE
feat(api): add ?format=csv to GET /api/v1/economics/trends (#2531)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -10146,6 +10146,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d" | "1y" | "all";
+                /** @description Response format override. Use `csv` to download the network economics trends as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10153,7 +10155,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -10204,6 +10206,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["EconomicsTrendsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -21834,6 +21834,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the network economics trends as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -21892,9 +21905,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -10146,6 +10146,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d" | "1y" | "all";
+                /** @description Response format override. Use `csv` to download the network economics trends as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10153,7 +10155,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -10204,6 +10206,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["EconomicsTrendsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1534,12 +1534,21 @@ export const API_ROUTES = [
     "Fetch the network-wide economics time series (#1307): per UTC day across all subnets — total stake, stake-weighted + median alpha price, total validator/miner counts, and mean emission share — aggregated live from the daily subnet_snapshots D1 rollup (the same source the per-subnet /trajectory reads). ?window=7d|30d|90d|1y|all (default 30d). Served live (no static file); day_count:0 / days:[] when the rollup is cold.",
     "short",
     ["subnets", "analytics"],
-    [
-      {
-        name: "window",
-        schema: { type: "string", enum: ["7d", "30d", "90d", "1y", "all"] },
-      },
-    ],
+    {
+      csvResponse: true,
+      parameters: [
+        {
+          name: "window",
+          schema: { type: "string", enum: ["7d", "30d", "90d", "1y", "all"] },
+        },
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the network economics trends as text/csv; `json` keeps the default response envelope.",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [],
   ),
   route(

--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -996,6 +996,9 @@ test("buildChainFees reports malformed median rows as null, not JSON numbers", (
 });
 
 test("GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL fees", async () => {
+  const testDay = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
   const captured = [];
   const env = {
     ...createLocalArtifactEnv(),
@@ -1007,7 +1010,7 @@ test("GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL f
             const rows = /ROW_NUMBER\(\) OVER/.test(sql)
               ? [
                   {
-                    day: "2026-06-25",
+                    day: testDay,
                     median_fee_tao: 0.006,
                     median_tip_tao: 0,
                   },
@@ -1015,7 +1018,7 @@ test("GET /api/v1/chain/fees returns daily series + top payers, COALESCEs NULL f
               : /GROUP BY day/.test(sql)
                 ? [
                     {
-                      day: "2026-06-25",
+                      day: testDay,
                       extrinsic_count: 50,
                       total_fee_tao: 0.5,
                       total_tip_tao: 0,

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -237,6 +237,72 @@ describe("handleEconomicsTrends", () => {
     assert.equal(day.miner_count, null);
     assert.equal(day.mean_emission_share, null);
   });
+
+  test("returns CSV response when ?format=csv is requested", async () => {
+    const env = d1Env({
+      "FROM subnet_snapshots": [
+        {
+          snapshot_date: "2026-06-02",
+          total_stake_tao: 300,
+          alpha_price_tao: 0.02,
+          validator_count: 8,
+          miner_count: 50,
+          emission_share: 0.04,
+        },
+      ],
+    });
+    const res = await handleEconomicsTrends(req("/"), env, url("/?format=csv"));
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    assert.ok(
+      res.headers
+        .get("content-disposition")
+        .includes('filename="economics-trends.csv"'),
+    );
+    const text = await res.text();
+    const lines = text.split("\r\n");
+    assert.equal(
+      lines[0],
+      "snapshot_date,subnet_count,total_stake_tao,alpha_price_tao_weighted,alpha_price_tao_median,validator_count,miner_count,mean_emission_share",
+    );
+    assert.equal(lines[1], "2026-06-02,1,300,0.02,0.02,8,50,0.04");
+  });
+
+  test("returns CSV response when Accept: text/csv header is present", async () => {
+    const env = d1Env({
+      "FROM subnet_snapshots": [
+        {
+          snapshot_date: "2026-06-02",
+          total_stake_tao: 300,
+          alpha_price_tao: 0.02,
+          validator_count: 8,
+          miner_count: 50,
+          emission_share: 0.04,
+        },
+      ],
+    });
+    const request = new Request("https://api.metagraph.sh/", {
+      headers: { accept: "text/csv" },
+    });
+    const res = await handleEconomicsTrends(request, env, url("/"));
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    const text = await res.text();
+    const lines = text.split("\r\n");
+    assert.equal(lines[1], "2026-06-02,1,300,0.02,0.02,8,50,0.04");
+  });
+
+  test("returns empty/header-only CSV when rollup is cold", async () => {
+    const res = await handleEconomicsTrends(req("/"), {}, url("/?format=csv"));
+    assert.equal(res.status, 200);
+    const text = await res.text();
+    const lines = text.split("\r\n");
+    assert.equal(
+      lines[0],
+      "snapshot_date,subnet_count,total_stake_tao,alpha_price_tao_weighted,alpha_price_tao_median,validator_count,miner_count,mean_emission_share",
+    );
+    assert.equal(lines.length, 1);
+  });
 });
 
 describe("handleUptime", () => {

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -20,6 +20,7 @@ import {
   markD1FallbackResponse,
   validateQueryParams,
 } from "./analytics.mjs";
+import { csvRequested, csvResponse } from "../csv.mjs";
 import {
   dailyLatencyColumns,
   surfaceStatusAvgLatencySql,
@@ -101,8 +102,19 @@ export async function handleTrajectory(request, env, netuid, url) {
 // emission share). Same source as the per-subnet trajectory; raw rows (not a GROUP
 // BY) so the weighted/median price is computed in the pure builder. Schema-stable
 // (day_count:0, days:[]) on a cold rollup. Bounded by ECONOMICS_TRENDS_ROW_CAP.
+const ECONOMICS_TRENDS_COLUMNS = [
+  "snapshot_date",
+  "subnet_count",
+  "total_stake_tao",
+  "alpha_price_tao_weighted",
+  "alpha_price_tao_median",
+  "validator_count",
+  "miner_count",
+  "mean_emission_share",
+];
+
 export async function handleEconomicsTrends(request, env, url) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "format"]);
   if (validationError) return analyticsQueryError(validationError);
   const { label, days, error } = parseHistoryWindow(
     url.searchParams.get("window"),
@@ -112,6 +124,15 @@ export async function handleEconomicsTrends(request, env, url) {
     (sql, params) => d1All(env, sql, params),
     { windowLabel: label, windowDays: days },
   );
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.days,
+      "economics-trends",
+      "short",
+      request,
+      ECONOMICS_TRENDS_COLUMNS,
+    );
+  }
   return envelopeWithD1Fallback(
     request,
     {


### PR DESCRIPTION
## Pick The Right Template

- [Backend/code change](?template=backend-code.md): scripts, schemas, contracts, workflows, or registry generator logic.

## Summary

- Add `?format=csv` (and `Accept: text/csv`) support to `GET /api/v1/economics/trends`.
- Consumes the CSV toolkit introduced in #2519 (`workers/csv.mjs`).
- Returns RFC 4180-compliant rows with a guaranteed header row even when the D1 rollup is cold/empty.
- Closes #2531 

## Template Used

- [Backend/code change](?template=backend-code.md)

## What Changed

- **[MODIFY] [analytics-routes.mjs](file:///home/tmalone1250/ToshibaDrive/Dev/OSS/maggie-pug/workspace/JSONbored/metagraphed/workers/request-handlers/analytics-routes.mjs)**:
  - Import `csvRequested` and `csvResponse` from `workers/csv.mjs`.
  - Define `ECONOMICS_TRENDS_COLUMNS` to pin header ordering.
  - In `handleEconomicsTrends`: when CSV is requested, serialize rows through `rowsToCsv` (with explicit column list) and return `csvResponse`; otherwise fall through to the existing JSON envelope.

- **[MODIFY] [contracts.mjs](file:///home/tmalone1250/ToshibaDrive/Dev/OSS/maggie-pug/workspace/JSONbored/metagraphed/src/contracts.mjs)**:
  - Add `csvResponse: true` flag to the `economics-trends` route descriptor.
  - Add `format` to the route's accepted query parameters.

- **[MODIFY] [request-handlers-analytics-routes.test.mjs](file:///home/tmalone1250/ToshibaDrive/Dev/OSS/maggie-pug/workspace/JSONbored/metagraphed/tests/request-handlers-analytics-routes.test.mjs)**:
  - Three new `handleEconomicsTrends` unit tests:
    1. `?format=csv` with synthetic data rows → verifies CSV text and `content-type: text/csv` header.
    2. `Accept: text/csv` header negotiation → same assertion path.
    3. Cold rollup (empty rows) → verifies header-only CSV (no data rows, no error).

- **[MODIFY] [chain-analytics.test.mjs](file:///home/tmalone1250/ToshibaDrive/Dev/OSS/maggie-pug/workspace/JSONbored/metagraphed/tests/chain-analytics.test.mjs)**:
  - Replace hardcoded `2026-06-25` date literal with a relative `Date.now() - 2 * 86400 * 1000` expression to prevent the test from rotting as real time progresses.

- **[MODIFY] Regenerated artifacts** (`public/metagraph/openapi.json`, `public/metagraph/types.d.ts`, `generated/metagraphed-api.d.ts`):
  - The `format` query parameter and CSV 200 response now appear in the OpenAPI spec.
  - TypeScript types regenerated to match.

## Registry Safety Checklist

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts (`npm run openapi:generate`, `npm run types:generate`), not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation Checklist

- Run analytics route unit tests (including new CSV cases):
  ```bash
  npx vitest run tests/request-handlers-analytics-routes.test.mjs
  ```
  Result: All tests passed (including the 3 new CSV cases).

- Run the full public-safety scan (standalone, avoids parallel timeout):
  ```bash
  npx vitest run tests/public-safety.test.mjs
  ```
  Result: `Test Files  1 passed (1) | Tests  20 passed (20)` — 24s.

- Checked linting & formatting:
  ```bash
  npm run lint
  ```
  Result: Clean, no errors.
