### PR TITLE
fix(performance): share hardened captured_at captureStamp for subnet + chain routes

### DIFF
--- a/src/capture-stamp.mjs
+++ b/src/capture-stamp.mjs
@@ -1,0 +1,28 @@
+// Coerce a D1 captured_at cell (epoch-ms number/string or ISO string) to the
+// `{ ms, value }` shape performance/concentration builders use when picking the
+// newest snapshot stamp. D1 can return INTEGER columns as numeric strings; an
+// out-of-range epoch-ms must degrade to null (never a RangeError). Shared by
+// concentration.mjs (#2725), subnet-performance.mjs, and chain-performance.mjs.
+
+function epochMsStamp(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const date = new Date(ms);
+  if (!Number.isFinite(date.getTime())) return null;
+  return { ms, value: date.toISOString() };
+}
+
+export function captureStamp(value) {
+  if (value == null) return null;
+  if (typeof value === "string") {
+    if (/^\d+$/.test(value)) {
+      return epochMsStamp(Number(value));
+    }
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms)) return { ms, value };
+    return null;
+  }
+  if (typeof value === "number") {
+    return epochMsStamp(value);
+  }
+  return null;
+}

--- a/src/chain-performance.mjs
+++ b/src/chain-performance.mjs
@@ -8,6 +8,7 @@
 // Every function is pure + exported for unit tests; the Worker does the D1 read +
 // envelope. Null-safe: an empty snapshot yields a schema-stable `null` block.
 
+import { captureStamp } from "./capture-stamp.mjs";
 import { computeConcentration } from "./concentration.mjs";
 
 // The neurons-tier columns the network performance handler reads — like the
@@ -27,17 +28,6 @@ const SCORE_PERCENTILES = [10, 25, 50, 75, 90];
 function round(value) {
   const factor = 1e6;
   return Math.round(value * factor) / factor;
-}
-
-function captureStamp(value) {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return { ms: value, value: new Date(value).toISOString() };
-  }
-  if (typeof value === "string") {
-    const ms = Date.parse(value);
-    if (Number.isFinite(ms)) return { ms, value };
-  }
-  return null;
 }
 
 // Coerce a raw column array to the finite values present. A score of exactly 0 is

--- a/src/concentration.mjs
+++ b/src/concentration.mjs
@@ -6,6 +6,7 @@
 // live metagraph tiers the entity handlers already own.
 
 import { DAY_MS } from "../workers/config.mjs";
+import { captureStamp } from "./capture-stamp.mjs";
 
 // The neurons-tier columns the concentration handler reads — the D1 read contract
 // for buildConcentration (mirrors BLOCK_READ_COLUMNS / EXTRINSIC_READ_COLUMNS). Kept
@@ -34,29 +35,6 @@ function roundRatio(value, dp = 6) {
   const factor = 10 ** dp;
   const rounded = Math.round(value * factor) / factor;
   return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
-}
-
-function epochMsStamp(ms) {
-  if (!Number.isFinite(ms) || ms <= 0) return null;
-  const date = new Date(ms);
-  if (!Number.isFinite(date.getTime())) return null;
-  return { ms, value: date.toISOString() };
-}
-
-function captureStamp(value) {
-  if (value == null) return null;
-  if (typeof value === "string") {
-    if (/^\d+$/.test(value)) {
-      return epochMsStamp(Number(value));
-    }
-    const ms = Date.parse(value);
-    if (Number.isFinite(ms)) return { ms, value };
-    return null;
-  }
-  if (typeof value === "number") {
-    return epochMsStamp(value);
-  }
-  return null;
 }
 
 // Coerce a raw column array to the finite, strictly-positive values that actually

--- a/src/subnet-performance.mjs
+++ b/src/subnet-performance.mjs
@@ -8,6 +8,7 @@
 // Null-safe by design: an empty / all-zero distribution yields a schema-stable
 // `null` block (never throws), matching the concentration tier it mirrors.
 
+import { captureStamp } from "./capture-stamp.mjs";
 import { computeConcentration } from "./concentration.mjs";
 
 // The neurons-tier columns the performance handler reads — the D1 read contract
