### PR TITLE
fix(health-prober): guard utcDayBounds against out-of-range epochs

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -682,10 +682,14 @@ async function persistToKv(kv, probed, runAt) {
 
 // UTC day bounds for a given epoch-ms instant: { date: "YYYY-MM-DD", start, end }.
 function utcDayBounds(ms) {
+  if (!Number.isFinite(ms)) return null;
   const d = new Date(ms);
+  if (!Number.isFinite(d.getTime())) return null;
   const start = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  const startDate = new Date(start);
+  if (!Number.isFinite(startDate.getTime())) return null;
   return {
-    date: new Date(start).toISOString().slice(0, 10),
+    date: startDate.toISOString().slice(0, 10),
     start,
     end: start + 24 * 60 * 60 * 1000,
   };
@@ -704,7 +708,12 @@ export async function rollupDailyUptime(env, overrides = {}) {
   const db = overrides.db || env.METAGRAPH_HEALTH_DB;
   if (!db?.prepare) return { rolled: false };
   const runAt = now();
-  const days = [utcDayBounds(runAt), utcDayBounds(runAt - 24 * 60 * 60 * 1000)];
+  const days = [utcDayBounds(runAt), utcDayBounds(runAt - 24 * 60 * 60 * 1000)].filter(
+    Boolean,
+  );
+  if (!days.length) {
+    return { rolled: false, error: "invalid run timestamp" };
+  }
   const conflictColumns = `
        surface_id = excluded.surface_id,
        surface_key = excluded.surface_key,

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -1904,6 +1904,23 @@ describe("rollupDailyUptime (durable daily history)", () => {
     assert.deepEqual(await rollupDailyUptime({}), { rolled: false });
   });
 
+  test("returns rolled:false when run timestamp is out of JS Date range", async () => {
+    const db = {
+      prepare: () => ({ bind: () => ({}) }),
+      async batch() {
+        throw new Error("batch should not run");
+      },
+    };
+    const result = await rollupDailyUptime(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => Number.NaN },
+    );
+    assert.deepEqual(result, {
+      rolled: false,
+      error: "invalid run timestamp",
+    });
+  });
+
   test("degrades to { rolled: false } when the batch write throws", async () => {
     const db = {
       prepare: () => ({ bind: () => ({}) }),


### PR DESCRIPTION
## Summary
- Guard `utcDayBounds()` with `getTime()` range checks before emitting day labels.
- Skip the daily uptime rollup when the cron run timestamp is non-finite, instead of throwing `RangeError` during `toISOString()`.

## Test plan
- [x] `npx vitest run tests/health-prober.test.mjs -t rollupDailyUptime`
