### PR TITLE
fix(chain): reject blank last_tx_block cells that coerce to block 0

### DIFF
--- a/src/chain-analytics.mjs
+++ b/src/chain-analytics.mjs
@@ -37,6 +37,8 @@ function toNullableTao(value) {
 // Coerce a block-height cell to a non-negative integer, or null when the value is
 // missing, non-finite, or negative — block numbers are never negative on-chain.
 function toBlockNumber(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : null;
 }

--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -519,6 +519,18 @@ test("buildChainSigners nulls non-finite and negative last_tx_block", () => {
   assert.equal(out.signers[2].last_tx_block, 12345);
 });
 
+test("buildChainSigners nulls blank last_tx_block cells (not block 0)", () => {
+  const out = buildChainSigners({
+    window: "7d",
+    rows: [
+      { signer: "5A", tx_count: 1, last_tx_block: "" },
+      { signer: "5B", tx_count: 2, last_tx_block: 100 },
+    ],
+  });
+  assert.equal(out.signers[0].last_tx_block, null);
+  assert.equal(out.signers[1].last_tx_block, 100);
+});
+
 test("GET /api/v1/chain/signers ranks by tx_count via the signer GROUP BY", async () => {
   const captured = [];
   const env = {


### PR DESCRIPTION
## Summary
- Reject blank last_tx_block cells in chain signer analytics.

## Test plan
- [x] npx vitest run tests/chain-analytics.test.mjs -t blank
