### PR TITLE
fix(feeds): guard RSS pubDate against corrupt timestamps

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -110,7 +110,11 @@ function toIso(value) {
 }
 
 function toRfc822(iso) {
-  return new Date(iso).toUTCString();
+  if (iso == null) return null;
+  const ms = Date.parse(String(iso));
+  if (!Number.isFinite(ms)) return null;
+  const date = new Date(ms);
+  return Number.isFinite(date.getTime()) ? date.toUTCString() : null;
 }
 
 // ── item builders (from existing served artifacts) ──────────────────────────
@@ -385,21 +389,23 @@ function jsonFeed(meta, items) {
 
 function rssFeed(meta, items) {
   const body = items
-    .map((it) =>
-      [
+    .map((it) => {
+      const pubDate = toRfc822(it.timestamp);
+      return [
         "    <item>",
         `      <guid isPermaLink="false">${escapeXml(it.id)}</guid>`,
         `      <link>${escapeXml(it.url)}</link>`,
         `      <title>${escapeXml(it.title)}</title>`,
         `      <description>${escapeXml(it.summary)}</description>`,
-        `      <pubDate>${toRfc822(it.timestamp)}</pubDate>`,
+        ...(pubDate ? [`      <pubDate>${escapeXml(pubDate)}</pubDate>`] : []),
         ...(it.tags || []).map(
           (t) => `      <category>${escapeXml(t)}</category>`,
         ),
         "    </item>",
-      ].join("\n"),
-    )
+      ].join("\n");
+    })
     .join("\n");
+  const lastBuildDate = toRfc822(meta.updated);
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
@@ -408,7 +414,9 @@ function rssFeed(meta, items) {
     `    <link>${escapeXml(meta.homeUrl)}</link>`,
     `    <atom:link href="${escapeXml(meta.feedUrl)}" rel="self" type="application/rss+xml"/>`,
     `    <description>${escapeXml(meta.description)}</description>`,
-    `    <lastBuildDate>${toRfc822(meta.updated)}</lastBuildDate>`,
+    ...(lastBuildDate
+      ? [`    <lastBuildDate>${escapeXml(lastBuildDate)}</lastBuildDate>`]
+      : []),
     body,
     "  </channel>",
     "</rss>",

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -765,6 +765,19 @@ describe("feeds — serializers", () => {
     assert.match(xml, /<pubDate>.*GMT<\/pubDate>/);
   });
 
+  test("rssFeed omits pubDate for corrupt item timestamps instead of throwing", () => {
+    const xml = rssFeed(meta, [
+      {
+        id: "bad-ts",
+        url: "https://example.com/x",
+        title: "bad",
+        summary: "bad",
+        timestamp: "not-a-date",
+      },
+    ]);
+    assert.doesNotMatch(xml, /<pubDate>/);
+  });
+
   test("atomFeed has the required feed + entry structure", () => {
     const xml = atomFeed(meta, items);
     assert.match(xml, /<feed xmlns="http:\/\/www\.w3\.org\/2005\/Atom">/);


### PR DESCRIPTION
## Summary
- Guard toRfc822 and omit pubDate/lastBuildDate when timestamps are invalid.

## Test plan
- [x] npx vitest run tests/feeds.test.mjs -t rssFeed
