### PR TITLE
fix(identity-history): coerce D1 string block_number when recording changes

### DIFF
--- a/src/subnet-identity-history.mjs
+++ b/src/subnet-identity-history.mjs
@@ -162,7 +162,9 @@ async function latestBlockNumber(db) {
     const res = await db
       .prepare("SELECT MAX(block_number) AS block_number FROM blocks")
       .all();
-    const block = res?.results?.[0]?.block_number;
+    const raw = res?.results?.[0]?.block_number;
+    if (raw == null || raw === "") return null;
+    const block = Number(raw);
     return Number.isSafeInteger(block) && block > 0 ? block : null;
   } catch {
     return null;

--- a/tests/subnet-identity-history.test.mjs
+++ b/tests/subnet-identity-history.test.mjs
@@ -692,6 +692,38 @@ describe("recordSubnetIdentityChanges", () => {
     assert.equal(binds[0]?.[1], 8_404_076);
   });
 
+  test("coerces D1 numeric-string block_number when recording changes", async () => {
+    const binds = [];
+    const db = {
+      prepare(sql) {
+        return {
+          bind(...args) {
+            if (/INSERT INTO subnet_identity_history/.test(sql)) {
+              binds.push(args);
+            }
+            return this;
+          },
+          all: async () => {
+            if (/FROM blocks/.test(sql)) {
+              return { results: [{ block_number: "8404076" }] };
+            }
+            return { results: [] };
+          },
+        };
+      },
+      batch: async () => {},
+    };
+    await recordSubnetIdentityChanges(
+      { METAGRAPH_HEALTH_DB: db },
+      {
+        profiles: [{ netuid: 7, native_identity: { subnet_name: "First" } }],
+        db,
+      },
+    );
+    assert.equal(binds[0]?.[1], 8_404_076);
+    assert.equal(typeof binds[0]?.[1], "number");
+  });
+
   test("batches large inserts in chunks of 100", async () => {
     let batches = 0;
     const db = {


### PR DESCRIPTION
## Summary

Coerce D1 numeric-string `block_number` when the identity-history cron records subnet identity changes.

## What Changed

- `latestBlockNumber` coerces `MAX(block_number)` via `Number()` before the safe-integer guard.
- Regression test with a string-typed blocks row.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npx vitest run tests/subnet-identity-history.test.mjs -t block_number`

No linked issue — write path missed the D1 coercion already applied on identity-history reads.