### PR TITLE
fix(api): stream endpoint CSV exports (#2523)

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1285,6 +1285,7 @@ describe("registry list CSV export", () => {
       res.headers.get("content-disposition"),
       'attachment; filename="endpoints.csv"',
     );
+    assert.equal(res.headers.get("etag"), null);
 
     const reader = res.body.getReader();
     const decoder = new TextDecoder();

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -80,6 +80,60 @@ function rpcEnv(overrides = {}) {
   };
 }
 
+const SYNTHETIC_ENDPOINT_ROWS = Array.from({ length: 260 }, (_, index) => ({
+  id: `ep-${index}`,
+  netuid: index % 2 === 0 ? 7 : 11,
+  provider: `provider-${index % 5}`,
+  kind: index % 3 === 0 ? "openapi" : "subnet-api",
+  layer: index % 4 === 0 ? "data-provider" : "subnet-app",
+  status: index % 6 === 0 ? "degraded" : "ok",
+  latency_ms: 25 + index,
+}));
+
+function endpointArtifact(value) {
+  return {
+    async json() {
+      return value;
+    },
+    async text() {
+      return JSON.stringify(value);
+    },
+  };
+}
+
+function createEndpointCsvEnv() {
+  const base = createLocalArtifactEnv();
+  const artifacts = new Map([
+    ["/metagraph/endpoints.json", { endpoints: SYNTHETIC_ENDPOINT_ROWS }],
+    [
+      "/metagraph/endpoints/7.json",
+      { endpoints: SYNTHETIC_ENDPOINT_ROWS.filter((row) => row.netuid === 7) },
+    ],
+  ]);
+
+  return {
+    ...base,
+    ASSETS: {
+      async fetch(request) {
+        const pathname = new URL(request.url).pathname;
+        if (artifacts.has(pathname)) {
+          return Response.json(artifacts.get(pathname));
+        }
+        return base.ASSETS.fetch(request);
+      },
+    },
+    METAGRAPH_ARCHIVE: {
+      async get(key) {
+        const pathname = `/metagraph/${String(key).replace(/^latest\//, "")}`;
+        if (artifacts.has(pathname)) {
+          return endpointArtifact(artifacts.get(pathname));
+        }
+        return base.METAGRAPH_ARCHIVE.get(key);
+      },
+    },
+  };
+}
+
 function withGlobals({ cache, fetchImpl }, run) {
   const originalCaches = globalThis.caches;
   const originalFetch = globalThis.fetch;
@@ -1214,6 +1268,70 @@ describe("registry list CSV export", () => {
     assert.equal(
       res.headers.get("content-disposition"),
       'attachment; filename="subnet-surfaces.csv"',
+    );
+  });
+
+  test("endpoints CSV export filters, projects, and streams the large route path (#2523)", async () => {
+    const res = await handleRequest(
+      req(
+        "/api/v1/endpoints?format=csv&fields=netuid,provider,status&status=ok&limit=3",
+      ),
+      createEndpointCsvEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="endpoints.csv"',
+    );
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    const first = await reader.read();
+    assert.equal(decoder.decode(first.value), "netuid,provider,status\r\n");
+
+    let body = "";
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      body += decoder.decode(chunk.value, { stream: true });
+    }
+    body += decoder.decode();
+
+    const lines = body.split("\r\n");
+    assert.equal(lines.length, 3);
+    assert.equal(
+      lines.every((line) => /^\d+,provider-\d+,ok$/.test(line)),
+      true,
+    );
+  });
+
+  test("subnet-endpoints CSV export keeps endpoint columns and honors projection (#2523)", async () => {
+    const res = await handleRequest(
+      req(
+        "/api/v1/subnets/7/endpoints?format=csv&fields=layer,kind,status,latency_ms&status=ok&limit=3",
+      ),
+      createEndpointCsvEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="subnet-endpoints.csv"',
+    );
+
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(lines[0], "layer,kind,status,latency_ms");
+    assert.equal(lines.length, 4);
+    assert.equal(
+      lines
+        .slice(1)
+        .every((line) =>
+          /^(data-provider|subnet-app),(openapi|subnet-api),ok,\d+$/.test(line),
+        ),
+      true,
     );
   });
 

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1322,6 +1322,7 @@ describe("registry list CSV export", () => {
       res.headers.get("content-disposition"),
       'attachment; filename="subnet-endpoints.csv"',
     );
+    assert.equal(res.headers.get("etag"), null);
 
     const lines = (await res.text()).split("\r\n");
     assert.equal(lines[0], "layer,kind,status,latency_ms");

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { csvRequested, csvResponse, rowsToCsv } from "../workers/csv.mjs";
+import {
+  csvBodyStream,
+  csvRequested,
+  csvResponse,
+  rowsToCsv,
+} from "../workers/csv.mjs";
 
 function url(search = "") {
   return new URL(`https://api.metagraph.sh/api/v1/subnets${search}`);
@@ -169,4 +174,53 @@ test("csvResponse suppresses the body on HEAD", async () => {
   );
   assert.equal(response.status, 200);
   assert.equal(await response.text(), "");
+});
+
+test("csvBodyStream emits the header before row chunks", async () => {
+  const stream = csvBodyStream(
+    [
+      { netuid: 7, name: "Allways" },
+      { netuid: 8, name: "Templar" },
+    ],
+    ["netuid", "name"],
+  );
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+
+  const first = await reader.read();
+  assert.equal(decoder.decode(first.value), "netuid,name\r\n");
+
+  const second = await reader.read();
+  assert.equal(decoder.decode(second.value), "7,Allways\r\n8,Templar");
+
+  const done = await reader.read();
+  assert.equal(done.done, true);
+});
+
+test("csvResponse can stream endpoint-sized exports without eager ETags", async () => {
+  const response = await csvResponse(
+    [
+      { netuid: 7, provider: "allways", status: "ok" },
+      { netuid: 8, provider: "templar", status: "degraded" },
+    ],
+    "endpoints",
+    "short",
+    null,
+    ["netuid", "provider", "status"],
+    {},
+    { stream: true },
+  );
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type"), /^text\/csv/);
+  assert.equal(response.headers.get("etag"), null);
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const first = await reader.read();
+  assert.equal(decoder.decode(first.value), "netuid,provider,status\r\n");
+  const second = await reader.read();
+  assert.equal(
+    decoder.decode(second.value),
+    "7,allways,ok\r\n8,templar,degraded",
+  );
 });

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -197,6 +197,73 @@ test("csvBodyStream emits the header before row chunks", async () => {
   assert.equal(done.done, true);
 });
 
+test("csvBodyStream closes immediately when no header can be derived", async () => {
+  const stream = csvBodyStream([]);
+  const done = await stream.getReader().read();
+  assert.equal(done.done, true);
+  assert.equal(done.value, undefined);
+});
+
+test("csvBodyStream emits a header-only export for explicit empty columns", async () => {
+  const stream = csvBodyStream([], ["netuid", "name"]);
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+
+  const first = await reader.read();
+  assert.equal(decoder.decode(first.value), "netuid,name");
+
+  const done = await reader.read();
+  assert.equal(done.done, true);
+});
+
+test("csvBodyStream tolerates non-array rows when explicit columns are provided", async () => {
+  const stream = csvBodyStream(null, ["netuid"]);
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+
+  const first = await reader.read();
+  assert.equal(decoder.decode(first.value), "netuid");
+
+  const done = await reader.read();
+  assert.equal(done.done, true);
+});
+
+test("csvBodyStream serializes malformed row entries as empty cells", async () => {
+  const stream = csvBodyStream([null], ["netuid"]);
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+
+  const first = await reader.read();
+  assert.equal(decoder.decode(first.value), "netuid\r\n");
+
+  const second = await reader.read();
+  assert.equal(decoder.decode(second.value), "");
+
+  const done = await reader.read();
+  assert.equal(done.done, true);
+});
+
+test("csvBodyStream emits continuation newlines when a large export spans multiple chunks", async () => {
+  const rows = Array.from({ length: 129 }, (_, index) => ({ netuid: index }));
+  const stream = csvBodyStream(rows, ["netuid"]);
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+
+  const header = await reader.read();
+  assert.equal(decoder.decode(header.value), "netuid\r\n");
+
+  const firstChunk = await reader.read();
+  const firstChunkText = decoder.decode(firstChunk.value);
+  assert.equal(firstChunkText.startsWith("0\r\n1\r\n2"), true);
+  assert.equal(firstChunkText.endsWith("\r\n"), true);
+
+  const secondChunk = await reader.read();
+  assert.equal(decoder.decode(secondChunk.value), "128");
+
+  const done = await reader.read();
+  assert.equal(done.done, true);
+});
+
 test("csvResponse can stream endpoint-sized exports without eager ETags", async () => {
   const response = await csvResponse(
     [
@@ -223,4 +290,43 @@ test("csvResponse can stream endpoint-sized exports without eager ETags", async 
     decoder.decode(second.value),
     "7,allways,ok\r\n8,templar,degraded",
   );
+});
+
+test("csvResponse falls back to the buffered ETag path on HEAD even when streaming is requested", async () => {
+  const response = await csvResponse(
+    [{ netuid: 7, provider: "allways", status: "ok" }],
+    "endpoints",
+    "short",
+    req({}, "HEAD"),
+    ["netuid", "provider", "status"],
+    {},
+    { stream: true },
+  );
+  assert.equal(response.status, 200);
+  assert.ok(response.headers.get("etag"));
+  assert.equal(await response.text(), "");
+});
+
+test("csvResponse keeps conditional requests on the buffered ETag path when streaming is requested", async () => {
+  const first = await csvResponse(
+    [{ netuid: 7, provider: "allways", status: "ok" }],
+    "endpoints",
+    "short",
+    req(),
+    ["netuid", "provider", "status"],
+  );
+  const etag = first.headers.get("etag");
+  assert.ok(etag);
+
+  const matched = await csvResponse(
+    [{ netuid: 7, provider: "allways", status: "ok" }],
+    "endpoints",
+    "short",
+    req({ "if-none-match": etag }),
+    ["netuid", "provider", "status"],
+    {},
+    { stream: true },
+  );
+  assert.equal(matched.status, 304);
+  assert.equal(await matched.text(), "");
 });

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -18,6 +18,19 @@ function req(headers = {}, method = "GET") {
   });
 }
 
+async function drainCsvStream(stream) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  for (;;) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    text += decoder.decode(chunk.value, { stream: true });
+  }
+  text += decoder.decode();
+  return text;
+}
+
 test("rowsToCsv returns an empty body for empty rows without explicit columns", () => {
   assert.equal(rowsToCsv([]), "");
 });
