### PR TITLE
fix: stop deleting oversized staged neuron snapshots in R2

### DIFF
--- a/tests/load-staged-neurons.test.mjs
+++ b/tests/load-staged-neurons.test.mjs
@@ -210,7 +210,13 @@ test("loadStagedNeurons rejects oversized and out-of-range rows", async () => {
   });
   const oversizedResult = await loadStagedNeurons(oversized.env);
   assert.equal(oversizedResult.reason, "too_large");
+  assert.equal(oversizedResult.size, 32_000_001);
   assert.equal(oversized.batches.length, 0);
+  assert.deepEqual(
+    oversized.deleted,
+    [],
+    "must NOT delete — that would drop staged rows",
+  );
 
   const m = mockEnv({ rows: signedEnvelope([neuronRow(999999, -7)]) });
   const r = await loadStagedNeurons(m.env);

--- a/tests/load-staged-neurons.test.mjs
+++ b/tests/load-staged-neurons.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHmac } from "node:crypto";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import { loadStagedNeurons } from "../workers/api.mjs";
 
 function neuronRow(netuid, uid) {
@@ -66,6 +66,7 @@ function mockEnv({
   runs = [],
   size,
 }) {
+  const jsonCalls = [];
   return {
     env: {
       METAGRAPH_STAGING_SIGNING_KEY: SIGNING_KEY,
@@ -76,6 +77,7 @@ function mockEnv({
           return {
             size: size ?? JSON.stringify(rows).length,
             async json() {
+              jsonCalls.push(1);
               if (bad) throw new Error("bad json");
               return rows;
             },
@@ -115,6 +117,7 @@ function mockEnv({
     prepared,
     batches,
     runs,
+    jsonCalls,
   };
 }
 
@@ -204,6 +207,7 @@ test("loadStagedNeurons accepts full-network snapshots above the old 2 MB cap", 
 });
 
 test("loadStagedNeurons rejects oversized and out-of-range rows", async () => {
+  const warn = vi.spyOn(console, "warn");
   const oversized = mockEnv({
     rows: signedEnvelope([neuronRow(1, 0)]),
     size: 32_000_001,
@@ -212,11 +216,45 @@ test("loadStagedNeurons rejects oversized and out-of-range rows", async () => {
   assert.equal(oversizedResult.reason, "too_large");
   assert.equal(oversizedResult.size, 32_000_001);
   assert.equal(oversized.batches.length, 0);
+  assert.equal(
+    oversized.jsonCalls.length,
+    0,
+    "oversized payloads must return before object.json()",
+  );
+  assert.equal(warn.mock.calls.length, 1);
+  assert.match(String(warn.mock.calls[0][0]), /32000001/);
   assert.deepEqual(
     oversized.deleted,
     [],
     "must NOT delete — that would drop staged rows",
   );
+  warn.mockRestore();
+
+  const missingSizeJsonCalls = [];
+  const missingSizeDeleted = [];
+  const missingSizeRows = signedEnvelope([neuronRow(1, 0)]);
+  const missingSizeEnv = {
+    METAGRAPH_STAGING_SIGNING_KEY: SIGNING_KEY,
+    METAGRAPH_ARCHIVE: {
+      async get(key) {
+        assert.equal(key, "metagraph/neurons-pending.json");
+        return {
+          async json() {
+            missingSizeJsonCalls.push(1);
+            return missingSizeRows;
+          },
+        };
+      },
+      async delete(key) {
+        missingSizeDeleted.push(key);
+      },
+    },
+    METAGRAPH_HEALTH_DB: mockEnv({ rows: missingSizeRows }).env
+      .METAGRAPH_HEALTH_DB,
+  };
+  const missingSizeResult = await loadStagedNeurons(missingSizeEnv);
+  assert.equal(missingSizeResult.ok, true);
+  assert.equal(missingSizeJsonCalls.length, 1);
 
   const m = mockEnv({ rows: signedEnvelope([neuronRow(999999, -7)]) });
   const r = await loadStagedNeurons(m.env);

--- a/workers/request-handlers/staging.mjs
+++ b/workers/request-handlers/staging.mjs
@@ -258,7 +258,7 @@ export async function loadStagedNeurons(env) {
     console.warn(
       `loadStagedNeurons: staged file ${object.size} bytes exceeds ${MAX_STAGED_NEURONS_BYTES}; skipping (poller overlap self-heals)`,
     );
-    return { ok: false, reason: "too_large", size: Number(object.size || 0) };
+    return { ok: false, reason: "too_large", size: Number(object.size) };
   }
   let envelope;
   try {

--- a/workers/request-handlers/staging.mjs
+++ b/workers/request-handlers/staging.mjs
@@ -249,9 +249,16 @@ export async function loadStagedNeurons(env) {
   }
   const object = await bucket.get(STAGED_NEURONS_KEY);
   if (!object) return { ok: false, reason: "none" };
+  // Byte cap: never materialize a pathological body. `size` is object metadata,
+  // available before the body is streamed. Do NOT delete — that would drop rows the
+  // producer staged; leave it (loud) and let the overlapping poller's next window
+  // self-heal it. A misconfigured backfill exceeding this should be chunked by the
+  // producer, not parsed here.
   if (Number(object.size || 0) > MAX_STAGED_NEURONS_BYTES) {
-    await bucket.delete(STAGED_NEURONS_KEY);
-    return { ok: false, reason: "too_large" };
+    console.warn(
+      `loadStagedNeurons: staged file ${object.size} bytes exceeds ${MAX_STAGED_NEURONS_BYTES}; skipping (poller overlap self-heals)`,
+    );
+    return { ok: false, reason: "too_large", size: Number(object.size || 0) };
   }
   let envelope;
   try {


### PR DESCRIPTION
## Summary

`loadStagedNeurons` deleted `metagraph/neurons-pending.json` when the R2 object exceeded the 32 MB byte cap. The sibling staged loaders (`loadStagedEvents`, `loadStagedBlocks`, `loadStagedExtrinsics`) explicitly skip oversized files without deleting them so the CI poller can self-heal on the next window.

## Root cause

An inconsistent error path in `workers/request-handlers/staging.mjs`: the neurons loader called `bucket.delete()` on `too_large`, permanently dropping a metagraph snapshot the refresh-metagraph CI job had already written.

## Fix approach

Align `loadStagedNeurons` with the other staged loaders: check `object.size` metadata, log a warning, return `{ reason: too_large, size }`, and **do not delete** the staged object.

## Impact

Prevents silent data loss when a valid full-network metagraph snapshot exceeds the byte cap. The */3 cron can retry after the producer chunks or the cap is adjusted.

## Risks / tradeoffs

- An oversized file now remains in R2 until the producer replaces it (same behavior as events/blocks/extrinsics). This is intentional: deletion was the bug.
- Maliciously huge objects still cannot be parsed (body is never materialized); they are only skipped.

## Test plan

- [x] `npx vitest run tests/load-staged-neurons.test.mjs` (16/16 pass)
- [x] Added assertion that oversized payloads are not deleted