### PR TITLE
feat(registry): add SN13 Data Universe TypeScript SDK surface

### DIFF
--- a/registry/subnets/data-universe.json
+++ b/registry/subnets/data-universe.json
@@ -281,6 +281,25 @@
         "https://huggingface.co/api/spaces/macrocosm-os/sn13-dashboard"
       ],
       "url": "https://huggingface.co/spaces/macrocosm-os/sn13-dashboard"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-13-macrocosmos-ts-sdk",
+      "kind": "sdk",
+      "name": "Macrocosmos TypeScript SDK",
+      "notes": "Official Macrocosmos TypeScript SDK (npm: macrocosmos). Ships the Sn13Client interface to the SN13 Data Universe Validator API; the TypeScript counterpart to the already-listed Python SDK (macrocosmos-py). In the team's macrocosm-os org.",
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/macrocosm-os/macrocosmos-ts/blob/main/README.md",
+        "https://www.npmjs.com/package/macrocosmos"
+      ],
+      "url": "https://github.com/macrocosm-os/macrocosmos-ts"
     }
   ],
   "website_url": "https://datauniverse.macrocosmos.ai/"


### PR DESCRIPTION
## Summary

Adds the official **Macrocosmos TypeScript SDK** as a community `sdk` surface to SN13 Data Universe. The registry already lists the Python SDK (`macrocosmos-py`); this is its TypeScript counterpart.

- **url:** https://github.com/macrocosm-os/macrocosmos-ts
- **source_url (proof):** https://github.com/macrocosm-os/macrocosmos-ts/blob/main/README.md — the README documents `npm install macrocosmos` and the `Sn13Client`, which "provides an interface for the SN13 Validator API."
- **independent proof:** https://www.npmjs.com/package/macrocosmos — published npm package `macrocosmos` (latest 2.2.2), whose `repository` field resolves to `macrocosm-os/macrocosmos-ts`.

## Why it qualifies

- **Owner-matched.** The repo lives in the `macrocosm-os` org — the same org as SN13's registered official `source_repo` (`macrocosm-os/data-universe`).
- **Fresh.** Repo last pushed 2026-05; npm `macrocosmos@2.2.2`.
- **Machine-undiscoverable.** An `sdk` surface is not auto-promoted by the native-chain (source-repo/website) pipeline, so a contributor submission adds real signal.
- **Non-duplicate.** Distinct repo/language from the listed Python SDK; single-file diff appending exactly one surface with `authority: community` / `review.state: community-submitted`.

## Validation

`npm run validate:surface -- registry/subnets/data-universe.json` → passed (13 surfaces, 1 file). `scan:public-safety`, `validate:intake`, and `format:check` all pass. Only `registry/subnets/data-universe.json` is touched.