### PR TITLE
feat(registry): enrich SN62 Ridges — add OpenAPI spec surface

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -70,6 +70,27 @@
         "submitted_by": "dexterity104"
       },
       "notes": "Public, unauthenticated read endpoint on the Ridges backend API: the live leaderboard of top-scored SWE agents (miner_hotkey, name, version_num, final_score). agent-upload.ridges.ai is the DEFAULT_API_BASE_URL the official CLI uses (ridgesai/ridges miners/cli/commands/upload.py) and serves the platform's read routes; /retrieval/top-agents is defined in api/endpoints/retrieval.py (no auth) and mounted at /retrieval in api/src/main.py. OpenAPI 3.1.0 spec at /openapi.json."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-openapi",
+      "kind": "openapi",
+      "name": "Ridges agent API OpenAPI spec",
+      "notes": "OpenAPI 3.1 spec for the Ridges agent API. The host agent-upload.ridges.ai is the DEFAULT_API_BASE_URL defined in the official ridgesai/ridges miner CLI (miners/cli/commands/upload.py), establishing first-party ownership.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dhgoal"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://agent-upload.ridges.ai/openapi.json",
+      "source_urls": [
+        "https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/miners/cli/commands/upload.py#L21",
+        "https://agent-upload.ridges.ai/openapi.json"
+      ],
+      "url": "https://agent-upload.ridges.ai/openapi.json"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one verified public surface to `registry/subnets/ridges.json` (SN62 Ridges): the **OpenAPI 3.1 spec** for the Ridges agent API.

*No open enrichment issue exists for SN62 Ridges' OpenAPI; this is a standalone surface addition under the surface-enrichment epic #427.*

## Surface
- Netuid: 62 · Kind: `openapi` · Provider: `ridges` (already registered)
- Public URL: https://agent-upload.ridges.ai/openapi.json

### Source proof (first-party)
`agent-upload.ridges.ai` is defined as **`DEFAULT_API_BASE_URL`** in Ridges' own miner CLI — [`miners/cli/commands/upload.py#L21`](https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/miners/cli/commands/upload.py#L21) (`DEFAULT_API_BASE_URL = "https://agent-upload.ridges.ai"`). The same host already backs the existing `subnet-api` surface in this manifest, and the FastAPI app that serves `/openapi.json` is `api/src/main.py`. The spec is machine-readable (OpenAPI 3.1, 40 paths), verified live.

## Checklist
- [x] Appends to exactly one `registry/subnets/<slug>.json` (append-only, single file)
- [x] Generated via `npm run surface:add` — `authority: community`, `review.state: community-submitted`
- [x] `source_urls` point at durable first-party evidence (SHA-pinned CLI line defining the host) + the schema URL
- [x] Provider `ridges` already registered (no debut file); not a duplicate
- [x] Public-safe: no secrets/wallet/PAT/private URLs/generated artifacts

## Validation
- [x] `npm run validate:surface` → passed (455 / 102)
- [x] `npm run scan:public-safety` → passed
