### PR TITLE
fix(analytics): reject blank netuid cells in network subnet_count

### DIFF
--- a/src/chain-performance.mjs
+++ b/src/chain-performance.mjs
@@ -108,8 +108,10 @@ export function buildChainPerformance(rows) {
     if (Number(row?.active) === 1) activeCount += 1;
     const rawNetuid = row?.netuid;
     if (rawNetuid != null) {
+      // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+      if (typeof rawNetuid === "string" && rawNetuid.trim() === "") continue;
       const netuid = Number(rawNetuid);
-      // Guard the coercion: a blank/non-numeric cell must not count as subnet 0.
+      // Guard the coercion: a non-numeric cell must not count as subnet 0.
       if (Number.isInteger(netuid) && netuid >= 0) netuids.add(netuid);
     }
   }

--- a/src/concentration.mjs
+++ b/src/concentration.mjs
@@ -268,8 +268,10 @@ export function buildChainConcentration(rows) {
     }
     const rawNetuid = row?.netuid;
     if (rawNetuid != null) {
+      // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+      if (typeof rawNetuid === "string" && rawNetuid.trim() === "") continue;
       const netuid = Number(rawNetuid);
-      // guard the coercion: a blank/non-numeric cell must not count as subnet 0.
+      // guard the coercion: a non-numeric cell must not count as subnet 0.
       if (Number.isInteger(netuid) && netuid >= 0) netuids.add(netuid);
     }
   }

--- a/tests/chain-concentration.test.mjs
+++ b/tests/chain-concentration.test.mjs
@@ -103,10 +103,21 @@ describe("buildChainConcentration", () => {
       { stake_tao: 1, coldkey: "b", netuid: 5 }, // same subnet, not double-counted
       { stake_tao: 1, coldkey: "c", netuid: null }, // never counts as subnet 0
       { stake_tao: 1, coldkey: "d" }, // missing netuid entirely
-      { stake_tao: 1, coldkey: "e", netuid: -3 }, // negative -> rejected by the >=0 guard
-      { stake_tao: 1, coldkey: "f", netuid: "x" }, // non-numeric -> NaN, rejected by isInteger
+      { stake_tao: 1, coldkey: "e", netuid: "" }, // blank -> must not coerce to subnet 0
+      { stake_tao: 1, coldkey: "f", netuid: "   " }, // whitespace-only -> same
+      { stake_tao: 1, coldkey: "g", netuid: -3 }, // negative -> rejected by the >=0 guard
+      { stake_tao: 1, coldkey: "h", netuid: "x" }, // non-numeric -> NaN, rejected by isInteger
     ]);
     assert.equal(out.subnet_count, 1); // still only subnet 5
+  });
+
+  test("counts root subnet (netuid 0) when explicitly present", () => {
+    const out = buildChainConcentration([
+      { stake_tao: 1, coldkey: "a", netuid: 0 },
+      { stake_tao: 1, coldkey: "b", netuid: "0" },
+      { stake_tao: 1, coldkey: "c", netuid: 7 },
+    ]);
+    assert.equal(out.subnet_count, 2); // root + subnet 7
   });
 
   test("is schema-stable-zero on a cold store (no rows)", () => {

--- a/tests/chain-performance.test.mjs
+++ b/tests/chain-performance.test.mjs
@@ -116,15 +116,18 @@ describe("buildChainPerformance", () => {
     assert.equal(out.validator_trust.min, 0.85);
   });
 
-  test("subnet_count ignores null and non-integer netuid cells", () => {
+  test("subnet_count ignores null, blank, and non-integer netuid cells", () => {
     const out = buildChainPerformance([
       { incentive: 0.5, netuid: 7 },
+      { incentive: 0.5, netuid: "7" }, // numeric string — same subnet, not double-counted
       { incentive: 0.5, netuid: null }, // rawNetuid == null → skipped
+      { incentive: 0.5, netuid: "" }, // blank → must not coerce to subnet 0
+      { incentive: 0.5, netuid: "   " }, // whitespace-only → must not coerce to subnet 0
       { incentive: 0.5, netuid: "abc" }, // non-integer → skipped
       { incentive: 0.5, netuid: -1 }, // negative → skipped
     ]);
     assert.equal(out.subnet_count, 1); // only netuid 7 counts
-    assert.equal(out.neuron_count, 4);
+    assert.equal(out.neuron_count, 7);
   });
 
   test("accepts a string (ISO) captured_at, ignoring null/unparseable stamps", () => {


### PR DESCRIPTION
## Summary

- Harden `subnet_count` in `buildChainPerformance` (#2788) and `buildChainConcentration` so blank D1 `netuid` cells (`""`, whitespace-only strings) are not coerced to subnet `0` via `Number("")`.
- Add regression tests for blank/whitespace rejection and confirm explicit `netuid: 0` / `"0"` still counts.

## Problem

D1 can return empty or whitespace `netuid` strings on sparse neuron rows. The network builders only guarded non-numeric coercion (`Number("abc")` → `NaN`) but not blank strings, which coerce to `0` and inflate `subnet_count` on:

- `GET /api/v1/chain/performance`
- `GET /api/v1/chain/concentration`

## Distinct from open work

| PR | Relationship |
|----|--------------|
| **#2808** / **#2809** | `captured_at` / `captureStamp` — different field |
| **#2804** / **#2802** | per-subnet performance stamping — different scope |

## Test plan

- [x] `npx vitest run tests/chain-performance.test.mjs tests/chain-concentration.test.mjs tests/concentration.test.mjs`