### PR TITLE
feat(api): add ?format=csv to the chain-events feed route

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -8524,6 +8524,8 @@ export interface operations {
                 cursor?: string;
                 before?: number;
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the raw all-events feed as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8531,7 +8533,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8584,6 +8586,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainEventsFeedArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,pallet,method,args,phase,extrinsic_index,observed_at
+                     *     8454388,0,System,ExtrinsicSuccess,{},ApplyExtrinsic,2,1719792000000
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5604,6 +5604,17 @@
             "minimum": 1,
             "type": "integer"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the raw all-events feed as text/csv; `json` (default) keeps the response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -20219,6 +20219,19 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the raw all-events feed as text/csv; `json` (default) keeps the response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -20279,9 +20292,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,event_index,pallet,method,args,phase,extrinsic_index,observed_at\r\n8454388,0,System,ExtrinsicSuccess,{},ApplyExtrinsic,2,1719792000000",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -8524,6 +8524,8 @@ export interface operations {
                 cursor?: string;
                 before?: number;
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the raw all-events feed as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -8531,7 +8533,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8584,6 +8586,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainEventsFeedArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,pallet,method,args,phase,extrinsic_index,observed_at
+                     *     8454388,0,System,ExtrinsicSuccess,{},ApplyExtrinsic,2,1719792000000
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2309,24 +2309,36 @@ export const API_ROUTES = [
     "Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs.",
     "short",
     ["chain", "analytics"],
-    [
-      { name: "pallet", schema: { type: "string", maxLength: 64 } },
-      { name: "method", schema: { type: "string", maxLength: 64 } },
-      { name: "block", schema: { type: "integer", minimum: 0 } },
-      { name: "extrinsic", schema: { type: "integer", minimum: 0 } },
-      {
-        name: "cursor",
-        schema: {
-          type: "string",
-          pattern: "^\\d+\\.\\d+$",
-          maxLength: 33,
-          description:
-            "Opaque block_number.event_index cursor returned as next_cursor; both parts are non-negative safe integers.",
+    {
+      csvResponse: true,
+      parameters: [
+        { name: "pallet", schema: { type: "string", maxLength: 64 } },
+        { name: "method", schema: { type: "string", maxLength: 64 } },
+        { name: "block", schema: { type: "integer", minimum: 0 } },
+        { name: "extrinsic", schema: { type: "integer", minimum: 0 } },
+        {
+          name: "cursor",
+          schema: {
+            type: "string",
+            pattern: "^\\d+\\.\\d+$",
+            maxLength: 33,
+            description:
+              "Opaque block_number.event_index cursor returned as next_cursor; both parts are non-negative safe integers.",
+          },
         },
-      },
-      { name: "before", schema: { type: "integer", minimum: 0 } },
-      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 200 } },
-    ],
+        { name: "before", schema: { type: "integer", minimum: 0 } },
+        {
+          name: "limit",
+          schema: { type: "integer", minimum: 1, maximum: 200 },
+        },
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the raw all-events feed as text/csv; `json` (default) keeps the response envelope.",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [],
   ),
   route(
@@ -3292,6 +3304,12 @@ function csvExampleForRoute(entry) {
     return [
       "extrinsic_id,block_number,signer,call_module,call_function,success",
       "8454388-2,8454388,5Signer,SubtensorModule,add_stake,true",
+    ].join("\r\n");
+  }
+  if (entry.id === "chain-events-feed") {
+    return [
+      "block_number,event_index,pallet,method,args,phase,extrinsic_index,observed_at",
+      "8454388,0,System,ExtrinsicSuccess,{},ApplyExtrinsic,2,1719792000000",
     ].join("\r\n");
   }
   return "netuid,name\r\n7,Allways";

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -70,6 +70,36 @@ test("GET /api/v1/chain-events returns the feed with a cursor (filters + before)
   expect(typeof body.events[0].observed_at).toBe("number");
 });
 
+test("GET /api/v1/chain-events?format=csv returns text/csv with the event columns", async () => {
+  const res = await req("/api/v1/chain-events?limit=1&format=csv");
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-type")).toMatch(/text\/csv/);
+  const text = await res.text();
+  const [header, firstRow] = text.split("\r\n");
+  // Explicit columns → stable header (a cold/empty feed still emits it).
+  expect(header).toBe(
+    "block_number,event_index,pallet,method,args,phase,extrinsic_index,observed_at",
+  );
+  // args serializes as a JSON-string cell; the row carries the coerced values.
+  expect(firstRow).toContain("123,0,System,ExtrinsicSuccess,");
+});
+
+test("chain-events ?pallet=Balances&format=csv still applies the pallet filter", async () => {
+  const res = await req(
+    "/api/v1/chain-events?pallet=Balances&format=csv&limit=1",
+  );
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-type")).toMatch(/text\/csv/);
+  expect(queryText()).toContain("AND pallet =");
+});
+
+test("chain-events rejects a ?format value outside json|csv", async () => {
+  const res = await req("/api/v1/chain-events?format=xml");
+  expect(res.status).toBe(400);
+  const body = await res.json();
+  expect(body.error).toMatch(/format must be one of/);
+});
+
 test("chain-events cursor seeks by block_number and event_index", async () => {
   const res = await req("/api/v1/chain-events?limit=1&cursor=123.4&before=500");
   expect(res.status).toBe(200);

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -11,10 +11,25 @@
 // closed via ctx.waitUntil so it never blocks the response.
 import postgres from "postgres";
 import { decodeCursor, encodeCursor } from "../src/cursor.mjs";
+import { csvRequested, csvResponse } from "./csv.mjs";
 
 const MAX_LIMIT = 200;
 const DEFAULT_LIMIT = 50;
 const FILTER_PATTERN = /^[A-Za-z][A-Za-z0-9_]{0,63}$/;
+
+// Explicit CSV column order for the chain-events ?format=csv export (#2530).
+// Passed to csvResponse so an empty feed still emits a header row and the column
+// order stays stable; `args` serializes as a JSON string cell.
+const CHAIN_EVENTS_CSV_COLUMNS = [
+  "block_number",
+  "event_index",
+  "pallet",
+  "method",
+  "args",
+  "phase",
+  "extrinsic_index",
+  "observed_at",
+];
 
 function validEventFilter(value) {
   return value == null || value === "" || FILTER_PATTERN.test(value);
@@ -120,6 +135,10 @@ export default {
             400,
           );
         }
+        const format = url.searchParams.get("format");
+        if (format !== null && format !== "json" && format !== "csv") {
+          return json({ error: "format must be one of: json, csv" }, 400);
+        }
         const numParam = (k) => {
           const v = url.searchParams.get(k);
           if (v == null || v === "") return null;
@@ -160,11 +179,21 @@ export default {
         const nextCursor = last
           ? encodeCursor([nextBlock, numberOrNull(last.event_index)])
           : null;
+        const events = rows.map(coerceEvent);
+        if (csvRequested(url, request)) {
+          return csvResponse(
+            events,
+            "chain-events",
+            "short",
+            request,
+            CHAIN_EVENTS_CSV_COLUMNS,
+          );
+        }
         return json({
           count: rows.length,
           next_before: nextBlock,
           next_cursor: nextCursor,
-          events: rows.map(coerceEvent),
+          events,
         });
       }
 


### PR DESCRIPTION
## Summary

Adds `?format=csv` to `GET /api/v1/chain-events` — the raw pallet.method all-events feed (Postgres-backed all-events tier, ADR 0013) — so the feed can be pulled straight into a spreadsheet or pipeline, matching the CSV export already on the subnet-list, validator-analytics, chain-analytics, registry, and economics routes.

Closes #2530

## What changed

- **`workers/data-api.mjs`** — after the filtered feed is assembled, a CSV branch: when `csvRequested(url, request)` (`?format=csv` or `Accept: text/csv`), the handler returns `csvResponse(events, "chain-events", "short", request, CHAIN_EVENTS_CSV_COLUMNS)`. Explicit columns (`block_number, event_index, pallet, method, args, phase, extrinsic_index, observed_at`) so an empty feed still emits a header-only CSV and column order is stable; `args` serializes as a JSON-string cell. All existing `?pallet/?method/?block/?extrinsic/?cursor/?before/?limit` filters apply unchanged before the CSV is produced.
- **`workers/data-api.mjs`** — the `format` enum is enforced: `?format=xml` returns `400` ("format must be one of: json, csv") rather than being silently accepted.
- **`src/contracts.mjs`** — added the `format` param (`enum: ["json","csv"]`) to the `chain-events-feed` route in object form (`{ csvResponse: true, parameters: [...] }`) so the OpenAPI generator emits a `text/csv` 200 response alongside `application/json`, plus a `csvExampleForRoute` case with the real chain-events columns. Regenerated + committed the OpenAPI/client/types artifacts.
- **`tests/data-api.test.mjs`** — `?format=csv` returns `text/csv` with the exact column header + coerced row; `?pallet=Balances&format=csv` still applies the pallet filter; `?format=xml` → 400.

## Validation

- [x] `npm run build` (OpenAPI/types/client regenerated + committed; deploy-owned artifacts reverted per contributor rules)
- [x] `npm run lint` · `format:check`
- [x] `validate:contract-drift` · `validate:openapi` · `validate:openapi-examples` · `validate:generated-client` · `validate:types` · `validate:api` · `validate:schemas` · `validate:docs`
- [x] `scan:public-safety`
- [x] `npm run test:coverage` — 4464 passed; new lines fully covered
