### PR TITLE
feat(mcp): add get_interface_gaps tool mirroring the network-wide gaps route

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -291,6 +291,24 @@ if (existsSync(gapsArtifactPath)) {
   );
 }
 
+// The network-wide gaps.json artifact is R2-only as well; exercise the happy
+// path when staged, otherwise assert the not_found guard loadArtifactData maps.
+const interfaceGapsPath = artifactFilePath("gaps.json");
+if (existsSync(interfaceGapsPath)) {
+  const interfaceGaps = await callOk("get_interface_gaps", {});
+  assert.ok(
+    Array.isArray(interfaceGaps.gaps),
+    "get_interface_gaps must return gaps[]",
+  );
+} else {
+  const interfaceGapsCold = await call("get_interface_gaps", {});
+  assert.equal(
+    interfaceGapsCold.isError,
+    true,
+    "get_interface_gaps must isError when the gaps artifact is absent",
+  );
+}
+
 // Economic opportunity boards project from the committed economics.json in the
 // cold local env; assert the call succeeds and returns the economic boards.
 const opportunities = await callOk("find_subnet_opportunities", { limit: 5 });

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -192,7 +192,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.20.0";
+export const MCP_SERVER_VERSION = "1.21.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -4377,6 +4377,26 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_interface_gaps",
+    title: "Get the network-wide interface gap report",
+    description:
+      "Fetch the registry-wide interface gap report: for every subnet its " +
+      "netuid, slug, name, resolved coverage_level and curation_level, the " +
+      "0-100 gap_priority (the backend's weighted reviewPriorityScore), the " +
+      "resolved gap_severity (critical/warning/info), and the list of missing " +
+      "surface kinds. Use it to rank the whole network by where contributor " +
+      "enrichment matters most in one call, rather than paging get_subnet_gaps " +
+      "subnet by subnet. Mirrors GET /api/v1/gaps.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadArtifactData(ctx, "/metagraph/gaps.json");
+    },
+  },
+  {
     name: "find_subnet_opportunities",
     title: "Rank subnets by economic opportunity",
     description:
@@ -6263,6 +6283,36 @@ const TOOL_OUTPUT_SCHEMAS = {
       name: NULLABLE_STRING,
       priorities: { type: "array", items: { type: "object" } },
       enrichment_queue: { type: "array", items: { type: "object" } },
+    },
+  },
+  get_interface_gaps: {
+    type: "object",
+    additionalProperties: true,
+    required: ["gaps"],
+    properties: {
+      schema_version: { type: "integer" },
+      generated_at: NULLABLE_STRING,
+      notes: ANY,
+      gaps: objectItems({
+        netuid: { type: "integer" },
+        slug: { type: "string" },
+        name: { type: "string" },
+        coverage_level: NULLABLE_STRING,
+        curation_level: NULLABLE_STRING,
+        gap_priority: NULLABLE_INT,
+        gap_severity: NULLABLE_STRING,
+        // Nested Gaps object: the resolved missing/supported surface kinds and
+        // free-text notes for this subnet (not a flat list).
+        gaps: {
+          type: "object",
+          additionalProperties: true,
+          properties: {
+            missing_kinds: { type: "array" },
+            supported_kinds: { type: "array" },
+            gap_notes: { type: "array" },
+          },
+        },
+      }),
     },
   },
   find_subnet_for_task: {

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.20.0");
+    assert.equal(MCP_SERVER_VERSION, "1.21.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1397,6 +1397,58 @@ describe("MCP tools (injected deps)", () => {
     assert.equal(res.body.result.isError, true);
   });
 
+  test("get_interface_gaps returns the network-wide gap report artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/gaps.json": {
+        schema_version: 1,
+        generated_at: "2026-07-01T00:00:00Z",
+        gaps: [
+          {
+            netuid: 7,
+            slug: "allways",
+            name: "Allways",
+            coverage_level: "callable",
+            curation_level: "verified",
+            gap_priority: 72,
+            gap_severity: "warning",
+            gaps: {
+              missing_kinds: ["openapi", "sdk"],
+              supported_kinds: ["docs", "website"],
+              gap_notes: ["No machine-readable interface published yet."],
+            },
+          },
+          {
+            netuid: 12,
+            slug: "compute",
+            name: "Compute",
+            coverage_level: "listed",
+            curation_level: "observed",
+            gap_priority: 40,
+            gap_severity: "info",
+            gaps: {
+              missing_kinds: ["openapi"],
+              supported_kinds: [],
+              gap_notes: [],
+            },
+          },
+        ],
+      },
+    });
+    const res = await callTool("get_interface_gaps", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.gaps.length, 2);
+    assert.equal(out.gaps[0].netuid, 7);
+    assert.equal(out.gaps[0].gap_severity, "warning");
+    assert.equal(out.gaps[0].gaps.missing_kinds[0], "openapi");
+    assert.equal(out.gaps[1].slug, "compute");
+  });
+
+  test("get_interface_gaps is not_found when the artifact is missing", async () => {
+    const res = await callTool("get_interface_gaps", {});
+    assert.equal(res.body.result.isError, true);
+    assert.equal(res.body.result.structuredContent.error.code, "not_found");
+  });
+
   const opportunityDeps = makeDeps({
     "/metagraph/economics.json": {
       captured_at: "2026-06-20T00:00:00Z",


### PR DESCRIPTION
Exposes the registry-wide interface gap report (`GET /api/v1/gaps`) as an MCP tool so an agent can rank the **whole network** by where contributor enrichment matters most in a single call — instead of paging `get_subnet_gaps` subnet by subnet.

For every subnet it returns netuid/slug/name, the resolved `coverage_level` and `curation_level`, the 0-100 `gap_priority` (the backend's weighted reviewPriorityScore), the resolved `gap_severity`, and the nested `Gaps` object (`missing_kinds` / `supported_kinds` / `gap_notes`).

Self-contained: the handler is a straight `loadArtifactData` read of the `gaps.json` artifact (no schema regeneration, no D1). Registers the tool + a typed output schema, a build-gated `validate-mcp` assertion (happy path when the artifact is staged, `not_found` guard when cold), the MCP server/registry version bump to 1.21.0 with the pinned version assertion updated, and unit tests for the populated and missing-artifact paths.

`npm run validate:mcp` passes (81 tools); the full `mcp-server` + `global-operational-health` suites pass.