### PR TITLE
fix(health): close probe SSRF-guard parity gap for special-use IP ranges

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -66,6 +66,17 @@ const UNSAFE_HOST_PATTERNS = [
   // 100.64.0.0/10 CGNAT — blocked by the webhook + build SSRF guards; the probe
   // literal guard must stay in parity (issue #2312).
   /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./,
+  // Non-global special-use IPv4 the webhook + build guards already reject; the
+  // probe literal guard drifted out of parity and let these through (both as a
+  // direct host and as an IPv4 tunnelled inside an IPv6 literal, since the
+  // embedded-v4 re-check below reuses this list). Mirror src/webhooks.mjs:
+  //   192.0.0.0/24   IETF protocol assignments
+  //   198.18.0.0/15  benchmarking (RFC 2544)
+  //   224.0.0.0/3    multicast 224/4 + reserved 240/4 (incl. 255/8 broadcast) —
+  //                  not global unicast, matching the a>=224 guard (#1538).
+  /^192\.0\.0\./,
+  /^198\.1[89]\./,
+  /^(22[4-9]|2[3-5]\d)\./,
 ];
 
 // IPv6-literal SSRF ranges, checked only when the host is an actual IPv6 literal
@@ -75,15 +86,20 @@ const UNSAFE_HOST_PATTERNS = [
 //   ::             unspecified
 //   fe00::/8       link-local fe80::/10 + deprecated site-local fec0::/10 (#1538)
 //   fc00::/7       unique-local — first hextet fc00–fdff, i.e. an fc__/fd__ prefix
+//   ff00::/8       multicast — not global unicast (2000::/3), matching the a>=224
+//                  IPv4 broadcast/multicast guard (#1538)
 // The full fc00::/7 range matters: the old /^fc00:/ only caught the literal fc00:
-// hextet and let other ULAs (fc12::1, fdab::1) through (#2375).
+// hextet and let other ULAs (fc12::1, fdab::1) through (#2375). The ff__ multicast
+// prefix was missing here while the webhook guard already blocked it, so the probe
+// literal guard let ff02::1 (all-routers) and other multicast targets through.
 function isUnsafeIpv6Literal(host) {
   return (
     host === "::1" ||
     host === "::" ||
     host.startsWith("fe") ||
     host.startsWith("fc") ||
-    host.startsWith("fd")
+    host.startsWith("fd") ||
+    host.startsWith("ff")
   );
 }
 

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -161,6 +161,50 @@ describe("isUnsafePublicUrl", () => {
     }
   });
 
+  test("blocks non-global special-use IPv4 the webhook guard already rejects", () => {
+    // The probe literal guard drifted out of parity with the webhook + build SSRF
+    // guards (src/webhooks.mjs PRIVATE_IPV4_PATTERNS), letting these through:
+    //   192.0.0.0/24  IETF protocol assignments
+    //   198.18.0.0/15 benchmarking (RFC 2544)
+    //   224.0.0.0/3   multicast 224/4 + reserved 240/4 + 255/8 broadcast
+    for (const url of [
+      "http://192.0.0.1/x",
+      "http://192.0.0.171/x",
+      "http://198.18.0.1/x",
+      "http://198.19.255.255/x",
+      "http://224.0.0.1/x", // all-hosts multicast
+      "http://239.255.255.255/x", // admin-scoped multicast
+      "http://240.0.0.1/x", // reserved 240/4
+      "http://255.255.255.255/x", // limited broadcast
+    ]) {
+      assert.equal(isUnsafePublicUrl(url), true, url);
+    }
+  });
+
+  test("blocks ff00::/8 IPv6 multicast (webhook-guard parity)", () => {
+    for (const url of [
+      "http://[ff02::1]/x", // all-nodes link-local multicast
+      "http://[ff05::c]/x", // site-local SSDP multicast
+      "http://[ff0e::1]/x", // global-scope multicast
+    ]) {
+      assert.equal(isUnsafePublicUrl(url), true, url);
+    }
+  });
+
+  test("blocks a reserved/multicast v4 tunnelled inside an IPv6 literal host", () => {
+    for (const url of [
+      "http://[2002:e000:1::]/x", // 6to4 of 224.0.0.1 multicast
+      "http://[2002:ffff:ffff::]/x", // 6to4 of 255.255.255.255 broadcast
+      "http://[2002:c600:2::]/x", // 6to4 of 198.0.0.2 → 198.x not in range, see below
+      "http://[::ffff:198.18.0.1]/x", // IPv4-mapped benchmarking range
+    ]) {
+      // Only the genuinely special-use targets must be blocked; the 198.0.0.2
+      // 6to4 case is a control that must NOT be blocked (198.0/16 ≠ 198.18/15).
+      const expected = url.includes("2002:c600") ? false : true;
+      assert.equal(isUnsafePublicUrl(url), expected, url);
+    }
+  });
+
   test("allows public http(s)/ws(s)", () => {
     for (const url of [
       "https://entrypoint-finney.opentensor.ai",
@@ -168,6 +212,9 @@ describe("isUnsafePublicUrl", () => {
       "wss://lite.chain.opentensor.ai:443",
       "https://172.15.0.1/x", // just outside the private 172.16-31 range
       "https://[2002:808:808::]/x", // 6to4 of public 8.8.8.8 stays allowed
+      "https://197.17.0.1/x", // just below the 198.18/15 benchmarking range
+      "https://199.20.0.1/x", // just above the 198.18/15 benchmarking range
+      "https://223.255.255.1/x", // just below the 224/3 multicast/reserved block
     ]) {
       assert.equal(isUnsafePublicUrl(url), false, url);
     }


### PR DESCRIPTION
## Summary

The Worker probe literal SSRF guard `isUnsafePublicUrl` (`src/health-probe-core.mjs`) is documented to mirror the webhook + build SSRF guards, but drifted out of parity — it treated several non-global special-use ranges as **safe** that `src/webhooks.mjs` (`PRIVATE_IPV4_PATTERNS`) already blocks.

Proven: `192.0.0.1`, `198.18.0.1`, `224.0.0.1`, `255.255.255.255`, `ff02::1`, and 6to4-tunnelled `2002:e000:1::` all returned `isUnsafePublicUrl === false` (safe), while the webhook guard blocks the same hosts.

## Ranges restored to parity

- **192.0.0.0/24** — IETF protocol assignments
- **198.18.0.0/15** — benchmarking (RFC 2544)
- **224.0.0.0/3** — multicast 224/4 + reserved 240/4 + 255/8 broadcast
- **ff00::/8** — IPv6 multicast

Fixed both as a direct literal host and as an IPv4 tunnelled inside an IPv6 literal (the embedded-v4 re-check reuses the same pattern list). Mirrors the prior parity fixes #2312 (CGNAT), #2375 (fc00::/7), #1538 (a≥224).

## Tests

Regression tests in `tests/health-probe-core.test.mjs` cover every newly-blocked range (direct + tunnelled + IPv6 multicast) and boundary hosts that must **stay allowed** (197.x, 199.x, 223.x just outside the ranges, and public 6to4).

```
npm run lint
npx vitest run tests/health-probe-core.test.mjs   # 110 passed
```

No schema/route/contract change → no artifact regeneration.
