### PR TITLE
fix(events): guard utcDayBounds and blank netuid cells

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -103,6 +103,7 @@ function toIso(ms) {
 // missing, non-finite, or negative — chain positions are never negative.
 function toBlockNumber(value) {
   if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isInteger(n) && n >= 0 ? n : null;
 }
@@ -149,10 +150,14 @@ export function formatAccountEvent(row) {
 // epoch ms. The rollup re-rolls the two active days each hour (past days are
 // already finalized + unchanged), keyed by these bounds.
 export function utcDayBounds(ms) {
+  if (!Number.isFinite(ms)) return null;
   const d = new Date(ms);
+  if (!Number.isFinite(d.getTime())) return null;
   const start = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  const startDate = new Date(start);
+  if (!Number.isFinite(startDate.getTime())) return null;
   return {
-    date: new Date(start).toISOString().slice(0, 10),
+    date: startDate.toISOString().slice(0, 10),
     start,
     end: start + 24 * 60 * 60 * 1000,
   };
@@ -167,7 +172,12 @@ export async function rollupAccountEventsDaily(env, overrides = {}) {
   const db = overrides.db || env.METAGRAPH_HEALTH_DB;
   if (!db?.prepare) return { rolled: false };
   const runAt = now();
-  const days = [utcDayBounds(runAt), utcDayBounds(runAt - 24 * 60 * 60 * 1000)];
+  const days = [utcDayBounds(runAt), utcDayBounds(runAt - 24 * 60 * 60 * 1000)].filter(
+    Boolean,
+  );
+  if (!days.length) {
+    return { rolled: false, error: "invalid run timestamp" };
+  }
   try {
     const stmt = db.prepare(
       `INSERT INTO account_events_daily

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -281,6 +281,8 @@ test("formatAccountEvent rejects non-integer or negative netuid/uid cells to nul
   assert.equal(formatAccountEvent({ netuid: -1 }).netuid, null);
   assert.equal(formatAccountEvent({ uid: 1.5 }).uid, null);
   assert.equal(formatAccountEvent({ netuid: "abc" }).netuid, null);
+  assert.equal(formatAccountEvent({ netuid: "" }).netuid, null);
+  assert.equal(formatAccountEvent({ netuid: "   " }).netuid, null);
 });
 
 test("formatAccountEvent coerces string-typed amount_tao and alpha_amount cells to Numbers", () => {
@@ -326,6 +328,24 @@ test("utcDayBounds returns the UTC day window", () => {
   assert.equal(b.date, "2026-06-21");
   assert.equal(b.start, Date.UTC(2026, 5, 21));
   assert.equal(b.end - b.start, 86400000);
+});
+
+test("utcDayBounds returns null for non-finite timestamps", () => {
+  assert.equal(utcDayBounds(Number.NaN), null);
+});
+
+test("rollupAccountEventsDaily skips invalid run timestamps", async () => {
+  const db = {
+    prepare: () => ({ bind: () => ({}) }),
+    async batch() {
+      throw new Error("batch should not run");
+    },
+  };
+  const result = await rollupAccountEventsDaily(
+    { METAGRAPH_HEALTH_DB: db },
+    { now: () => Number.NaN },
+  );
+  assert.deepEqual(result, { rolled: false, error: "invalid run timestamp" });
 });
 
 test("rollupAccountEventsDaily rolls today + yesterday via upsert", async () => {


### PR DESCRIPTION
## Summary
- Guard `utcDayBounds()` and skip the account-events daily rollup when the run timestamp is non-finite.
- Reject blank `netuid`/`uid` cells in `toBlockNumber()` so `Number("")` cannot fabricate subnet 0 in event payloads.

## Test plan
- [x] `npx vitest run tests/account-events.test.mjs`
