### PR TITLE
feat(registry): enrich SN15 ORO — add public evaluation-suites subnet-api surface

### DIFF
--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -146,6 +146,25 @@
         "https://api.oroagents.com/openapi.json"
       ],
       "url": "https://api.oroagents.com/v1/public/top"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-subnet-api-api-oroagents-com",
+      "kind": "subnet-api",
+      "name": "ORO public evaluation-suites API",
+      "notes": "Public no-auth GET returning the ORO evaluation-suite catalog. Documented in the subnet's own OpenAPI (api.oroagents.com/openapi.json); same host as the existing openapi + subnet-api + data-artifact surfaces.",
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dhgoal"
+      },
+      "source_urls": [
+        "https://api.oroagents.com/openapi.json",
+        "https://oroagents.com/"
+      ],
+      "url": "https://api.oroagents.com/v1/public/suites"
     }
   ],
   "website_url": "https://oroagents.com/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one verified public surface to `registry/subnets/oro.json` (SN15 ORO): the public **evaluation-suite catalog** endpoint.

*No open enrichment issue exists for this; standalone surface addition under the surface-enrichment epic #427.*

## Surface
- Netuid: 15 · Kind: `subnet-api` · Provider: `oro` (already registered)
- Public URL: https://api.oroagents.com/v1/public/suites

### Source proof (first-party)
The endpoint is documented in ORO's own OpenAPI spec ([`api.oroagents.com/openapi.json`](https://api.oroagents.com/openapi.json)), and `api.oroagents.com` already backs ORO's existing `openapi`, `subnet-api` (`/v1/public/leaderboard`), and `data-artifact` surfaces in this manifest. The `/v1/public/` path is self-declared public; verified live (HTTP 200, no-auth JSON — the evaluation-suite catalog).

## Checklist
- [x] Appends to exactly one `registry/subnets/<slug>.json` (append-only, single file)
- [x] Generated via `npm run surface:add` — `authority: community`, `review.state: community-submitted`
- [x] `url` public + no-auth; documented in the subnet's own OpenAPI on an already-trusted host
- [x] Provider `oro` already registered (no debut file); not a duplicate (distinct from the existing `/leaderboard` subnet-api)
- [x] Public-safe: no secrets/private URLs/generated artifacts

## Validation
- [x] `npm run validate:surface` → passed
- [x] `npm run scan:public-safety` → passed
