### PR TITLE
feat(api): add ?format=csv to GET /api/v1/economics/trends (#2531)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -10458,6 +10458,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d" | "1y" | "all";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10465,7 +10467,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -10516,6 +10518,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["EconomicsTrendsArtifact"];
                     };
+                    /**
+                     * @example snapshot_date,subnet_count,total_stake_tao,alpha_price_tao_weighted,alpha_price_tao_median,validator_count,miner_count,mean_emission_share
+                     *     2026-06-02,129,1250000.5,0.03125,0.028,2048,28672,0.007752
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -640,7 +640,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the network-wide economics time series (#1307): per UTC day across all subnets — total stake, stake-weighted + median alpha price, total validator/miner counts, and mean emission share — aggregated live from the daily subnet_snapshots D1 rollup (the same source the per-subnet /trajectory reads). ?window=7d|30d|90d|1y|all (default 30d). Served live (no static file); day_count:0 / days:[] when the rollup is cold. */
+        /** Fetch the network-wide economics time series (#1307): per UTC day across all subnets — total stake, stake-weighted + median alpha price, total validator/miner counts, and mean emission share — aggregated live from the daily subnet_snapshots D1 rollup (the same source the per-subnet /trajectory reads). ?window=7d|30d|90d|1y|all (default 30d). Pass ?format=csv to download the per-day series as CSV. Served live (no static file); day_count:0 / days:[] when the rollup is cold. */
         get: operations["economicsTrends"];
         put?: never;
         post?: never;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2730,6 +2730,17 @@
             ],
             "type": "string"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2710,7 +2710,7 @@
     {
       "artifact_path": "/metagraph/economics/trends.json",
       "cache": "short",
-      "description": "Fetch the network-wide economics time series (#1307): per UTC day across all subnets — total stake, stake-weighted + median alpha price, total validator/miner counts, and mean emission share — aggregated live from the daily subnet_snapshots D1 rollup (the same source the per-subnet /trajectory reads). ?window=7d|30d|90d|1y|all (default 30d). Served live (no static file); day_count:0 / days:[] when the rollup is cold.",
+      "description": "Fetch the network-wide economics time series (#1307): per UTC day across all subnets — total stake, stake-weighted + median alpha price, total validator/miner counts, and mean emission share — aggregated live from the daily subnet_snapshots D1 rollup (the same source the per-subnet /trajectory reads). ?window=7d|30d|90d|1y|all (default 30d). Pass ?format=csv to download the per-day series as CSV. Served live (no static file); day_count:0 / days:[] when the rollup is cold.",
       "id": "economics-trends",
       "method": "GET",
       "path": "/api/v1/economics/trends",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -246,7 +246,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.1",
-      "description": "Network-wide economics time series (#1307) aggregated per UTC day across all subnets from the daily subnet_snapshots D1 rollup (the same source the per-subnet trajectory reads), served live at /api/v1/economics/trends (no static file).",
+      "description": "Network-wide economics time series (#1307) aggregated per UTC day across all subnets from the daily subnet_snapshots D1 rollup (the same source the per-subnet trajectory reads), served live at /api/v1/economics/trends; pass ?format=csv to download the per-day series as CSV (no static file).",
       "id": "economics-trends",
       "path": "/metagraph/economics/trends.json",
       "schema_ref": "#/components/schemas/EconomicsTrendsArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -22369,6 +22369,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -22427,9 +22440,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "snapshot_date,subnet_count,total_stake_tao,alpha_price_tao_weighted,alpha_price_tao_median,validator_count,miner_count,mean_emission_share\r\n2026-06-02,129,1250000.5,0.03125,0.028,2048,28672,0.007752",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -22505,7 +22505,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the network-wide economics time series (#1307): per UTC day across all subnets — total stake, stake-weighted + median alpha price, total validator/miner counts, and mean emission share — aggregated live from the daily subnet_snapshots D1 rollup (the same source the per-subnet /trajectory reads). ?window=7d|30d|90d|1y|all (default 30d). Served live (no static file); day_count:0 / days:[] when the rollup is cold.",
+        "summary": "Fetch the network-wide economics time series (#1307): per UTC day across all subnets — total stake, stake-weighted + median alpha price, total validator/miner counts, and mean emission share — aggregated live from the daily subnet_snapshots D1 rollup (the same source the per-subnet /trajectory reads). ?window=7d|30d|90d|1y|all (default 30d). Pass ?format=csv to download the per-day series as CSV. Served live (no static file); day_count:0 / days:[] when the rollup is cold.",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -10458,6 +10458,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d" | "1y" | "all";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10465,7 +10467,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -10516,6 +10518,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["EconomicsTrendsArtifact"];
                     };
