### PR TITLE
fix: pin redirect:manual on Worker balance RPC and WSS probe egress

### DIFF
--- a/src/account-balance.mjs
+++ b/src/account-balance.mjs
@@ -96,6 +96,10 @@ export async function loadAccountBalance(env, ss58) {
     const rpcResp = await fetch(FINNEY_RPC_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      // Never auto-follow upstream redirects: only the finney entrypoint was chosen,
+      // so a 3xx would re-POST the JSON-RPC body to an unvetted host. Mirrors the
+      // redirect:"manual" invariant in rpc-proxy.mjs / health-probe-core.mjs.
+      redirect: "manual",
       signal: AbortSignal.timeout(BALANCE_RPC_TIMEOUT_MS),
       body: JSON.stringify({
         jsonrpc: "2.0",

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -253,7 +253,12 @@ export function workerWebSocketConnector(fetchImpl = fetch) {
         }
       }
 
-      fetchImpl(httpUrl, { headers: { Upgrade: "websocket" } })
+      fetchImpl(httpUrl, {
+        headers: { Upgrade: "websocket" },
+        // Never auto-follow an upgrade redirect: only the initial WSS URL passed the
+        // SSRF guard, so following a 3xx would open a socket to an unvetted host.
+        redirect: "manual",
+      })
         .then((response) => {
           socket = response.webSocket;
           if (!socket) {

--- a/tests/account-balance-loader.test.mjs
+++ b/tests/account-balance-loader.test.mjs
@@ -126,6 +126,26 @@ describe("loadAccountBalance", () => {
     }
   });
 
+  test("does not follow redirects from the finney RPC upstream", async () => {
+    const fetchCalls = [];
+    const orig = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ url, init });
+      return new Response(null, {
+        status: 302,
+        headers: { location: "http://169.254.169.254/rpc" },
+      });
+    };
+    try {
+      const data = await loadAccountBalance({}, SS58);
+      assert.equal(data.balance_tao, null);
+      assert.equal(fetchCalls.length, 1, "must not follow the redirect hop");
+      assert.equal(fetchCalls[0].init.redirect, "manual");
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
   test("returns balance_tao:null when finney RPC times out (#2075)", async () => {
     const orig = globalThis.fetch;
     globalThis.fetch = async (_url, init) => {
@@ -145,10 +165,10 @@ describe("loadAccountBalance", () => {
   });
 
   test("passes AbortSignal.timeout to the finney fetch", async () => {
-    let seenSignal;
+    let seenInit;
     const orig = globalThis.fetch;
     globalThis.fetch = async (_url, init) => {
-      seenSignal = init?.signal;
+      seenInit = init;
       return {
         ok: true,
         json: async () => ({
@@ -160,8 +180,9 @@ describe("loadAccountBalance", () => {
     };
     try {
       await loadAccountBalance({}, SS58);
-      assert.ok(seenSignal);
-      assert.equal(typeof seenSignal.aborted, "boolean");
+      assert.ok(seenInit?.signal);
+      assert.equal(seenInit.redirect, "manual");
+      assert.equal(typeof seenInit.signal.aborted, "boolean");
       assert.equal(BALANCE_RPC_TIMEOUT_MS, 5000);
     } finally {
       globalThis.fetch = orig;

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -860,10 +860,11 @@ describe("workerWebSocketConnector", () => {
     );
     const promise = connect("wss://node.example/rpc", RPC_CALLS, 1000);
 
-    // ws→http rewrite + Upgrade header.
+    // ws→http rewrite + Upgrade header + redirect guard.
     assert.equal(calls.length, 1);
     assert.equal(calls[0].url, "https://node.example/rpc");
     assert.equal(calls[0].init.headers.Upgrade, "websocket");
+    assert.equal(calls[0].init.redirect, "manual");
 
     // Wait for the fetch().then() to run so accept()/send() have happened.
     await Promise.resolve();


### PR DESCRIPTION
## Summary

Two production Worker egress paths still used default `fetch` redirect following while every sibling outbound client (`rpc-proxy.mjs`, `webhooks.mjs`, `health-probe-core.mjs`) pins `redirect: "manual"`. This PR closes that gap for:

- **`loadAccountBalance`** — `GET /api/v1/accounts/{ss58}/balance` and MCP `get_account_balance` (#1818)
- **`workerWebSocketConnector`** — outbound WSS subtensor RPC probes in the health cron

## Root cause

Cloudflare `fetch` follows redirects by default. If an upstream finney entrypoint or WSS surface returns `302 Location: http://169.254.169.254/...`, the Worker would follow it and POST JSON-RPC / open a WebSocket to an unvetted host. The RPC proxy already documents and tests this invariant (`rpc-failover.test.mjs`); these two paths missed it.

## Fix approach

Add `redirect: "manual"` to both fetches. A 3xx is treated as failure (`balance_tao: null` for balance; upgrade rejection for WSS) — same posture as the RPC proxy classifying redirects as transient failures.

## Why this matters

ADR 0004's trust model is built around **never calling unvetted hosts**. Redirect following bypasses the URL that passed the guard. Balance lookup is a public, unauthenticated Worker route; WSS probes run on curated surfaces every 15 minutes from the edge.

## Testing

- [x] `npx vitest run tests/account-balance-loader.test.mjs` (10/10)
- [x] `npx vitest run tests/health-prober.test.mjs` (78/78)
- [x] `npm run lint`
- [x] New: balance fetch does not follow a 302 to a private address
- [x] Extended: `workerWebSocketConnector` asserts `redirect: "manual"` on upgrade fetch

## Risks / tradeoffs

- If finney ever legitimately requires a redirect to another public host, balance/WSS calls would fail closed (`null` balance / probe error) instead of following. This matches the existing RPC proxy policy and is the intended security posture.

Closes gap relative to #1818 / ADR 0004 redirect hardening; does not change happy-path behavior for direct 200 responses.
