### PR TITLE
fix(worker): pin redirect:manual on balance RPC and WSS probe egress

### DIFF
--- a/src/account-balance.mjs
+++ b/src/account-balance.mjs
@@ -96,6 +96,10 @@ export async function loadAccountBalance(env, ss58) {
     const rpcResp = await fetch(FINNEY_RPC_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      // Never auto-follow upstream redirects: only the finney entrypoint was chosen,
+      // so a 3xx would re-POST the JSON-RPC body to an unvetted host. Mirrors the
+      // redirect:"manual" invariant in rpc-proxy.mjs / health-probe-core.mjs.
+      redirect: "manual",
       signal: AbortSignal.timeout(BALANCE_RPC_TIMEOUT_MS),
       body: JSON.stringify({
         jsonrpc: "2.0",

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -253,7 +253,12 @@ export function workerWebSocketConnector(fetchImpl = fetch) {
         }
       }
 
-      fetchImpl(httpUrl, { headers: { Upgrade: "websocket" } })
+      fetchImpl(httpUrl, {
+        headers: { Upgrade: "websocket" },
+        // Never auto-follow an upgrade redirect: only the initial WSS URL passed the
+        // SSRF guard, so following a 3xx would open a socket to an unvetted host.
+        redirect: "manual",
+      })
         .then((response) => {
           socket = response.webSocket;
           if (!socket) {

--- a/tests/account-balance-loader.test.mjs
+++ b/tests/account-balance-loader.test.mjs
@@ -126,6 +126,26 @@ describe("loadAccountBalance", () => {
     }
   });
 
+  test("does not follow redirects from the finney RPC upstream", async () => {
+    const fetchCalls = [];
+    const orig = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ url, init });
+      return new Response(null, {
+        status: 302,
+        headers: { location: "http://169.254.169.254/rpc" },
+      });
+    };
+    try {
+      const data = await loadAccountBalance({}, SS58);
+      assert.equal(data.balance_tao, null);
+      assert.equal(fetchCalls.length, 1, "must not follow the redirect hop");
+      assert.equal(fetchCalls[0].init.redirect, "manual");
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
   test("returns balance_tao:null when finney RPC times out (#2075)", async () => {
     const orig = globalThis.fetch;
     globalThis.fetch = async (_url, init) => {
@@ -145,10 +165,10 @@ describe("loadAccountBalance", () => {
   });
 
   test("passes AbortSignal.timeout to the finney fetch", async () => {
-    let seenSignal;
+    let seenInit;
     const orig = globalThis.fetch;
     globalThis.fetch = async (_url, init) => {
-      seenSignal = init?.signal;
+      seenInit = init;
       return {
         ok: true,
         json: async () => ({
@@ -160,8 +180,9 @@ describe("loadAccountBalance", () => {
     };
     try {
       await loadAccountBalance({}, SS58);
-      assert.ok(seenSignal);
-      assert.equal(typeof seenSignal.aborted, "boolean");
+      assert.ok(seenInit?.signal);
+      assert.equal(seenInit.redirect, "manual");
+      assert.equal(typeof seenInit.signal.aborted, "boolean");
       assert.equal(BALANCE_RPC_TIMEOUT_MS, 5000);
     } finally {
       globalThis.fetch = orig;

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -860,10 +860,11 @@ describe("workerWebSocketConnector", () => {
     );
     const promise = connect("wss://node.example/rpc", RPC_CALLS, 1000);
 
-    // ws→http rewrite + Upgrade header.
+    // ws→http rewrite + Upgrade header + redirect guard.
     assert.equal(calls.length, 1);
     assert.equal(calls[0].url, "https://node.example/rpc");
     assert.equal(calls[0].init.headers.Upgrade, "websocket");
+    assert.equal(calls[0].init.redirect, "manual");
 
     // Wait for the fetch().then() to run so accept()/send() have happened.
     await Promise.resolve();


### PR DESCRIPTION
## Summary

Two production Worker egress paths still use fetch default `redirect: "follow"` after SSRF guards validate only the **initial** URL:

| Path | Production route / cron |
|------|-------------------------|
| `loadAccountBalance` | `GET /api/v1/accounts/:ss58/balance` — POST to finney RPC |
| `workerWebSocketConnector` | 15-minute health prober WSS upgrade |

A 302 from upstream would re-POST the JSON-RPC body or open a WebSocket to an **unvetted** host (e.g. `169.254.169.254`). `rpc-proxy.mjs` (#2100) and `health-probe-core.mjs` already pin `redirect: "manual"`; this closes the remaining parity gap after #2797.

## Test plan

- [x] `npx vitest run tests/account-balance-loader.test.mjs tests/health-prober.test.mjs`
- [x] `npm run lint`
- [x] Rebased on latest `main` (`92fa199c`)
