### PR TITLE
fix(analytics): coerce D1 numeric-string captured_at in neurons cache stamps

### DIFF
--- a/tests/chain-concentration.test.mjs
+++ b/tests/chain-concentration.test.mjs
@@ -5,7 +5,7 @@ import {
   loadChainConcentration,
 } from "../src/concentration.mjs";
 import { handleRequest } from "../workers/api.mjs";
-import { readNeuronsCacheStamp } from "../workers/request-handlers/analytics.mjs";
+import { readNeuronsCacheStamp, readSubnetNeuronsCacheStamp } from "../workers/request-handlers/analytics.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 
 // buildChainConcentration reuses the (separately tested) computeConcentration /
@@ -312,6 +312,12 @@ describe("readNeuronsCacheStamp", () => {
 
   test("returns null when D1 is unbound (fallback rows)", async () => {
     assert.equal(await readNeuronsCacheStamp({}), null);
+  });
+
+  test("coerces D1 numeric-string captured_at cells", async () => {
+    const env = stampEnv([{ captured_at: "1700000000000" }]);
+    assert.equal(await readNeuronsCacheStamp(env), "1700000000000");
+    assert.equal(await readSubnetNeuronsCacheStamp(env, 7), "1700000000000");
   });
 });
 

--- a/tests/chain-concentration.test.mjs
+++ b/tests/chain-concentration.test.mjs
@@ -5,7 +5,10 @@ import {
   loadChainConcentration,
 } from "../src/concentration.mjs";
 import { handleRequest } from "../workers/api.mjs";
-import { readNeuronsCacheStamp, readSubnetNeuronsCacheStamp } from "../workers/request-handlers/analytics.mjs";
+import {
+  readNeuronsCacheStamp,
+  readSubnetNeuronsCacheStamp,
+} from "../workers/request-handlers/analytics.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 
 // buildChainConcentration reuses the (separately tested) computeConcentration /

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -307,6 +307,14 @@ export async function withEdgeCache(
   return response;
 }
 
+// D1 MAX(captured_at) is INTEGER but often surfaces as a numeric string; coerce
+// before the integer guard so neurons-tier edge-cache stamps are not always null.
+function coerceCapturedAtStamp(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0 ? String(n) : null;
+}
+
 // Neurons-tier routes refresh on the ~3-minute events/metagraph cron, not the
 // 15-minute health prober — bust their edge cache on per-subnet snapshot time.
 export async function readSubnetNeuronsCacheStamp(env, netuid) {
@@ -316,10 +324,7 @@ export async function readSubnetNeuronsCacheStamp(env, netuid) {
     [netuid],
   );
   if (hasD1FallbackRows(rows)) return null;
-  const capturedAt = rows[0]?.captured_at;
-  return Number.isInteger(capturedAt) && capturedAt > 0
-    ? String(capturedAt)
-    : null;
+  return coerceCapturedAtStamp(rows[0]?.captured_at);
 }
 
 // Network-wide neuron cache stamp: the newest captured_at across ALL subnets, so a
@@ -336,10 +341,7 @@ export async function readNeuronsCacheStamp(env) {
     [],
   );
   if (hasD1FallbackRows(rows)) return null;
-  const capturedAt = rows[0]?.captured_at;
-  return Number.isInteger(capturedAt) && capturedAt > 0
-    ? String(capturedAt)
-    : null;
+  return coerceCapturedAtStamp(rows[0]?.captured_at);
 }
 
 export function withNeuronsEdgeCache(


### PR DESCRIPTION
## Summary

Coerce D1 numeric-string `captured_at` cells in neurons-tier edge-cache stamp readers.

## What Changed

- Add `coerceCapturedAtStamp` and use it in `readNeuronsCacheStamp` / `readSubnetNeuronsCacheStamp`.
- Regression test with string-typed `MAX(captured_at)`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npx vitest run tests/chain-concentration.test.mjs -t readNeuronsCacheStamp`

No linked issue — D1 stamp coercion gap found during neurons edge-cache audit.