### PR TITLE
feat(api): add ?format=csv to GET /api/v1/accounts/{ss58}/extrinsics and /transfers

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -96,7 +96,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
         get: operations["accountExtrinsics"];
         put?: never;
         post?: never;
@@ -164,7 +164,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
         get: operations["accountTransfers"];
         put?: never;
         post?: never;
@@ -6737,6 +6737,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -6746,7 +6748,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -6800,6 +6802,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountExtrinsicsArtifact"];
                     };
+                    /**
+                     * @example extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at
+                     *     6702485-2,6702485,2,0xhash_sample,5F_sample,SubtensorModule,add_stake,true,0.000123,0,2026-06-02T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -7211,6 +7218,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -7220,7 +7229,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -7275,6 +7284,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountTransfersArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,from,to,amount_tao,direction,observed_at
+                     *     6702485,3,5F_sample,5G_sample,12.5,sent,2026-06-02T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5237,7 +5237,7 @@
     {
       "artifact_path": "/metagraph/accounts/{ss58}/extrinsics.json",
       "cache": "short",
-      "description": "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+      "description": "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
       "id": "account-extrinsics",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/extrinsics",
@@ -5279,13 +5279,24 @@
           "schema": {
             "type": "string"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
     {
       "artifact_path": "/metagraph/accounts/{ss58}/transfers.json",
       "cache": "short",
-      "description": "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+      "description": "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
       "id": "account-transfers",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/transfers",
@@ -5336,6 +5347,17 @@
         {
           "name": "cursor",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
             "type": "string"
           }
         }

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -642,7 +642,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Paginated extrinsics this account signed (by signer), newest first, served live from the extrinsics D1 tier at /api/v1/accounts/{ss58}/extrinsics (no static file).",
+      "description": "Paginated extrinsics this account signed (by signer), newest first, served live from the extrinsics D1 tier at /api/v1/accounts/{ss58}/extrinsics; pass ?format=csv to download the page as CSV (no static file).",
       "id": "account-extrinsics",
       "path": "/metagraph/accounts/{ss58}/extrinsics.json",
       "schema_ref": "#/components/schemas/AccountExtrinsicsArtifact",
@@ -651,7 +651,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers (no static file).",
+      "description": "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers; pass ?format=csv to download the page as CSV (no static file).",
       "id": "account-transfers",
       "path": "/metagraph/accounts/{ss58}/transfers.json",
       "schema_ref": "#/components/schemas/AccountTransfersArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -17952,6 +17952,19 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -18013,9 +18026,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at\r\n6702485-2,6702485,2,0xhash_sample,5F_sample,SubtensorModule,add_stake,true,0.000123,0,2026-06-02T00:00:00.000Z",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -18072,7 +18091,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+        "summary": "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
         "tags": [
           "accounts",
           "analytics"
@@ -18644,6 +18663,19 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -18706,9 +18738,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,event_index,from,to,amount_tao,direction,observed_at\r\n6702485,3,5F_sample,5G_sample,12.5,sent,2026-06-02T00:00:00.000Z",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -18765,7 +18803,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+        "summary": "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
         "tags": [
           "accounts",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -96,7 +96,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
         get: operations["accountExtrinsics"];
         put?: never;
         post?: never;
@@ -164,7 +164,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
         get: operations["accountTransfers"];
         put?: never;
         post?: never;
@@ -6737,6 +6737,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -6746,7 +6748,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -6800,6 +6802,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountExtrinsicsArtifact"];
                     };
+                    /**
+                     * @example extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at
+                     *     6702485-2,6702485,2,0xhash_sample,5F_sample,SubtensorModule,add_stake,true,0.000123,0,2026-06-02T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -7211,6 +7218,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -7220,7 +7229,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -7275,6 +7284,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountTransfersArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,from,to,amount_tao,direction,observed_at
+                     *     6702485,3,5F_sample,5G_sample,12.5,sent,2026-06-02T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1046,13 +1046,13 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "account-extrinsics",
     "/metagraph/accounts/{ss58}/extrinsics.json",
-    "Paginated extrinsics this account signed (by signer), newest first, served live from the extrinsics D1 tier at /api/v1/accounts/{ss58}/extrinsics (no static file).",
+    "Paginated extrinsics this account signed (by signer), newest first, served live from the extrinsics D1 tier at /api/v1/accounts/{ss58}/extrinsics; pass ?format=csv to download the page as CSV (no static file).",
     "AccountExtrinsicsArtifact",
   ),
   artifact(
     "account-transfers",
     "/metagraph/accounts/{ss58}/transfers.json",
-    "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers (no static file).",
+    "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers; pass ?format=csv to download the page as CSV (no static file).",
     "AccountTransfersArtifact",
   ),
   artifact(
@@ -2152,16 +2152,16 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/extrinsics",
     "/metagraph/accounts/{ss58}/extrinsics.json",
-    "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+    "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
     "short",
     ["accounts", "analytics"],
-    [
+    csvRouteQuery([
       { name: "block_start", schema: { type: "integer", minimum: 0 } },
       { name: "block_end", schema: { type: "integer", minimum: 0 } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "cursor", schema: { type: "string" } },
-    ],
+    ]),
     [{ name: "ss58", schema: { type: "string" } }],
   ),
   route(
@@ -2169,10 +2169,10 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/transfers",
     "/metagraph/accounts/{ss58}/transfers.json",
-    "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+    "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
     "short",
     ["accounts", "analytics"],
-    [
+    csvRouteQuery([
       {
         name: "direction",
         schema: { type: "string", enum: ["all", "sent", "received"] },
@@ -2182,7 +2182,7 @@ export const API_ROUTES = [
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "cursor", schema: { type: "string" } },
-    ],
+    ]),
     [{ name: "ss58", schema: { type: "string" } }],
   ),
   route(
@@ -3433,6 +3433,18 @@ function csvExampleForRoute(entry) {
     return [
       "block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at",
       "8454388,0xblock,0xparent,5Author,3,12,204,2026-07-03T00:00:00.000Z",
+    ].join("\r\n");
+  }
+  if (entry.id === "account-extrinsics") {
+    return [
+      "extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at",
+      "6702485-2,6702485,2,0xhash_sample,5F_sample,SubtensorModule,add_stake,true,0.000123,0,2026-06-02T00:00:00.000Z",
+    ].join("\r\n");
+  }
+  if (entry.id === "account-transfers") {
+    return [
+      "block_number,event_index,from,to,amount_tao,direction,observed_at",
+      "6702485,3,5F_sample,5G_sample,12.5,sent,2026-06-02T00:00:00.000Z",
     ].join("\r\n");
   }
   return "netuid,name\r\n7,Allways";

--- a/tests/account-routes.test.mjs
+++ b/tests/account-routes.test.mjs
@@ -242,6 +242,61 @@ test("GET /accounts/{ss58}/extrinsics is schema-stable when D1 is cold (never 40
   assert.equal(Array.isArray(body.data.extrinsics), true);
 });
 
+test("GET /accounts/{ss58}/extrinsics?format=csv exports extrinsic_id/block_number/call_module columns (#2534)", async () => {
+  const env = dbWith({
+    extrinsics: [
+      {
+        block_number: 200,
+        extrinsic_index: 2,
+        extrinsic_hash: `0x${"a".repeat(64)}`,
+        signer: SS58,
+        call_module: "SubtensorModule",
+        call_function: "add_stake",
+        call_args: null,
+        fee_tao: 0.0125,
+        success: 1,
+        observed_at: 1750009000000,
+      },
+    ],
+  });
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/extrinsics?format=csv`),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /^text\/csv/);
+  assert.equal(
+    res.headers.get("content-disposition"),
+    'attachment; filename="account-extrinsics.csv"',
+  );
+  const lines = (await res.text()).split("\r\n");
+  assert.equal(
+    lines[0],
+    "extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at",
+  );
+  assert.equal(
+    lines[1],
+    `200-2,200,2,0x${"a".repeat(64)},${SS58},SubtensorModule,add_stake,true,0.0125,,2025-06-15T17:36:40.000Z`,
+  );
+  assert.equal(lines.length, 2);
+});
+
+test("GET /accounts/{ss58}/extrinsics?format=csv emits a header-only CSV when D1 is cold", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/extrinsics?format=csv`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 200);
+  const lines = (await res.text()).split("\r\n");
+  assert.equal(
+    lines[0],
+    "extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at",
+  );
+  assert.equal(lines.length, 1);
+});
+
 test("GET /accounts/{ss58}/transfers reshapes Transfer rows directionally (#1850)", async () => {
   const env = dbWith({
     // The poller stores hotkey=from / coldkey=to for Transfer events.
@@ -306,6 +361,60 @@ test("GET /accounts/{ss58}/transfers is schema-stable when D1 is cold (never 404
   assert.equal(body.data.ss58, SS58);
   assert.equal(body.data.transfer_count, 0);
   assert.equal(Array.isArray(body.data.transfers), true);
+});
+
+test("GET /accounts/{ss58}/transfers?direction=sent&format=csv filters direction and exports from/to/amount_tao columns (#2534)", async () => {
+  const env = dbWith({
+    events: [
+      {
+        block_number: 300,
+        event_index: 0,
+        event_kind: "Transfer",
+        hotkey: SS58, // sender == queried account -> "sent"
+        coldkey: "5Recipient",
+        netuid: null,
+        uid: null,
+        amount_tao: 4.2,
+        observed_at: 1750009000000,
+      },
+    ],
+  });
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/transfers?direction=sent&format=csv`),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /^text\/csv/);
+  assert.equal(
+    res.headers.get("content-disposition"),
+    'attachment; filename="account-transfers.csv"',
+  );
+  const lines = (await res.text()).split("\r\n");
+  assert.equal(
+    lines[0],
+    "block_number,event_index,from,to,amount_tao,direction,observed_at",
+  );
+  assert.equal(
+    lines[1],
+    `300,0,${SS58},5Recipient,4.2,sent,2025-06-15T17:36:40.000Z`,
+  );
+  assert.equal(lines.length, 2);
+});
+
+test("GET /accounts/{ss58}/transfers?format=csv emits a header-only CSV when D1 is cold", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/transfers?format=csv`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 200);
+  const lines = (await res.text()).split("\r\n");
+  assert.equal(
+    lines[0],
+    "block_number,event_index,from,to,amount_tao,direction,observed_at",
+  );
+  assert.equal(lines.length, 1);
 });
 
 test("GET /accounts/{ss58}/stake-flow routes to the per-account stake-flow handler", async () => {

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -220,6 +220,14 @@ describe("public contract registry", () => {
         "/api/v1/subnets/{netuid}/trajectory",
         "date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share",
       ],
+      [
+        "/api/v1/accounts/{ss58}/extrinsics",
+        "extrinsic_id,block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at",
+      ],
+      [
+        "/api/v1/accounts/{ss58}/transfers",
+        "block_number,event_index,from,to,amount_tao,direction,observed_at",
+      ],
     ];
     for (const [path, expectedHeader] of csvExamples) {
       const csvContent =

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -219,6 +219,28 @@ const BLOCK_CSV_COLUMNS = [
   "spec_version",
   "observed_at",
 ];
+const ACCOUNT_EXTRINSICS_CSV_COLUMNS = [
+  "extrinsic_id",
+  "block_number",
+  "extrinsic_index",
+  "extrinsic_hash",
+  "signer",
+  "call_module",
+  "call_function",
+  "success",
+  "fee_tao",
+  "tip_tao",
+  "observed_at",
+];
+const ACCOUNT_TRANSFERS_CSV_COLUMNS = [
+  "block_number",
+  "event_index",
+  "from",
+  "to",
+  "amount_tao",
+  "direction",
+  "observed_at",
+];
 
 function validateResponseFormat(url) {
   const raw = url.searchParams.get("format");
@@ -1440,12 +1462,13 @@ export async function handleAccountHistory(request, env, ss58, url) {
 // constrain block height; ?limit (<=1000) / ?offset, or ?cursor=. Cold/absent store →
 // schema-stable zero (never 404).
 export async function handleAccountExtrinsics(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "block_start",
     "block_end",
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const blockStart = parseNonNegativeIntParam(
@@ -1465,6 +1488,19 @@ export async function handleAccountExtrinsics(request, env, ss58, url) {
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });
+  if (csvRequested(url, request)) {
+    const csvRows = data.extrinsics.map((extrinsic) => ({
+      ...extrinsic,
+      extrinsic_id: `${extrinsic.block_number}-${extrinsic.extrinsic_index}`,
+    }));
+    return csvResponse(
+      csvRows,
+      "account-extrinsics",
+      "short",
+      request,
+      ACCOUNT_EXTRINSICS_CSV_COLUMNS,
+    );
+  }
   return accountEnvelopeResponse(
     request,
     {
@@ -1487,13 +1523,14 @@ export async function handleAccountExtrinsics(request, env, ss58, url) {
 // transfer feed only, NOT a full balance ledger. Cold/absent store →
 // schema-stable zero (never 404).
 export async function handleAccountTransfers(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "direction",
     "block_start",
     "block_end",
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const direction = url.searchParams.get("direction");
@@ -1529,6 +1566,15 @@ export async function handleAccountTransfers(request, env, ss58, url) {
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.transfers,
+      "account-transfers",
+      "short",
+      request,
+      ACCOUNT_TRANSFERS_CSV_COLUMNS,
+    );
+  }
   return accountEnvelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

-

## What Changed

- Added a `csvRouteQuery(...)`-backed `?format=csv` branch to `handleAccountExtrinsics` and `handleAccountTransfers` in `workers/request-handlers/entities.mjs`, mirroring the existing `economics-trends` / `subnet-metagraph` CSV routes.
- `account-extrinsics` CSV columns: `extrinsic_id` (derived `block_number-extrinsic_index`), `block_number`, `extrinsic_index`, `extrinsic_hash`, `signer`, `call_module`, `call_function`, `success`, `fee_tao`, `tip_tao`, `observed_at`.
- `account-transfers` CSV columns: `block_number`, `event_index`, `from`, `to`, `amount_tao`, `direction`, `observed_at` — `?direction=sent|received|all` still filters before the CSV branch.
- Both routes accept `?format=csv` or an `Accept: text/csv` header; empty results emit a header-only CSV (schema-stable, same as the JSON envelope).
- Updated `src/contracts.mjs` route/artifact descriptions and regenerated `openapi.json` / `types.d.ts` / `generated/metagraphed-api.d.ts` / `contracts.json` / `api-index.json` via `npm run build`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check` (repo-wide CRLF/Windows-checkout noise only; no real diff in touched files once normalized)
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types` (same CRLF-only false positive as format:check)
- [x] `npm run validate:contract-drift`
- [x] `npm run validate:mcp`
- [x] `npm run validate:ai`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows` (pre-existing failures in `publish-cloudflare.yml`, untouched by this PR)
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

Closes #2534