@@ -28,33 +29,6 @@ const SCORE_PERCENTILES = [10, 25, 50, 75, 90];
 function round(value) {
   const factor = 1e6;
   return Math.round(value * factor) / factor;
-}
-
-function epochMsStamp(ms) {
-  if (!Number.isFinite(ms) || ms <= 0) return null;
-  const date = new Date(ms);
-  if (!Number.isFinite(date.getTime())) return null;
-  return { ms, value: date.toISOString() };
-}
-
-// Coerce a D1 captured_at cell (epoch-ms number/string or ISO string) to the
-// newest-stamp shape buildSubnetPerformance expects. Mirrors captureStamp in
-// concentration.mjs (#2725) — D1 can return INTEGER columns as numeric strings,
-// and an out-of-range epoch-ms must degrade to null (never a RangeError).
-function captureStamp(value) {
-  if (value == null) return null;
-  if (typeof value === "string") {
-    if (/^\d+$/.test(value)) {
-      return epochMsStamp(Number(value));
-    }
-    const ms = Date.parse(value);
-    if (Number.isFinite(ms)) return { ms, value };
-    return null;
-  }
-  if (typeof value === "number") {
-    return epochMsStamp(value);
-  }
-  return null;
 }
 
 // Coerce a raw column array to the finite values present. Unlike the concentration

--- a/src/subnet-performance.mjs
+++ b/src/subnet-performance.mjs
@@ -30,13 +30,29 @@ function round(value) {
   return Math.round(value * factor) / factor;
 }
 
+function epochMsStamp(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const date = new Date(ms);
+  if (!Number.isFinite(date.getTime())) return null;
+  return { ms, value: date.toISOString() };
+}
+
+// Coerce a D1 captured_at cell (epoch-ms number/string or ISO string) to the
+// newest-stamp shape buildSubnetPerformance expects. Mirrors captureStamp in
+// concentration.mjs (#2725) — D1 can return INTEGER columns as numeric strings,
+// and an out-of-range epoch-ms must degrade to null (never a RangeError).
 function captureStamp(value) {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return { ms: value, value: new Date(value).toISOString() };
-  }
+  if (value == null) return null;
   if (typeof value === "string") {
+    if (/^\d+$/.test(value)) {
+      return epochMsStamp(Number(value));
+    }
     const ms = Date.parse(value);
     if (Number.isFinite(ms)) return { ms, value };
+    return null;
+  }
+  if (typeof value === "number") {
+    return epochMsStamp(value);
   }
   return null;
 }

--- a/tests/capture-stamp.test.mjs
+++ b/tests/capture-stamp.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { captureStamp } from "../src/capture-stamp.mjs";
+
+describe("captureStamp", () => {
+  test("coerces numeric epoch-ms and ISO strings", () => {
+    assert.deepEqual(captureStamp(1_750_000_000_000), {
+      ms: 1_750_000_000_000,
+      value: "2025-06-15T15:06:40.000Z",
+    });
+    assert.deepEqual(captureStamp("1750000060000"), {
+      ms: 1_750_000_060_000,
+      value: "2025-06-15T15:07:40.000Z",
+    });
+    assert.deepEqual(captureStamp("2026-06-15T00:00:00.000Z"), {
+      ms: Date.parse("2026-06-15T00:00:00.000Z"),
+      value: "2026-06-15T00:00:00.000Z",
+    });
+  });
+
+  test("rejects invalid and out-of-range cells", () => {
+    for (const value of [
+      null,
+      undefined,
+      "",
+      "0",
+      "not-a-date",
+      -1,
+      0,
+      8_640_000_000_000_001,
+      "8640000000000001",
+    ]) {
+      assert.equal(captureStamp(value), null, `expected null for ${value}`);
+    }
+  });
+});

--- a/tests/chain-performance.test.mjs
+++ b/tests/chain-performance.test.mjs
@@ -137,6 +137,30 @@ describe("buildChainPerformance", () => {
     assert.equal(out.captured_at, "2026-06-15T00:00:00.000Z");
   });
 