@@ -259,6 +272,26 @@ test("csvBodyStream emits continuation newlines when a large export spans multip
 
   const done = await reader.read();
   assert.equal(done.done, true);
+});
+
+test("csvBodyStream matches rowsToCsv for small and multi-chunk exports", async () => {
+  const smallRows = [
+    { netuid: 7, name: "Allways" },
+    { netuid: 8, name: "Templar" },
+  ];
+  assert.equal(
+    await drainCsvStream(csvBodyStream(smallRows, ["netuid", "name"])),
+    rowsToCsv(smallRows, ["netuid", "name"]),
+  );
+
+  const largeRows = Array.from({ length: 129 }, (_, index) => ({
+    netuid: index,
+    status: index % 2 === 0 ? "ok" : "degraded",
+  }));
+  assert.equal(
+    await drainCsvStream(csvBodyStream(largeRows, ["netuid", "status"])),
+    rowsToCsv(largeRows, ["netuid", "status"]),
+  );
 });
 
 test("csvResponse can stream endpoint-sized exports without eager ETags", async () => {

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -330,3 +330,18 @@ test("csvResponse keeps conditional requests on the buffered ETag path when stre
   assert.equal(matched.status, 304);
   assert.equal(await matched.text(), "");
 });
+
+test("csvResponse returns a buffered 200 with an ETag for stale conditional requests when streaming is requested", async () => {
+  const response = await csvResponse(
+    [{ netuid: 7, provider: "allways", status: "ok" }],
+    "endpoints",
+    "short",
+    req({ "if-none-match": 'W/"not-a-match"' }),
+    ["netuid", "provider", "status"],
+    {},
+    { stream: true },
+  );
+  assert.equal(response.status, 200);
+  assert.ok(response.headers.get("etag"));
+  assert.equal(await response.text(), "netuid,provider,status\r\n7,allways,ok");
+});

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -236,9 +236,6 @@ test("csvBodyStream serializes malformed row entries as empty cells", async () =
   const first = await reader.read();
   assert.equal(decoder.decode(first.value), "netuid\r\n");
 
-  const second = await reader.read();
-  assert.equal(decoder.decode(second.value), "");
-
   const done = await reader.read();
   assert.equal(done.done, true);
 });

