### PR TITLE
test(worker): expand domain tag and keyword search coverage

### DIFF
--- a/tests/domain-tags.test.mjs
+++ b/tests/domain-tags.test.mjs
@@ -8,6 +8,33 @@ describe("DOMAIN_TAGS", () => {
     assert.deepEqual(DOMAIN_TAGS, [...DOMAIN_TAGS].sort());
     assert.ok(new Set(DOMAIN_TAGS).size === DOMAIN_TAGS.length);
   });
+
+  test("can match every configured domain rule at least once", () => {
+    const tagSamples = {
+      agents: "autonomous agents and software agentic workflows",
+      compute: "distributed compute and GPU acceleration",
+      data: "data mining and web scraping pipelines",
+      finance: "liquidity and yield farming for traders",
+      inference: "large language model inference service",
+      media: "image generation and text-to-speech voice generation",
+      prediction: "prediction markets for market forecasting",
+      privacy: "zero knowledge proofs and encrypted messages",
+      robotics: "autonomous drones and robotic vehicles",
+      science: "protein and molecular biology research",
+      search: "semantic search and information retrieval",
+      security: "cyber security threat detection and anomaly detection",
+      storage: "decentralized storage for datasets",
+      training: "fine-tuning and pre-training of a model",
+    };
+
+    for (const [tag, text] of Object.entries(tagSamples)) {
+      const tags = deriveDomainTags({ description: text });
+      assert.ok(
+        tags.includes(tag),
+        `expected ${tag} from ${JSON.stringify(text)}, got ${JSON.stringify(tags)}`,
+      );
+    }
+  });
 });
 
 describe("deriveDomainTags", () => {
@@ -117,5 +144,52 @@ describe("deriveDomainTags", () => {
     assert.deepEqual(first, second);
     assert.deepEqual(first, ["compute", "media"]);
     assert.equal(first.length, new Set(first).size);
+  });
+
+  test("drops non-string description/additional values", () => {
+    const tags = deriveDomainTags({
+      description: null,
+      additional: 42,
+      categories: ["finance", 77],
+    });
+    assert.deepEqual(tags, ["finance"]);
+  });
+
+  test("accepts case-insensitive curated categories and ignores unknown list entries", () => {
+    const tags = deriveDomainTags({
+      description: "a subnet with nothing to match",
+      categories: ["Finance", "not-a-domain-tag", "MEDIA"],
+    });
+    assert.deepEqual(tags, ["finance", "media"]);
+  });
+
+  test("accepts a non-array categories value without errors", () => {
+    assert.deepEqual(
+      deriveDomainTags({
+        description: "large language model inference",
+        categories: "inference",
+      }),
+      ["inference"],
+    );
+  });
+
+  test("merges text-derived and curated categories without duplicates", () => {
+    const tags = deriveDomainTags({
+      description: "large language model inference and data scraping",
+      categories: ["finance", "media", "inference"],
+    });
+    assert.deepEqual(tags, ["data", "finance", "inference", "media"]);
+  });
+
+  test("returns empty for fully null text and non-array category values that do not match", () => {
+    assert.deepEqual(deriveDomainTags({ description: null, additional: null }), []);
+    assert.deepEqual(
+      deriveDomainTags({
+        description: null,
+        additional: null,
+        categories: false,
+      }),
+      [],
+    );
   });
 });

--- a/tests/domain-tags.test.mjs
+++ b/tests/domain-tags.test.mjs
@@ -182,7 +182,10 @@ describe("deriveDomainTags", () => {
   });
 
   test("returns empty for fully null text and non-array category values that do not match", () => {
-    assert.deepEqual(deriveDomainTags({ description: null, additional: null }), []);
+    assert.deepEqual(
+      deriveDomainTags({ description: null, additional: null }),
+      [],
+    );
     assert.deepEqual(
       deriveDomainTags({
         description: null,

--- a/tests/keyword-search.test.mjs
+++ b/tests/keyword-search.test.mjs
@@ -190,9 +190,13 @@ describe("keywordScore — precision boosts", () => {
     };
 
     // Exact name token sequence gets the larger name boost than a mention-only match.
-    assert.ok(score(nameMatch, "targon search") > score(byText, "targon search"));
+    assert.ok(
+      score(nameMatch, "targon search") > score(byText, "targon search"),
+    );
     // Exact slug token sequence also receives the same boost.
-    assert.ok(score(nameMatch, "targon-search") > score(byText, "targon-search"));
+    assert.ok(
+      score(nameMatch, "targon-search") > score(byText, "targon-search"),
+    );
   });
 });
 

--- a/tests/keyword-search.test.mjs
+++ b/tests/keyword-search.test.mjs
@@ -47,6 +47,14 @@ describe("queryTerms", () => {
       Array.from({ length: MAX_QUERY_TERMS }, (_, i) => `t${i}`),
     );
   });
+
+  test("preserves original order while deduplicating", () => {
+    assert.deepEqual(queryTerms("gpu compute gpu vision"), [
+      "gpu",
+      "compute",
+      "vision",
+    ]);
+  });
 });
 
 describe("keywordScore — substring noise is gone (whole-word / prefix only)", () => {
@@ -147,6 +155,44 @@ describe("keywordScore — precision boosts", () => {
       "Stable Diffusion",
       "Art Engine",
     ]);
+  });
+
+  test("full coverage boost applies when every term matches", () => {
+    const both = {
+      name: "Image Engine",
+      slug: "image-engine",
+      text: ["render", "generation"],
+    };
+    const partialOnly = {
+      name: "Image Engine",
+      slug: "image-engine",
+      text: ["render"],
+    };
+
+    assert.ok(score(both, "render generation") > score(partialOnly, "render"));
+    assert.equal(
+      keywordScore(both, ["render", "generation"]),
+      keywordScore(both, ["render", "generation", "unknown"]) + 2,
+      "full query coverage should add the documented boost",
+    );
+  });
+
+  test("exact-name and exact-slug boosts are applied after term matching", () => {
+    const nameMatch = {
+      name: "Targon Search",
+      slug: "targon-search",
+      text: ["targon", "search"],
+    };
+    const byText = {
+      name: "Searcher",
+      slug: "searcher",
+      text: ["targon", "search"],
+    };
+
+    // Exact name token sequence gets the larger name boost than a mention-only match.
+    assert.ok(score(nameMatch, "targon search") > score(byText, "targon search"));
+    // Exact slug token sequence also receives the same boost.
+    assert.ok(score(nameMatch, "targon-search") > score(byText, "targon-search"));
   });
 });
 


### PR DESCRIPTION
## Summary
Add regression coverage for domain tag derivation and keyword search scoring logic.

## Changes
- Expand `tests/domain-tags.test.mjs` coverage for `deriveDomainTags`:
  - validate each configured domain rule is exercised,
  - non-string text field handling,
  - curated categories normalization and merge behavior, including duplicates and mixed inputs.
- Expand `tests/keyword-search.test.mjs` coverage for:
  - `queryTerms` dedupe/order behavior,
  - full-query coverage scoring behavior in `keywordScore`.

## Validation
- `npx vitest run tests/domain-tags.test.mjs tests/keyword-search.test.mjs`

## Notes
- This PR is intentionally test-only and scoped to existing behavior coverage.
- No schema/data files or generated artifacts were modified.
- No `source_url` or surface changes are included in this PR.
