### PR TITLE
feat(api): add ?format=csv export to the recent-block feed (#2528)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -249,7 +249,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Computed live from the first-party blocks D1 tier (#1345). */
+        /** Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Pass ?format=csv to download the filtered block rows as CSV. Computed live from the first-party blocks D1 tier (#1345). */
         get: operations["blocksFeed"];
         put?: never;
         post?: never;
@@ -7700,6 +7700,8 @@ export interface operations {
                 block_end?: number;
                 min_extrinsics?: number;
                 min_events?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -7707,7 +7709,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -7759,6 +7761,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BlocksFeedArtifact"];
                     };
+                    /**
+                     * @example block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at
+                     *     8454388,0xblock,0xparent,5Author,3,12,204,2026-07-03T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5388,7 +5388,7 @@
     {
       "artifact_path": "/metagraph/blocks.json",
       "cache": "short",
-      "description": "Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Computed live from the first-party blocks D1 tier (#1345).",
+      "description": "Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Pass ?format=csv to download the filtered block rows as CSV. Computed live from the first-party blocks D1 tier (#1345).",
       "id": "blocks-feed",
       "method": "GET",
       "path": "/api/v1/blocks",
@@ -5470,6 +5470,17 @@
           "schema": {
             "minimum": 0,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -696,7 +696,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "The recent-block feed (newest first) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks (no static file).",
+      "description": "The recent-block feed (newest first) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks; pass ?format=csv to download the filtered block rows as CSV (no static file).",
       "id": "blocks-feed",
       "path": "/metagraph/blocks.json",
       "schema_ref": "#/components/schemas/BlocksFeedArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -19028,6 +19028,19 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -19087,9 +19100,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at\r\n8454388,0xblock,0xparent,5Author,3,12,204,2026-07-03T00:00:00.000Z",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -19146,7 +19165,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Computed live from the first-party blocks D1 tier (#1345).",
+        "summary": "Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Pass ?format=csv to download the filtered block rows as CSV. Computed live from the first-party blocks D1 tier (#1345).",
         "tags": [
           "blocks",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -249,7 +249,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Computed live from the first-party blocks D1 tier (#1345). */
+        /** Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Pass ?format=csv to download the filtered block rows as CSV. Computed live from the first-party blocks D1 tier (#1345). */
         get: operations["blocksFeed"];
         put?: never;
         post?: never;
@@ -7700,6 +7700,8 @@ export interface operations {
                 block_end?: number;
                 min_extrinsics?: number;
                 min_events?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -7707,7 +7709,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -7759,6 +7761,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BlocksFeedArtifact"];
                     };
+                    /**
+                     * @example block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at
+                     *     8454388,0xblock,0xparent,5Author,3,12,204,2026-07-03T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1081,7 +1081,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "blocks-feed",
     "/metagraph/blocks.json",
-    "The recent-block feed (newest first) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks (no static file).",
+    "The recent-block feed (newest first) for the block explorer (#1345), served live from the first-party blocks D1 tier at /api/v1/blocks; pass ?format=csv to download the filtered block rows as CSV (no static file).",
     "BlocksFeedArtifact",
   ),
   artifact(
@@ -2244,10 +2244,10 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/blocks",
     "/metagraph/blocks.json",
-    "Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Computed live from the first-party blocks D1 tier (#1345).",
+    "Fetch the recent-block feed (newest first) for the block explorer; ?limit (<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851). A conjunctive (AND-ed) filter set (#1991) narrows the feed: ?author=<ss58>, ?spec_version=<n>, ?from / ?to (observed_at epoch-ms), ?block_start / ?block_end (height range), ?min_extrinsics / ?min_events (non-empty blocks). Pass ?format=csv to download the filtered block rows as CSV. Computed live from the first-party blocks D1 tier (#1345).",
     "short",
     ["blocks", "analytics"],
-    [
+    csvRouteQuery([
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "cursor", schema: { type: "string" } },
@@ -2259,7 +2259,7 @@ export const API_ROUTES = [
       { name: "block_end", schema: { type: "integer", minimum: 0 } },
       { name: "min_extrinsics", schema: { type: "integer", minimum: 0 } },
       { name: "min_events", schema: { type: "integer", minimum: 0 } },
-    ],
+    ]),
     [],
   ),
   route(
@@ -3364,6 +3364,12 @@ function csvExampleForRoute(entry) {
     return [
       "day,extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao",
       "2026-07-01,15000,42.5,0.002833,0.0025,0,0,0",
+    ].join("\r\n");
+  }
+  if (entry.id === "blocks-feed") {
+    return [
+      "block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at",
+      "8454388,0xblock,0xparent,5Author,3,12,204,2026-07-03T00:00:00.000Z",
     ].join("\r\n");
   }
   return "netuid,name\r\n7,Allways";

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -3645,6 +3645,90 @@ describe("handleBlocks", () => {
     assert.equal(body.data.limit, 25);
   });
 
+  test("?format=csv returns a named text/csv download with block columns (#2528)", async () => {
+    const { env } = dbWith({
+      blocksFeed: [
+        blockRow(),
+        blockRow({
+          block_number: BLOCK_NUM - 1,
+          block_hash: `0x${"c".repeat(64)}`,
+        }),
+      ],
+    });
+    const res = await handleBlocks(
+      req("/api/v1/blocks?format=csv"),
+      env,
+      url("/api/v1/blocks?format=csv"),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="blocks.csv"',
+    );
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(
+      lines[0],
+      "block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at",
+    );
+    assert.equal(lines.length, 3);
+    assert.match(lines[1], new RegExp(`^${BLOCK_NUM},`));
+  });
+
+  test("Accept: text/csv negotiates CSV without an explicit format", async () => {
+    const { env } = dbWith({ blocksFeed: [blockRow()] });
+    const res = await handleBlocks(
+      new Request("https://api.metagraph.sh/api/v1/blocks", {
+        headers: { accept: "text/csv" },
+      }),
+      env,
+      url("/api/v1/blocks"),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+  });
+
+  test("empty CSV export still emits the header row", async () => {
+    const { env } = dbWith({ blocksFeed: [] });
+    const res = await handleBlocks(
+      req("/api/v1/blocks?format=csv"),
+      env,
+      url("/api/v1/blocks?format=csv"),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      await res.text(),
+      "block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at",
+    );
+  });
+
+  test("?format=json keeps the JSON envelope even under Accept: text/csv", async () => {
+    const { env } = dbWith({ blocksFeed: [blockRow()] });
+    const res = await handleBlocks(
+      new Request("https://api.metagraph.sh/api/v1/blocks?format=json", {
+        headers: { accept: "text/csv" },
+      }),
+      env,
+      url("/api/v1/blocks?format=json"),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^application\/json/);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(Array.isArray(body.data.blocks), true);
+  });
+
+  test("rejects an unsupported format value with 400", async () => {
+    await errorJson(
+      await handleBlocks(
+        req("/api/v1/blocks?format=xml"),
+        emptyEnv(),
+        url("/api/v1/blocks?format=xml"),
+      ),
+    );
+  });
+
   test("clamps limit to <=100", async () => {
     const { env } = dbWith({ blocksFeed: [] });
     const body = await json(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -191,6 +191,20 @@ const GLOBAL_VALIDATOR_CSV_COLUMNS = [
   "latest_block_number",
   "subnets",
 ];
+
+// CSV projection for the recent-block feed (#2528). The block rows are already
+// flat (formatBlock), so the feed's own fields are the columns in read order.
+const BLOCK_CSV_COLUMNS = [
+  "block_number",
+  "block_hash",
+  "parent_hash",
+  "author",
+  "extrinsic_count",
+  "event_count",
+  "spec_version",
+  "observed_at",
+];
+
 function validateResponseFormat(url) {
   const raw = url.searchParams.get("format");
   if (raw === null && !url.searchParams.has("format")) return null;
@@ -1685,7 +1699,7 @@ export async function handleAccountBalance(request, env, ss58) {
 // absent store → schema-stable zero (never throws). Reuses the chain-events meta
 // (source:"chain-events") since the same first-party poller fills this tier.
 export async function handleBlocks(request, env, url) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "limit",
     "offset",
     "cursor",
@@ -1697,6 +1711,7 @@ export async function handleBlocks(request, env, url) {
     "block_end",
     "min_extrinsics",
     "min_events",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset, cursor } = parsePagination(url, BLOCK_PAGINATION);
@@ -1738,6 +1753,15 @@ export async function handleBlocks(request, env, url) {
     minExtrinsics,
     minEvents,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.blocks,
+      "blocks",
+      "short",
+      request,
+      BLOCK_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

Adds `?format=csv` (and `Accept: text/csv`) content negotiation to `GET /api/v1/blocks`, the recent-block feed, so the block explorer's block list can be downloaded as CSV. Follows the exact established feed-CSV pattern already merged for `/api/v1/validators`, `/api/v1/subnets/movers`, and the per-UID metagraph routes.

Closes #2528.

## What Changed

- **`src/contracts.mjs`** — the `blocks-feed` route now uses `csvRouteQuery([...])` (adds `csv_response: true` + the `format` `json|csv` parameter); the route and artifact descriptions note `?format=csv`; and `csvExampleForRoute` gains a `blocks-feed` example for the OpenAPI `text/csv` response.
- **`workers/request-handlers/entities.mjs`** — `handleBlocks` now validates via `validateEntityQuery` (accepting `format`) and, when CSV is requested, returns `csvResponse(data.blocks, "blocks", "short", request, BLOCK_CSV_COLUMNS)`. The block feed rows are already flat (`formatBlock`), so the columns are the feed's own fields: `block_number, block_hash, parent_hash, author, extrinsic_count, event_count, spec_version, observed_at`. No serving/caching change — `handleBlocks` is a direct (uncached) dispatch, so no cache-variance handling is needed.
- **Regenerated contract artifacts** (`npm run build`) — `openapi.json` (blocks route now documents the `format` param + a `text/csv` 200 response with a worked example), `api-index.json`, `contracts.json`, `generated/metagraphed-api.d.ts`, `types.d.ts`.
- **`tests/request-handlers-entities.test.mjs`** — five new `handleBlocks` cases: `?format=csv` returns a named `blocks.csv` download with the exact header + data rows; `Accept: text/csv` negotiation; empty feed still emits the header row; `?format=json` keeps the envelope even under `Accept: text/csv`; and an unsupported `format` value → 400.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by `npm run build`, not hand-edited.
- [x] Deploy-owned artifacts (`r2-manifest.json`, `schemas/index.json`, `operational-surfaces.json`) reverted against `origin/main` — not in this diff.
- [x] Public API/OpenAPI/schema change is intentional and documented (additive `format` param + `text/csv` response; JSON default unchanged).

## Validation

- [x] `npm run build` — regenerated + committed the contract artifacts.
- [x] `validate:contract-drift` · `validate:openapi` · `validate:openapi-examples` · `validate:api` · `validate:types` · `validate:generated-client` · `validate:committed-seed` · `validate:schema-enums` — all pass.
- [x] `vitest run tests/request-handlers-entities.test.mjs` — 270 pass (incl. 5 new blocks-CSV cases).
- [x] `eslint` + `prettier --check` on changed files — clean.
- [x] `git diff --check` — clean.