--- a/tests/csv.test.mjs
+++ b/tests/csv.test.mjs
@@ -290,6 +290,9 @@ test("csvResponse can stream endpoint-sized exports without eager ETags", async 
     decoder.decode(second.value),
     "7,allways,ok\r\n8,templar,degraded",
   );
+
+  const done = await reader.read();
+  assert.equal(done.done, true);
 });
 
 test("csvResponse falls back to the buffered ETag path on HEAD even when streaming is requested", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -2669,6 +2669,9 @@ async function handleApiRequest(
       request,
       transformed.meta.projection?.fields,
       linkValue ? { link: linkValue } : {},
+      {
+        stream: matched.id === "endpoints" || matched.id === "subnet-endpoints",
+      },
     );
   }
   // Real publish time from the KV latest pointer (null until a publish has

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -68,17 +68,7 @@ export function rowsToCsv(rows, columns) {
 
   const lines = [
     header.map(escapeCell).join(","),
-    ...safeRows.map((row) =>
-      header
-        .map((column) =>
-          escapeCell(
-            row && typeof row === "object" && !Array.isArray(row)
-              ? row[column]
-              : undefined,
-          ),
-        )
-        .join(","),
-    ),
+    ...safeRows.map((row) => csvLineForRow(row, header)),
   ];
   return lines.join("\r\n");
 }
