### PR TITLE
fix(account-events): reject zero/blank observed_at cells to avoid epoch 1970

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -80,9 +80,15 @@ export const INGESTED_EVENT_KINDS = [
 ];
 
 function toIso(ms) {
+  // D1 can return the INTEGER observed_at as a numeric string; coerce first, and
+  // require n > 0 so a null/blank/zero/invalid cell stays null instead of epoch
+  // 1970. Mirrors the toIso guards in blocks.mjs (#2708) and extrinsics.mjs
+  // (#2714).
   if (ms == null) return null;
   const n = Number(ms);
-  return Number.isFinite(n) ? new Date(n).toISOString() : null;
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const d = new Date(n);
+  return Number.isFinite(d.getTime()) ? d.toISOString() : null;
 }
 
 // Coerce a block height or index cell to a non-negative integer, or null when

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -189,6 +189,21 @@ test("formatAccountEvent drops invalid observed_at strings to null", () => {
   assert.equal(out.observed_at, null);
 });
 
+test("formatAccountEvent drops zero/blank observed_at to null (not epoch 1970)", () => {
+  for (const observed_at of [0, "0", "", "   "]) {
+    const out = formatAccountEvent({
+      block_number: 1,
+      event_kind: "Transfer",
+      observed_at,
+    });
+    assert.equal(
+      out.observed_at,
+      null,
+      `observed_at=${JSON.stringify(observed_at)} must not become epoch 1970`,
+    );
+  }
+});
+
 test("buildAccountTransfers coerces string-typed observed_at cells to ISO timestamps", () => {
   const out = buildAccountTransfers(
     [

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -204,6 +204,21 @@ test("formatAccountEvent drops zero/blank observed_at to null (not epoch 1970)",
   }
 });
 
+test("formatAccountEvent drops out-of-range observed_at to null", () => {
+  for (const observed_at of ["8640000000000001", 8640000000000001]) {
+    const out = formatAccountEvent({
+      block_number: 1,
+      event_kind: "Transfer",
+      observed_at,
+    });
+    assert.equal(
+      out.observed_at,
+      null,
+      `observed_at=${JSON.stringify(observed_at)} must not leak an invalid ISO string`,
+    );
+  }
+});
+
 test("buildAccountTransfers coerces string-typed observed_at cells to ISO timestamps", () => {
   const out = buildAccountTransfers(
     [


### PR DESCRIPTION
## Summary
- Harden `toIso` in `src/account-events.mjs` so zero, blank, or non-positive `observed_at` cells return `null` instead of `1970-01-01T00:00:00.000Z`
- Aligns account-event formatters with the guards already applied in `blocks.mjs` (#2708) and `extrinsics.mjs` (#2714)
- Covers `formatAccountEvent`, transfer rows, and account summary timestamp fields that share the same helper

## Test plan
- [x] `npm test -- tests/account-events.test.mjs`
- [x] New regression: `formatAccountEvent` drops `observed_at` values `0`, `"0"`, `""`, and `"   "` to `null`