### PR TITLE
feat(mcp): add get_source_snapshots tool mirroring the source-snapshots route

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -384,6 +384,11 @@ assert.ok(
   Array.isArray(metaValidators.neurons),
   "get_subnet_metagraph (validator_permit) must return neurons[]",
 );
+const sourceSnaps = await callOk("get_source_snapshots", {});
+assert.ok(
+  Array.isArray(sourceSnaps.sources),
+  "get_source_snapshots must return sources[]",
+);
 const vals = await callOk("list_subnet_validators", { netuid: 7 });
 assert.ok(
   Array.isArray(vals.validators),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -192,7 +192,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.20.0";
+export const MCP_SERVER_VERSION = "1.21.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -1893,6 +1893,28 @@ export const MCP_TOOLS = [
     },
     async handler(_args, ctx) {
       return loadChainPerformance(mcpD1Runner(ctx));
+    },
+  },
+  {
+    name: "get_source_snapshots",
+    title: "Get canonical source input hashes & counts",
+    description:
+      "Fetch the provenance snapshot of the canonical source inputs the " +
+      "pipeline ingested: for each source its stable id, kind " +
+      "(adapter-snapshot, candidate-discovery, native-chain, probe-results, " +
+      "registry-manifest, or review-ledger), the 64-hex content hash, the " +
+      "capture timestamp, the storage path, and the record_count — plus a " +
+      "summary rolling up source_count, provider_count, candidate_count, " +
+      "overlay_count, adapter_snapshot_count, and verification_result_count. " +
+      "Use it to audit exactly which inputs a build derived from and detect " +
+      "when an upstream hash changed. Mirrors GET /api/v1/source-snapshots.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadArtifactData(ctx, "/metagraph/source-snapshots.json");
     },
   },
   {
@@ -5267,6 +5289,36 @@ const TOOL_OUTPUT_SCHEMAS = {
       trust: { type: ["object", "null"] },
       consensus: { type: ["object", "null"] },
       validator_trust: { type: ["object", "null"] },
+    },
+  },
+  get_source_snapshots: {
+    type: "object",
+    additionalProperties: true,
+    required: ["sources", "summary"],
+    properties: {
+      schema_version: { type: "integer" },
+      generated_at: NULLABLE_STRING,
+      content_hash: NULLABLE_STRING,
+      sources: objectItems({
+        id: { type: "string" },
+        kind: { type: "string" },
+        hash: { type: "string" },
+        captured_at: { type: "string" },
+        path: { type: "string" },
+        record_count: { type: "integer" },
+      }),
+      summary: {
+        type: "object",
+        additionalProperties: true,
+        properties: {
+          source_count: NULLABLE_INT,
+          provider_count: NULLABLE_INT,
+          candidate_count: NULLABLE_INT,
+          overlay_count: NULLABLE_INT,
+          adapter_snapshot_count: NULLABLE_INT,
+          verification_result_count: NULLABLE_INT,
+        },
+      },
     },
   },
   get_subnet_concentration_history: {

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.20.0");
+    assert.equal(MCP_SERVER_VERSION, "1.21.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5683,6 +5683,38 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.validator_trust.count, 1);
   });
 
+  test("get_source_snapshots returns the source provenance artifact", async () => {
+    const snapDeps = makeDeps({
+      "/metagraph/source-snapshots.json": {
+        schema_version: 1,
+        sources: [
+          {
+            id: "native-chain",
+            kind: "native-chain",
+            hash: "a".repeat(64),
+            captured_at: "2026-01-01T00:00:00Z",
+            path: "/metagraph/native.json",
+            record_count: 42,
+          },
+        ],
+        summary: {
+          source_count: 1,
+          provider_count: 1,
+          candidate_count: 0,
+          overlay_count: 0,
+          adapter_snapshot_count: 0,
+          verification_result_count: 0,
+        },
+      },
+    });
+    const res = await callTool("get_source_snapshots", {}, { deps: snapDeps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.sources.length, 1);
+    assert.equal(out.sources[0].kind, "native-chain");
+    assert.equal(out.sources[0].record_count, 42);
+    assert.equal(out.summary.source_count, 1);
+  });
+
   test("get_subnet_concentration_history defaults to 30d and returns points", async () => {
     const res = await callTool(
       "get_subnet_concentration_history",


### PR DESCRIPTION
Exposes the canonical source-input provenance snapshot (GET /api/v1/source-snapshots) as an MCP tool: for each ingested source its id, kind, 64-hex content hash, capture timestamp, storage path, and record_count — plus the summary rollup (source/provider/candidate/overlay/adapter-snapshot/verification-result counts). Lets an agent audit which inputs a build derived from and detect upstream hash drift. Registers the tool + output schema, a validate-mcp smoke assertion, the MCP server version bump, and a unit test.

Self-contained: reuses the existing loadArtifactData reader; no schema regeneration.