### PR TITLE
feat(api): add ?format=csv export to the event and account-activity feeds (#2533, #2534)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -79,7 +79,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
+        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). Pass ?format=csv to download the filtered event rows as CSV. */
         get: operations["accountEvents"];
         put?: never;
         post?: never;
@@ -96,7 +96,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the filtered extrinsic rows as CSV. */
         get: operations["accountExtrinsics"];
         put?: never;
         post?: never;
@@ -164,7 +164,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the filtered transfer rows as CSV. */
         get: operations["accountTransfers"];
         put?: never;
         post?: never;
@@ -1439,7 +1439,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. */
+        /** Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. Pass ?format=csv to download the filtered event rows as CSV. */
         get: operations["subnetEvents"];
         put?: never;
         post?: never;
@@ -6460,6 +6460,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -6469,7 +6471,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -6523,6 +6525,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountEventsArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index
+                     *     8454388,1,StakeAdded,5Hotkey,,7,3,1.5,,2026-07-03T00:00:00.000Z,2
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -6578,6 +6585,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -6587,7 +6596,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -6641,6 +6650,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountExtrinsicsArtifact"];
                     };
+                    /**
+                     * @example block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at
+                     *     8454388,2,0xhash,5Signer,SubtensorModule,add_stake,true,0.0125,,2026-07-03T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -7052,6 +7066,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -7061,7 +7077,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -7116,6 +7132,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountTransfersArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,from,to,amount_tao,direction,observed_at
+                     *     8454388,1,5FromAddress,5ToAddress,4.2,sent,2026-07-03T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -17587,6 +17608,8 @@ export interface operations {
                 block_end?: number;
                 limit?: number;
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -17596,7 +17619,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -17650,6 +17673,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetEventsArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index
+                     *     8454388,1,StakeAdded,5Hotkey,,7,3,1.5,,2026-07-03T00:00:00.000Z,2
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4904,7 +4904,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/events.json",
       "cache": "short",
-      "description": "Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset.",
+      "description": "Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. Pass ?format=csv to download the filtered event rows as CSV.",
       "id": "subnet-events",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/events",
@@ -4945,6 +4945,17 @@
           "schema": {
             "minimum": 0,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]
@@ -5082,7 +5093,7 @@
     {
       "artifact_path": "/metagraph/accounts/{ss58}/events.json",
       "cache": "short",
-      "description": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+      "description": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). Pass ?format=csv to download the filtered event rows as CSV.",
       "id": "account-events",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/events",
@@ -5135,6 +5146,17 @@
         {
           "name": "cursor",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
             "type": "string"
           }
         }
@@ -5192,7 +5214,7 @@
     {
       "artifact_path": "/metagraph/accounts/{ss58}/extrinsics.json",
       "cache": "short",
-      "description": "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+      "description": "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the filtered extrinsic rows as CSV.",
       "id": "account-extrinsics",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/extrinsics",
@@ -5234,13 +5256,24 @@
           "schema": {
             "type": "string"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
     {
       "artifact_path": "/metagraph/accounts/{ss58}/transfers.json",
       "cache": "short",
-      "description": "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+      "description": "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the filtered transfer rows as CSV.",
       "id": "account-transfers",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/transfers",
@@ -5291,6 +5324,17 @@
         {
           "name": "cursor",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
             "type": "string"
           }
         }

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -570,7 +570,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "First-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, served live from the account_events D1 tier filtered by netuid at /api/v1/subnets/{netuid}/events (no static file).",
+      "description": "First-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, served live from the account_events D1 tier filtered by netuid at /api/v1/subnets/{netuid}/events; pass ?format=csv to download the filtered event rows as CSV (no static file).",
       "id": "subnet-events",
       "path": "/metagraph/subnets/{netuid}/events.json",
       "schema_ref": "#/components/schemas/SubnetEventsArtifact",
@@ -624,7 +624,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events (no static file).",
+      "description": "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events; pass ?format=csv to download the filtered event rows as CSV (no static file).",
       "id": "account-events",
       "path": "/metagraph/accounts/{ss58}/events.json",
       "schema_ref": "#/components/schemas/AccountEventsArtifact",
@@ -642,7 +642,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Paginated extrinsics this account signed (by signer), newest first, served live from the extrinsics D1 tier at /api/v1/accounts/{ss58}/extrinsics (no static file).",
+      "description": "Paginated extrinsics this account signed (by signer), newest first, served live from the extrinsics D1 tier at /api/v1/accounts/{ss58}/extrinsics; pass ?format=csv to download the filtered extrinsic rows as CSV (no static file).",
       "id": "account-extrinsics",
       "path": "/metagraph/accounts/{ss58}/extrinsics.json",
       "schema_ref": "#/components/schemas/AccountExtrinsicsArtifact",
@@ -651,7 +651,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers (no static file).",
+      "description": "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers; pass ?format=csv to download the filtered transfer rows as CSV (no static file).",
       "id": "account-transfers",
       "path": "/metagraph/accounts/{ss58}/transfers.json",
       "schema_ref": "#/components/schemas/AccountTransfersArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -17311,6 +17311,19 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -17372,9 +17385,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index\r\n8454388,1,StakeAdded,5Hotkey,,7,3,1.5,,2026-07-03T00:00:00.000Z,2",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -17431,7 +17450,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+        "summary": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). Pass ?format=csv to download the filtered event rows as CSV.",
         "tags": [
           "accounts",
           "analytics"
@@ -17492,6 +17511,19 @@
             "name": "cursor",
             "required": false,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
               "type": "string"
             }
           }
@@ -17555,9 +17587,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at\r\n8454388,2,0xhash,5Signer,SubtensorModule,add_stake,true,0.0125,,2026-07-03T00:00:00.000Z",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -17614,7 +17652,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+        "summary": "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the filtered extrinsic rows as CSV.",
         "tags": [
           "accounts",
           "analytics"
@@ -18186,6 +18224,19 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -18248,9 +18299,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,event_index,from,to,amount_tao,direction,observed_at\r\n8454388,1,5FromAddress,5ToAddress,4.2,sent,2026-07-03T00:00:00.000Z",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -18307,7 +18364,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+        "summary": "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the filtered transfer rows as CSV.",
         "tags": [
           "accounts",
           "analytics"
@@ -34430,6 +34487,19 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -34491,9 +34561,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index\r\n8454388,1,StakeAdded,5Hotkey,,7,3,1.5,,2026-07-03T00:00:00.000Z,2",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -34550,7 +34626,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset.",
+        "summary": "Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. Pass ?format=csv to download the filtered event rows as CSV.",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -79,7 +79,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
+        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). Pass ?format=csv to download the filtered event rows as CSV. */
         get: operations["accountEvents"];
         put?: never;
         post?: never;
