### PR TITLE
fix(movers): reject blank netuid cells that coerce to subnet 0

### DIFF
--- a/src/account-stake-flow.mjs
+++ b/src/account-stake-flow.mjs
@@ -43,8 +43,10 @@ function toNumber(value) {
 
 // A non-negative integer netuid, or null for a malformed/absent cell. Guard null
 // explicitly so a null netuid is skipped rather than coerced to subnet 0 (Number(null) === 0).
+// Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only (#2813 parity).
 function normalizedNetuid(value) {
   if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const netuid = Number(value);
   return Number.isSafeInteger(netuid) && netuid >= 0 ? netuid : null;
 }

--- a/src/movers.mjs
+++ b/src/movers.mjs
@@ -33,8 +33,11 @@ function toNumber(value) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-// A non-negative integer netuid, or null for a malformed cell.
+// A non-negative integer netuid, or null for a malformed cell. Blank D1 cells coerce
+// via Number("") → 0; trim rejects "" / whitespace-only before coercion (#2813 parity).
 function normalizedNetuid(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const netuid = Number(value);
   return Number.isSafeInteger(netuid) && netuid >= 0 ? netuid : null;
 }

--- a/tests/account-stake-flow.test.mjs
+++ b/tests/account-stake-flow.test.mjs
@@ -71,6 +71,28 @@ describe("buildAccountStakeFlow", () => {
     assert.equal(d.subnet_count, 2);
   });
 
+  test("skips blank and whitespace-only netuid rows (does not coerce to subnet 0)", () => {
+    const d = buildAccountStakeFlow(
+      [
+        added(7, 100),
+        row("", STAKE_ADDED_KIND, 50, 1, 1000),
+        row("   ", STAKE_REMOVED_KIND, 25, 1, 1000),
+      ],
+      ADDR,
+    );
+    assert.equal(d.subnet_count, 1);
+    assert.equal(d.subnets.length, 1);
+    assert.equal(d.subnets[0].netuid, 7);
+    assert.equal(d.total_staked_tao, 100);
+  });
+
+  test("counts root subnet (netuid 0) when explicitly present", () => {
+    const d = buildAccountStakeFlow([added(0, 10), added("0", 5)], ADDR);
+    assert.equal(d.subnet_count, 1);
+    assert.equal(d.subnets[0].netuid, 0);
+    assert.equal(d.subnets[0].staked_tao, 15);
+  });
+
   test("classifies direction by the net/gross lean", () => {
     // accumulating: net>0 past the ratio
     assert.equal(

--- a/tests/movers.test.mjs
+++ b/tests/movers.test.mjs
@@ -196,6 +196,53 @@ describe("computeMovers", () => {
     assert.equal(m[0].stake_delta_tao, 50);
   });
 
+  test("skips blank and whitespace-only netuid cells (does not coerce to subnet 0)", () => {
+    const m = computeMovers(
+      [
+        agg(7, "s", { neurons: 1, validators: 0, stake: 100, emission: 0 }),
+        {
+          netuid: "",
+          snapshot_date: "s",
+          neuron_count: 1,
+          validator_count: 0,
+          total_stake_tao: 50,
+          total_emission_tao: 0,
+        },
+        {
+          netuid: "   ",
+          snapshot_date: "s",
+          neuron_count: 1,
+          validator_count: 0,
+          total_stake_tao: 25,
+          total_emission_tao: 0,
+        },
+      ],
+      [agg(7, "e", { neurons: 1, validators: 0, stake: 110, emission: 0 })],
+      { sort: "stake" },
+    );
+    assert.equal(m.length, 1);
+    assert.equal(m[0].netuid, 7);
+  });
+
+  test("counts root subnet (netuid 0) when explicitly present", () => {
+    const m = computeMovers(
+      [
+        agg(0, "s", { neurons: 1, validators: 0, stake: 10, emission: 0 }),
+        agg("0", "s", { neurons: 1, validators: 0, stake: 5, emission: 0 }),
+        agg(7, "s", { neurons: 1, validators: 0, stake: 1, emission: 0 }),
+      ],
+      [
+        agg(0, "e", { neurons: 1, validators: 0, stake: 12, emission: 0 }),
+        agg(7, "e", { neurons: 1, validators: 0, stake: 2, emission: 0 }),
+      ],
+      { sort: "stake" },
+    );
+    assert.deepEqual(
+      m.map((x) => x.netuid),
+      [0, 7],
+    );
+  });
+
   test("non-array inputs yield an empty ranking", () => {
     assert.deepEqual(computeMovers(null, undefined, { sort: "stake" }), []);
   });


### PR DESCRIPTION
## Summary

Blank `netuid` strings from D1 coerce via `Number("")` to **subnet 0**, attributing malformed rollup rows to the root subnet. This inflated `GET /api/v1/subnets/movers` rankings and per-account stake-flow scorecards with phantom root-subnet activity.

#2813 fixed the same coercion bug in `chain-performance` and `concentration`; `movers` and `account-stake-flow` still lacked the guard.

## Root cause

`normalizedNetuid()` only checked `Number.isSafeInteger` after coercion. Empty / whitespace-only strings pass as integer **0** before the guard runs.

## Fix approach

Trim-reject `""` and whitespace-only strings before `Number()` coercion. Explicit `0` / `"0"` still counts as root subnet.

## Why this matters

The movers leaderboard is a public REST + MCP surface (`get_subnet_movers`). A single bad D1 cell must be dropped, not mis-bucketed as SN0 — same contract as #2813.

## Testing

- [x] `npx vitest run tests/movers.test.mjs tests/account-stake-flow.test.mjs` (56/56)
- [x] `npm run lint`
- [x] New: blank / whitespace netuid rows skipped; explicit netuid 0 preserved

## Risks / tradeoffs

- None for valid data. Only malformed blank cells change behavior (dropped instead of counted as SN0).
