### PR TITLE
feat(api): add ?format=csv to the chain analytics routes

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -8744,6 +8744,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d";
+                /** @description Response format override. Use `csv` to download the daily activity series as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8751,7 +8753,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8808,6 +8810,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainActivityArtifact"];
                     };
+                    /**
+                     * @example day,block_count,extrinsic_count,event_count,successful_extrinsics,success_rate,unique_signers
+                     *     2026-07-01,7200,15000,42000,14950,0.9967,320
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -8862,6 +8869,8 @@ export interface operations {
                 group_by?: "module" | "module_function";
                 limit?: number;
                 call_module?: string;
+                /** @description Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8869,7 +8878,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8925,6 +8934,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainCallsArtifact"];
                     };
+                    /**
+                     * @example call_module,count,share
+                     *     SubtensorModule,8200,0.5467
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -9152,6 +9166,8 @@ export interface operations {
                 window?: "7d" | "30d";
                 limit?: number;
                 call_module?: string;
+                /** @description Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers). */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -9159,7 +9175,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -9225,6 +9241,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainFeesArtifact"];
                     };
+                    /**
+                     * @example day,extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao
+                     *     2026-07-01,15000,42.5,0.002833,0.0025,0,0,0
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -9444,6 +9465,8 @@ export interface operations {
                 sort?: "tx_count" | "total_fee_tao";
                 limit?: number;
                 call_module?: string;
+                /** @description Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -9451,7 +9474,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -9507,6 +9530,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainSignersArtifact"];
                     };
+                    /**
+                     * @example signer,tx_count,total_fee_tao,total_tip_tao,last_tx_block
+                     *     5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,1200,3.42,0,8454388
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5780,6 +5780,17 @@
             ],
             "type": "string"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the daily activity series as text/csv; `json` (default) keeps the response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -5828,6 +5839,17 @@
             "maxLength": 100,
             "type": "string"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -5874,6 +5896,17 @@
           "name": "call_module",
           "schema": {
             "maxLength": 100,
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
             "type": "string"
           }
         }
@@ -5984,6 +6017,17 @@
           "name": "call_module",
           "schema": {
             "maxLength": 100,
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers).",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
             "type": "string"
           }
         }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -20497,6 +20497,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the daily activity series as text/csv; `json` (default) keeps the response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -20561,9 +20574,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "day,block_count,extrinsic_count,event_count,successful_extrinsics,success_rate,unique_signers\r\n2026-07-01,7200,15000,42000,14950,0.9967,320",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -20673,6 +20692,19 @@
               "maxLength": 100,
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -20736,9 +20768,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "call_module,count,share\r\nSubtensorModule,8200,0.5467",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -21029,6 +21067,19 @@
               "maxLength": 100,
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers).",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -21102,9 +21153,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "day,extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao\r\n2026-07-01,15000,42.5,0.002833,0.0025,0,0,0",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -21398,6 +21455,19 @@
               "maxLength": 100,
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -21461,9 +21531,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "signer,tx_count,total_fee_tao,total_tip_tao,last_tx_block\r\n5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,1200,3.42,0,8454388",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -8744,6 +8744,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d";
+                /** @description Response format override. Use `csv` to download the daily activity series as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8751,7 +8753,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8808,6 +8810,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainActivityArtifact"];
                     };
+                    /**
+                     * @example day,block_count,extrinsic_count,event_count,successful_extrinsics,success_rate,unique_signers
+                     *     2026-07-01,7200,15000,42000,14950,0.9967,320
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -8862,6 +8869,8 @@ export interface operations {
                 group_by?: "module" | "module_function";
                 limit?: number;
                 call_module?: string;
+                /** @description Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8869,7 +8878,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8925,6 +8934,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainCallsArtifact"];
                     };
+                    /**
+                     * @example call_module,count,share
+                     *     SubtensorModule,8200,0.5467
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -9152,6 +9166,8 @@ export interface operations {
                 window?: "7d" | "30d";
                 limit?: number;
                 call_module?: string;
+                /** @description Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers). */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -9159,7 +9175,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -9225,6 +9241,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainFeesArtifact"];
                     };
