### PR TITLE
feat(registry): add SN23 Trishool docs surface

### DIFF
--- a/registry/subnets/trishool.json
+++ b/registry/subnets/trishool.json
@@ -86,6 +86,24 @@
         "timeout_ms": 10000
       },
       "notes": "Official Trishool phase two source repository."
+    },
+    {
+      "id": "sn-23-trishool-docs",
+      "name": "Trishool documentation",
+      "kind": "docs",
+      "url": "https://docs.trishool.ai",
+      "provider": "trishool",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://trishool.ai/"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "devmixa702"
+      },
+      "notes": "Official Trishool documentation site (docs.trishool.ai), hosted on the subnet's own domain and linked from the official website trishool.ai."
     }
   ],
   "social": { "x": "https://x.com/trishoolai" },

--- a/registry/subnets/trishool.json
+++ b/registry/subnets/trishool.json
@@ -96,9 +96,7 @@
       "auth_required": false,
       "authority": "community",
       "public_safe": true,
-      "source_urls": [
-        "https://trishool.ai/"
-      ],
+      "source_urls": ["https://trishool.ai/"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "devmixa702"


### PR DESCRIPTION
## Summary

- Adds a `docs` surface to SN23 Trishool pointing at the official documentation site, `https://docs.trishool.ai`.
- Trishool has dashboard, API-landing, and source-repo surfaces but no documentation surface yet.

## Template Used

- Subnet surface (one `registry/subnets/trishool.json` changed; append-only)

## Surface

- Netuid: 23 (Trishool)
- Kind: `docs`
- URL: `https://docs.trishool.ai` (HTTP 200)
- Provider: `trishool` · authority `community` · `review.state: community-submitted`
- Source URL (proof): `https://trishool.ai/` — the subnet's registered official website links `docs.trishool.ai`, and the docs live on the subnet's own domain, so ownership matches the subnet identity.

Note: this is the dedicated `docs.trishool.ai` site, distinct from the `api.trishool.ai/docs` path noted as auth-gated in the manifest.

## Validation

- `https://docs.trishool.ai` returns HTTP 200.
- The official website (`trishool.ai`) links the docs site (independent ownership proof).
- Exactly one file changed (`registry/subnets/trishool.json`); JSON parses; surface ids unique; no health/verification/secrets set by hand.
