### PR TITLE
fix(movers): skip null and blank netuid cells before subnet 0 coercion

### DIFF
--- a/src/movers.mjs
+++ b/src/movers.mjs
@@ -33,8 +33,12 @@ function toNumber(value) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-// A non-negative integer netuid, or null for a malformed cell.
+// A non-negative integer netuid, or null for a malformed/absent cell. Guard null
+// explicitly so a null netuid is skipped rather than coerced to subnet 0
+// (Number(null) === 0). Mirrors normalizedNetuid in account-stake-flow.mjs.
 function normalizedNetuid(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const netuid = Number(value);
   return Number.isSafeInteger(netuid) && netuid >= 0 ? netuid : null;
 }

--- a/tests/movers.test.mjs
+++ b/tests/movers.test.mjs
@@ -196,6 +196,35 @@ describe("computeMovers", () => {
     assert.equal(m[0].stake_delta_tao, 50);
   });
 
+  test("skips rows with a null or blank netuid instead of coercing to subnet 0", () => {
+    const m = computeMovers(
+      [
+        agg(0, "s", { neurons: 1, validators: 0, stake: 10, emission: 0 }),
+        {
+          netuid: null,
+          snapshot_date: "s",
+          neuron_count: 5,
+          validator_count: 0,
+          total_stake_tao: 99,
+          total_emission_tao: 0,
+        },
+        {
+          netuid: "  ",
+          snapshot_date: "s",
+          neuron_count: 3,
+          validator_count: 0,
+          total_stake_tao: 88,
+          total_emission_tao: 0,
+        },
+      ],
+      [agg(0, "e", { neurons: 1, validators: 0, stake: 20, emission: 0 })],
+      { sort: "stake" },
+    );
+    assert.equal(m.length, 1);
+    assert.equal(m[0].netuid, 0);
+    assert.equal(m[0].stake_start_tao, 10);
+  });
+
   test("non-array inputs yield an empty ranking", () => {
     assert.deepEqual(computeMovers(null, undefined, { sort: "stake" }), []);
   });


### PR DESCRIPTION
## Summary

- Guard `normalizedNetuid` in `buildSubnetMovers` so null and blank `netuid` cells are skipped instead of coerced to subnet 0 (`Number(null) === 0`).
- Mirrors the explicit null guard already used in `account-stake-flow.mjs`.

## Test plan

- [x] `npm test -- tests/movers.test.mjs`
