### PR TITLE
feat(api): add ?format=csv to GET /api/v1/blocks (#2528)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -249,7 +249,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Computed live from the first-party blocks D1 tier (#1345). */
+        /** Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Pass ?format=csv to download the filtered block rows as CSV. Computed live from the first-party blocks D1 tier (#1345). */
         get: operations["blocksFeed"];
         put?: never;
         post?: never;
@@ -7484,6 +7484,8 @@ export interface operations {
                 block_end?: number;
                 min_extrinsics?: number;
                 min_events?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -7491,7 +7493,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -7543,6 +7545,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BlocksFeedArtifact"];
                     };
+                    /**
+                     * @example block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at
+                     *     8454388,0xabc,0xdef,5Author,12,48,423,2026-07-03T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5328,7 +5328,7 @@
     {
       "artifact_path": "/metagraph/blocks.json",
       "cache": "short",
-      "description": "Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Computed live from the first-party blocks D1 tier (#1345).",
+      "description": "Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Pass ?format=csv to download the filtered block rows as CSV. Computed live from the first-party blocks D1 tier (#1345).",
       "id": "blocks-feed",
       "method": "GET",
       "path": "/api/v1/blocks",
@@ -5410,6 +5410,17 @@
           "schema": {
             "minimum": 0,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -687,7 +687,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.1",
-      "description": "The recent-block feed (newest first) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks (no static file).",
+      "description": "The recent-block feed (newest first) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks; pass ?format=csv to download the filtered block rows as CSV (no static file).",
       "id": "blocks-feed",
       "path": "/metagraph/blocks.json",
       "schema_ref": "#/components/schemas/BlocksFeedArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -18329,6 +18329,19 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -18388,9 +18401,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at\r\n8454388,0xabc,0xdef,5Author,12,48,423,2026-07-03T00:00:00.000Z",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -18447,7 +18466,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Computed live from the first-party blocks D1 tier (#1345).",
+        "summary": "Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Pass ?format=csv to download the filtered block rows as CSV. Computed live from the first-party blocks D1 tier (#1345).",
         "tags": [
           "blocks",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -249,7 +249,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Computed live from the first-party blocks D1 tier (#1345). */
+        /** Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Pass ?format=csv to download the filtered block rows as CSV. Computed live from the first-party blocks D1 tier (#1345). */
         get: operations["blocksFeed"];
         put?: never;
         post?: never;
@@ -7484,6 +7484,8 @@ export interface operations {
                 block_end?: number;
                 min_extrinsics?: number;
                 min_events?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -7491,7 +7493,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -7543,6 +7545,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BlocksFeedArtifact"];
                     };
+                    /**
+                     * @example block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at
+                     *     8454388,0xabc,0xdef,5Author,12,48,423,2026-07-03T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1075,7 +1075,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "blocks-feed",
     "/metagraph/blocks.json",
-    "The recent-block feed (newest first) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks (no static file).",
+    "The recent-block feed (newest first) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks; pass ?format=csv to download the filtered block rows as CSV (no static file).",
     "BlocksFeedArtifact",
   ),
   artifact(
@@ -2203,10 +2203,10 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/blocks",
     "/metagraph/blocks.json",
-    "Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Computed live from the first-party blocks D1 tier (#1345).",
+    "Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Pass ?format=csv to download the filtered block rows as CSV. Computed live from the first-party blocks D1 tier (#1345).",
     "short",
     ["blocks", "analytics"],
-    [
+    csvRouteQuery([
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "cursor", schema: { type: "string" } },
@@ -2218,7 +2218,7 @@ export const API_ROUTES = [
       { name: "block_end", schema: { type: "integer", minimum: 0 } },
       { name: "min_extrinsics", schema: { type: "integer", minimum: 0 } },
       { name: "min_events", schema: { type: "integer", minimum: 0 } },
-    ],
+    ]),
     [],
   ),
   route(
@@ -3196,6 +3196,12 @@ function csvExampleForRoute(entry) {
     return [
       "snapshot_date,subnet_count,total_stake_tao,alpha_price_tao_weighted,alpha_price_tao_median,validator_count,miner_count,mean_emission_share",
       "2026-06-02,129,1250000.5,0.03125,0.028,2048,28672,0.007752",
+    ].join("\r\n");
+  }
+  if (entry.id === "blocks-feed") {
+    return [
+      "block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at",
+      "8454388,0xabc,0xdef,5Author,12,48,423,2026-07-03T00:00:00.000Z",
     ].join("\r\n");
   }
   return "netuid,name\r\n7,Allways";

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -3631,6 +3631,56 @@ describe("handleBlocks", () => {
     assert.ok(!/WHERE/.test(sql));
     assert.ok(/ORDER BY block_number DESC LIMIT \? OFFSET \?/.test(sql));
   });
+
+  const BLOCKS_CSV_HEADER =
+    "block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at";
+
+  test("?format=csv exports filtered block rows (#2528)", async () => {
+    const { env } = dbWith({ blocksFeed: [blockRow()] });
+    const res = await handleBlocks(
+      req("/api/v1/blocks"),
+      env,
+      url("/api/v1/blocks?limit=10&format=csv"),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="blocks.csv"',
+    );
+    const text = await res.text();
+    const lines = text.split("\r\n");
+    assert.equal(lines[0], BLOCKS_CSV_HEADER);
+    assert.equal(lines[1].split(",")[0], String(BLOCK_NUM));
+    assert.equal(lines[1].split(",")[4], "5");
+    assert.equal(lines[1].split(",")[5], "20");
+    assert.equal(lines[1].split(",")[6], "201");
+    assert.equal(lines[1].split(",")[7], new Date(OBSERVED_AT).toISOString());
+  });
+
+  test("?format=csv emits a header-only export on cold D1", async () => {
+    const res = await handleBlocks(
+      req("/api/v1/blocks"),
+      emptyEnv(),
+      url("/api/v1/blocks?format=csv"),
+    );
+    assert.equal(res.status, 200);
+    const text = await res.text();
+    const lines = text.split("\r\n");
+    assert.equal(lines[0], BLOCKS_CSV_HEADER);
+    assert.equal(lines.length, 1);
+  });
+
+  test("rejects an unsupported format value", async () => {
+    const body = await errorJson(
+      await handleBlocks(
+        req("/api/v1/blocks"),
+        emptyEnv(),
+        url("/api/v1/blocks?format=pdf"),
+      ),
+    );
+    assert.equal(body.meta.parameter, "format");
+  });
 });
 
 describe("handleBlock", () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -173,6 +173,16 @@ const GLOBAL_VALIDATOR_CSV_COLUMNS = [
   "latest_block_number",
   "subnets",
 ];
+const BLOCKS_CSV_COLUMNS = [
+  "block_number",
+  "block_hash",
+  "parent_hash",
+  "author",
+  "extrinsic_count",
+  "event_count",
+  "spec_version",
+  "observed_at",
+];
 
 function validateResponseFormat(url) {
   const raw = url.searchParams.get("format");
@@ -1542,7 +1552,7 @@ export async function handleAccountBalance(request, env, ss58) {
 // absent store → schema-stable zero (never throws). Reuses the chain-events meta
 // (source:"chain-events") since the same first-party poller fills this tier.
 export async function handleBlocks(request, env, url) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "limit",
     "offset",
     "cursor",
@@ -1554,6 +1564,7 @@ export async function handleBlocks(request, env, url) {
     "block_end",
     "min_extrinsics",
     "min_events",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset, cursor } = parsePagination(url, BLOCK_PAGINATION);
@@ -1595,6 +1606,15 @@ export async function handleBlocks(request, env, url) {
     minExtrinsics,
     minEvents,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.blocks,
+      "blocks",
+      "short",
+      request,
+      BLOCKS_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

Closes #2528 — add `?format=csv` to `GET /api/v1/blocks`, mirroring the merged economics-trends CSV pattern ([#2817](https://github.com/JSONbored/metagraphed/pull/2817)).

## What changed

- **`handleBlocks`**: after the live D1 feed is assembled, `csvRequested()` → `csvResponse(data.blocks, "blocks", …)` with stable column order.
- **`src/contracts.mjs`**: `blocks-feed` route advertises `format=json|csv`; OpenAPI/types regenerated.
- **Tests**: CSV export, cold header-only export, and invalid `format` rejection.

## Why this should merge

- Open bounty issue ([#2528](https://github.com/JSONbored/metagraphed/issues/2528)), `gittensor:bug`, no competing PR.
- Same shape as recently merged CSV PRs (#2794, #2817).
- Focused diff (~130 lines), CI-friendly validations pass locally.

## Test plan

- [x] `npx vitest run tests/request-handlers-entities.test.mjs -t handleBlocks` — 14/14
- [x] `npm run validate:api` + `validate:contract-drift` + `lint`
