### PR TITLE
feat(registry): enrich SN43 Graphite — add public subnet-stats API surface

### DIFF
--- a/registry/subnets/graphite.json
+++ b/registry/subnets/graphite.json
@@ -117,6 +117,26 @@
         "https://github.com/GraphiteAI/subnet_tools/blob/main/.example.env"
       ],
       "url": "https://huggingface.co/datasets/Graphite-AI/Graphite_Past_Problems"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-43-graphite-ai-subnet-api",
+      "kind": "subnet-api",
+      "name": "Graphite SN43 subnet stats API",
+      "notes": "Public, unauthenticated JSON endpoint on Graphite's official SN43 API (api.graphite-ai.net) returning the live subnet-43 metagraph aggregate: netuid, total registered neurons, validator/miner counts, total alpha stake, and an availability flag. Documented in the subnet's OpenAPI spec as GET /api/v1/stats/subnet.",
+      "provider": "graphite-ai",
+      "public_safe": true,
+      "review": {
+        "confidence": "medium",
+        "state": "community-submitted",
+        "submitted_by": "boskodev790"
+      },
+      "source_urls": [
+        "https://api.graphite-ai.net/openapi.json",
+        "https://api.graphite-ai.net/docs"
+      ],
+      "url": "https://api.graphite-ai.net/api/v1/stats/subnet"
     }
   ],
   "website_url": "https://graphite-ai.net/"


### PR DESCRIPTION
This PR enriches SN43 Graphite with the one first-party public data endpoint the subnet exposes that was not yet registered.

## Surface

- **kind:** `subnet-api`
- **url:** `https://api.graphite-ai.net/api/v1/stats/subnet`
- **auth:** none (public GET)
- **returns:** the live SN43 metagraph aggregate, e.g. `{"netuid":43,"total_registered":256,"validators":11,"miners":245,"total_alpha_stake":...,"available":true}`

## Proof

- `source_urls[0]` — Graphite's official OpenAPI spec (`api.graphite-ai.net/openapi.json`) documents this endpoint as `GET /api/v1/stats/subnet` (title: "SN43 Knowledge Graph API").
- `source_urls[1]` — the interactive Swagger docs (`api.graphite-ai.net/docs`).
- Same official `api.graphite-ai.net` host as the already-registered Graphite website + OpenAPI surfaces (provider `graphite-ai`).
- Verified live + public (HTTP 200, JSON) across repeated probes.

## Scope

Changes **only** `registry/subnets/graphite.json` — one new `community` / `community-submitted` surface of a distinct `kind` (`subnet-api`) not previously present for this subnet. No generated artifacts.

Refs #427