### PR TITLE
fix(chain-performance): coerce D1 numeric-string captured_at to ISO

### DIFF
--- a/src/chain-performance.mjs
+++ b/src/chain-performance.mjs
@@ -29,14 +29,26 @@ function round(value) {
   return Math.round(value * factor) / factor;
 }
 
+function epochMsStamp(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const date = new Date(ms);
+  if (!Number.isFinite(date.getTime())) return null;
+  return { ms, value: date.toISOString() };
+}
+
 function captureStamp(value) {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return { ms: value, value: new Date(value).toISOString() };
-  }
+  // D1 returns the INTEGER captured_at as a numeric string, so match the all-digit
+  // form and coerce it as epoch-ms before falling back to Date.parse for ISO text —
+  // Date.parse("1750000000000") is NaN, which would silently drop the timestamp to
+  // null. Mirrors the canonical captureStamp/epochMsStamp in concentration.mjs.
+  if (value == null) return null;
   if (typeof value === "string") {
+    if (/^\d+$/.test(value)) return epochMsStamp(Number(value));
     const ms = Date.parse(value);
     if (Number.isFinite(ms)) return { ms, value };
+    return null;
   }
+  if (typeof value === "number") return epochMsStamp(value);
   return null;
 }
 

--- a/tests/chain-performance.test.mjs
+++ b/tests/chain-performance.test.mjs
@@ -137,6 +137,26 @@ describe("buildChainPerformance", () => {
     assert.equal(out.captured_at, "2026-06-15T00:00:00.000Z");
   });
 
+  test("coerces a D1 numeric-string captured_at to an ISO timestamp", () => {
+    // D1 hands back the INTEGER captured_at as a numeric string; it must stamp
+    // like the numeric form, not drop to null via Date.parse("<digits>") === NaN.
+    const out = buildChainPerformance([
+      { incentive: 0.2, captured_at: "1750000000000" },
+      { incentive: 0.3, captured_at: "1750000060000" }, // newer
+    ]);
+    assert.equal(out.captured_at, new Date(1_750_000_060_000).toISOString());
+  });
+
+  test("drops a non-positive, out-of-range, or non-scalar captured_at to null", () => {
+    // Guard branches of the epoch coercion: "0" is non-positive, the 16-digit
+    // string is a finite-but-out-of-range epoch (new Date → Invalid Date, no
+    // RangeError leak), and a boolean is neither string nor number.
+    for (const captured_at of ["0", "8640000000000001", true]) {
+      const out = buildChainPerformance([{ incentive: 0.2, captured_at }]);
+      assert.equal(out.captured_at, null);
+    }
+  });
+
   test("cold/empty network → schema-stable zero (every metric null)", () => {
     const out = buildChainPerformance([]);
     assert.equal(out.subnet_count, 0);


### PR DESCRIPTION
## What

`captureStamp` in `src/chain-performance.mjs` (added in #2788) only produced a timestamp for a `number` `captured_at`; for a string it relied on `Date.parse`. But D1 returns the INTEGER `captured_at` column as a **numeric string**, and `Date.parse("1750000000000")` is `NaN` — so a numeric-string cell silently dropped the network snapshot timestamp to `null`.

## Impact

`captured_at` was lost (returned `null`) whenever D1 handed back the epoch-ms as a string on:

- `GET /api/v1/chain/performance`
- the `get_chain_performance` MCP tool

both of which flow through `buildChainPerformance` → `captureStamp(row?.captured_at)`.

## Fix

Match the all-digit form and coerce it as epoch-ms before falling back to `Date.parse` for ISO text, guarding the constructed `Date` against out-of-range values — mirroring the canonical `captureStamp` / `epochMsStamp` in `src/concentration.mjs`. This is the same coercion just applied to the sibling per-subnet builder in #2804; the two performance builders are now behaviorally identical for a digit-only D1 `captured_at`.

## Test

Adds regressions to `tests/chain-performance.test.mjs`: a D1 numeric-string `captured_at` (`"1750000000000"`) stamps to its ISO value instead of `null` (fails before the fix), plus guard-branch coverage for non-positive (`"0"`), finite-but-out-of-range (`"8640000000000001"` → no `RangeError`), and non-scalar inputs. Existing number-input and ISO-string cases are unchanged.

Robustness-only; the `captured_at` output type (`["string","null"]`) is unchanged, so no contract/schema regeneration is required.
