### PR TITLE
fix(yield): reject blank uid cells that coerce to uid 0

### DIFF
--- a/src/subnet-yield.mjs
+++ b/src/subnet-yield.mjs
@@ -25,6 +25,8 @@ function toNumber(value) {
 // so guard null explicitly rather than coercing it to uid 0).
 function normalizedUid(value) {
   if (value == null) return null;
+  // D1 can surface a blank TEXT uid as ""; Number("") === 0 would fabricate uid 0.
+  if (typeof value === "string" && value.trim() === "") return null;
   const uid = Number(value);
   return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
 }

--- a/tests/subnet-yield.test.mjs
+++ b/tests/subnet-yield.test.mjs
@@ -179,6 +179,22 @@ describe("buildSubnetYield", () => {
     assert.equal(d.captured_at, null);
   });
 
+  test("skips blank uid cells that would coerce to uid 0", () => {
+    const d = buildSubnetYield(
+      [
+        { ...neuron(1, { stake: 5, emission: 1 }), uid: "" },
+        { ...neuron(2, { stake: 3, emission: 1 }), uid: "   " },
+        neuron(0, { validator: true, stake: 10, emission: 1 }),
+      ],
+      7,
+    );
+    assert.equal(d.neuron_count, 1);
+    assert.deepEqual(
+      d.neurons.map((row) => row.uid),
+      [0],
+    );
+  });
+
   test("drops blank or out-of-range captured_at strings to null", () => {
     for (const captured of ["", "   ", "not-a-date", "8640000000000001"]) {
       const d = buildSubnetYield(


### PR DESCRIPTION
## Summary
- Reject blank/whitespace `uid` cells in `buildSubnetYield` before `Number()` coercion.
- `Number("") === 0` would otherwise fabricate uid 0 and pollute the yield leaderboard with a phantom neuron row.
- Parity with merged #2813 (blank netuid guard) and the trim guard in `concentration.mjs` / `neuron-history.mjs`.

## Test plan
- [x] `npx vitest run tests/subnet-yield.test.mjs`
- [x] `npm run lint`
