### PR TITLE
fix(account-events): guard out-of-range observed_at in toIso (no RangeError)

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -82,7 +82,13 @@ export const INGESTED_EVENT_KINDS = [
 function toIso(ms) {
   if (ms == null) return null;
   const n = Number(ms);
-  return Number.isFinite(n) ? new Date(n).toISOString() : null;
+  if (!Number.isFinite(n)) return null;
+  // An out-of-range epoch-ms (|n| > 8.64e15) is finite but new Date(n) is an
+  // Invalid Date whose .toISOString() THROWS a RangeError — one bad observed_at
+  // cell would break the whole events feed instead of nulling that one field.
+  // Guard it, mirroring the blocks toIso fix (#2762).
+  const d = new Date(n);
+  return Number.isFinite(d.getTime()) ? d.toISOString() : null;
 }
 
 // Coerce a block height or index cell to a non-negative integer, or null when

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -154,6 +154,19 @@ test("formatAccountEvent maps a D1 row to an API event (ISO time)", () => {
   assert.equal(out.extrinsic_index, 2);
 });
 
+test("formatAccountEvent drops an out-of-range observed_at to null (no RangeError)", () => {
+  // 8.64e15 ms is the max valid Date; a larger epoch-ms cell is finite but
+  // new Date(n).toISOString() throws RangeError. One bad cell must null that
+  // field, not throw and break the whole events feed. Mirrors #2762.
+  const out = formatAccountEvent({
+    block_number: 1,
+    event_index: 0,
+    event_kind: "Transfer",
+    observed_at: 8640000000000001,
+  });
+  assert.equal(out.observed_at, null);
+});
+
 test("formatAccountEvent is null-safe on junk + sparse rows", () => {
   assert.equal(formatAccountEvent(null), null);
   assert.equal(formatAccountEvent("x"), null);


### PR DESCRIPTION
## Summary

`account-events` `toIso` called `new Date(n).toISOString()` whenever `Number.isFinite(n)` — but an out-of-range epoch-ms (`|n| > 8.64e15`, the max valid `Date`) is finite while `new Date(n)` is an Invalid Date whose `.toISOString()` **throws `RangeError: Invalid time value`**. Since `toIso` formats the `observed_at` (and `last_tx_at`/`first_seen_at`/`last_seen_at`) cells of every account/subnet event via `formatAccountEvent`, a single corrupted/overflowed D1 timestamp **threw and broke the entire** `GET /api/v1/accounts/{ss58}/events` (and subnet-events) response instead of nulling that one field.

This is the identical defect the maintainers just fixed in `blocks.mjs` `toIso` (#2762) and guarded in `subnet-yield`/`concentration`; `account-events` was the sibling holdout.

## What Changed

- `src/account-events.mjs` — after the finite check, build the `Date` and require `Number.isFinite(d.getTime())` before `toISOString()`, so an out-of-range value nulls the field instead of throwing. Byte-identical guard shape to the `blocks.mjs` fix (#2762). Null/normal-epoch/numeric-string behavior is unchanged.
- `tests/account-events.test.mjs` — regression test: `formatAccountEvent({ …, observed_at: 8640000000000001 })` returns `observed_at: null` (previously threw `RangeError`).

Contract: `observed_at` is `{"type":["string","null"],"format":"date-time"}`. No schema change.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (no contract change; robustness fix)

## Validation

- [x] `npx vitest run tests/account-events.test.mjs` — 97 passed (incl. the new case)
- [x] Confirmed the test **throws `RangeError` on the pre-fix tree** and **passes after** the fix
- [x] `npx eslint` + `npx prettier --check --end-of-line auto` on both files — clean
- [x] `git diff --check` — clean
