### PR TITLE
feat(badge): add ?labelColor= to theme the left badge segment

### DIFF
--- a/src/badge.mjs
+++ b/src/badge.mjs
@@ -18,6 +18,8 @@
 //   style=flat-square  square corners, no gradient (default: flat)
 //   style=for-the-badge  taller (28px), uppercase bold, letter-spaced, matte
 //   label=…            override the left "metagraphed" segment text
+//   labelColor=…       override the left segment color: a #hex code or a
+//                      shields-style color name (default: #555)
 //
 // Worker-computed image/svg+xml, read-only, edge-cached, CORS-open. Unknown
 // entities or missing data render an "n/a" badge (200) so an <img> never breaks.
@@ -43,6 +45,42 @@ const BADGE_METRICS = {
 };
 // Allow-listed render styles; an unknown value falls back to "flat".
 const BADGE_STYLES = new Set(["flat", "flat-square", "for-the-badge"]);
+
+// The default left ("metagraphed") segment color; overridable via ?labelColor=.
+const DEFAULT_LABEL_COLOR = "#555";
+// Shields-style named colors that are safe to drop straight into a fill="".
+const NAMED_BADGE_COLORS = new Set([
+  "brightgreen",
+  "green",
+  "yellowgreen",
+  "yellow",
+  "orange",
+  "red",
+  "blue",
+  "lightgrey",
+  "lightgray",
+  "grey",
+  "gray",
+  "black",
+  "white",
+  "success",
+  "important",
+  "critical",
+  "informational",
+  "inactive",
+]);
+const HEX_COLOR = /^#?(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+// Sanitize a user-supplied badge color to a #hex code or an allow-listed name,
+// falling back to `fallback`. The result is ALWAYS a hex code or a known safe
+// word, so it can never break out of the SVG `fill="…"` attribute (no escaping
+// needed) — the same defensive stance as the allow-listed style/metric params.
+export function sanitizeBadgeColor(value, fallback = DEFAULT_LABEL_COLOR) {
+  if (typeof value !== "string") return fallback;
+  const v = value.trim().toLowerCase();
+  if (HEX_COLOR.test(v)) return v.startsWith("#") ? v : `#${v}`;
+  return NAMED_BADGE_COLORS.has(v) ? v : fallback;
+}
 const FOR_THE_BADGE_HEIGHT = 28;
 const FOR_THE_BADGE_PAD = 12;
 const FOR_THE_BADGE_LETTER_SPACING = 1.25;
