### PR TITLE
fix(health): guard reliability loaders against invalid now timestamps

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1198,6 +1198,9 @@ export async function loadSubnetReliability({
     return null;
   }
   const nowMs = now ? Date.parse(now) : Date.now();
+  if (!Number.isFinite(nowMs)) {
+    return null;
+  }
   const cutoff = new Date(nowMs - windowDays * 24 * 60 * 60 * 1000)
     .toISOString()
     .slice(0, 10);
@@ -1246,6 +1249,9 @@ export async function loadReliabilityAggregate({
     return null;
   }
   const nowMs = now ? Date.parse(now) : Date.now();
+  if (!Number.isFinite(nowMs)) {
+    return null;
+  }
   const cutoff = new Date(nowMs - windowDays * 24 * 60 * 60 * 1000)
     .toISOString()
     .slice(0, 10);

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -2797,6 +2797,17 @@ describe("loadSubnetReliability (D1-backed)", () => {
       null,
     );
   });
+
+  test("returns null when now parses to a non-finite timestamp", async () => {
+    assert.equal(
+      await loadSubnetReliability({
+        db: uptimeDb([]),
+        netuid: 7,
+        now: "not-a-date",
+      }),
+      null,
+    );
+  });
 });
 
 describe("loadReliabilityAggregate (D1-backed, one query for many subnets)", () => {
@@ -2893,6 +2904,17 @@ describe("loadReliabilityAggregate (D1-backed, one query for many subnets)", () 
       await loadReliabilityAggregate({
         db: aggregateDb(null),
         netuids: [7],
+      }),
+      null,
+    );
+  });
+
+  test("returns null when now parses to a non-finite timestamp", async () => {
+    assert.equal(
+      await loadReliabilityAggregate({
+        db: aggregateDb({ samples: 1, ok_count: 1 }),
+        netuids: [7],
+        now: "not-a-date",
       }),
       null,
     );


### PR DESCRIPTION
## Summary
- Return null from loadSubnetReliability / loadReliabilityAggregate when now parses to NaN.
- Prevents RangeError from new Date(NaN).toISOString() on corrupt clock inputs.

## Test plan
- [x] npx vitest run tests/health-serving.test.mjs -t non-finite