### PR TITLE
feat(registry): add SN62 Ridges docs surface

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -70,6 +70,25 @@
         "submitted_by": "dexterity104"
       },
       "notes": "Public, unauthenticated read endpoint on the Ridges backend API: the live leaderboard of top-scored SWE agents (miner_hotkey, name, version_num, final_score). agent-upload.ridges.ai is the DEFAULT_API_BASE_URL the official CLI uses (ridgesai/ridges miners/cli/commands/upload.py) and serves the platform's read routes; /retrieval/top-agents is defined in api/endpoints/retrieval.py (no auth) and mounted at /retrieval in api/src/main.py. OpenAPI 3.1.0 spec at /openapi.json."
+    },
+    {
+      "id": "sn-62-ridges-docs",
+      "name": "Ridges documentation",
+      "kind": "docs",
+      "url": "https://docs.ridges.ai",
+      "provider": "ridges",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/ridgesai/ridges/blob/main/README.md",
+        "https://raw.githubusercontent.com/ridgesai/ridges/main/README.md"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "devmixa702"
+      },
+      "notes": "Official Ridges documentation site, linked from the subnet's registered source repository README (ridgesai/ridges). Covers agent submission and costs, sandboxing, and validator/miner setup guides."
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Summary

- Adds a `docs` surface to SN62 Ridges pointing at the official documentation site, `https://docs.ridges.ai`.
- Fills the manifest's own gap note ("No verified docs site yet") with a live, owner-matched URL.

## Template Used

- Subnet surface (one `registry/subnets/ridges.json` changed; append-only)

## Surface

- Netuid: 62 (Ridges)
- Kind: `docs`
- URL: `https://docs.ridges.ai`
- Provider: `ridges` · authority `community` · `review.state: community-submitted`
- Source URL (proof): `https://github.com/ridgesai/ridges/blob/main/README.md` — the subnet's registered source repository README links `docs.ridges.ai`, so ownership matches the subnet identity.

## Validation

- `https://docs.ridges.ai` returns HTTP 200.
- The registered source repo README links the docs site (independent ownership proof).
- Exactly one file changed (`registry/subnets/ridges.json`); JSON parses; surface ids unique; no health/verification/secrets set by hand.
