### PR TITLE
fix(subnet-performance): harden captured_at stamping (string cells + RangeError)

### DIFF
--- a/src/subnet-performance.mjs
+++ b/src/subnet-performance.mjs
@@ -30,14 +30,30 @@ function round(value) {
   return Math.round(value * factor) / factor;
 }
 
+// Stamp a positive, in-range epoch-ms as { ms, value:ISO }, or null. Guarding
+// getTime() matters: a finite but out-of-range epoch (|ms| > 8.64e15, the JS
+// Date limit) makes toISOString() throw a RangeError, which would 500 the whole
+// performance route on one corrupt captured_at cell. Mirrors epochMsStamp in
+// concentration.mjs.
+function epochMsStamp(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const date = new Date(ms);
+  if (!Number.isFinite(date.getTime())) return null;
+  return { ms, value: date.toISOString() };
+}
+
 function captureStamp(value) {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return { ms: value, value: new Date(value).toISOString() };
-  }
+  if (value == null) return null;
+  // D1 can hand the INTEGER captured_at back as a numeric string; route a bare
+  // digit run through the epoch path (Date.parse would misread it) so a
+  // string-typed cell still stamps instead of dropping to null. Mirrors
+  // captureStamp in concentration.mjs.
   if (typeof value === "string") {
+    if (/^\d+$/.test(value)) return epochMsStamp(Number(value));
     const ms = Date.parse(value);
-    if (Number.isFinite(ms)) return { ms, value };
+    return Number.isFinite(ms) ? { ms, value } : null;
   }
+  if (typeof value === "number") return epochMsStamp(value);
   return null;
 }
 

--- a/tests/subnet-performance.test.mjs
+++ b/tests/subnet-performance.test.mjs
@@ -114,6 +114,22 @@ describe("buildSubnetPerformance", () => {
     assert.equal(out.captured_at, null);
   });
 
+  test("captureStamp rejects every unstampable captured_at without throwing", () => {
+    // Cover each reject arm: a non-finite epoch, a non-positive epoch, and a
+    // cell that is neither a string nor a number — all degrade to null.
+    const out = buildSubnetPerformance(
+      [
+        { incentive: 0.5, captured_at: Number.NaN }, // non-finite
+        { incentive: 0.4, captured_at: 0 }, // ms <= 0
+        { incentive: 0.3, captured_at: -1000 }, // ms <= 0
+        { incentive: 0.2, captured_at: true }, // neither string nor number
+        { incentive: 0.1, captured_at: {} }, // neither string nor number
+      ],
+      7,
+    );
+    assert.equal(out.captured_at, null);
+  });
+
   test("incentive concentration is over ALL neurons with a positive incentive", () => {
     const out = buildSubnetPerformance(ROWS, 7);
     // incentives 0.6/0.3/0.1 are positive (the 0 is dropped) → 3 holders.

--- a/tests/subnet-performance.test.mjs
+++ b/tests/subnet-performance.test.mjs
@@ -90,6 +90,30 @@ describe("buildSubnetPerformance", () => {
     assert.equal(out.captured_at, new Date(1_750_000_000_000).toISOString());
   });
 
+  test("stamps a string-typed (D1) captured_at and survives an out-of-range one", () => {
+    // D1 can return the INTEGER captured_at as a numeric string; it must still
+    // stamp, not drop to null (Date.parse would misread a bare digit run).
+    const strRows = ROWS.map((r) => ({
+      ...r,
+      captured_at: String(r.captured_at),
+    }));
+    assert.equal(
+      buildSubnetPerformance(strRows, 7).captured_at,
+      new Date(1_750_000_000_000).toISOString(),
+    );
+
+    // A finite but out-of-range captured_at must degrade to null, not throw a
+    // RangeError that 500s the performance route.
+    let out;
+    assert.doesNotThrow(() => {
+      out = buildSubnetPerformance(
+        ROWS.map((r) => ({ ...r, captured_at: 9e15 })),
+        7,
+      );
+    });
+    assert.equal(out.captured_at, null);
+  });
+
   test("incentive concentration is over ALL neurons with a positive incentive", () => {
     const out = buildSubnetPerformance(ROWS, 7);
     // incentives 0.6/0.3/0.1 are positive (the 0 is dropped) → 3 holders.


### PR DESCRIPTION
## Summary
`captureStamp` had two gaps versus the `concentration.mjs` version it mirrors:
- The number branch called `new Date(value).toISOString()` with no range guard, so a finite but out-of-range epoch (`|ms| > 8.64e15`) throws a **RangeError** and 500s the whole performance route on one corrupt `captured_at` cell.
- A D1 INTEGER `captured_at` returned as a numeric string was fed to `Date.parse`, which returns `NaN` for a bare digit run, silently dropping a real timestamp.

Routes `captured_at` through an `epochMsStamp` helper (finite + positive + `getTime()` range check) and sends numeric-string cells down the same epoch path, matching `concentration.mjs`.

## Validation
- `npm test -- tests/subnet-performance.test.mjs` — green, incl. string-cell + out-of-range tests
- `npx prettier --check` + `npx eslint` — clean