### PR TITLE
fix(health): complete #2807 RangeError guard on cron, rollup, and GET /health

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -914,3 +914,9 @@ export async function writeSubnetSnapshot(env, overrides = {}) {
     };
   }
 }
+
+// Exported for unit tests.
+export const __test = {
+  iso,
+  utcDayBounds,
+};

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -67,8 +67,15 @@ const RPC_BLOCK_PLAUSIBILITY_TOLERANCE = 10;
 // last_ok for a surface that has never probed OK. Treat any falsy/zero ms as
 // null at the source so consumers don't each need a pre-2000 sentinel guard. A
 // real timestamp (run time, last OK) is always a large positive ms.
-const iso = (ms) =>
-  Number.isFinite(ms) && ms > 0 ? new Date(ms).toISOString() : null;
+// A finite but out-of-range epoch (|ms| > 8.64e15, the JS Date limit) makes
+// toISOString() throw a RangeError, which would abort the 15-minute cron on one
+// corrupt surface_status.last_ok cell. Range-guard via getTime() and drop to
+// null — mirrors isoFromMs in health-serving.mjs (#2807).
+const iso = (ms) => {
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const date = new Date(ms);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+};
 
 function safeRpcBlockNumber(value) {
   if (value == null) return null;
@@ -682,10 +689,14 @@ async function persistToKv(kv, probed, runAt) {
 
 // UTC day bounds for a given epoch-ms instant: { date: "YYYY-MM-DD", start, end }.
 function utcDayBounds(ms) {
+  if (!Number.isFinite(ms)) return null;
   const d = new Date(ms);
+  if (!Number.isFinite(d.getTime())) return null;
   const start = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  const startDate = new Date(start);
+  if (!Number.isFinite(startDate.getTime())) return null;
   return {
-    date: new Date(start).toISOString().slice(0, 10),
+    date: startDate.toISOString().slice(0, 10),
     start,
     end: start + 24 * 60 * 60 * 1000,
   };
@@ -704,7 +715,13 @@ export async function rollupDailyUptime(env, overrides = {}) {
   const db = overrides.db || env.METAGRAPH_HEALTH_DB;
   if (!db?.prepare) return { rolled: false };
   const runAt = now();
-  const days = [utcDayBounds(runAt), utcDayBounds(runAt - 24 * 60 * 60 * 1000)];
+  const days = [
+    utcDayBounds(runAt),
+    utcDayBounds(runAt - 24 * 60 * 60 * 1000),
+  ].filter(Boolean);
+  if (!days.length) {
+    return { rolled: false, error: "invalid run timestamp" };
+  }
   const conflictColumns = `
        surface_id = excluded.surface_id,
        surface_key = excluded.surface_key,

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -328,6 +328,35 @@ describe("/health readiness", () => {
     assert.equal(body.chain_events.age_seconds, null);
   });
 
+  test("chain_events survives an out-of-range observed_at (no RangeError)", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: makeKv({
+        "metagraph:latest": { published_at: new Date().toISOString() },
+      }),
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  return {
+                    results: [{ block: 8461200, at: 8640000000000001 }],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    });
+    const res = await handleRequest(req("/health"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.chain_events.latest_indexed_block, 8461200);
+    assert.equal(body.chain_events.latest_event_at, null);
+    assert.equal(body.chain_events.age_seconds, null);
+  });
+
   test("chain_events is null when no health DB is bound (#1361)", async () => {
     const env = {
       ASSETS: {

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { describe, test, vi } from "vitest";
 import {
   KV_HEALTH_CURRENT,
   KV_HEALTH_META,
@@ -13,7 +13,10 @@ import {
   runHealthProber,
   workerResolvedUrlSafetyGuard,
   workerWebSocketConnector,
+  __test,
 } from "../src/health-prober.mjs";
+
+const { iso, utcDayBounds } = __test;
 import { handleScheduled } from "../workers/api.mjs";
 import {
   EMBEDDING_SYNC_CRON,
@@ -1962,6 +1965,37 @@ describe("rollupDailyUptime (durable daily history)", () => {
       rolled: false,
       error: "invalid run timestamp",
     });
+  });
+
+  test("rollupDailyUptime skips an out-of-range UTC day bound without aborting", async () => {
+    const db = makeDb();
+    const result = await rollupDailyUptime(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => 8640000000000001 },
+    );
+    assert.equal(result.rolled, true);
+    assert.equal(result.days.length, 1);
+    assert.equal(db.calls.batches.length, 1);
+    assert.equal(db.calls.batches[0].length, 1);
+  });
+
+  test("iso and utcDayBounds drop out-of-range epochs without RangeError (#2807)", () => {
+    assert.equal(iso(8640000000000001), null);
+    assert.equal(iso(50000), new Date(50000).toISOString());
+    assert.equal(utcDayBounds(Number.NaN), null);
+    assert.equal(utcDayBounds(8640000000000001), null);
+    const bounds = utcDayBounds(Date.UTC(2026, 5, 13, 10, 0, 0));
+    assert.equal(bounds.date, "2026-06-13");
+    const getTime = vi.spyOn(Date.prototype, "getTime");
+    getTime.mockReturnValueOnce(Date.UTC(2026, 5, 13, 10));
+    getTime.mockReturnValueOnce(Number.NaN);
+    assert.equal(utcDayBounds(Date.UTC(2026, 5, 13, 10)), null);
+    getTime.mockRestore();
+    const isoGetTime = vi
+      .spyOn(Date.prototype, "getTime")
+      .mockReturnValueOnce(Number.NaN);
+    assert.equal(iso(50000), null);
+    isoGetTime.mockRestore();
   });
 
   test("degrades to { rolled: false } when the batch write throws", async () => {

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -383,6 +383,49 @@ describe("runHealthProber", () => {
     assert.equal(meta.last_run_at, new Date(50000).toISOString());
   });
 
+  test("survives an out-of-range prior last_ok from D1 (no RangeError)", async () => {
+    // A corrupt surface_status.last_ok beyond the ±8.64e15 JS Date limit is carried
+    // forward on a failed probe. iso() must drop it to null instead of throwing a
+    // RangeError and aborting the whole 15-minute cron — mirrors #2807 / isoFromMs.
+    const kv = makeKv();
+    const db = makeDb({
+      priorStatus: [
+        {
+          surface_id: "sn7-api",
+          surface_key: "srf-sn7apikey000000",
+          last_ok: 8640000000000001,
+          consecutive_failures: 0,
+        },
+      ],
+    });
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 50000,
+        db,
+        kv,
+        loadSurfaces: async () => [SURFACES[0]],
+        probeSurface: async () => ({
+          status: "failed",
+          classification: "dead",
+          latency_ms: null,
+          status_code: 404,
+        }),
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    const apiRow = kv
+      .json(KV_HEALTH_CURRENT)
+      .surfaces.find((s) => s.surface_id === "sn7-api");
+    assert.equal(apiRow.last_ok, null);
+    const subnet = kv
+      .json(KV_HEALTH_CURRENT)
+      .subnets.find((s) => s.netuid === 7);
+    assert.equal(subnet.last_ok, null);
+  });
+
   test("folds unrecognized probe status into unknown in global status_counts", async () => {
     const kv = makeKv();
     const result = await runHealthProber(
@@ -1902,6 +1945,23 @@ describe("rollupDailyUptime (durable daily history)", () => {
 
   test("no-ops without a D1 binding", async () => {
     assert.deepEqual(await rollupDailyUptime({}), { rolled: false });
+  });
+
+  test("returns rolled:false when run timestamp is out of JS Date range", async () => {
+    const db = {
+      prepare: () => ({ bind: () => ({}) }),
+      async batch() {
+        throw new Error("batch should not run");
+      },
+    };
+    const result = await rollupDailyUptime(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => Number.NaN },
+    );
+    assert.deepEqual(result, {
+      rolled: false,
+      error: "invalid run timestamp",
+    });
   });
 
   test("degrades to { rolled: false } when the batch write throws", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -2794,6 +2794,17 @@ function matchRoute(pathname) {
   return null;
 }
 
+// Epoch-ms → ISO string for /health observability fields. A finite but
+// out-of-range epoch (|ms| > 8.64e15, the JS Date limit) makes toISOString()
+// throw a RangeError, which would 500 GET /health on one corrupt observed_at
+// cell. Range-guard via getTime() and drop to null — mirrors isoFromMs in
+// health-serving.mjs (#2807).
+function isoFromFiniteMs(ms) {
+  if (!Number.isFinite(ms)) return null;
+  const date = new Date(ms);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
 // Lightweight readiness probe for uptime checks and load balancers. Reports
 // which bindings are wired; KV reads are in-isolate memoized.
 async function handleHealthRequest(request, env) {
@@ -2858,13 +2869,11 @@ async function handleHealthRequest(request, env) {
   if (bindings.health_db) {
     const chainEventsRow = await readChainEventsDb(env);
     const chainEventsAtMs = chainEventsRow ? Number(chainEventsRow.at) : NaN;
-    const chainEventsFresh = Number.isFinite(chainEventsAtMs);
+    const chainEventsAtIso = isoFromFiniteMs(chainEventsAtMs);
     chainEvents = {
       latest_indexed_block: chainEventsRow?.block ?? null,
-      latest_event_at: chainEventsFresh
-        ? new Date(chainEventsAtMs).toISOString()
-        : null,
-      age_seconds: chainEventsFresh
+      latest_event_at: chainEventsAtIso,
+      age_seconds: chainEventsAtIso
         ? Math.round((Date.now() - chainEventsAtMs) / 1000)
         : null,
     };


### PR DESCRIPTION
## Summary

Completes the **#2807 parity gap** left after `health-serving.mjs` got `isoFromMs()` — three production paths still called `new Date(ms).toISOString()` without a range guard:

1. **`src/health-prober.mjs` `iso()`** — corrupt `surface_status.last_ok` from D1 aborts the **15-minute health cron** with `RangeError` when a failed probe carries the prior timestamp forward.
2. **`src/health-prober.mjs` `utcDayBounds()`** — an out-of-range `now()` during the **hourly uptime rollup** throws before the batch runs, leaving daily history stale.
3. **`GET /health` `chain_events.latest_event_at`** — one corrupt `account_events.observed_at` **500s the public readiness probe** that uptime monitors hit.

All three now use the same `getTime()` range guard as `isoFromMs()` in `health-serving.mjs` (#2807): drop invalid epochs to `null` instead of throwing.

## Why this (not blank-cell guards)

Recent merges (#2807, #2809, #2813) are **production crash / 500 prevention** on live routes and crons. This PR is the same category: one bad D1 cell must not take down `/health` or abort scheduled Workers.

## Test plan

- [x] `npx vitest run tests/health-prober.test.mjs`
- [x] `npx vitest run tests/api-coverage.test.mjs -t "chain_events survives"`
- [x] `npm run lint`
