### PR TITLE
fix(turnover): reject blank uid cells that coerce to uid 0

### DIFF
--- a/src/turnover.mjs
+++ b/src/turnover.mjs
@@ -54,6 +54,7 @@ function validatorHotkeys(rows) {
 
 function normalizedUid(value) {
   if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const uid = Number(value);
   return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
 }

--- a/tests/turnover.test.mjs
+++ b/tests/turnover.test.mjs
@@ -525,6 +525,29 @@ describe("buildTurnover — invariants", () => {
 });
 
 describe("buildTurnover — regressions", () => {
+  test("skips blank uid cells that would coerce to uid 0", () => {
+    const rows = [
+      {
+        snapshot_date: "2026-05-01",
+        uid: "",
+        hotkey: "ghost",
+        validator_permit: 0,
+      },
+      {
+        snapshot_date: "2026-05-01",
+        uid: 0,
+        hotkey: "real",
+        validator_permit: 0,
+      },
+    ];
+    const data = buildTurnover(rows, 1, {
+      window: "30d",
+      startDate: "2026-05-01",
+      endDate: "2026-05-01",
+    });
+    assert.equal(data.neurons_start, 1);
+  });
+
   test("a validator that moves UID slot but keeps its hotkey is retained (keyed by hotkey)", () => {
     const rows = [
       {


### PR DESCRIPTION
## Summary
- Reject blank/whitespace `uid` cells in turnover snapshot shaping before `Number()` coercion.
- `Number("") === 0` would otherwise fabricate uid 0 and skew neuron retention/churn metrics.

## Test plan
- [x] `npx vitest run tests/turnover.test.mjs`
