### PR TITLE
fix(subnet-performance): coerce D1 numeric-string captured_at to ISO

### DIFF
--- a/src/subnet-performance.mjs
+++ b/src/subnet-performance.mjs
@@ -30,14 +30,26 @@ function round(value) {
   return Math.round(value * factor) / factor;
 }
 
+function epochMsStamp(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const date = new Date(ms);
+  if (!Number.isFinite(date.getTime())) return null;
+  return { ms, value: date.toISOString() };
+}
+
 function captureStamp(value) {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return { ms: value, value: new Date(value).toISOString() };
-  }
+  // D1 returns the INTEGER captured_at as a numeric string, so match the all-digit
+  // form and coerce it as epoch-ms before falling back to Date.parse for ISO text —
+  // Date.parse("1750000000000") is NaN, which would silently drop the timestamp to
+  // null. Mirrors the canonical captureStamp/epochMsStamp in concentration.mjs.
+  if (value == null) return null;
   if (typeof value === "string") {
+    if (/^\d+$/.test(value)) return epochMsStamp(Number(value));
     const ms = Date.parse(value);
     if (Number.isFinite(ms)) return { ms, value };
+    return null;
   }
+  if (typeof value === "number") return epochMsStamp(value);
   return null;
 }
 

--- a/tests/subnet-performance.test.mjs
+++ b/tests/subnet-performance.test.mjs
@@ -140,6 +140,16 @@ describe("buildSubnetPerformance", () => {
     assert.equal(out.captured_at, new Date(1_750_000_060_000).toISOString());
   });
 
+  test("drops a non-positive, out-of-range, or non-scalar captured_at to null", () => {
+    // Guard branches of the epoch coercion: "0" is non-positive, the 16-digit
+    // string is a finite-but-out-of-range epoch (new Date → Invalid Date, no
+    // RangeError leak), and a boolean is neither string nor number.
+    for (const captured_at of ["0", "8640000000000001", true]) {
+      const out = buildSubnetPerformance([{ incentive: 0.2, captured_at }], 7);
+      assert.equal(out.captured_at, null);
+    }
+  });
+
   test("cold/empty subnet → schema-stable zero (every metric null)", () => {
     const out = buildSubnetPerformance([], 3);
     assert.equal(out.neuron_count, 0);

--- a/tests/subnet-performance.test.mjs
+++ b/tests/subnet-performance.test.mjs
@@ -127,6 +127,19 @@ describe("buildSubnetPerformance", () => {
     assert.equal(out.captured_at, "2026-06-15T00:00:00.000Z"); // newest of the two
   });
 
+  test("coerces a D1 numeric-string captured_at to an ISO timestamp", () => {
+    // D1 hands back the INTEGER captured_at as a numeric string; it must stamp
+    // like the numeric form, not drop to null via Date.parse("<digits>") === NaN.
+    const out = buildSubnetPerformance(
+      [
+        { incentive: 0.2, captured_at: "1750000000000" },
+        { incentive: 0.3, captured_at: "1750000060000" }, // newer
+      ],
+      7,
+    );
+    assert.equal(out.captured_at, new Date(1_750_000_060_000).toISOString());
+  });
+
   test("cold/empty subnet → schema-stable zero (every metric null)", () => {
     const out = buildSubnetPerformance([], 3);
     assert.equal(out.neuron_count, 0);


### PR DESCRIPTION
## What

`captureStamp` in `src/subnet-performance.mjs` only produced a timestamp for a `number` `captured_at`; for a string it relied on `Date.parse`. But D1 returns the INTEGER `captured_at` column as a **numeric string**, and `Date.parse("1750000000000")` is `NaN` — so a numeric-string cell silently dropped the timestamp to `null`.

## Impact

`captured_at` was lost (returned `null`) whenever D1 handed back the epoch-ms as a string on:

- `GET /api/v1/subnets/{netuid}/performance`
- the `get_subnet_performance` MCP tool

both of which flow through `buildSubnetPerformance` → `captureStamp(row?.captured_at)`.

## Fix

Match the all-digit form and coerce it as epoch-ms before falling back to `Date.parse` for ISO text, guarding the constructed `Date` against out-of-range values — mirroring the canonical `captureStamp` / `epochMsStamp` already used in the sibling `src/concentration.mjs`.

## Test

Adds a regression to `tests/subnet-performance.test.mjs` asserting a D1 numeric-string `captured_at` (`"1750000000000"`) stamps to its ISO value instead of `null`. Fails before the fix (`Date.parse` → `NaN` → `null`), passes after. Existing number-input and ISO-string cases are unchanged.

Robustness-only; the `captured_at` output type (`["string","null"]`) is unchanged, so no contract/schema regeneration is required.
