### PR TITLE
fix(aliases): coerce string netuid cells and reject blanks

### DIFF
--- a/src/surface-aliases.mjs
+++ b/src/surface-aliases.mjs
@@ -22,7 +22,10 @@ function nullableString(value) {
 }
 
 function nullableInteger(value) {
-  return Number.isInteger(value) ? value : null;
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isInteger(n) ? n : null;
 }
 
 function buildCurrentSurfaceMap(surfaces = []) {

--- a/tests/surface-aliases.test.mjs
+++ b/tests/surface-aliases.test.mjs
@@ -45,6 +45,30 @@ describe("surface alias artifact (#1005)", () => {
     );
   });
 
+  test("coerces string-typed netuid cells and rejects blank netuid", () => {
+    const artifact = buildSurfaceAliasArtifact({
+      previousSurfaces: [
+        {
+          id: "7:subnet-api:old",
+          key: "srf-stable00000000",
+          netuid: "",
+          kind: "subnet-api",
+          url: "https://api.example",
+        },
+      ],
+      currentSurfaces: [
+        {
+          id: "7:subnet-api:new",
+          key: "srf-stable00000000",
+          netuid: "7",
+          kind: "subnet-api",
+          url: "https://api.example",
+        },
+      ],
+    });
+    assert.equal(artifact.aliases[0].netuid, 7);
+  });
+
   test("carries prior aliases and drops aliases whose key disappeared", () => {
     const artifact = buildSurfaceAliasArtifact({
       previousAliases: {


### PR DESCRIPTION
## Summary
- Coerce numeric-string netuid cells in surface alias artifacts; reject blanks instead of subnet 0.

## Test plan
- [x] npx vitest run tests/surface-aliases.test.mjs -t netuid
