### PR TITLE
fix(health): guard chain_events observed_at on GET /health (no RangeError)

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -328,6 +328,35 @@ describe("/health readiness", () => {
     assert.equal(body.chain_events.age_seconds, null);
   });
 
+  test("chain_events survives an out-of-range observed_at (no RangeError)", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: makeKv({
+        "metagraph:latest": { published_at: new Date().toISOString() },
+      }),
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  return {
+                    results: [{ block: 8461200, at: 8640000000000001 }],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    });
+    const res = await handleRequest(req("/health"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.chain_events.latest_indexed_block, 8461200);
+    assert.equal(body.chain_events.latest_event_at, null);
+    assert.equal(body.chain_events.age_seconds, null);
+  });
+
   test("chain_events is null when no health DB is bound (#1361)", async () => {
     const env = {
       ASSETS: {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -2773,6 +2773,17 @@ function matchRoute(pathname) {
   return null;
 }
 
+// Epoch-ms → ISO string for /health observability fields. A finite but
+// out-of-range epoch (|ms| > 8.64e15, the JS Date limit) makes toISOString()
+// throw a RangeError, which would 500 GET /health on one corrupt observed_at
+// cell. Range-guard via getTime() and drop to null — mirrors isoFromMs in
+// health-serving.mjs (#2807).
+function isoFromFiniteMs(ms) {
+  if (!Number.isFinite(ms)) return null;
+  const date = new Date(ms);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
 // Lightweight readiness probe for uptime checks and load balancers. Reports
 // which bindings are wired; KV reads are in-isolate memoized.
 async function handleHealthRequest(request, env) {
@@ -2837,13 +2848,11 @@ async function handleHealthRequest(request, env) {
   if (bindings.health_db) {
     const chainEventsRow = await readChainEventsDb(env);
     const chainEventsAtMs = chainEventsRow ? Number(chainEventsRow.at) : NaN;
-    const chainEventsFresh = Number.isFinite(chainEventsAtMs);
+    const chainEventsAtIso = isoFromFiniteMs(chainEventsAtMs);
     chainEvents = {
       latest_indexed_block: chainEventsRow?.block ?? null,
-      latest_event_at: chainEventsFresh
-        ? new Date(chainEventsAtMs).toISOString()
-        : null,
-      age_seconds: chainEventsFresh
+      latest_event_at: chainEventsAtIso,
+      age_seconds: chainEventsAtIso
         ? Math.round((Date.now() - chainEventsAtMs) / 1000)
         : null,
     };


### PR DESCRIPTION
## Summary

`GET /health` reports `chain_events.latest_event_at` from the newest `account_events.observed_at` row. A finite but out-of-range epoch-ms (beyond the ±8.64e15 JS Date limit) made `new Date(ms).toISOString()` throw a **RangeError**, returning **500** on the public readiness probe that uptime monitors hit.

`health-serving.mjs` already guards this via `isoFromMs()` (#2807); the `/health` chain-events branch did not — a parity gap.

## Root cause

`handleHealthRequest` treated any `Number.isFinite(chainEventsAtMs)` as safe to format. Out-of-range finite values (e.g. `8640000000000001`) pass `Number.isFinite` but still throw on `toISOString()`.

## Fix approach

Add `isoFromFiniteMs()` with a `getTime()` range guard. When the timestamp is invalid, `latest_event_at` and `age_seconds` are both `null`; the probe still returns 200 with block height intact.

## Why this matters

`/health` is the uptime/load-balancer endpoint. A single corrupt D1 cell must degrade observability fields, not 500 the probe — same contract as #2807 / #2792 / #2791.

## Testing

- [x] `npx vitest run tests/api-coverage.test.mjs` (health chain_events tests)
- [x] `npm run lint`
- [x] New: out-of-range `observed_at` → 200 with null timestamps (no RangeError)

## Risks / tradeoffs

- Corrupt `observed_at` now surfaces as null freshness instead of crashing `/health`. Raw D1 remains inspectable; monitors stay green.