### PR TITLE
feat(registry): enrich SN94 Bitsota — add OpenAPI spec surface

### DIFF
--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -25,6 +25,27 @@
       },
       "source_urls": ["https://bitsota.ai/docs/autoresearch-backend-routes"],
       "url": "https://autoresearch.bitsota.com/api/v1/tasks"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-alveus-labs-openapi",
+      "kind": "openapi",
+      "name": "Bitsota AutoResearch coordinator OpenAPI spec",
+      "notes": "OpenAPI 3.1 spec for the Bitsota AutoResearch coordinator API. Host autoresearch.bitsota.com is the SN94 coordinator operated by Alveus Labs (referenced across the official AlveusLabs/SN94-BitSota repo docs); same host as the existing subnet-api surface.",
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dhgoal"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://autoresearch.bitsota.com/openapi.json",
+      "source_urls": [
+        "https://github.com/AlveusLabs/SN94-BitSota/blob/a2d7a45e4f668232c435306911faf2608ffd196b/docs/guides/how-to-mine.md",
+        "https://bitsota.ai/"
+      ],
+      "url": "https://autoresearch.bitsota.com/openapi.json"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends one verified public surface to `registry/subnets/bitsota.json` (SN94 Bitsota): the **OpenAPI 3.1 spec** for the Bitsota AutoResearch coordinator API.

*No open enrichment issue exists for SN94's OpenAPI; standalone surface addition under the surface-enrichment epic #427.*

## Surface
- Netuid: 94 · Kind: `openapi` · Provider: `alveus-labs` (already registered)
- Public URL: https://autoresearch.bitsota.com/openapi.json

### Source proof (first-party)
`autoresearch.bitsota.com` is the SN94 AutoResearch coordinator operated by Alveus Labs, referenced throughout the official [`AlveusLabs/SN94-BitSota`](https://github.com/AlveusLabs/SN94-BitSota/blob/a2d7a45e4f668232c435306911faf2608ffd196b/docs/guides/how-to-mine.md) repo docs, with the official site at https://bitsota.ai/. The same host already backs the existing `subnet-api` surface in this manifest. Spec verified live (OpenAPI 3.1, 37 paths).

## Checklist
- [x] Appends to exactly one `registry/subnets/<slug>.json` (append-only, single file)
- [x] Generated via `npm run surface:add` — `authority: community`, `review.state: community-submitted`
- [x] `source_urls` = first-party repo doc naming the host + official site; provider `alveus-labs` already registered (no debut file)
- [x] Not a duplicate; public-safe (no secrets/private URLs/generated artifacts)

## Validation
- [x] `npm run validate:surface` → passed (459 / 102)
- [x] `npm run scan:public-safety` → passed
