### PR TITLE
fix(health): complete #2807 RangeError guard on prober cron and GET /health

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -67,8 +67,15 @@ const RPC_BLOCK_PLAUSIBILITY_TOLERANCE = 10;
 // last_ok for a surface that has never probed OK. Treat any falsy/zero ms as
 // null at the source so consumers don't each need a pre-2000 sentinel guard. A
 // real timestamp (run time, last OK) is always a large positive ms.
-const iso = (ms) =>
-  Number.isFinite(ms) && ms > 0 ? new Date(ms).toISOString() : null;
+// A finite but out-of-range epoch (|ms| > 8.64e15, the JS Date limit) makes
+// toISOString() throw a RangeError, which would abort the 15-minute cron on one
+// corrupt surface_status.last_ok cell. Range-guard via getTime() and drop to
+// null — mirrors isoFromMs in health-serving.mjs (#2807).
+const iso = (ms) => {
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const date = new Date(ms);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+};
 
 function safeRpcBlockNumber(value) {
   if (value == null) return null;

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -328,6 +328,35 @@ describe("/health readiness", () => {
     assert.equal(body.chain_events.age_seconds, null);
   });
 
+  test("chain_events survives an out-of-range observed_at (no RangeError)", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: makeKv({
+        "metagraph:latest": { published_at: new Date().toISOString() },
+      }),
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  return {
+                    results: [{ block: 8461200, at: 8640000000000001 }],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    });
+    const res = await handleRequest(req("/health"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.chain_events.latest_indexed_block, 8461200);
+    assert.equal(body.chain_events.latest_event_at, null);
+    assert.equal(body.chain_events.age_seconds, null);
+  });
+
   test("chain_events is null when no health DB is bound (#1361)", async () => {
     const env = {
       ASSETS: {

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -383,6 +383,49 @@ describe("runHealthProber", () => {
     assert.equal(meta.last_run_at, new Date(50000).toISOString());
   });
 
+  test("survives an out-of-range prior last_ok from D1 (no RangeError)", async () => {
+    // A corrupt surface_status.last_ok beyond the ±8.64e15 JS Date limit is carried
+    // forward on a failed probe. iso() must drop it to null instead of throwing a
+    // RangeError and aborting the whole 15-minute cron — mirrors #2807 / isoFromMs.
+    const kv = makeKv();
+    const db = makeDb({
+      priorStatus: [
+        {
+          surface_id: "sn7-api",
+          surface_key: "srf-sn7apikey000000",
+          last_ok: 8640000000000001,
+          consecutive_failures: 0,
+        },
+      ],
+    });
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 50000,
+        db,
+        kv,
+        loadSurfaces: async () => [SURFACES[0]],
+        probeSurface: async () => ({
+          status: "failed",
+          classification: "dead",
+          latency_ms: null,
+          status_code: 404,
+        }),
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    const apiRow = kv
+      .json(KV_HEALTH_CURRENT)
+      .surfaces.find((s) => s.surface_id === "sn7-api");
+    assert.equal(apiRow.last_ok, null);
+    const subnet = kv
+      .json(KV_HEALTH_CURRENT)
+      .subnets.find((s) => s.netuid === 7);
+    assert.equal(subnet.last_ok, null);
+  });
+
   test("folds unrecognized probe status into unknown in global status_counts", async () => {
     const kv = makeKv();
     const result = await runHealthProber(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -2773,6 +2773,17 @@ function matchRoute(pathname) {
   return null;
 }
 
+// Epoch-ms → ISO string for /health observability fields. A finite but
+// out-of-range epoch (|ms| > 8.64e15, the JS Date limit) makes toISOString()
+// throw a RangeError, which would 500 GET /health on one corrupt observed_at
+// cell. Range-guard via getTime() and drop to null — mirrors isoFromMs in
+// health-serving.mjs (#2807).
+function isoFromFiniteMs(ms) {
+  if (!Number.isFinite(ms)) return null;
+  const date = new Date(ms);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
 // Lightweight readiness probe for uptime checks and load balancers. Reports
 // which bindings are wired; KV reads are in-isolate memoized.
 async function handleHealthRequest(request, env) {
@@ -2837,13 +2848,11 @@ async function handleHealthRequest(request, env) {
   if (bindings.health_db) {
     const chainEventsRow = await readChainEventsDb(env);
     const chainEventsAtMs = chainEventsRow ? Number(chainEventsRow.at) : NaN;
-    const chainEventsFresh = Number.isFinite(chainEventsAtMs);
+    const chainEventsAtIso = isoFromFiniteMs(chainEventsAtMs);
     chainEvents = {
       latest_indexed_block: chainEventsRow?.block ?? null,
-      latest_event_at: chainEventsFresh
-        ? new Date(chainEventsAtMs).toISOString()
-        : null,
-      age_seconds: chainEventsFresh
+      latest_event_at: chainEventsAtIso,
+      age_seconds: chainEventsAtIso
         ? Math.round((Date.now() - chainEventsAtMs) / 1000)
         : null,
     };


### PR DESCRIPTION
## Summary

Completes the **#2807 RangeError guard** for the two remaining production paths that still call `new Date(ms).toISOString()` without a `getTime()` check:

1. **`health-prober.mjs` `iso()`** — the 15-minute cron prober. A single corrupt `surface_status.last_ok` from D1 (finite but out-of-range epoch-ms) throws `RangeError` and **aborts the entire probe sweep**, stopping KV/D1 health writes for all surfaces.

2. **`GET /health` `chain_events.latest_event_at`** — the uptime/readiness probe. The same corrupt `observed_at` cell **500s `/health`**, breaking load-balancer and external uptime checks.

Merged #2807 fixed this for the live health API (`health-serving.mjs` `isoFromMs`); this PR applies the identical guard to the cron + readiness paths left behind.

## Why this matters

| Path | Without fix | With fix |
|------|-------------|----------|
| 15-min cron | Whole prober run crashes | Corrupt cell → `null`, sweep continues |
| `GET /health` | 500 for uptime monitors | 200 with `latest_event_at: null` |

## Test plan

- [x] `npx vitest run tests/health-prober.test.mjs -t "out-of-range prior last_ok"`
- [x] `npx vitest run tests/api-coverage.test.mjs -t "out-of-range observed_at"`
- [x] `npm run lint`

## Related

- Merged: #2807 (`health-serving` live endpoint guard)
- Supersedes intent of #2854 + #2857 (same root cause, one focused follow-up)
