### PR TITLE
feat(mcp): add get_endpoint_incidents tool mirroring the endpoint-incidents route

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -264,6 +264,7 @@ assert.ok(
 await callOk("get_agent_catalog", {});
 await callOk("get_agent_catalog", { netuid: 7 });
 await callOk("registry_summary", {});
+await callOk("get_endpoint_incidents", {});
 
 // Per-subnet gap artifacts are R2-only (review/gaps/{netuid}.json); the cold
 // env has them only after `npm run build` stages dist/. Exercise the happy path

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -192,7 +192,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.20.0";
+export const MCP_SERVER_VERSION = "1.21.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -4236,6 +4236,24 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_endpoint_incidents",
+    title: "Get operational endpoint incident history",
+    description:
+      "Fetch the network-wide operational-endpoint incident ledger: every " +
+      "recorded downtime/degradation incident across probed subnet APIs and " +
+      "RPC endpoints, plus a summary rollup (incident/active counts, broken " +
+      "down by kind, layer, provider, severity, and status). Use it to see " +
+      "which surfaces have been unstable. Mirrors GET /api/v1/endpoint-incidents.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadArtifactData(ctx, "/metagraph/endpoint-incidents.json");
+    },
+  },
+  {
     name: "list_enrichment_targets",
     title: "List ranked enrichment targets",
     description:
@@ -6219,6 +6237,17 @@ const TOOL_OUTPUT_SCHEMAS = {
       recent_changes: { type: "object" },
       top_subnets: { type: "array", items: { type: "object" } },
       generated_at: NULLABLE_STRING,
+    },
+  },
+  get_endpoint_incidents: {
+    type: "object",
+    additionalProperties: true,
+    required: ["summary", "incidents"],
+    properties: {
+      schema_version: { type: "integer" },
+      generated_at: NULLABLE_STRING,
+      summary: { type: "object" },
+      incidents: { type: "array", items: { type: "object" } },
     },
   },
   list_enrichment_targets: {

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.20.0");
+    assert.equal(MCP_SERVER_VERSION, "1.21.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1296,6 +1296,23 @@ describe("MCP tools (injected deps)", () => {
     assert.equal(res.body.result.structuredContent.completeness, 0.42);
   });
 
+  test("get_endpoint_incidents returns the incident ledger artifact", async () => {
+    const incidentDeps = makeDeps({
+      "/metagraph/endpoint-incidents.json": {
+        schema_version: 1,
+        summary: { incident_count: 3, active_count: 1 },
+        incidents: [{ surface_id: "7:subnet-api:x", status: "resolved" }],
+      },
+    });
+    const res = await callTool(
+      "get_endpoint_incidents",
+      {},
+      { deps: incidentDeps },
+    );
+    assert.equal(res.body.result.structuredContent.summary.incident_count, 3);
+    assert.equal(res.body.result.structuredContent.incidents.length, 1);
+  });
+
   test("list_enrichment_targets returns ranked coverage-depth targets", async () => {
     const res = await callTool(
       "list_enrichment_targets",


### PR DESCRIPTION
Exposes the probe-derived endpoint incidents feed (GET /api/v1/endpoint-incidents) as an MCP tool so an agent can pull the current provider/subnet endpoint incidents and their severity/state without a REST call. Registers the tool + output schema, a validate-mcp smoke assertion, the MCP server version bump (1.20.0 -> 1.21.0), and a unit test.

Self-contained: reuses the existing loadArtifactData reader; no schema regeneration.