### PR TITLE
fix(metagraph-neurons): coerce string-typed captured_at cells in the snapshot stamp + neuron detail

### DIFF
--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -50,7 +50,16 @@ const GLOBAL_VALIDATOR_SUBNET_LIMIT = 10;
 const RAO_PER_TAO = 1e9;
 
 function toIso(ms) {
-  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+  // D1 can return the INTEGER captured_at as a numeric string; a bare
+  // Number.isFinite(ms) is false for a string, so the old form dropped a real
+  // snapshot timestamp to null. Coerce first and require n > 0 so null/blank/
+  // invalid cells stay null (never epoch 1970). Mirrors the blocks/extrinsics
+  // toIso fixes (#2708/#2714) and the captured_at coercion in #2725.
+  if (ms == null) return null;
+  const n = Number(ms);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const d = new Date(n);
+  return Number.isFinite(d.getTime()) ? d.toISOString() : null;
 }
 
 function numberOrZero(value) {

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -260,6 +260,36 @@ describe("metagraph-neurons builders", () => {
     );
   });
 
+  test("coerces a string-typed D1 captured_at to an ISO timestamp in the snapshot stamp + neuron detail", () => {
+    // captured_at is a D1 INTEGER (epoch ms) that can come back as a numeric
+    // string; the old Number.isFinite(string) guard dropped a real timestamp to
+    // null. Coerce it like block_number beside it. Mirrors #2714/#2725.
+    const iso = new Date(1750000000000).toISOString();
+    const meta = buildSubnetMetagraph(
+      [{ ...ROW, captured_at: "1750000000000" }],
+      7,
+    );
+    assert.equal(meta.captured_at, iso);
+    const vals = buildSubnetValidators(
+      [{ ...ROW, captured_at: "1750000000000" }],
+      7,
+    );
+    assert.equal(vals.captured_at, iso);
+    const detail = buildNeuronDetail(
+      { ...ROW, captured_at: "1750000000000" },
+      7,
+    );
+    assert.equal(detail.captured_at, iso);
+    // null / blank / invalid stay null (never epoch 1970).
+    for (const captured_at of [null, "", "not-a-date"]) {
+      assert.equal(
+        buildNeuronDetail({ ...ROW, captured_at }, 7).captured_at,
+        null,
+        `captured_at=${JSON.stringify(captured_at)}`,
+      );
+    }
+  });
+
   test("buildGlobalValidators groups validator identities across subnets", () => {
     const data = buildGlobalValidators(
       [

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -280,8 +280,10 @@ describe("metagraph-neurons builders", () => {
       7,
     );
     assert.equal(detail.captured_at, iso);
-    // null / blank / invalid stay null (never epoch 1970).
-    for (const captured_at of [null, "", "not-a-date"]) {
+    // null / blank / invalid / out-of-range stay null (never epoch 1970, never
+    // a RangeError). 8.64e15 ms is the max valid Date, so 8640000000000001 is
+    // finite but new Date(n) is an Invalid Date.
+    for (const captured_at of [null, "", "not-a-date", 8640000000000001]) {
       assert.equal(
         buildNeuronDetail({ ...ROW, captured_at }, 7).captured_at,
         null,


### PR DESCRIPTION
## Summary

`metagraph-neurons` `toIso` used `Number.isFinite(ms)`, which is `false` for a string, so a D1 numeric-string `captured_at` dropped a real snapshot timestamp to `null` in `buildSubnetMetagraph` / `buildSubnetValidators` (via `snapshotStamp`) and `buildNeuronDetail`. These serve `captured_at` on `GET /api/v1/subnets/{netuid}/metagraph`, `.../validators`, and `.../neurons/{uid}`.

This is the identical D1 numeric-string epoch-ms class the maintainers have been closing across the tiers — `blocks`/`extrinsics` `toIso` (#2708/#2714), concentration `captureStamp` (#2725), and the stake/yield epoch-ms sweep (#2726). `metagraph-neurons` was the remaining holdout: `block_number` right beside `captured_at` in `snapshotStamp`/`buildNeuronDetail` was already coerced (#2611/#2623), but `captured_at` still used the old `toIso`.

## What Changed

- `src/metagraph-neurons.mjs` — harden `toIso` to coerce with `Number()` first and require `n > 0` (rejecting a null/blank/invalid cell to `null`, never epoch 1970), byte-identical to the `blocks.mjs` fix in #2708. A numeric-string `"1750000000000"` now becomes the ISO timestamp; `null`/blank/invalid stay `null`.
- `tests/metagraph-neurons.test.mjs` — regression test mirroring the existing `block_number` string-coercion test: a string `captured_at` coerces to ISO across `buildSubnetMetagraph` / `buildSubnetValidators` / `buildNeuronDetail`, and null/blank/invalid stay null.

Contract: the affected `captured_at` fields are `{"type":["string","null"],"format":"date-time"}`. No schema change — this aligns runtime output with the contract.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (no contract change)

## Validation

- [x] `npx vitest run tests/metagraph-neurons.test.mjs` — 41 passed (incl. the new case)
- [x] Confirmed the coercion test **fails on the pre-fix tree** (`captured_at` was `null`) and **passes after** the fix
- [x] `npx eslint` + `npx prettier --check --end-of-line auto` on both files — clean
- [x] `git diff --check` — clean