@@ -153,7 +191,11 @@ export function gradeColor(grade) {
 // (rounded + glossy gradient), "flat-square" (square, matte), or "for-the-badge"
 // (28px tall, uppercase bold, letter-spaced, matte).
 export function renderBadge(message, color, options = {}) {
-  const { label = BADGE_LABEL, style = "flat" } = options;
+  const {
+    label = BADGE_LABEL,
+    style = "flat",
+    labelColor = DEFAULT_LABEL_COLOR,
+  } = options;
   if (style === "for-the-badge") {
     const displayLabel = String(label).toUpperCase();
     const displayMessage = String(message).toUpperCase();
@@ -171,7 +213,7 @@ export function renderBadge(message, color, options = {}) {
       `<title>${eLabel}: ${eMsg}</title>`,
       `<clipPath id="r"><rect width="${total}" height="${FOR_THE_BADGE_HEIGHT}" rx="0" fill="#fff"/></clipPath>`,
       `<g clip-path="url(#r)">`,
-      `<rect width="${labelW}" height="${FOR_THE_BADGE_HEIGHT}" fill="#555"/>`,
+      `<rect width="${labelW}" height="${FOR_THE_BADGE_HEIGHT}" fill="${labelColor}"/>`,
       `<rect x="${labelW}" width="${msgW}" height="${FOR_THE_BADGE_HEIGHT}" fill="${color}"/>`,
       `</g>`,
       `<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="10" font-weight="bold">`,
@@ -201,7 +243,7 @@ export function renderBadge(message, color, options = {}) {
       : `<linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>`,
     `<clipPath id="r"><rect width="${total}" height="20" rx="${rx}" fill="#fff"/></clipPath>`,
     `<g clip-path="url(#r)">`,
-    `<rect width="${labelW}" height="20" fill="#555"/>`,
+    `<rect width="${labelW}" height="20" fill="${labelColor}"/>`,
     `<rect x="${labelW}" width="${msgW}" height="20" fill="${color}"/>`,
     square ? null : `<rect width="${total}" height="20" fill="url(#s)"/>`,
     `</g>`,
@@ -313,7 +355,8 @@ export function parseBadgeOptions(searchParams) {
   const style = BADGE_STYLES.has(styleParam) ? styleParam : "flat";
   const rawLabel = searchParams.get("label");
   const label = rawLabel == null ? BADGE_LABEL : sanitizeLabel(rawLabel);
-  return { metric, style, label };
+  const labelColor = sanitizeBadgeColor(searchParams.get("labelColor"));
+  return { metric, style, label, labelColor };
 }
 
 // Completeness: the subnet's coverage completeness_score, or a provider's mean.
@@ -459,7 +502,9 @@ function badgeHeaders() {
 export async function handleBadgeRequest(request, env, url, deps = {}) {
   const readArtifact = deps.readArtifact;
   const target = parseBadgePath(url.pathname);
-  const { metric, style, label } = parseBadgeOptions(url.searchParams);
+  const { metric, style, label, labelColor } = parseBadgeOptions(
+    url.searchParams,
+  );
   const ctx = {
     target,
     readArtifact,
@@ -481,7 +526,11 @@ export async function handleBadgeRequest(request, env, url, deps = {}) {
     }
   }
 
-  const svg = renderBadge(content.message, content.color, { label, style });
+  const svg = renderBadge(content.message, content.color, {
+    label,
+    style,
+    labelColor,
+  });
   return new Response(request.method === "HEAD" ? null : svg, {
     status: 200,
     headers: badgeHeaders(),

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -8,6 +8,7 @@ import {
   parseBadgePath,
   parseBadgeOptions,
   formatUptimePercent,
+  sanitizeBadgeColor,
 } from "../src/badge.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
@@ -145,6 +146,47 @@ describe("badge — rendering", () => {
     assert.match(square, /rx="0"/);
     // Still a valid two-segment badge with both text layers.
     assert.ok((square.match(/<text /g) || []).length === 4);
+  });
+
+  test("renderBadge applies a valid labelColor to the left segment only", () => {
+    const svg = renderBadge("92/100", "#2ea44f", { labelColor: "#0a0" });
+    assert.match(svg, /<rect width="\d+" height="20" fill="#0a0"\/>/); // left
+    assert.match(svg, /fill="#2ea44f"/); // right (message) untouched
+    // default stays #555 when labelColor is omitted (backward-compatible).
+    assert.match(renderBadge("x", "#000"), /fill="#555"/);
+  });
+
+  test("sanitizeBadgeColor accepts hex + named colors, rejects everything else", () => {
+    assert.equal(sanitizeBadgeColor("#0a0"), "#0a0");
+    assert.equal(sanitizeBadgeColor("00aa00"), "#00aa00"); // # optional
+    assert.equal(sanitizeBadgeColor("BrightGreen"), "brightgreen"); // named, ci
+    assert.equal(sanitizeBadgeColor("blue"), "blue");
+    // invalid / SVG-injection attempts fall back to the safe default.
+    assert.equal(sanitizeBadgeColor('"/><script>'), "#555");
+    assert.equal(sanitizeBadgeColor("red; fill:url(#x)"), "#555");
+    assert.equal(sanitizeBadgeColor("notacolor"), "#555");
+    assert.equal(sanitizeBadgeColor(null), "#555");
+  });
+
+  test("parseBadgeOptions parses ?labelColor and defaults an unsafe value", () => {
+    const opts = (query) =>
+      parseBadgeOptions(
+        new URL(`https://api.metagraph.sh/?${query}`).searchParams,
+      );
+    assert.equal(opts("labelColor=%23112233").labelColor, "#112233");
+    assert.equal(
+      opts(`labelColor=${encodeURIComponent('"><script>')}`).labelColor,
+      "#555",
+    );
+    assert.equal(opts("").labelColor, "#555");
+  });
+
+  test("renderBadge with an injection labelColor stays script-free", () => {
+    const svg = renderBadge("92/100", "#2ea44f", {
+      labelColor: sanitizeBadgeColor('"/><script>alert(1)</script>'),
+    });
+    assert.ok(!svg.includes("<script"));
+    assert.match(svg, /fill="#555"/);
   });
 
   test("renderBadge flat + flat-square output is unchanged (regression)", () => {


### PR DESCRIPTION
## Summary

- The embeddable SVG badges (`/api/v1/{subnets/{netuid}|providers/{slug}}/badge.svg`) hard-coded the left "metagraphed" segment to `#555`. This adds an optional **`?labelColor=`** so embedders can theme it to match their docs/site — the shields.io-standard companion to the existing `?label=` / `?style=` options.

## What Changed

- `src/badge.mjs`:
  - `sanitizeBadgeColor` — strictly normalizes a user value to a `#hex` code (3/4/6/8-digit, `#` optional) or an allow-listed shields color name (`brightgreen`, `blue`, `red`, …), falling back to `#555` for anything else. The result is **always** a hex code or a known safe word, so it can never break out of the SVG `fill="…"` attribute (same allow-list stance as `?style=` / `?metric=`).
  - `parseBadgeOptions` parses `?labelColor=`; `renderBadge` paints only the **left** segment with it (the data-derived message color is untouched).
- Backward-compatible: default output is unchanged (the golden `flat`/`flat-square` regression test still passes).

Badges are computed images **outside the OpenAPI contract**, so no schema/OpenAPI/generated-artifact regeneration is required.

### Example

```
![badge](https://api.metagraph.sh/api/v1/subnets/7/badge.svg?metric=uptime&labelColor=%23222)
![badge](https://api.metagraph.sh/api/v1/subnets/7/badge.svg?labelColor=blue)
?labelColor="><script>   → falls back to #555 (never injected)
```

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None touched — badges are not in the contract.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — badge SVG param only.)

## Validation

- [x] `npx vitest run tests/badge.test.mjs` — 58 pass (incl. sanitizer, render, param, and SVG-injection tests)
- [x] Default output unchanged (golden regression test intact)
- [x] `npx eslint` + `npx prettier --check` clean · `git diff --check`
