### PR TITLE
fix(backfill): report inserted from D1 meta.changes not rows.length

### DIFF
--- a/tests/economics-backfill.test.mjs
+++ b/tests/economics-backfill.test.mjs
@@ -40,6 +40,7 @@ function dbCapture(captured) {
     },
     async batch(stmts) {
       captured.push(stmts);
+      return stmts.map(() => ({ meta: { changes: 1 } }));
     },
   };
 }
@@ -106,6 +107,42 @@ test("economics backfill upserts valid rows + filters invalid (200, parameterize
     /alpha_price_tao = COALESCE\(subnet_snapshots\.alpha_price_tao, excluded\.alpha_price_tao\)/,
   );
   assert.deepEqual(first.v, [8, "2025-12-01", 0.030678787, 1700000000000]);
+});
+
+test("economics backfill reports actually-inserted rows, not validated rows (idempotent upsert)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: {
+      prepare: (sql) => ({ bind: (...v) => ({ sql, v }) }),
+      async batch(stmts) {
+        return stmts.map(() => ({ meta: { changes: 0 } }));
+      },
+    },
+  };
+  const res = await handleEconomicsBackfill(
+    post([row(), row({ netuid: 9 })], { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).inserted, 0);
+});
+
+test("economics backfill tolerates a batch result missing meta.changes (counts 0)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: {
+      prepare: (sql) => ({ bind: (...v) => ({ sql, v }) }),
+      async batch(stmts) {
+        return stmts.map(() => ({}));
+      },
+    },
+  };
+  const res = await handleEconomicsBackfill(
+    post([row()], { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).inserted, 0);
 });
 
 test("economics backfill accepts the {rows:[...]} envelope + no-ops on empty", async () => {

--- a/tests/neuron-backfill.test.mjs
+++ b/tests/neuron-backfill.test.mjs
@@ -50,6 +50,7 @@ function dbCapture(captured) {
     },
     async batch(stmts) {
       captured.push(stmts.length);
+      return stmts.map(() => ({ meta: { changes: 1 } }));
     },
   };
 }
@@ -101,6 +102,42 @@ test("backfill upserts valid rows + filters invalid (200, parameterized)", async
   assert.equal(body.received, 5);
   assert.equal(body.inserted, 2);
   assert.deepEqual(captured, [2]); // one batch of the 2 valid rows
+});
+
+test("backfill reports actually-inserted rows, not validated rows (idempotent upsert)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: {
+      prepare: (sql) => ({ bind: (...v) => ({ sql, v }) }),
+      async batch(stmts) {
+        return stmts.map(() => ({ meta: { changes: 0 } }));
+      },
+    },
+  };
+  const res = await handleNeuronBackfill(
+    post([row(), row({ uid: 2 })], { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).inserted, 0);
+});
+
+test("backfill tolerates a batch result missing meta.changes (counts 0)", async () => {
+  const env = {
+    METAGRAPH_EVENTS_INGEST_SECRET: SECRET,
+    METAGRAPH_HEALTH_DB: {
+      prepare: (sql) => ({ bind: (...v) => ({ sql, v }) }),
+      async batch(stmts) {
+        return stmts.map((_, i) => (i === 0 ? { meta: { changes: 1 } } : {}));
+      },
+    },
+  };
+  const res = await handleNeuronBackfill(
+    post([row(), row({ uid: 2 })], { secret: SECRET }),
+    env,
+  );
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).inserted, 1);
 });
 
 test("backfill accepts the {rows:[...]} envelope + no-ops on empty", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -649,14 +649,19 @@ export async function handleNeuronBackfill(request, env) {
     );
   }
   const rows = validNeuronDailyRows(incoming);
+  // Report rows ACTUALLY inserted, not rows validated. Upserts are idempotent on
+  // (netuid, uid, snapshot_date), so re-POSTing a window reports inserted:0.
+  // Sum per-statement D1 meta.changes — mirrors handleEventIngest / handleBlockIngest.
+  let inserted = 0;
   if (rows.length) {
-    await db.batch(neuronDailyUpsertStatements(db, rows));
+    const results = await db.batch(neuronDailyUpsertStatements(db, rows));
+    for (const result of results) inserted += result?.meta?.changes ?? 0;
   }
   return new Response(
     JSON.stringify({
       ok: true,
       received: incoming.length,
-      inserted: rows.length,
+      inserted,
     }),
     { status: 200, headers: { "content-type": JSON_CONTENT_TYPE } },
   );
@@ -737,14 +742,18 @@ export async function handleEconomicsBackfill(request, env) {
     );
   }
   const rows = validEconomicsBackfillRows(incoming);
+  // Sum D1 meta.changes so idempotent re-upserts report inserted:0 instead of
+  // rows.length (mirrors handleEventIngest / handleNeuronBackfill).
+  let inserted = 0;
   if (rows.length) {
-    await db.batch(economicsSnapshotUpsertStatements(db, rows));
+    const results = await db.batch(economicsSnapshotUpsertStatements(db, rows));
+    for (const result of results) inserted += result?.meta?.changes ?? 0;
   }
   return new Response(
     JSON.stringify({
       ok: true,
       received: incoming.length,
-      inserted: rows.length,
+      inserted,
     }),
     { status: 200, headers: { "content-type": JSON_CONTENT_TYPE } },
   );


### PR DESCRIPTION
## Summary

`POST /api/v1/internal/backfill-neurons` and `POST /api/v1/internal/backfill-economics` returned `inserted: rows.length` even though both use **idempotent upserts**. Re-POSTing an already-loaded window falsely reported every row as newly inserted, breaking progress tracking in `scripts/backfill-neuron-history.py` and `scripts/backfill-economics-history.py`.

`handleEventIngest` and `handleBlockIngest` already sum D1 `meta.changes` on main — this closes the same gap on the two backfill ingest paths.

## Test plan

- [x] `npx vitest run tests/neuron-backfill.test.mjs tests/economics-backfill.test.mjs`
- [x] `npm run lint`
- [x] Tests mirror `event-ingest.test.mjs`: idempotent re-upsert (`inserted: 0`), missing `meta.changes` fallback
