### PR TITLE
feat(registry): add SN64 Chutes authenticated SSE surface

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -395,13 +395,7 @@
       "id": "sn-64-chutes-sse",
       "kind": "sse",
       "name": "Chutes streaming chat completions",
-      "notes": "POST /v1/chat/completions with `stream: true` yields line-streamed chunks. Endpoint requires API key in X-API-Key or Authorization header.",
-      "probe": {
-        "enabled": false,
-        "expect": "sse",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
+      "notes": "POST /v1/chat/completions with `stream: true` yields line-streamed chunks. Endpoint requires an Authorization: Bearer token.",
       "provider": "chutes",
       "public_safe": true,
       "review": {
@@ -410,6 +404,7 @@
       },
       "source_urls": [
         "https://chutes.ai/docs/getting-started/running-a-chute",
+        "https://chutes.ai/docs/guides/streaming",
         "https://chutes.ai/llms.txt"
       ],
       "url": "https://llm.chutes.ai/v1/chat/completions"

--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -388,6 +388,31 @@
       "schema_status": "not-captured",
       "source_urls": ["https://chutes.ai/llms.txt"],
       "url": "https://llm.chutes.ai/v1/models"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-64-chutes-sse",
+      "kind": "sse",
+      "name": "Chutes streaming chat completions",
+      "notes": "POST /v1/chat/completions with `stream: true` yields line-streamed chunks. Endpoint requires API key in X-API-Key or Authorization header.",
+      "probe": {
+        "enabled": false,
+        "expect": "sse",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "statxc"
+      },
+      "source_urls": [
+        "https://chutes.ai/docs/getting-started/running-a-chute",
+        "https://chutes.ai/llms.txt"
+      ],
+      "url": "https://llm.chutes.ai/v1/chat/completions"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends exactly one community surface to `registry/subnets/chutes.json` (SN64 Chutes).

## Surface

- Netuid: 64
- Kind: `sse`
- Public URL: https://llm.chutes.ai/v1/chat/completions
- Source URL (proves the claim):
  - https://chutes.ai/docs/getting-started/running-a-chute
  - https://chutes.ai/docs/guides/streaming
  - https://chutes.ai/llms.txt
- Provider slug: `chutes`
- Auth: `Authorization: Bearer <token>`

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only
- [x] Generated with `npm run surface:add` (identity + review markers set)
- [x] The `url` and `source_urls` are public and document a real streaming surface
- [x] Public-safe and no secrets/private links
- [x] Does not duplicate existing surfaces
- [x] No linked issue claim in this PR body

## Notes

This PR does not claim to resolve #1273. Issue #1273 requests a public no-auth SSE surface, while this submission registers the documented authenticated streaming endpoint exposed by Chutes.

## Validation

- [x] `npm run validate:surface -- registry/subnets/chutes.json`
- [x] `npm run scan:public-safety`