### PR TITLE
fix(counterparties): reject blank netuid cells that coerce to subnet 0

### DIFF
--- a/src/counterparties.mjs
+++ b/src/counterparties.mjs
@@ -46,6 +46,7 @@ function nullableNumber(value) {
 
 function nullableInteger(value) {
   if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : null;
 }

--- a/tests/counterparties.test.mjs
+++ b/tests/counterparties.test.mjs
@@ -324,6 +324,37 @@ describe("buildCounterpartyRelationship", () => {
     assert.equal(data.transfers[2].amount_tao, 7.5);
   });
 
+  test("drops blank netuid cells that would coerce to subnet 0", () => {
+    const data = buildCounterpartyRelationship(
+      [
+        {
+          block_number: 1,
+          event_index: 0,
+          hotkey: ME,
+          coldkey: "A",
+          netuid: "",
+          amount_tao: 1,
+          observed_at: Date.UTC(2026, 5, 1),
+        },
+        {
+          block_number: 2,
+          event_index: 1,
+          hotkey: ME,
+          coldkey: "A",
+          netuid: 7,
+          amount_tao: 2,
+          observed_at: Date.UTC(2026, 5, 2),
+        },
+      ],
+      ME,
+      "A",
+      {},
+    );
+    assert.equal(data.transfer_count, 2);
+    assert.equal(data.transfers[0].netuid, null);
+    assert.equal(data.transfers[1].netuid, 7);
+  });
+
   test("blank or out-of-range observed_at cells stay null on relationship evidence (not epoch 1970)", () => {
     const data = buildCounterpartyRelationship(
       [


### PR DESCRIPTION
## Summary
- Reject blank/whitespace `netuid` cells in counterparty relationship evidence before `Number()` coercion.
- `Number("") === 0` would otherwise report subnet 0 on transfer drill-down rows.

## Test plan
- [x] `npx vitest run tests/counterparties.test.mjs -t "blank netuid"`
