### PR TITLE
fix(health-prober): guard iso() against out-of-range D1 timestamps

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -67,8 +67,15 @@ const RPC_BLOCK_PLAUSIBILITY_TOLERANCE = 10;
 // last_ok for a surface that has never probed OK. Treat any falsy/zero ms as
 // null at the source so consumers don't each need a pre-2000 sentinel guard. A
 // real timestamp (run time, last OK) is always a large positive ms.
-const iso = (ms) =>
-  Number.isFinite(ms) && ms > 0 ? new Date(ms).toISOString() : null;
+// A finite but out-of-range epoch (|ms| > 8.64e15, the JS Date limit) makes
+// toISOString() throw a RangeError, which would abort the 15-minute cron on one
+// corrupt surface_status.last_ok cell. Range-guard via getTime() and drop to
+// null — mirrors isoFromMs in health-serving.mjs (#2807).
+const iso = (ms) => {
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const date = new Date(ms);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+};
 
 function safeRpcBlockNumber(value) {
   if (value == null) return null;

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -383,6 +383,49 @@ describe("runHealthProber", () => {
     assert.equal(meta.last_run_at, new Date(50000).toISOString());
   });
 
+  test("survives an out-of-range prior last_ok from D1 (no RangeError)", async () => {
+    // A corrupt surface_status.last_ok beyond the ±8.64e15 JS Date limit is carried
+    // forward on a failed probe. iso() must drop it to null instead of throwing a
+    // RangeError and aborting the whole 15-minute cron — mirrors #2807 / isoFromMs.
+    const kv = makeKv();
+    const db = makeDb({
+      priorStatus: [
+        {
+          surface_id: "sn7-api",
+          surface_key: "srf-sn7apikey000000",
+          last_ok: 8640000000000001,
+          consecutive_failures: 0,
+        },
+      ],
+    });
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 50000,
+        db,
+        kv,
+        loadSurfaces: async () => [SURFACES[0]],
+        probeSurface: async () => ({
+          status: "failed",
+          classification: "dead",
+          latency_ms: null,
+          status_code: 404,
+        }),
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    const apiRow = kv
+      .json(KV_HEALTH_CURRENT)
+      .surfaces.find((s) => s.surface_id === "sn7-api");
+    assert.equal(apiRow.last_ok, null);
+    const subnet = kv
+      .json(KV_HEALTH_CURRENT)
+      .subnets.find((s) => s.netuid === 7);
+    assert.equal(subnet.last_ok, null);
+  });
+
   test("folds unrecognized probe status into unknown in global status_counts", async () => {
     const kv = makeKv();
     const result = await runHealthProber(


### PR DESCRIPTION
## Summary

The 15-minute health cron calls `iso()` when writing KV snapshots and when a failed probe carries forward `surface_status.last_ok` from D1. A finite but out-of-range epoch-ms (beyond the ±8.64e15 JS Date limit) made `new Date(ms).toISOString()` throw a **RangeError**, aborting the entire probe sweep.

`health-serving.mjs` already guards this path via `isoFromMs()` (#2807); the cron prober's local `iso()` helper did not — a parity gap.

## Root cause

`prior?.last_ok` is read directly from D1 `surface_status`. On a non-ok probe run, that value is passed through to `persistToKv` → `iso(row.last_ok_ms)` with no Date-range check. One corrupt cell crashes the cron.

## Fix approach

Range-guard `iso()` via `getTime()` and drop invalid epochs to `null`, preserving the existing #1757 zero-sentinel behavior.

## Why this matters

The health cron is production-critical (KV `health:current`, RPC pool eligibility, operational rollups). A single bad timestamp must degrade, not take down the sweep — same contract as #2807 / #2792 / #2791.

## Testing

- [x] `npx vitest run tests/health-prober.test.mjs` (79/79)
- [x] `npm run lint`
- [x] New: survives out-of-range prior `last_ok` from D1 (no RangeError)

## Risks / tradeoffs

- A corrupt `last_ok` now surfaces as `null` (never healthy) instead of crashing the cron. Operators can still inspect raw D1; serving stays live.