### PR TITLE
fix(api): reject unknown list query parameters (#2578)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+coverage-tmp
 *.lcov
 
 # Test reporter output (JUnit XML written via VITEST_JUNIT_PATH in CI)

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -787,6 +787,32 @@ describe("invalid query handling", () => {
     assert.equal((await res.json()).meta.parameter, "order");
   });
 
+  test("400 invalid_query for an unknown list query parameter", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets?statuss=active"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.error.message, "unknown query parameter.");
+    assert.equal(body.meta.parameter, "statuss");
+  });
+
+  test("400 invalid_query for an unsupported format value on CSV list routes", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets?format=xml"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.error.message, "format must be json or csv.");
+    assert.equal(body.meta.parameter, "format");
+  });
+
   test("400 invalid_query for an unsupported projected field", async () => {
     const res = await handleRequest(
       req("/api/v1/subnets?fields=netuid,not_a_field"),
@@ -1067,19 +1093,15 @@ describe("pagination Link header", () => {
     assert.match(res.headers.get("access-control-expose-headers"), /\blink\b/);
   });
 
-  test("page links drop ignored/tracker query params end-to-end (#1932 cache-key safety)", async () => {
-    // Drive the canonicalization through the real Worker: tracker/attacker params
-    // the edge cache key ignores must not ride along in the cacheable Link header,
-    // while the body-affecting sort/cursor/limit are preserved.
-    const { res, links } = await page(
+  test("page links reject ignored/tracker query params end-to-end", async () => {
+    const { res } = await page(
       "limit=50&cursor=0&utm_campaign=evil&token=SECRET123",
     );
-    assert.equal(res.status, 200);
-    assert.equal(links.next.searchParams.has("utm_campaign"), false);
-    assert.equal(links.next.searchParams.has("token"), false);
-    assert.equal(links.next.searchParams.get("sort"), "netuid");
-    assert.equal(links.next.searchParams.get("cursor"), "50");
-    assert.equal(links.next.searchParams.get("limit"), "50");
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.error.message, "unknown query parameter.");
+    assert.equal(body.meta.parameter, "utm_campaign");
   });
 
   test("middle page advertises all four relations", async () => {

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
+import { API_QUERY_COLLECTIONS } from "../src/contracts.mjs";
 import {
   applyQueryFilters,
   canonicalListSearch,
   paginationLinkHeader,
+  validateListQueryParams,
 } from "../workers/list-query.mjs";
 
 function query(path) {
@@ -473,6 +475,229 @@ describe("list-query numeric range filters", () => {
   });
 });
 
+describe("list-query unknown parameter validation (#2578)", () => {
+  const data = {
+    subnets: [
+      {
+        netuid: 1,
+        name: "Alpha Inference",
+        slug: "alpha",
+        status: "active",
+        categories: ["inference"],
+        block: 150,
+      },
+      {
+        netuid: 2,
+        name: "Beta Compute",
+        slug: "beta",
+        status: "inactive",
+        categories: ["compute"],
+        block: 50,
+      },
+    ],
+  };
+
+  test("rejects a typoed query parameter before silently returning an unfiltered list", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?statuss=active"),
+      "subnets",
+    );
+
+    assert.equal(result.error.parameter, "statuss");
+    assert.equal(result.error.message, "unknown query parameter.");
+  });
+
+  test("accepts every supported list parameter family", () => {
+    const result = applyQueryFilters(
+      data,
+      query(
+        "/api/v1/subnets?q=alpha&fields=netuid,name&limit=10&cursor=0" +
+          "&sort=netuid&order=asc&status=active&netuids=1" +
+          "&domain=inference&min_block=100&max_block=200",
+      ),
+      "subnets",
+    );
+
+    assert.equal(result.error, undefined);
+    assert.deepEqual(result.data.subnets, [
+      { netuid: 1, name: "Alpha Inference" },
+    ]);
+    assert.equal(result.meta.pagination.total, 1);
+  });
+
+  test("accepts format=csv on csv-enabled list routes", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?format=csv&status=active"),
+      "subnets",
+      [],
+      { csvResponse: true },
+    );
+
+    assert.equal(result.error, undefined);
+    assert.deepEqual(
+      result.data.subnets.map((row) => row.netuid),
+      [1],
+    );
+  });
+
+  test("accepts format=json on csv-enabled list routes", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?format=json&status=active"),
+      "subnets",
+      [],
+      { csvResponse: true },
+    );
+
+    assert.equal(result.error, undefined);
+    assert.deepEqual(
+      result.data.subnets.map((row) => row.netuid),
+      [1],
+    );
+  });
+
+  test("rejects an unsupported format value on csv-enabled list routes", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?format=xml"),
+      "subnets",
+      [],
+      { csvResponse: true },
+    );
+
+    assert.equal(result.error.parameter, "format");
+    assert.equal(result.error.message, "format must be json or csv.");
+  });
+
+  test("preflight rejects an unsupported format value before artifact reads", () => {
+    const error = validateListQueryParams(
+      query("/api/v1/subnets?format=xml"),
+      "subnets",
+      [],
+      { csvResponse: true },
+    );
+
+    assert.equal(error.parameter, "format");
+    assert.equal(error.message, "format must be json or csv.");
+  });
+
+  test("rejects format on routes without csv export", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?format=csv"),
+      "subnets",
+    );
+
+    assert.equal(result.error.parameter, "format");
+    assert.equal(result.error.message, "unknown query parameter.");
+  });
+
+  test("accepts an empty query string", () => {
+    const result = applyQueryFilters(data, query("/api/v1/subnets"), "subnets");
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.data.subnets.length, 2);
+  });
+
+  test("rejects filters excluded by a route-level queryFilterNames allowlist", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?curation_level=native"),
+      "subnets",
+      ["netuid"],
+    );
+
+    assert.equal(result.error.parameter, "curation_level");
+    assert.equal(result.error.message, "unknown query parameter.");
+  });
+
+  test("rejects all filters when a route allowlist has no configured filter names", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?status=active"),
+      "subnets",
+      ["not_a_configured_filter"],
+    );
+
+    assert.equal(result.error.parameter, "status");
+    assert.equal(result.error.message, "unknown query parameter.");
+  });
+
+  test("preflight skips routes without list-query contracts", () => {
+    assert.equal(
+      validateListQueryParams(
+        query("/api/v1/not-a-list?anything=1"),
+        undefined,
+      ),
+      null,
+    );
+    assert.equal(
+      validateListQueryParams(query("/api/v1/not-a-list?anything=1"), "nope"),
+      null,
+    );
+  });
+
+  test("allowlist keeps only configured filter names that exist on the collection", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/subnets?netuid=1"),
+      "subnets",
+      ["netuid", "not_a_configured_filter"],
+    );
+
+    assert.equal(result.error, undefined);
+    assert.deepEqual(
+      result.data.subnets.map((row) => row.netuid),
+      [1],
+    );
+  });
+
+  test("transform stays a no-op when the artifact data key is not a list", () => {
+    const result = applyQueryFilters(
+      { subnets: null },
+      query("/api/v1/subnets?statuss=active"),
+      "subnets",
+    );
+
+    assert.deepEqual(result, { data: { subnets: null }, meta: {} });
+  });
+
+  test("handles sparse collection configs without optional filter families", () => {
+    const collection = "__test_sparse_rows";
+    const previous = API_QUERY_COLLECTIONS[collection];
+    API_QUERY_COLLECTIONS[collection] = { data_key: "rows" };
+    try {
+      assert.equal(
+        validateListQueryParams(query("/api/v1/sparse?limit=1"), collection),
+        null,
+      );
+
+      const sortError = validateListQueryParams(
+        query("/api/v1/sparse?sort=name"),
+        collection,
+      );
+      assert.equal(sortError.parameter, "sort");
+      assert.equal(sortError.message, "sort is not supported for rows.");
+
+      const result = applyQueryFilters(
+        { rows: [] },
+        query("/api/v1/sparse?surprise=1"),
+        collection,
+      );
+      assert.equal(result.error.parameter, "surprise");
+      assert.equal(result.error.message, "unknown query parameter.");
+    } finally {
+      if (previous === undefined) {
+        delete API_QUERY_COLLECTIONS[collection];
+      } else {
+        API_QUERY_COLLECTIONS[collection] = previous;
+      }
+    }
+  });
+});
+
 // #2085: integration_readiness was sortable/filterable via MCP list_subnets but
 // not on the equivalent REST subnets collection. After wiring it into the
 // contract's sort + rangeFilters, the generic list-query engine reads row[key]
