### PR TITLE
fix(fixtures): block unsafe redirect targets during capture

### DIFF
--- a/scripts/capture-fixtures.mjs
+++ b/scripts/capture-fixtures.mjs
@@ -13,6 +13,7 @@ import {
   flattenSurfaces,
   isJsonContentType,
   isUnsafeUrl,
+  resolveFixtureRedirectTarget,
   resolvePublicUrlAddresses,
   loadSubnets,
   sanitizeFixtureBody,
@@ -80,9 +81,12 @@ async function fetchSample(url, redirectCount = 0) {
       location &&
       redirectCount < 5
     ) {
-      const target = new URL(location, url).toString();
+      const redirect = resolveFixtureRedirectTarget(url, location);
       response.destroy();
-      return fetchSample(target, redirectCount + 1);
+      if (!redirect.ok) {
+        return { ok: false, error: redirect.error };
+      }
+      return fetchSample(redirect.target, redirectCount + 1);
     }
     const contentType = headerValue(response, "content-type") || "";
     const ok = response.statusCode >= 200 && response.statusCode < 300;

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -876,6 +876,18 @@ export function isUnsafeUrl(value) {
   }
 }
 
+export function resolveFixtureRedirectTarget(sourceUrl, location) {
+  try {
+    const target = new URL(location, sourceUrl).toString();
+    if (isUnsafeUrl(target)) {
+      return { ok: false, error: "redirect target is unsafe" };
+    }
+    return { ok: true, target };
+  } catch {
+    return { ok: false, error: "invalid redirect location" };
+  }
+}
+
 export async function resolvePublicUrlAddresses(value, resolver = lookup) {
   try {
     const url = new URL(value);

--- a/tests/fixture-redirect-guard.test.mjs
+++ b/tests/fixture-redirect-guard.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { resolveFixtureRedirectTarget } from "../scripts/lib.mjs";
+
+describe("fixture redirect target guard", () => {
+  test("blocks redirects into private addresses", () => {
+    const result = resolveFixtureRedirectTarget(
+      "https://api.example.com/v1/data",
+      "http://127.0.0.1/private",
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "redirect target is unsafe");
+  });
+
+  test("allows safe public redirect targets", () => {
+    const result = resolveFixtureRedirectTarget(
+      "https://api.example.com/v1/data",
+      "https://cdn.example.com/v1/data",
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.target, "https://cdn.example.com/v1/data");
+  });
+});


### PR DESCRIPTION
## Summary
- Re-validate each fixture-capture redirect Location with isUnsafeUrl before following.
- A public API URL could otherwise 30x into a private address during the refresh pipeline.

## Test plan
- [x] npx vitest run tests/fixture-redirect-guard.test.mjs