@@ -135,13 +125,11 @@ export function csvBodyStream(rows, columns) {
         lines.push(csvLineForRow(safeRows[index], header));
         index += 1;
       }
-      controller.enqueue(
-        encoder.encode(
-          index < safeRows.length
-            ? `${lines.join("\r\n")}\r\n`
-            : lines.join("\r\n"),
-        ),
-      );
+      const chunkText =
+        index < safeRows.length ? `${lines.join("\r\n")}\r\n` : lines.join("\r\n");
+      if (chunkText.length > 0) {
+        controller.enqueue(encoder.encode(chunkText));
+      }
       if (index >= safeRows.length) {
         controller.close();
       }

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -127,11 +127,6 @@ export function csvBodyStream(rows, columns) {
         return;
       }
 
-      if (index >= safeRows.length) {
-        controller.close();
-        return;
-      }
-
       const lines = [];
       while (
         index < safeRows.length &&

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -1,6 +1,7 @@
 import { apiHeaders, ifNoneMatchSatisfied, weakEtag } from "./http.mjs";
 
 const SPREADSHEET_FORMULA_PREFIX = /^[=+\-@\t\r\n]/;
+const CSV_STREAM_ROWS_PER_CHUNK = 128;
 
 function normalizeColumns(rows, columns) {
   if (Array.isArray(columns) && columns.length > 0) {
@@ -82,6 +83,77 @@ export function rowsToCsv(rows, columns) {
   return lines.join("\r\n");
 }
 
+function csvLineForRow(row, header) {
+  return header
+    .map((column) =>
+      escapeCell(
+        row && typeof row === "object" && !Array.isArray(row)
+          ? row[column]
+          : undefined,
+      ),
+    )
+    .join(",");
+}
+
+export function csvBodyStream(rows, columns) {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const header = normalizeColumns(safeRows, columns);
+  const encoder = new TextEncoder();
+
+  if (header.length === 0) {
+    return new globalThis.ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+  }
+
+  const headerLine = header.map(escapeCell).join(",");
+  let index = 0;
+  let sentHeader = false;
+
+  return new globalThis.ReadableStream({
+    pull(controller) {
+      if (!sentHeader) {
+        sentHeader = true;
+        controller.enqueue(
+          encoder.encode(
+            safeRows.length > 0 ? `${headerLine}\r\n` : headerLine,
+          ),
+        );
+        if (safeRows.length === 0) {
+          controller.close();
+        }
+        return;
+      }
+
+      if (index >= safeRows.length) {
+        controller.close();
+        return;
+      }
+
+      const lines = [];
+      while (
+        index < safeRows.length &&
+        lines.length < CSV_STREAM_ROWS_PER_CHUNK
+      ) {
+        lines.push(csvLineForRow(safeRows[index], header));
+        index += 1;
+      }
+      controller.enqueue(
+        encoder.encode(
+          index < safeRows.length
+            ? `${lines.join("\r\n")}\r\n`
+            : lines.join("\r\n"),
+        ),
+      );
+      if (index >= safeRows.length) {
+        controller.close();
+      }
+    },
+  });
+}
+
 export function csvRequested(url, request) {
   const format = url.searchParams.get("format")?.toLowerCase();
   if (format === "csv") {
@@ -133,20 +205,33 @@ export async function csvResponse(
   request = null,
   columns = undefined,
   extraHeaders = {},
+  options = {},
 ) {
-  const body = rowsToCsv(rows, columns);
   const headers = apiHeaders(cacheProfile);
-  const etag = await weakEtag(body);
   headers.set("content-type", "text/csv; charset=utf-8");
   headers.set(
     "content-disposition",
     `attachment; filename="${csvFilename(filename)}"`,
   );
-  headers.set("etag", etag);
   headers.set("vary", "Accept, Accept-Encoding");
   for (const [key, value] of Object.entries(extraHeaders)) {
     headers.set(key, value);
   }
+
+  const shouldStream =
+    options.stream === true &&
+    request?.method !== "HEAD" &&
+    !request?.headers?.get("if-none-match");
+  if (shouldStream) {
+    return new Response(csvBodyStream(rows, columns), {
+      status: 200,
+      headers,
+    });
+  }
+
+  const body = rowsToCsv(rows, columns);
+  const etag = await weakEtag(body);
+  headers.set("etag", etag);
 
   if (request && ifNoneMatchSatisfied(request, etag)) {
     return new Response(null, { status: 304, headers });

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -208,8 +208,9 @@ export async function csvResponse(
     request?.method !== "HEAD" &&
     !request?.headers?.get("if-none-match");
   if (shouldStream) {
-    // Stream plain GET exports without precomputing the full body; HEAD and
-    // conditional requests stay buffered so they keep the weak ETag path.
+    // Stream plain GET exports without precomputing the full body; that skips
+    // issuing a weak ETag on those large downloads, so HEAD and conditional
+    // requests stay buffered and keep the validator path.
     return new Response(csvBodyStream(rows, columns), {
       status: 200,
       headers,

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -218,6 +218,8 @@ export async function csvResponse(
     request?.method !== "HEAD" &&
     !request?.headers?.get("if-none-match");
   if (shouldStream) {
+    // Stream plain GET exports without precomputing the full body; HEAD and
+    // conditional requests stay buffered so they keep the weak ETag path.
     return new Response(csvBodyStream(rows, columns), {
       status: 200,
       headers,

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -1,6 +1,8 @@
 import { apiHeaders, ifNoneMatchSatisfied, weakEtag } from "./http.mjs";
 
 const SPREADSHEET_FORMULA_PREFIX = /^[=+\-@\t\r\n]/;
+// Keep each stream pull bounded without fragmenting typical endpoint exports
+// into overly small chunks.
 const CSV_STREAM_ROWS_PER_CHUNK = 128;
 
 function normalizeColumns(rows, columns) {

--- a/workers/csv.mjs
+++ b/workers/csv.mjs
@@ -126,7 +126,9 @@ export function csvBodyStream(rows, columns) {
         index += 1;
       }
       const chunkText =
-        index < safeRows.length ? `${lines.join("\r\n")}\r\n` : lines.join("\r\n");
+        index < safeRows.length
+          ? `${lines.join("\r\n")}\r\n`
+          : lines.join("\r\n");
       if (chunkText.length > 0) {
         controller.enqueue(encoder.encode(chunkText));
       }


### PR DESCRIPTION
## Summary

- stream CSV serialization for `/api/v1/endpoints` and `/api/v1/subnets/{netuid}/endpoints` so the large endpoint registry export does not materialize a second full response body before returning.
- add regression coverage for projected/filtering endpoint CSV exports and the streaming helper path.

## Template Used

- backend-code.md

## What Changed

- added `csvBodyStream` and an opt-in streaming mode in `workers/csv.mjs`, while preserving the existing ETag/304 path for HEAD and conditional requests.
- enabled the streaming path for the large endpoint export routes in `workers/api.mjs`.
- added endpoint-route CSV coverage in `tests/api-coverage.test.mjs` and helper coverage in `tests/csv.test.mjs`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [ ] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [ ] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

Additional focused tests:
- [x] `npm test -- tests/csv.test.mjs tests/api-coverage.test.mjs`

Closes #2523