### PR TITLE
feat(api): add CSV exports for validator analytics

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -11563,7 +11563,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "/metagraph/fixtures/7:subnet-api:new_v2.json",
                      *         "cache": "standard",
-                     *         "contract_version": "2026-07-02.1",
+                     *         "contract_version": "2026-07-03.1",
                      *         "generated_at": "1970-01-01T00:00:00.000Z",
                      *         "published_at": null,
                      *         "source": "r2"
@@ -17901,6 +17901,8 @@ export interface operations {
         parameters: {
             query?: {
                 validator_permit?: "true";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -17910,7 +17912,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -17966,6 +17968,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetMetagraphArtifact"];
                     };
+                    /**
+                     * @example uid,hotkey,coldkey,active,validator_permit,rank,trust,validator_trust,consensus,incentive,dividends,emission_tao,stake_tao,registered_at_block,is_immunity_period,axon
+                     *     0,hk_sample,ck_sample,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -19712,7 +19719,10 @@ export interface operations {
     };
     subnetValidators: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
+            };
             header?: never;
             path: {
                 netuid: number;
@@ -19721,7 +19731,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19777,6 +19787,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetValidatorsArtifact"];
                     };
+                    /**
+                     * @example uid,hotkey,coldkey,active,validator_permit,rank,trust,validator_trust,consensus,incentive,dividends,emission_tao,stake_tao,registered_at_block,is_immunity_period,axon
+                     *     0,hk_sample,ck_sample,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -19965,6 +19980,8 @@ export interface operations {
                 window?: "7d" | "30d" | "90d";
                 sort?: "stake" | "emission" | "validators";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -19972,7 +19989,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -20039,6 +20056,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetMoversArtifact"];
                     };
+                    /**
+                     * @example netuid,stake_start_tao,stake_end_tao,stake_delta_tao,stake_pct_change,emission_start_tao,emission_end_tao,emission_delta_tao,emission_pct_change,validators_start,validators_end,validators_delta,neurons_start,neurons_end,neurons_delta
+                     *     7,1000,1250,250,25,10,12,2,20,16,18,2,256,256,0
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -20216,6 +20238,8 @@ export interface operations {
             query?: {
                 sort?: "avg_validator_trust" | "max_validator_trust" | "stake_dominance" | "subnet_count" | "total_emission" | "total_stake" | "uid_count";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -20223,7 +20247,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -20296,6 +20320,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["GlobalValidatorsArtifact"];
                     };
+                    /**
+                     * @example hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,total_emission_tao,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets
+                     *     hk_sample,ck_sample,1,3,3,1234.5,10.25,0.12,0.98,0.99,2026-07-03T00:00:00.000Z,8454388,"[{""netuid"":1,""uid"":0}]"
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1,833 +1,833 @@
 {
   "artifact_contracts": [
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "contracts",
       "path": "/metagraph/contracts.json",
       "schema_ref": "#/components/schemas/ContractsArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "providers",
       "path": "/metagraph/providers.json",
       "schema_ref": "#/components/schemas/ProvidersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "provider-detail",
       "path": "/metagraph/providers/{slug}.json",
       "schema_ref": "#/components/schemas/ProviderArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",
       "schema_ref": "#/components/schemas/ProviderEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "api-index",
       "path": "/metagraph/api-index.json",
       "schema_ref": "#/components/schemas/ApiIndexArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "openapi",
       "path": "/metagraph/openapi.json",
       "schema_ref": "#/components/schemas/OpenApiArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "type-definitions",
       "path": "/metagraph/types.d.ts",
       "schema_ref": null,
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "changelog",
       "path": "/metagraph/changelog.json",
       "schema_ref": "#/components/schemas/ChangelogArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnets",
       "path": "/metagraph/subnets.json",
       "schema_ref": "#/components/schemas/SubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "metagraph-latest",
       "path": "/metagraph/metagraph/latest.json",
       "schema_ref": "#/components/schemas/SubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-detail",
       "path": "/metagraph/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-overview",
       "path": "/metagraph/overview/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetOverviewArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "profiles",
       "path": "/metagraph/profiles.json",
       "schema_ref": "#/components/schemas/SubnetProfilesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "profile-detail",
       "path": "/metagraph/profiles/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetProfileArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "surfaces",
       "path": "/metagraph/surfaces.json",
       "schema_ref": "#/components/schemas/SurfacesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "surface-aliases",
       "path": "/metagraph/surface-aliases.json",
       "schema_ref": "#/components/schemas/SurfaceAliasesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "surfaces-subnet",
       "path": "/metagraph/surfaces/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetSurfacesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "endpoints",
       "path": "/metagraph/endpoints.json",
       "schema_ref": "#/components/schemas/EndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "endpoints-subnet",
       "path": "/metagraph/endpoints/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "candidates",
       "path": "/metagraph/candidates.json",
       "schema_ref": "#/components/schemas/CandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "candidates-subnet",
       "path": "/metagraph/candidates/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetCandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "review-queue",
       "path": "/metagraph/review-queue.json",
       "schema_ref": "#/components/schemas/ReviewQueueArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "search",
       "path": "/metagraph/search.json",
       "schema_ref": "#/components/schemas/SearchArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "search-index",
       "path": "/metagraph/search-index.json",
       "schema_ref": "#/components/schemas/SearchIndexArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "coverage",
       "path": "/metagraph/coverage.json",
       "schema_ref": "#/components/schemas/CoverageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "coverage-depth",
       "path": "/metagraph/coverage-depth.json",
       "schema_ref": "#/components/schemas/CoverageDepthArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "economics",
       "path": "/metagraph/economics.json",
       "schema_ref": "#/components/schemas/EconomicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "economics-trends",
       "path": "/metagraph/economics/trends.json",
       "schema_ref": "#/components/schemas/EconomicsTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "registry-summary",
       "path": "/metagraph/registry-summary.json",
       "schema_ref": "#/components/schemas/RegistrySummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "lineage",
       "path": "/metagraph/lineage.json",
       "schema_ref": "#/components/schemas/LineageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "fixtures-index",
       "path": "/metagraph/fixtures.json",
       "schema_ref": "#/components/schemas/FixturesIndexArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "agent-resources",
       "path": "/metagraph/agent-resources.json",
       "schema_ref": "#/components/schemas/AgentResourcesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "fixture-detail",
       "path": "/metagraph/fixtures/{surface_id}.json",
       "schema_ref": "#/components/schemas/FixtureArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "curation",
       "path": "/metagraph/curation.json",
       "schema_ref": "#/components/schemas/CurationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "gaps",
       "path": "/metagraph/gaps.json",
       "schema_ref": "#/components/schemas/GapsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "verification",
       "path": "/metagraph/verification/latest.json",
       "schema_ref": "#/components/schemas/VerificationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "verification-subnet",
       "path": "/metagraph/verification/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetVerificationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "freshness",
       "path": "/metagraph/freshness.json",
       "schema_ref": "#/components/schemas/FreshnessArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "source-health",
       "path": "/metagraph/source-health.json",
       "schema_ref": "#/components/schemas/SourceHealthArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "source-snapshots",
       "path": "/metagraph/source-snapshots.json",
       "schema_ref": "#/components/schemas/SourceSnapshotsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "evidence-ledger",
       "path": "/metagraph/evidence-ledger.json",
       "schema_ref": "#/components/schemas/EvidenceLedgerArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "evidence-subnet",
       "path": "/metagraph/evidence/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetEvidenceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "health-latest",
       "path": "/metagraph/health/latest.json",
       "schema_ref": "#/components/schemas/HealthLatestArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "health-summary",
       "path": "/metagraph/health/summary.json",
       "schema_ref": "#/components/schemas/HealthSummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "health-history",
       "path": "/metagraph/health/history/{date}.json",
       "schema_ref": "#/components/schemas/HealthHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "health-subnet",
       "path": "/metagraph/health/subnets/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthSubnetArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "health-badge",
       "path": "/metagraph/health/badges/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthBadgeArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "health-trends",
       "path": "/metagraph/health/trends/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "health-trends-bulk",
       "path": "/metagraph/health/trends.json",
       "schema_ref": "#/components/schemas/BulkHealthTrendsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "health-percentiles",
       "path": "/metagraph/health/percentiles/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthPercentilesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "health-incidents",
       "path": "/metagraph/health/incidents/{netuid}.json",
       "schema_ref": "#/components/schemas/HealthIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-trajectory",
       "path": "/metagraph/subnets/{netuid}/trajectory.json",
       "schema_ref": "#/components/schemas/SubnetTrajectoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-concentration",
       "path": "/metagraph/subnets/{netuid}/concentration.json",
       "schema_ref": "#/components/schemas/SubnetConcentrationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-performance",
       "path": "/metagraph/subnets/{netuid}/performance.json",
       "schema_ref": "#/components/schemas/SubnetPerformanceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-concentration-history",
       "path": "/metagraph/subnets/{netuid}/concentration/history.json",
       "schema_ref": "#/components/schemas/SubnetConcentrationHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-turnover",
       "path": "/metagraph/subnets/{netuid}/turnover.json",
       "schema_ref": "#/components/schemas/SubnetTurnoverArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-stake-flow",
       "path": "/metagraph/subnets/{netuid}/stake-flow.json",
       "schema_ref": "#/components/schemas/SubnetStakeFlowArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-movers",
       "path": "/metagraph/subnets/movers.json",
       "schema_ref": "#/components/schemas/SubnetMoversArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "global-validators",
       "path": "/metagraph/validators.json",
       "schema_ref": "#/components/schemas/GlobalValidatorsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-metagraph",
       "path": "/metagraph/subnets/{netuid}/metagraph.json",
       "schema_ref": "#/components/schemas/SubnetMetagraphArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-neuron",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}.json",
       "schema_ref": "#/components/schemas/NeuronDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-validators",
       "path": "/metagraph/subnets/{netuid}/validators.json",
       "schema_ref": "#/components/schemas/SubnetValidatorsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-yield",
       "path": "/metagraph/subnets/{netuid}/yield.json",
       "schema_ref": "#/components/schemas/SubnetYieldArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-events",
       "path": "/metagraph/subnets/{netuid}/events.json",
       "schema_ref": "#/components/schemas/SubnetEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-neuron-history",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}/history.json",
       "schema_ref": "#/components/schemas/NeuronHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-history",
       "path": "/metagraph/subnets/{netuid}/history.json",
       "schema_ref": "#/components/schemas/SubnetHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-identity-history",
       "path": "/metagraph/subnets/{netuid}/identity-history.json",
       "schema_ref": "#/components/schemas/SubnetIdentityHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "account-summary",
       "path": "/metagraph/accounts/{ss58}.json",
       "schema_ref": "#/components/schemas/AccountSummaryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "account-events",
       "path": "/metagraph/accounts/{ss58}/events.json",
       "schema_ref": "#/components/schemas/AccountEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "account-history",
       "path": "/metagraph/accounts/{ss58}/history.json",
       "schema_ref": "#/components/schemas/AccountHistoryArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "account-extrinsics",
       "path": "/metagraph/accounts/{ss58}/extrinsics.json",
       "schema_ref": "#/components/schemas/AccountExtrinsicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "account-transfers",
       "path": "/metagraph/accounts/{ss58}/transfers.json",
       "schema_ref": "#/components/schemas/AccountTransfersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "account-counterparties",
       "path": "/metagraph/accounts/{ss58}/counterparties.json",
       "schema_ref": "#/components/schemas/AccountCounterpartiesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "account-stake-flow",
       "path": "/metagraph/accounts/{ss58}/stake-flow.json",
       "schema_ref": "#/components/schemas/AccountStakeFlowArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "account-subnets",
       "path": "/metagraph/accounts/{ss58}/subnets.json",
       "schema_ref": "#/components/schemas/AccountSubnetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "account-balance",
       "path": "/metagraph/accounts/{ss58}/balance.json",
       "schema_ref": "#/components/schemas/AccountBalanceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "blocks-feed",
       "path": "/metagraph/blocks.json",
       "schema_ref": "#/components/schemas/BlocksFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "block-detail",
       "path": "/metagraph/blocks/{ref}.json",
       "schema_ref": "#/components/schemas/BlockDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "block-extrinsics",
       "path": "/metagraph/blocks/{ref}/extrinsics.json",
       "schema_ref": "#/components/schemas/BlockExtrinsicsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "block-events",
       "path": "/metagraph/blocks/{ref}/events.json",
       "schema_ref": "#/components/schemas/BlockEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "chain-events-feed",
       "path": "/metagraph/chain-events.json",
       "schema_ref": "#/components/schemas/ChainEventsFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "block-chain-events",
       "path": "/metagraph/blocks/{ref}/chain-events.json",
       "schema_ref": "#/components/schemas/BlockChainEventsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "chain-events-stats",
       "path": "/metagraph/chain-events/stats.json",
       "schema_ref": "#/components/schemas/ChainEventsStatsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "extrinsics-feed",
       "path": "/metagraph/extrinsics.json",
       "schema_ref": "#/components/schemas/ExtrinsicsFeedArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "extrinsic-detail",
       "path": "/metagraph/extrinsics/{hash}.json",
       "schema_ref": "#/components/schemas/ExtrinsicDetailArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "chain-activity",
       "path": "/metagraph/chain/activity.json",
       "schema_ref": "#/components/schemas/ChainActivityArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "chain-calls",
       "path": "/metagraph/chain/calls.json",
       "schema_ref": "#/components/schemas/ChainCallsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "chain-signers",
       "path": "/metagraph/chain/signers.json",
       "schema_ref": "#/components/schemas/ChainSignersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "chain-transfers",
       "path": "/metagraph/chain/transfers.json",
       "schema_ref": "#/components/schemas/ChainTransfersArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "chain-fees",
       "path": "/metagraph/chain/fees.json",
       "schema_ref": "#/components/schemas/ChainFeesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "chain-concentration",
       "path": "/metagraph/chain/concentration.json",
       "schema_ref": "#/components/schemas/ChainConcentrationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "chain-performance",
       "path": "/metagraph/chain/performance.json",
       "schema_ref": "#/components/schemas/ChainPerformanceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-uptime",
       "path": "/metagraph/subnets/{netuid}/uptime.json",
       "schema_ref": "#/components/schemas/UptimeArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "global-incidents",
       "path": "/metagraph/incidents.json",
       "schema_ref": "#/components/schemas/GlobalIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",
       "schema_ref": "#/components/schemas/RegistryLeaderboardsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "compare",
       "path": "/metagraph/compare.json",
       "schema_ref": "#/components/schemas/CompareArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "rpc-usage",
       "path": "/metagraph/rpc/usage.json",
       "schema_ref": "#/components/schemas/RpcUsageArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
       "schema_ref": "#/components/schemas/RpcEndpointsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "rpc-pools",
       "path": "/metagraph/rpc/pools.json",
       "schema_ref": "#/components/schemas/RpcPoolsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "endpoint-pools",
       "path": "/metagraph/endpoint-pools.json",
       "schema_ref": "#/components/schemas/EndpointPoolsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "endpoint-incidents",
       "path": "/metagraph/endpoint-incidents.json",
       "schema_ref": "#/components/schemas/EndpointIncidentsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "operational-surfaces",
       "path": "/metagraph/operational-surfaces.json",
       "schema_ref": "#/components/schemas/OperationalSurfacesArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "agent-catalog",
       "path": "/metagraph/agent-catalog.json",
       "schema_ref": "#/components/schemas/AgentCatalogArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "agent-catalog-subnet",
       "path": "/metagraph/agent-catalog/{netuid}.json",
       "schema_ref": "#/components/schemas/AgentCatalogSubnetArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",
       "schema_ref": "#/components/schemas/SchemaDriftArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "schema-index",
       "path": "/metagraph/schemas/index.json",
       "schema_ref": "#/components/schemas/SchemaIndexArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "schema-snapshot",
       "path": "/metagraph/schemas/{surface_id}.json",
       "schema_ref": "#/components/schemas/JsonObject",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",
       "schema_ref": "#/components/schemas/AdapterArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "r2-manifest",
       "path": "/metagraph/r2-manifest.json",
       "schema_ref": "#/components/schemas/R2ManifestArtifact",
       "storage_tier": "dual"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "review-curation",
       "path": "/metagraph/review/curation.json",
       "schema_ref": "#/components/schemas/ReviewCurationArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "review-gap-priorities",
       "path": "/metagraph/review/gap-priorities.json",
       "schema_ref": "#/components/schemas/ReviewGapPrioritiesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "subnet-gaps",
       "path": "/metagraph/review/gaps/{netuid}.json",
       "schema_ref": "#/components/schemas/SubnetGapsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "review-profile-completeness",
       "path": "/metagraph/review/profile-completeness.json",
       "schema_ref": "#/components/schemas/ReviewProfileCompletenessArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "review-adapter-candidates",
       "path": "/metagraph/review/adapter-candidates.json",
       "schema_ref": "#/components/schemas/ReviewAdapterCandidatesArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "review-enrichment-queue",
       "path": "/metagraph/review/enrichment-queue.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentQueueArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "review-enrichment-evidence",
       "path": "/metagraph/review/enrichment-evidence.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentEvidenceArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "review-enrichment-targets",
       "path": "/metagraph/review/enrichment-targets.json",
       "schema_ref": "#/components/schemas/ReviewEnrichmentTargetsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
       "schema_ref": "#/components/schemas/ReviewDecisionsArtifact",
       "storage_tier": "r2"
     },
     {
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "id": "build-summary",
       "path": "/metagraph/build-summary.json",
       "schema_ref": "#/components/schemas/BuildSummaryArtifact",
@@ -835,7 +835,7 @@
     }
   ],
   "base_path": "/api/v1",
-  "contract_version": "2026-07-02.1",
+  "contract_version": "2026-07-03.1",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "openapi_url": "/api/v1/openapi.json",
   "primary_domain": "api.metagraph.sh",
@@ -4609,6 +4609,17 @@
             "minimum": 1,
             "type": "integer"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -4645,6 +4656,17 @@
             "minimum": 1,
             "type": "integer"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -4664,6 +4686,17 @@
           "schema": {
             "enum": [
               "true"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
             ],
             "type": "string"
           }
@@ -4692,7 +4725,19 @@
       "public": true,
       "query_collection": null,
       "query_filter_names": [],
-      "query_parameters": []
+      "query_parameters": [
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/subnets/{netuid}/yield.json",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -2,7 +2,7 @@
   "artifacts": [
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Public artifact contract metadata for metagraph.sh consumers.",
       "id": "contracts",
       "path": "/metagraph/contracts.json",
@@ -11,7 +11,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Provider/source registry.",
       "id": "providers",
       "path": "/metagraph/providers.json",
@@ -20,7 +20,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-provider detail payload.",
       "id": "provider-detail",
       "path": "/metagraph/providers/{slug}.json",
@@ -29,7 +29,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Endpoint resources for one provider or operator.",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",
@@ -38,7 +38,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Clean API route index for metagraph.sh consumers.",
       "id": "api-index",
       "path": "/metagraph/api-index.json",
@@ -47,7 +47,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "OpenAPI 3.1 contract for the metagraph.sh backend API.",
       "id": "openapi",
       "path": "/metagraph/openapi.json",
@@ -56,7 +56,7 @@
     },
     {
       "content_type": "text/plain; charset=utf-8",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Generated TypeScript definitions for metagraph.sh backend consumers.",
       "id": "type-definitions",
       "path": "/metagraph/types.d.ts",
@@ -65,7 +65,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Reviewable generated artifact and subnet-change summary.",
       "id": "changelog",
       "path": "/metagraph/changelog.json",
@@ -74,7 +74,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "All active Finney subnets with compact registry metadata.",
       "id": "subnets",
       "path": "/metagraph/subnets.json",
@@ -83,7 +83,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Latest normalized all-subnet metagraph index with chain-native state and registry coverage metadata.",
       "id": "metagraph-latest",
       "path": "/metagraph/metagraph/latest.json",
@@ -92,7 +92,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-subnet detail payload.",
       "id": "subnet-detail",
       "path": "/metagraph/subnets/{netuid}.json",
@@ -101,7 +101,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Composed per-subnet overview: profile + health + curation + gaps + counts.",
       "id": "subnet-overview",
       "path": "/metagraph/overview/{netuid}.json",
@@ -110,7 +110,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Public-safe subnet identity and completeness profiles.",
       "id": "profiles",
       "path": "/metagraph/profiles.json",
@@ -119,7 +119,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-subnet public-safe profile detail.",
       "id": "profile-detail",
       "path": "/metagraph/profiles/{netuid}.json",
@@ -128,7 +128,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Curated public interface surfaces only.",
       "id": "surfaces",
       "path": "/metagraph/surfaces.json",
@@ -137,7 +137,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Deprecated surface display-id aliases mapped to stable surface keys for renamed surfaces.",
       "id": "surface-aliases",
       "path": "/metagraph/surface-aliases.json",
@@ -146,7 +146,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Curated public interface surfaces for one subnet.",
       "id": "surfaces-subnet",
       "path": "/metagraph/surfaces/{netuid}.json",
@@ -155,7 +155,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Generalized endpoint/resource registry derived from curated surfaces and probe observations.",
       "id": "endpoints",
       "path": "/metagraph/endpoints.json",
@@ -164,7 +164,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Generalized endpoint/resource registry for one subnet.",
       "id": "endpoints-subnet",
       "path": "/metagraph/endpoints/{netuid}.json",
@@ -173,7 +173,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Unpromoted candidate surfaces from public discovery.",
       "id": "candidates",
       "path": "/metagraph/candidates.json",
@@ -182,7 +182,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Unpromoted candidate surfaces for one subnet.",
       "id": "candidates-subnet",
       "path": "/metagraph/candidates/{netuid}.json",
@@ -191,7 +191,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Candidate surfaces queued for maintainer review.",
       "id": "review-queue",
       "path": "/metagraph/review-queue.json",
@@ -200,7 +200,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Compact search index for subnets, surfaces, and providers.",
       "id": "search",
       "path": "/metagraph/search.json",
@@ -209,7 +209,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Slim search index (the same documents as search.json without the per-document token blobs) for fast browser typeahead and listing.",
       "id": "search-index",
       "path": "/metagraph/search-index.json",
@@ -218,7 +218,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Registry coverage counts and source precedence.",
       "id": "coverage",
       "path": "/metagraph/coverage.json",
@@ -227,7 +227,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Machine-usable coverage depth scorecard with per-subnet readiness dimensions and a ranked enrichment queue.",
       "id": "coverage-depth",
       "path": "/metagraph/coverage-depth.json",
@@ -236,7 +236,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-subnet validator and economic metrics from the chain: validator/miner counts, total + max stake, registration cost, alpha price, derived alpha market-cap and FDV proxies, price-weighted emission share, and on-chain registration block height.",
       "id": "economics",
       "path": "/metagraph/economics.json",
@@ -245,7 +245,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Network-wide economics time series (#1307) aggregated per UTC day across all subnets from the daily subnet_snapshots D1 rollup (the same source the per-subnet trajectory reads), served live at /api/v1/economics/trends (no static file).",
       "id": "economics-trends",
       "path": "/metagraph/economics/trends.json",
@@ -254,7 +254,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Registry-wide summary: completeness rollup, top subnets, level counts, latest changes.",
       "id": "registry-summary",
       "path": "/metagraph/registry-summary.json",
@@ -263,7 +263,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Cross-network subnet lineage: maintainer-approved mainnet ↔ testnet pairs with reviewed match evidence.",
       "id": "lineage",
       "path": "/metagraph/lineage.json",
@@ -272,7 +272,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Index of captured live request/response fixtures (which surfaces carry a sanitized sample).",
       "id": "fixtures-index",
       "path": "/metagraph/fixtures.json",
@@ -281,7 +281,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Machine index of every AI resource: the copyable agent, the MCP server + tools, the skill, llms.txt, OpenAPI, and the agent-facing APIs.",
       "id": "agent-resources",
       "path": "/metagraph/agent-resources.json",
@@ -290,7 +290,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "A captured, sanitized live request/response sample for one surface.",
       "id": "fixture-detail",
       "path": "/metagraph/fixtures/{surface_id}.json",
@@ -299,7 +299,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Curation state and gaps for every active subnet.",
       "id": "curation",
       "path": "/metagraph/curation.json",
@@ -308,7 +308,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Missing public interface facets by subnet.",
       "id": "gaps",
       "path": "/metagraph/gaps.json",
@@ -317,7 +317,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Latest candidate verification snapshot.",
       "id": "verification",
       "path": "/metagraph/verification/latest.json",
@@ -326,7 +326,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Latest candidate verification snapshot for one subnet.",
       "id": "verification-subnet",
       "path": "/metagraph/verification/subnets/{netuid}.json",
@@ -335,7 +335,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Freshness and staleness summary for generated backend data.",
       "id": "freshness",
       "path": "/metagraph/freshness.json",
@@ -344,7 +344,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Upstream source and provider health summary.",
       "id": "source-health",
       "path": "/metagraph/source-health.json",
@@ -353,7 +353,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Compact hashes and counts for canonical source inputs.",
       "id": "source-snapshots",
       "path": "/metagraph/source-snapshots.json",
@@ -362,7 +362,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Public evidence ledger for subnet and surface claims.",
       "id": "evidence-ledger",
       "path": "/metagraph/evidence-ledger.json",
@@ -371,7 +371,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Public evidence ledger claims for one subnet.",
       "id": "evidence-subnet",
       "path": "/metagraph/evidence/{netuid}.json",
@@ -380,7 +380,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Latest surface health snapshot.",
       "id": "health-latest",
       "path": "/metagraph/health/latest.json",
@@ -389,7 +389,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Global and per-subnet health rollup.",
       "id": "health-summary",
       "path": "/metagraph/health/summary.json",
@@ -398,7 +398,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Compact daily health-history snapshot.",
       "id": "health-history",
       "path": "/metagraph/health/history/{date}.json",
@@ -407,7 +407,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-subnet health payload for metagraph.sh consumers.",
       "id": "health-subnet",
       "path": "/metagraph/health/subnets/{netuid}.json",
@@ -416,7 +416,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Badge data contract for status rendering.",
       "id": "health-badge",
       "path": "/metagraph/health/badges/{netuid}.json",
@@ -425,7 +425,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Computed 7d/30d uptime + success-only latency trends (mean, p50/p95/p99 tail, and healthy-sample count) for one subnet's operational surfaces. Served live from D1 at /api/v1/subnets/{netuid}/health/trends (no static file).",
       "id": "health-trends",
       "path": "/metagraph/health/trends/{netuid}.json",
@@ -434,7 +434,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Compact all-subnet 7d/30d daily uptime + success-only latency trend matrix (mean + healthy-sample count). Served live from D1 at /api/v1/health/trends (no static file).",
       "id": "health-trends-bulk",
       "path": "/metagraph/health/trends.json",
@@ -443,7 +443,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Latency percentiles (p50/p95/p99 + avg/min/max) per operational surface for one subnet, computed live from D1 at /api/v1/subnets/{netuid}/health/percentiles (no static file).",
       "id": "health-percentiles",
       "path": "/metagraph/health/percentiles/{netuid}.json",
@@ -452,7 +452,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "SLA (uptime ratio) and reconstructed downtime incidents per operational surface for one subnet, computed live from D1 at /api/v1/subnets/{netuid}/health/incidents (no static file).",
       "id": "health-incidents",
       "path": "/metagraph/health/incidents/{netuid}.json",
@@ -461,7 +461,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Week-over-week structural trajectory (completeness + surface/endpoint counts) for one subnet from daily snapshots, served live from D1 at /api/v1/subnets/{netuid}/trajectory (no static file).",
       "id": "subnet-trajectory",
       "path": "/metagraph/subnets/{netuid}/trajectory.json",
@@ -470,7 +470,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Stake & emission concentration metrics (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) for one subnet across three lenses — per-UID, per-entity (coldkeys collapsed to the true control distribution), and validator-only consensus power — served live from the neurons D1 tier at /api/v1/subnets/{netuid}/concentration (no static file).",
       "id": "subnet-concentration",
       "path": "/metagraph/subnets/{netuid}/concentration.json",
@@ -479,7 +479,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Reward-distribution & score-spread metrics for one subnet: concentration of the actual rewards (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) for incentive across all neurons and dividends across validators, plus the p10–p90 spread of the 0–1 trust, consensus, and validator_trust scores — the reward-flow companion to concentration, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/performance (no static file).",
       "id": "subnet-performance",
       "path": "/metagraph/subnets/{netuid}/performance.json",
@@ -488,7 +488,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/concentration/history (no static file).",
       "id": "subnet-concentration-history",
       "path": "/metagraph/subnets/{netuid}/concentration/history.json",
@@ -497,7 +497,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + Jaccard retention, UID deregistrations, and a 0-100 stability score — served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/turnover (no static file).",
       "id": "subnet-turnover",
       "path": "/metagraph/subnets/{netuid}/turnover.json",
@@ -506,7 +506,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Net stake flow for one subnet over a recent window (7d/30d/90d): total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and event counts, with optional ?direction=all|in|out to filter inflow or outflow only, summed live from the account_events stream at /api/v1/subnets/{netuid}/stake-flow (no static file).",
       "id": "subnet-stake-flow",
       "path": "/metagraph/subnets/{netuid}/stake-flow.json",
@@ -515,7 +515,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between a window's start and end snapshots, computed live from the neuron_daily D1 rollup at /api/v1/subnets/movers (no static file).",
       "id": "subnet-movers",
       "path": "/metagraph/subnets/movers.json",
@@ -524,7 +524,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships and ranked by subnet footprint, UID footprint, validator trust, or cross-subnet stake/emission totals, computed live from the neurons D1 tier at /api/v1/validators (no static file).",
       "id": "global-validators",
       "path": "/metagraph/validators.json",
@@ -533,7 +533,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-UID metagraph (stake, trust, consensus, incentive, dividends, emission, validator_permit, rank, axon) for one subnet, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/metagraph (no static file).",
       "id": "subnet-metagraph",
       "path": "/metagraph/subnets/{netuid}/metagraph.json",
@@ -542,7 +542,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "A single neuron's metagraph state by UID, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/neurons/{uid} (no static file).",
       "id": "subnet-neuron",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}.json",
@@ -551,7 +551,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Validators (validator_permit) of one subnet ranked by stake, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/validators (no static file).",
       "id": "subnet-validators",
       "path": "/metagraph/subnets/{netuid}/validators.json",
@@ -560,7 +560,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-UID emission yield (emission/stake return rate) for one subnet over the current metagraph snapshot, ranked high to low with a distribution summary (subnet aggregate yield, mean, p25/median/p75/p90 percentiles), a validator/miner split, and a per-UID above/below-median label, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/yield (no static file).",
       "id": "subnet-yield",
       "path": "/metagraph/subnets/{netuid}/yield.json",
@@ -569,7 +569,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "First-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, served live from the account_events D1 tier filtered by netuid at /api/v1/subnets/{netuid}/events (no static file).",
       "id": "subnet-events",
       "path": "/metagraph/subnets/{netuid}/events.json",
@@ -578,7 +578,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-UID daily metagraph history (stake/trust/emission/rank over time) for one UID, served live from the neuron_daily D1 rollup tier at /api/v1/subnets/{netuid}/neurons/{uid}/history (no static file).",
       "id": "subnet-neuron-history",
       "path": "/metagraph/subnets/{netuid}/neurons/{uid}/history.json",
@@ -587,7 +587,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-subnet daily aggregate history (neuron/validator counts + stake/emission totals) for one subnet, served live from the neuron_daily D1 rollup tier at /api/v1/subnets/{netuid}/history (no static file).",
       "id": "subnet-history",
       "path": "/metagraph/subnets/{netuid}/history.json",
@@ -596,7 +596,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Append-only on-chain identity timeline for one subnet (SubnetIdentitiesV3 field snapshots on change), served live from the subnet_identity_history D1 tier at /api/v1/subnets/{netuid}/identity-history (no static file).",
       "id": "subnet-identity-history",
       "path": "/metagraph/subnets/{netuid}/identity-history.json",
@@ -605,7 +605,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Cross-subnet activity summary for one account (hotkey or coldkey): chain-event aggregates joined to current registrations, served live from D1 at /api/v1/accounts/{ss58} (no static file).",
       "id": "account-summary",
       "path": "/metagraph/accounts/{ss58}.json",
@@ -614,7 +614,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events (no static file).",
       "id": "account-events",
       "path": "/metagraph/accounts/{ss58}/events.json",
@@ -623,7 +623,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Durable per-day activity series for one account (hotkey-keyed, newest day first), served live from the account_events_daily rollup at /api/v1/accounts/{ss58}/history (no static file).",
       "id": "account-history",
       "path": "/metagraph/accounts/{ss58}/history.json",
@@ -632,7 +632,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Paginated extrinsics this account signed (by signer), newest first, served live from the extrinsics D1 tier at /api/v1/accounts/{ss58}/extrinsics (no static file).",
       "id": "account-extrinsics",
       "path": "/metagraph/accounts/{ss58}/extrinsics.json",
@@ -641,7 +641,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers (no static file).",
       "id": "account-transfers",
       "path": "/metagraph/accounts/{ss58}/transfers.json",
@@ -650,7 +650,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-counterparty fund-flow rollup for one account, with optional ?counterparty=<ss58> relationship evidence — native-TAO transfers from the account_events D1 tier at /api/v1/accounts/{ss58}/counterparties (no static file).",
       "id": "account-counterparties",
       "path": "/metagraph/accounts/{ss58}/counterparties.json",
@@ -659,7 +659,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "One account's StakeAdded vs StakeRemoved flow per subnet over a recent window (7d/30d/90d): per-subnet net and gross flow with a direction label, plus account totals, an HHI concentration of where the flow is focused, and the dominant subnet — summed live from the account_events D1 tier at /api/v1/accounts/{ss58}/stake-flow (no static file).",
       "id": "account-stake-flow",
       "path": "/metagraph/accounts/{ss58}/stake-flow.json",
@@ -668,7 +668,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "The subnets where an account's hotkey is currently registered, served live from the neurons D1 tier at /api/v1/accounts/{ss58}/subnets (no static file).",
       "id": "account-subnets",
       "path": "/metagraph/accounts/{ss58}/subnets.json",
@@ -677,7 +677,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Live TAO balance (free+reserved, in TAO) for a finney account, queried from the RPC at request time with 60s KV cache. balance_tao is null on RPC failure. (#1818)",
       "id": "account-balance",
       "path": "/metagraph/accounts/{ss58}/balance.json",
@@ -686,7 +686,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "The recent-block feed (newest first) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks (no static file).",
       "id": "blocks-feed",
       "path": "/metagraph/blocks.json",
@@ -695,7 +695,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-block detail (by numeric block_number or 0x block_hash) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks/{ref} (no static file).",
       "id": "block-detail",
       "path": "/metagraph/blocks/{ref}.json",
@@ -704,7 +704,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "The extrinsics in one block (by numeric block_number or 0x block_hash), in natural order, served live from the first-party extrinsics D1 tier at /api/v1/blocks/{ref}/extrinsics (no static file).",
       "id": "block-extrinsics",
       "path": "/metagraph/blocks/{ref}/extrinsics.json",
@@ -713,7 +713,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "The decoded chain events in one block (by numeric block_number or 0x block_hash), in natural order, served live from the first-party account_events D1 tier filtered by block_number at /api/v1/blocks/{ref}/events (no static file).",
       "id": "block-events",
       "path": "/metagraph/blocks/{ref}/events.json",
@@ -722,7 +722,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events (no static file). Distinct from the curated account-attributed event stream; empty before the all-events backfill runs.",
       "id": "chain-events-feed",
       "path": "/metagraph/chain-events.json",
@@ -731,7 +731,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Every raw pallet-level event in one block (event_index ascending) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/blocks/{ref}/chain-events (no static file). Distinct from /blocks/{ref}/events (the curated account-attributed D1 stream).",
       "id": "block-chain-events",
       "path": "/metagraph/blocks/{ref}/chain-events.json",
@@ -740,7 +740,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Chain-activity aggregate (pallet.method event distribution over the most recent N blocks) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events/stats (no static file) and consumed by the get_chain_activity MCP tool.",
       "id": "chain-events-stats",
       "path": "/metagraph/chain-events/stats.json",
@@ -749,7 +749,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "The recent-extrinsic feed (newest first) for the block explorer (#1345), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics (no static file).",
       "id": "extrinsics-feed",
       "path": "/metagraph/extrinsics.json",
@@ -758,7 +758,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-extrinsic detail (by 0x extrinsic_hash OR the composite <block_number>-<extrinsic_index> id) for the block explorer (#1345/#1848), served live from the first-party extrinsics D1 tier at /api/v1/extrinsics/{hash} (no static file).",
       "id": "extrinsic-detail",
       "path": "/metagraph/extrinsics/{hash}.json",
@@ -767,7 +767,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Daily network-activity aggregates (extrinsic/event/block counts, success rate, unique signers) over a 7d or 30d window for the block explorer (#1987), computed live from the first-party chain D1 tiers at /api/v1/chain/activity (no static file).",
       "id": "chain-activity",
       "path": "/metagraph/chain/activity.json",
@@ -776,7 +776,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Extrinsic call-mix breakdown (count + share per call_module / call_function) over a 7d or 30d window for the block explorer (#1989), computed live from the first-party extrinsics D1 tier at /api/v1/chain/calls (no static file).",
       "id": "chain-calls",
       "path": "/metagraph/chain/calls.json",
@@ -785,7 +785,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Windowed most-active-account leaderboard (signers ranked by tx_count or total_fee_tao, with fees/tips + newest block) over a 7d or 30d window for the block explorer (#1990), computed live from the first-party extrinsics D1 tier at /api/v1/chain/signers (no static file).",
       "id": "chain-signers",
       "path": "/metagraph/chain/signers.json",
@@ -794,7 +794,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Network-wide native-TAO transfer analytics over a 7d or 30d window: total Balances.Transfer volume + count, distinct senders/receivers, the top senders and receivers ranked by volume, and the top senders' share of total volume (a concentration signal), computed live from the account_events Transfer feed at /api/v1/chain/transfers (no static file).",
       "id": "chain-transfers",
       "path": "/metagraph/chain/transfers.json",
@@ -803,7 +803,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Fee/tip market analytics (daily totals, averages, exact medians, and a top-fee-payer list) over a 7d or 30d window for the block explorer (#1988), computed live from the first-party extrinsics D1 tier at /api/v1/chain/fees (no static file).",
       "id": "chain-fees",
       "path": "/metagraph/chain/fees.json",
@@ -812,7 +812,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Network-wide stake and emission concentration metrics (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) aggregated across all subnets' neurons over three lenses (per-UID, per-entity with coldkeys collapsed across subnets into the network control distribution, and validator-only consensus power), computed live from the neurons D1 tier at /api/v1/chain/concentration (no static file).",
       "id": "chain-concentration",
       "path": "/metagraph/chain/concentration.json",
@@ -821,7 +821,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Network-wide reward-distribution & score-spread metrics aggregated across all subnets' neurons: reward concentration (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) for incentive across all neurons and dividends across validators, plus the p10–p90 spread of the 0–1 trust, consensus, and validator_trust scores, and the subnet_count the snapshot spans — the network-wide reward-flow companion to chain-concentration, computed live from the neurons D1 tier at /api/v1/chain/performance (no static file).",
       "id": "chain-performance",
       "path": "/metagraph/chain/performance.json",
@@ -830,7 +830,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Long-term daily uptime history per operational surface for one subnet (90d/1y window), served live from the surface_uptime_daily D1 rollup (no static file).",
       "id": "subnet-uptime",
       "path": "/metagraph/subnets/{netuid}/uptime.json",
@@ -839,7 +839,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window, served live from D1 at /api/v1/incidents (no static file).",
       "id": "global-incidents",
       "path": "/metagraph/incidents.json",
@@ -848,7 +848,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Registry leaderboards — operational (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable) and economic opportunity (open-slots, cheapest-registration, highest-emission, validator-headroom) — computed live from D1 + registry projections + the economics tier at /api/v1/registry/leaderboards (no static file).",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",
@@ -857,7 +857,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Cross-subnet comparison — registry structure (completeness + surface counts), the live economics tier, and the live per-subnet health rollup placed side by side for the requested netuids in requested order — computed live from registry projections + the economics tier + D1 at /api/v1/compare (no static file).",
       "id": "compare",
       "path": "/metagraph/compare.json",
@@ -866,7 +866,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets) over a 7d/30d window, computed live from the rpc_proxy_events telemetry at /api/v1/rpc/usage (no static file).",
       "id": "rpc-usage",
       "path": "/metagraph/rpc/usage.json",
@@ -875,7 +875,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Bittensor base-layer RPC endpoint registry and probe status.",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
@@ -884,7 +884,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Endpoint pool scoring for future read-only RPC routing.",
       "id": "rpc-pools",
       "path": "/metagraph/rpc/pools.json",
@@ -893,7 +893,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Generalized endpoint pool scoring for future read-only routing.",
       "id": "endpoint-pools",
       "path": "/metagraph/endpoint-pools.json",
@@ -902,7 +902,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Probe-derived endpoint incident summary and active endpoint failures.",
       "id": "endpoint-incidents",
       "path": "/metagraph/endpoint-incidents.json",
@@ -911,7 +911,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Operational surfaces (RPC/WSS/subnet-api/SSE/data-artifact) probed live by the cron health prober; input list for the 15-minute scheduled prober.",
       "id": "operational-surfaces",
       "path": "/metagraph/operational-surfaces.json",
@@ -920,7 +920,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Compact index of subnets exposing callable services (subnet-api/openapi/sse/data-artifact) — the machine-readable 'which subnet does X + how to call it' index for AI agents.",
       "id": "agent-catalog",
       "path": "/metagraph/agent-catalog.json",
@@ -929,7 +929,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Per-subnet agent capability catalog: each callable service with its base URL, auth, machine-readable schema, and live-build health/eligibility.",
       "id": "agent-catalog-subnet",
       "path": "/metagraph/agent-catalog/{netuid}.json",
@@ -938,7 +938,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "OpenAPI schema snapshot/drift status.",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",
@@ -947,7 +947,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Index of captured machine-readable schemas.",
       "id": "schema-index",
       "path": "/metagraph/schemas/index.json",
@@ -956,7 +956,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Captured machine-readable OpenAPI/Swagger schema snapshot detail.",
       "id": "schema-snapshot",
       "path": "/metagraph/schemas/{surface_id}.json",
@@ -965,7 +965,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Adapter-backed public metrics by subnet slug.",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",
@@ -974,7 +974,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "R2 upload manifest for generated artifact history.",
       "id": "r2-manifest",
       "path": "/metagraph/r2-manifest.json",
@@ -983,7 +983,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Maintainer curation and adapter candidate report.",
       "id": "review-curation",
       "path": "/metagraph/review/curation.json",
@@ -992,7 +992,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Subnet interface gap priorities.",
       "id": "review-gap-priorities",
       "path": "/metagraph/review/gap-priorities.json",
@@ -1001,7 +1001,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Interface gap priorities and enrichment queue for one subnet.",
       "id": "subnet-gaps",
       "path": "/metagraph/review/gaps/{netuid}.json",
@@ -1010,7 +1010,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Profile completeness and contributor targeting report.",
       "id": "review-profile-completeness",
       "path": "/metagraph/review/profile-completeness.json",
@@ -1019,7 +1019,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Subnets worth deeper adapter work.",
       "id": "review-adapter-candidates",
       "path": "/metagraph/review/adapter-candidates.json",
@@ -1028,7 +1028,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Prioritized all-subnet enrichment work queue for contributor-safe registry improvements.",
       "id": "review-enrichment-queue",
       "path": "/metagraph/review/enrichment-queue.json",
@@ -1037,7 +1037,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Detailed candidate evidence by missing or contributor-target surface kind for enrichment work.",
       "id": "review-enrichment-evidence",
       "path": "/metagraph/review/enrichment-evidence.json",
@@ -1046,7 +1046,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Contributor-oriented enrichment target pack grouped by submission kind, review route, and evidence action.",
       "id": "review-enrichment-targets",
       "path": "/metagraph/review/enrichment-targets.json",
@@ -1055,7 +1055,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Public-safe maintainer review decision ledger.",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
@@ -1064,7 +1064,7 @@
     },
     {
       "content_type": "application/json",
-      "contract_version": "2026-07-02.1",
+      "contract_version": "2026-07-03.1",
       "description": "Generated build summary.",
       "id": "build-summary",
       "path": "/metagraph/build-summary.json",
@@ -1073,7 +1073,7 @@
     }
   ],
   "base_path": "/metagraph",
-  "contract_version": "2026-07-02.1",
+  "contract_version": "2026-07-03.1",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "name": "Metagraphed public backend artifact contract",
   "notes": [

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -15809,7 +15809,7 @@
   "info": {
     "description": "Public, read-only API over canonical Metagraphed registry artifacts for Bittensor subnet interfaces. **No authentication** — every operation is an unauthenticated GET. Responses use a stable JSON envelope `{ ok, schema_version, data, meta }` (errors: `{ ok: false, error }`) and carry `ETag` + `Cache-Control` for conditional caching. Rate-limited per client. Multi-network: insert a `/{network}/` segment after `/api/v1/` (mainnet is the default — omit it) to read testnet data, e.g. `/api/v1/testnet/subnets`. Testnet exposes the subset of routes that have data; `/api/v1/lineage` tracks which testnet subnets have graduated.",
     "title": "Metagraphed API",
-    "version": "2026-07-02.1"
+    "version": "2026-07-03.1"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -24136,7 +24136,7 @@
                   "meta": {
                     "artifact_path": "/metagraph/fixtures/7:subnet-api:new_v2.json",
                     "cache": "standard",
-                    "contract_version": "2026-07-02.1",
+                    "contract_version": "2026-07-03.1",
                     "generated_at": "1970-01-01T00:00:00.000Z",
                     "published_at": null,
                     "source": "r2"
@@ -34415,6 +34415,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -34478,9 +34491,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "uid,hotkey,coldkey,active,validator_permit,rank,trust,validator_trust,consensus,incentive,dividends,emission_tao,stake_tao,registered_at_block,is_immunity_period,axon\r\n0,hk_sample,ck_sample,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -36696,6 +36715,19 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -36759,9 +36791,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "uid,hotkey,coldkey,active,validator_permit,rank,trust,validator_trust,consensus,incentive,dividends,emission_tao,stake_tao,registered_at_block,is_immunity_period,axon\r\n0,hk_sample,ck_sample,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -37026,6 +37064,19 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -37100,9 +37151,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,stake_start_tao,stake_end_tao,stake_delta_tao,stake_pct_change,emission_start_tao,emission_end_tao,emission_delta_tao,emission_pct_change,validators_start,validators_end,validators_delta,neurons_start,neurons_end,neurons_delta\r\n7,1000,1250,250,25,10,12,2,20,16,18,2,256,256,0",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -37426,6 +37483,19 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -37506,9 +37576,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,total_emission_tao,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets\r\nhk_sample,ck_sample,1,3,3,1234.5,10.25,0.12,0.98,0.99,2026-07-03T00:00:00.000Z,8454388,\"[{\"\"netuid\"\":1,\"\"uid\"\":0}]\"",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -37582,7 +37658,7 @@
   ],
   "x-metagraphed": {
     "canonical_artifact_base_path": "/metagraph",
-    "contract_version": "2026-07-02.1",
+    "contract_version": "2026-07-03.1",
     "generated_at": "1970-01-01T00:00:00.000Z",
     "notes": "OpenAPI describes Worker response envelopes and canonical artifact payloads. Raw /metagraph JSON remains the reviewed source contract.",
     "schema_version": 1

--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": "2026-06-30.14",
+  "contract_version": "2026-07-03.1",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "kinds": [
     "archive",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11563,7 +11563,7 @@ export interface operations {
                      *       "meta": {
                      *         "artifact_path": "/metagraph/fixtures/7:subnet-api:new_v2.json",
                      *         "cache": "standard",
-                     *         "contract_version": "2026-07-02.1",
+                     *         "contract_version": "2026-07-03.1",
                      *         "generated_at": "1970-01-01T00:00:00.000Z",
                      *         "published_at": null,
                      *         "source": "r2"
@@ -17901,6 +17901,8 @@ export interface operations {
         parameters: {
             query?: {
                 validator_permit?: "true";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -17910,7 +17912,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -17966,6 +17968,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetMetagraphArtifact"];
                     };
+                    /**
+                     * @example uid,hotkey,coldkey,active,validator_permit,rank,trust,validator_trust,consensus,incentive,dividends,emission_tao,stake_tao,registered_at_block,is_immunity_period,axon
+                     *     0,hk_sample,ck_sample,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -19712,7 +19719,10 @@ export interface operations {
     };
     subnetValidators: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
+            };
             header?: never;
             path: {
                 netuid: number;
@@ -19721,7 +19731,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19777,6 +19787,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetValidatorsArtifact"];
                     };
+                    /**
+                     * @example uid,hotkey,coldkey,active,validator_permit,rank,trust,validator_trust,consensus,incentive,dividends,emission_tao,stake_tao,registered_at_block,is_immunity_period,axon
+                     *     0,hk_sample,ck_sample,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -19965,6 +19980,8 @@ export interface operations {
                 window?: "7d" | "30d" | "90d";
                 sort?: "stake" | "emission" | "validators";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -19972,7 +19989,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -20039,6 +20056,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetMoversArtifact"];
                     };
+                    /**
+                     * @example netuid,stake_start_tao,stake_end_tao,stake_delta_tao,stake_pct_change,emission_start_tao,emission_end_tao,emission_delta_tao,emission_pct_change,validators_start,validators_end,validators_delta,neurons_start,neurons_end,neurons_delta
+                     *     7,1000,1250,250,25,10,12,2,20,16,18,2,256,256,0
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -20216,6 +20238,8 @@ export interface operations {
             query?: {
                 sort?: "avg_validator_trust" | "max_validator_trust" | "stake_dominance" | "subnet_count" | "total_emission" | "total_stake" | "uid_count";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -20223,7 +20247,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -20296,6 +20320,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["GlobalValidatorsArtifact"];
                     };
+                    /**
+                     * @example hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,total_emission_tao,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets
+                     *     hk_sample,ck_sample,1,3,3,1234.5,10.25,0.12,0.98,0.99,2026-07-03T00:00:00.000Z,8454388,"[{""netuid"":1,""uid"":0}]"
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -79,17 +79,18 @@ const patterns = [
     // TS type member) is legitimate metagraph vocabulary (#1304) — an ss58 coldkey
     // is public on-chain data, not a secret. Also allow the "hotkey or coldkey" /
     // "hotkey/coldkey" field-pair phrase (account routes #1347 doc text + the
-    // generated MCP server-card prose), the "coldkey-only" behaviour descriptor (a
-    // coldkey-only ss58 address has no hotkey-attributed rollup), and the
-    // `coldkey =` SQL column comparison. Strip those legitimate spans so only
-    // suspicious prose ("your coldkey seed phrase" — still caught here and by the
+    // generated MCP server-card prose), generated CSV headers for public exports,
+    // the "coldkey-only" behaviour descriptor (a coldkey-only ss58 address has no
+    // hotkey-attributed rollup), and the `coldkey =` SQL column comparison. Strip
+    // those legitimate spans so only suspicious prose ("your coldkey seed phrase"
+    // — still caught here and by the
     // wallet/key-wording rule) trips. The "coldkey-only" exemption is the exact
     // hyphenated phrase, NOT a blanket `coldkey-` strip, so a hyphen can't be used
     // to smuggle a secret ("coldkey-seedphrase: …" still trips). Same rationale as
     // the isMirroredExternalSpec exemption, scoped to the safe forms so the guard
     // stays active everywhere else.
     allow:
-      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bhotkey(?:\s+or\s+|\s*\/\s*)coldkey\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*=/gi,
+      /"coldkey"\s*:?|\bcoldkey(?=,)|\bcoldkey\s*\??\s*:|\bhotkey(?:\s+or\s+|\s*\/\s*)coldkey\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*=/gi,
     soft: true,
   },
   {

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2,7 +2,7 @@ import { artifactStorageTierForPath } from "./artifact-storage.mjs";
 import { DOMAIN_TAGS } from "./domain-tags.mjs";
 import { sampleFromSchema } from "./openapi-sample.mjs";
 
-export const CONTRACT_VERSION = "2026-07-02.1";
+export const CONTRACT_VERSION = "2026-07-03.1";
 export const SCHEMA_VERSION = 1;
 // The API + artifacts are served from the api subdomain; the bare apex
 // (metagraph.sh) is the metagraphed-ui UI. PRIMARY_DOMAIN drives the OpenAPI
@@ -1874,7 +1874,7 @@ export const API_ROUTES = [
     "Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, and validator count between the window's start and end neuron_daily snapshots, with start/end values, deltas, and percentage changes. Sort by stake (default), emission, or validators; limit caps the list (default 20, max 100). Computed live from the neuron_daily D1 rollup.",
     "short",
     ["subnets", "analytics"],
-    [
+    csvRouteQuery([
       {
         name: "window",
         schema: { type: "string", enum: ["7d", "30d", "90d"] },
@@ -1887,7 +1887,7 @@ export const API_ROUTES = [
         name: "limit",
         schema: { type: "integer", minimum: 1, maximum: 100 },
       },
-    ],
+    ]),
     [],
   ),
   route(
@@ -1898,7 +1898,7 @@ export const API_ROUTES = [
     "Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 100). Computed live from the neurons D1 tier.",
     "short",
     ["validators", "analytics"],
-    [
+    csvRouteQuery([
       {
         name: "sort",
         schema: {
@@ -1918,7 +1918,7 @@ export const API_ROUTES = [
         name: "limit",
         schema: { type: "integer", minimum: 1, maximum: 100 },
       },
-    ],
+    ]),
     [],
   ),
   route(
@@ -1929,7 +1929,9 @@ export const API_ROUTES = [
     "Fetch the per-UID metagraph (stake, trust, consensus, incentive, dividends, emission, validator_permit, rank, axon) for one subnet, computed live from the neurons D1 tier. Add ?validator_permit=true for validators only.",
     "short",
     ["subnets", "analytics"],
-    [{ name: "validator_permit", schema: { type: "string", enum: ["true"] } }],
+    csvRouteQuery([
+      { name: "validator_permit", schema: { type: "string", enum: ["true"] } },
+    ]),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(
@@ -1954,7 +1956,7 @@ export const API_ROUTES = [
     "Fetch the validators (validator_permit) of one subnet ranked by stake, computed live from the neurons D1 tier.",
     "short",
     ["subnets", "analytics"],
-    [],
+    csvRouteQuery(),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(
@@ -2807,7 +2809,7 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
         ? {
             "text/csv": {
               schema: { type: "string" },
-              example: "netuid,name\r\n7,Allways",
+              example: csvExampleForRoute(entry),
             },
           }
         : {}),
@@ -2836,7 +2838,7 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
         responses: {
           200: {
             description: entry.csv_response
-              ? "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested."
+              ? csvResponseDescriptionForRoute(entry)
               : "Canonical artifact wrapped in the Metagraphed API envelope.",
             headers: apiResponseHeaders(),
             content: successContent,
@@ -3149,6 +3151,52 @@ function csvListQuery(collection, options = {}) {
       },
     ],
   };
+}
+
+function csvRouteQuery(parameters = []) {
+  return {
+    collection: null,
+    filterNames: [],
+    csvResponse: true,
+    parameters: [
+      ...parameters,
+      {
+        name: "format",
+        description:
+          "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+        schema: { type: "string", enum: ["json", "csv"] },
+      },
+    ],
+  };
+}
+
+function csvExampleForRoute(entry) {
+  if (entry.id === "subnet-movers") {
+    return [
+      "netuid,stake_start_tao,stake_end_tao,stake_delta_tao,stake_pct_change,emission_start_tao,emission_end_tao,emission_delta_tao,emission_pct_change,validators_start,validators_end,validators_delta,neurons_start,neurons_end,neurons_delta",
+      "7,1000,1250,250,25,10,12,2,20,16,18,2,256,256,0",
+    ].join("\r\n");
+  }
+  if (entry.id === "global-validators") {
+    return [
+      "hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,total_emission_tao,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets",
+      'hk_sample,ck_sample,1,3,3,1234.5,10.25,0.12,0.98,0.99,2026-07-03T00:00:00.000Z,8454388,"[{""netuid"":1,""uid"":0}]"',
+    ].join("\r\n");
+  }
+  if (entry.id === "subnet-metagraph" || entry.id === "subnet-validators") {
+    return [
+      "uid,hotkey,coldkey,active,validator_permit,rank,trust,validator_trust,consensus,incentive,dividends,emission_tao,stake_tao,registered_at_block,is_immunity_period,axon",
+      "0,hk_sample,ck_sample,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091",
+    ].join("\r\n");
+  }
+  return "netuid,name\r\n7,Allways";
+}
+
+function csvResponseDescriptionForRoute(entry) {
+  if (entry.query_collection) {
+    return "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.";
+  }
+  return "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.";
 }
 
 function normalizeQueryParameters(queryParameters) {

--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -966,6 +966,34 @@ describe("analytics edge cache", () => {
       );
     }
   });
+
+  test("subnet movers CSV requests use a distinct cache key", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = analyticsEnv(queries);
+
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/movers?sort=emission",
+        { headers: { accept: "text/csv" } },
+      ),
+      env,
+      ctx,
+    );
+    await Promise.resolve();
+
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.deepEqual(cache.putKeys, [
+      expectedKey(
+        "subnet-movers",
+        "/api/v1/subnets/movers",
+        "?window=30d&sort=emission&limit=20&format=csv",
+      ),
+    ]);
+  });
 });
 
 const NEURON_CAPTURED_AT = 1_781_500_000_000;
@@ -1131,6 +1159,60 @@ describe("neurons-tier edge cache", () => {
       ),
     ]);
     assert.equal(cache.store.size, 1);
+  });
+
+  test("CSV requests use distinct neuron-tier cache keys", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const queries = [];
+    const env = neuronsEnv(queries);
+
+    const routes = [
+      {
+        keyParts: "global-validators",
+        path: "/api/v1/validators?limit=1",
+        cachePath: "/api/v1/validators",
+        search: "?sort=subnet_count&limit=1&format=csv",
+      },
+      {
+        keyParts: "subnet-metagraph",
+        path: "/api/v1/subnets/7/metagraph",
+        cachePath: "/api/v1/subnets/7/metagraph",
+        search: "?format=csv",
+      },
+      {
+        keyParts: "subnet-validators",
+        path: "/api/v1/subnets/7/validators",
+        cachePath: "/api/v1/subnets/7/validators",
+        search: "?format=csv",
+      },
+    ];
+
+    for (const route of routes) {
+      const res = await handleRequest(
+        new Request(`https://api.metagraph.sh${route.path}`, {
+          headers: { accept: "text/csv" },
+        }),
+        env,
+        ctx,
+      );
+      await Promise.resolve();
+      assert.equal(res.status, 200, route.keyParts);
+      assert.match(res.headers.get("content-type"), /^text\/csv/);
+    }
+
+    assert.deepEqual(
+      cache.putKeys,
+      routes.map((route) =>
+        expectedStampKey(
+          NEURON_CAPTURED_AT,
+          route.keyParts,
+          route.cachePath,
+          route.search,
+        ),
+      ),
+    );
   });
 
   test("a new neuron captured_at busts cache while health last_run_at is unchanged", async () => {

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -19,7 +19,7 @@ import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
 
 describe("public contract registry", () => {
   test("keeps API routes and artifacts unique", () => {
-    assert.equal(CONTRACT_VERSION, "2026-07-02.1");
+    assert.equal(CONTRACT_VERSION, "2026-07-03.1");
     assert.equal(CACHE_SECONDS.short, 60);
     assert.equal(
       new Set(API_ROUTES.map((route) => route.id)).size,
@@ -194,6 +194,31 @@ describe("public contract registry", () => {
     assert.equal(fixtureExample.meta.source, "r2");
     assert.equal(fixtureExample.meta.pagination, undefined);
     assert.equal(fixtureExample.meta.stale_contract, undefined);
+
+    const csvExamples = [
+      [
+        "/api/v1/subnets/{netuid}/metagraph",
+        "uid,hotkey,coldkey,active,validator_permit,rank,trust,validator_trust,consensus,incentive,dividends,emission_tao,stake_tao,registered_at_block,is_immunity_period,axon",
+      ],
+      [
+        "/api/v1/subnets/{netuid}/validators",
+        "uid,hotkey,coldkey,active,validator_permit,rank,trust,validator_trust,consensus,incentive,dividends,emission_tao,stake_tao,registered_at_block,is_immunity_period,axon",
+      ],
+      [
+        "/api/v1/subnets/movers",
+        "netuid,stake_start_tao,stake_end_tao,stake_delta_tao,stake_pct_change,emission_start_tao,emission_end_tao,emission_delta_tao,emission_pct_change,validators_start,validators_end,validators_delta,neurons_start,neurons_end,neurons_delta",
+      ],
+      [
+        "/api/v1/validators",
+        "hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,total_emission_tao,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets",
+      ],
+    ];
+    for (const [path, expectedHeader] of csvExamples) {
+      const csvContent =
+        openapi.paths[path].get.responses["200"].content["text/csv"];
+      assert.equal(csvContent.schema.type, "string");
+      assert.equal(csvContent.example.split("\r\n")[0], expectedHeader);
+    }
 
     const subnetParameters = openapi.paths["/api/v1/subnets"].get.parameters;
     assert.equal(

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -34,6 +34,12 @@ const ROW = {
   captured_at: 1750000000000,
 };
 const MINER = { ...ROW, uid: 5, validator_permit: 0, hotkey: "5Hk5" };
+const NEURON_CSV_HEADER =
+  "uid,hotkey,coldkey,active,validator_permit,rank,trust,validator_trust,consensus,incentive,dividends,emission_tao,stake_tao,registered_at_block,is_immunity_period,axon";
+const MOVERS_CSV_HEADER =
+  "netuid,stake_start_tao,stake_end_tao,stake_delta_tao,stake_pct_change,emission_start_tao,emission_end_tao,emission_delta_tao,emission_pct_change,validators_start,validators_end,validators_delta,neurons_start,neurons_end,neurons_delta";
+const GLOBAL_VALIDATOR_CSV_HEADER =
+  "hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,total_emission_tao,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets";
 
 describe("metagraph-neurons builders", () => {
   test("formatNeuron coerces 0/1 INTEGER flags to real booleans", () => {
@@ -769,6 +775,84 @@ const getJson = async (path, env) => {
   return { res, body: await res.json() };
 };
 
+const getText = async (path, env, init = {}) => {
+  const res = await handleRequest(
+    new Request(`https://api.metagraph.sh${path}`, init),
+    env,
+    {},
+  );
+  return { res, text: await res.text() };
+};
+
+function createMoversEnv({ comparable = true } = {}) {
+  return {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              all() {
+                if (/MIN\(snapshot_date\)/.test(sql)) {
+                  return Promise.resolve({
+                    results: [
+                      comparable
+                        ? { start_date: "2026-05-31", end_date: "2026-06-30" }
+                        : {
+                            start_date: "2026-06-30",
+                            end_date: "2026-06-30",
+                          },
+                    ],
+                  });
+                }
+                if (/GROUP BY netuid, snapshot_date/.test(sql)) {
+                  return Promise.resolve({
+                    results: [
+                      {
+                        netuid: 1,
+                        snapshot_date: "2026-05-31",
+                        neuron_count: 10,
+                        validator_count: 3,
+                        total_stake_tao: 100,
+                        total_emission_tao: 5,
+                      },
+                      {
+                        netuid: 1,
+                        snapshot_date: "2026-06-30",
+                        neuron_count: 12,
+                        validator_count: 4,
+                        total_stake_tao: 250,
+                        total_emission_tao: 9,
+                      },
+                      {
+                        netuid: 2,
+                        snapshot_date: "2026-05-31",
+                        neuron_count: 8,
+                        validator_count: 2,
+                        total_stake_tao: 50,
+                        total_emission_tao: 4,
+                      },
+                      {
+                        netuid: 2,
+                        snapshot_date: "2026-06-30",
+                        neuron_count: 8,
+                        validator_count: 2,
+                        total_stake_tao: 30,
+                        total_emission_tao: 4,
+                      },
+                    ],
+                  });
+                }
+                return Promise.resolve({ results: [] });
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
 describe("metagraph routes (#1304/#1305) via the Worker", () => {
   const env = {
     ...createLocalArtifactEnv(),
@@ -783,6 +867,27 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
     assert.equal(body.data.neurons[0].validator_permit, true);
   });
 
+  test("GET /subnets/{n}/metagraph?format=csv exports neuron rows", async () => {
+    const { res, text } = await getText(
+      "/api/v1/subnets/7/metagraph?format=csv",
+      env,
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="subnet-metagraph.csv"',
+    );
+    const lines = text.split("\r\n");
+    assert.equal(lines[0], NEURON_CSV_HEADER);
+    assert.equal(lines.length, 3);
+    assert.equal(
+      lines[1],
+      "0,5Hk1,5Co1,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091",
+    );
+    assert.match(lines[2], /^5,5Hk5,5Co1,true,false,/);
+  });
+
   test("?validator_permit=true filters to validators", async () => {
     const { body } = await getJson(
       "/api/v1/subnets/7/metagraph?validator_permit=true",
@@ -790,6 +895,31 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
     );
     assert.equal(body.data.neurons.length, 1);
     assert.equal(body.data.neurons[0].uid, 0);
+  });
+
+  test("?validator_permit=true&format=csv narrows metagraph CSV to validators", async () => {
+    const { text } = await getText(
+      "/api/v1/subnets/7/metagraph?validator_permit=true&format=csv",
+      env,
+    );
+    const lines = text.split("\r\n");
+    assert.deepEqual(lines, [
+      NEURON_CSV_HEADER,
+      "0,5Hk1,5Co1,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091",
+    ]);
+  });
+
+  test("GET /subnets/{n}/metagraph?format=csv emits a header-only cold export", async () => {
+    const coldEnv = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_HEALTH_DB: neuronsD1([]),
+    };
+    const { res, text } = await getText(
+      "/api/v1/subnets/7/metagraph?format=csv",
+      coldEnv,
+    );
+    assert.equal(res.status, 200);
+    assert.equal(text, NEURON_CSV_HEADER);
   });
 
   test("GET /subnets/{n}/yield routes to the emission-yield handler", async () => {
@@ -946,67 +1076,7 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
   });
 
   test("GET /subnets/movers routes to the cross-subnet movers handler", async () => {
-    const moversEnv = {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
-          return {
-            bind() {
-              return {
-                all() {
-                  if (/MIN\(snapshot_date\)/.test(sql)) {
-                    return Promise.resolve({
-                      results: [
-                        { start_date: "2026-05-31", end_date: "2026-06-30" },
-                      ],
-                    });
-                  }
-                  if (/GROUP BY netuid, snapshot_date/.test(sql)) {
-                    return Promise.resolve({
-                      results: [
-                        {
-                          netuid: 1,
-                          snapshot_date: "2026-05-31",
-                          neuron_count: 10,
-                          validator_count: 3,
-                          total_stake_tao: 100,
-                          total_emission_tao: 5,
-                        },
-                        {
-                          netuid: 1,
-                          snapshot_date: "2026-06-30",
-                          neuron_count: 12,
-                          validator_count: 4,
-                          total_stake_tao: 250,
-                          total_emission_tao: 9,
-                        },
-                        {
-                          netuid: 2,
-                          snapshot_date: "2026-05-31",
-                          neuron_count: 8,
-                          validator_count: 2,
-                          total_stake_tao: 50,
-                          total_emission_tao: 4,
-                        },
-                        {
-                          netuid: 2,
-                          snapshot_date: "2026-06-30",
-                          neuron_count: 8,
-                          validator_count: 2,
-                          total_stake_tao: 30,
-                          total_emission_tao: 4,
-                        },
-                      ],
-                    });
-                  }
-                  return Promise.resolve({ results: [] });
-                },
-              };
-            },
-          };
-        },
-      },
-    };
+    const moversEnv = createMoversEnv();
     const { res, body } = await getJson(
       "/api/v1/subnets/movers?window=30d&sort=stake&limit=10",
       moversEnv,
@@ -1027,10 +1097,62 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
     assert.equal(body.meta.generated_at, "2026-06-30");
   });
 
+  test("GET /subnets/movers?format=csv exports ranked mover rows", async () => {
+    const { res, text } = await getText(
+      "/api/v1/subnets/movers?window=30d&sort=emission&limit=10&format=csv",
+      createMoversEnv(),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="subnet-movers.csv"',
+    );
+    const lines = text.split("\r\n");
+    assert.deepEqual(lines, [
+      MOVERS_CSV_HEADER,
+      "1,100,250,150,150,5,9,4,80,3,4,1,10,12,2",
+      "2,50,30,'-20,'-40,4,4,0,0,2,2,0,8,8,0",
+    ]);
+  });
+
+  test("GET /subnets/movers?format=csv emits a header-only cold export", async () => {
+    const { text } = await getText(
+      "/api/v1/subnets/movers?format=csv",
+      createMoversEnv({ comparable: false }),
+    );
+    assert.equal(text, MOVERS_CSV_HEADER);
+  });
+
+  test("GET /subnets/movers rejects invalid response formats", async () => {
+    const { res } = await getJson("/api/v1/subnets/movers?format=xml", env);
+    assert.equal(res.status, 400);
+  });
+
   test("GET /subnets/{n}/validators returns only validators", async () => {
     const { body } = await getJson("/api/v1/subnets/7/validators", env);
     assert.equal(body.data.validator_count, 1);
     assert.equal(body.data.validators[0].validator_permit, true);
+  });
+
+  test("GET /subnets/{n}/validators?format=csv exports validator rows", async () => {
+    const { res, text } = await getText(
+      "/api/v1/subnets/7/validators?format=csv",
+      env,
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(text.split("\r\n"), [
+      NEURON_CSV_HEADER,
+      "0,5Hk1,5Co1,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091",
+    ]);
+  });
+
+  test("GET /subnets/{n}/validators rejects invalid response formats", async () => {
+    const { res } = await getJson(
+      "/api/v1/subnets/7/validators?format=xml",
+      env,
+    );
+    assert.equal(res.status, 400);
   });
 
   test("GET /validators returns the global validator leaderboard", async () => {
@@ -1059,6 +1181,39 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
     assert.equal(body.meta.source, "metagraph-snapshot");
   });
 
+  test("GET /validators?format=csv exports the global validator leaderboard", async () => {
+    const globalEnv = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_HEALTH_DB: neuronsD1([
+        { ...ROW, netuid: 1, uid: 0, hotkey: "hk-a", stake_tao: 10 },
+        { ...ROW, netuid: 2, uid: 1, hotkey: "hk-a", stake_tao: 20 },
+        { ...ROW, netuid: 3, uid: 0, hotkey: "hk-b", stake_tao: 100 },
+        { ...MINER, netuid: 4, uid: 0, hotkey: "hk-miner", stake_tao: 999 },
+      ]),
+    };
+    const { res, text } = await getText(
+      "/api/v1/validators?sort=uid_count&limit=2&format=csv",
+      globalEnv,
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    const lines = text.split("\r\n");
+    assert.equal(lines[0], GLOBAL_VALIDATOR_CSV_HEADER);
+    assert.equal(lines.length, 3);
+    assert.match(lines[1], /^hk-a,5Co1,1,2,2,30,44\.2,0\.230769/);
+    assert.match(lines[1], /"\{""netuid"":2/);
+    assert.match(lines[2], /^hk-b,5Co1,1,1,1,100,22\.1,0\.769231/);
+  });
+
+  test("GET /validators?format=csv emits a header-only cold export", async () => {
+    const coldEnv = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_HEALTH_DB: neuronsD1([]),
+    };
+    const { text } = await getText("/api/v1/validators?format=csv", coldEnv);
+    assert.equal(text, GLOBAL_VALIDATOR_CSV_HEADER);
+  });
+
   test("GET /validators defaults the sort when omitted", async () => {
     const globalEnv = {
       ...createLocalArtifactEnv(),
@@ -1083,6 +1238,12 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
 
     const badLimit = await getJson("/api/v1/validators?limit=0", env);
     assert.equal(badLimit.res.status, 400);
+
+    const badFormat = await getJson("/api/v1/validators?format=xml", env);
+    assert.equal(badFormat.res.status, 400);
+
+    const emptyFormat = await getJson("/api/v1/validators?format=", env);
+    assert.equal(emptyFormat.res.status, 400);
   });
 
   test("GET /subnets/{n}/neurons/{uid} returns the neuron", async () => {
@@ -1100,5 +1261,11 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
   test("an unsupported query param → 400", async () => {
     const { res } = await getJson("/api/v1/subnets/7/metagraph?bogus=1", env);
     assert.equal(res.status, 400);
+
+    const badFormat = await getJson(
+      "/api/v1/subnets/7/metagraph?format=xml",
+      env,
+    );
+    assert.equal(badFormat.res.status, 400);
   });
 });

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -394,6 +394,25 @@ describe("captured-fixture body scan", () => {
     );
   });
 
+  test("allows generated CSV headers with a coldkey column", async () => {
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      [
+        "uid,hotkey,coldkey,active,validator_permit",
+        "hotkey,coldkey,coldkey_count,subnet_count,uid_count",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.equal(
+      output.includes(TEST_PUBLIC_FILE),
+      false,
+      `generated CSV headers should be exempt; got:\n${output}`,
+    );
+
+    await import("../scripts/scan-public-safety.mjs");
+  });
+
   test("still flags suspicious coldkey prose that a hyphen can't smuggle past", async () => {
     // The coldkey-only exemption is the exact phrase, not a blanket `coldkey-`
     // strip: a hyphenated secret attempt must still trip the terminology guard.

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -49,6 +49,7 @@ import {
   canonicalSubnetStakeFlowCachePath,
   canonicalSubnetMoversCachePath,
   canonicalSubnetMetagraphCachePath,
+  canonicalSubnetValidatorsCachePath,
   canonicalGlobalValidatorsCachePath,
 } from "../workers/request-handlers/entities.mjs";
 
@@ -823,6 +824,31 @@ describe("canonicalGlobalValidatorsCachePath", () => {
     assert.equal(omitted.response, undefined);
     assert.equal(omitted.cachePathAndSearch, explicit.cachePathAndSearch);
   });
+
+  test("explicit CSV and JSON format overrides produce distinct cache variants", () => {
+    const csv = canonicalGlobalValidatorsCachePath(
+      url("/api/v1/validators?format=csv"),
+    );
+    assert.equal(
+      csv.cachePathAndSearch,
+      "/api/v1/validators?sort=subnet_count&limit=20&format=csv",
+    );
+
+    const csvAccept = new Request(
+      "https://api.metagraph.sh/api/v1/validators",
+      {
+        headers: { accept: "text/csv" },
+      },
+    );
+    const json = canonicalGlobalValidatorsCachePath(
+      url("/api/v1/validators?format=json"),
+      csvAccept,
+    );
+    assert.equal(
+      json.cachePathAndSearch,
+      "/api/v1/validators?sort=subnet_count&limit=20",
+    );
+  });
 });
 
 describe("handleNeuronHistory", () => {
@@ -1540,12 +1566,66 @@ describe("handleSubnetTurnover", () => {
       assert.equal(key, "/api/v1/subnets/1/metagraph?validator_permit=true");
     });
 
+    test("explicit CSV and JSON format overrides produce distinct cache variants", () => {
+      const csv = canonicalSubnetMetagraphCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/1/metagraph?format=csv",
+        ),
+      );
+      assert.equal(csv, "/api/v1/subnets/1/metagraph?format=csv");
+
+      const filteredCsv = canonicalSubnetMetagraphCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/1/metagraph?validator_permit=true&format=csv",
+        ),
+      );
+      assert.equal(
+        filteredCsv,
+        "/api/v1/subnets/1/metagraph?validator_permit=true&format=csv",
+      );
+
+      const csvAccept = new Request(
+        "https://api.metagraph.sh/api/v1/subnets/1/metagraph",
+        { headers: { accept: "text/csv" } },
+      );
+      const json = canonicalSubnetMetagraphCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/1/metagraph?format=json",
+        ),
+        csvAccept,
+      );
+      assert.equal(json, "/api/v1/subnets/1/metagraph");
+    });
+
     test("returns raw search on an unsupported query parameter", () => {
       const raw = "/api/v1/subnets/1/metagraph?unknown=1";
       const key = canonicalSubnetMetagraphCachePath(
         new URL(`https://api.metagraph.sh${raw}`),
       );
       assert.equal(key, raw);
+    });
+  });
+
+  describe("canonicalSubnetValidatorsCachePath", () => {
+    test("explicit CSV and JSON format overrides produce distinct cache variants", () => {
+      const csv = canonicalSubnetValidatorsCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/1/validators?format=csv",
+        ),
+      );
+      assert.equal(csv, "/api/v1/subnets/1/validators?format=csv");
+
+      const csvAccept = new Request(
+        "https://api.metagraph.sh/api/v1/subnets/1/validators",
+        { headers: { accept: "text/csv" } },
+      );
+      const json = canonicalSubnetValidatorsCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/1/validators?format=json",
+        ),
+        csvAccept,
+      );
+      assert.equal(json, "/api/v1/subnets/1/validators");
     });
   });
 });
@@ -1900,6 +1980,29 @@ describe("handleSubnetMovers", () => {
       assert.equal(omitted, explicit);
       assert.equal(
         omitted,
+        "/api/v1/subnets/movers?window=30d&sort=stake&limit=20",
+      );
+    });
+
+    test("explicit CSV and JSON format overrides produce distinct cache variants", () => {
+      const csv = canonicalSubnetMoversCachePath(
+        new URL("https://api.metagraph.sh/api/v1/subnets/movers?format=csv"),
+      );
+      assert.equal(
+        csv,
+        "/api/v1/subnets/movers?window=30d&sort=stake&limit=20&format=csv",
+      );
+
+      const csvAccept = new Request(
+        "https://api.metagraph.sh/api/v1/subnets/movers",
+        { headers: { accept: "text/csv" } },
+      );
+      const json = canonicalSubnetMoversCachePath(
+        new URL("https://api.metagraph.sh/api/v1/subnets/movers?format=json"),
+        csvAccept,
+      );
+      assert.equal(
+        json,
         "/api/v1/subnets/movers?window=30d&sort=stake&limit=20",
       );
     });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -90,6 +90,7 @@ import {
   handleGlobalValidators,
   canonicalGlobalValidatorsCachePath,
   canonicalSubnetMetagraphCachePath,
+  canonicalSubnetValidatorsCachePath,
   handleAccount,
   handleAccountHistory,
   handleAccountBalance,
@@ -1194,7 +1195,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // validator's permit=1 row wouldn't touch a filtered MAX(captured_at), leaving this
   // leaderboard's edge cache stale for that change.
   if (url.pathname === "/api/v1/validators") {
-    const validatorsCache = canonicalGlobalValidatorsCachePath(url);
+    const validatorsCache = canonicalGlobalValidatorsCachePath(url, request);
     if (validatorsCache.response) return validatorsCache.response;
     return withEdgeCache(
       request,
@@ -1217,7 +1218,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
       env,
       "subnet-movers",
       () => handleSubnetMovers(request, env, url),
-      canonicalSubnetMoversCachePath(url),
+      canonicalSubnetMoversCachePath(url, request),
     );
   }
 
@@ -1493,7 +1494,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
             Number(metagraphMatch[1]),
             resolved.url,
           ),
-        canonicalSubnetMetagraphCachePath(resolved.url),
+        canonicalSubnetMetagraphCachePath(resolved.url, request),
       );
     }
     const neuronMatch = SUBNET_NEURON_PATH_PATTERN.exec(resolved.url.pathname);
@@ -1523,6 +1524,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
             Number(validatorsMatch[1]),
             resolved.url,
           ),
+        canonicalSubnetValidatorsCachePath(resolved.url, request),
       );
     }
     // Per-subnet chain-event stream (#1345): account_events filtered by netuid.

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -33,6 +33,7 @@ import {
   envelopeResponse,
   publishedAt,
 } from "../responses.mjs";
+import { csvRequested, csvResponse } from "../csv.mjs";
 import {
   analyticsQueryError,
   d1All,
@@ -121,6 +122,83 @@ import {
 } from "../../src/movers.mjs";
 import { loadSubnetIdentityHistory } from "../../src/subnet-identity-history.mjs";
 
+const RESPONSE_FORMATS = ["json", "csv"];
+const NEURON_CSV_COLUMNS = [
+  "uid",
+  "hotkey",
+  "coldkey",
+  "active",
+  "validator_permit",
+  "rank",
+  "trust",
+  "validator_trust",
+  "consensus",
+  "incentive",
+  "dividends",
+  "emission_tao",
+  "stake_tao",
+  "registered_at_block",
+  "is_immunity_period",
+  "axon",
+];
+const MOVERS_CSV_COLUMNS = [
+  "netuid",
+  "stake_start_tao",
+  "stake_end_tao",
+  "stake_delta_tao",
+  "stake_pct_change",
+  "emission_start_tao",
+  "emission_end_tao",
+  "emission_delta_tao",
+  "emission_pct_change",
+  "validators_start",
+  "validators_end",
+  "validators_delta",
+  "neurons_start",
+  "neurons_end",
+  "neurons_delta",
+];
+const GLOBAL_VALIDATOR_CSV_COLUMNS = [
+  "hotkey",
+  "coldkey",
+  "coldkey_count",
+  "subnet_count",
+  "uid_count",
+  "total_stake_tao",
+  "total_emission_tao",
+  "stake_dominance",
+  "avg_validator_trust",
+  "max_validator_trust",
+  "latest_captured_at",
+  "latest_block_number",
+  "subnets",
+];
+
+function validateResponseFormat(url) {
+  const raw = url.searchParams.get("format");
+  if (raw === null && !url.searchParams.has("format")) return null;
+  const normalized = String(raw || "").toLowerCase();
+  if (RESPONSE_FORMATS.includes(normalized)) return null;
+  return {
+    parameter: "format",
+    message: `format must be one of: ${RESPONSE_FORMATS.join(", ")}.`,
+  };
+}
+
+function validateEntityQuery(url, allowedParams) {
+  const validationError = validateQueryParams(url, allowedParams);
+  if (validationError) return validationError;
+  return validateResponseFormat(url);
+}
+
+function csvCacheVariant(url, request, canonicalPath) {
+  const format = url.searchParams.get("format")?.toLowerCase();
+  const wantsCsv = format === "csv" || (request && csvRequested(url, request));
+  if (!wantsCsv) return canonicalPath;
+  const separator = canonicalPath.includes("?") ? "&" : "?";
+  return `${canonicalPath}${separator}format=csv`;
+}
+
 function parseBoundedIntParam(url, parameter, { def, min, max }) {
   const raw = url.searchParams.get(parameter);
   if (raw == null || raw === "") return { value: def };
@@ -173,12 +251,24 @@ async function metagraphMeta(env, artifactPath, generatedAt) {
 }
 
 export async function handleSubnetMetagraph(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, ["validator_permit"]);
+  const validationError = validateEntityQuery(url, [
+    "validator_permit",
+    "format",
+  ]);
   if (validationError) return analyticsQueryError(validationError);
   const validatorsOnly = url.searchParams.get("validator_permit") === "true";
   const data = await loadSubnetMetagraph(d1Runner(env), netuid, {
     validatorsOnly,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.neurons,
+      "subnet-metagraph",
+      "short",
+      request,
+      NEURON_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {
@@ -234,9 +324,18 @@ export async function handleNeuron(request, env, netuid, uid) {
 }
 
 export async function handleSubnetValidators(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, []);
+  const validationError = validateEntityQuery(url, ["format"]);
   if (validationError) return analyticsQueryError(validationError);
   const data = await loadSubnetValidators(d1Runner(env), netuid);
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.validators,
+      "subnet-validators",
+      "short",
+      request,
+      NEURON_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {
@@ -258,7 +357,7 @@ export async function handleSubnetValidators(request, env, netuid, url) {
 // scoped to each membership row because those source units are not globally aggregated.
 // Cold/absent D1 returns a schema-stable empty list.
 function parseGlobalValidatorsQuery(url) {
-  const validationError = validateQueryParams(url, ["sort", "limit"]);
+  const validationError = validateEntityQuery(url, ["sort", "limit", "format"]);
   if (validationError) return { error: validationError };
 
   const sort = url.searchParams.get("sort") || DEFAULT_GLOBAL_VALIDATOR_SORT;
@@ -283,13 +382,19 @@ function parseGlobalValidatorsQuery(url) {
   return { sort, limit: limit.value };
 }
 
-export function canonicalGlobalValidatorsCachePath(url) {
+export function canonicalGlobalValidatorsCachePath(url, request = null) {
   const parsed = parseGlobalValidatorsQuery(url);
   if (parsed.error) {
     return { response: analyticsQueryError(parsed.error) };
   }
   const search = `sort=${encodeURIComponent(parsed.sort)}&limit=${parsed.limit}`;
-  return { cachePathAndSearch: `${url.pathname}?${search}` };
+  return {
+    cachePathAndSearch: csvCacheVariant(
+      url,
+      request,
+      `${url.pathname}?${search}`,
+    ),
+  };
 }
 
 export async function handleGlobalValidators(request, env, url) {
@@ -299,6 +404,15 @@ export async function handleGlobalValidators(request, env, url) {
     sort: parsed.sort,
     limit: parsed.limit,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.validators,
+      "global-validators",
+      "short",
+      request,
+      GLOBAL_VALIDATOR_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {
@@ -591,8 +705,13 @@ export function canonicalSubnetStakeFlowCachePath(url) {
 
 // Canonical edge-cache key for the cross-subnet movers route: window/sort/limit, each
 // canonicalized to its default when omitted, so equivalent requests share one slot.
-export function canonicalSubnetMoversCachePath(url) {
-  const validationError = validateQueryParams(url, ["window", "sort", "limit"]);
+export function canonicalSubnetMoversCachePath(url, request = null) {
+  const validationError = validateEntityQuery(url, [
+    "window",
+    "sort",
+    "limit",
+    "format",
+  ]);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam = url.searchParams.get("window") || DEFAULT_MOVERS_WINDOW;
   if (!Object.hasOwn(MOVERS_WINDOWS, windowParam)) {
@@ -608,19 +727,35 @@ export function canonicalSubnetMoversCachePath(url) {
     max: MOVERS_LIMIT_MAX,
   });
   if (limit.error) return `${url.pathname}${url.search}`;
-  return `${url.pathname}?window=${windowParam}&sort=${sortParam}&limit=${limit.value}`;
+  return csvCacheVariant(
+    url,
+    request,
+    `${url.pathname}?window=${windowParam}&sort=${sortParam}&limit=${limit.value}`,
+  );
 }
 
 // Canonical edge-cache key for the subnet-metagraph route. Only
 // ?validator_permit=true changes the response; omission and =false both serve
 // the full metagraph and must share one cache slot.
-export function canonicalSubnetMetagraphCachePath(url) {
-  const validationError = validateQueryParams(url, ["validator_permit"]);
+export function canonicalSubnetMetagraphCachePath(url, request = null) {
+  const validationError = validateEntityQuery(url, [
+    "validator_permit",
+    "format",
+  ]);
   if (validationError) return `${url.pathname}${url.search}`;
   const validatorsOnly = url.searchParams.get("validator_permit") === "true";
-  return validatorsOnly
+  const canonicalPath = validatorsOnly
     ? `${url.pathname}?validator_permit=true`
     : url.pathname;
+  return csvCacheVariant(url, request, canonicalPath);
+}
+
+// Canonical edge-cache key for the subnet validators route. The default JSON
+// envelope and explicit ?format=json share one cache slot; CSV receives its own.
+export function canonicalSubnetValidatorsCachePath(url, request = null) {
+  const validationError = validateEntityQuery(url, ["format"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  return csvCacheVariant(url, request, url.pathname);
 }
 
 // GET /api/v1/subnets/{netuid}/concentration/history?window=7d|30d|90d: the per-day
@@ -764,7 +899,12 @@ export async function handleSubnetStakeFlow(request, env, netuid, url) {
 // snapshot_date read). Cold/absent or single-snapshot store → 200 with movers:[]
 // (schema-stable, never 404), mirroring the sibling history/turnover routes.
 export async function handleSubnetMovers(request, env, url) {
-  const validationError = validateQueryParams(url, ["window", "sort", "limit"]);
+  const validationError = validateEntityQuery(url, [
+    "window",
+    "sort",
+    "limit",
+    "format",
+  ]);
   if (validationError) return analyticsQueryError(validationError);
   const windowParam = url.searchParams.get("window") || DEFAULT_MOVERS_WINDOW;
   if (!Object.hasOwn(MOVERS_WINDOWS, windowParam)) {
@@ -793,6 +933,15 @@ export async function handleSubnetMovers(request, env, url) {
     sort: sortParam,
     limit: limit.value,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.movers,
+      "subnet-movers",
+      "short",
+      request,
+      MOVERS_CSV_COLUMNS,
+    );
+  }
   // neuron_daily-derived, so the meta reports the metagraph-snapshot source; generated_at
   // is the end snapshot date (string), matching the turnover/history routes.
   return envelopeResponse(


### PR DESCRIPTION
## Summary
Adds CSV response support to the validator and metagraph analytics routes that currently expose live D1-backed JSON envelopes.

Closes #2535
Closes #2536

## What changed
- Added `format=csv` and `Accept: text/csv` support for `/api/v1/subnets/{netuid}/metagraph`, `/api/v1/subnets/{netuid}/validators`, `/api/v1/subnets/movers`, and `/api/v1/validators`.
- Reused the shared CSV serializer so exports keep stable column order, RFC 4180 escaping, and spreadsheet-formula hardening.
- Split CSV and JSON edge-cache keys for negotiated responses so cache entries cannot cross content types.
- Added route-specific OpenAPI CSV examples that match emitted headers, bumped the public contract version, and regenerated OpenAPI, contracts, API index, and TypeScript artifacts.
- Added worker, contract, public-safety, and edge-cache coverage for ranked exports, validator-only filters, cold header-only CSV, invalid formats, and cache variants.

## Why
These endpoints are useful leaderboard and per-UID drilldown surfaces, but users currently need custom JSON flattening before spreadsheet or data-workbench analysis.

## Validation
- `npm run build`
- `npm run validate:contract-drift`
- `npm run scan:public-safety`
- `npm run format:check`
- `npm run lint`
- `npm run validate`
- `npx vitest run tests/request-handlers-entities.test.mjs tests/metagraph-neurons.test.mjs tests/analytics-edge-cache.test.mjs tests/contracts.test.mjs tests/openapi-sample.test.mjs tests/public-safety.test.mjs` (401 tests)
- `npm run test:coverage` (164 files, 4402 tests)
- `git diff --check`