@@ -96,7 +96,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the filtered extrinsic rows as CSV. */
         get: operations["accountExtrinsics"];
         put?: never;
         post?: never;
@@ -164,7 +164,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the filtered transfer rows as CSV. */
         get: operations["accountTransfers"];
         put?: never;
         post?: never;
@@ -1439,7 +1439,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. */
+        /** Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. Pass ?format=csv to download the filtered event rows as CSV. */
         get: operations["subnetEvents"];
         put?: never;
         post?: never;
@@ -6460,6 +6460,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -6469,7 +6471,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -6523,6 +6525,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountEventsArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index
+                     *     8454388,1,StakeAdded,5Hotkey,,7,3,1.5,,2026-07-03T00:00:00.000Z,2
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -6578,6 +6585,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -6587,7 +6596,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -6641,6 +6650,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountExtrinsicsArtifact"];
                     };
+                    /**
+                     * @example block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at
+                     *     8454388,2,0xhash,5Signer,SubtensorModule,add_stake,true,0.0125,,2026-07-03T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -7052,6 +7066,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -7061,7 +7077,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -7116,6 +7132,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountTransfersArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,from,to,amount_tao,direction,observed_at
+                     *     8454388,1,5FromAddress,5ToAddress,4.2,sent,2026-07-03T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -17587,6 +17608,8 @@ export interface operations {
                 block_end?: number;
                 limit?: number;
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -17596,7 +17619,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -17650,6 +17673,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetEventsArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index
+                     *     8454388,1,StakeAdded,5Hotkey,,7,3,1.5,,2026-07-03T00:00:00.000Z,2
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -997,7 +997,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "subnet-events",
     "/metagraph/subnets/{netuid}/events.json",
-    "First-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, served live from the account_events D1 tier filtered by netuid at /api/v1/subnets/{netuid}/events (no static file).",
+    "First-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, served live from the account_events D1 tier filtered by netuid at /api/v1/subnets/{netuid}/events; pass ?format=csv to download the filtered event rows as CSV (no static file).",
     "SubnetEventsArtifact",
   ),
   artifact(
@@ -1033,7 +1033,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "account-events",
     "/metagraph/accounts/{ss58}/events.json",
-    "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events (no static file).",
+    "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events; pass ?format=csv to download the filtered event rows as CSV (no static file).",
     "AccountEventsArtifact",
   ),
   artifact(
@@ -1045,13 +1045,13 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "account-extrinsics",
     "/metagraph/accounts/{ss58}/extrinsics.json",
-    "Paginated extrinsics this account signed (by signer), newest first, served live from the extrinsics D1 tier at /api/v1/accounts/{ss58}/extrinsics (no static file).",
+    "Paginated extrinsics this account signed (by signer), newest first, served live from the extrinsics D1 tier at /api/v1/accounts/{ss58}/extrinsics; pass ?format=csv to download the filtered extrinsic rows as CSV (no static file).",
     "AccountExtrinsicsArtifact",
   ),
   artifact(
     "account-transfers",
     "/metagraph/accounts/{ss58}/transfers.json",
-    "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers (no static file).",
+    "The native-TAO Balances.Transfer feed for one account (directional sent/received), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/transfers; pass ?format=csv to download the filtered transfer rows as CSV (no static file).",
     "AccountTransfersArtifact",
   ),
   artifact(
@@ -2002,16 +2002,16 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/events",
     "/metagraph/subnets/{netuid}/events.json",
-    "Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset.",
+    "Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. Pass ?format=csv to download the filtered event rows as CSV.",
     "short",
     ["subnets", "analytics"],
-    [
+    csvRouteQuery([
       { name: "kind", schema: { type: "string" } },
       { name: "block_start", schema: { type: "integer", minimum: 0 } },
       { name: "block_end", schema: { type: "integer", minimum: 0 } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
-    ],
+    ]),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(
@@ -2097,10 +2097,10 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/events",
     "/metagraph/accounts/{ss58}/events.json",
-    "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+    "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). Pass ?format=csv to download the filtered event rows as CSV.",
     "short",
     ["accounts", "analytics"],
-    [
+    csvRouteQuery([
       { name: "kind", schema: { type: "string" } },
       { name: "netuid", schema: { type: "integer", minimum: 0 } },
       { name: "block_start", schema: { type: "integer", minimum: 0 } },
@@ -2108,7 +2108,7 @@ export const API_ROUTES = [
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "cursor", schema: { type: "string" } },
-    ],
+    ]),
     [{ name: "ss58", schema: { type: "string" } }],
   ),
   route(
@@ -2133,16 +2133,16 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/extrinsics",
     "/metagraph/accounts/{ss58}/extrinsics.json",
-    "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+    "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the filtered extrinsic rows as CSV.",
     "short",
     ["accounts", "analytics"],
-    [
+    csvRouteQuery([
       { name: "block_start", schema: { type: "integer", minimum: 0 } },
       { name: "block_end", schema: { type: "integer", minimum: 0 } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "cursor", schema: { type: "string" } },
-    ],
+    ]),
     [{ name: "ss58", schema: { type: "string" } }],
   ),
   route(
@@ -2150,10 +2150,10 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/transfers",
     "/metagraph/accounts/{ss58}/transfers.json",
-    "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+    "Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events D1 tier. ?direction=all|sent|received; optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the filtered transfer rows as CSV.",
     "short",
     ["accounts", "analytics"],
-    [
+    csvRouteQuery([
       {
         name: "direction",
         schema: { type: "string", enum: ["all", "sent", "received"] },
@@ -2163,7 +2163,7 @@ export const API_ROUTES = [
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "cursor", schema: { type: "string" } },
-    ],
+    ]),
     [{ name: "ss58", schema: { type: "string" } }],
   ),
   route(
@@ -3370,6 +3370,24 @@ function csvExampleForRoute(entry) {
     return [
       "block_number,block_hash,parent_hash,author,extrinsic_count,event_count,spec_version,observed_at",
       "8454388,0xblock,0xparent,5Author,3,12,204,2026-07-03T00:00:00.000Z",
+    ].join("\r\n");
+  }
+  if (entry.id === "subnet-events" || entry.id === "account-events") {
+    return [
+      "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index",
+      "8454388,1,StakeAdded,5Hotkey,,7,3,1.5,,2026-07-03T00:00:00.000Z,2",
+    ].join("\r\n");
+  }
+  if (entry.id === "account-extrinsics") {
+    return [
+      "block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at",
+      "8454388,2,0xhash,5Signer,SubtensorModule,add_stake,true,0.0125,,2026-07-03T00:00:00.000Z",
+    ].join("\r\n");
+  }
+  if (entry.id === "account-transfers") {
+    return [
+      "block_number,event_index,from,to,amount_tao,direction,observed_at",
+      "8454388,1,5FromAddress,5ToAddress,4.2,sent,2026-07-03T00:00:00.000Z",
     ].join("\r\n");
   }
   return "netuid,name\r\n7,Allways";

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -5256,6 +5256,136 @@ describe("canonicalSubnetHistoryCachePath", () => {
   });
 });
 
+describe("event & account-activity feed CSV export (#2533, #2534)", () => {
+  const EVENT_HEADER =
+    "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index";
+
+  async function csvLines(res, filename) {
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      res.headers.get("content-disposition"),
+      `attachment; filename="${filename}"`,
+    );
+    return (await res.text()).split("\r\n");
+  }
+
+  test("subnet-events ?format=csv returns the event columns", async () => {
+    const { env } = dbWith({
+      subnetEvents: [accountEventRow(), accountEventRow({ event_index: 2 })],
+    });
+    const lines = await csvLines(
+      await handleSubnetEvents(
+        req(`/api/v1/subnets/${NETUID}/events?format=csv`),
+        env,
+        NETUID,
+        url(`/api/v1/subnets/${NETUID}/events?format=csv`),
+      ),
+      "subnet-events.csv",
+    );
+    assert.equal(lines[0], EVENT_HEADER);
+    assert.equal(lines.length, 3);
+  });
+
+  test("account-events negotiates CSV via Accept: text/csv", async () => {
+    const { env } = dbWith({ accountEvents: [accountEventRow()] });
+    const lines = await csvLines(
+      await handleAccountEvents(
+        new Request(`https://api.metagraph.sh/api/v1/accounts/${SS58}/events`, {
+          headers: { accept: "text/csv" },
+        }),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/events`),
+      ),
+      "account-events.csv",
+    );
+    assert.equal(lines[0], EVENT_HEADER);
+    assert.equal(lines.length, 2);
+  });
+
+  test("account-extrinsics ?format=csv returns the extrinsic columns", async () => {
+    const { env } = dbWith({ extrinsics: [extrinsicRow()] });
+    const lines = await csvLines(
+      await handleAccountExtrinsics(
+        req(`/api/v1/accounts/${SS58}/extrinsics?format=csv`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/extrinsics?format=csv`),
+      ),
+      "account-extrinsics.csv",
+    );
+    assert.equal(
+      lines[0],
+      "block_number,extrinsic_index,extrinsic_hash,signer,call_module,call_function,success,fee_tao,tip_tao,observed_at",
+    );
+    assert.equal(lines.length, 2);
+    assert.match(lines[1], /SubtensorModule,add_stake/);
+  });
+
+  test("account-transfers ?format=csv returns the transfer columns", async () => {
+    const { env } = dbWith({ transfers: [transferEventRow()] });
+    const lines = await csvLines(
+      await handleAccountTransfers(
+        req(`/api/v1/accounts/${SS58}/transfers?format=csv`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/transfers?format=csv`),
+      ),
+      "account-transfers.csv",
+    );
+    assert.equal(
+      lines[0],
+      "block_number,event_index,from,to,amount_tao,direction,observed_at",
+    );
+    assert.equal(lines.length, 2);
+    assert.match(lines[1], /,sent,/);
+  });
+
+  test("an empty feed still emits the header row", async () => {
+    const { env } = dbWith({ accountEvents: [] });
+    const res = await handleAccountEvents(
+      req(`/api/v1/accounts/${SS58}/events?format=csv`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(await res.text(), EVENT_HEADER);
+  });
+
+  test("?format=json keeps the JSON envelope under Accept: text/csv", async () => {
+    const { env } = dbWith({ transfers: [transferEventRow()] });
+    const res = await handleAccountTransfers(
+      new Request(
+        `https://api.metagraph.sh/api/v1/accounts/${SS58}/transfers?format=json`,
+        { headers: { accept: "text/csv" } },
+      ),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/transfers?format=json`),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^application\/json/);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(Array.isArray(body.data.transfers), true);
+  });
+
+  test("rejects an unsupported format value with 400", async () => {
+    const { env } = dbWith({ accountEvents: [] });
+    await errorJson(
+      await handleAccountEvents(
+        req(`/api/v1/accounts/${SS58}/events?format=xml`),
+        env,
+        SS58,
+        url(`/api/v1/accounts/${SS58}/events?format=xml`),
+      ),
+    );
+  });
+});
+
 // Fixture documentation: each factory above mirrors the D1 column contracts used
 // by workers/request-handlers/entities.mjs. When adding a new handler test,
 // prefer reusing these rows so formatters stay aligned with production schemas.

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -205,6 +205,46 @@ const BLOCK_CSV_COLUMNS = [
   "observed_at",
 ];
 
+// CSV projections for the block-explorer event/activity feeds (#2533, #2534).
+// Each feed row is already flat (formatAccountEvent / formatExtrinsic /
+// buildTransferFeed), so the feed's own fields are the columns in read order.
+const EVENT_CSV_COLUMNS = [
+  "block_number",
+  "event_index",
+  "event_kind",
+  "hotkey",
+  "coldkey",
+  "netuid",
+  "uid",
+  "amount_tao",
+  "alpha_amount",
+  "observed_at",
+  "extrinsic_index",
+];
+
+const EXTRINSIC_CSV_COLUMNS = [
+  "block_number",
+  "extrinsic_index",
+  "extrinsic_hash",
+  "signer",
+  "call_module",
+  "call_function",
+  "success",
+  "fee_tao",
+  "tip_tao",
+  "observed_at",
+];
+
+const TRANSFER_CSV_COLUMNS = [
+  "block_number",
+  "event_index",
+  "from",
+  "to",
+  "amount_tao",
+  "direction",
+  "observed_at",
+];
+
 function validateResponseFormat(url) {
   const raw = url.searchParams.get("format");
   if (raw === null && !url.searchParams.has("format")) return null;
@@ -1168,7 +1208,7 @@ export async function handleAccount(request, env, ss58) {
 // GET /api/v1/accounts/{ss58}/events: paginated event history (newest first),
 // optional ?kind= filter, ?limit (<=1000) / ?offset.
 export async function handleAccountEvents(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "kind",
     "netuid",
     "block_start",
@@ -1176,6 +1216,7 @@ export async function handleAccountEvents(request, env, ss58, url) {
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   // Optional block-height range filter, parity with the extrinsics and
@@ -1218,6 +1259,15 @@ export async function handleAccountEvents(request, env, ss58, url) {
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.events,
+      "account-events",
+      "short",
+      request,
+      EVENT_CSV_COLUMNS,
+    );
+  }
   return accountEnvelopeResponse(
     request,
     {
@@ -1364,12 +1414,13 @@ export async function handleAccountHistory(request, env, ss58, url) {
 // constrain block height; ?limit (<=1000) / ?offset, or ?cursor=. Cold/absent store →
 // schema-stable zero (never 404).
 export async function handleAccountExtrinsics(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "block_start",
     "block_end",
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const blockStart = parseNonNegativeIntParam(
@@ -1389,6 +1440,15 @@ export async function handleAccountExtrinsics(request, env, ss58, url) {
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.extrinsics,
+      "account-extrinsics",
+      "short",
+      request,
+      EXTRINSIC_CSV_COLUMNS,
+    );
+  }
   return accountEnvelopeResponse(
     request,
     {
@@ -1411,13 +1471,14 @@ export async function handleAccountExtrinsics(request, env, ss58, url) {
 // transfer feed only, NOT a full balance ledger. Cold/absent store →
 // schema-stable zero (never 404).
 export async function handleAccountTransfers(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "direction",
     "block_start",
     "block_end",
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const direction = url.searchParams.get("direction");
@@ -1453,6 +1514,15 @@ export async function handleAccountTransfers(request, env, ss58, url) {
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.transfers,
+      "account-transfers",
+      "short",
+      request,
+      TRANSFER_CSV_COLUMNS,
+    );
+  }
   return accountEnvelopeResponse(
     request,
     {
@@ -1552,13 +1622,14 @@ export async function handleAccountSubnets(request, env, ss58) {
 // ?kind= filter; ?limit (<=1000)/?offset. Cold/absent store → schema-stable zero
 // (never 404), mirroring handleAccountEvents.
 export async function handleSubnetEvents(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "kind",
     "block_start",
     "block_end",
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const kind = url.searchParams.get("kind");
@@ -1593,6 +1664,15 @@ export async function handleSubnetEvents(request, env, netuid, url) {
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.events,
+      "subnet-events",
+      "short",
+      request,
+      EVENT_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

Adds `?format=csv` (and `Accept: text/csv`) content negotiation to **four** block-explorer feed routes, so their rows can be downloaded as CSV. Follows the exact established feed-CSV pattern already merged for `/api/v1/validators`, `/api/v1/subnets/movers`, and the per-UID metagraph routes.

Closes #2533, #2534.

## What Changed

Enabled CSV on four live-feed handlers by wrapping each route's parameters in `csvRouteQuery(...)` (adds `csv_response: true` + the `format` `json|csv` param) and adding a `csvResponse(...)` branch to each handler. The feed rows are already flat, so a column constant per row shape is all that's needed.

| Issue | Routes | CSV columns |
| --- | --- | --- |
| #2533 | `GET /api/v1/subnets/{netuid}/events`, `GET /api/v1/accounts/{ss58}/events` | `block_number, event_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at, extrinsic_index` |
| #2534 | `GET /api/v1/accounts/{ss58}/extrinsics` | `block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, success, fee_tao, tip_tao, observed_at` |
| #2534 | `GET /api/v1/accounts/{ss58}/transfers` | `block_number, event_index, from, to, amount_tao, direction, observed_at` |

- **`workers/request-handlers/entities.mjs`** — three CSV column constants (`EVENT_CSV_COLUMNS` shared by both event routes, `EXTRINSIC_CSV_COLUMNS`, `TRANSFER_CSV_COLUMNS`); each of the four handlers now validates via `validateEntityQuery` (accepting `format`) and returns `csvResponse(...)` when CSV is requested. These are direct (uncached) feed dispatches, so no cache-variance handling is needed.
- **`src/contracts.mjs`** — `csvRouteQuery(...)` on the four routes; route + artifact descriptions note `?format=csv`; `csvExampleForRoute` gains correct worked examples for each row shape.
- **Regenerated contract artifacts** (`npm run build`) — `openapi.json`, `api-index.json`, `contracts.json`, `generated/metagraphed-api.d.ts`, `types.d.ts`. Deploy-owned artifacts reverted against `origin/main`.
- **`tests/request-handlers-entities.test.mjs`** — a new CSV describe block: named `text/csv` download + exact header/rows for each of the four routes, `Accept: text/csv` negotiation, empty-feed-still-emits-header, `?format=json` non-regression under `Accept: text/csv`, and 400 on an unsupported `format`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts produced by `npm run build`, not hand-edited.
- [x] Deploy-owned artifacts (`r2-manifest.json`, `schemas/index.json`, `operational-surfaces.json`) reverted — not in this diff.
- [x] Public API/OpenAPI/schema change is intentional and documented (additive `format` param + `text/csv` response; JSON default unchanged).

## Validation

- [x] `npm run build` — regenerated + committed the contract artifacts.
- [x] `validate:contract-drift` · `validate:openapi` · `validate:openapi-examples` · `validate:api` · `validate:types` · `validate:generated-client` · `validate:committed-seed` · `validate:schema-enums` · `validate:docs` — all pass.
- [x] `vitest run tests/request-handlers-entities.test.mjs` — 272 pass (incl. the new CSV cases across all four routes).
- [x] `eslint` + `prettier --check` on changed files — clean · `git diff --check` clean.