### PR TITLE
fix(mcp): validate get_account_history from/to dates before D1

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -15,6 +15,7 @@ import {
   resolveClientIp,
   SS58_ADDRESS_PATTERN,
 } from "../workers/config.mjs";
+import { DAY_PATTERN } from "../workers/request-params.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { d1TimeoutMs, withTimeout } from "../workers/storage.mjs";
 import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
@@ -901,6 +902,16 @@ function optionalString(args, key) {
     );
   }
   return value.trim();
+}
+
+// Optional YYYY-MM-DD day bound — mirrors parseDateRange() on REST history routes.
+function optionalDayArg(args, key) {
+  const value = optionalString(args, key);
+  if (value === null) return null;
+  if (!DAY_PATTERN.test(value)) {
+    throw toolError("invalid_params", "from/to must be YYYY-MM-DD dates.");
+  }
+  return value;
 }
 
 // Require a bare SS58 address (hotkey or coldkey) — the same shape the REST
@@ -2716,10 +2727,9 @@ export const MCP_TOOLS = [
     },
     async handler(args, ctx) {
       const ss58 = requireSs58(args);
-      const netuid =
-        typeof args?.netuid === "number" ? Math.floor(args.netuid) : undefined;
-      const from = optionalString(args, "from");
-      const to = optionalString(args, "to");
+      const netuid = optionalNonNegativeInt(args, "netuid") ?? undefined;
+      const from = optionalDayArg(args, "from");
+      const to = optionalDayArg(args, "to");
       const cursor = optionalString(args, "cursor");
       return loadAccountHistory(mcpD1Runner(ctx), ss58, {
         netuid,

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6717,6 +6717,24 @@ describe("MCP account tail tools (history, extrinsics, transfers)", () => {
     assert.deepEqual(res.body.result.structuredContent.days, []);
   });
 
+  test("get_account_history rejects malformed from/to dates before D1", async () => {
+    const res = await callTool("get_account_history", {
+      ss58: SS58,
+      from: "June",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /YYYY-MM-DD/i);
+  });
+
+  test("get_account_history rejects a non-integer netuid filter", async () => {
+    const res = await callTool("get_account_history", {
+      ss58: SS58,
+      netuid: 7.5,
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /netuid/i);
+  });
+
   test("get_account_extrinsics returns signed extrinsics with correct fields", async () => {
     const env = tailD1({
       extrinsics: [


### PR DESCRIPTION
## Summary

`get_account_history` MCP passed `from`/`to` strings straight to `loadAccountHistory()` without validating the `YYYY-MM-DD` shape. REST `GET /api/v1/accounts/{ss58}/history` already rejects malformed dates via `parseDateRange()` with 400 — MCP now mirrors that validation before any D1 query.

## What Changed

- `src/mcp-server.mjs`: add `optionalDayArg()` using shared `DAY_PATTERN`; use it in `get_account_history` for `from`/`to`; tighten optional `netuid` through `optionalNonNegativeInt` (rejects floats like REST).
- `tests/mcp-server.test.mjs`: reject `from: "June"` and non-integer `netuid` before D1.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run lint`
- [x] `npx vitest run tests/mcp-server.test.mjs -t "get_account_history"`
- [x] `npm run check` (CI)

## Distinct from other open PRs

No overlap with extrinsic events embed (#2770), turnover `changes` (#2747), `list_global_validators` (#2764), or unknown event kind (#2739). Validation-only MCP parity; no SemVer bump (additive error path, no schema change).