+                    /**
+                     * @example snapshot_date,subnet_count,total_stake_tao,alpha_price_tao_weighted,alpha_price_tao_median,validator_count,miner_count,mean_emission_share
+                     *     2026-06-02,129,1250000.5,0.03125,0.028,2048,28672,0.007752
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -640,7 +640,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the network-wide economics time series (#1307): per UTC day across all subnets — total stake, stake-weighted + median alpha price, total validator/miner counts, and mean emission share — aggregated live from the daily subnet_snapshots D1 rollup (the same source the per-subnet /trajectory reads). ?window=7d|30d|90d|1y|all (default 30d). Served live (no static file); day_count:0 / days:[] when the rollup is cold. */
+        /** Fetch the network-wide economics time series (#1307): per UTC day across all subnets — total stake, stake-weighted + median alpha price, total validator/miner counts, and mean emission share — aggregated live from the daily subnet_snapshots D1 rollup (the same source the per-subnet /trajectory reads). ?window=7d|30d|90d|1y|all (default 30d). Pass ?format=csv to download the per-day series as CSV. Served live (no static file); day_count:0 / days:[] when the rollup is cold. */
         get: operations["economicsTrends"];
         put?: never;
         post?: never;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1547,12 +1547,12 @@ export const API_ROUTES = [
     "Fetch the network-wide economics time series (#1307): per UTC day across all subnets — total stake, stake-weighted + median alpha price, total validator/miner counts, and mean emission share — aggregated live from the daily subnet_snapshots D1 rollup (the same source the per-subnet /trajectory reads). ?window=7d|30d|90d|1y|all (default 30d). Served live (no static file); day_count:0 / days:[] when the rollup is cold.",
     "short",
     ["subnets", "analytics"],
-    [
+    csvRouteQuery([
       {
         name: "window",
         schema: { type: "string", enum: ["7d", "30d", "90d", "1y", "all"] },
       },
-    ],
+    ]),
     [],
   ),
   route(
@@ -3187,6 +3187,12 @@ function csvExampleForRoute(entry) {
     return [
       "uid,hotkey,coldkey,active,validator_permit,rank,trust,validator_trust,consensus,incentive,dividends,emission_tao,stake_tao,registered_at_block,is_immunity_period,axon",
       "0,hk_sample,ck_sample,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091",
+    ].join("\r\n");
+  }
+  if (entry.id === "economics-trends") {
+    return [
+      "snapshot_date,subnet_count,total_stake_tao,alpha_price_tao_weighted,alpha_price_tao_median,validator_count,miner_count,mean_emission_share",
+      "2026-06-02,129,1250000.5,0.03125,0.028,2048,28672,0.007752",
     ].join("\r\n");
   }
   return "netuid,name\r\n7,Allways";

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -781,7 +781,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "economics-trends",
     "/metagraph/economics/trends.json",
-    "Network-wide economics time series (#1307) aggregated per UTC day across all subnets from the daily subnet_snapshots D1 rollup (the same source the per-subnet trajectory reads), served live at /api/v1/economics/trends (no static file).",
+    "Network-wide economics time series (#1307) aggregated per UTC day across all subnets from the daily subnet_snapshots D1 rollup (the same source the per-subnet trajectory reads), served live at /api/v1/economics/trends; pass ?format=csv to download the per-day series as CSV (no static file).",
     "EconomicsTrendsArtifact",
   ),
   artifact(
@@ -1544,7 +1544,7 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/economics/trends",
     "/metagraph/economics/trends.json",
-    "Fetch the network-wide economics time series (#1307): per UTC day across all subnets — total stake, stake-weighted + median alpha price, total validator/miner counts, and mean emission share — aggregated live from the daily subnet_snapshots D1 rollup (the same source the per-subnet /trajectory reads). ?window=7d|30d|90d|1y|all (default 30d). Served live (no static file); day_count:0 / days:[] when the rollup is cold.",
+    "Fetch the network-wide economics time series (#1307): per UTC day across all subnets — total stake, stake-weighted + median alpha price, total validator/miner counts, and mean emission share — aggregated live from the daily subnet_snapshots D1 rollup (the same source the per-subnet /trajectory reads). ?window=7d|30d|90d|1y|all (default 30d). Pass ?format=csv to download the per-day series as CSV. Served live (no static file); day_count:0 / days:[] when the rollup is cold.",
     "short",
     ["subnets", "analytics"],
     csvRouteQuery([

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -212,6 +212,10 @@ describe("public contract registry", () => {
         "/api/v1/validators",
         "hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,total_emission_tao,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets",
       ],
+      [
+        "/api/v1/economics/trends",
+        "snapshot_date,subnet_count,total_stake_tao,alpha_price_tao_weighted,alpha_price_tao_median,validator_count,miner_count,mean_emission_share",
+      ],
     ];
     for (const [path, expectedHeader] of csvExamples) {
       const csvContent =

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -237,6 +237,109 @@ describe("handleEconomicsTrends", () => {
     assert.equal(day.miner_count, null);
     assert.equal(day.mean_emission_share, null);
   });
+
+  test("returns CSV response when ?format=csv is requested", async () => {
+    const env = d1Env({
+      "FROM subnet_snapshots": [
+        {
+          snapshot_date: "2026-06-02",
+          total_stake_tao: 300,
+          alpha_price_tao: 0.02,
+          validator_count: 8,
+          miner_count: 50,
+          emission_share: 0.04,
+        },
+      ],
+    });
+    const res = await handleEconomicsTrends(req("/"), env, url("/?format=csv"));
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    assert.ok(
+      res.headers
+        .get("content-disposition")
+        .includes('filename="economics-trends.csv"'),
+    );
+    const text = await res.text();
+    const lines = text.split("\r\n");
+    assert.equal(
+      lines[0],
+      "snapshot_date,subnet_count,total_stake_tao,alpha_price_tao_weighted,alpha_price_tao_median,validator_count,miner_count,mean_emission_share",
+    );
+    assert.equal(lines[1], "2026-06-02,1,300,0.02,0.02,8,50,0.04");
+  });
+
+  test("returns CSV response when Accept: text/csv header is present", async () => {
+    const env = d1Env({
+      "FROM subnet_snapshots": [
+        {
+          snapshot_date: "2026-06-02",
+          total_stake_tao: 300,
+          alpha_price_tao: 0.02,
+          validator_count: 8,
+          miner_count: 50,
+          emission_share: 0.04,
+        },
+      ],
+    });
+    const request = new Request("https://api.metagraph.sh/", {
+      headers: { accept: "text/csv" },
+    });
+    const res = await handleEconomicsTrends(request, env, url("/"));
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    const text = await res.text();
+    const lines = text.split("\r\n");
+    assert.equal(lines[1], "2026-06-02,1,300,0.02,0.02,8,50,0.04");
+  });
+
+  test("returns empty/header-only CSV when rollup is cold", async () => {
+    const res = await handleEconomicsTrends(req("/"), {}, url("/?format=csv"));
+    assert.equal(res.status, 200);
+    const text = await res.text();
+    const lines = text.split("\r\n");
+    assert.equal(
+      lines[0],
+      "snapshot_date,subnet_count,total_stake_tao,alpha_price_tao_weighted,alpha_price_tao_median,validator_count,miner_count,mean_emission_share",
+    );
+    assert.equal(lines.length, 1);
+  });
+
+  test("rejects an unsupported format value", async () => {
+    const res = await handleEconomicsTrends(req("/"), {}, url("/?format=pdf"));
+    const body = await errorJson(res);
+    assert.equal(res.status, 400);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("rejects an empty format parameter", async () => {
+    const res = await handleEconomicsTrends(req("/"), {}, url("/?format="));
+    const body = await errorJson(res);
+    assert.equal(res.status, 400);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("?format=json keeps the JSON envelope even when Accept asks for CSV", async () => {
+    const env = d1Env({
+      "FROM subnet_snapshots": [
+        {
+          snapshot_date: "2026-06-02",
+          total_stake_tao: 300,
+          alpha_price_tao: 0.02,
+          validator_count: 8,
+          miner_count: 50,
+          emission_share: 0.04,
+        },
+      ],
+    });
+    const request = new Request("https://api.metagraph.sh/", {
+      headers: { accept: "text/csv" },
+    });
+    const res = await handleEconomicsTrends(request, env, url("/?format=json"));
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /application\/json/);
+    const body = await res.json();
+    assert.equal(body.data.day_count, 1);
+  });
 });
 
 describe("handleUptime", () => {
@@ -600,6 +703,49 @@ describe("canonicalEconomicsTrendsCachePath", () => {
 
   test("falls back to raw search on invalid window value", () => {
     const raw = "/api/v1/economics/trends?window=bogus";
+    assert.equal(canonicalEconomicsTrendsCachePath(url(raw)), raw);
+  });
+
+  test("adds format=csv to the cache key when CSV is requested", () => {
+    assert.equal(
+      canonicalEconomicsTrendsCachePath(
+        url("/api/v1/economics/trends?window=7d&format=csv"),
+      ),
+      "/api/v1/economics/trends?window=7d&format=csv",
+    );
+  });
+
+  test("explicit CSV and JSON format overrides produce distinct cache variants", () => {
+    const csv = canonicalEconomicsTrendsCachePath(
+      url("/api/v1/economics/trends?format=csv"),
+    );
+    assert.equal(csv, "/api/v1/economics/trends?window=30d&format=csv");
+
+    const csvAccept = new Request("https://api.metagraph.sh/", {
+      headers: { accept: "text/csv" },
+    });
+    const json = canonicalEconomicsTrendsCachePath(
+      url("/api/v1/economics/trends?format=json"),
+      csvAccept,
+    );
+    assert.equal(json, "/api/v1/economics/trends?window=30d");
+  });
+
+  test("adds format=csv when only Accept: text/csv is present", () => {
+    const csvAccept = new Request("https://api.metagraph.sh/", {
+      headers: { accept: "text/csv" },
+    });
+    assert.equal(
+      canonicalEconomicsTrendsCachePath(
+        url("/api/v1/economics/trends?window=7d"),
+        csvAccept,
+      ),
+      "/api/v1/economics/trends?window=7d&format=csv",
+    );
+  });
+
+  test("falls back to raw search on invalid format", () => {
+    const raw = "/api/v1/economics/trends?format=pdf";
     assert.equal(canonicalEconomicsTrendsCachePath(url(raw)), raw);
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1724,7 +1724,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         env,
         "economics-trends",
         () => handleEconomicsTrends(request, env, resolved.url),
-        canonicalEconomicsTrendsCachePath(resolved.url),
+        canonicalEconomicsTrendsCachePath(resolved.url, request),
       );
     }
     return handleApiRequest(request, env, resolved.url, DEFAULT_NETWORK, ctx);

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -9,6 +9,7 @@
 // injected once at module-init so this file never imports api.mjs back.
 
 import { DAY_MS, MAX_UPTIME_ROWS, UPTIME_WINDOWS } from "../config.mjs";
+import { csvRequested, csvResponse } from "../csv.mjs";
 import { errorResponse } from "../http.mjs";
 import { readArtifact } from "../storage.mjs";
 import { contractVersion, envelopeResponse } from "../responses.mjs";
@@ -45,6 +46,39 @@ let readHealthMetaKv = () => {
 let readEconomicsCurrentKv = () => {
   throw new Error("analytics routes used before configureAnalyticsRoutes()");
 };
+
+const RESPONSE_FORMATS = ["json", "csv"];
+
+const ECONOMICS_TRENDS_CSV_COLUMNS = [
+  "snapshot_date",
+  "subnet_count",
+  "total_stake_tao",
+  "alpha_price_tao_weighted",
+  "alpha_price_tao_median",
+  "validator_count",
+  "miner_count",
+  "mean_emission_share",
+];
+
+function validateFormatParam(url) {
+  const raw = url.searchParams.get("format");
+  if (raw === null && !url.searchParams.has("format")) return null;
+  const normalized = String(raw || "").toLowerCase();
+  if (RESPONSE_FORMATS.includes(normalized)) return null;
+  return {
+    parameter: "format",
+    message: `format must be one of: ${RESPONSE_FORMATS.join(", ")}.`,
+  };
+}
+
+function economicsTrendsCacheVariant(url, request, canonicalPath) {
+  const format = url.searchParams.get("format")?.toLowerCase();
+  const wantsCsv =
+    format === "csv" || (request != null && csvRequested(url, request));
+  if (!wantsCsv) return canonicalPath;
+  // canonicalEconomicsTrendsCachePath always supplies ?window=…, so & is safe.
+  return `${canonicalPath}&format=csv`;
+}
 
 export function configureAnalyticsRoutes(deps) {
   readHealthMetaKv = deps.readHealthMetaKv;
@@ -102,8 +136,10 @@ export async function handleTrajectory(request, env, netuid, url) {
 // BY) so the weighted/median price is computed in the pure builder. Schema-stable
 // (day_count:0, days:[]) on a cold rollup. Bounded by ECONOMICS_TRENDS_ROW_CAP.
 export async function handleEconomicsTrends(request, env, url) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "format"]);
   if (validationError) return analyticsQueryError(validationError);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { label, days, error } = parseHistoryWindow(
     url.searchParams.get("window"),
   );
@@ -112,6 +148,15 @@ export async function handleEconomicsTrends(request, env, url) {
     (sql, params) => d1All(env, sql, params),
     { windowLabel: label, windowDays: days },
   );
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.days,
+      "economics-trends",
+      "short",
+      request,
+      ECONOMICS_TRENDS_CSV_COLUMNS,
+    );
+  }
   return envelopeWithD1Fallback(
     request,
     {
@@ -214,12 +259,18 @@ export function canonicalUptimeCachePath(url) {
 // Normalises the economics-trends URL so that a bare ?-free request and an explicit
 // ?window=30d request both resolve to the same edge-cache entry — mirrors
 // canonicalSubnetHistoryCachePath in entities.mjs.
-export function canonicalEconomicsTrendsCachePath(url) {
-  const validationError = validateQueryParams(url, ["window"]);
+export function canonicalEconomicsTrendsCachePath(url, request = null) {
+  const validationError = validateQueryParams(url, ["window", "format"]);
   if (validationError) return `${url.pathname}${url.search}`;
+  const formatError = validateFormatParam(url);
+  if (formatError) return `${url.pathname}${url.search}`;
   const { label, error } = parseHistoryWindow(url.searchParams.get("window"));
   if (error) return `${url.pathname}${url.search}`;
-  return `${url.pathname}?window=${encodeURIComponent(label)}`;
+  return economicsTrendsCacheVariant(
+    url,
+    request,
+    `${url.pathname}?window=${encodeURIComponent(label)}`,
+  );
 }
 
 // Normalises the leaderboards URL so that a bare ?-free request and an explicit


### PR DESCRIPTION
## Summary

- Add `?format=csv` (and `Accept: text/csv`) to `GET /api/v1/economics/trends`, exporting the per-day network economics time series as a spreadsheet-friendly download.
- Emit stable CSV headers: `snapshot_date`, `subnet_count`, `total_stake_tao`, `alpha_price_tao_weighted`, `alpha_price_tao_median`, `validator_count`, `miner_count`, `mean_emission_share`.
- Cold rollup returns a header-only CSV (no rows), matching the JSON `days:[]` contract.
- Include `format=csv` in the edge-cache canonical key so JSON and CSV responses do not share a slot.

Closes #2537

## Distinct from open work

| PR / area | Relationship |
|-----------|--------------|
| **#2794** / list-route CSV | Different routes (registry list vs economics trends) |
| **#2748** (closed) | Same feature — superseded; this adds cache-key safety |
| **#2808** chain-performance | Unrelated tier |

## Test plan

- [x] `npx vitest run tests/request-handlers-analytics-routes.test.mjs`
- [x] `npm run build` (OpenAPI + generated types committed)
- [ ] `npm test` full suite before push