### PR TITLE
fix(health): reject blank netuid cells in bulk trends matrix

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -366,7 +366,9 @@ export function formatBulkTrends({ observedAt, windows, windowDays = {} }) {
   const formatWindow = (rows, days) => {
     const bySubnet = new Map();
     for (const row of rows || []) {
-      const netuid = Number(row.netuid);
+      const rawNetuid = row.netuid;
+      if (typeof rawNetuid === "string" && rawNetuid.trim() === "") continue;
+      const netuid = Number(rawNetuid);
       const date = String(row.date || "");
       if (
         !Number.isInteger(netuid) ||

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -953,6 +953,21 @@ describe("formatBulkTrends", () => {
     assert.deepEqual(out.windows["7d"].subnets, []);
   });
 
+  test("skips blank netuid cells that would coerce to subnet 0", () => {
+    const out = formatBulkTrends({
+      windows: {
+        "7d": [
+          { netuid: "", date: "2026-06-10", total: 4, ok_count: 2 },
+          { netuid: "   ", date: "2026-06-10", total: 3, ok_count: 1 },
+          { netuid: 7, date: "2026-06-10", total: 10, ok_count: 8 },
+        ],
+      },
+      windowDays: { "7d": 7 },
+    });
+    assert.equal(out.windows["7d"].subnet_count, 1);
+    assert.deepEqual(out.windows["7d"].subnets.map((row) => row.netuid), [7]);
+  });
+
   test("covers zero-sample and omitted-window fallback branches", () => {
     const empty = formatBulkTrends({});
     assert.deepEqual(empty.windows, {});


### PR DESCRIPTION
## Summary
- Skip blank/whitespace `netuid` cells in `formatBulkTrends` before `Number()` coercion.
- `Number("") === 0` would otherwise attribute corrupt D1 rollup rows to subnet 0 in the bulk health trends matrix.
- Parity with merged #2813 and the trim guard in `concentration.mjs` / `chain-performance.mjs`.

## Test plan
- [x] `npx vitest run tests/health-serving.test.mjs -t formatBulkTrends`
- [x] `npm run lint`
