### PR TITLE
feat(api): add ?format=csv to the chain analytics routes

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -8378,6 +8378,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d";
+                /** @description Response format override. Use `csv` to download the daily activity series as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8385,7 +8387,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8442,6 +8444,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainActivityArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -8496,6 +8503,8 @@ export interface operations {
                 group_by?: "module" | "module_function";
                 limit?: number;
                 call_module?: string;
+                /** @description Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8503,7 +8512,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8559,6 +8568,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainCallsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -8786,6 +8800,8 @@ export interface operations {
                 window?: "7d" | "30d";
                 limit?: number;
                 call_module?: string;
+                /** @description Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers). */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8793,7 +8809,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8859,6 +8875,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainFeesArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -8913,6 +8934,8 @@ export interface operations {
                 sort?: "tx_count" | "total_fee_tao";
                 limit?: number;
                 call_module?: string;
+                /** @description Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8920,7 +8943,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8976,6 +8999,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainSignersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5381,6 +5381,17 @@
             ],
             "type": "string"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the daily activity series as text/csv; `json` (default) keeps the response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -5429,6 +5440,17 @@
             "maxLength": 100,
             "type": "string"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -5475,6 +5497,17 @@
           "name": "call_module",
           "schema": {
             "maxLength": 100,
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
             "type": "string"
           }
         }
@@ -5544,6 +5577,17 @@
           "name": "call_module",
           "schema": {
             "maxLength": 100,
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers).",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
             "type": "string"
           }
         }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -19403,6 +19403,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the daily activity series as text/csv; `json` (default) keeps the response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -19467,9 +19480,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -19579,6 +19598,19 @@
               "maxLength": 100,
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -19642,9 +19674,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -19935,6 +19973,19 @@
               "maxLength": 100,
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers).",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -20008,9 +20059,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -20120,6 +20177,19 @@
               "maxLength": 100,
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -20183,9 +20253,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -8378,6 +8378,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d";
+                /** @description Response format override. Use `csv` to download the daily activity series as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8385,7 +8387,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8442,6 +8444,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainActivityArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -8496,6 +8503,8 @@ export interface operations {
                 group_by?: "module" | "module_function";
                 limit?: number;
                 call_module?: string;
+                /** @description Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8503,7 +8512,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8559,6 +8568,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainCallsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -8786,6 +8800,8 @@ export interface operations {
                 window?: "7d" | "30d";
                 limit?: number;
                 call_module?: string;
+                /** @description Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers). */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8793,7 +8809,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8859,6 +8875,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainFeesArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -8913,6 +8934,8 @@ export interface operations {
                 sort?: "tx_count" | "total_fee_tao";
                 limit?: number;
                 call_module?: string;
+                /** @description Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8920,7 +8943,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8976,6 +8999,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainSignersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2309,7 +2309,18 @@ export const API_ROUTES = [
     "Fetch daily network-activity aggregates (extrinsic/event/block counts, success rate, unique signers) over a 7d or 30d window, newest day first. Computed live from the first-party chain D1 tiers (#1987); schema-stable day_count:0/days:[] when the store is cold.",
     "short",
     ["chain", "analytics"],
-    [{ name: "window", schema: { type: "string", enum: ["7d", "30d"] } }],
+    {
+      csvResponse: true,
+      parameters: [
+        { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the daily activity series as text/csv; `json` (default) keeps the response envelope.",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [],
   ),
   route(
@@ -2320,15 +2331,27 @@ export const API_ROUTES = [
     "Fetch the extrinsic call-mix breakdown (count + share per call_module, or call_module/call_function with group_by=module_function) over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. When scoped, total_extrinsics and share use the scoped module denominator. Computed live from the first-party extrinsics D1 tier (#1989); schema-stable call_count:0/calls:[] when cold.",
     "short",
     ["chain", "analytics"],
-    [
-      { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
-      {
-        name: "group_by",
-        schema: { type: "string", enum: ["module", "module_function"] },
-      },
-      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
-      { name: "call_module", schema: { type: "string", maxLength: 100 } },
-    ],
+    {
+      csvResponse: true,
+      parameters: [
+        { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
+        {
+          name: "group_by",
+          schema: { type: "string", enum: ["module", "module_function"] },
+        },
+        {
+          name: "limit",
+          schema: { type: "integer", minimum: 1, maximum: 100 },
+        },
+        { name: "call_module", schema: { type: "string", maxLength: 100 } },
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope.",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [],
   ),
   route(
@@ -2339,15 +2362,27 @@ export const API_ROUTES = [
     "Fetch the windowed most-active-account leaderboard (signers ranked by ?sort=tx_count or ?sort=total_fee_tao, with total fees/tips + newest signed block) over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. Computed live from the first-party extrinsics D1 tier (#1990); schema-stable signer_count:0/signers:[] when cold.",
     "short",
     ["chain", "analytics"],
-    [
-      { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
-      {
-        name: "sort",
-        schema: { type: "string", enum: ["tx_count", "total_fee_tao"] },
-      },
-      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
-      { name: "call_module", schema: { type: "string", maxLength: 100 } },
-    ],
+    {
+      csvResponse: true,
+      parameters: [
+        { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
+        {
+          name: "sort",
+          schema: { type: "string", enum: ["tx_count", "total_fee_tao"] },
+        },
+        {
+          name: "limit",
+          schema: { type: "integer", minimum: 1, maximum: 100 },
+        },
+        { name: "call_module", schema: { type: "string", maxLength: 100 } },
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope.",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [],
   ),
   route(
@@ -2372,11 +2407,23 @@ export const API_ROUTES = [
     "Fetch fee/tip market analytics — a per-UTC-day fee series (totals, averages, and exact ordered-offset medians) plus a windowed top-fee-payer list — over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. Computed live from the first-party extrinsics D1 tier (#1988); schema-stable day_count:0 + empty lists when cold.",
     "short",
     ["chain", "analytics"],
-    [
-      { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
-      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
-      { name: "call_module", schema: { type: "string", maxLength: 100 } },
-    ],
+    {
+      csvResponse: true,
+      parameters: [
+        { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
+        {
+          name: "limit",
+          schema: { type: "integer", minimum: 1, maximum: 100 },
+        },
+        { name: "call_module", schema: { type: "string", maxLength: 100 } },
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers).",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [],
   ),
   route(

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -13,6 +13,10 @@ import {
   handleHealthPercentiles,
   handleHealthIncidents,
   handleGlobalIncidents,
+  handleChainActivity,
+  handleChainCalls,
+  handleChainSigners,
+  handleChainFees,
   validateQueryParams,
   analyticsWindow,
   d1All,
@@ -1629,5 +1633,104 @@ describe("analytics handler invariants", () => {
     );
     await Promise.resolve();
     assert.deepEqual(cache.putKeys, []);
+  });
+});
+
+// ---- Chain-analytics CSV export (#2532) ------------------------------------
+
+describe("chain analytics ?format=csv export", () => {
+  const cases = [
+    {
+      name: "chain-activity",
+      path: "/api/v1/chain/activity",
+      handler: handleChainActivity,
+      header:
+        "day,block_count,extrinsic_count,event_count,successful_extrinsics,success_rate,unique_signers",
+    },
+    {
+      name: "chain-calls",
+      path: "/api/v1/chain/calls",
+      handler: handleChainCalls,
+      header: "call_module,call_function,count,share",
+    },
+    {
+      name: "chain-signers",
+      path: "/api/v1/chain/signers",
+      handler: handleChainSigners,
+      header: "signer,tx_count,total_fee_tao,total_tip_tao,last_tx_block",
+    },
+    {
+      name: "chain-fees",
+      path: "/api/v1/chain/fees",
+      handler: handleChainFees,
+      header:
+        "day,extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao",
+    },
+  ];
+
+  for (const { name, path, handler, header } of cases) {
+    test(`${name} ?window=7d&format=csv emits its columns as text/csv`, async () => {
+      const { env } = dbWith({ rows: [] });
+      const p = `${path}?window=7d&format=csv`;
+      const res = await handler(req(p), env, url(p));
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get("content-type") || "", /text\/csv/);
+      // Explicit columns → a cold store still emits a header-only CSV (never empty).
+      const text = await res.text();
+      assert.equal(text.split("\r\n")[0], header);
+    });
+
+    test(`${name} keeps the JSON envelope when format is absent`, async () => {
+      const { env } = dbWith({ rows: [] });
+      const res = await handler(
+        req(`${path}?window=7d`),
+        env,
+        url(`${path}?window=7d`),
+      );
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get("content-type") || "", /application\/json/);
+    });
+
+    test(`${name} rejects a ?format value outside the json|csv enum`, async () => {
+      const p = `${path}?window=7d&format=xml`;
+      const res = await handler(req(p), emptyEnv(), url(p));
+      const body = await errorJson(res);
+      assert.equal(body.error.code, "invalid_query");
+      assert.equal(body.meta.parameter, "format");
+    });
+
+    test(`${name} still serves header-only CSV when the D1 read degrades (marks fallback)`, async () => {
+      // A degraded D1 read yields fallback-marked rows; the CSV response must
+      // still be a valid header-only CSV (never a 500) and be tagged as fallback
+      // so withEdgeCache never persists the degraded body.
+      const { env } = dbWith({ d1Error: new Error("d1 down") });
+      const p = `${path}?window=7d&format=csv`;
+      const res = await handler(req(p), env, url(p));
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get("content-type") || "", /text\/csv/);
+      const text = await res.text();
+      assert.equal(text.split("\r\n")[0], header);
+    });
+  }
+
+  test("Accept: text/csv negotiates CSV without an explicit ?format", async () => {
+    const { env } = dbWith({ rows: [] });
+    const p = "/api/v1/chain/signers?window=7d";
+    const res = await handleChainSigners(
+      req(p, { headers: { accept: "text/csv" } }),
+      env,
+      url(p),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type") || "", /text\/csv/);
+  });
+
+  test("chain-calls scoped by ?call_module still exports CSV", async () => {
+    const { env } = dbWith({ rows: [] });
+    const p =
+      "/api/v1/chain/calls?window=7d&call_module=SubtensorModule&format=csv";
+    const res = await handleChainCalls(req(p), env, url(p));
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type") || "", /text\/csv/);
   });
 });

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -35,6 +35,7 @@ import {
 } from "../config.mjs";
 import { parseLimitParam } from "../request-params.mjs";
 import { errorResponse, ifNoneMatchSatisfied } from "../http.mjs";
+import { csvRequested, csvResponse } from "../csv.mjs";
 import {
   contractVersion,
   envelopeResponse,
@@ -159,6 +160,13 @@ function validateEnumParam(url, parameter, allowedValues) {
     parameter,
     message: `${parameter} must be one of: ${allowedValues.join(", ")}.`,
   };
+}
+
+// Enforce the declared `format` enum (json|csv). The per-handler allow-list only
+// gates the param NAME, not its value — without this a `?format=xml` would be
+// silently accepted, contradicting the contract's `enum: [json, csv]` (#2532).
+function validateFormatParam(url) {
+  return validateEnumParam(url, "format", ["json", "csv"]);
 }
 
 // Bound an optional free-text filter so an oversized value never reaches D1.
@@ -652,6 +660,45 @@ export async function handleGlobalIncidents(request, env, url) {
     : response;
 }
 
+// Explicit CSV column order for the chain-analytics ?format=csv exports (#2532).
+// Passed to csvResponse so a cold store (empty array) still emits a header row,
+// and column order stays stable regardless of row-key insertion order.
+const CHAIN_ACTIVITY_CSV_COLUMNS = [
+  "day",
+  "block_count",
+  "extrinsic_count",
+  "event_count",
+  "successful_extrinsics",
+  "success_rate",
+  "unique_signers",
+];
+const CHAIN_CALLS_CSV_COLUMNS = [
+  "call_module",
+  "call_function",
+  "count",
+  "share",
+];
+const CHAIN_SIGNERS_CSV_COLUMNS = [
+  "signer",
+  "tx_count",
+  "total_fee_tao",
+  "total_tip_tao",
+  "last_tx_block",
+];
+// The fee-market CSV exports the per-day fee series (data.daily) — the primary
+// row-shaped table, mirroring chain-activity; the top_fee_payers leaderboard
+// stays JSON-only in the envelope.
+const CHAIN_FEES_CSV_COLUMNS = [
+  "day",
+  "extrinsic_count",
+  "total_fee_tao",
+  "avg_fee_tao",
+  "median_fee_tao",
+  "total_tip_tao",
+  "avg_tip_tao",
+  "median_tip_tao",
+];
+
 // Daily network-activity aggregates over the first-party chain D1 tiers (#1987):
 // per-UTC-day extrinsic/event/block counts, success rate, and unique signers —
 // the foundation time-series for the block-explorer "network at a glance" view
@@ -659,8 +706,11 @@ export async function handleGlobalIncidents(request, env, url) {
 // run in parallel and merge in the pure builder, so the route is schema-stable
 // (day_count:0, days:[]) on a cold store and never re-aggregates on an edge hit.
 export async function handleChainActivity(request, env, url, ctx = {}) {
-  const { label, error } = analyticsWindow(url);
+  const { label, error } = analyticsWindow(url, ["format"]);
   if (error) return analyticsQueryError(error);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
+  const csv = csvRequested(url, request);
   return withEdgeCache(
     request,
     ctx,
@@ -675,6 +725,18 @@ export async function handleChainActivity(request, env, url, ctx = {}) {
           observedAt: meta?.last_run_at || null,
         },
       );
+      if (csv) {
+        const csvRes = await csvResponse(
+          data.days,
+          "chain-activity",
+          "short",
+          request,
+          CHAIN_ACTIVITY_CSV_COLUMNS,
+        );
+        return hasD1FallbackRows(extrinsicRows, blockRows)
+          ? markD1FallbackResponse(csvRes)
+          : csvRes;
+      }
       const response = await envelopeResponse(
         request,
         {
@@ -695,7 +757,7 @@ export async function handleChainActivity(request, env, url, ctx = {}) {
     // explicit ?window=<default>, and reordered/duplicate variants all share one
     // entry instead of fragmenting the cache (mirrors the percentiles/incidents/
     // economics-trends windowed routes). `label` is the validated window.
-    `${url.pathname}?window=${encodeURIComponent(label)}`,
+    `${url.pathname}?window=${encodeURIComponent(label)}${csv ? "&format=csv" : ""}`,
   );
 }
 
@@ -707,8 +769,11 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
     "group_by",
     "limit",
     "call_module",
+    "format",
   ]);
   if (error) return analyticsQueryError(error);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const groupByError = validateEnumParam(url, "group_by", [
     "module",
     "module_function",
@@ -723,6 +788,7 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
   const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
+  const csv = csvRequested(url, request);
   return withEdgeCache(
     request,
     ctx,
@@ -743,6 +809,16 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
         limit,
         observedAt: meta?.last_run_at || null,
       });
+      if (csv) {
+        const csvRes = await csvResponse(
+          data.calls,
+          "chain-calls",
+          "short",
+          request,
+          CHAIN_CALLS_CSV_COLUMNS,
+        );
+        return usedFallback ? markD1FallbackResponse(csvRes) : csvRes;
+      }
       const response = await envelopeResponse(
         request,
         {
@@ -757,7 +833,7 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
       );
       return usedFallback ? markD1FallbackResponse(response) : response;
     },
-    canonicalAnalyticsCacheRoute(url, ["group_by", "limit", "call_module"]),
+    `${canonicalAnalyticsCacheRoute(url, ["group_by", "limit", "call_module"])}${csv ? "&format=csv" : ""}`,
   );
 }
 
@@ -769,8 +845,11 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
     "limit",
     "call_module",
     "sort",
+    "format",
   ]);
   if (error) return analyticsQueryError(error);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const sortError = validateEnumParam(url, "sort", CHAIN_SIGNERS_SORTS);
   if (sortError) return analyticsQueryError(sortError);
   const { limit, error: limitError } = parseLimitParam(url, {
@@ -783,6 +862,7 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
   const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
+  const csv = csvRequested(url, request);
   return withEdgeCache(
     request,
     ctx,
@@ -798,6 +878,18 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
         callModule,
         sort,
       });
+      if (csv) {
+        const csvRes = await csvResponse(
+          data.signers,
+          "chain-signers",
+          "short",
+          request,
+          CHAIN_SIGNERS_CSV_COLUMNS,
+        );
+        return hasD1FallbackRows(rows)
+          ? markD1FallbackResponse(csvRes)
+          : csvRes;
+      }
       const response = await envelopeResponse(
         request,
         {
@@ -814,7 +906,7 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
         ? markD1FallbackResponse(response)
         : response;
     },
-    canonicalAnalyticsCacheRoute(url, ["limit", "call_module", "sort"]),
+    `${canonicalAnalyticsCacheRoute(url, ["limit", "call_module", "sort"])}${csv ? "&format=csv" : ""}`,
   );
 }
 
@@ -876,8 +968,14 @@ export async function handleChainTransfers(request, env, url, ctx = {}) {
 // exact medians) plus a windowed top-fee-payer list. COALESCE keeps NULL
 // fees/tips out of the SUMs and medians.
 export async function handleChainFees(request, env, url, ctx = {}) {
-  const { label, error } = analyticsWindow(url, ["limit", "call_module"]);
+  const { label, error } = analyticsWindow(url, [
+    "limit",
+    "call_module",
+    "format",
+  ]);
   if (error) return analyticsQueryError(error);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { limit, error: limitError } = parseLimitParam(url, {
     defaultLimit: 25,
     maxLimit: 100,
@@ -888,6 +986,7 @@ export async function handleChainFees(request, env, url, ctx = {}) {
   const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
+  const csv = csvRequested(url, request);
   return withEdgeCache(
     request,
     ctx,
@@ -904,6 +1003,18 @@ export async function handleChainFees(request, env, url, ctx = {}) {
           observedAt: meta?.last_run_at || null,
         },
       );
+      if (csv) {
+        const csvRes = await csvResponse(
+          data.daily,
+          "chain-fees",
+          "short",
+          request,
+          CHAIN_FEES_CSV_COLUMNS,
+        );
+        return hasD1FallbackRows(dailyRows, payerRows, medianRows)
+          ? markD1FallbackResponse(csvRes)
+          : csvRes;
+      }
       const response = await envelopeResponse(
         request,
         {
@@ -920,7 +1031,7 @@ export async function handleChainFees(request, env, url, ctx = {}) {
         ? markD1FallbackResponse(response)
         : response;
     },
-    canonicalAnalyticsCacheRoute(url, ["limit", "call_module"]),
+    `${canonicalAnalyticsCacheRoute(url, ["limit", "call_module"])}${csv ? "&format=csv" : ""}`,
   );
 }
 


### PR DESCRIPTION
## Summary

Adds `?format=csv` to the four block-explorer chain-analytics routes — `/api/v1/chain/activity`, `/chain/calls`, `/chain/signers`, `/chain/fees` — so their primary row tables can be pulled straight into a spreadsheet or a data pipeline, matching the CSV export already offered on the subnet list routes (#2718).

Closes #2532

## What changed

- **`workers/request-handlers/analytics.mjs`** — wired a CSV branch into each of the four handlers. When `csvRequested(url, request)` (either `?format=csv` or `Accept: text/csv`), the handler returns `csvResponse(<primary array>, "<route id>", "short", request, <columns>)` from inside the edge-cache builder, so CSV responses are still cached — under a distinct key (the cache route gets a `format=csv` marker), so a CSV request can never collide with the JSON envelope for the same URL.
  - Primary array per route: activity → `days`, calls → `calls`, signers → `signers`, fees → `daily` (the per-day fee series; `top_fee_payers` stays JSON-only in the envelope, documented in the contract).
  - Explicit column lists are passed so a **cold store emits a header-only CSV** (never an empty body) and column order is stable.
  - `"format"` added to each handler's `analyticsWindow(...)` allow-list so the param isn't rejected by the unknown-param guard.
- **`src/contracts.mjs`** — added the `format` query param (`enum: ["json","csv"]`) to the four route contracts; regenerated OpenAPI + client/types artifacts (`npm run build`) and committed them.
- **`tests/request-handlers-analytics.test.mjs`** — per route: `?window=7d&format=csv` returns `text/csv` with the exact column header; the JSON envelope is unchanged when `format` is absent. Plus `Accept: text/csv` negotiation and a `?call_module`-scoped CSV case.

Attribute/column choices follow the existing row builders in `src/chain-analytics.mjs`.

## Validation

- [x] `npm run build` (OpenAPI/types/client regenerated + committed; `r2-manifest.json` / `schemas/index.json` reverted per contributor rules)
- [x] `npm run lint` · `npm run format:check`
- [x] `npm run validate:contract-drift` · `validate:schemas` · `validate:api` · `validate:openapi` · `validate:types`
- [x] `npm run scan:public-safety`
- [x] `npm test` — 4226 passed (158 files), incl. the new CSV cases
