### PR TITLE
feat(mcp): add list_curation mirroring GET /api/v1/curation

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -263,6 +263,11 @@ assert.ok(
 
 await callOk("get_agent_catalog", {});
 await callOk("get_agent_catalog", { netuid: 7 });
+const curationPage = await callOk("list_curation", { limit: 3 });
+assert.ok(
+  Array.isArray(curationPage.curation),
+  "list_curation must return curation[]",
+);
 await callOk("registry_summary", {});
 
 // Per-subnet gap artifacts are R2-only (review/gaps/{netuid}.json); the cold

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.20.0",
+  "version": "1.22.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/curation-mcp.mjs
+++ b/src/curation-mcp.mjs
@@ -1,0 +1,202 @@
+// Curation list loader for MCP parity on GET /api/v1/curation.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/curation.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const CURATION_ARTIFACT = "/metagraph/curation.json";
+
+const CURATION_SORT_FIELDS = API_QUERY_COLLECTIONS.curation.sort_fields;
+const COVERAGE_LEVELS = QUERY_ENUMS.coverageLevel;
+
+export function curationMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw curationMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw curationMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function curationQueryUrl(args) {
+  const url = new URL("https://mcp.internal/curation");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw curationMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const coverageLevel = optionalEnum(args, "coverage_level", COVERAGE_LEVELS);
+  if (coverageLevel) {
+    url.searchParams.set("coverage_level", coverageLevel);
+  }
+  const sort = optionalEnum(args, "sort", CURATION_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw curationMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadCurationList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = curationQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, CURATION_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw curationMcpError("not_found", "Curation snapshot unavailable.");
+    }
+    throw curationMcpError(
+      code,
+      `Could not load ${CURATION_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw curationMcpError("not_found", "Curation snapshot unavailable.");
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "curation", []);
+  if (transformed.error) {
+    throw curationMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.curation) ? data.curation : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    curation: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_CURATION_INSTRUCTIONS =
+  "list_curation per-subnet curation states (coverage_level, curation_level, " +
+  "source counts; mirrors GET /api/v1/curation), ";
+
+export const LIST_CURATION_MCP_TOOL = {
+  name: "list_curation",
+  title: "List subnet curation states",
+  description:
+    "Fetch per-subnet curation states from the registry: coverage_level, " +
+    "curation_level, source counts, and review posture for every active subnet. " +
+    "Filter by netuid or coverage_level, sort with sort + order, and page with " +
+    "limit (1-100) / cursor. Mirrors GET /api/v1/curation.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter to one subnet netuid.",
+        minimum: 0,
+      },
+      coverage_level: {
+        type: "string",
+        enum: COVERAGE_LEVELS,
+        description:
+          "Filter by coverage depth: native-only, manifested, or probed.",
+      },
+      sort: {
+        type: "string",
+        enum: CURATION_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description:
+          "Comma-separated projection of curation row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_CURATION_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["curation"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: NULLABLE_STRING,
+    curation: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -26,6 +26,12 @@ import {
   loadNetworkEconomics,
 } from "./network-economics.mjs";
 import {
+  LIST_CURATION_INSTRUCTIONS,
+  LIST_CURATION_MCP_TOOL,
+  LIST_CURATION_OUTPUT_SCHEMA,
+  loadCurationList,
+} from "./curation-mcp.mjs";
+import {
   GET_NETWORK_HEALTH_INSTRUCTIONS,
   GET_NETWORK_HEALTH_MCP_TOOL,
   GET_NETWORK_HEALTH_OUTPUT_SCHEMA,
@@ -192,7 +198,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.20.0";
+export const MCP_SERVER_VERSION = "1.22.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -246,6 +252,7 @@ export const MCP_INSTRUCTIONS =
   "language answer with citations; get_subnet / get_subnet_health for detail, " +
   "list_subnet_apis + get_api_schema to integrate a subnet's API, and " +
   "get_best_rpc_endpoint for a live-healthy Bittensor base-layer RPC endpoint. " +
+  LIST_CURATION_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
   "fixtures, examples, provenance, and candidate-review gaps, and " +
   "get_subnet_gaps for one subnet's interface gap priorities and contributor " +
@@ -4027,6 +4034,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_CURATION_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadCurationList(ctx, args);
+    },
+  },
+  {
     name: "get_lineage",
     title: "Get cross-network subnet lineage",
     description:
@@ -6135,6 +6148,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       notes: NULLABLE_STRING,
     },
   },
+  list_curation: LIST_CURATION_OUTPUT_SCHEMA,
   get_lineage: {
     type: "object",
     additionalProperties: true,

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { describe, test, vi } from "vitest";
 import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
 import {
   CURATION_ARTIFACT,
   LIST_CURATION_INSTRUCTIONS,
@@ -93,6 +94,40 @@ describe("curation-mcp", () => {
     );
   });
 
+  test("curationQueryUrl rejects non-string fields", () => {
+    assert.throws(
+      () => curationQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("curationQueryUrl trims and forwards a fields projection", () => {
+    const url = curationQueryUrl({ fields: " netuid,name " });
+    assert.equal(url.searchParams.get("fields"), "netuid,name");
+  });
+
+  test("curationQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = curationQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("curationQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = curationQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("curationQueryUrl clamps limit above the MCP maximum", () => {
+    const url = curationQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("curationQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => curationQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
   test("loadCurationList returns filtered rows with pagination meta", async () => {
     const out = await loadCurationList(
       { env: {}, readArtifact },
@@ -166,9 +201,69 @@ describe("curation-mcp", () => {
   test("loadCurationList rejects invalid list-query params from REST parity", async () => {
     await assert.rejects(
       () =>
-        loadCurationList({ env: {}, readArtifact }, { sort: "not_a_field" }),
+        loadCurationList({ env: {}, readArtifact }, { fields: "not_a_column" }),
       (err) => err.code === "invalid_params",
     );
+  });
+
+  test("loadCurationList projects row fields when requested", async () => {
+    const out = await loadCurationList(
+      { env: {}, readArtifact },
+      { fields: "netuid,coverage_level", limit: 1 },
+    );
+    assert.deepEqual(out.curation[0], {
+      netuid: 7,
+      coverage_level: "probed",
+    });
+  });
+
+  test("loadCurationList omits nullable artifact metadata when absent", async () => {
+    const out = await loadCurationList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { curation: [{ netuid: 0 }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.notes, null);
+  });
+
+  test("loadCurationList treats a non-array curation key as empty", async () => {
+    const out = await loadCurationList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { curation: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.curation, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadCurationList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { curation: [{ netuid: 9 }, { netuid: 10 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadCurationList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   test("loadCurationList rejects a malformed artifact payload", async () => {

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import {
+  CURATION_ARTIFACT,
+  LIST_CURATION_INSTRUCTIONS,
+  LIST_CURATION_MCP_TOOL,
+  LIST_CURATION_OUTPUT_SCHEMA,
+  curationMcpError,
+  curationQueryUrl,
+  loadCurationList,
+} from "../src/curation-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: "test",
+  curation: [
+    {
+      netuid: 7,
+      name: "Allways",
+      coverage_level: "probed",
+      curation_level: "verified",
+    },
+    {
+      netuid: 31,
+      name: "Candles",
+      coverage_level: "manifested",
+      curation_level: "adapter-backed",
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === CURATION_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("curation-mcp", () => {
+  test("curationMcpError is shaped for MCP toolError handling", () => {
+    const err = curationMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("curationQueryUrl validates netuid and cursor", () => {
+    const url = curationQueryUrl({
+      netuid: 7,
+      coverage_level: "probed",
+      sort: "netuid",
+      order: "desc",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("coverage_level"), "probed");
+    assert.equal(url.searchParams.get("sort"), "netuid");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("curationQueryUrl rejects invalid coverage_level", () => {
+    assert.throws(
+      () => curationQueryUrl({ coverage_level: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("curationQueryUrl rejects invalid netuid", () => {
+    assert.throws(
+      () => curationQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("curationQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => curationQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("curationQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => curationQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadCurationList returns filtered rows with pagination meta", async () => {
+    const out = await loadCurationList(
+      { env: {}, readArtifact },
+      { netuid: 7 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.curation[0].netuid, 7);
+    assert.equal(out.curation[0].coverage_level, "probed");
+  });
+
+  test("loadCurationList sorts and pages the collection", async () => {
+    const out = await loadCurationList(
+      { env: {}, readArtifact },
+      { sort: "netuid", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.curation[0].netuid, 31);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadCurationList uses an injected readArtifact dep", async () => {
+    const out = await loadCurationList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { curation: [{ netuid: 0 }] },
+        }),
+      },
+    );
+    assert.equal(out.curation[0].netuid, 0);
+  });
+
+  test("loadCurationList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadCurationList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadCurationList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadCurationList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" && /curation\.json/.test(err.message),
+    );
+  });
+
+  test("loadCurationList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadCurationList({ env: {}, readArtifact }, { sort: "not_a_field" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadCurationList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadCurationList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadCurationList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadCurationList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_CURATION_MCP_TOOL.name, "list_curation");
+    assert.match(LIST_CURATION_INSTRUCTIONS, /list_curation/);
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_CURATION_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_curation at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.22.0");
+    assert.match(MCP_INSTRUCTIONS, /list_curation/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
+    assert.ok(tool);
+    assert.equal(tool.title, "List subnet curation states");
+  });
+});

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.20.0");
+    assert.equal(MCP_SERVER_VERSION, "1.22.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -609,6 +609,23 @@ describe("get_network_health — branch coverage", () => {
   });
 });
 
+// ── list_curation — curation artifact list ────────────────────────────────
+describe("list_curation — branch coverage", () => {
+  test("surfaces non-not_found artifact failures", async () => {
+    const deps = {
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+      readHealthKv: async () => null,
+    };
+    const res = await callTool("list_curation", {}, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /artifact_timeout/);
+    assert.match(res.body.result.content[0].text, /curation\.json/);
+  });
+});
+
 // ── list_subnet_apis fallbacks ────────────────────────────
 describe("list_subnet_apis — detail fallback fields", () => {
   test("falls back to the requested netuid + empty services when detail is bare", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1316,6 +1316,22 @@ describe("MCP tools (injected deps)", () => {
     );
   });
 
+  test("list_curation payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_curation",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/curation.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        notes: "ok",
+        curation: [{ netuid: 7, coverage_level: "probed" }],
+      },
+    });
+    const res = await callTool("list_curation", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("registry_summary returns the summary artifact", async () => {
     const res = await callTool("registry_summary", {}, { deps });
     assert.equal(res.body.result.structuredContent.completeness, 0.42);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1291,6 +1291,31 @@ describe("MCP tools (injected deps)", () => {
     assert.equal(res.body.result.structuredContent.eligible_count, 0);
   });
 
+  test("list_curation returns filtered curation rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/curation.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        curation: [
+          { netuid: 7, coverage_level: "probed", curation_level: "verified" },
+          { netuid: 31, coverage_level: "manifested" },
+        ],
+      },
+    });
+    const res = await callTool("list_curation", { netuid: 7 }, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.curation[0].netuid, 7);
+  });
+
+  test("list_curation reports not_found when the artifact is absent", async () => {
+    const res = await callTool("list_curation", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Curation snapshot unavailable/,
+    );
+  });
+
   test("registry_summary returns the summary artifact", async () => {
     const res = await callTool("registry_summary", {}, { deps });
     assert.equal(res.body.result.structuredContent.completeness, 0.42);


### PR DESCRIPTION
## Summary
- Adds **`list_curation`** MCP tool with REST parity on `GET /api/v1/curation` (filter/sort/page over `/metagraph/curation.json` via shared `applyQueryFilters`).
- Extracts logic to **`src/curation-mcp.mjs`** with dedicated unit + MCP branch tests (~97% line coverage on the module).
- Bumps `MCP_SERVER_VERSION` / `server.json` to **1.22.0** (intentionally skips **1.21.0**, which four other open MCP PRs all target).

## Merge-friendly layout (no rebase after open MCP PRs land)
| Hot file | This PR's touch | Open MCP PRs | Conflict risk |
|----------|-----------------|--------------|---------------|
| `src/curation-mcp.mjs` | **new file** | none | none |
| `src/mcp-server.mjs` | insert after `list_schemas` (~4030) | #2844 registry, #2826 profiles, #2824 health-history, #2840 stake-flow | **low** (different regions) |
| `scripts/validate-mcp.mjs` | `list_curation` before `registry_summary` | #2844 adds `get_coverage` after `registry_summary` | **low** |
| `tests/global-operational-health.test.mjs` | **untouched** | all four MCP PRs edit version assert | **none** |
| `server.json` / SemVer | **1.22.0** | others → 1.21.0 | **low** (sequential bump after they merge) |

Distinct from `list_enrichment_targets` (coverage-depth queue), `registry_summary`, and open **#2844** `get_coverage`.

## Overlap check (open PRs avoided)
- **#2824** `get_health_history`, **#2826** profiles, **#2840** stake-flow direction — different MCP regions
- **#2844** `get_coverage` — different tool + file (`registry-coverage.mjs`)
- API-only CSV/chain PRs — no overlap

## Test plan
- [x] `npx vitest run tests/curation-mcp.test.mjs tests/mcp-server.test.mjs tests/mcp-server-branch-coverage.test.mjs`
- [x] `node scripts/validate-mcp.mjs`
- [x] `npm run lint` + `npm run format:check`
- [ ] CI `codecov/patch`

