### PR TITLE
feat(api): add CSV export to review enrichment list routes

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -13153,6 +13153,8 @@ export interface operations {
                 sort?: "candidate_api_count" | "candidate_api_kinds" | "curation_level" | "name" | "netuid" | "operational_kinds" | "operational_surface_count" | "priority_score" | "recommended_adapter_kind";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -13160,7 +13162,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -13245,6 +13247,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewAdapterCandidatesArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -13473,6 +13480,8 @@ export interface operations {
                 sort?: "adapter_score" | "candidate_count" | "completeness_score" | "curation_level" | "endpoint_count" | "evidence_action" | "identity_level" | "identity_surface_count" | "lane" | "name" | "netuid" | "operational_interface_count" | "priority_score" | "profile_level" | "review_state" | "stale_candidate_count" | "surface_count" | "verified_candidate_count";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -13480,7 +13489,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -13612,6 +13621,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewEnrichmentQueueArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -13893,6 +13907,8 @@ export interface operations {
                 sort?: "candidate_count" | "curation_level" | "missing_kinds" | "name" | "netuid" | "priority_score" | "surface_count" | "verified_candidate_count";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -13900,7 +13916,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -13963,6 +13979,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewGapPrioritiesArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -14026,6 +14047,8 @@ export interface operations {
                 sort?: "candidate_count" | "completeness_score" | "identity_level" | "identity_promotion_kind_count" | "identity_surface_count" | "live_identity_candidate_kind_count" | "missing_critical_count" | "name" | "native_identity_signal_count" | "native_name_quality" | "netuid" | "priority_score" | "profile_level" | "stale_identity_candidate_kind_count";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -14033,7 +14056,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -14160,6 +14183,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewProfileCompletenessArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2849,6 +2849,17 @@
               "desc"
             ]
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -3085,6 +3096,17 @@
               "desc"
             ]
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -3237,6 +3259,17 @@
               "asc",
               "desc"
             ]
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]
@@ -3466,6 +3499,17 @@
               "asc",
               "desc"
             ]
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -26609,6 +26609,19 @@
                 "desc"
               ]
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -26701,9 +26714,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -27326,6 +27345,19 @@
                 "desc"
               ]
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -27465,9 +27497,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -28113,6 +28151,19 @@
                 "desc"
               ]
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -28183,9 +28234,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -28405,6 +28462,19 @@
                 "desc"
               ]
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -28539,9 +28609,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -13153,6 +13153,8 @@ export interface operations {
                 sort?: "candidate_api_count" | "candidate_api_kinds" | "curation_level" | "name" | "netuid" | "operational_kinds" | "operational_surface_count" | "priority_score" | "recommended_adapter_kind";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -13160,7 +13162,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -13245,6 +13247,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewAdapterCandidatesArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -13473,6 +13480,8 @@ export interface operations {
                 sort?: "adapter_score" | "candidate_count" | "completeness_score" | "curation_level" | "endpoint_count" | "evidence_action" | "identity_level" | "identity_surface_count" | "lane" | "name" | "netuid" | "operational_interface_count" | "priority_score" | "profile_level" | "review_state" | "stale_candidate_count" | "surface_count" | "verified_candidate_count";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -13480,7 +13489,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -13612,6 +13621,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewEnrichmentQueueArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -13893,6 +13907,8 @@ export interface operations {
                 sort?: "candidate_count" | "curation_level" | "missing_kinds" | "name" | "netuid" | "priority_score" | "surface_count" | "verified_candidate_count";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -13900,7 +13916,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -13963,6 +13979,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewGapPrioritiesArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -14026,6 +14047,8 @@ export interface operations {
                 sort?: "candidate_count" | "completeness_score" | "identity_level" | "identity_promotion_kind_count" | "identity_surface_count" | "live_identity_candidate_kind_count" | "missing_critical_count" | "name" | "native_identity_signal_count" | "native_name_quality" | "netuid" | "priority_score" | "profile_level" | "stale_identity_candidate_kind_count";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -14033,7 +14056,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -14160,6 +14183,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewProfileCompletenessArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1606,7 +1606,7 @@ export const API_ROUTES = [
     "Fetch contributor-targeted subnet gap priorities.",
     "standard",
     ["registry", "review"],
-    listQuery("review-gap-priorities"),
+    csvListQuery("review-gap-priorities"),
   ),
   route(
     "subnet-gaps",
@@ -1627,7 +1627,7 @@ export const API_ROUTES = [
     "Fetch profile completeness gaps for contributor targeting.",
     "standard",
     ["registry", "review", "profiles"],
-    listQuery("profile-completeness"),
+    csvListQuery("profile-completeness"),
   ),
   route(
     "review-adapter-candidates",
@@ -1637,7 +1637,7 @@ export const API_ROUTES = [
     "Fetch subnets worth deeper adapter work.",
     "standard",
     ["adapters", "review"],
-    listQuery("adapter-candidates"),
+    csvListQuery("adapter-candidates"),
   ),
   route(
     "review-enrichment-queue",
@@ -1647,7 +1647,7 @@ export const API_ROUTES = [
     "Fetch the prioritized all-subnet enrichment queue.",
     "standard",
     ["registry", "review", "profiles"],
-    listQuery("enrichment-queue"),
+    csvListQuery("enrichment-queue"),
   ),
   route(
     "review-enrichment-evidence",

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -917,10 +917,15 @@ describe("review enrichment list CSV export", () => {
     assert.match(res.headers.get("content-type"), /^text\/csv/);
     const lines = (await res.text()).split("\r\n");
     const header = lines[0].split(",");
-    const rows = lines.slice(1).filter(Boolean).map((line) => {
-      const values = line.split(",");
-      return Object.fromEntries(header.map((name, index) => [name, values[index]]));
-    });
+    const rows = lines
+      .slice(1)
+      .filter(Boolean)
+      .map((line) => {
+        const values = line.split(",");
+        return Object.fromEntries(
+          header.map((name, index) => [name, values[index]]),
+        );
+      });
     return { header, rows, lines };
   };
 
@@ -935,7 +940,9 @@ describe("review enrichment list CSV export", () => {
     const { header, rows } = await parseCsv(res);
     assert.equal(header.join(","), "netuid,priority_score,curation_level");
     assert.ok(rows.length > 0);
-    assert.ok(rows.every((row) => row.curation_level === "candidate-discovered"));
+    assert.ok(
+      rows.every((row) => row.curation_level === "candidate-discovered"),
+    );
     assert.ok(rows.every((row) => /^\d+$/.test(row.netuid)));
     assert.ok(rows.every((row) => row.priority_score !== ""));
   });

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -910,6 +910,82 @@ describe("subnets CSV export", () => {
   });
 });
 
+// --- Review enrichment list CSV export (#2527) --------------------------------
+describe("review enrichment list CSV export", () => {
+  const parseCsv = async (res) => {
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    const lines = (await res.text()).split("\r\n");
+    const header = lines[0].split(",");
+    const rows = lines.slice(1).filter(Boolean).map((line) => {
+      const values = line.split(",");
+      return Object.fromEntries(header.map((name, index) => [name, values[index]]));
+    });
+    return { header, rows, lines };
+  };
+
+  test("review/gaps ?format=csv exports priority_score and honors curation_level", async () => {
+    const res = await handleRequest(
+      req(
+        "/api/v1/review/gaps?format=csv&fields=netuid,priority_score,curation_level&sort=priority_score&limit=5&curation_level=candidate-discovered",
+      ),
+      createLocalArtifactEnv(),
+      {},
+    );
+    const { header, rows } = await parseCsv(res);
+    assert.equal(header.join(","), "netuid,priority_score,curation_level");
+    assert.ok(rows.length > 0);
+    assert.ok(rows.every((row) => row.curation_level === "candidate-discovered"));
+    assert.ok(rows.every((row) => /^\d+$/.test(row.netuid)));
+    assert.ok(rows.every((row) => row.priority_score !== ""));
+  });
+
+  test("review/profile-completeness ?format=csv exports priority_score and honors identity_level", async () => {
+    const res = await handleRequest(
+      req(
+        "/api/v1/review/profile-completeness?format=csv&fields=netuid,priority_score,identity_level&sort=priority_score&limit=5&identity_level=partial",
+      ),
+      createLocalArtifactEnv(),
+      {},
+    );
+    const { header, rows } = await parseCsv(res);
+    assert.equal(header.join(","), "netuid,priority_score,identity_level");
+    assert.ok(rows.length > 0);
+    assert.ok(rows.every((row) => row.identity_level === "partial"));
+    assert.ok(rows.every((row) => row.priority_score !== ""));
+  });
+
+  test("review/adapter-candidates ?format=csv exports priority_score and honors operational_kinds", async () => {
+    const res = await handleRequest(
+      req(
+        "/api/v1/review/adapter-candidates?format=csv&fields=netuid,priority_score,operational_kinds&sort=priority_score&limit=5&operational_kinds=openapi",
+      ),
+      createLocalArtifactEnv(),
+      {},
+    );
+    const { header, rows } = await parseCsv(res);
+    assert.equal(header.join(","), "netuid,priority_score,operational_kinds");
+    assert.ok(rows.length > 0);
+    assert.ok(rows.every((row) => row.operational_kinds.includes("openapi")));
+    assert.ok(rows.every((row) => row.priority_score !== ""));
+  });
+
+  test("review/enrichment-queue ?format=csv exports priority_score and honors lane", async () => {
+    const res = await handleRequest(
+      req(
+        "/api/v1/review/enrichment-queue?format=csv&fields=netuid,priority_score,lane&sort=priority_score&limit=5&lane=direct-submission",
+      ),
+      createLocalArtifactEnv(),
+      {},
+    );
+    const { header, rows } = await parseCsv(res);
+    assert.equal(header.join(","), "netuid,priority_score,lane");
+    assert.ok(rows.length > 0);
+    assert.ok(rows.every((row) => row.lane === "direct-submission"));
+    assert.ok(rows.every((row) => row.priority_score !== ""));
+  });
+});
+
 // --- RFC 8288 pagination Link header (#1686) ----------------------------------
 // /api/v1/subnets is the only end-to-end list fixture; the header is built once
 // for every cursor-paginated collection in workers/list-query.mjs, so proving it


### PR DESCRIPTION
## Summary

- Switch the four contributor-facing review list routes (`/api/v1/review/gaps`, `/api/v1/review/profile-completeness`, `/api/v1/review/adapter-candidates`, `/api/v1/review/enrichment-queue`) from `listQuery` to `csvListQuery` so `?format=csv` is advertised and honored via the existing generic list-CSV branch.
- Regenerate OpenAPI, api-index, and TypeScript types.
- Add `?format=csv` coverage tests for each route with one filter per route to prove filter passthrough.

Closes #2527

## Template Used

Backend/code change

## What Changed

- `src/contracts.mjs`: use `csvListQuery` for `review-gap-priorities`, `profile-completeness`, `adapter-candidates`, and `enrichment-queue` collections.
- `tests/api-coverage.test.mjs`: four CSV export tests asserting `text/csv`, `priority_score` columns, and filter passthrough.
- Regenerated `public/metagraph/openapi.json`, `public/metagraph/api-index.json`, `generated/metagraphed-api.d.ts`, `public/metagraph/types.d.ts`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run validate:contract-drift`
- [x] `npm run validate:api`
- [x] `npx vitest run tests/api-coverage.test.mjs -t "review enrichment list CSV export"`
