### PR TITLE
fix(ci): ensure `validate:private-boundary` runs for docs-only PRs

### DIFF
--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -100,9 +100,10 @@ future non-`.md` file under `.claude/skills/`, disqualifies the whole PR), the `
 `docs_only=true` and `checks` skips only its build/contract/registry/deploy-dry-run steps via a
 **per-step** `if: env.DOCS_ONLY != 'true'` guard — never a job-level skip, so `checks` always reports
 a real `success`/`failure` conclusion, never `skipped`. `Lint + format`, `validate:docs`,
-`validate:intake`, and `scan:public-safety` still run unconditionally on every PR, docs-only or
-not — they're cheap (no build, no network) and are exactly what a stray secret or broken
-doc-contract reference in a "docs-only" PR would trip. **Hard guardrail, no exceptions:** any diff
+`validate:intake`, `scan:public-safety`, and `validate:private-boundary` still run
+unconditionally on every PR, docs-only or not — they're cheap (no build, no network) and are
+exactly what a stray secret, private-boundary leak, or broken doc-contract reference in a
+"docs-only" PR would trip. **Hard guardrail, no exceptions:** any diff
 touching `registry/` forces `docs_only=false` regardless of what else is in the diff — computed as an
 independent override in the same `changes` job step, before the docs-pattern check even runs. This
 exists because the retired "ugc" lane above was scoped to registry/community-surface PRs specifically

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,11 +22,11 @@ concurrency:
 # private-boundary, all below).
 #
 # The DOCS FAST-LANE below is a narrower, separate thing: it does not skip any
-# job or reduce the safety/contract/registry gates for anything that could
-# plausibly need them. It only lets a diff that is PURELY prose (**/*.md +
-# .claude/skills/**) — which cannot touch registry data, schemas, code, or CI
-# config — finish `checks` in seconds instead of minutes, while still reporting
-# a real `success` conclusion (not `skipped`) on every step.
+# job or reduce the safety/security gates, including validate:private-boundary,
+# for anything that could plausibly need them. It only lets a diff that is
+# PURELY prose (**/*.md + .claude/skills/**) — which cannot touch registry data,
+# schemas, code, or CI config — skip build/contract/registry/deploy work, while
+# still reporting a real `success` conclusion (not `skipped`) on every step.
 #
 # The work splits across two parallel jobs that both build: `test` builds then
 # runs the suite + coverage; `checks` builds then runs lint + the ~20 contract /
@@ -371,11 +371,12 @@ jobs:
       - name: Install
         run: npm ci
 
-      # Lint + format + the documentation/intake/safety scans below run
-      # UNCONDITIONALLY, docs fast lane or not — they're cheap (no build, no
-      # network), and directly relevant to a docs-only diff (a stray secret,
-      # broken doc-contract reference, or malformed intake template can land in
-      # a "docs-only" PR just as easily as in a code PR).
+      # Lint + format + the documentation/intake/safety/security scans below
+      # run UNCONDITIONALLY, docs fast lane or not — they're cheap (no build,
+      # no network), and directly relevant to a docs-only diff (a stray secret,
+      # private-boundary leak, broken doc-contract reference, or malformed
+      # intake template can land in a "docs-only" PR just as easily as in a
+      # code PR).
       - name: Lint + format
         run: |
           npm run lint
@@ -581,8 +582,10 @@ jobs:
       - name: Public-safety scan
         run: npm run scan:public-safety
 
+      # Always runs, docs fast lane or not: this scans all tracked files,
+      # including Markdown, for private review internals and provider-private
+      # routes. It is a security boundary, not a build/contract gate.
       - name: Validate private boundary
-        if: env.DOCS_ONLY != 'true'
         run: npm run validate:private-boundary
 
   # The Python SDK (python/) ships its own hermetic unittest suite (37 cases) but


### PR DESCRIPTION
### Motivation
- The docs fast-lane previously skipped the `validate:private-boundary` step when `DOCS_ONLY=true`, which allowed Markdown-only PRs to bypass a security boundary that scans all tracked files for secrets and private review internals.
- This change restores the private-boundary check as an unconditional security gate so prose edits cannot introduce provider-private routes, webhook URLs, or other sensitive content undetected.

### Description
- Removed the `if: env.DOCS_ONLY != 'true'` guard from the `Validate private boundary` step in `.github/workflows/validate.yml` so it always runs for PRs, including docs-only diffs.
- Clarified and tightened workflow comments in `.github/workflows/validate.yml` to explicitly document that `validate:private-boundary` is a security boundary and will not be skipped by the docs fast lane.
- Updated `.claude/skills/metagraphed/reference.md` to state that `validate:private-boundary` runs unconditionally alongside other always-run checks for docs-only PRs.
- No functionality of the validators themselves was changed; only the workflow control and reference documentation were updated.

### Testing
- Ran `npm run validate:workflows` and observed it complete successfully.
- Ran `npm run validate:private-boundary` and observed the validator pass on the current tree.
- Ran `npm run scan:public-safety` and observed the scan pass on the current tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4746598094832c98f28d98ed64dc44)