### PR TITLE
fix(feeds): guard toIso string epochs and harden RSS pubDate serialization

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -103,14 +103,25 @@ function toIso(value) {
     return Number.isFinite(date.getTime()) ? date.toISOString() : null;
   }
   if (typeof value === "string") {
+    if (/^\d+$/.test(value)) {
+      const date = new Date(Number(value));
+      return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+    }
     const t = Date.parse(value);
-    if (!Number.isNaN(t)) return new Date(t).toISOString();
+    if (!Number.isNaN(t)) {
+      const date = new Date(t);
+      return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+    }
   }
   return null;
 }
 
 function toRfc822(iso) {
-  return new Date(iso).toUTCString();
+  if (iso == null) return null;
+  const ms = Date.parse(String(iso));
+  if (!Number.isFinite(ms)) return null;
+  const date = new Date(ms);
+  return Number.isFinite(date.getTime()) ? date.toUTCString() : null;
 }
 
 // ── item builders (from existing served artifacts) ──────────────────────────
@@ -385,21 +396,23 @@ function jsonFeed(meta, items) {
 
 function rssFeed(meta, items) {
   const body = items
-    .map((it) =>
-      [
+    .map((it) => {
+      const pubDate = toRfc822(it.timestamp);
+      return [
         "    <item>",
         `      <guid isPermaLink="false">${escapeXml(it.id)}</guid>`,
         `      <link>${escapeXml(it.url)}</link>`,
         `      <title>${escapeXml(it.title)}</title>`,
         `      <description>${escapeXml(it.summary)}</description>`,
-        `      <pubDate>${toRfc822(it.timestamp)}</pubDate>`,
+        ...(pubDate ? [`      <pubDate>${escapeXml(pubDate)}</pubDate>`] : []),
         ...(it.tags || []).map(
           (t) => `      <category>${escapeXml(t)}</category>`,
         ),
         "    </item>",
-      ].join("\n"),
-    )
+      ].join("\n");
+    })
     .join("\n");
+  const lastBuildDate = toRfc822(meta.updated);
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
@@ -408,7 +421,9 @@ function rssFeed(meta, items) {
     `    <link>${escapeXml(meta.homeUrl)}</link>`,
     `    <atom:link href="${escapeXml(meta.feedUrl)}" rel="self" type="application/rss+xml"/>`,
     `    <description>${escapeXml(meta.description)}</description>`,
-    `    <lastBuildDate>${toRfc822(meta.updated)}</lastBuildDate>`,
+    ...(lastBuildDate
+      ? [`    <lastBuildDate>${escapeXml(lastBuildDate)}</lastBuildDate>`]
+      : []),
     body,
     "  </channel>",
     "</rss>",
@@ -743,6 +758,7 @@ export function feedLinkHeader(originUrl, netuid) {
 
 // Exported for unit tests.
 export const __test = {
+  toIso,
   registryItems,
   incidentItems,
   gapsItems,

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -39,6 +39,7 @@ function installMockCache() {
 }
 
 const {
+  toIso,
   registryItems,
   incidentItems,
   gapsItems,
@@ -425,6 +426,11 @@ describe("feeds — item builders", () => {
     assert.ok(Number.isFinite(Date.parse(item.timestamp)));
   });
 
+  test("toIso drops out-of-range string epoch-ms without RangeError (#2809 parity)", () => {
+    assert.equal(toIso("8640000000000001"), null);
+    assert.equal(toIso("1750000000000"), "2025-06-15T15:06:40.000Z");
+  });
+
   test("gapsItems builds ranked enrichment targets with lane/kind tags", () => {
     const items = gapsItems(ENRICHMENT_QUEUE);
     assert.equal(items.length, 3);
@@ -763,6 +769,21 @@ describe("feeds — serializers", () => {
     assert.match(xml, /<channel>[\s\S]*<\/channel>/);
     assert.ok((xml.match(/<item>/g) || []).length === items.length);
     assert.match(xml, /<pubDate>.*GMT<\/pubDate>/);
+  });
+
+  test("rssFeed omits pubDate for corrupt item timestamps instead of throwing", () => {
+    const xml = rssFeed(meta, [
+      {
+        id: "bad-ts",
+        url: "https://example.com/x",
+        title: "bad",
+        summary: "bad",
+        timestamp: "not-a-date",
+        tags: [],
+      },
+    ]);
+    assert.doesNotMatch(xml, /<pubDate>/);
+    assert.match(xml, /<item>/);
   });
 
   test("atomFeed has the required feed + entry structure", () => {


### PR DESCRIPTION
## Summary

Public `GET /api/v1/feeds/*` routes build items via `toIso()`. The **number** branch already had a `#2807` range guard, but the **string** branch did not:

- D1 **numeric-string** epoch-ms (e.g. `"1750000000000"`) went through `Date.parse()` → **NaN** → timestamp dropped silently
- Out-of-range parsed epochs could **`RangeError`** on `toISOString()`
- `rssFeed()` called `toRfc822()` unguarded → **500** on a corrupt item timestamp

This mirrors `captureStamp()` / `epochMsStamp()` from **chain-performance.mjs (#2809)** and hardens RSS serialization to omit `pubDate` when a timestamp is invalid.

## Test plan

- [x] `npx vitest run tests/feeds.test.mjs`
- [x] `npm run lint`
- [x] Out-of-range `"8640000000000001"` → `null`; valid `"1750000000000"` → ISO
- [x] RSS omits `<pubDate>` for `"not-a-date"` instead of throwing
