### PR TITLE
fix(account-events): reject blank integer cells that coerce to block/subnet/uid 0

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -103,6 +103,8 @@ function toIso(ms) {
 // missing, non-finite, or negative — chain positions are never negative.
 function toBlockNumber(value) {
   if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isInteger(n) && n >= 0 ? n : null;
 }

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -283,6 +283,25 @@ test("formatAccountEvent rejects non-integer or negative netuid/uid cells to nul
   assert.equal(formatAccountEvent({ netuid: "abc" }).netuid, null);
 });
 
+test("formatAccountEvent rejects blank integer cells that coerce to 0 (not block 0 / subnet 0 / uid 0)", () => {
+  // Mirrors the blank-cell guard in blocks.mjs (#2879): Number("") and
+  // Number("   ") are 0, which would fabricate genesis height / subnet / uid 0.
+  for (const blank of ["", "   "]) {
+    const out = formatAccountEvent({
+      block_number: blank,
+      event_index: blank,
+      netuid: blank,
+      uid: blank,
+      extrinsic_index: blank,
+    });
+    assert.equal(out.block_number, null, `block_number for ${JSON.stringify(blank)}`);
+    assert.equal(out.event_index, null, `event_index for ${JSON.stringify(blank)}`);
+    assert.equal(out.netuid, null, `netuid for ${JSON.stringify(blank)}`);
+    assert.equal(out.uid, null, `uid for ${JSON.stringify(blank)}`);
+    assert.equal(out.extrinsic_index, null, `extrinsic_index for ${JSON.stringify(blank)}`);
+  }
+});
+
 test("formatAccountEvent coerces string-typed amount_tao and alpha_amount cells to Numbers", () => {
   // D1 can return a REAL column as a numeric string; the bare `?? null`
   // pass-through this replaced would have leaked strings into the JSON payload.

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -294,11 +294,23 @@ test("formatAccountEvent rejects blank integer cells that coerce to 0 (not block
       uid: blank,
       extrinsic_index: blank,
     });
-    assert.equal(out.block_number, null, `block_number for ${JSON.stringify(blank)}`);
-    assert.equal(out.event_index, null, `event_index for ${JSON.stringify(blank)}`);
+    assert.equal(
+      out.block_number,
+      null,
+      `block_number for ${JSON.stringify(blank)}`,
+    );
+    assert.equal(
+      out.event_index,
+      null,
+      `event_index for ${JSON.stringify(blank)}`,
+    );
     assert.equal(out.netuid, null, `netuid for ${JSON.stringify(blank)}`);
     assert.equal(out.uid, null, `uid for ${JSON.stringify(blank)}`);
-    assert.equal(out.extrinsic_index, null, `extrinsic_index for ${JSON.stringify(blank)}`);
+    assert.equal(
+      out.extrinsic_index,
+      null,
+      `extrinsic_index for ${JSON.stringify(blank)}`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary
- Reject blank D1 integer cells before `Number()` coercion in `account-events.mjs` `toBlockNumber()`.
- Prevents `""` / whitespace-only strings from fabricating block height 0, subnet 0, or uid 0 in account event payloads.
- Mirrors the blank-cell guard landing in `blocks.mjs` (#2879); closes the parity gap for the shared coercion helper used by `formatAccountEvent`.

## Test plan
- [x] `npx vitest run tests/account-events.test.mjs`