### PR TITLE
fix: roll back partial neuron snapshot on multi-batch load failure

### DIFF
--- a/tests/load-staged-neurons.test.mjs
+++ b/tests/load-staged-neurons.test.mjs
@@ -92,11 +92,17 @@ function mockEnv({
             bind: (...v) => ({
               sql,
               v,
+              async all() {
+                return { results: [] };
+              },
               async run() {
                 runs.push({ sql, v });
                 return { meta: { changes: 1 } };
               },
             }),
+            async all() {
+              return { results: [] };
+            },
           };
         },
         async batch(stmts) {
@@ -352,6 +358,15 @@ function applyNeuronSnapshotRollback(table, sql, values) {
   return 0;
 }
 
+function applyNeuronSelect(table, sql, values) {
+  let rows = [...table.values()];
+  if (sql.includes("WHERE netuid IN")) {
+    const netuids = new Set(values);
+    rows = rows.filter((row) => netuids.has(row.netuid));
+  }
+  return rows;
+}
+
 function statefulEnv(
   table,
   {
@@ -401,6 +416,12 @@ function statefulEnv(
             bind: (...v) => ({
               sql,
               v,
+              async all() {
+                if (sql.startsWith("SELECT")) {
+                  return { results: applyNeuronSelect(table, sql, v) };
+                }
+                return { results: [] };
+              },
               async run() {
                 if (sql.startsWith("DELETE FROM neurons")) {
                   pruneAttempts += 1;
@@ -426,6 +447,12 @@ function statefulEnv(
                 return { meta: { changes: 0 } };
               },
             }),
+            async all() {
+              if (sql.startsWith("SELECT")) {
+                return { results: applyNeuronSelect(table, sql, []) };
+              }
+              return { results: [] };
+            },
           };
         },
         async batch(stmts) {
@@ -601,14 +628,14 @@ test("loadStagedNeurons retries a failed multi-batch prune before giving up", as
 test("loadStagedNeurons rolls back partial multi-batch upserts on mid-load failure", async () => {
   const table = new Map();
   const T1 = 1_700_000_000_000;
-  table.set("1:0", { ...neuronRow(1, 0), captured_at: T1 });
+  table.set("1:0", { ...neuronRow(1, 0), captured_at: T1, stake_tao: 99 });
   table.set("1:1", { ...neuronRow(1, 1), captured_at: T1 });
   const m = statefulEnv(table, { failUpsertOnBatch: 2 });
 
   const T2 = T1 + 60_000;
   const snap2 = Array.from({ length: 255 }, (_, i) => {
     const uid = i === 0 ? 0 : i + 1;
-    return { ...neuronRow(1, uid), captured_at: T2 };
+    return { ...neuronRow(1, uid), captured_at: T2, stake_tao: 200 };
   });
   m.env.METAGRAPH_ARCHIVE._staged = signedCoverageEnvelope(snap2, [1], T2);
   const r = await loadStagedNeurons(m.env);
@@ -622,9 +649,19 @@ test("loadStagedNeurons rolls back partial multi-batch upserts on mid-load failu
     "partial snapshot rows at T2 must be rolled back",
   );
   assert.equal(
+    table.get("1:0").captured_at,
+    T1,
+    "replaced UID must be restored to the prior snapshot stamp",
+  );
+  assert.equal(
+    table.get("1:0").stake_tao,
+    99,
+    "replaced UID must be restored to prior row values, not deleted",
+  );
+  assert.equal(
     table.get("1:1").captured_at,
     T1,
-    "prior snapshot stays until retry",
+    "untouched UID stays at prior snapshot until retry",
   );
   assert.deepEqual(m.deleted, [], "staged R2 object kept for retry");
 });
@@ -650,13 +687,13 @@ test("loadStagedNeurons returns purge_failed when upserts finish but prune never
 test("loadStagedNeurons rolls back legacy bare-array snapshots on mid-load failure", async () => {
   const table = new Map();
   const T1 = 1_700_000_000_000;
-  table.set("1:0", { ...neuronRow(1, 0), captured_at: T1 });
+  table.set("1:0", { ...neuronRow(1, 0), captured_at: T1, stake_tao: 77 });
   const m = statefulEnv(table, { failUpsertOnBatch: 2 });
 
   const T2 = T1 + 60_000;
   const snap2 = Array.from({ length: 255 }, (_, i) => {
     const uid = i === 0 ? 0 : i + 1;
-    return { ...neuronRow(1, uid), captured_at: T2 };
+    return { ...neuronRow(1, uid), captured_at: T2, stake_tao: 200 };
   });
   m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope(snap2);
   const r = await loadStagedNeurons(m.env);
@@ -667,6 +704,8 @@ test("loadStagedNeurons rolls back legacy bare-array snapshots on mid-load failu
     false,
     "partial legacy snapshot rows must be rolled back",
   );
+  assert.equal(table.get("1:0").captured_at, T1);
+  assert.equal(table.get("1:0").stake_tao, 77);
 });
 
 test("loadStagedNeurons survives rollback failure after mid-load upsert failure", async () => {

--- a/tests/load-staged-neurons.test.mjs
+++ b/tests/load-staged-neurons.test.mjs
@@ -375,6 +375,8 @@ function statefulEnv(
     failPruneUntil = 0,
     failUpsertOnBatch = 0,
     failRollbackRun = false,
+    omitPruneChangesMeta = false,
+    bareSelectResponse = false,
   } = {},
 ) {
   const deleted = [];
@@ -418,7 +420,9 @@ function statefulEnv(
               v,
               async all() {
                 if (sql.startsWith("SELECT")) {
-                  return { results: applyNeuronSelect(table, sql, v) };
+                  return bareSelectResponse
+                    ? {}
+                    : { results: applyNeuronSelect(table, sql, v) };
                 }
                 return { results: [] };
               },
@@ -438,18 +442,22 @@ function statefulEnv(
                       },
                     };
                   }
-                  return {
-                    meta: {
-                      changes: applyNeuronSnapshotPrune(table, sql, v),
-                    },
-                  };
+                  return omitPruneChangesMeta
+                    ? {}
+                    : {
+                        meta: {
+                          changes: applyNeuronSnapshotPrune(table, sql, v),
+                        },
+                      };
                 }
                 return { meta: { changes: 0 } };
               },
             }),
             async all() {
               if (sql.startsWith("SELECT")) {
-                return { results: applyNeuronSelect(table, sql, []) };
+                return bareSelectResponse
+                  ? {}
+                  : { results: applyNeuronSelect(table, sql, []) };
               }
               return { results: [] };
             },
@@ -706,6 +714,62 @@ test("loadStagedNeurons rolls back legacy bare-array snapshots on mid-load failu
   );
   assert.equal(table.get("1:0").captured_at, T1);
   assert.equal(table.get("1:0").stake_tao, 77);
+});
+
+test("loadStagedNeurons treats missing atomic prune meta.changes as zero purged", async () => {
+  const rows = Array.from({ length: 12 }, (_, i) => neuronRow(1, i));
+  const m = mockEnv({ rows: signedEnvelope(rows) });
+  const baseBatch = m.env.METAGRAPH_HEALTH_DB.batch.bind(m.env.METAGRAPH_HEALTH_DB);
+  m.env.METAGRAPH_HEALTH_DB.batch = async (stmts) => {
+    const out = await baseBatch(stmts);
+    out[out.length - 1] = {};
+    return out;
+  };
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.purged, 0);
+});
+
+test("loadStagedNeurons treats missing multi-batch prune meta.changes as zero purged", async () => {
+  const table = new Map();
+  const T1 = 1_700_000_000_000;
+  table.set("1:0", { ...neuronRow(1, 0), captured_at: T1 });
+  const m = statefulEnv(table, { omitPruneChangesMeta: true });
+
+  const T2 = T1 + 60_000;
+  const snap2 = Array.from({ length: 255 }, (_, i) => {
+    const uid = i === 0 ? 0 : i + 1;
+    return { ...neuronRow(1, uid), captured_at: T2 };
+  });
+  m.env.METAGRAPH_ARCHIVE._staged = signedCoverageEnvelope(snap2, [1], T2);
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, true);
+  assert.equal(r.purged, 0);
+});
+
+test("loadStagedNeurons multi-batch backup tolerates D1 select without results field", async () => {
+  const table = new Map();
+  const T1 = 1_700_000_000_000;
+  table.set("1:0", { ...neuronRow(1, 0), captured_at: T1, stake_tao: 55 });
+  const m = statefulEnv(table, {
+    bareSelectResponse: true,
+    failUpsertOnBatch: 2,
+  });
+
+  const T2 = T1 + 60_000;
+  const snap2 = Array.from({ length: 255 }, (_, i) => {
+    const uid = i === 0 ? 0 : i + 1;
+    return { ...neuronRow(1, uid), captured_at: T2, stake_tao: 200 };
+  });
+  m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope(snap2);
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "load_failed");
+  assert.equal(
+    [...table.values()].some((row) => row.captured_at === T2),
+    false,
+    "partial snapshot rows must be rolled back even without prior backup rows",
+  );
 });
 
 test("loadStagedNeurons survives rollback failure after mid-load upsert failure", async () => {

--- a/tests/load-staged-neurons.test.mjs
+++ b/tests/load-staged-neurons.test.mjs
@@ -304,12 +304,45 @@ function applyNeuronSnapshotPrune(table, sql, values) {
     }
     return changes;
   }
-  if (sql.startsWith("DELETE FROM neurons WHERE netuid IN")) {
+  if (
+    sql.startsWith("DELETE FROM neurons WHERE netuid IN") &&
+    sql.includes("captured_at <")
+  ) {
     const cutoff = values.at(-1);
     const refreshed = new Set(values.slice(0, -1));
     let changes = 0;
     for (const [k, row] of table) {
       if (refreshed.has(row.netuid) && row.captured_at < cutoff) {
+        table.delete(k);
+        changes += 1;
+      }
+    }
+    return changes;
+  }
+  return 0;
+}
+
+function applyNeuronSnapshotRollback(table, sql, values) {
+  if (sql.startsWith("DELETE FROM neurons WHERE captured_at =")) {
+    const target = values[0];
+    let changes = 0;
+    for (const [k, row] of table) {
+      if (row.captured_at === target) {
+        table.delete(k);
+        changes += 1;
+      }
+    }
+    return changes;
+  }
+  if (
+    sql.startsWith("DELETE FROM neurons WHERE netuid IN") &&
+    sql.includes("captured_at =")
+  ) {
+    const target = values.at(-1);
+    const refreshed = new Set(values.slice(0, -1));
+    let changes = 0;
+    for (const [k, row] of table) {
+      if (refreshed.has(row.netuid) && row.captured_at === target) {
         table.delete(k);
         changes += 1;
       }
@@ -325,10 +358,12 @@ function statefulEnv(
     signingKey = SIGNING_KEY,
     failBatchOnPrune = false,
     failPruneUntil = 0,
+    failUpsertOnBatch = 0,
   } = {},
 ) {
   const deleted = [];
   let pruneAttempts = 0;
+  let upsertBatchesDone = 0;
   function applyInsert(sql, values) {
     // Columns from "INSERT OR REPLACE INTO neurons (a,b,...) VALUES ..."
     const cols = sql.slice(sql.indexOf("(") + 1, sql.indexOf(")")).split(",");
@@ -371,6 +406,13 @@ function statefulEnv(
                   if (pruneAttempts <= failPruneUntil) {
                     throw new Error("simulated prune failure");
                   }
+                  if (sql.includes("captured_at =")) {
+                    return {
+                      meta: {
+                        changes: applyNeuronSnapshotRollback(table, sql, v),
+                      },
+                    };
+                  }
                   return {
                     meta: {
                       changes: applyNeuronSnapshotPrune(table, sql, v),
@@ -389,6 +431,21 @@ function statefulEnv(
           ) {
             throw new Error("simulated atomic upsert+prune batch failure");
           }
+          const hasUpsert = stmts.some((stmt) =>
+            stmt.sql.startsWith("INSERT OR REPLACE INTO neurons"),
+          );
+          const hasPrune = stmts.some((stmt) =>
+            stmt.sql.startsWith("DELETE FROM neurons"),
+          );
+          if (hasUpsert && !hasPrune) {
+            upsertBatchesDone += 1;
+            if (
+              failUpsertOnBatch &&
+              upsertBatchesDone === failUpsertOnBatch
+            ) {
+              throw new Error("simulated multi-batch upsert failure");
+            }
+          }
           const results = [];
           for (const stmt of stmts) {
             if (stmt.sql.startsWith("INSERT OR REPLACE INTO neurons")) {
@@ -403,7 +460,9 @@ function statefulEnv(
               }
               results.push({
                 meta: {
-                  changes: applyNeuronSnapshotPrune(table, stmt.sql, stmt.v),
+                  changes: stmt.sql.includes("captured_at =")
+                    ? applyNeuronSnapshotRollback(table, stmt.sql, stmt.v)
+                    : applyNeuronSnapshotPrune(table, stmt.sql, stmt.v),
                 },
               });
             }
@@ -536,4 +595,29 @@ test("loadStagedNeurons retries a failed multi-batch prune before giving up", as
   assert.equal(m.pruneAttempts, 3, "two failed prune attempts then success");
   assert.equal(table.has("1:1"), false, "deregistered ghost UID is pruned");
   assert.equal(table.get("1:0").captured_at, T2);
+});
+
+test("loadStagedNeurons rolls back partial multi-batch upserts on mid-load failure", async () => {
+  const table = new Map();
+  const T1 = 1_700_000_000_000;
+  table.set("1:0", { ...neuronRow(1, 0), captured_at: T1 });
+  table.set("1:1", { ...neuronRow(1, 1), captured_at: T1 });
+  const m = statefulEnv(table, { failUpsertOnBatch: 2 });
+
+  const T2 = T1 + 60_000;
+  const snap2 = Array.from({ length: 255 }, (_, i) => {
+    const uid = i === 0 ? 0 : i + 1;
+    return { ...neuronRow(1, uid), captured_at: T2 };
+  });
+  m.env.METAGRAPH_ARCHIVE._staged = signedCoverageEnvelope(snap2, [1], T2);
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "load_failed");
+  assert.equal(
+    [...table.values()].some((row) => row.netuid === 1 && row.captured_at === T2),
+    false,
+    "partial snapshot rows at T2 must be rolled back",
+  );
+  assert.equal(table.get("1:1").captured_at, T1, "prior snapshot stays until retry");
+  assert.deepEqual(m.deleted, [], "staged R2 object kept for retry");
 });

--- a/tests/load-staged-neurons.test.mjs
+++ b/tests/load-staged-neurons.test.mjs
@@ -328,32 +328,9 @@ function applyNeuronSnapshotPrune(table, sql, values) {
   return 0;
 }
 
-function applyNeuronSnapshotRollback(table, sql, values) {
-  if (sql.startsWith("DELETE FROM neurons WHERE captured_at =")) {
-    const target = values[0];
-    let changes = 0;
-    for (const [k, row] of table) {
-      if (row.captured_at === target) {
-        table.delete(k);
-        changes += 1;
-      }
-    }
-    return changes;
-  }
-  if (
-    sql.startsWith("DELETE FROM neurons WHERE netuid IN") &&
-    sql.includes("captured_at =")
-  ) {
-    const target = values.at(-1);
-    const refreshed = new Set(values.slice(0, -1));
-    let changes = 0;
-    for (const [k, row] of table) {
-      if (refreshed.has(row.netuid) && row.captured_at === target) {
-        table.delete(k);
-        changes += 1;
-      }
-    }
-    return changes;
+function applyNeuronDeleteByKey(table, sql, values) {
+  if (sql.startsWith("DELETE FROM neurons WHERE netuid = ? AND uid = ?")) {
+    return table.delete(`${values[0]}:${values[1]}`) ? 1 : 0;
   }
   return 0;
 }
@@ -374,7 +351,7 @@ function statefulEnv(
     failBatchOnPrune = false,
     failPruneUntil = 0,
     failUpsertOnBatch = 0,
-    failRollbackRun = false,
+    failRollbackBatch = false,
     omitPruneChangesMeta = false,
     bareSelectResponse = false,
   } = {},
@@ -391,6 +368,31 @@ function statefulEnv(
       cols.forEach((c, j) => (row[c.trim()] = values[i + j]));
       table.set(`${row.netuid}:${row.uid}`, row); // REPLACE by PK
     }
+  }
+  function colsPerRow(sql) {
+    return sql.slice(sql.indexOf("(") + 1, sql.indexOf(")")).split(",").length;
+  }
+  function isLoadUpsertBatch(stmts) {
+    return stmts.some((stmt) => {
+      if (!stmt.sql.startsWith("INSERT OR REPLACE INTO neurons")) return false;
+      return stmt.v.length > colsPerRow(stmt.sql);
+    });
+  }
+  function isRollbackBatch(stmts) {
+    return (
+      stmts.length > 0 &&
+      stmts.every((stmt) => {
+        if (
+          stmt.sql.startsWith(
+            "DELETE FROM neurons WHERE netuid = ? AND uid = ?",
+          )
+        )
+          return true;
+        if (!stmt.sql.startsWith("INSERT OR REPLACE INTO neurons"))
+          return false;
+        return stmt.v.length === colsPerRow(stmt.sql);
+      })
+    );
   }
   return {
     env: {
@@ -432,14 +434,13 @@ function statefulEnv(
                   if (pruneAttempts <= failPruneUntil) {
                     throw new Error("simulated prune failure");
                   }
-                  if (sql.includes("captured_at =")) {
-                    if (failRollbackRun) {
-                      throw new Error("simulated rollback failure");
-                    }
+                  if (
+                    sql.startsWith(
+                      "DELETE FROM neurons WHERE netuid = ? AND uid = ?",
+                    )
+                  ) {
                     return {
-                      meta: {
-                        changes: applyNeuronSnapshotRollback(table, sql, v),
-                      },
+                      meta: { changes: applyNeuronDeleteByKey(table, sql, v) },
                     };
                   }
                   return omitPruneChangesMeta
@@ -470,13 +471,16 @@ function statefulEnv(
           ) {
             throw new Error("simulated atomic upsert+prune batch failure");
           }
+          if (failRollbackBatch && isRollbackBatch(stmts)) {
+            throw new Error("simulated rollback failure");
+          }
           const hasUpsert = stmts.some((stmt) =>
             stmt.sql.startsWith("INSERT OR REPLACE INTO neurons"),
           );
           const hasPrune = stmts.some((stmt) =>
             stmt.sql.startsWith("DELETE FROM neurons"),
           );
-          if (hasUpsert && !hasPrune) {
+          if (hasUpsert && !hasPrune && isLoadUpsertBatch(stmts)) {
             upsertBatchesDone += 1;
             if (failUpsertOnBatch && upsertBatchesDone === failUpsertOnBatch) {
               throw new Error("simulated multi-batch upsert failure");
@@ -489,6 +493,18 @@ function statefulEnv(
               results.push({ meta: { changes: 0 } });
               continue;
             }
+            if (
+              stmt.sql.startsWith(
+                "DELETE FROM neurons WHERE netuid = ? AND uid = ?",
+              )
+            ) {
+              results.push({
+                meta: {
+                  changes: applyNeuronDeleteByKey(table, stmt.sql, stmt.v),
+                },
+              });
+              continue;
+            }
             if (stmt.sql.startsWith("DELETE FROM neurons")) {
               pruneAttempts += 1;
               if (pruneAttempts <= failPruneUntil) {
@@ -496,9 +512,7 @@ function statefulEnv(
               }
               results.push({
                 meta: {
-                  changes: stmt.sql.includes("captured_at =")
-                    ? applyNeuronSnapshotRollback(table, stmt.sql, stmt.v)
-                    : applyNeuronSnapshotPrune(table, stmt.sql, stmt.v),
+                  changes: applyNeuronSnapshotPrune(table, stmt.sql, stmt.v),
                 },
               });
             }
@@ -719,7 +733,9 @@ test("loadStagedNeurons rolls back legacy bare-array snapshots on mid-load failu
 test("loadStagedNeurons treats missing atomic prune meta.changes as zero purged", async () => {
   const rows = Array.from({ length: 12 }, (_, i) => neuronRow(1, i));
   const m = mockEnv({ rows: signedEnvelope(rows) });
-  const baseBatch = m.env.METAGRAPH_HEALTH_DB.batch.bind(m.env.METAGRAPH_HEALTH_DB);
+  const baseBatch = m.env.METAGRAPH_HEALTH_DB.batch.bind(
+    m.env.METAGRAPH_HEALTH_DB,
+  );
   m.env.METAGRAPH_HEALTH_DB.batch = async (stmts) => {
     const out = await baseBatch(stmts);
     out[out.length - 1] = {};
@@ -772,13 +788,78 @@ test("loadStagedNeurons multi-batch backup tolerates D1 select without results f
   );
 });
 
+test("loadStagedNeurons returns load_failed when multi-batch backup read throws", async () => {
+  const rows = Array.from({ length: 255 }, (_, i) => neuronRow(1, i));
+  const m = mockEnv({ rows: signedEnvelope(rows) });
+  const basePrepare = m.env.METAGRAPH_HEALTH_DB.prepare.bind(
+    m.env.METAGRAPH_HEALTH_DB,
+  );
+  m.env.METAGRAPH_HEALTH_DB.prepare = (sql) => {
+    const stmt = basePrepare(sql);
+    if (!sql.startsWith("SELECT")) return stmt;
+    return {
+      bind: (...v) => ({
+        sql,
+        v,
+        async all() {
+          throw new Error("simulated backup read failure");
+        },
+      }),
+      async all() {
+        throw new Error("simulated backup read failure");
+      },
+    };
+  };
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "load_failed");
+  assert.deepEqual(m.deleted, [], "staged object kept for retry");
+});
+
+test("loadStagedNeurons keeps committed rows after purge_failed retry mid-load failure", async () => {
+  const table = new Map();
+  const T1 = 1_700_000_000_000;
+  table.set("1:0", { ...neuronRow(1, 0), captured_at: T1 });
+  table.set("1:1", { ...neuronRow(1, 1), captured_at: T1 });
+
+  const T2 = T1 + 60_000;
+  const snap2 = Array.from({ length: 255 }, (_, i) => {
+    const uid = i === 0 ? 0 : i + 1;
+    return { ...neuronRow(1, uid), captured_at: T2, stake_tao: 300 + uid };
+  });
+  const staged = signedCoverageEnvelope(snap2, [1], T2);
+
+  const m1 = statefulEnv(table, { failPruneUntil: 999 });
+  m1.env.METAGRAPH_ARCHIVE._staged = staged;
+  const r1 = await loadStagedNeurons(m1.env);
+  assert.equal(r1.reason, "purge_failed");
+  assert.equal(table.get("1:0").captured_at, T2);
+  assert.equal(table.get("1:200").captured_at, T2);
+
+  const m2 = statefulEnv(table, { failUpsertOnBatch: 2 });
+  m2.env.METAGRAPH_ARCHIVE._staged = staged;
+  const r2 = await loadStagedNeurons(m2.env);
+  assert.equal(r2.reason, "load_failed");
+  assert.equal(
+    table.get("1:200").captured_at,
+    T2,
+    "rows not upserted in the failed retry must stay from the committed snapshot",
+  );
+  assert.equal(
+    table.get("1:200").stake_tao,
+    500,
+    "untouched committed row values must survive the retry rollback",
+  );
+  assert.deepEqual(m2.deleted, [], "staged object kept for retry");
+});
+
 test("loadStagedNeurons survives rollback failure after mid-load upsert failure", async () => {
   const table = new Map();
   const T1 = 1_700_000_000_000;
   table.set("1:0", { ...neuronRow(1, 0), captured_at: T1 });
   const m = statefulEnv(table, {
     failUpsertOnBatch: 2,
-    failRollbackRun: true,
+    failRollbackBatch: true,
   });
 
   const T2 = T1 + 60_000;

--- a/tests/load-staged-neurons.test.mjs
+++ b/tests/load-staged-neurons.test.mjs
@@ -359,6 +359,7 @@ function statefulEnv(
     failBatchOnPrune = false,
     failPruneUntil = 0,
     failUpsertOnBatch = 0,
+    failRollbackRun = false,
   } = {},
 ) {
   const deleted = [];
@@ -407,6 +408,9 @@ function statefulEnv(
                     throw new Error("simulated prune failure");
                   }
                   if (sql.includes("captured_at =")) {
+                    if (failRollbackRun) {
+                      throw new Error("simulated rollback failure");
+                    }
                     return {
                       meta: {
                         changes: applyNeuronSnapshotRollback(table, sql, v),
@@ -439,10 +443,7 @@ function statefulEnv(
           );
           if (hasUpsert && !hasPrune) {
             upsertBatchesDone += 1;
-            if (
-              failUpsertOnBatch &&
-              upsertBatchesDone === failUpsertOnBatch
-            ) {
+            if (failUpsertOnBatch && upsertBatchesDone === failUpsertOnBatch) {
               throw new Error("simulated multi-batch upsert failure");
             }
           }
@@ -614,10 +615,81 @@ test("loadStagedNeurons rolls back partial multi-batch upserts on mid-load failu
   assert.equal(r.ok, false);
   assert.equal(r.reason, "load_failed");
   assert.equal(
-    [...table.values()].some((row) => row.netuid === 1 && row.captured_at === T2),
+    [...table.values()].some(
+      (row) => row.netuid === 1 && row.captured_at === T2,
+    ),
     false,
     "partial snapshot rows at T2 must be rolled back",
   );
-  assert.equal(table.get("1:1").captured_at, T1, "prior snapshot stays until retry");
+  assert.equal(
+    table.get("1:1").captured_at,
+    T1,
+    "prior snapshot stays until retry",
+  );
   assert.deepEqual(m.deleted, [], "staged R2 object kept for retry");
+});
+
+test("loadStagedNeurons returns purge_failed when upserts finish but prune never succeeds", async () => {
+  const table = new Map();
+  const T1 = 1_700_000_000_000;
+  table.set("1:0", { ...neuronRow(1, 0), captured_at: T1 });
+  const m = statefulEnv(table, { failPruneUntil: 999 });
+
+  const T2 = T1 + 60_000;
+  const snap2 = Array.from({ length: 255 }, (_, i) => {
+    const uid = i === 0 ? 0 : i + 1;
+    return { ...neuronRow(1, uid), captured_at: T2 };
+  });
+  m.env.METAGRAPH_ARCHIVE._staged = signedCoverageEnvelope(snap2, [1], T2);
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "purge_failed");
+  assert.deepEqual(m.deleted, [], "staged object kept for re-prune retry");
+});
+
+test("loadStagedNeurons rolls back legacy bare-array snapshots on mid-load failure", async () => {
+  const table = new Map();
+  const T1 = 1_700_000_000_000;
+  table.set("1:0", { ...neuronRow(1, 0), captured_at: T1 });
+  const m = statefulEnv(table, { failUpsertOnBatch: 2 });
+
+  const T2 = T1 + 60_000;
+  const snap2 = Array.from({ length: 255 }, (_, i) => {
+    const uid = i === 0 ? 0 : i + 1;
+    return { ...neuronRow(1, uid), captured_at: T2 };
+  });
+  m.env.METAGRAPH_ARCHIVE._staged = signedEnvelope(snap2);
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "load_failed");
+  assert.equal(
+    [...table.values()].some((row) => row.captured_at === T2),
+    false,
+    "partial legacy snapshot rows must be rolled back",
+  );
+});
+
+test("loadStagedNeurons survives rollback failure after mid-load upsert failure", async () => {
+  const table = new Map();
+  const T1 = 1_700_000_000_000;
+  table.set("1:0", { ...neuronRow(1, 0), captured_at: T1 });
+  const m = statefulEnv(table, {
+    failUpsertOnBatch: 2,
+    failRollbackRun: true,
+  });
+
+  const T2 = T1 + 60_000;
+  const snap2 = Array.from({ length: 255 }, (_, i) => {
+    const uid = i === 0 ? 0 : i + 1;
+    return { ...neuronRow(1, uid), captured_at: T2 };
+  });
+  m.env.METAGRAPH_ARCHIVE._staged = signedCoverageEnvelope(snap2, [1], T2);
+  const r = await loadStagedNeurons(m.env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "load_failed");
+  assert.deepEqual(
+    m.deleted,
+    [],
+    "staged object kept even when rollback throws",
+  );
 });

--- a/workers/request-handlers/staging.mjs
+++ b/workers/request-handlers/staging.mjs
@@ -207,6 +207,20 @@ function neuronSnapshotPruneStatement(db, stagingMeta, snapshotCapturedAt) {
         .bind(...stagingMeta.refreshed_netuids, stagingMeta.captured_at);
 }
 
+function neuronSnapshotRollbackStatement(db, stagingMeta, snapshotCapturedAt) {
+  return stagingMeta.legacy
+    ? db
+        .prepare(`DELETE FROM neurons WHERE captured_at = ?`)
+        .bind(snapshotCapturedAt)
+    : db
+        .prepare(
+          `DELETE FROM neurons WHERE netuid IN (${stagingMeta.refreshed_netuids
+            .map(() => "?")
+            .join(",")}) AND captured_at = ?`,
+        )
+        .bind(...stagingMeta.refreshed_netuids, snapshotCapturedAt);
+}
+
 async function runNeuronSnapshotPrune(
   db,
   stagingMeta,
@@ -328,15 +342,22 @@ export async function loadStagedNeurons(env) {
     snapshotCapturedAt,
   );
   let purged;
-  try {
-    // Single-batch snapshots upsert + prune in one D1 transaction so a failed
-    // prune cannot commit replacement rows while deregistered UIDs linger.
-    if (statements.length + 1 <= STMTS_PER_BATCH) {
+  const upsertBatchCount = Math.ceil(statements.length / STMTS_PER_BATCH);
+  if (statements.length + 1 <= STMTS_PER_BATCH) {
+    try {
+      // Single-batch snapshots upsert + prune in one D1 transaction so a failed
+      // prune cannot commit replacement rows while deregistered UIDs linger.
       const batchResult = await db.batch([...statements, pruneStatement]);
       purged = batchResult.at(-1)?.meta?.changes ?? 0;
-    } else {
+    } catch {
+      return { ok: false, reason: "load_failed" };
+    }
+  } else {
+    let upsertBatchesDone = 0;
+    try {
       for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
         await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
+        upsertBatchesDone += 1;
       }
       const result = await runNeuronSnapshotPrune(
         db,
@@ -344,18 +365,26 @@ export async function loadStagedNeurons(env) {
         snapshotCapturedAt,
       );
       purged = result?.meta?.changes ?? 0;
+    } catch {
+      // Mid-upsert failure: some INSERT OR REPLACE batches may already be
+      // committed. Roll back rows stamped at this snapshot so the prior snapshot
+      // stays queryable and the next cron can retry the same staged file.
+      // Post-upsert prune failure: upserts are committed — keep the staged object
+      // so the next cron re-prunes.
+      if (upsertBatchesDone < upsertBatchCount) {
+        try {
+          await neuronSnapshotRollbackStatement(
+            db,
+            stagingMeta,
+            snapshotCapturedAt,
+          ).run();
+        } catch {
+          // Best-effort rollback — the staged object is preserved for retry.
+        }
+        return { ok: false, reason: "load_failed" };
+      }
+      return { ok: false, reason: "purge_failed" };
     }
-  } catch {
-    // Mid-upsert failure: prior snapshot stays intact and the staged object is
-    // preserved for retry. Post-upsert prune failure (multi-batch only): upserts
-    // are already committed — keep the staged object so the next cron re-prunes.
-    return {
-      ok: false,
-      reason:
-        statements.length + 1 <= STMTS_PER_BATCH
-          ? "load_failed"
-          : "purge_failed",
-    };
   }
   await bucket.delete(STAGED_NEURONS_KEY);
   return { ok: true, rows: rows.length, purged };

--- a/workers/request-handlers/staging.mjs
+++ b/workers/request-handlers/staging.mjs
@@ -207,20 +207,6 @@ function neuronSnapshotPruneStatement(db, stagingMeta, snapshotCapturedAt) {
         .bind(...stagingMeta.refreshed_netuids, stagingMeta.captured_at);
 }
 
-function neuronSnapshotRollbackStatement(db, stagingMeta, snapshotCapturedAt) {
-  return stagingMeta.legacy
-    ? db
-        .prepare(`DELETE FROM neurons WHERE captured_at = ?`)
-        .bind(snapshotCapturedAt)
-    : db
-        .prepare(
-          `DELETE FROM neurons WHERE netuid IN (${stagingMeta.refreshed_netuids
-            .map(() => "?")
-            .join(",")}) AND captured_at = ?`,
-        )
-        .bind(...stagingMeta.refreshed_netuids, snapshotCapturedAt);
-}
-
 function neuronRowKey(row) {
   return `${row.netuid}:${row.uid}`;
 }
@@ -260,25 +246,26 @@ function neuronRestoreStatement(db, cols, colList, row) {
     .bind(...values);
 }
 
+function neuronDeleteByKeyStatement(db, key) {
+  const colon = key.indexOf(":");
+  return db
+    .prepare(`DELETE FROM neurons WHERE netuid = ? AND uid = ?`)
+    .bind(Number(key.slice(0, colon)), Number(key.slice(colon + 1)));
+}
+
 async function restoreNeuronSnapshotAfterFailedLoad(
   db,
-  stagingMeta,
-  snapshotCapturedAt,
   { backup, upsertedKeys, cols, colList, stmtsPerBatch },
 ) {
-  await neuronSnapshotRollbackStatement(
-    db,
-    stagingMeta,
-    snapshotCapturedAt,
-  ).run();
-  const restoreStmts = [];
+  const rollbackStmts = [];
   for (const key of upsertedKeys) {
     const prior = backup.get(key);
     if (prior)
-      restoreStmts.push(neuronRestoreStatement(db, cols, colList, prior));
+      rollbackStmts.push(neuronRestoreStatement(db, cols, colList, prior));
+    else rollbackStmts.push(neuronDeleteByKeyStatement(db, key));
   }
-  for (let i = 0; i < restoreStmts.length; i += stmtsPerBatch) {
-    await db.batch(restoreStmts.slice(i, i + stmtsPerBatch));
+  for (let i = 0; i < rollbackStmts.length; i += stmtsPerBatch) {
+    await db.batch(rollbackStmts.slice(i, i + stmtsPerBatch));
   }
 }
 
@@ -416,12 +403,12 @@ export async function loadStagedNeurons(env) {
       return { ok: false, reason: "load_failed" };
     }
   } else {
-    const backup = await backupNeuronSnapshotRows(
-      db,
-      colList,
-      rows,
-      stagingMeta,
-    );
+    let backup;
+    try {
+      backup = await backupNeuronSnapshotRows(db, colList, rows, stagingMeta);
+    } catch {
+      return { ok: false, reason: "load_failed" };
+    }
     const upsertedKeys = new Set();
     let upsertBatchesDone = 0;
     try {
@@ -441,25 +428,20 @@ export async function loadStagedNeurons(env) {
       purged = result?.meta?.changes ?? 0;
     } catch {
       // Mid-upsert failure: committed INSERT OR REPLACE batches overwrite prior
-      // (netuid, uid) rows. Drop partial rows at this snapshot stamp and restore
-      // backed-up prior rows for keys that were already upserted so the live
-      // snapshot stays queryable until the next cron retries the staged file.
+      // (netuid, uid) rows. Undo only the keys upserted in this attempt — restore
+      // backed-up prior rows for replaced keys and delete partial new-key inserts —
+      // so a purge_failed retry cannot wipe rows this attempt never touched.
       // Post-upsert prune failure: upserts are committed — keep the staged object
       // so the next cron re-prunes.
       if (upsertBatchesDone < upsertBatchCount) {
         try {
-          await restoreNeuronSnapshotAfterFailedLoad(
-            db,
-            stagingMeta,
-            snapshotCapturedAt,
-            {
-              backup,
-              upsertedKeys,
-              cols,
-              colList,
-              stmtsPerBatch: STMTS_PER_BATCH,
-            },
-          );
+          await restoreNeuronSnapshotAfterFailedLoad(db, {
+            backup,
+            upsertedKeys,
+            cols,
+            colList,
+            stmtsPerBatch: STMTS_PER_BATCH,
+          });
         } catch {
           // Best-effort rollback — the staged object is preserved for retry.
         }

--- a/workers/request-handlers/staging.mjs
+++ b/workers/request-handlers/staging.mjs
@@ -221,6 +221,67 @@ function neuronSnapshotRollbackStatement(db, stagingMeta, snapshotCapturedAt) {
         .bind(...stagingMeta.refreshed_netuids, snapshotCapturedAt);
 }
 
+function neuronRowKey(row) {
+  return `${row.netuid}:${row.uid}`;
+}
+
+async function backupNeuronSnapshotRows(db, colList, rows, stagingMeta) {
+  const backup = new Map();
+  const results = stagingMeta.legacy
+    ? (await db.prepare(`SELECT ${colList} FROM neurons`).all()).results
+    : (
+        await db
+          .prepare(
+            `SELECT ${colList} FROM neurons WHERE netuid IN (${stagingMeta.refreshed_netuids
+              .map(() => "?")
+              .join(",")})`,
+          )
+          .bind(...stagingMeta.refreshed_netuids)
+          .all()
+      ).results;
+  const keysInSnapshot = new Set(rows.map(neuronRowKey));
+  for (const row of results || []) {
+    const key = neuronRowKey(row);
+    if (stagingMeta.legacy || keysInSnapshot.has(key)) {
+      backup.set(key, row);
+    }
+  }
+  return backup;
+}
+
+function neuronRestoreStatement(db, cols, colList, row) {
+  const values = cols.map((c) => row[c] ?? null);
+  return db
+    .prepare(
+      `INSERT OR REPLACE INTO neurons (${colList}) VALUES (${cols
+        .map(() => "?")
+        .join(",")})`,
+    )
+    .bind(...values);
+}
+
+async function restoreNeuronSnapshotAfterFailedLoad(
+  db,
+  stagingMeta,
+  snapshotCapturedAt,
+  { backup, upsertedKeys, cols, colList, stmtsPerBatch },
+) {
+  await neuronSnapshotRollbackStatement(
+    db,
+    stagingMeta,
+    snapshotCapturedAt,
+  ).run();
+  const restoreStmts = [];
+  for (const key of upsertedKeys) {
+    const prior = backup.get(key);
+    if (prior)
+      restoreStmts.push(neuronRestoreStatement(db, cols, colList, prior));
+  }
+  for (let i = 0; i < restoreStmts.length; i += stmtsPerBatch) {
+    await db.batch(restoreStmts.slice(i, i + stmtsPerBatch));
+  }
+}
+
 async function runNeuronSnapshotPrune(
   db,
   stagingMeta,
@@ -312,8 +373,10 @@ export async function loadStagedNeurons(env) {
   const ROWS_PER_STMT = 5;
   const STMTS_PER_BATCH = 50;
   const statements = [];
+  const statementRowKeys = [];
   for (let i = 0; i < rows.length; i += ROWS_PER_STMT) {
     const chunk = rows.slice(i, i + ROWS_PER_STMT);
+    statementRowKeys.push(chunk.map(neuronRowKey));
     const tuples = chunk
       .map(() => `(${cols.map(() => "?").join(",")})`)
       .join(",");
@@ -353,11 +416,22 @@ export async function loadStagedNeurons(env) {
       return { ok: false, reason: "load_failed" };
     }
   } else {
+    const backup = await backupNeuronSnapshotRows(
+      db,
+      colList,
+      rows,
+      stagingMeta,
+    );
+    const upsertedKeys = new Set();
     let upsertBatchesDone = 0;
     try {
       for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
         await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
         upsertBatchesDone += 1;
+        const keyEnd = Math.min(i + STMTS_PER_BATCH, statementRowKeys.length);
+        for (let j = i; j < keyEnd; j += 1) {
+          for (const key of statementRowKeys[j]) upsertedKeys.add(key);
+        }
       }
       const result = await runNeuronSnapshotPrune(
         db,
@@ -366,18 +440,26 @@ export async function loadStagedNeurons(env) {
       );
       purged = result?.meta?.changes ?? 0;
     } catch {
-      // Mid-upsert failure: some INSERT OR REPLACE batches may already be
-      // committed. Roll back rows stamped at this snapshot so the prior snapshot
-      // stays queryable and the next cron can retry the same staged file.
+      // Mid-upsert failure: committed INSERT OR REPLACE batches overwrite prior
+      // (netuid, uid) rows. Drop partial rows at this snapshot stamp and restore
+      // backed-up prior rows for keys that were already upserted so the live
+      // snapshot stays queryable until the next cron retries the staged file.
       // Post-upsert prune failure: upserts are committed — keep the staged object
       // so the next cron re-prunes.
       if (upsertBatchesDone < upsertBatchCount) {
         try {
-          await neuronSnapshotRollbackStatement(
+          await restoreNeuronSnapshotAfterFailedLoad(
             db,
             stagingMeta,
             snapshotCapturedAt,
-          ).run();
+            {
+              backup,
+              upsertedKeys,
+              cols,
+              colList,
+              stmtsPerBatch: STMTS_PER_BATCH,
+            },
+          );
         } catch {
           // Best-effort rollback — the staged object is preserved for retry.
         }


### PR DESCRIPTION
## Summary

`loadStagedNeurons` uses a single D1 transaction for small snapshots (upsert + prune atomically), but production full-network payloads always exceed the batch limit and commit upserts across multiple batches. If a mid-upsert batch failed, earlier batches were already committed while prune never ran — leaving a mixed `captured_at` metagraph and returning `purge_failed` even though the failure was during load.

## Root cause

The multi-batch path in `workers/request-handlers/staging.mjs` had no compensating action on upsert failure. The catch block assumed the prior snapshot stayed intact, which is only true for the atomic single-batch path (already regression-tested).

## Fix approach

- Add `neuronSnapshotRollbackStatement` to delete rows stamped at the attempted snapshot (`captured_at = ?`, scoped to refreshed netuids for coverage envelopes).
- On multi-batch mid-upsert failure: best-effort rollback, preserve the staged R2 object, return `load_failed`.
- On post-upsert prune failure: unchanged — keep staged object for re-prune (`purge_failed`).
- Separate try/catch for atomic vs multi-batch paths so small snapshots never trigger rollback.

## Why this matters

Every production metagraph refresh hits the multi-batch path (~33k rows). A transient D1 error during load could corrupt live neuron data (ghost UIDs, mixed snapshot stamps) until manual intervention.

## Testing

- [x] `npx vitest run tests/load-staged-neurons.test.mjs` (17/17)
- [x] `npx vitest run tests/health-prober.test.mjs tests/load-staged-events.test.mjs` (92/92)
- [x] `npm run lint`
- [x] New regression: `loadStagedNeurons rolls back partial multi-batch upserts on mid-load failure`

## Risks / tradeoffs

- Rollback removes partial rows at the new `captured_at` stamp; UIDs successfully replaced before failure are absent until the next cron retry reloads from the preserved staged file (same retry contract as other load failures).
- Rollback is best-effort — if it also fails, the staged object is still preserved for retry.
