### PR TITLE
fix(extrinsics): guard out-of-range observed_at in toIso (no RangeError)

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -43,7 +43,13 @@ function toIso(ms) {
   // cell stays null instead of epoch 1970. Mirrors the blocks toIso fix (#2708).
   if (ms == null) return null;
   const n = Number(ms);
-  return Number.isFinite(n) && n > 0 ? new Date(n).toISOString() : null;
+  if (!Number.isFinite(n) || n <= 0) return null;
+  // A finite but out-of-range epoch (|ms| > 8.64e15, the JS Date limit) makes
+  // new Date(n).toISOString() throw a RangeError, which would 500 the whole
+  // extrinsics feed on a single corrupt observed_at cell. Drop it to null
+  // instead, mirroring the getTime() range guard in the stake-flow coerceEpochMs.
+  const date = new Date(n);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
 }
 
 // Coerce a chain-position cell (block_number / extrinsic_index) to a

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -159,8 +159,11 @@ test("formatExtrinsic drops an out-of-range observed_at instead of throwing", ()
   assert.equal(out.observed_at, null);
   // A valid timestamp still renders as ISO (no regression).
   assert.equal(
-    formatExtrinsic({ block_number: 5, extrinsic_index: 0, observed_at: 1750000000000 })
-      .observed_at,
+    formatExtrinsic({
+      block_number: 5,
+      extrinsic_index: 0,
+      observed_at: 1750000000000,
+    }).observed_at,
     new Date(1750000000000).toISOString(),
   );
 });

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -144,6 +144,27 @@ test("formatExtrinsic maps a D1 row to an API extrinsic (ISO time, bool success)
   assert.equal(out.observed_at, new Date(1750000000000).toISOString());
 });
 
+test("formatExtrinsic drops an out-of-range observed_at instead of throwing", () => {
+  // A finite but out-of-range epoch (beyond the ±8.64e15 ms JS Date limit) would
+  // make new Date(n).toISOString() throw a RangeError and 500 the extrinsics feed.
+  // A single corrupt observed_at cell must degrade to null, not crash the row.
+  let out;
+  assert.doesNotThrow(() => {
+    out = formatExtrinsic({
+      block_number: 5,
+      extrinsic_index: 0,
+      observed_at: 9e15,
+    });
+  });
+  assert.equal(out.observed_at, null);
+  // A valid timestamp still renders as ISO (no regression).
+  assert.equal(
+    formatExtrinsic({ block_number: 5, extrinsic_index: 0, observed_at: 1750000000000 })
+      .observed_at,
+    new Date(1750000000000).toISOString(),
+  );
+});
+
 test("formatExtrinsic coerces D1 numeric-string fee_tao/tip_tao and rounds to rao", () => {
   // D1 can return the REAL fee/tip columns as numeric strings; a bare `?? null`
   // would leak the string into the ["number","null"] contract field. Coercion


### PR DESCRIPTION
## Summary
`formatExtrinsic`'s `toIso` coerced the `observed_at` cell and required `n > 0`, but did not bound it to the JS `Date` range. A finite but out-of-range epoch-ms (`|ms| > 8.64e15`) makes `new Date(n).toISOString()` throw a **RangeError**, which 500s the entire extrinsics feed on a single corrupt D1 cell.

Adds the `getTime()` range guard so an out-of-range cell degrades to `null`, mirroring `coerceEpochMs` in the stake-flow formatters.

## Validation
- `npm test -- tests/extrinsics.test.mjs` — green, incl. a new does-not-throw test for an out-of-range `observed_at`