### PR TITLE
feat(registry): enrich SN11 TrajectoryRL — add public network-stats subnet-api surface (#712)

### DIFF
--- a/registry/subnets/trajectoryrl.json
+++ b/registry/subnets/trajectoryrl.json
@@ -184,7 +184,9 @@
       "auth_required": false,
       "authority": "community",
       "public_safe": true,
-      "source_urls": ["https://github.com/trajectoryRL/trajrl/blob/main/trajrl/subnet/api.py"],
+      "source_urls": [
+        "https://github.com/trajectoryRL/trajrl/blob/main/trajrl/subnet/api.py"
+      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "boskodev790"

--- a/registry/subnets/trajectoryrl.json
+++ b/registry/subnets/trajectoryrl.json
@@ -174,6 +174,22 @@
         "timeout_ms": 10000
       },
       "notes": "Official TrajectoryRL source repository."
+    },
+    {
+      "id": "sn-11-trajectoryrl-subnet-api",
+      "name": "TrajectoryRL network stats API",
+      "kind": "subnet-api",
+      "url": "https://trajrl.com/api/stats",
+      "provider": "trajectoryrl",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://github.com/trajectoryRL/trajrl/blob/main/trajrl/subnet/api.py"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "notes": "Public read-only REST JSON endpoint reporting SN11 network totals (reports, LLM calls, tokens, cost); no auth. Documented in the official trajrl API client."
     }
   ],
   "social": { "x": "https://x.com/trajectoryrl" },


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community surface to exactly one subnet manifest —
`registry/subnets/trajectoryrl.json` (SN11 TrajectoryRL). Append-only; no other
file and no other surface is touched.

Closes #712

## Surface

- Netuid: 11
- Kind: `subnet-api`
- Public URL: https://trajrl.com/api/stats
- Source URL (proves the claim): https://github.com/trajectoryRL/trajrl/blob/main/trajrl/subnet/api.py
- Provider slug: `trajectoryrl` (already registered)

### Source proof (first-party)

The surface is TrajectoryRL's own read-only public API. The official first-party
API client [`trajrl/subnet/api.py`](https://github.com/trajectoryRL/trajrl/blob/main/trajrl/subnet/api.py)
(in the `trajectoryRL/trajrl` org repo) sets `DEFAULT_BASE_URL = "https://trajrl.com"`
and documents the endpoint directly:

```python
def stats(self) -> dict[str, Any]:
    """GET /api/stats — network totals (reports, cost, llm calls, tokens)."""
    return self._get("/api/stats")
```

The subnet's `README` also states: *"Public API: … read-only, no auth, base URL
`https://trajrl.com`"*.

Verified live: `GET https://trajrl.com/api/stats` → **HTTP 200**,
`content-type: application/json`, no authentication, e.g.
`{"totalReports":"67527","totalCostUsd":373.47,"totalLlmCalls":"389218","totalTokens":"1472751785","updatedAt":"…"}`.
This is a net-new callable surface — the SN11 manifest previously had no
`subnet-api`/`openapi`/`sse`/`data-artifact` surface.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file (append-only).
- [x] Generated with `npm run surface:add` — lands `authority: community` and
      `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url`
      independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data,
      private URLs, private dashboards, validator internals, or generated
      `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #712`).

## Validation

- [x] `npm run validate:surface -- registry/subnets/trajectoryrl.json` → passed (8 surfaces, 1 file)
- [x] `npm run scan:public-safety` → passed