+                    /**
+                     * @example day,extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao
+                     *     2026-07-01,15000,42.5,0.002833,0.0025,0,0,0
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -9444,6 +9465,8 @@ export interface operations {
                 sort?: "tx_count" | "total_fee_tao";
                 limit?: number;
                 call_module?: string;
+                /** @description Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -9451,7 +9474,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -9507,6 +9530,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainSignersArtifact"];
                     };
+                    /**
+                     * @example signer,tx_count,total_fee_tao,total_tip_tao,last_tx_block
+                     *     5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,1200,3.42,0,8454388
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2399,7 +2399,18 @@ export const API_ROUTES = [
     "Fetch daily network-activity aggregates (extrinsic/event/block counts, success rate, unique signers) over a 7d or 30d window, newest day first. Computed live from the first-party chain D1 tiers (#1987); schema-stable day_count:0/days:[] when the store is cold.",
     "short",
     ["chain", "analytics"],
-    [{ name: "window", schema: { type: "string", enum: ["7d", "30d"] } }],
+    {
+      csvResponse: true,
+      parameters: [
+        { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the daily activity series as text/csv; `json` (default) keeps the response envelope.",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [],
   ),
   route(
@@ -2410,15 +2421,27 @@ export const API_ROUTES = [
     "Fetch the extrinsic call-mix breakdown (count + share per call_module, or call_module/call_function with group_by=module_function) over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. When scoped, total_extrinsics and share use the scoped module denominator. Computed live from the first-party extrinsics D1 tier (#1989); schema-stable call_count:0/calls:[] when cold.",
     "short",
     ["chain", "analytics"],
-    [
-      { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
-      {
-        name: "group_by",
-        schema: { type: "string", enum: ["module", "module_function"] },
-      },
-      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
-      { name: "call_module", schema: { type: "string", maxLength: 100 } },
-    ],
+    {
+      csvResponse: true,
+      parameters: [
+        { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
+        {
+          name: "group_by",
+          schema: { type: "string", enum: ["module", "module_function"] },
+        },
+        {
+          name: "limit",
+          schema: { type: "integer", minimum: 1, maximum: 100 },
+        },
+        { name: "call_module", schema: { type: "string", maxLength: 100 } },
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the call-mix rows as text/csv; `json` (default) keeps the response envelope.",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [],
   ),
   route(
@@ -2429,15 +2452,27 @@ export const API_ROUTES = [
     "Fetch the windowed most-active-account leaderboard (signers ranked by ?sort=tx_count or ?sort=total_fee_tao, with total fees/tips + newest signed block) over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. Computed live from the first-party extrinsics D1 tier (#1990); schema-stable signer_count:0/signers:[] when cold.",
     "short",
     ["chain", "analytics"],
-    [
-      { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
-      {
-        name: "sort",
-        schema: { type: "string", enum: ["tx_count", "total_fee_tao"] },
-      },
-      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
-      { name: "call_module", schema: { type: "string", maxLength: 100 } },
-    ],
+    {
+      csvResponse: true,
+      parameters: [
+        { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
+        {
+          name: "sort",
+          schema: { type: "string", enum: ["tx_count", "total_fee_tao"] },
+        },
+        {
+          name: "limit",
+          schema: { type: "integer", minimum: 1, maximum: 100 },
+        },
+        { name: "call_module", schema: { type: "string", maxLength: 100 } },
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the signer leaderboard as text/csv; `json` (default) keeps the response envelope.",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [],
   ),
   route(
@@ -2480,11 +2515,23 @@ export const API_ROUTES = [
     "Fetch fee/tip market analytics — a per-UTC-day fee series (totals, averages, and exact ordered-offset medians) plus a windowed top-fee-payer list — over a 7d or 30d window, optionally scoped to one pallet with ?call_module=. Computed live from the first-party extrinsics D1 tier (#1988); schema-stable day_count:0 + empty lists when cold.",
     "short",
     ["chain", "analytics"],
-    [
-      { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
-      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
-      { name: "call_module", schema: { type: "string", maxLength: 100 } },
-    ],
+    {
+      csvResponse: true,
+      parameters: [
+        { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
+        {
+          name: "limit",
+          schema: { type: "integer", minimum: 1, maximum: 100 },
+        },
+        { name: "call_module", schema: { type: "string", maxLength: 100 } },
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the daily fee series as text/csv; `json` (default) keeps the response envelope (which also carries top_fee_payers).",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [],
   ),
   route(
@@ -3292,6 +3339,31 @@ function csvExampleForRoute(entry) {
     return [
       "extrinsic_id,block_number,signer,call_module,call_function,success",
       "8454388-2,8454388,5Signer,SubtensorModule,add_stake,true",
+    ].join("\r\n");
+  }
+  if (entry.id === "chain-activity") {
+    return [
+      "day,block_count,extrinsic_count,event_count,successful_extrinsics,success_rate,unique_signers",
+      "2026-07-01,7200,15000,42000,14950,0.9967,320",
+    ].join("\r\n");
+  }
+  if (entry.id === "chain-calls") {
+    // Default grouping (group_by=module) omits call_function; add ?group_by=
+    // module_function for the call_module,call_function,count,share shape.
+    return ["call_module,count,share", "SubtensorModule,8200,0.5467"].join(
+      "\r\n",
+    );
+  }
+  if (entry.id === "chain-signers") {
+    return [
+      "signer,tx_count,total_fee_tao,total_tip_tao,last_tx_block",
+      "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,1200,3.42,0,8454388",
+    ].join("\r\n");
+  }
+  if (entry.id === "chain-fees") {
+    return [
+      "day,extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao",
+      "2026-07-01,15000,42.5,0.002833,0.0025,0,0,0",
     ].join("\r\n");
   }
   return "netuid,name\r\n7,Allways";

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -13,6 +13,10 @@ import {
   handleHealthPercentiles,
   handleHealthIncidents,
   handleGlobalIncidents,
+  handleChainActivity,
+  handleChainCalls,
+  handleChainSigners,
+  handleChainFees,
   validateQueryParams,
   analyticsWindow,
   d1All,
@@ -1629,5 +1633,148 @@ describe("analytics handler invariants", () => {
     );
     await Promise.resolve();
     assert.deepEqual(cache.putKeys, []);
+  });
+});
+
+// ---- Chain-analytics CSV export (#2532) ------------------------------------
+
+describe("chain analytics ?format=csv export", () => {
+  const cases = [
+    {
+      name: "chain-activity",
+      path: "/api/v1/chain/activity",
+      handler: handleChainActivity,
+      header:
+        "day,block_count,extrinsic_count,event_count,successful_extrinsics,success_rate,unique_signers",
+    },
+    {
+      name: "chain-calls",
+      path: "/api/v1/chain/calls",
+      handler: handleChainCalls,
+      header: "call_module,count,share",
+    },
+    {
+      name: "chain-signers",
+      path: "/api/v1/chain/signers",
+      handler: handleChainSigners,
+      header: "signer,tx_count,total_fee_tao,total_tip_tao,last_tx_block",
+    },
+    {
+      name: "chain-fees",
+      path: "/api/v1/chain/fees",
+      handler: handleChainFees,
+      header:
+        "day,extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao",
+    },
+  ];
+
+  for (const { name, path, handler, header } of cases) {
+    test(`${name} ?window=7d&format=csv emits its columns as text/csv`, async () => {
+      const { env } = dbWith({ rows: [] });
+      const p = `${path}?window=7d&format=csv`;
+      const res = await handler(req(p), env, url(p));
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get("content-type") || "", /text\/csv/);
+      // Explicit columns → a cold store still emits a header-only CSV (never empty).
+      const text = await res.text();
+      assert.equal(text.split("\r\n")[0], header);
+    });
+
+    test(`${name} keeps the JSON envelope when format is absent`, async () => {
+      const { env } = dbWith({ rows: [] });
+      const res = await handler(
+        req(`${path}?window=7d`),
+        env,
+        url(`${path}?window=7d`),
+      );
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get("content-type") || "", /application\/json/);
+    });
+
+    test(`${name} rejects a ?format value outside the json|csv enum`, async () => {
+      const p = `${path}?window=7d&format=xml`;
+      const res = await handler(req(p), emptyEnv(), url(p));
+      const body = await errorJson(res);
+      assert.equal(body.error.code, "invalid_query");
+      assert.equal(body.meta.parameter, "format");
+    });
+
+    test(`${name} degraded D1 still emits header-only CSV, marked fallback (not edge-cached)`, async () => {
+      // A degraded D1 read yields fallback-marked rows; the CSV response must
+      // still be a valid header-only CSV (never a 500) AND be tagged as fallback
+      // so withEdgeCache never persists the degraded body.
+      originalCaches = globalThis.caches;
+      const cache = mockCaches();
+      cache.install();
+      const { env } = dbWith({ d1Error: new Error("d1 down") });
+      const p = `${path}?window=7d&format=csv`;
+      const res = await handler(req(p), env, url(p), ctx);
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get("content-type") || "", /text\/csv/);
+      const text = await res.text();
+      assert.equal(text.split("\r\n")[0], header);
+      assert.deepEqual(cache.putKeys, []);
+    });
+  }
+
+  test("Accept: text/csv negotiates CSV without an explicit ?format", async () => {
+    const { env } = dbWith({ rows: [] });
+    const p = "/api/v1/chain/signers?window=7d";
+    const res = await handleChainSigners(
+      req(p, { headers: { accept: "text/csv" } }),
+      env,
+      url(p),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type") || "", /text\/csv/);
+  });
+
+  test("?format=json forces JSON even when Accept prefers text/csv", async () => {
+    const { env } = dbWith({ rows: [] });
+    const p = "/api/v1/chain/signers?window=7d&format=json";
+    const res = await handleChainSigners(
+      req(p, { headers: { accept: "text/csv" } }),
+      env,
+      url(p),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type") || "", /application\/json/);
+  });
+
+  test("chain-calls ?group_by=module_function adds the call_function column", async () => {
+    const { env } = dbWith({ rows: [] });
+    const p =
+      "/api/v1/chain/calls?window=7d&group_by=module_function&format=csv";
+    const res = await handleChainCalls(req(p), env, url(p));
+    assert.equal(res.status, 200);
+    const text = await res.text();
+    assert.equal(
+      text.split("\r\n")[0],
+      "call_module,call_function,count,share",
+    );
+  });
+
+  test("chain-calls scoped by ?call_module still exports CSV", async () => {
+    const { env } = dbWith({ rows: [] });
+    const p =
+      "/api/v1/chain/calls?window=7d&call_module=SubtensorModule&format=csv";
+    const res = await handleChainCalls(req(p), env, url(p));
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type") || "", /text\/csv/);
+  });
+
+  test("a healthy CSV response is edge-cached under a distinct format=csv key", async () => {
+    // Proves the CSV path participates in the edge cache (so the degraded
+    // not-cached assertion above is meaningful) and that CSV gets its own cache
+    // entry, never colliding with the JSON envelope for the same URL.
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const { env } = dbWith({ rows: [] });
+    const p = "/api/v1/chain/activity?window=7d&format=csv";
+    const res = await handleChainActivity(req(p), env, url(p), ctx);
+    assert.equal(res.status, 200);
+    assert.equal(cache.putKeys.length, 1);
+    assert.match(cache.putKeys[0], /format=csv/);
   });
 });

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -35,6 +35,7 @@ import {
 } from "../config.mjs";
 import { parseLimitParam } from "../request-params.mjs";
 import { errorResponse, ifNoneMatchSatisfied } from "../http.mjs";
+import { csvRequested, csvResponse } from "../csv.mjs";
 import {
   contractVersion,
   envelopeResponse,
@@ -163,6 +164,13 @@ function validateEnumParam(url, parameter, allowedValues) {
     parameter,
     message: `${parameter} must be one of: ${allowedValues.join(", ")}.`,
   };
+}
+
+// Enforce the declared `format` enum (json|csv). The per-handler allow-list only
+// gates the param NAME, not its value — without this a `?format=xml` would be
+// silently accepted, contradicting the contract's `enum: [json, csv]` (#2532).
+function validateFormatParam(url) {
+  return validateEnumParam(url, "format", ["json", "csv"]);
 }
 
 // Bound an optional free-text filter so an oversized value never reaches D1.
@@ -674,6 +682,48 @@ export async function handleGlobalIncidents(request, env, url) {
     : response;
 }
 
+// Explicit CSV column order for the chain-analytics ?format=csv exports (#2532).
+// Passed to csvResponse so a cold store (empty array) still emits a header row,
+// and column order stays stable regardless of row-key insertion order.
+const CHAIN_ACTIVITY_CSV_COLUMNS = [
+  "day",
+  "block_count",
+  "extrinsic_count",
+  "event_count",
+  "successful_extrinsics",
+  "success_rate",
+  "unique_signers",
+];
+// group_by=module rows carry call_function:null, so the default export omits that
+// column; group_by=module_function adds it — keeping the CSV header honest per grouping.
+const CHAIN_CALLS_CSV_COLUMNS = ["call_module", "count", "share"];
+const CHAIN_CALLS_FUNCTION_CSV_COLUMNS = [
+  "call_module",
+  "call_function",
+  "count",
+  "share",
+];
+const CHAIN_SIGNERS_CSV_COLUMNS = [
+  "signer",
+  "tx_count",
+  "total_fee_tao",
+  "total_tip_tao",
+  "last_tx_block",
+];
+// The fee-market CSV exports the per-day fee series (data.daily) — the primary
+// row-shaped table, mirroring chain-activity; the top_fee_payers leaderboard
+// stays JSON-only in the envelope.
+const CHAIN_FEES_CSV_COLUMNS = [
+  "day",
+  "extrinsic_count",
+  "total_fee_tao",
+  "avg_fee_tao",
+  "median_fee_tao",
+  "total_tip_tao",
+  "avg_tip_tao",
+  "median_tip_tao",
+];
+
 // Daily network-activity aggregates over the first-party chain D1 tiers (#1987):
 // per-UTC-day extrinsic/event/block counts, success rate, and unique signers —
 // the foundation time-series for the block-explorer "network at a glance" view
@@ -681,8 +731,11 @@ export async function handleGlobalIncidents(request, env, url) {
 // run in parallel and merge in the pure builder, so the route is schema-stable
 // (day_count:0, days:[]) on a cold store and never re-aggregates on an edge hit.
 export async function handleChainActivity(request, env, url, ctx = {}) {
-  const { label, error } = analyticsWindow(url);
+  const { label, error } = analyticsWindow(url, ["format"]);
   if (error) return analyticsQueryError(error);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
+  const csv = csvRequested(url, request);
   return withEdgeCache(
     request,
     ctx,
@@ -697,6 +750,18 @@ export async function handleChainActivity(request, env, url, ctx = {}) {
           observedAt: meta?.last_run_at || null,
         },
       );
+      if (csv) {
+        const csvRes = await csvResponse(
+          data.days,
+          "chain-activity",
+          "short",
+          request,
+          CHAIN_ACTIVITY_CSV_COLUMNS,
+        );
+        return hasD1FallbackRows(extrinsicRows, blockRows)
+          ? markD1FallbackResponse(csvRes)
+          : csvRes;
+      }
       const response = await envelopeResponse(
         request,
         {
@@ -717,7 +782,7 @@ export async function handleChainActivity(request, env, url, ctx = {}) {
     // explicit ?window=<default>, and reordered/duplicate variants all share one
     // entry instead of fragmenting the cache (mirrors the percentiles/incidents/
     // economics-trends windowed routes). `label` is the validated window.
-    `${url.pathname}?window=${encodeURIComponent(label)}`,
+    `${url.pathname}?window=${encodeURIComponent(label)}${csv ? "&format=csv" : ""}`,
   );
 }
 
@@ -729,8 +794,11 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
     "group_by",
     "limit",
     "call_module",
+    "format",
   ]);
   if (error) return analyticsQueryError(error);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const groupByError = validateEnumParam(url, "group_by", [
     "module",
     "module_function",
@@ -745,6 +813,7 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
   const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
+  const csv = csvRequested(url, request);
   return withEdgeCache(
     request,
     ctx,
@@ -765,6 +834,18 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
         limit,
         observedAt: meta?.last_run_at || null,
       });
+      if (csv) {
+        const csvRes = await csvResponse(
+          data.calls,
+          "chain-calls",
+          "short",
+          request,
+          groupBy === "module_function"
+            ? CHAIN_CALLS_FUNCTION_CSV_COLUMNS
+            : CHAIN_CALLS_CSV_COLUMNS,
+        );
+        return usedFallback ? markD1FallbackResponse(csvRes) : csvRes;
+      }
       const response = await envelopeResponse(
         request,
         {
@@ -779,7 +860,7 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
       );
       return usedFallback ? markD1FallbackResponse(response) : response;
     },
-    canonicalAnalyticsCacheRoute(url, ["group_by", "limit", "call_module"]),
+    `${canonicalAnalyticsCacheRoute(url, ["group_by", "limit", "call_module"])}${csv ? "&format=csv" : ""}`,
   );
 }
 
@@ -791,8 +872,11 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
     "limit",
     "call_module",
     "sort",
+    "format",
   ]);
   if (error) return analyticsQueryError(error);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const sortError = validateEnumParam(url, "sort", CHAIN_SIGNERS_SORTS);
   if (sortError) return analyticsQueryError(sortError);
   const { limit, error: limitError } = parseLimitParam(url, {
@@ -805,6 +889,7 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
   const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
+  const csv = csvRequested(url, request);
   return withEdgeCache(
     request,
     ctx,
@@ -820,6 +905,18 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
         callModule,
         sort,
       });
+      if (csv) {
+        const csvRes = await csvResponse(
+          data.signers,
+          "chain-signers",
+          "short",
+          request,
+          CHAIN_SIGNERS_CSV_COLUMNS,
+        );
+        return hasD1FallbackRows(rows)
+          ? markD1FallbackResponse(csvRes)
+          : csvRes;
+      }
       const response = await envelopeResponse(
         request,
         {
@@ -836,7 +933,7 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
         ? markD1FallbackResponse(response)
         : response;
     },
-    canonicalAnalyticsCacheRoute(url, ["limit", "call_module", "sort"]),
+    `${canonicalAnalyticsCacheRoute(url, ["limit", "call_module", "sort"])}${csv ? "&format=csv" : ""}`,
   );
 }
 
@@ -952,8 +1049,14 @@ export async function handleChainTransferPairs(request, env, url, ctx = {}) {
 // exact medians) plus a windowed top-fee-payer list. COALESCE keeps NULL
 // fees/tips out of the SUMs and medians.
 export async function handleChainFees(request, env, url, ctx = {}) {
-  const { label, error } = analyticsWindow(url, ["limit", "call_module"]);
+  const { label, error } = analyticsWindow(url, [
+    "limit",
+    "call_module",
+    "format",
+  ]);
   if (error) return analyticsQueryError(error);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { limit, error: limitError } = parseLimitParam(url, {
     defaultLimit: 25,
     maxLimit: 100,
@@ -964,6 +1067,7 @@ export async function handleChainFees(request, env, url, ctx = {}) {
   const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
+  const csv = csvRequested(url, request);
   return withEdgeCache(
     request,
     ctx,
@@ -980,6 +1084,18 @@ export async function handleChainFees(request, env, url, ctx = {}) {
           observedAt: meta?.last_run_at || null,
         },
       );
+      if (csv) {
+        const csvRes = await csvResponse(
+          data.daily,
+          "chain-fees",
+          "short",
+          request,
+          CHAIN_FEES_CSV_COLUMNS,
+        );
+        return hasD1FallbackRows(dailyRows, payerRows, medianRows)
+          ? markD1FallbackResponse(csvRes)
+          : csvRes;
+      }
       const response = await envelopeResponse(
         request,
         {
@@ -996,7 +1112,7 @@ export async function handleChainFees(request, env, url, ctx = {}) {
         ? markD1FallbackResponse(response)
         : response;
     },
-    canonicalAnalyticsCacheRoute(url, ["limit", "call_module"]),
+    `${canonicalAnalyticsCacheRoute(url, ["limit", "call_module"])}${csv ? "&format=csv" : ""}`,
   );
 }
 


### PR DESCRIPTION
## Summary

Adds `?format=csv` to the four block-explorer chain-analytics routes — `/api/v1/chain/activity`, `/chain/calls`, `/chain/signers`, `/chain/fees` — so each route's primary row table can be pulled into a spreadsheet or data pipeline, matching the CSV export already offered on the subnet-list, validator-analytics, registry, and economics routes.

Closes #2532

Resubmit of #2784 (closed for contract-quality): this version wires each route's real columns into the per-route `csvExampleForRoute` switch, so the generated OpenAPI `text/csv` examples show the actual chain-analytics columns rather than the placeholder `netuid,name`.

## What changed

- **`workers/request-handlers/analytics.mjs`** — a CSV branch in each of the four handlers. When `csvRequested(url, request)` (via `?format=csv` or `Accept: text/csv`), the handler returns `csvResponse(<primary array>, "<route id>", "short", request, <columns>)` from inside the edge-cache builder, under a distinct cache key (a `format=csv` marker) so CSV never collides with the JSON envelope. Explicit column lists → a cold store emits a header-only CSV. A degraded D1 read still wraps the CSV with `markD1FallbackResponse`, so a degraded body is never persisted to the edge cache. Primary arrays: activity→`days`, calls→`calls`, signers→`signers`, fees→`daily` (`top_fee_payers` stays JSON-only).
- **`src/contracts.mjs`** — added the `format` param (`enum: ["json","csv"]`) to the four routes in object form (`{ csvResponse: true, parameters: [...] }`), so the OpenAPI generator emits a `text/csv` 200 response alongside `application/json`; and added a `csvExampleForRoute` case per route with a realistic header + sample row. Regenerated + committed the OpenAPI/client/types artifacts.
- **`workers/request-handlers/analytics.mjs`** — the `format` enum is enforced per handler (`validateFormatParam` → `validateEnumParam(url,"format",["json","csv"])`), so `?format=xml` returns `400 invalid_query` rather than being silently accepted.
- **`tests/request-handlers-analytics.test.mjs`** — per route: `?format=csv` returns `text/csv` with the exact column header; JSON envelope unchanged when `format` is absent; `?format=xml` → 400; a degraded-D1 read still serves header-only CSV; plus `Accept: text/csv` negotiation and a `?call_module`-scoped case.

## Validation

- [x] `npm run build` (OpenAPI/types/client regenerated + committed; deploy-owned artifacts reverted per contributor rules)
- [x] `npm run lint` · `format:check`
- [x] `validate:contract-drift` · `validate:openapi` · `validate:openapi-examples` · `validate:generated-client` · `validate:types` · `validate:api` · `validate:schemas`
- [x] `scan:public-safety`
- [x] `npm run test:coverage` — 4479 passed; new lines fully covered
