### PR TITLE
fix(blocks): reject blank block_number cells that coerce to height 0

### DIFF
--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -44,6 +44,7 @@ function toIso(ms) {
 // and the `nullableInteger` coercion added to counterparties in #2414.
 function toBlockNumber(value) {
   if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isInteger(n) && n >= 0 ? n : null;
 }

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -229,6 +229,8 @@ test("formatBlock rejects a negative or non-integer block_number cell to null", 
   assert.equal(formatBlock({ block_number: -1 }).block_number, null);
   assert.equal(formatBlock({ block_number: 1.5 }).block_number, null);
   assert.equal(formatBlock({ block_number: "abc" }).block_number, null);
+  assert.equal(formatBlock({ block_number: "" }).block_number, null);
+  assert.equal(formatBlock({ block_number: "   " }).block_number, null);
 });
 
 test("loadBlock resolves neighbors when D1 returns a string-typed block_number (#1853)", async () => {


### PR DESCRIPTION
## Summary
- Reject blank block_number cells before Number() coercion in the blocks feed.

## Test plan
- [x] npx vitest run tests/blocks.test.mjs
