### PR TITLE
feat(registry): add SN107 Minos docs surface

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -36,6 +36,25 @@
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md"
       ],
       "url": "https://api.theminos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-docs",
+      "kind": "docs",
+      "name": "Minos documentation",
+      "notes": "Official Minos subnet documentation, hosted on the subnet's own domain (docs.theminos.ai) and linked from the official website theminos.ai.",
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "devmixa702"
+      },
+      "source_urls": [
+        "https://theminos.ai/",
+        "https://docs.theminos.ai/overview"
+      ],
+      "url": "https://docs.theminos.ai"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a `docs` surface to SN107 Minos pointing at the official documentation site, `https://docs.theminos.ai`.
- Minos currently exposes only a `subnet-api` surface; this adds its public documentation.

## Template Used

- Subnet surface (one `registry/subnets/minos.json` changed; append-only)

## Surface

- Netuid: 107 (Minos)
- Kind: `docs`
- URL: `https://docs.theminos.ai` (200; resolves to `/overview`)
- Provider: `minos` · authority `community` · `review.state: community-submitted`
- Source URL (proof): `https://theminos.ai/` — the subnet's registered official website links `docs.theminos.ai`, and the docs live on the subnet's own domain, so ownership matches the subnet identity.

## Validation

- `https://docs.theminos.ai` returns HTTP 200.
- The official website (`theminos.ai`) links the docs site (independent ownership proof).
- Exactly one file changed (`registry/subnets/minos.json`); JSON parses; surface ids unique; no health/verification/secrets set by hand.
