### PR TITLE
fix(feeds): guard out-of-range timestamps in toIso (no RangeError)

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -91,7 +91,12 @@ function clamp(value, max = 500) {
 // Accept an ISO string or epoch-ms; return a normalized ISO string or null.
 function toIso(value) {
   if (typeof value === "number" && Number.isFinite(value)) {
-    return new Date(value).toISOString();
+    // A finite but out-of-range epoch (|ms| > 8.64e15, the JS Date limit) makes
+    // toISOString() throw a RangeError, which would 500 the whole feed on a
+    // single corrupt incident/changelog timestamp. Guard the Date range and drop
+    // it to null instead, matching the string branch's NaN guard below.
+    const date = new Date(value);
+    return Number.isFinite(date.getTime()) ? date.toISOString() : null;
   }
   if (typeof value === "string") {
     const t = Date.parse(value);

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -408,6 +408,23 @@ describe("feeds — item builders", () => {
     assert.ok(item.tags.includes("ongoing"));
   });
 
+  test("incidentItems survives an out-of-range started_at (no RangeError)", () => {
+    // A finite but out-of-range epoch-ms (beyond the ±8.64e15 JS Date limit)
+    // would make toIso -> new Date().toISOString() throw a RangeError and 500
+    // the whole incidents feed. A single corrupt timestamp must degrade, not crash.
+    const incidents = {
+      surfaces: [
+        { netuid: 1, surface_id: "api", incidents: [{ started_at: 9e15 }] },
+      ],
+    };
+    let item;
+    assert.doesNotThrow(() => {
+      item = incidentItems(incidents)[0];
+    });
+    // The item is still emitted with a valid fallback (request-time) timestamp.
+    assert.ok(Number.isFinite(Date.parse(item.timestamp)));
+  });
+
   test("gapsItems builds ranked enrichment targets with lane/kind tags", () => {
     const items = gapsItems(ENRICHMENT_QUEUE);
     assert.equal(items.length, 3);


### PR DESCRIPTION
## Summary
The feeds `toIso` number branch called `new Date(value).toISOString()` on any finite value. A finite but out-of-range epoch-ms (`|ms| > 8.64e15`) throws a **RangeError**, which 500s the incidents / changelog / registry feeds on a single corrupt timestamp cell.

Range-guards the `Date` before `toISOString()` and drops an out-of-range value to `null`, matching the `NaN` guard already on the string branch.

## Validation
- `npm test -- tests/feeds.test.mjs` — green, incl. a new does-not-throw test on the incidents feed