### PR TITLE
fix(analytics): coerce string-typed D1 netuid at Map-key sites

### DIFF
--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -64,7 +64,13 @@ export function profilesProjectionFromRows(profiles) {
 export function growthRowsFromSamples(growthSamples) {
   const growthByNetuid = new Map();
   for (const row of growthSamples || []) {
-    const entry = growthByNetuid.get(row.netuid) || {
+    // D1 can hand the INTEGER netuid back as a numeric string on this GROUP BY
+    // read path; the emitted netuid keys the integer-keyed subnetMeta map in
+    // formatLeaderboards, so a raw string netuid drops the fastest-growing
+    // entry's slug/name metadata and violates the integer netuid contract.
+    const netuid = Number(row.netuid);
+    if (!Number.isInteger(netuid) || netuid < 0) continue;
+    const entry = growthByNetuid.get(netuid) || {
       first: null,
       last: null,
     };
@@ -83,7 +89,7 @@ export function growthRowsFromSamples(growthSamples) {
       if (entry.first == null) entry.first = score;
       entry.last = score;
     }
-    growthByNetuid.set(row.netuid, entry);
+    growthByNetuid.set(netuid, entry);
   }
   return [...growthByNetuid.entries()].map(([netuid, entry]) => ({
     netuid,

--- a/src/subnet-identity-history.mjs
+++ b/src/subnet-identity-history.mjs
@@ -140,6 +140,16 @@ async function runStatementBatches(db, statements) {
   }
 }
 
+// D1 hands INTEGER columns back as numeric strings on GROUP BY / JOIN read paths
+// (the same convention account-events.mjs and analytics-routes.mjs coerce for:
+// "a string-typed row netuid must key on 7 or the tier drops to null"). A raw
+// string netuid used as a Map key silently misses the integer netuid the callers
+// look up by, so coerce every D1-row netuid to a non-negative integer here.
+function rowNetuid(value) {
+  const netuid = Number(value);
+  return Number.isInteger(netuid) && netuid >= 0 ? netuid : null;
+}
+
 async function latestIdentityHashes(db) {
   const res = await db
     .prepare(
@@ -152,9 +162,12 @@ async function latestIdentityHashes(db) {
        ) latest ON h.netuid = latest.netuid AND h.id = latest.max_id`,
     )
     .all();
-  return new Map(
-    (res?.results || []).map((row) => [row.netuid, row.identity_hash]),
-  );
+  const map = new Map();
+  for (const row of res?.results || []) {
+    const netuid = rowNetuid(row.netuid);
+    if (netuid != null) map.set(netuid, row.identity_hash);
+  }
+  return map;
 }
 
 async function latestBlockNumber(db) {
@@ -298,8 +311,13 @@ export async function loadPreviouslyKnownAsForNetuids(d1, entries) {
   );
   const grouped = new Map();
   for (const row of rows || []) {
-    let list = grouped.get(row.netuid);
-    if (!list) grouped.set(row.netuid, (list = []));
+    // Coerce the D1-row netuid so it keys on the same integer the caller and
+    // currentByNetuid use — a raw string key both drops the alias from the
+    // agent-catalog lookup and lets the current name leak into the history.
+    const netuid = rowNetuid(row.netuid);
+    if (netuid == null) continue;
+    let list = grouped.get(netuid);
+    if (!list) grouped.set(netuid, (list = []));
     list.push(row);
   }
   const out = new Map();

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -179,6 +179,21 @@ describe("analytics-live projections", () => {
       [{ netuid: 7, delta: 60 }],
     );
   });
+
+  test("growthRowsFromSamples emits an integer netuid when D1 returns a string", () => {
+    // D1 hands the INTEGER netuid back as the string "5" on this GROUP BY read
+    // path. The emitted netuid keys the integer-keyed subnetMeta map in
+    // formatLeaderboards, so a raw string netuid drops the fastest-growing
+    // entry's slug/name metadata and breaks the integer netuid contract.
+    const rows = growthRowsFromSamples([
+      { netuid: "5", completeness_score: 20 },
+      { netuid: "5", completeness_score: 50 },
+      { netuid: "not-a-number", completeness_score: 10 }, // dropped
+      { netuid: -1, completeness_score: 10 }, // dropped
+    ]);
+    assert.deepEqual(rows, [{ netuid: 5, delta: 30 }]);
+    assert.equal(typeof rows[0].netuid, "number");
+  });
 });
 
 describe("analytics-live loaders", () => {

--- a/tests/subnet-identity-history.test.mjs
+++ b/tests/subnet-identity-history.test.mjs
@@ -550,6 +550,51 @@ describe("recordSubnetIdentityChanges", () => {
     assert.equal(result.rows, 0);
   });
 
+  test("skips unchanged identities when D1 returns netuid as a string (coercion)", async () => {
+    // D1 hands the INTEGER netuid back as the string "7" on the GROUP BY read
+    // path. The dedup map must key on 7 so the integer profile.netuid lookup
+    // hits — otherwise the "unchanged" guard never fires and the cron re-inserts
+    // an identical row every run, growing the append-only table unbounded.
+    const snapshot = identitySnapshotFromProfile({
+      netuid: 7,
+      symbol: "T",
+      native_identity: { subnet_name: "Subnet" },
+    });
+    const hash = await identityHash(snapshot);
+    const db = {
+      prepare() {
+        return {
+          bind() {
+            return this;
+          },
+          all: async () => ({
+            results: [
+              { netuid: "bad", identity_hash: "junk" }, // non-numeric → skipped
+              { netuid: "7", identity_hash: hash }, // string netuid
+            ],
+          }),
+        };
+      },
+      batch: async () => {
+        throw new Error("should not write for an unchanged identity");
+      },
+    };
+    const result = await recordSubnetIdentityChanges(
+      {},
+      {
+        profiles: [
+          {
+            netuid: 7,
+            symbol: "T",
+            native_identity: { subnet_name: "Subnet" },
+          },
+        ],
+        db,
+      },
+    );
+    assert.equal(result.rows, 0);
+  });
+
   test("returns unavailable when profiles are missing", async () => {
     assert.deepEqual(await recordSubnetIdentityChanges({}, { profiles: [] }), {
       recorded: false,
@@ -842,6 +887,28 @@ describe("loadPreviouslyKnownAsForNetuids", () => {
     ]);
     assert.deepEqual(map.get(86), ["MIAO"]);
     assert.deepEqual(map.get(7), ["Old7"]);
+  });
+
+  test("keys on the integer netuid when D1 returns it as a string (coercion)", async () => {
+    // D1 hands the INTEGER netuid back as the string "1" on this GROUP BY read
+    // path. Without coercion the map keys on "1", so the caller's integer
+    // aliasMap.get(1) misses (alias never attached) AND currentByNetuid.get("1")
+    // misses, leaking the current name into previously_known_as.
+    const d1 = async () => [
+      { netuid: "1", subnet_name: "OldName", observed_at: 1000 },
+      { netuid: "1", subnet_name: "CurrentName", observed_at: 2000 },
+      { netuid: "bad", subnet_name: "Junk", observed_at: 3000 }, // malformed → dropped
+    ];
+    const map = await loadPreviouslyKnownAsForNetuids(d1, [
+      { netuid: 1, name: "CurrentName" },
+    ]);
+    // Attached under the integer key (not the string "1")...
+    assert.deepEqual(map.get(1), ["OldName"]);
+    assert.equal(map.get("1"), undefined);
+    // ...and the current name is excluded, not leaked.
+    assert.ok(!(map.get(1) || []).includes("CurrentName"));
+    // A non-numeric netuid cell is dropped, not keyed under a junk string.
+    assert.equal(map.get("bad"), undefined);
   });
 
   test("merges multiple rows for the same netuid", async () => {


### PR DESCRIPTION
## Summary

D1 hands INTEGER columns back as numeric strings on GROUP BY / JOIN read paths (the documented convention `account-events.mjs` and `analytics-routes.mjs` coerce for: *"a string-typed row netuid must key on 7 or the tier drops to null"*). Three sites keyed a `Map` on the raw string netuid while callers looked it up with an integer, so the lookups silently missed:

1. **`src/subnet-identity-history.mjs` `latestIdentityHashes`** — the `recordSubnetIdentityChanges` dedup guard never fires, so the hourly identity-change cron re-inserts an identical row for **every subnet every run**, growing the append-only `subnet_identity_history` table **unbounded**.
2. **`src/subnet-identity-history.mjs` `loadPreviouslyKnownAsForNetuids`** — `previously_known_as` is **never attached** to agent-catalog subnets (caller `aliasMap.get(int)` misses the string key) **and** the current name **leaks** into the alias list.
3. **`src/analytics-live.mjs` `growthRowsFromSamples`** — the fastest-growing leaderboard loses each entry's slug/name metadata (integer-keyed `subnetMeta` join misses) and emits a string netuid.

## Fix

Coerce every D1-row netuid to a non-negative integer at these Map-key/emit sites, matching the existing convention. Regression tests cover the string-netuid path plus malformed cells.

```
npm run lint
npx vitest run tests/subnet-identity-history.test.mjs tests/analytics-live.test.mjs
```

No schema/route/contract change → no artifact regeneration.
