### PR TITLE
fix(counterparties): reject blank integer cells in relationship evidence

### DIFF
--- a/src/counterparties.mjs
+++ b/src/counterparties.mjs
@@ -46,6 +46,7 @@ function nullableNumber(value) {
 
 function nullableInteger(value) {
   if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : null;
 }

--- a/tests/counterparties.test.mjs
+++ b/tests/counterparties.test.mjs
@@ -324,6 +324,26 @@ describe("buildCounterpartyRelationship", () => {
     assert.equal(data.transfers[2].amount_tao, 7.5);
   });
 
+  test("drops blank block_number cells that would coerce to block 0", () => {
+    const data = buildCounterpartyRelationship(
+      [
+        {
+          block_number: "",
+          event_index: 0,
+          hotkey: ME,
+          coldkey: "A",
+          netuid: 7,
+          amount_tao: 1,
+          observed_at: Date.UTC(2026, 5, 1),
+        },
+      ],
+      ME,
+      "A",
+      {},
+    );
+    assert.equal(data.transfers[0].block_number, null);
+  });
+
   test("blank or out-of-range observed_at cells stay null on relationship evidence (not epoch 1970)", () => {
     const data = buildCounterpartyRelationship(
       [


### PR DESCRIPTION
## Summary
- Reject blank block_number/event_index/netuid cells before Number() coercion.

## Test plan
- [x] npx vitest run tests/counterparties.test.mjs -t blank
