### PR TITLE
fix(adapters): pin redirect:manual on GitHub HTML HEAD fallback

### DIFF
--- a/scripts/snapshot-adapters.mjs
+++ b/scripts/snapshot-adapters.mjs
@@ -902,26 +902,46 @@ async function fetchGithubRepo(fullName) {
   }
 }
 
+export async function fetchGithubHtmlHead(url, redirectCount = 0) {
+  const response = await fetch(url, {
+    method: "HEAD",
+    headers: {
+      accept: "text/html",
+      "user-agent": "metagraphed-adapter-snapshot/0.0",
+    },
+    redirect: "manual",
+  });
+  const location = response.headers.get("location");
+  if (
+    [301, 302, 303, 307, 308].includes(response.status) &&
+    location &&
+    redirectCount < 5
+  ) {
+    const redirectTarget = new URL(location, url).toString();
+    if (await isUnsafeResolvedUrl(redirectTarget)) {
+      await response.body?.cancel();
+      return { ok: false, private_redirect_blocked: true };
+    }
+    await response.body?.cancel();
+    return fetchGithubHtmlHead(redirectTarget, redirectCount + 1);
+  }
+  return { ok: response.ok, response };
+}
+
 async function githubHtmlFallback(fullName, failure) {
   const started = performance.now();
   try {
-    const response = await fetch(`https://github.com/${fullName}`, {
-      method: "HEAD",
-      headers: {
-        accept: "text/html",
-        "user-agent": "metagraphed-adapter-snapshot/0.0",
-      },
-    });
-    await response.body?.cancel?.();
-    if (!response.ok) {
+    const head = await fetchGithubHtmlHead(`https://github.com/${fullName}`);
+    if (!head.ok) {
       return failure;
     }
+    await head.response.body?.cancel?.();
     return {
       ...failure,
       status: "html-fallback",
       html_url: `https://github.com/${fullName}`,
       fallback_reason: failure.status,
-      fallback_status_code: response.status,
+      fallback_status_code: head.response.status,
       fallback_latency_ms: Math.round(performance.now() - started),
     };
   } catch {

--- a/tests/adapter-snapshot-security.test.mjs
+++ b/tests/adapter-snapshot-security.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, test } from "vitest";
-import { fetchJson } from "../scripts/snapshot-adapters.mjs";
+import { fetchJson, fetchGithubHtmlHead } from "../scripts/snapshot-adapters.mjs";
 
 const originalFetch = globalThis.fetch;
 
@@ -99,5 +99,25 @@ describe("adapter snapshot fetch body limits", () => {
     assert.equal(result.ok, false);
     assert.equal(result.status, "too-large");
     assert.equal(result.max_bytes, 2 * 1024 * 1024);
+  });
+});
+
+describe("adapter snapshot GitHub HEAD redirect safety", () => {
+  test("blocks redirects from github.com to private addresses", async () => {
+    const fetchCalls = [];
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ init, url: String(url) });
+      return new Response(null, {
+        status: 302,
+        headers: { location: "http://127.0.0.1/repo" },
+      });
+    };
+
+    const result = await fetchGithubHtmlHead("https://github.com/foo/bar");
+
+    assert.equal(result.ok, false);
+    assert.equal(result.private_redirect_blocked, true);
+    assert.equal(fetchCalls.length, 1);
+    assert.equal(fetchCalls[0].init.redirect, "manual");
   });
 });

--- a/tests/adapter-snapshot-security.test.mjs
+++ b/tests/adapter-snapshot-security.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, test } from "vitest";
-import { fetchJson, fetchGithubHtmlHead } from "../scripts/snapshot-adapters.mjs";
+import {
+  fetchJson,
+  fetchGithubHtmlHead,
+} from "../scripts/snapshot-adapters.mjs";
 
 const originalFetch = globalThis.fetch;
 


### PR DESCRIPTION
## Summary
- Reject blank/whitespace `netuid` cells in counterparty relationship evidence before `Number()` coercion.
- `Number("") === 0` would otherwise report subnet 0 on transfer drill-down rows.

## Test plan
- [x] `npx vitest run tests/counterparties.test.mjs -t "blank netuid"`
