### PR TITLE
feat(events): ingest SubtensorModule AxonInfoRemoved axon-clear event

### DIFF
--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -308,7 +308,11 @@ EXTRACTORS = {
     "StakeRemoved": _stake,
     "StakeMoved": _moved,
     "AxonServed": _axon,
-    "AxonInfoRemoved": _axon,  # [netuid, hotkey] — axon clear/withdraw counterpart to AxonServed
+    # Forward-compat (#2555): axon clear/withdraw counterpart to AxonServed.
+    # [netuid, hotkey] — same tuple as AxonServed/PrometheusServed. Not present in
+    # finney spec-424 metadata today (verified 2026-07-03); poller skips unknown kinds
+    # harmlessly until upstream ships the variant — no rows emitted until then.
+    "AxonInfoRemoved": _axon,
     "PrometheusServed": _axon,  # [netuid, hotkey]
     "WeightsSet": _weights,
     "RootClaimed": _root,

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -308,6 +308,7 @@ EXTRACTORS = {
     "StakeRemoved": _stake,
     "StakeMoved": _moved,
     "AxonServed": _axon,
+    "AxonInfoRemoved": _axon,  # [netuid, hotkey] — axon clear/withdraw counterpart to AxonServed
     "PrometheusServed": _axon,  # [netuid, hotkey]
     "WeightsSet": _weights,
     "RootClaimed": _root,

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -308,7 +308,6 @@ EXTRACTORS = {
     "StakeRemoved": _stake,
     "StakeMoved": _moved,
     "AxonServed": _axon,
-    "AxonInfoRemoved": _axon,  # [netuid, hotkey] — axon clear/withdraw counterpart to AxonServed
     "PrometheusServed": _axon,  # [netuid, hotkey]
     "WeightsSet": _weights,
     "RootClaimed": _root,

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -370,7 +370,9 @@ class NeuronDeregisteredExtractorTest(unittest.TestCase):
 class AxonInfoRemovedExtractorTest(unittest.TestCase):
     """Tests for SubtensorModule.AxonInfoRemoved (#2555).
 
-    [netuid, hotkey] positional tuple — same shape as AxonServed.
+    [netuid, hotkey] positional tuple — same shape as AxonServed. Variant name
+    pinned per issue #2555; absent from finney spec-424 metadata as of 2026-07-03
+    (see PR body) — extractor is forward-compat until upstream ships the event.
     """
 
     def test_positional_netuid_hotkey(self):

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -367,6 +367,28 @@ class NeuronDeregisteredExtractorTest(unittest.TestCase):
         self.assertIsNone(_extract("NeuronDeregistered", []))
 
 
+class AxonInfoRemovedExtractorTest(unittest.TestCase):
+    """Tests for SubtensorModule.AxonInfoRemoved (#2555).
+
+    [netuid, hotkey] positional tuple — same shape as AxonServed.
+    """
+
+    def test_positional_netuid_hotkey(self):
+        result = _extract("AxonInfoRemoved", [7, _SS58_A])
+        self.assertEqual(result["netuid"], 7)
+        self.assertEqual(result["hotkey"], _SS58_A)
+        self.assertIsNone(result["coldkey"])
+        self.assertIsNone(result["uid"])
+
+    def test_invalid_hotkey_gives_null(self):
+        result = _extract("AxonInfoRemoved", [7, "not-an-address"])
+        self.assertEqual(result["netuid"], 7)
+        self.assertIsNone(result["hotkey"])
+
+    def test_empty_shape_drift_is_skipped(self):
+        self.assertIsNone(_extract("AxonInfoRemoved", []))
+
+
 class PrometheusServedExtractorTest(unittest.TestCase):
     """Tests for the SubtensorModule.PrometheusServed extractor (#2554)."""
 

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -367,28 +367,6 @@ class NeuronDeregisteredExtractorTest(unittest.TestCase):
         self.assertIsNone(_extract("NeuronDeregistered", []))
 
 
-class AxonInfoRemovedExtractorTest(unittest.TestCase):
-    """Tests for SubtensorModule.AxonInfoRemoved (#2555).
-
-    [netuid, hotkey] positional tuple — same shape as AxonServed.
-    """
-
-    def test_positional_netuid_hotkey(self):
-        result = _extract("AxonInfoRemoved", [7, _SS58_A])
-        self.assertEqual(result["netuid"], 7)
-        self.assertEqual(result["hotkey"], _SS58_A)
-        self.assertIsNone(result["coldkey"])
-        self.assertIsNone(result["uid"])
-
-    def test_invalid_hotkey_gives_null(self):
-        result = _extract("AxonInfoRemoved", [7, "not-an-address"])
-        self.assertEqual(result["netuid"], 7)
-        self.assertIsNone(result["hotkey"])
-
-    def test_empty_shape_drift_is_skipped(self):
-        self.assertIsNone(_extract("AxonInfoRemoved", []))
-
-
 class PrometheusServedExtractorTest(unittest.TestCase):
     """Tests for the SubtensorModule.PrometheusServed extractor (#2554)."""
 

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -76,6 +76,7 @@ export const INGESTED_EVENT_KINDS = [
   "HotkeySwapped",
   "ColdkeySwapped",
   "ColdkeySwapScheduled",
+  // #2555 forward-compat: absent finney spec 424 today; ?kind= accepts once runtime emits
   "AxonInfoRemoved",
   "Transfer",
 ];

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -76,6 +76,7 @@ export const INGESTED_EVENT_KINDS = [
   "HotkeySwapped",
   "ColdkeySwapped",
   "ColdkeySwapScheduled",
+  "AxonInfoRemoved",
   "Transfer",
 ];
 

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -76,7 +76,6 @@ export const INGESTED_EVENT_KINDS = [
   "HotkeySwapped",
   "ColdkeySwapped",
   "ColdkeySwapScheduled",
-  "AxonInfoRemoved",
   "Transfer",
 ];
 

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -114,6 +114,10 @@ test("INGESTED_EVENT_KINDS accepts PrometheusServed for kind filters", () => {
   assert.ok(INGESTED_EVENT_KINDS.includes("PrometheusServed"));
 });
 
+test("INGESTED_EVENT_KINDS accepts AxonInfoRemoved for kind filters", () => {
+  assert.ok(INGESTED_EVENT_KINDS.includes("AxonInfoRemoved"));
+});
+
 test("INGESTED_EVENT_KINDS accepts BurnSet (subnet registration cost) for kind filters", () => {
   assert.ok(INGESTED_EVENT_KINDS.includes("BurnSet"));
 });

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -114,10 +114,6 @@ test("INGESTED_EVENT_KINDS accepts PrometheusServed for kind filters", () => {
   assert.ok(INGESTED_EVENT_KINDS.includes("PrometheusServed"));
 });
 
-test("INGESTED_EVENT_KINDS accepts AxonInfoRemoved for kind filters", () => {
-  assert.ok(INGESTED_EVENT_KINDS.includes("AxonInfoRemoved"));
-});
-
 test("INGESTED_EVENT_KINDS accepts BurnSet (subnet registration cost) for kind filters", () => {
   assert.ok(INGESTED_EVENT_KINDS.includes("BurnSet"));
 });


### PR DESCRIPTION
## Summary

- Add `AxonInfoRemoved` to `EXTRACTORS` in `scripts/fetch-events.py`, reusing the existing `_axon` extractor for the `[netuid, hotkey]` shape.
- Add `AxonInfoRemoved` to `INGESTED_EVENT_KINDS` in `src/account-events.mjs` so the public `?kind=` filter accepts it once the runtime emits the variant.
- Add Python extractor regression tests and a JS kind-filter guard.

Closes #2555

## Response to Gittensory review

The [Gittensory blocker](https://github.com/JSONbored/metagraphed/pull/2781#issuecomment-4872841058) is acknowledged: **neither `AxonInfoRemoved` nor `AxonRemoved` is present in current Finney metadata (spec 424)**. This PR is intentionally **forward-compatible** wiring per #2555:

- The poller only ingests kinds that actually decode from chain events — with the variant absent today, **no rows are emitted** until upstream subtensor ships and deploys the event.
- `EXTRACTORS` / `INGESTED_EVENT_KINDS` are documented as forward-compat (see inline comments in `fetch-events.py` and `account-events.mjs`).
- The variant name is pinned to `AxonInfoRemoved` per issue #2555 title/candidates; **re-verify against live metadata** when Finney upgrades and amend the kind string if upstream chose `AxonRemoved` instead.

### Scope / risk

| Risk | Mitigation |
|------|------------|
| Kind not yet on Finney | Zero on-chain rows until runtime ships; extractor tests lock the expected tuple shape |
| Wrong variant name at deploy | PR body + comments record metadata check; one-line rename if upstream differs |
| Public `?kind=` exposes unknown kind | Same pattern as other forward-compat kinds (e.g. `NeuronDeregistered` in #2701); filter accepts, chain must emit |

## Finney metadata verification (spec 424)

Queried `state_getMetadata` on `wss://entrypoint-finney.opentensor.ai:443` (2026-07-03, spec **424**). Decoded `SubtensorModule`'s `PalletSubtensorEvent` enum (137 variants). Cross-checked `RaoFoundation/subtensor` `pallets/subtensor/src/macros/events.rs` on `main`.

| Candidate | Finney metadata | Upstream `events.rs` | Payload shape |
|-----------|----------------|------------------------|---------------|
| `AxonInfoRemoved` | **No** | **No** | — |
| `AxonRemoved` | **No** | **No** | — |
| `AxonServed` | Yes | Yes | `(u16, AccountId32)` / `[netuid, hotkey]` |
| `PrometheusServed` | Yes | Yes | `(u16, AccountId32)` / `[netuid, hotkey]` |

Today, axon clearing on-chain (e.g. `serve_axon` with zero IP) still emits `AxonServed`; `Axons::remove` on hotkey swap emits no dedicated event. This PR prepares ingestion for the separate removal event described in #2555.

No new D1 columns — fits existing `account_events` shape.

## Test plan

- [x] `python3 scripts/test_fetch_events.py`
- [x] `npx vitest run tests/account-events.test.mjs -t INGESTED_EVENT_KINDS`