@@ -735,8 +960,12 @@ describe("list-query pagination Link header", () => {
 
   test("drops ignored query parameters from cacheable page links", () => {
     const links = parseLink(
-      pageLink(
-        "/api/v1/subnets?sort=netuid&limit=2&utm_campaign=evil&token=SECRET123",
+      paginationLinkHeader(
+        query(
+          "/api/v1/subnets?sort=netuid&limit=2&utm_campaign=evil&token=SECRET123",
+        ),
+        { cursor: 0, limit: 2, next_cursor: 2, total: 5 },
+        { queryCollection: "subnets" },
       ),
     );
 
@@ -858,6 +1087,28 @@ describe("list-query canonicalListSearch (cache-key safety)", () => {
 
   test("an unknown collection canonicalizes to an empty search", () => {
     assert.equal(canonicalListSearch(query("/api/v1/x?a=1"), "nope"), "");
+  });
+
+  test("sparse collection configs without filter families still canonicalize static controls", () => {
+    const collection = "__test_sparse_canonical";
+    const previous = API_QUERY_COLLECTIONS[collection];
+    API_QUERY_COLLECTIONS[collection] = { data_key: "rows" };
+    try {
+      const search = canonicalListSearch(
+        query("/api/v1/sparse?limit=5&cursor=2"),
+        collection,
+      );
+      const p = params(search);
+      assert.equal(p.get("limit"), "5");
+      assert.equal(p.get("cursor"), "2");
+      assert.equal(p.has("status"), false);
+    } finally {
+      if (previous === undefined) {
+        delete API_QUERY_COLLECTIONS[collection];
+      } else {
+        API_QUERY_COLLECTIONS[collection] = previous;
+      }
+    }
   });
 
   test("an explicit queryFilterNames allowlist overrides the collection filters", () => {

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -782,6 +782,8 @@ describe("Worker runtime", () => {
       ["/api/v1/subnets?fields=netuid,nope", "fields"],
       ["/api/v1/subnets?netuid=nope", "netuid"],
       ["/api/v1/subnets?subnet_type=nope", "subnet_type"],
+      ["/api/v1/subnets/7/endpoints?netuid=7", "netuid"],
+      ["/api/v1/subnets?statuss=active", "statuss"],
     ];
 
     for (const [path, parameter] of invalidCases) {
@@ -1644,7 +1646,7 @@ describe("Worker runtime", () => {
     }
   });
 
-  test("canonicalizes overlay cache keys for ignored query parameters", async () => {
+  test("rejects unknown list query parameters before overlay cache reads", async () => {
     const store = new Map();
     const cachePutKeys = [];
     let r2Gets = 0;
@@ -1716,18 +1718,13 @@ describe("Worker runtime", () => {
         overlayEnv,
         ctx,
       );
-      assert.equal(first.status, 200);
-      assert.equal(second.status, 200);
-      assert.equal(await second.text(), await first.text());
-      assert.equal(
-        r2Gets,
-        1,
-        "ignored query params must not bust overlay cache",
-      );
-      assert.equal(store.size, 1, "ignored query params share one cache entry");
-      assert.deepEqual(cachePutKeys, [
-        `https://edge-cache.metagraph.sh/overlay/mainnet/${CONTRACT_VERSION}/2026-06-18T00%3A00%3A00.000Z/api/v1/endpoints`,
-      ]);
+      assert.equal(first.status, 400);
+      assert.equal(second.status, 400);
+      assert.equal((await first.json()).meta.parameter, "junk");
+      assert.equal((await second.json()).meta.parameter, "junk");
+      assert.equal(r2Gets, 0, "invalid list queries do not read R2 overlays");
+      assert.equal(store.size, 0, "invalid list queries are not cached");
+      assert.deepEqual(cachePutKeys, []);
     } finally {
       globalThis.caches = originalCaches;
     }

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -9,6 +9,7 @@ import {
   applyQueryFilters,
   canonicalListSearch,
   paginationLinkHeader,
+  validateListQueryParams,
 } from "./list-query.mjs";
 import { csvRequested, csvResponse } from "./csv.mjs";
 import {
@@ -2360,6 +2361,19 @@ async function handleApiRequest(
   if (!matched) {
     return errorResponse("not_found", "No API route matched this path.", 404);
   }
+  const artifactPath = artifactPathForNetwork(matched.artifactPath, network);
+  const queryError = validateListQueryParams(
+    url,
+    matched.queryCollection,
+    matched.queryFilterNames,
+    { csvResponse: matched.csvResponse === true },
+  );
+  if (queryError) {
+    return errorResponse("invalid_query", queryError.message, 400, {
+      artifact_path: artifactPath,
+      parameter: queryError.parameter,
+    });
+  }
   const wantsCsv = matched.csvResponse === true && csvRequested(url, request);
   // Edge-cache idempotent GETs for pure static-artifact routes (mirrors the
   // RPC-proxy Cache API pattern). Live-overlay routes are excluded by route id,
@@ -2430,7 +2444,6 @@ async function handleApiRequest(
   }
   // Mainnet (default) reads the unprefixed artifact (no-op); non-default networks
   // read metagraph/{prefix}/… — see artifactPathForNetwork.
-  const artifactPath = artifactPathForNetwork(matched.artifactPath, network);
 
   // Live operational-health overlay (Phase 3): current health is live-only.
   // Static current-health artifacts are not read for mainnet health routes, so
@@ -2583,6 +2596,7 @@ async function handleApiRequest(
     url,
     matched.queryCollection,
     matched.queryFilterNames,
+    { csvResponse: matched.csvResponse === true },
   );
   if (transformed.error) {
     return errorResponse("invalid_query", transformed.error.message, 400, {

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -2,7 +2,8 @@
 // and cursor pagination over in-memory artifact collections. Extracted from
 // workers/api.mjs (issue #510, de-monolith) as a leaf module: it imports only
 // the query-collection contract and nothing from api.mjs, so there is no cycle.
-// `applyQueryFilters` is the single public entry; the rest are internal helpers.
+// `applyQueryFilters` is the main public entry; route preflight uses the same
+// validator before artifact/cache reads.
 import { API_QUERY_COLLECTIONS } from "../src/contracts.mjs";
 import { linkHeader } from "./http.mjs";
 import { DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT } from "./request-params.mjs";
@@ -14,6 +15,7 @@ export function applyQueryFilters(
   url,
   queryCollection,
   queryFilterNames = [],
+  { csvResponse = false } = {},
 ) {
   const params = url.searchParams;
   const config = API_QUERY_COLLECTIONS[queryCollection];
@@ -23,15 +25,48 @@ export function applyQueryFilters(
   if (!Array.isArray(data?.[config.data_key])) {
     return { data, meta: {} };
   }
-  return applyListTransform(data, params, {
+  return applyListTransform(
+    data,
+    params,
+    listQueryConfig(config, queryFilterNames),
+    { csvResponse },
+  );
+}
+
+export function validateListQueryParams(
+  url,
+  queryCollection,
+  queryFilterNames = [],
+  { csvResponse = false } = {},
+) {
+  const config = API_QUERY_COLLECTIONS[queryCollection];
+  if (!config) {
+    return null;
+  }
+  return validateListQuery(
+    url.searchParams,
+    listQueryConfig(config, queryFilterNames),
+    { csvResponse },
+  );
+}
+
+function listQueryConfig(config, queryFilterNames = []) {
+  return {
     ...config,
     filters: Object.fromEntries(
-      (queryFilterNames.length > 0
-        ? queryFilterNames
-        : Object.keys(config.filters)
-      ).map((name) => [name, config.filters[name]]),
+      effectiveFilterNames(config, queryFilterNames).map((name) => [
+        name,
+        config.filters[name],
+      ]),
     ),
-  });
+  };
+}
+
+function effectiveFilterNames(config, queryFilterNames = []) {
+  const filters = config.filters || {};
+  return queryFilterNames.length > 0
+    ? queryFilterNames.filter((name) => Object.hasOwn(filters, name))
+    : Object.keys(filters);
 }
 
 // RFC 8288 Link header for a cursor-paginated response (window from
@@ -43,17 +78,25 @@ export function applyQueryFilters(
 function listQueryParamNames(queryCollection, queryFilterNames = []) {
   const config = API_QUERY_COLLECTIONS[queryCollection];
   if (!config) return [];
+  return listQueryParamNamesForConfig(config, queryFilterNames);
+}
+
+function listQueryParamNamesForConfig(
+  config,
+  queryFilterNames = [],
+  { csvResponse = false } = {},
+) {
   const filterNames =
     queryFilterNames.length > 0
-      ? queryFilterNames
-      : Object.keys(config.filters);
+      ? effectiveFilterNames(config, queryFilterNames)
+      : Object.keys(config.filters || {});
   const rangeNames = (config.range_filters || []).flatMap((field) => [
     `min_${field}`,
     `max_${field}`,
   ]);
   const csvNames = Object.keys(config.csv_filters || {});
   const arrayNames = Object.keys(config.array_filters || {});
-  return [
+  const names = [
     "q",
     "fields",
     "limit",
@@ -65,6 +108,10 @@ function listQueryParamNames(queryCollection, queryFilterNames = []) {
     ...arrayNames,
     ...rangeNames,
   ];
+  if (csvResponse) {
+    names.push("format");
+  }
+  return names;
 }
 
 export function canonicalListSearch(
@@ -189,8 +236,8 @@ function rangeFilterRows(rows, params, rangeFields) {
   );
 }
 
-function applyListTransform(data, params, config) {
-  const queryError = validateListQuery(params, config);
+function applyListTransform(data, params, config, options = {}) {
+  const queryError = validateListQuery(params, config, options);
   if (queryError) {
     return { error: queryError };
   }
@@ -322,7 +369,31 @@ function paginateRows(rows, params) {
   };
 }
 
-function validateListQuery(params, config) {
+function validateListQuery(params, config, { csvResponse = false } = {}) {
+  const allowedParams = new Set(
+    listQueryParamNamesForConfig(config, [], { csvResponse }),
+  );
+  for (const key of params.keys()) {
+    if (!allowedParams.has(key)) {
+      return {
+        parameter: key,
+        message: "unknown query parameter.",
+      };
+    }
+  }
+
+  const format = params.get("format");
+  if (
+    format !== null &&
+    csvResponse &&
+    !["json", "csv"].includes(format.toLowerCase())
+  ) {
+    return {
+      parameter: "format",
+      message: "format must be json or csv.",
+    };
+  }
+
   const limit = params.get("limit");
   if (
     limit !== null &&
@@ -357,7 +428,7 @@ function validateListQuery(params, config) {
   }
 
   const sort = params.get("sort");
-  if (sort !== null && !config.sort_fields.includes(sort)) {
+  if (sort !== null && !(config.sort_fields || []).includes(sort)) {
     return {
       parameter: "sort",
       message: `sort is not supported for ${config.data_key}.`,
@@ -399,7 +470,7 @@ function validateListQuery(params, config) {
     }
   }
 
-  for (const field of config.range_filters) {
+  for (const field of config.range_filters || []) {
     for (const bound of ["min", "max"]) {
       const key = `${bound}_${field}`;
       if (params.has(key) && numberParam(params.get(key)) === null) {


### PR DESCRIPTION
## Summary
- Return `400 invalid_query` with `{ parameter, message: "unknown query parameter." }` when a list route receives a query param outside its allow-list, instead of silently ignoring it and returning an unfiltered list.
- Centralize allow-list derivation in `listQueryParamNamesForConfig` and run the same validator in both the Worker preflight (`validateListQueryParams`, before artifact/cache reads) and `applyListTransform`.
- Allow `format` on CSV-enabled list routes; reject it elsewhere. Validate `format` enum (`json` / `csv`) when CSV export is enabled.

Closes #2578

## Test plan
- [x] `npm test -- tests/list-query.test.mjs` — typo `?statuss=active` → 400; all real param families still accepted; empty query OK
- [x] `?format=csv` accepted on CSV routes, rejected on non-CSV routes
- [x] Route-level `queryFilterNames` allowlist respected (excluded filters → 400)
- [x] Sparse collection configs (no optional filter families) handled safely
- [x] Worker preflight rejects unknown params before overlay cache / R2 reads
- [x] Canonical pagination Link headers still strip ignored params (unit-level)