### PR TITLE
feat(events): decode SubtensorModule Faucet account credits

### DIFF
--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -234,6 +234,16 @@ def _transfer(a):  # Balances.Transfer: [from, to, amount] or {from, to, amount}
     return {"hotkey": _ss58(sender), "coldkey": _ss58(recipient), "amount_tao": _tao(amount)}
 
 
+def _faucet(a):  # Faucet: [account, amount_rao] - finney spec 424 (2026-07-03)
+    if isinstance(a, dict):
+        account = a.get("account", a.get("coldkey", a.get("who")))
+        amount = a.get("amount", a.get("amount_rao"))
+    else:
+        account = a[0] if len(a) > 0 else None
+        amount = a[1] if len(a) > 1 else None
+    return {"coldkey": _ss58(account), "amount_tao": _tao(amount)}
+
+
 def _net(a):  # NetworkAdded/NetworkRemoved: {netuid, ...} or [netuid, ...]
     netuid = a.get("netuid") if isinstance(a, dict) else (a[0] if len(a) > 0 else None)
     return {"netuid": _idx(netuid)}
@@ -331,6 +341,9 @@ EXTRACTORS = {
     "HotkeySwapped": _hotkey_swapped,
     "ColdkeySwapped": _coldkey_swap,
     "ColdkeySwapScheduled": _coldkey_swap,  # historical: v161–v377; extra execution_block/swap_cost ignored
+    # Testnet faucet account credits (#2560). Live finney spec 424 names this
+    # SubtensorModule.Faucet, not FaucetMinted: (T::AccountId, u64 amount_rao).
+    "Faucet": _faucet,
     # Balances pallet — native TAO transfers between accounts (#1814)
     "Transfer": _transfer,
 }

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -337,6 +337,57 @@ class TransferExtractorTest(unittest.TestCase):
         self.assertIsNone(result["amount_tao"])
 
 
+class FaucetExtractorTest(unittest.TestCase):
+    """Tests for SubtensorModule.Faucet (#2560).
+
+    Live finney spec 424 names the event `Faucet` and exposes positional fields
+    (T::AccountId, u64 amount_rao). The metadata docs describe it as the testnet
+    faucet call.
+    """
+
+    def test_list_form_positional_account_and_amount(self):
+        result = _extract("Faucet", [_SS58_A, _RAO_100])
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertAlmostEqual(result["amount_tao"], 100.0)
+        self.assertIsNone(result["hotkey"])
+        self.assertIsNone(result["netuid"])
+        self.assertIsNone(result["uid"])
+
+    def test_dict_form_named_account_and_amount(self):
+        result = _extract("Faucet", {"account": _SS58_B, "amount": _RAO_100})
+        self.assertEqual(result["coldkey"], _SS58_B)
+        self.assertAlmostEqual(result["amount_tao"], 100.0)
+
+    def test_dict_form_accepts_coldkey_alias(self):
+        result = _extract("Faucet", {"coldkey": _SS58_B, "amount_rao": 500_000_000})
+        self.assertEqual(result["coldkey"], _SS58_B)
+        self.assertAlmostEqual(result["amount_tao"], 0.5)
+
+    def test_zero_amount(self):
+        result = _extract("Faucet", [_SS58_A, 0])
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertAlmostEqual(result["amount_tao"], 0.0)
+
+    def test_invalid_recipient_gives_null_coldkey(self):
+        result = _extract("Faucet", ["not-an-address", _RAO_100])
+        self.assertIsNone(result["coldkey"])
+        self.assertAlmostEqual(result["amount_tao"], 100.0)
+
+    def test_missing_amount_gives_null(self):
+        result = _extract("Faucet", [_SS58_A])
+        self.assertEqual(result["coldkey"], _SS58_A)
+        self.assertIsNone(result["amount_tao"])
+
+    def test_empty_shape_drift_never_raises(self):
+        result = _extract("Faucet", [])
+        self.assertIsNotNone(result)
+        self.assertIsNone(result["coldkey"])
+        self.assertIsNone(result["amount_tao"])
+
+    def test_unconfirmed_faucet_minted_alias_is_not_indexed(self):
+        self.assertIsNone(_extract("FaucetMinted", [_SS58_A, _RAO_100]))
+
+
 class NeuronDeregisteredExtractorTest(unittest.TestCase):
     """Tests for SubtensorModule.NeuronDeregistered (#2553).
 

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -78,6 +78,7 @@ export const INGESTED_EVENT_KINDS = [
   "ColdkeySwapScheduled",
   // #2555 forward-compat: absent finney spec 424 today; ?kind= accepts once runtime emits
   "AxonInfoRemoved",
+  "Faucet",
   "Transfer",
 ];
 

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -137,6 +137,10 @@ test("INGESTED_EVENT_KINDS accepts ColdkeySwapScheduled for kind filters", () =>
   assert.ok(INGESTED_EVENT_KINDS.includes("ColdkeySwapScheduled"));
 });
 
+test("INGESTED_EVENT_KINDS accepts Faucet for testnet account credit filters", () => {
+  assert.ok(INGESTED_EVENT_KINDS.includes("Faucet"));
+});
+
 test("formatAccountEvent maps a D1 row to an API event (ISO time)", () => {
   const out = formatAccountEvent({
     block_number: 1000,


### PR DESCRIPTION
## Summary

Adds first-party decoding for SubtensorModule `Faucet` account-credit events so testnet faucet activity can appear in the account event stream.

Closes #2560.

## What changed

- Confirmed live finney runtime spec 424 exposes `SubtensorModule.Faucet`, not `FaucetMinted`, with fields `(T::AccountId, u64)`.
- Added a `Faucet` extractor that maps the recipient account to `coldkey` and converts the `u64` rao amount into `amount_tao`.
- Added `Faucet` to `INGESTED_EVENT_KINDS` so public `?kind=Faucet` filters are accepted.
- Added extractor regressions for positional and dict shapes, rao conversion, zero amounts, invalid recipients, and shape drift.

## Why

Faucet mints are account-crediting events but were not decoded by the event poller, leaving a gap in testnet account activity coverage.

## Validation

- `npm run build`
- `python3 scripts/test_fetch_events.py`
- `npm test -- tests/account-events.test.mjs`
- `npm test`
- `npm run validate && npm run validate:api && npm run validate:schemas && npm run validate:contract-drift && npm run validate:openapi && npm run validate:types && npm run validate:schema-enums && npm run validate:openapi-examples && npm run validate:generated-client`
- `npm run lint && npm run format:check && npm run validate:docs && git diff --check`

## Notes

No migration is required; this reuses the existing `account_events` `coldkey` and `amount_tao` columns.
