### PR TITLE
fix(verify): pin redirect:manual on GitHub API fetch egress

### DIFF
--- a/scripts/verification-github-fetch.mjs
+++ b/scripts/verification-github-fetch.mjs
@@ -1,0 +1,61 @@
+import { isUnsafeResolvedUrl } from "./lib.mjs";
+
+// SSRF-safe GitHub API GET for candidate verification. Mirrors probeUrl /
+// snapshot-adapters fetchJson: `redirect: "manual"` plus an explicit hop loop so
+// a public github.com URL cannot auto-follow into a private redirect target.
+export async function fetchGithubJson(url, headers = {}, redirectCount = 0) {
+  if (await isUnsafeResolvedUrl(url)) {
+    return {
+      ok: false,
+      error: "unsafe URL",
+      unsafe_url: true,
+    };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 12000);
+  try {
+    const response = await fetch(url, {
+      headers: {
+        accept: "application/vnd.github+json",
+        "user-agent": "metagraphed-candidate-verifier/0.0",
+        ...headers,
+      },
+      redirect: "manual",
+      signal: controller.signal,
+    });
+    const location = response.headers.get("location");
+    if (
+      [301, 302, 303, 307, 308].includes(response.status) &&
+      location &&
+      redirectCount < 5
+    ) {
+      const redirectTarget = new URL(location, url).toString();
+      if (await isUnsafeResolvedUrl(redirectTarget)) {
+        await response.body?.cancel();
+        return {
+          ok: false,
+          error: "redirect target is unsafe",
+          private_redirect_blocked: true,
+          status_code: response.status,
+        };
+      }
+      await response.body?.cancel();
+      return fetchGithubJson(redirectTarget, headers, redirectCount + 1);
+    }
+
+    const text = await response.text();
+    return {
+      ok: response.ok,
+      body: text ? JSON.parse(text) : null,
+      status_code: response.status,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error.message,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/scripts/verify-candidates.mjs
+++ b/scripts/verify-candidates.mjs
@@ -22,6 +22,7 @@ import {
   optionalHttpStatus,
   preservePreviousGithubMetadata,
 } from "./verification-quality.mjs";
+import { fetchGithubJson } from "./verification-github-fetch.mjs";
 
 const args = new Set(process.argv.slice(2));
 const shouldWrite = args.has("--write");
@@ -223,7 +224,7 @@ function stripNullish(value) {
 
 async function verifyGithubRepo(base, repo) {
   const apiUrl = `https://api.github.com/repos/${repo.owner}/${repo.repo}`;
-  const api = await fetchJson(apiUrl, githubHeaders());
+  const api = await fetchGithubJson(apiUrl, githubHeaders());
   if (api.ok) {
     return githubMetadataResult(base, apiUrl, api.body, {
       classification: "live",
@@ -249,7 +250,7 @@ async function verifyGithubRepo(base, repo) {
   const redirectedRepo = parseGithubRepo(fallback.redirect_target);
   if (redirectedRepo) {
     const redirectApiUrl = `https://api.github.com/repos/${redirectedRepo.owner}/${redirectedRepo.repo}`;
-    const redirectApi = await fetchJson(redirectApiUrl, githubHeaders());
+    const redirectApi = await fetchGithubJson(redirectApiUrl, githubHeaders());
     if (redirectApi.ok) {
       return githubMetadataResult(base, redirectApiUrl, redirectApi.body, {
         api_error: api.error || null,
@@ -447,34 +448,6 @@ async function probeUrl(url, method, accept, redirectCount = 0) {
       error_class: error.name,
       latency_ms: Math.round(performance.now() - started),
       method_tested: method,
-    };
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-async function fetchJson(url, headers = {}) {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 12000);
-  try {
-    const response = await fetch(url, {
-      headers: {
-        accept: "application/vnd.github+json",
-        "user-agent": "metagraphed-candidate-verifier/0.0",
-        ...headers,
-      },
-      signal: controller.signal,
-    });
-    const text = await response.text();
-    return {
-      ok: response.ok,
-      body: text ? JSON.parse(text) : null,
-      status_code: response.status,
-    };
-  } catch (error) {
-    return {
-      ok: false,
-      error: error.message,
     };
   } finally {
     clearTimeout(timer);

--- a/tests/verification-github-fetch.test.mjs
+++ b/tests/verification-github-fetch.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "vitest";
+import { fetchGithubJson } from "../scripts/verification-github-fetch.mjs";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("verification GitHub fetch redirect safety", () => {
+  test("blocks redirects from public GitHub URLs to private addresses", async () => {
+    const fetchCalls = [];
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ init, url: String(url) });
+      return new Response(null, {
+        status: 302,
+        headers: { location: "http://127.0.0.1/repos/foo/bar" },
+      });
+    };
+
+    const result = await fetchGithubJson("https://api.github.com/repos/foo/bar");
+
+    assert.equal(result.ok, false);
+    assert.equal(result.private_redirect_blocked, true);
+    assert.equal(result.error, "redirect target is unsafe");
+    assert.equal(fetchCalls.length, 1);
+    assert.equal(fetchCalls[0].init.redirect, "manual");
+  });
+
+  test("follows safe redirects while keeping redirects manual", async () => {
+    const fetchCalls = [];
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ init, url: String(url) });
+      if (fetchCalls.length === 1) {
+        return new Response(null, {
+          status: 302,
+          headers: {
+            location: "https://api.github.com/repos/foo/bar/redirected",
+          },
+        });
+      }
+      return Response.json({ full_name: "foo/bar" });
+    };
+
+    const result = await fetchGithubJson("https://api.github.com/repos/foo/bar");
+
+    assert.equal(result.ok, true);
+    assert.equal(result.body.full_name, "foo/bar");
+    assert.deepEqual(
+      fetchCalls.map((call) => call.url),
+      [
+        "https://api.github.com/repos/foo/bar",
+        "https://api.github.com/repos/foo/bar/redirected",
+      ],
+    );
+    assert.equal(
+      fetchCalls.every((call) => call.init.redirect === "manual"),
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `fetchGithubJson` with `redirect: "manual"` and unsafe-redirect blocking for GitHub API calls in candidate verification.
- `probeUrl` already had manual redirect handling; `fetchJson` did not, so a compromised redirect on a GitHub metadata fetch could bypass the SSRF guard.
- Mirrors the pattern merged in #2100 and used by `snapshot-adapters.mjs` / `fetchSseSummary` (#2862).

## Test plan
- [x] `npx vitest run tests/verification-github-fetch.test.mjs`
- [x] `npm run lint`
