### PR TITLE
fix(extrinsics): reject blank block_number and extrinsic_index cells

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -61,6 +61,7 @@ function toIso(ms) {
 // blocks.mjs in #2435.
 function toChainPosition(value) {
   if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isInteger(n) && n >= 0 ? n : null;
 }

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -144,6 +144,11 @@ test("formatExtrinsic maps a D1 row to an API extrinsic (ISO time, bool success)
   assert.equal(out.observed_at, new Date(1750000000000).toISOString());
 });
 
+test("formatExtrinsic rejects blank chain-position cells to null", () => {
+  assert.equal(formatExtrinsic({ block_number: "" }).block_number, null);
+  assert.equal(formatExtrinsic({ extrinsic_index: "   " }).extrinsic_index, null);
+});
+
 test("formatExtrinsic drops an out-of-range observed_at instead of throwing", () => {
   // A finite but out-of-range epoch (beyond the ±8.64e15 ms JS Date limit) would
   // make new Date(n).toISOString() throw a RangeError and 500 the extrinsics feed.


### PR DESCRIPTION
## Summary
- Reject blank chain-position cells before Number() coercion.

## Test plan
- [x] npx vitest run tests/extrinsics.test.mjs -t blank
