### PR TITLE
fix(health): guard trajectory shiftDate against invalid snapshot dates

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1088,6 +1088,7 @@ function diff(now, then) {
 // strings compared lexically (valid for ISO dates).
 function pointAtOrBefore(points, latestDate, days) {
   const target = shiftDate(latestDate, -days);
+  if (target == null) return null;
   let chosen = null;
   for (const point of points) {
     if (String(point.date) <= target) chosen = point;
@@ -1098,8 +1099,13 @@ function pointAtOrBefore(points, latestDate, days) {
 
 function shiftDate(isoDate, days) {
   const [y, m, d] = String(isoDate).split("-").map(Number);
-  const base = Date.UTC(y, (m || 1) - 1, d || 1) + days * 24 * 60 * 60 * 1000;
-  return new Date(base).toISOString().slice(0, 10);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) {
+    return null;
+  }
+  const base = Date.UTC(y, m - 1, d) + days * 24 * 60 * 60 * 1000;
+  const date = new Date(base);
+  if (!Number.isFinite(date.getTime())) return null;
+  return date.toISOString().slice(0, 10);
 }
 
 // Long-term daily uptime series per surface, from surface_uptime_daily rows

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -687,6 +687,21 @@ describe("formatTrajectory", () => {
     assert.deepEqual(out.points, []);
     assert.equal(out.deltas["7d"], null);
   });
+  test("returns null deltas when latest snapshot_date is not ISO-shaped", () => {
+    const out = formatTrajectory({
+      netuid: 7,
+      rows: [
+        {
+          snapshot_date: "not-a-date",
+          completeness_score: 50,
+          surface_count: 1,
+          endpoint_count: 1,
+        },
+      ],
+    });
+    assert.equal(out.deltas["7d"], null);
+    assert.equal(out.deltas["30d"], null);
+  });
   test("coerces D1 numeric-string snapshot cells to schema types", () => {
     const out = formatTrajectory({
       netuid: 3,


### PR DESCRIPTION
## Summary
- Guard shiftDate/pointAtOrBefore so corrupt snapshot_date values cannot RangeError trajectory deltas.

## Test plan
- [x] npx vitest run tests/analytics.test.mjs -t ISO-shaped
