### PR TITLE
fix(health-serving): guard out-of-range last_checked/last_ok (no RangeError)

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1281,6 +1281,16 @@ export async function loadReliabilityAggregate({
 // baked value). The overlay helpers below are pure: they take the resolved
 // snapshot and replace the embedded health on composed artifacts.
 
+// A finite but out-of-range epoch-ms (|ms| > 8.64e15, the JS Date limit) makes
+// toISOString() throw a RangeError, which would 500 the live endpoint response
+// on one corrupt last_checked/last_ok cell. Range-guard via getTime() and drop
+// to null, preserving the existing non-finite -> null behavior.
+function isoFromMs(ms) {
+  if (!Number.isFinite(ms)) return null;
+  const date = new Date(ms);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
 function liveFromD1Rows(rows) {
   const surfaces = rows.map((r) => ({
     surface_id: r.surface_id,
@@ -1293,12 +1303,8 @@ function liveFromD1Rows(rows) {
     classification: r.classification,
     latency_ms: Number.isFinite(r.latency_ms) ? r.latency_ms : null,
     status_code: Number.isInteger(r.status_code) ? r.status_code : null,
-    last_checked: Number.isFinite(r.last_checked)
-      ? new Date(r.last_checked).toISOString()
-      : null,
-    last_ok: Number.isFinite(r.last_ok)
-      ? new Date(r.last_ok).toISOString()
-      : null,
+    last_checked: isoFromMs(r.last_checked),
+    last_ok: isoFromMs(r.last_ok),
   }));
   const byNetuid = new Map();
   for (const row of surfaces) {

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -1335,6 +1335,40 @@ describe("resolveLiveHealth (KV → D1 → null)", () => {
     assert.match(live.surfaces[0].last_checked, /^20\d\d-/);
   });
 
+  test("D1 fallback survives an out-of-range last_checked/last_ok (no RangeError)", async () => {
+    // A finite but out-of-range epoch-ms (beyond the ±8.64e15 JS Date limit)
+    // would make new Date().toISOString() throw a RangeError and 500 the live
+    // health response. One corrupt cell must degrade to null, not crash the row.
+    const db = d1With([
+      {
+        surface_id: "7:subnet-api:x",
+        surface_key: "srf-oob00000000000",
+        netuid: 7,
+        kind: "subnet-api",
+        provider: "x",
+        url: "https://x",
+        status: "ok",
+        classification: "up",
+        latency_ms: 10,
+        status_code: 200,
+        last_checked: 9e15, // out of the JS Date range
+        last_ok: 1_699_000_000_000,
+      },
+    ]);
+    let live;
+    await assert.doesNotReject(async () => {
+      live = await resolveLiveHealth({
+        readHealthKv: async () => null,
+        env: {},
+        db,
+        now: () => 1_700_000_600_000,
+      });
+    });
+    assert.equal(live.surfaces[0].last_checked, null);
+    // The valid last_ok still renders as ISO.
+    assert.match(live.surfaces[0].last_ok, /^20\d\d-/);
+  });
+
   test("D1 fallback folds unrecognized surface status into unknown in global status_counts", async () => {
     const now = 1_700_000_600_000;
     const db = {


### PR DESCRIPTION
## Summary
`liveFromD1Rows` rendered `last_checked`/`last_ok` with `Number.isFinite(ms) ? new Date(ms).toISOString() : null`, which does not bound the value to the JS `Date` range. A finite but out-of-range epoch-ms (`|ms| > 8.64e15`) makes `toISOString()` throw a **RangeError**, 500-ing the live health response on one corrupt `surface_status` cell.

Routes both timestamps through an `isoFromMs` helper that adds the `getTime()` range guard, preserving the existing non-finite → null behavior.

## Validation
- `npm test -- tests/health-serving.test.mjs` — green (137), incl. a D1-fallback does-not-throw test
- `npx prettier --check` + `npx eslint` — clean