### PR TITLE
feat(api): add netuid filter to account events route (#2585)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -79,7 +79,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
+        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
         get: operations["accountEvents"];
         put?: never;
         post?: never;
@@ -6096,6 +6096,7 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: string;
+                netuid?: number;
                 block_start?: number;
                 block_end?: number;
                 limit?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4701,7 +4701,7 @@
     {
       "artifact_path": "/metagraph/accounts/{ss58}/events.json",
       "cache": "short",
-      "description": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+      "description": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
       "id": "account-events",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/events",
@@ -4713,6 +4713,13 @@
           "name": "kind",
           "schema": {
             "type": "string"
+          }
+        },
+        {
+          "name": "netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
           }
         },
         {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -16194,6 +16194,15 @@
           },
           {
             "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
             "name": "block_start",
             "required": false,
             "schema": {
@@ -16356,7 +16365,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+        "summary": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
         "tags": [
           "accounts",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -79,7 +79,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
+        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
         get: operations["accountEvents"];
         put?: never;
         post?: never;
@@ -6096,6 +6096,7 @@ export interface operations {
         parameters: {
             query?: {
                 kind?: string;
+                netuid?: number;
                 block_start?: number;
                 block_end?: number;
                 limit?: number;

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -696,7 +696,7 @@ export async function loadAccountSummary(d1, ss58) {
 export async function loadAccountEvents(
   d1,
   ss58,
-  { limit, offset, kind, cursor, blockStart, blockEnd } = {},
+  { limit, offset, kind, netuid, cursor, blockStart, blockEnd } = {},
 ) {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
@@ -714,6 +714,10 @@ export async function loadAccountEvents(
   if (kind) {
     filterParts.push("AND event_kind = ?");
     filterParams.push(kind);
+  }
+  if (netuid != null) {
+    filterParts.push("AND netuid = ?");
+    filterParams.push(netuid);
   }
   // Block-height range filter, parity with the extrinsics and chain-events
   // feeds: the per-branch hotkey/coldkey indexes both lead block_number, so a

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2008,11 +2008,12 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/events",
     "/metagraph/accounts/{ss58}/events.json",
-    "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+    "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
     "short",
     ["accounts", "analytics"],
     [
       { name: "kind", schema: { type: "string" } },
+      { name: "netuid", schema: { type: "integer", minimum: 0 } },
       { name: "block_start", schema: { type: "integer", minimum: 0 } },
       { name: "block_end", schema: { type: "integer", minimum: 0 } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -1325,6 +1325,42 @@ test("loadAccountEvents applies the ?kind filter as a bound param", async () => 
   ]);
 });
 
+test("loadAccountEvents applies the ?netuid filter as a bound param on both branches", async () => {
+  let captured;
+  await loadAccountEvents(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [];
+    },
+    "5Hk",
+    { netuid: 7 },
+  );
+  assert.ok(/AND netuid = \?/.test(captured.sql));
+  assert.equal(captured.sql.match(/AND netuid = \?/g)?.length, 2);
+  assert.deepEqual(captured.params, [
+    "5Hk",
+    7,
+    "5Hk",
+    "5Hk",
+    7,
+    100,
+    0,
+  ]);
+});
+
+test("loadAccountEvents omits netuid filter when absent", async () => {
+  let captured;
+  await loadAccountEvents(
+    async (sql, params) => {
+      captured = { sql, params };
+      return [];
+    },
+    "5Hk",
+    {},
+  );
+  assert.ok(!/AND netuid = \?/.test(captured.sql));
+});
+
 test("loadAccountEvents short-circuits an inverted block range before D1", async () => {
   let called = false;
   const out = await loadAccountEvents(

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -1337,15 +1337,7 @@ test("loadAccountEvents applies the ?netuid filter as a bound param on both bran
   );
   assert.ok(/AND netuid = \?/.test(captured.sql));
   assert.equal(captured.sql.match(/AND netuid = \?/g)?.length, 2);
-  assert.deepEqual(captured.params, [
-    "5Hk",
-    7,
-    "5Hk",
-    "5Hk",
-    7,
-    100,
-    0,
-  ]);
+  assert.deepEqual(captured.params, ["5Hk", 7, "5Hk", "5Hk", 7, 100, 0]);
 });
 
 test("loadAccountEvents omits netuid filter when absent", async () => {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2018,6 +2018,70 @@ describe("handleAccountEvents", () => {
     assert.equal(body.meta.parameter, "block_end");
   });
 
+  test("rejects a malformed netuid with 400", async () => {
+    const res = await handleAccountEvents(
+      req(`/api/v1/accounts/${SS58}/events`),
+      emptyEnv(),
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events?netuid=abc`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "netuid");
+  });
+
+  test("netuid filter narrows results to one subnet", async () => {
+    const { env, captures } = dbWith({
+      accountEvents: [accountEventRow({ netuid: 7 })],
+    });
+    await handleAccountEvents(
+      req(`/api/v1/accounts/${SS58}/events`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events?netuid=7`),
+    );
+    assert.ok(
+      captures.sql.some((s) => /AND netuid = \?/.test(s)),
+      "expected netuid filter in SQL",
+    );
+    const eventsSql = captures.sql.find((s) => /FROM account_events/.test(s));
+    assert.equal(
+      eventsSql.match(/AND netuid = \?/g)?.length,
+      2,
+      "expected netuid filter on both union branches",
+    );
+  });
+
+  test("netuid absent leaves the feed unfiltered", async () => {
+    const { env, captures } = dbWith({
+      accountEvents: [accountEventRow()],
+    });
+    await handleAccountEvents(
+      req(`/api/v1/accounts/${SS58}/events`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events`),
+    );
+    assert.ok(
+      captures.sql.every((s) => !/AND netuid = \?/.test(s)),
+      "expected no netuid filter when param is absent",
+    );
+  });
+
+  test("netuid combines with kind filter", async () => {
+    const { env, captures } = dbWith({
+      accountEvents: [accountEventRow({ event_kind: "WeightsSet", netuid: 3 })],
+    });
+    await handleAccountEvents(
+      req(`/api/v1/accounts/${SS58}/events`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events?netuid=3&kind=WeightsSet`),
+    );
+    const eventsSql = captures.sql.find((s) => /FROM account_events/.test(s));
+    assert.ok(/AND event_kind = \?/.test(eventsSql));
+    assert.equal(eventsSql.match(/AND netuid = \?/g)?.length, 2);
+  });
+
   test("short-circuits an inverted block_start>block_end window before D1", async () => {
     const { env, captures } = dbWith({
       accountEvents: [accountEventRow()],

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -853,6 +853,7 @@ export async function handleAccount(request, env, ss58) {
 export async function handleAccountEvents(request, env, ss58, url) {
   const validationError = validateQueryParams(url, [
     "kind",
+    "netuid",
     "block_start",
     "block_end",
     "limit",
@@ -874,6 +875,11 @@ export async function handleAccountEvents(request, env, ss58, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
+  const netuid = parseNonNegativeIntParam(
+    url.searchParams.get("netuid"),
+    "netuid",
+  );
+  if (netuid.error) return analyticsQueryError(netuid.error);
   const kind = url.searchParams.get("kind");
   // Reject an unknown ?kind= up front, validated against the FULL ingested set
   // (not just INDEXED_EVENT_KINDS, which would wrongly reject Transfer/NetworkAdded
@@ -890,6 +896,7 @@ export async function handleAccountEvents(request, env, ss58, url) {
     limit: url.searchParams.get("limit"),
     offset: url.searchParams.get("offset"),
     kind,
+    netuid: netuid.value,
     cursor: url.searchParams.get("cursor"),
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,


### PR DESCRIPTION
## Summary

- Add optional `?netuid=` query parameter to `GET /api/v1/accounts/{ss58}/events`, matching the sibling `/history` route and letting callers scope an account's event stream to one subnet.
- Validate `netuid` as a non-negative safe integer (400 on malformed input) and thread it into `loadAccountEvents` as a bound `AND netuid = ?` predicate on both indexed UNION branches.
- Update the route contract and regenerate OpenAPI/types; add handler and loader tests for netuid filtering, malformed input, absent param, and netuid+kind combination.

Closes #2585

## Test plan

- [x] `npx vitest run tests/account-events.test.mjs tests/request-handlers-entities.test.mjs -t "handleAccountEvents|loadAccountEvents"`
- [x] `npm run build` (reverted deploy-owned `r2-manifest.json` and `schemas/index.json`)
- [x] `npm run validate` (full CI gate before push)