### PR TITLE
fix(analytics): reject blank netuid cells in growth leaderboard

### DIFF
--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -64,7 +64,11 @@ export function profilesProjectionFromRows(profiles) {
 export function growthRowsFromSamples(growthSamples) {
   const growthByNetuid = new Map();
   for (const row of growthSamples || []) {
-    const entry = growthByNetuid.get(row.netuid) || {
+    const rawNetuid = row.netuid;
+    if (typeof rawNetuid === "string" && rawNetuid.trim() === "") continue;
+    const netuid = Number(rawNetuid);
+    if (!Number.isInteger(netuid) || netuid < 0) continue;
+    const entry = growthByNetuid.get(netuid) || {
       first: null,
       last: null,
     };
@@ -83,7 +87,7 @@ export function growthRowsFromSamples(growthSamples) {
       if (entry.first == null) entry.first = score;
       entry.last = score;
     }
-    growthByNetuid.set(row.netuid, entry);
+    growthByNetuid.set(netuid, entry);
   }
   return [...growthByNetuid.entries()].map(([netuid, entry]) => ({
     netuid,

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -179,6 +179,17 @@ describe("analytics-live projections", () => {
       [{ netuid: 7, delta: 60 }],
     );
   });
+
+  test("growthRowsFromSamples skips blank netuid cells that would coerce to subnet 0", () => {
+    assert.deepEqual(
+      growthRowsFromSamples([
+        { netuid: "", completeness_score: 10 },
+        { netuid: 7, completeness_score: 20 },
+        { netuid: 7, completeness_score: 40 },
+      ]),
+      [{ netuid: 7, delta: 20 }],
+    );
+  });
 });
 
 describe("analytics-live loaders", () => {


### PR DESCRIPTION
## Summary
- Skip blank netuid rows in growthRowsFromSamples before subnet 0 coercion.

## Test plan
- [x] npx vitest run tests/analytics-live.test.mjs -t blank netuid
