### PR TITLE
fix(deploy): correct subtensor --chain flag to the real finney genesis

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -64,7 +64,12 @@ services:
     # on every restart.
     command:
       - --base-path=/data
-      - --chain=finney
+      # NOT the bare name "finney" — verified against a real deploy that this
+      # image's `--chain=finney` silently resolves to a DIFFERENT embedded
+      # chainspec (wrong genesis) with zero error, so the node endlessly
+      # rejects every real peer as "Genesis mismatch" and never syncs. The
+      # image ships the correct spec as a file; point at it explicitly.
+      - --chain=/home/subtensor/chainspecs/raw_spec_finney.json
       - --sync=${SUBTENSOR_SYNC:-full}
       - --pruning=${SUBTENSOR_PRUNING:-archive}
       - --rpc-external


### PR DESCRIPTION
## Summary
- `--chain=finney` silently loads the wrong embedded chainspec in `ghcr.io/opentensor/subtensor:latest` — no error, just a different genesis block, so the node rejects every real peer forever ("Genesis mismatch") and never actually syncs against mainnet.
- Fix: point `--chain` at the chainspec file the image ships on disk (`/home/subtensor/chainspecs/raw_spec_finney.json`) instead of the bare name.

## Verification
Ran this against a real bare-metal box tonight:
- `--chain=finney` → node's own `chain_getBlockHash(0)` returned a genesis hash that did **not** match `entrypoint-finney.opentensor.ai` / `archive.chain.opentensor.ai`'s genesis, despite `system_chain` correctly reporting "Bittensor" and correct ss58/token properties — nothing else about the node looked wrong, which is what makes this dangerous to hit blind.
- Same box, `--chain=/home/subtensor/chainspecs/raw_spec_finney.json` (after wiping the already-initialized data dir, since changing `--chain` on an existing data dir does nothing) → genesis hash matches exactly, real peers connect, real historical blocks replay.

## Test plan
- [x] YAML syntax validated
- [x] Verified live against a real archive-node deploy (genesis hash match + real peer sync)
- [ ] CI green