### PR TITLE
fix(backfill): report inserted from D1 meta.changes not rows.length

### DIFF
--- a/tests/economics-backfill.test.mjs
+++ b/tests/economics-backfill.test.mjs
@@ -40,6 +40,7 @@ function dbCapture(captured) {
     },
     async batch(stmts) {
       captured.push(stmts);
+      return stmts.map(() => ({ meta: { changes: 1 } }));
     },
   };
 }
@@ -106,6 +107,26 @@ test("economics backfill upserts valid rows + filters invalid (200, parameterize
     /alpha_price_tao = COALESCE\(subnet_snapshots\.alpha_price_tao, excluded\.alpha_price_tao\)/,
   );
   assert.deepEqual(first.v, [8, "2025-12-01", 0.030678787, 1700000000000]);
+});
+
+test("economics backfill reports inserted:0 on idempotent re-upsert (meta.changes)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return { bind: (...v) => ({ sql, v }) };
+      },
+      async batch(stmts) {
+        return stmts.map(() => ({ meta: { changes: 0 } }));
+      },
+    },
+  };
+  const res = await handleEconomicsBackfill(
+    post([row(), row({ netuid: 9 })], { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).inserted, 0);
 });
 
 test("economics backfill accepts the {rows:[...]} envelope + no-ops on empty", async () => {

--- a/tests/neuron-backfill.test.mjs
+++ b/tests/neuron-backfill.test.mjs
@@ -50,6 +50,7 @@ function dbCapture(captured) {
     },
     async batch(stmts) {
       captured.push(stmts.length);
+      return stmts.map(() => ({ meta: { changes: 1 } }));
     },
   };
 }
@@ -101,6 +102,26 @@ test("backfill upserts valid rows + filters invalid (200, parameterized)", async
   assert.equal(body.received, 5);
   assert.equal(body.inserted, 2);
   assert.deepEqual(captured, [2]); // one batch of the 2 valid rows
+});
+
+test("backfill reports inserted:0 on idempotent re-upsert (meta.changes)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return { bind: (...v) => ({ sql, v }) };
+      },
+      async batch(stmts) {
+        return stmts.map(() => ({ meta: { changes: 0 } }));
+      },
+    },
+  };
+  const res = await handleNeuronBackfill(
+    post([row(), row({ uid: 2 })], { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).inserted, 0);
 });
 
 test("backfill accepts the {rows:[...]} envelope + no-ops on empty", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -648,14 +648,18 @@ export async function handleNeuronBackfill(request, env) {
     );
   }
   const rows = validNeuronDailyRows(incoming);
+  // Sum D1 meta.changes so idempotent re-upserts report inserted:0 instead of
+  // rows.length (mirrors handleEventIngest / handleBlockIngest).
+  let inserted = 0;
   if (rows.length) {
-    await db.batch(neuronDailyUpsertStatements(db, rows));
+    const results = await db.batch(neuronDailyUpsertStatements(db, rows));
+    for (const result of results) inserted += result?.meta?.changes ?? 0;
   }
   return new Response(
     JSON.stringify({
       ok: true,
       received: incoming.length,
-      inserted: rows.length,
+      inserted,
     }),
     { status: 200, headers: { "content-type": JSON_CONTENT_TYPE } },
   );
@@ -736,14 +740,16 @@ export async function handleEconomicsBackfill(request, env) {
     );
   }
   const rows = validEconomicsBackfillRows(incoming);
+  let inserted = 0;
   if (rows.length) {
-    await db.batch(economicsSnapshotUpsertStatements(db, rows));
+    const results = await db.batch(economicsSnapshotUpsertStatements(db, rows));
+    for (const result of results) inserted += result?.meta?.changes ?? 0;
   }
   return new Response(
     JSON.stringify({
       ok: true,
       received: incoming.length,
-      inserted: rows.length,
+      inserted,
     }),
     { status: 200, headers: { "content-type": JSON_CONTENT_TYPE } },
   );


### PR DESCRIPTION
## Summary

Neuron and economics backfill handlers returned `inserted: rows.length`, counting validated rows rather than rows actually written. Idempotent re-POSTs of the same upsert payload reported a full insert count even when D1 applied zero changes.

`handleEventIngest` and `handleBlockIngest` already sum `result.meta.changes` for this reason.

## Fix approach

Sum `meta.changes` across the batch for both `handleNeuronBackfill` and `handleEconomicsBackfill`.

## Testing

- [x] `npx vitest run tests/neuron-backfill.test.mjs tests/economics-backfill.test.mjs` (28/28)
- [x] `npm run lint`
- [x] New: idempotent re-upsert reports `inserted: 0` when `meta.changes` is 0
