### PR TITLE
fix(stake-flow): reject blank netuid cells that coerce to subnet 0

### DIFF
--- a/src/account-stake-flow.mjs
+++ b/src/account-stake-flow.mjs
@@ -45,6 +45,7 @@ function toNumber(value) {
 // explicitly so a null netuid is skipped rather than coerced to subnet 0 (Number(null) === 0).
 function normalizedNetuid(value) {
   if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const netuid = Number(value);
   return Number.isSafeInteger(netuid) && netuid >= 0 ? netuid : null;
 }

--- a/tests/account-stake-flow.test.mjs
+++ b/tests/account-stake-flow.test.mjs
@@ -181,6 +181,18 @@ describe("buildAccountStakeFlow", () => {
     assert.equal(d.stake_events, 0); // undefined event_count -> 0
     assert.equal(d.subnet_count, 1);
   });
+
+  test("skips blank netuid cells that would coerce to subnet 0", () => {
+    const d = buildAccountStakeFlow(
+      [
+        { netuid: "", event_kind: STAKE_ADDED_KIND, total_tao: 5 },
+        { netuid: 7, event_kind: STAKE_ADDED_KIND, total_tao: 3 },
+      ],
+      ADDR,
+    );
+    assert.equal(d.subnet_count, 1);
+    assert.equal(d.subnets[0].netuid, 7);
+  });
 });
 
 describe("loadAccountStakeFlow", () => {


### PR DESCRIPTION
## Summary
- Skip blank netuid cells in account stake-flow shaping before Number() coercion.
- Parity with #2813 / movers blank-netuid guard.

## Test plan
- [x] npx vitest run tests/account-stake-flow.test.mjs