### PR TITLE
fix(adapters): pin redirect:manual on fetchSseSummary egress

### DIFF
--- a/scripts/snapshot-adapters.mjs
+++ b/scripts/snapshot-adapters.mjs
@@ -672,7 +672,7 @@ export async function fetchJson(url, redirectCount = 0) {
   }
 }
 
-async function fetchSseSummary(url) {
+export async function fetchSseSummary(url, redirectCount = 0) {
   if (await isUnsafeResolvedUrl(url)) {
     return {
       status: "unsafe",
@@ -691,8 +691,33 @@ async function fetchSseSummary(url) {
         accept: "text/event-stream",
         "user-agent": "metagraphed-adapter-snapshot/0.0",
       },
+      // Never auto-follow redirects: validate each hop with isUnsafeResolvedUrl
+      // before connecting, mirroring fetchJson in this module.
+      redirect: "manual",
       signal: controller.signal,
     });
+    const location = response.headers.get("location");
+    if (
+      [301, 302, 303, 307, 308].includes(response.status) &&
+      location &&
+      redirectCount < 5
+    ) {
+      const redirectTarget = new URL(location, url).toString();
+      if (await isUnsafeResolvedUrl(redirectTarget)) {
+        await response.body?.cancel?.();
+        return {
+          status: "unsafe",
+          url,
+          error: "redirect target is unsafe",
+          private_redirect_blocked: true,
+          status_code: response.status,
+          latency_ms: Math.round(performance.now() - started),
+          captured_at: new Date().toISOString(),
+        };
+      }
+      await response.body?.cancel?.();
+      return fetchSseSummary(redirectTarget, redirectCount + 1);
+    }
     let firstChunkBytes = 0;
     if (response.body) {
       const reader = response.body.getReader();

--- a/tests/adapter-snapshot-security.test.mjs
+++ b/tests/adapter-snapshot-security.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, test } from "vitest";
-import { fetchJson } from "../scripts/snapshot-adapters.mjs";
+import { fetchJson, fetchSseSummary } from "../scripts/snapshot-adapters.mjs";
 
 const originalFetch = globalThis.fetch;
 
@@ -50,6 +50,57 @@ describe("adapter snapshot fetch redirect safety", () => {
     assert.deepEqual(
       fetchCalls.map((call) => call.url),
       ["http://1.1.1.1/openapi.json", "http://1.0.0.1/openapi.json"],
+    );
+    assert.equal(
+      fetchCalls.every((call) => call.init.redirect === "manual"),
+      true,
+    );
+  });
+});
+
+describe("adapter snapshot SSE fetch redirect safety", () => {
+  test("blocks redirects from public SSE URLs to private addresses", async () => {
+    const fetchCalls = [];
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ init, url: String(url) });
+      return new Response(null, {
+        status: 302,
+        headers: { location: "http://127.0.0.1/sse" },
+      });
+    };
+
+    const result = await fetchSseSummary("http://1.1.1.1/sse");
+
+    assert.equal(result.status, "unsafe");
+    assert.equal(result.private_redirect_blocked, true);
+    assert.equal(result.error, "redirect target is unsafe");
+    assert.equal(fetchCalls.length, 1);
+    assert.equal(fetchCalls[0].init.redirect, "manual");
+  });
+
+  test("follows safe SSE redirects while keeping redirects manual", async () => {
+    const fetchCalls = [];
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ init, url: String(url) });
+      if (fetchCalls.length === 1) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "http://1.0.0.1/sse" },
+        });
+      }
+      return new Response("event: ping\ndata: {}\n\n", {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    };
+
+    const result = await fetchSseSummary("http://1.1.1.1/sse");
+
+    assert.equal(result.status, "captured");
+    assert.equal(result.first_chunk_bytes > 0, true);
+    assert.deepEqual(
+      fetchCalls.map((call) => call.url),
+      ["http://1.1.1.1/sse", "http://1.0.0.1/sse"],
     );
     assert.equal(
       fetchCalls.every((call) => call.init.redirect === "manual"),


### PR DESCRIPTION
## Summary

`fetchSseSummary` in the adapter snapshot pipeline used default `fetch` redirect following while the sibling `fetchJson` helper in the same module pins `redirect: "manual"` and re-validates every hop with `isUnsafeResolvedUrl`. A public SSE URL returning `302 Location: http://169.254.169.254/...` would have been followed during scheduled publish / CI adapter snapshots.

## Root cause

`fetchSseSummary` was added without the redirect guard that `fetchJson` already documents and tests (`adapter-snapshot-security.test.mjs`).

## Fix approach

- Export `fetchSseSummary` for direct regression testing.
- Add `redirect: "manual"` and the same bounded manual redirect loop as `fetchJson`: block unsafe targets (`private_redirect_blocked`), follow safe public hops (max 5).

## Why this matters

Adapter snapshots run in CI/publish with outbound network access. Redirect following bypasses the URL that passed the initial SSRF guard — same invariant as #2100 / ADR 0004 redirect hardening.

## Testing

- [x] `npx vitest run tests/adapter-snapshot-security.test.mjs` (6/6)
- [x] `npm run lint`
- [x] New: SSE redirect blocked to private address; safe redirect followed with `redirect:manual`

## Risks / tradeoffs

- If an SSE endpoint legitimately requires a redirect to another public host, the manual loop still follows it (same as `fetchJson`). Unsafe redirects fail closed with `status: "unsafe"`.
