### PR TITLE
feat(mcp): add get_network_health mirroring GET /api/v1/health

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -554,6 +554,13 @@ assert.ok(
     Array.isArray(healthTrendsCold.windows["7d"].subnets),
   "get_health_trends must return windows.7d.subnets[] on cold D1",
 );
+const networkHealthCold = await callOk("get_network_health", {});
+assert.ok(
+  networkHealthCold.scope === "operational" &&
+    networkHealthCold.global &&
+    Array.isArray(networkHealthCold.subnets),
+  "get_network_health must return scope + global + subnets[] on cold KV",
+);
 const blockExtrinsicsCold = await callOk("list_block_extrinsics", {
   ref: "4200000",
 });

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/global-operational-health.mjs
+++ b/src/global-operational-health.mjs
@@ -1,0 +1,81 @@
+// Global operational health loader for REST + MCP parity on GET /api/v1/health.
+// Live-only: KV health:current → D1 surface_status, with an explicit unknown
+// payload when the live store is cold (never a stale baked fallback).
+
+import { buildGlobalHealth, resolveLiveHealth } from "./health-serving.mjs";
+
+export function unknownGlobalHealth(contractVersionValue) {
+  return {
+    schema_version: 1,
+    contract_version: contractVersionValue,
+    source: "unavailable",
+    scope: "operational",
+    operational_observed_at: null,
+    health_source: "unavailable",
+    global: {
+      surface_count: 0,
+      status_counts: { ok: 0, degraded: 0, failed: 0, unknown: 0 },
+    },
+    subnets: [],
+  };
+}
+
+export async function loadGlobalOperationalHealth(
+  { env, readHealthKv, db },
+  { contractVersion } = {},
+) {
+  const contractVersionValue =
+    typeof contractVersion === "function"
+      ? contractVersion(env)
+      : contractVersion;
+  const liveSnapshot = await resolveLiveHealth({
+    readHealthKv,
+    env,
+    db: db ?? env?.METAGRAPH_HEALTH_DB,
+  });
+  const liveData = liveSnapshot
+    ? buildGlobalHealth(liveSnapshot, {
+        contract_version: contractVersionValue,
+      })
+    : null;
+  return liveData || unknownGlobalHealth(contractVersionValue);
+}
+
+export const GET_NETWORK_HEALTH_INSTRUCTIONS =
+  "get_network_health the live global operational rollup " +
+  "(per-subnet surface status + global counts), ";
+
+export const GET_NETWORK_HEALTH_MCP_TOOL = {
+  name: "get_network_health",
+  title: "Get global operational health",
+  description:
+    "Fetch the live global operational health rollup: global surface counts " +
+    "by status (ok/degraded/failed/unknown) and per-subnet operational status " +
+    "from the ~15-minute health prober (KV health:current → D1 surface_status). " +
+    "Use it for a network-wide health snapshot before drilling into " +
+    "get_subnet_health or get_health_trends. Mirrors GET /api/v1/health.",
+  inputSchema: {
+    type: "object",
+    properties: {},
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+
+export const GET_NETWORK_HEALTH_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["schema_version", "scope", "global", "subnets"],
+  properties: {
+    schema_version: { type: "integer" },
+    contract_version: { type: ["integer", "string", "null"] },
+    generated_at: NULLABLE_STRING,
+    source: NULLABLE_STRING,
+    health_source: NULLABLE_STRING,
+    scope: { type: "string" },
+    operational_observed_at: NULLABLE_STRING,
+    global: { type: "object" },
+    subnets: { type: "array", items: { type: "object" } },
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -25,6 +25,12 @@ import {
   loadNetworkEconomics,
 } from "./network-economics.mjs";
 import {
+  GET_NETWORK_HEALTH_INSTRUCTIONS,
+  GET_NETWORK_HEALTH_MCP_TOOL,
+  GET_NETWORK_HEALTH_OUTPUT_SCHEMA,
+  loadGlobalOperationalHealth,
+} from "./global-operational-health.mjs";
+import {
   loadChainConcentration,
   loadSubnetConcentration,
   loadSubnetConcentrationHistory,
@@ -172,7 +178,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.19.0";
+export const MCP_SERVER_VERSION = "1.20.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -239,7 +245,9 @@ export const MCP_INSTRUCTIONS =
   "get_economics_trends the network-wide " +
   "per-day economics series (stake, alpha price, validator/miner counts), " +
   "get_subnet_trajectory its week-over-week trend, get_subnet_uptime its " +
-  "long-term surface uptime history, get_health_trends the all-subnet 7d/30d " +
+  "long-term surface uptime history, " +
+  GET_NETWORK_HEALTH_INSTRUCTIONS +
+  "get_health_trends the all-subnet 7d/30d " +
   "uptime + latency matrix, get_subnet_health_trends one subnet's per-surface " +
   "health trends, get_subnet_health_percentiles its " +
   "per-surface p50/p95/p99 request-latency distribution, " +
@@ -1544,6 +1552,19 @@ export const MCP_TOOLS = [
       );
       const live = await mcpLiveHealth(ctx);
       return overlayOverviewHealth(overview, live, netuid) || overview;
+    },
+  },
+  {
+    ...GET_NETWORK_HEALTH_MCP_TOOL,
+    async handler(_args, ctx) {
+      return loadGlobalOperationalHealth(
+        {
+          env: ctx.env,
+          readHealthKv: ctx.readHealthKv,
+          db: ctx.env?.METAGRAPH_HEALTH_DB,
+        },
+        { contractVersion: () => mcpContractVersion(ctx) },
+      );
     },
   },
   {
@@ -4943,6 +4964,7 @@ const TOOL_OUTPUT_SCHEMAS = {
     },
   },
   get_economics: GET_ECONOMICS_OUTPUT_SCHEMA,
+  get_network_health: GET_NETWORK_HEALTH_OUTPUT_SCHEMA,
   get_subnet_trajectory: {
     type: "object",
     additionalProperties: true,

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -1,12 +1,19 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { describe, test, vi } from "vitest";
 import Ajv2020 from "ajv/dist/2020.js";
+import * as healthServing from "../src/health-serving.mjs";
 import {
+  GET_NETWORK_HEALTH_INSTRUCTIONS,
   GET_NETWORK_HEALTH_MCP_TOOL,
   GET_NETWORK_HEALTH_OUTPUT_SCHEMA,
   loadGlobalOperationalHealth,
   unknownGlobalHealth,
 } from "../src/global-operational-health.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
 
 const FRESH_RUN = new Date(Date.now() - 60_000).toISOString();
 
@@ -58,12 +65,63 @@ describe("global-operational-health", () => {
     assert.equal(out.global.surface_count, 0);
   });
 
+  test("accepts a static contractVersion without calling it as a function", async () => {
+    const out = await loadGlobalOperationalHealth(
+      { env: {}, readHealthKv: async () => null },
+      { contractVersion: 77 },
+    );
+    assert.equal(out.contract_version, 77);
+    assert.equal(out.health_source, "unavailable");
+  });
+
+  test("falls back to unknown when live KV lacks a summary block", async () => {
+    const out = await loadGlobalOperationalHealth(
+      {
+        env: {},
+        readHealthKv: async (_env, key) =>
+          key === "health:current" ? { generated_at: "2026-06-11T00:00:00.000Z" } : null,
+      },
+      { contractVersion: () => 5 },
+    );
+    assert.equal(out.health_source, "unavailable");
+    assert.equal(out.contract_version, 5);
+  });
+
+  test("forwards an explicit db binding instead of env.METAGRAPH_HEALTH_DB", async () => {
+    const seen = { db: null };
+    const spy = vi
+      .spyOn(healthServing, "resolveLiveHealth")
+      .mockImplementation(async ({ db }) => {
+        seen.db = db;
+        return null;
+      });
+    try {
+      const explicitDb = { prepare: () => ({}) };
+      await loadGlobalOperationalHealth(
+        { env: { METAGRAPH_HEALTH_DB: { prepare: () => ({}) } }, readHealthKv: async () => null, db: explicitDb },
+        { contractVersion: () => 1 },
+      );
+      assert.equal(seen.db, explicitDb);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   test("MCP tool metadata and outputSchema compile", () => {
     assert.equal(GET_NETWORK_HEALTH_MCP_TOOL.name, "get_network_health");
+    assert.match(GET_NETWORK_HEALTH_INSTRUCTIONS, /get_network_health/);
     assert.deepEqual(
       Object.keys(GET_NETWORK_HEALTH_MCP_TOOL.inputSchema.properties),
       [],
     );
-    assert.ok(new Ajv2020().compile(GET_NETWORK_HEALTH_OUTPUT_SCHEMA));
+    assert.ok(new Ajv2020({ strict: false }).compile(GET_NETWORK_HEALTH_OUTPUT_SCHEMA));
+  });
+
+  test("MCP server exports wire get_network_health at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.20.0");
+    assert.match(MCP_INSTRUCTIONS, /get_network_health/);
+    const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
+    assert.ok(tool?.handler);
+    assert.equal(tool.title, GET_NETWORK_HEALTH_MCP_TOOL.title);
   });
 });

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -79,7 +79,9 @@ describe("global-operational-health", () => {
       {
         env: {},
         readHealthKv: async (_env, key) =>
-          key === "health:current" ? { generated_at: "2026-06-11T00:00:00.000Z" } : null,
+          key === "health:current"
+            ? { generated_at: "2026-06-11T00:00:00.000Z" }
+            : null,
       },
       { contractVersion: () => 5 },
     );
@@ -98,7 +100,11 @@ describe("global-operational-health", () => {
     try {
       const explicitDb = { prepare: () => ({}) };
       await loadGlobalOperationalHealth(
-        { env: { METAGRAPH_HEALTH_DB: { prepare: () => ({}) } }, readHealthKv: async () => null, db: explicitDb },
+        {
+          env: { METAGRAPH_HEALTH_DB: { prepare: () => ({}) } },
+          readHealthKv: async () => null,
+          db: explicitDb,
+        },
         { contractVersion: () => 1 },
       );
       assert.equal(seen.db, explicitDb);
@@ -114,7 +120,9 @@ describe("global-operational-health", () => {
       Object.keys(GET_NETWORK_HEALTH_MCP_TOOL.inputSchema.properties),
       [],
     );
-    assert.ok(new Ajv2020({ strict: false }).compile(GET_NETWORK_HEALTH_OUTPUT_SCHEMA));
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(GET_NETWORK_HEALTH_OUTPUT_SCHEMA),
+    );
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import {
+  GET_NETWORK_HEALTH_MCP_TOOL,
+  GET_NETWORK_HEALTH_OUTPUT_SCHEMA,
+  loadGlobalOperationalHealth,
+  unknownGlobalHealth,
+} from "../src/global-operational-health.mjs";
+
+const FRESH_RUN = new Date(Date.now() - 60_000).toISOString();
+
+const LIVE_KV = {
+  generated_at: "2026-06-11T00:00:00.000Z",
+  last_run_at: FRESH_RUN,
+  health_source: "live-cron-prober",
+  summary: {
+    surface_count: 58,
+    status_counts: { ok: 57, degraded: 1, failed: 0, unknown: 0 },
+  },
+  subnets: [{ netuid: 0, status: "ok", surface_count: 2, ok_count: 2 }],
+};
+
+function readHealthKv(_env, key) {
+  if (key === "health:current") return Promise.resolve(LIVE_KV);
+  return Promise.resolve(null);
+}
+
+describe("global-operational-health", () => {
+  test("unknownGlobalHealth is schema-stable when the live store is cold", () => {
+    const out = unknownGlobalHealth(42);
+    assert.equal(out.scope, "operational");
+    assert.equal(out.health_source, "unavailable");
+    assert.equal(out.global.surface_count, 0);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.contract_version, 42);
+  });
+
+  test("loadGlobalOperationalHealth builds the live global rollup from KV", async () => {
+    const out = await loadGlobalOperationalHealth(
+      { env: {}, readHealthKv },
+      { contractVersion: () => 99 },
+    );
+    assert.equal(out.scope, "operational");
+    assert.equal(out.health_source, "live-cron-prober");
+    assert.equal(out.operational_observed_at, FRESH_RUN);
+    assert.equal(out.global.surface_count, 58);
+    assert.equal(out.subnets[0].netuid, 0);
+    assert.equal(out.contract_version, 99);
+  });
+
+  test("loadGlobalOperationalHealth returns unknown when KV is cold", async () => {
+    const out = await loadGlobalOperationalHealth(
+      { env: {}, readHealthKv: async () => null },
+      { contractVersion: () => 1 },
+    );
+    assert.equal(out.health_source, "unavailable");
+    assert.equal(out.global.surface_count, 0);
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(GET_NETWORK_HEALTH_MCP_TOOL.name, "get_network_health");
+    assert.deepEqual(
+      Object.keys(GET_NETWORK_HEALTH_MCP_TOOL.inputSchema.properties),
+      [],
+    );
+    assert.ok(new Ajv2020().compile(GET_NETWORK_HEALTH_OUTPUT_SCHEMA));
+  });
+});

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -580,6 +580,35 @@ describe("get_economics — branch coverage", () => {
   });
 });
 
+// ── get_network_health — global operational rollup ──────────────────────
+describe("get_network_health — branch coverage", () => {
+  test("serves unknown when ctx has no METAGRAPH_HEALTH_DB binding", async () => {
+    const res = await callTool("get_network_health", {}, { env: {} });
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.health_source, "unavailable");
+    assert.equal(out.global.surface_count, 0);
+  });
+
+  test("overlays live KV when health:current is present", async () => {
+    const deps = makeDeps(
+      {},
+      {
+        "health:current": {
+          last_run_at: FRESH_RUN,
+          summary: { surface_count: 3, status_counts: { ok: 3 } },
+          subnets: [{ netuid: 1, status: "ok" }],
+        },
+      },
+    );
+    const res = await callTool("get_network_health", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.health_source, "live-cron-prober");
+    assert.equal(out.global.surface_count, 3);
+    assert.equal(out.subnets[0].netuid, 1);
+  });
+});
+
 // ── list_subnet_apis fallbacks ────────────────────────────
 describe("list_subnet_apis — detail fallback fields", () => {
   test("falls back to the requested netuid + empty services when detail is bare", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5668,6 +5668,51 @@ describe("MCP economics + metagraph data tools", () => {
     assert.deepEqual(out.windows["30d"].subnets, []);
   });
 
+  test("get_network_health returns unknown when the live store is cold", async () => {
+    const res = await callTool("get_network_health", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.scope, "operational");
+    assert.equal(out.health_source, "unavailable");
+    assert.equal(out.global.surface_count, 0);
+    assert.deepEqual(out.subnets, []);
+  });
+
+  test("get_network_health overlays the live KV rollup", async () => {
+    const globalLiveKv = {
+      generated_at: "2026-06-11T00:00:00.000Z",
+      last_run_at: FRESH_RUN,
+      health_source: "live-cron-prober",
+      summary: {
+        surface_count: 58,
+        status_counts: { ok: 57, degraded: 1, failed: 0, unknown: 0 },
+      },
+      subnets: [{ netuid: 0, status: "ok", surface_count: 2, ok_count: 2 }],
+    };
+    const deps = makeDeps({}, { "health:current": globalLiveKv });
+    const res = await callTool("get_network_health", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.health_source, "live-cron-prober");
+    assert.equal(out.operational_observed_at, FRESH_RUN);
+    assert.equal(out.global.surface_count, 58);
+    assert.equal(out.subnets[0].netuid, 0);
+  });
+
+  test("get_network_health payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_network_health",
+    )?.outputSchema;
+    const globalLiveKv = {
+      last_run_at: FRESH_RUN,
+      summary: { surface_count: 1, status_counts: { ok: 1 } },
+      subnets: [{ netuid: 0, status: "ok" }],
+    };
+    const deps = makeDeps({}, { "health:current": globalLiveKv });
+    const res = await callTool("get_network_health", {}, { deps });
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("get_health_trends aggregates bulk trend rows from D1", async () => {
     const env = {
       METAGRAPH_HEALTH_DB: {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -162,7 +162,6 @@ import {
 } from "../src/health-prober.mjs";
 import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.mjs";
 import {
-  buildGlobalHealth,
   mergeFreshness,
   mergeRpcEndpoints,
   overlayArtifactEndpoints,
@@ -208,6 +207,7 @@ import {
   economicsSnapshotUpsertStatements,
   validEconomicsBackfillRows,
 } from "../src/economics-backfill.mjs";
+import { loadGlobalOperationalHealth } from "../src/global-operational-health.mjs";
 import { handleMcpRequest } from "../src/mcp-server.mjs";
 import { handleFeedRequest, resolveFeedFormat } from "../src/feeds.mjs";
 import { handleBadgeRequest } from "../src/badge.mjs";
@@ -2420,17 +2420,12 @@ async function handleApiRequest(
     // Live-only global operational health: KV health:current → D1
     // surface_status, and an explicit `unknown` global when the live store is
     // cold. There is no stored health summary to fall back to (live-only).
-    const liveSnapshot = await resolveLiveHealth({
-      readHealthKv,
-      env,
-      db: env.METAGRAPH_HEALTH_DB,
-    });
-    const liveData = liveSnapshot
-      ? buildGlobalHealth(liveSnapshot, {
-          contract_version: contractVersion(env),
-        })
-      : null;
-    live = { data: liveData || unknownGlobalHealth(contractVersion(env)) };
+    live = {
+      data: await loadGlobalOperationalHealth(
+        { env, readHealthKv, db: env.METAGRAPH_HEALTH_DB },
+        { contractVersion: (e) => contractVersion(e) },
+      ),
+    };
     artifact = { ok: false };
   } else if (matched.id === "subnet-health") {
     artifact = { ok: false };
@@ -3293,24 +3288,6 @@ async function handleAskRequest(request, env) {
       502,
     );
   }
-}
-
-// Explicit `unknown` health payloads for the live-only routes when the live
-// store (KV + D1) is cold — served instead of a stale baked value or a 404.
-function unknownGlobalHealth(contractVersionValue) {
-  return {
-    schema_version: 1,
-    contract_version: contractVersionValue,
-    source: "unavailable",
-    scope: "operational",
-    operational_observed_at: null,
-    health_source: "unavailable",
-    global: {
-      surface_count: 0,
-      status_counts: { ok: 0, degraded: 0, failed: 0, unknown: 0 },
-    },
-    subnets: [],
-  };
 }
 
 function unknownSubnetHealth(netuid) {


### PR DESCRIPTION
## Summary

Adds **`get_network_health`** MCP tool for the live global operational health rollup (`GET /api/v1/health`): global surface status counts and per-subnet operational status from the ~15-minute prober (KV `health:current` → D1 `surface_status`).

- Extracts shared loader in `src/global-operational-health.mjs`; REST health route reuses it (no behavior change).
- MCP SemVer **1.19.0 → 1.20.0** (`server.json` + `MCP_SERVER_VERSION`).
- Unit + MCP tests; `validate-mcp` cold-path check.

7 files, +234/−33.

## Distinct from open/merged work

| PR | Relationship |
|----|----------------|
| **#2770** | `get_extrinsic_chain_events` / extrinsic embed — no overlap |
| **#2764** | `list_global_validators` — different endpoint |
| **#2747** | turnover `changes` filter — no overlap |
| **#2773** | account-history date validation (fix) — different tool |
| **#2735** (merged) | `get_economics` — no overlap |
| Existing tools | `get_health_trends` = bulk 7d/30d matrix; `get_subnet_health` = per-subnet — this is the **global snapshot** |

Touches `mcp-server.mjs` health-tool region (~1550) only; avoids extrinsic/validator/turnover areas claimed by open PRs.

## Test plan

- [x] `npm run lint` / `format:check`
- [x] `vitest run tests/global-operational-health.test.mjs`
- [x] MCP tests for `get_network_health` (cold KV + live overlay + outputSchema)
- [x] `node scripts/validate-mcp.mjs` (75 tools)
- [x] `/api/v1/health` regression (`tests/health-serving.test.mjs`)

