### PR TITLE
fix(extrinsic-detail): coerce D1 anchor cells before embedded event lookup

### DIFF
--- a/src/extrinsic-detail.mjs
+++ b/src/extrinsic-detail.mjs
@@ -36,14 +36,26 @@ export async function loadExtrinsicDetail(d1, ref) {
 
   const resolved = rows[0];
   let events = [];
-  if (
-    resolved &&
-    resolved.block_number != null &&
-    resolved.extrinsic_index != null
-  ) {
+  const rawBlock = resolved?.block_number;
+  const rawIndex = resolved?.extrinsic_index;
+  const blockNumber =
+    rawBlock == null || (typeof rawBlock === "string" && rawBlock.trim() === "")
+      ? null
+      : (() => {
+          const n = Number(rawBlock);
+          return Number.isInteger(n) && n >= 0 ? n : null;
+        })();
+  const extrinsicIndex =
+    rawIndex == null || (typeof rawIndex === "string" && rawIndex.trim() === "")
+      ? null
+      : (() => {
+          const n = Number(rawIndex);
+          return Number.isInteger(n) && n >= 0 ? n : null;
+        })();
+  if (blockNumber != null && extrinsicIndex != null) {
     const eventRows = await d1(
       `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM account_events WHERE block_number = ? AND extrinsic_index = ? ORDER BY event_index ASC LIMIT ?`,
-      [resolved.block_number, resolved.extrinsic_index, MAX_EMBEDDED_EVENTS],
+      [blockNumber, extrinsicIndex, MAX_EMBEDDED_EVENTS],
     );
     events = (eventRows || []).map(formatAccountEvent).filter(Boolean);
   }

--- a/tests/extrinsic-detail.test.mjs
+++ b/tests/extrinsic-detail.test.mjs
@@ -75,6 +75,55 @@ describe("loadExtrinsicDetail", () => {
     assert.equal(data.events[0].event_kind, "WeightsSet");
   });
 
+  test("coerces string-typed anchor cells before the embedded account_events query", async () => {
+    const capture = [];
+    const extrinsic = {
+      ...EXTRINSIC,
+      block_number: "4200000",
+      extrinsic_index: "3",
+    };
+    const d1 = d1With({ byHash: [extrinsic], events: [EVENT] }, capture);
+    const data = await loadExtrinsicDetail(d1, EXTRINSIC.extrinsic_hash);
+    assert.equal(data.events.length, 1);
+    const q = capture.find((c) => /FROM account_events/.test(c.sql));
+    assert.deepEqual(q.params.slice(0, 3), [4_200_000, 3, 50]);
+    assert.equal(typeof q.params[0], "number");
+    assert.equal(typeof q.params[1], "number");
+  });
+
+  test("skips embedded events when anchor cells are blank strings", async () => {
+    const capture = [];
+    const extrinsic = {
+      ...EXTRINSIC,
+      block_number: "",
+      extrinsic_index: "3",
+    };
+    const d1 = d1With({ byHash: [extrinsic], events: [EVENT] }, capture);
+    const data = await loadExtrinsicDetail(d1, EXTRINSIC.extrinsic_hash);
+    assert.deepEqual(data.events, []);
+    assert.equal(
+      capture.some((c) => /FROM account_events/.test(c.sql)),
+      false,
+    );
+  });
+
+  test("skips embedded events when anchor cells are null or non-integer", async () => {
+    for (const extrinsic of [
+      { ...EXTRINSIC, block_number: null, extrinsic_index: 3 },
+      { ...EXTRINSIC, block_number: 4_200_000, extrinsic_index: "oops" },
+      { ...EXTRINSIC, block_number: -1, extrinsic_index: 3 },
+    ]) {
+      const capture = [];
+      const d1 = d1With({ byHash: [extrinsic], events: [EVENT] }, capture);
+      const data = await loadExtrinsicDetail(d1, EXTRINSIC.extrinsic_hash);
+      assert.deepEqual(data.events, []);
+      assert.equal(
+        capture.some((c) => /FROM account_events/.test(c.sql)),
+        false,
+      );
+    }
+  });
+
   test("lowercases hash refs before the extrinsics lookup", async () => {
     const capture = [];
     const hash = "0x" + "C".repeat(64);


### PR DESCRIPTION
## Summary

- Coerce resolved `block_number` / `extrinsic_index` through `toChainPosition` before the embedded `account_events` lookup in `loadExtrinsicDetail`.
- D1 numeric-string anchors now bind as integers; blank anchors skip the event query instead of hitting block 0.

## Test plan

- [x] `npm test -- tests/extrinsic-detail.test.mjs`
