### PR TITLE
fix(health): reject blank netuid cells in global incidents ledger

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -680,7 +680,9 @@ export function formatGlobalIncidents({
     if (acceptedIncidents >= incidentLimit) {
       break;
     }
-    const netuid = Number(row.netuid);
+    const rawNetuid = row.netuid;
+    if (typeof rawNetuid === "string" && rawNetuid.trim() === "") continue;
+    const netuid = Number(rawNetuid);
     const key = `${netuid}/${surfaceLookupKey(row)}`;
     const entry = bySurface.get(key) || {
       netuid,

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -2974,6 +2974,29 @@ describe("formatGlobalIncidents (cross-subnet ledger)", () => {
     });
     assert.equal(capped.summary.incident_count, 1);
   });
+
+  test("skips blank netuid cells that would coerce to subnet 0", () => {
+    const out = formatGlobalIncidents({
+      incidentRows: [
+        {
+          netuid: "",
+          surface_id: "a",
+          started_at: 1,
+          ended_at: 2,
+          failed_samples: 1,
+        },
+        {
+          netuid: 7,
+          surface_id: "b",
+          started_at: 3,
+          ended_at: 4,
+          failed_samples: 1,
+        },
+      ],
+    });
+    assert.equal(out.surfaces.length, 1);
+    assert.equal(out.surfaces[0].netuid, 7);
+  });
 });
 
 describe("global incidents route", () => {


### PR DESCRIPTION
## Summary
- Skip blank/whitespace `netuid` cells in `formatGlobalIncidents` before `Number()` coercion.
- Corrupt D1 incident rows would otherwise attribute downtime to subnet 0 in the cross-subnet incidents feed.

## Test plan
- [x] `npx vitest run tests/health-serving.test.mjs -t formatGlobalIncidents`
