### PR TITLE
fix(webhooks): guard redelivery scheduling against invalid nowMs

### DIFF
--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -662,7 +662,7 @@ export async function dispatchChangeEvent({
 // --- at-least-once delivery (persisted redelivery + dead-letter) --------------
 // Fold one failed round into a parked record: bump the round, schedule the next
 // attempt with bounded backoff, and dead-letter at the cap or on a hard failure.
-function nextDeliveryRecord({
+export function nextDeliveryRecord({
   existing,
   result,
   bodyText,
@@ -686,7 +686,15 @@ function nextDeliveryRecord({
     status_code: result.status_code ?? null,
     first_failed_at: existing?.first_failed_at || nowIso,
     last_attempt_at: nowIso,
-    next_attempt_at: dead ? null : new Date(nowMs + delayMs).toISOString(),
+    next_attempt_at:
+      dead || !Number.isFinite(nowMs)
+        ? null
+        : (() => {
+            const date = new Date(nowMs + delayMs);
+            return Number.isFinite(date.getTime())
+              ? date.toISOString()
+              : null;
+          })(),
   };
 }
 

--- a/tests/webhooks-delivery-record.test.mjs
+++ b/tests/webhooks-delivery-record.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { nextDeliveryRecord } from "../src/webhooks.mjs";
+
+describe("nextDeliveryRecord", () => {
+  test("returns null next_attempt_at when nowMs is non-finite", () => {
+    const record = nextDeliveryRecord({
+      existing: null,
+      result: {
+        id: "sub-1",
+        event_id: "evt-1",
+        idempotency_key: "key-1",
+        retryable: true,
+      },
+      bodyText: "{}",
+      nowIso: "2026-06-01T00:00:00.000Z",
+      nowMs: Number.NaN,
+      maxRounds: 8,
+      baseMs: 60_000,
+      maxMs: 3_600_000,
+    });
+    assert.equal(record.state, "pending");
+    assert.equal(record.next_attempt_at, null);
+  });
+});


### PR DESCRIPTION
## Summary
- Return null next_attempt_at when nowMs is non-finite instead of throwing RangeError.

## Test plan
- [x] npx vitest run tests/webhooks-delivery-record.test.mjs