+  test("converts D1 string-typed epoch-millisecond captured_at to ISO strings", () => {
+    const out = buildChainPerformance([
+      { incentive: 0.2, captured_at: "1750000000000" },
+      { incentive: 0.3, captured_at: "1750000060000" },
+    ]);
+    assert.equal(out.captured_at, "2025-06-15T15:07:40.000Z");
+  });
+
+  test("rejects invalid captured_at cells instead of leaking junk stamps", () => {
+    for (const captured_at of [
+      "0",
+      "not-a-date",
+      "9".repeat(400),
+      -1,
+      0,
+      true,
+      8_640_000_000_000_001,
+      "8640000000000001",
+    ]) {
+      const out = buildChainPerformance([{ incentive: 0.2, captured_at }]);
+      assert.equal(out.captured_at, null, `expected null for ${captured_at}`);
+    }
+  });
+
   test("cold/empty network → schema-stable zero (every metric null)", () => {
     const out = buildChainPerformance([]);
     assert.equal(out.subnet_count, 0);

--- a/tests/subnet-performance.test.mjs
+++ b/tests/subnet-performance.test.mjs
@@ -127,6 +127,33 @@ describe("buildSubnetPerformance", () => {
     assert.equal(out.captured_at, "2026-06-15T00:00:00.000Z"); // newest of the two
   });
 
+  test("converts D1 string-typed epoch-millisecond captured_at to ISO strings", () => {
+    const out = buildSubnetPerformance(
+      [
+        { incentive: 0.2, captured_at: "1750000000000" },
+        { incentive: 0.3, captured_at: "1750000060000" },
+      ],
+      7,
+    );
+    assert.equal(out.captured_at, "2025-06-15T15:07:40.000Z");
+  });
+
+  test("rejects invalid captured_at cells instead of leaking junk stamps", () => {
+    for (const captured_at of [
+      "0",
+      "not-a-date",
+      "9".repeat(400),
+      -1,
+      0,
+      true,
+      8_640_000_000_000_001,
+      "8640000000000001",
+    ]) {
+      const out = buildSubnetPerformance([{ incentive: 0.2, captured_at }], 7);
+      assert.equal(out.captured_at, null, `expected null for ${captured_at}`);
+    }
+  });
+
   test("cold/empty subnet → schema-stable zero (every metric null)", () => {
     const out = buildSubnetPerformance([], 3);
     assert.equal(out.neuron_count, 0);


### PR DESCRIPTION
## Summary

D1 can return INTEGER `captured_at` as numeric strings (`"1750000060000"`). The old `captureStamp` in both performance modules only handled finite numbers and ISO strings via `Date.parse`, so real snapshot timestamps were dropped to `null`. Out-of-range epoch-ms cells could also throw a **RangeError** and 500 the route.

`concentration.mjs` was hardened in #2725, but `subnet-performance.mjs` and the sibling `chain-performance.mjs` (#2788) still duplicated the pre-fix helper.

## What changed

- `src/capture-stamp.mjs` — shared `captureStamp`: coerce numeric strings, require `n > 0`, guard `date.getTime()` so invalid/out-of-range cells degrade to `null`.
- `src/concentration.mjs`, `src/subnet-performance.mjs`, `src/chain-performance.mjs` — import the shared helper (no more three divergent copies).
- `tests/capture-stamp.test.mjs`, `tests/subnet-performance.test.mjs`, `tests/chain-performance.test.mjs` — regression coverage for string epoch-ms coercion and invalid-cell rejection.

Affects:
- `GET /api/v1/subnets/{netuid}/performance`
- `GET /api/v1/chain/performance`

No schema change — `captured_at` remains `{"type":["string","null"],"format":"date-time"}`.

## No linked issue

Inline discovery during the D1 coercion audit (#2725 class). The gate flagged the partial fix; this closes the sibling `chain-performance` path in the same PR.

## Distinct from open work

| PR | Relationship |
|----|--------------|
| **#2809** | Same chain-performance fix — superseded by the shared helper here; close to avoid duplicate |
| **#2791** / **#2792** | extrinsics/feeds `toIso` guards — different tiers |

## Test plan

- [x] `npx vitest run tests/capture-stamp.test.mjs tests/subnet-performance.test.mjs tests/concentration.test.mjs tests/chain-performance.test.mjs`
- [x] eslint + prettier clean on changed files