### PR TITLE
fix(data-api): require integer chain event filters

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -107,6 +107,33 @@ test("chain-events accepts block + extrinsic filters (extrinsic-detail view)", a
   expect(res2.status).toBe(200);
 });
 
+test("chain-events ignores malformed integer position filters", async () => {
+  const cases = [
+    "/api/v1/chain-events?block=1.5&extrinsic=2&before=3",
+    "/api/v1/chain-events?block=-1&extrinsic=2&before=3",
+    "/api/v1/chain-events?block=1e3&extrinsic=2&before=3",
+    "/api/v1/chain-events?block=9007199254740993&extrinsic=2&before=3",
+    "/api/v1/chain-events?block=12&extrinsic=3.5",
+    "/api/v1/chain-events?block=12&extrinsic=-3",
+    "/api/v1/chain-events?before=3.5",
+    "/api/v1/chain-events?before=-3",
+    "/api/v1/chain-events?before=1e3",
+    "/api/v1/chain-events?before=9007199254740993",
+  ];
+
+  for (const path of cases) {
+    sqlCalls.length = 0;
+    const res = await req(path);
+    expect(res.status).toBe(200);
+    const values = sqlCalls.flatMap((call) => call.values);
+    expect(values).not.toContain(1.5);
+    expect(values).not.toContain(3.5);
+    expect(values).not.toContain(-1);
+    expect(values).not.toContain(-3);
+    expect(values).not.toContain(1000);
+  }
+});
+
 test("chain-events ignores extrinsic without block to avoid global scans", async () => {
   const res = await req("/api/v1/chain-events?extrinsic=999999&limit=1");
   expect(res.status).toBe(200);

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -51,6 +51,15 @@ function clampStatsBlocks(raw) {
 function numberOrNull(v) {
   return v == null ? null : Number(v);
 }
+
+function nonNegativeIntegerParam(params, key) {
+  const value = params.get(key);
+  if (value == null || value === "") return null;
+  if (!/^\d+$/.test(value)) return null;
+  const n = Number(value);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
 function coerceEvent(row) {
   return {
     ...row,
@@ -120,16 +129,15 @@ export default {
             400,
           );
         }
-        const numParam = (k) => {
-          const v = url.searchParams.get(k);
-          if (v == null || v === "") return null;
-          const n = Number(v);
-          return Number.isFinite(n) ? n : null;
-        };
-        const blockN = numParam("block");
-        const extrN = blockN != null ? numParam("extrinsic") : null;
+        const blockN = nonNegativeIntegerParam(url.searchParams, "block");
+        const extrN =
+          blockN != null
+            ? nonNegativeIntegerParam(url.searchParams, "extrinsic")
+            : null;
         const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
-        const beforeBn = cursor ? null : numParam("before"); // legacy block_number cursor
+        const beforeBn = cursor
+          ? null
+          : nonNegativeIntegerParam(url.searchParams, "before"); // legacy block_number cursor
         if (method && !pallet && blockN == null) {
           return json(
             {


### PR DESCRIPTION
## Summary

Fixes `/api/v1/chain-events` integer filter parsing so chain-position query params only bind non-negative safe integers.

Previously `block`, `extrinsic`, and legacy `before` accepted any finite `Number(...)` value, so malformed inputs like `1.5`, `-1`, `1e3`, or unsafe integers could reach the Postgres predicates. These fields represent integer chain positions, so malformed values are now ignored consistently.

## Changes

- Add a strict non-negative integer query-param parser in `workers/data-api.mjs`
- Apply it to `block`, `extrinsic`, and `before`
- Add regression coverage for fractional, negative, exponent-form, and unsafe integer inputs

## Validation

- [x] `npm test -- tests/data-api.test.mjs`
- [x] `npm test -- tests/request-params.test.mjs tests/data-api.test.mjs tests/block-events.test.mjs`
- [x] `npm run lint`