### PR TITLE
feat(feeds): add a ?limit= item cap to the registry/incident feeds

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -30,6 +30,10 @@
 // inclusive of the whole UTC day (end-of-day), so `?until=2026-06-30` keeps
 // every item from June 30 rather than only the midnight tick — symmetric with
 // the inclusive start-of-day a bare-date `?since=` resolves to.
+//
+// Optional `?limit=<1..50>` caps the number of returned items (default/max 50);
+// it composes with `?since=`/`?until=`/`?tag=` and clamps a larger value to the
+// 50-item hard cap. A non-integer or `< 1` value is a 400.
 
 import {
   EXPOSED_RESPONSE_HEADERS_VALUE,
@@ -304,10 +308,22 @@ function incidentItems(incidents, netuid) {
 
 // ── serializers ─────────────────────────────────────────────────────────────
 
-function sortAndCap(items) {
+function sortAndCap(items, max = FEED_MAX_ITEMS) {
   return [...items]
     .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
-    .slice(0, FEED_MAX_ITEMS);
+    .slice(0, max);
+}
+
+// Optional `?limit=` cap on the number of returned items: a positive integer,
+// clamped to the FEED_MAX_ITEMS hard cap (so `?limit=100` yields at most 50).
+// Returns NaN for a non-integer or < 1 value (→ 400), mirroring the strict
+// `?since=`/`?until=` parsing.
+function parseFeedLimit(raw) {
+  const value = raw.trim();
+  if (!/^\d+$/.test(value)) return Number.NaN;
+  const n = Number(value);
+  if (!Number.isSafeInteger(n) || n < 1) return Number.NaN;
+  return Math.min(n, FEED_MAX_ITEMS);
 }
 
 // Optional `?tag=` filter: keep only items whose tags array includes the value.
@@ -601,6 +617,21 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
     }
   }
 
+  // Optional `?limit=` cap (1..FEED_MAX_ITEMS), parsed up front like the window
+  // bounds so a malformed value is rejected before any artifact work.
+  let limit = FEED_MAX_ITEMS;
+  const limitParam = url.searchParams.get("limit");
+  if (limitParam != null) {
+    limit = parseFeedLimit(limitParam);
+    if (Number.isNaN(limit)) {
+      return fail(
+        "invalid_limit",
+        `\`limit\` must be an integer between 1 and ${FEED_MAX_ITEMS}.`,
+        400,
+      );
+    }
+  }
+
   let items;
   let title;
   let description;
@@ -655,7 +686,7 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
   items = filterByTag(items, url.searchParams.get("tag"));
   items = filterSince(items, sinceMs);
   items = filterUntil(items, untilMs);
-  items = sortAndCap(items);
+  items = sortAndCap(items, limit);
   const meta = {
     title,
     description,

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -1349,6 +1349,37 @@ describe("feeds — Worker dispatch integration", () => {
     );
   });
 
+  test("handleRequest keys edge-cached feeds by limit", async () => {
+    installMockCache();
+    const env = createLocalArtifactEnv();
+    const ctx = { waitUntil: (promise) => promise };
+
+    // ?limit is threaded into the feed edge-cache key, so a capped request and a
+    // later unlimited request do not share a cache slot.
+    const capped = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/feeds/registry.json?limit=1",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(capped.status, 200);
+    assert.ok((await capped.json()).items.length <= 1);
+
+    const invalid = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/feeds/registry.json?limit=0",
+      ),
+      env,
+      ctx,
+    );
+    assert.equal(invalid.status, 400);
+    assert.equal(
+      invalid.headers.get("x-metagraph-error-code"),
+      "invalid_limit",
+    );
+  });
+
   test("an unknown feed path is a 404 with the canonical error envelope", async () => {
     const env = createLocalArtifactEnv();
     const res = await handleRequest(

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -565,6 +565,43 @@ describe("feeds — filterUntil", () => {
   });
 });
 
+describe("feeds — ?limit= filter", () => {
+  test("?limit caps the number of returned items", async () => {
+    const full = JSON.parse(
+      (await feed("/api/v1/feeds/registry.json")).text,
+    ).items;
+    assert.ok(full.length > 1, "fixture must have >1 item to exercise the cap");
+    const { res, text } = await feed("/api/v1/feeds/registry.json?limit=1");
+    assert.equal(res.status, 200);
+    assert.equal(JSON.parse(text).items.length, 1);
+  });
+
+  test("?limit above the 50-item cap clamps instead of erroring", async () => {
+    const { res, text } = await feed("/api/v1/feeds/registry.json?limit=100");
+    assert.equal(res.status, 200);
+    assert.ok(JSON.parse(text).items.length <= 50);
+  });
+
+  test("?limit composes with ?tag=", async () => {
+    const { res, text } = await feed(
+      "/api/v1/feeds/registry.json?limit=1&tag=registry",
+    );
+    assert.equal(res.status, 200);
+    const items = JSON.parse(text).items;
+    assert.equal(items.length, 1);
+    assert.ok((items[0].tags || []).includes("registry"));
+  });
+
+  test("a malformed ?limit is rejected with 400", async () => {
+    for (const value of ["0", "-1", "1.5", "abc", "10x"]) {
+      const { res } = await feed(
+        `/api/v1/feeds/registry.json?limit=${encodeURIComponent(value)}`,
+      );
+      assert.equal(res.status, 400, value);
+    }
+  });
+});
+
 describe("feeds — ?since= filter", () => {
   test("a future since yields an empty but valid feed (200)", async () => {
     const { res, text } = await feed(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1051,6 +1051,10 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     if (until != null) {
       feedCacheParams.push(`until=${encodeURIComponent(until)}`);
     }
+    const limit = url.searchParams.get("limit");
+    if (limit != null) {
+      feedCacheParams.push(`limit=${encodeURIComponent(limit)}`);
+    }
     const feedCachePath = `${url.pathname}?${feedCacheParams.join("&")}`;
     const feedRequest =
       request.method === "HEAD"


### PR DESCRIPTION
## Summary

- The RSS/Atom/JSON registry & incident feeds always returned up to the fixed `FEED_MAX_ITEMS` (50) cap, so a poller wanting only the newest few items had to fetch all 50. This adds an optional **`?limit=<1..50>`** that caps the returned items — composing with the existing `?since=` / `?until=` / `?tag=` filters.

## What Changed

- `src/feeds.mjs`:
  - `parseFeedLimit` — a positive integer clamped to the 50-item hard cap (so `?limit=100` yields at most 50); a non-integer or `< 1` value returns `NaN` → `400`, mirroring the strict `?since=` / `?until=` parsing.
  - `handleFeedRequest` parses `?limit` up front (rejecting malformed values before any artifact work) and threads it into `sortAndCap(items, limit)`.
  - Doc comment updated.
- `workers/api.mjs`: `limit` added to the feed edge-cache key, so `?limit` variants get distinct cache slots (same pattern as `since`/`until`).

Feeds are **outside the OpenAPI contract** (not in `contracts.mjs`), so no schema/OpenAPI/generated-artifact regeneration is required.

### Example

```
GET /api/v1/feeds/registry.json?limit=5          # newest 5 items
GET /api/v1/feeds/incidents.rss?since=2026-06-01&limit=10   # composes with ?since
GET /api/v1/feeds/registry.json?limit=0          # 400 invalid_limit
```

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None touched — feeds are not in the contract.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — feeds live outside the OpenAPI contract.)

## Validation

- [x] `npx vitest run tests/feeds.test.mjs` — 92 pass (incl. 4 new `?limit` tests: cap, >50 clamp, compose-with-`?tag`, malformed→400)
- [x] The cap/malformed tests fail without the change (genuine regression)
- [x] `npx eslint` + `npx prettier --check` clean · `git diff --check`
