### PR TITLE
fix(neurons): reject blank uid cells that coerce to uid 0

### DIFF
--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -77,6 +77,7 @@ function nonNegativeInt(value) {
   // nullable INTEGER) would masquerade as the real chain height / netuid / uid 0
   // instead of "absent". A numeric string like "10" from D1 must still pass.
   if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
 }

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -57,6 +57,11 @@ describe("metagraph-neurons builders", () => {
     assert.equal(formatNeuron(undefined), null);
   });
 
+  test("formatNeuron rejects blank uid cells to null", () => {
+    assert.equal(formatNeuron({ uid: "" }).uid, null);
+    assert.equal(formatNeuron({ uid: "   " }).uid, null);
+  });
+
   test("formatNeuron defaults every missing field to null/false", () => {
     // Exercises the ?? null + Boolean(falsy) branches (sparse chain row).
     const n = formatNeuron({ uid: 3 });


### PR DESCRIPTION
## Summary
- Reject blank uid cells in metagraph neuron formatting.

## Test plan
- [x] npx vitest run tests/metagraph-neurons.test.mjs -t blank
