### PR TITLE
fix(chain-yield): guard captureStamp against out-of-range captured_at

### DIFF
--- a/src/chain-yield.mjs
+++ b/src/chain-yield.mjs
@@ -45,13 +45,25 @@ function subnetNetuid(value) {
   return null;
 }
 
+function epochMsStamp(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const date = new Date(ms);
+  if (!Number.isFinite(date.getTime())) return null;
+  return { ms, value: date.toISOString() };
+}
+
 function captureStamp(value) {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return { ms: value, value: new Date(value).toISOString() };
-  }
+  if (value == null) return null;
   if (typeof value === "string") {
+    if (/^\d+$/.test(value)) {
+      return epochMsStamp(Number(value));
+    }
     const ms = Date.parse(value);
     if (Number.isFinite(ms)) return { ms, value };
+    return null;
+  }
+  if (typeof value === "number") {
+    return epochMsStamp(value);
   }
   return null;
 }

--- a/tests/chain-yield.test.mjs
+++ b/tests/chain-yield.test.mjs
@@ -126,6 +126,32 @@ describe("buildChainYield", () => {
     assert.equal(out.captured_at, "2026-06-15T00:00:00.000Z");
   });
 
+  test("rejects invalid captured_at cells instead of leaking junk stamps (no RangeError)", () => {
+    for (const captured_at of [
+      "0",
+      "not-a-date",
+      "9".repeat(400),
+      -1,
+      0,
+      true,
+      8_640_000_000_000_001,
+      "8640000000000001",
+    ]) {
+      const out = buildChainYield([
+        { stake_tao: 1, emission_tao: 0, captured_at },
+      ]);
+      assert.equal(out.captured_at, null, `expected null for ${captured_at}`);
+    }
+  });
+
+  test("converts D1 string-typed epoch-millisecond captured_at to ISO strings", () => {
+    const out = buildChainYield([
+      { stake_tao: 1, emission_tao: 0, captured_at: "1750000000000" },
+      { stake_tao: 1, emission_tao: 0, captured_at: "1750000060000" },
+    ]);
+    assert.equal(out.captured_at, "2025-06-15T15:07:40.000Z");
+  });
+
   test("coerces numeric-string stake/emission cells from D1", () => {
     const out = buildChainYield([
       {


### PR DESCRIPTION
## Summary

`GET /api/v1/chain/yield` (#2823) shapes `neurons.captured_at` via `captureStamp()`, which called `new Date(ms).toISOString()` without a range guard. A finite but out-of-range epoch-ms (beyond ±8.64e15) throws **RangeError** and **500s the whole route** on one corrupt D1 cell.

`chain-performance.mjs` already guards this via `epochMsStamp()` ([#2809](https://github.com/JSONbored/metagraphed/pull/2809), merged). This mirrors that pattern on the new chain-yield sibling endpoint.

## Test plan

- [x] `npx vitest run tests/chain-yield.test.mjs`
- [x] `npm run lint`
- [x] Rejects out-of-range / junk `captured_at` cells (including `"8640000000000001"`) without throwing
