### PR TITLE
feat(registry): enrich SN97 Albedo — add public API + data-artifact surfaces (#679)

### DIFF
--- a/registry/subnets/albedo.json
+++ b/registry/subnets/albedo.json
@@ -1,0 +1,51 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "Albedo",
+  "netuid": 97,
+  "schema_version": 1,
+  "slug": "sn-97",
+  "source_repo": "https://github.com/unarbos/albedo",
+  "status": "active",
+  "website_url": "https://albedo.tech",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-97-albedo-subnet-api",
+      "kind": "subnet-api",
+      "name": "Albedo King Chat config API",
+      "provider": "albedo",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "statxc"
+      },
+      "source_urls": [
+        "https://albedo.tech",
+        "https://github.com/unarbos/albedo/blob/main/website/index.html"
+      ],
+      "url": "https://chat.albedo.tech/api/config"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-97-albedo-data-artifact",
+      "kind": "data-artifact",
+      "name": "Albedo live dashboard data",
+      "provider": "albedo",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "statxc"
+      },
+      "source_urls": [
+        "https://github.com/unarbos/albedo/blob/main/website/js/config.js"
+      ],
+      "url": "https://s3.hippius.com/albedo/data/dashboard.json"
+    }
+  ]
+}


### PR DESCRIPTION
## Add or update a subnet surface

This PR adds SN97 Albedo as a new subnet manifest and appends two community surfaces in that same one-file manifest.

## Surface

- Netuid: `97`
- Kind: `subnet-api`, `data-artifact`
- Public URL:
  - `https://chat.albedo.tech/api/config`
  - `https://s3.hippius.com/albedo/data/dashboard.json`
- Source URL (proves the claim):
  - `https://albedo.tech`
  - `https://github.com/unarbos/albedo/blob/main/website/index.html`
  - `https://github.com/unarbos/albedo/blob/main/website/js/config.js`
- Provider slug: `albedo`

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest, or a `subnet:new` scaffold plus surface(s) for a missing manifest (optionally plus one `registry/providers/*.json` for a debut provider).
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #<n>`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass. Base-layer RPC/WSS/archive, authenticated surfaces, unknown providers, and identity disputes route to manual review.

## Validation

- [x] `npm run validate:surface -- registry/subnets/albedo.json`
- [x] `npm run scan:public-safety`

Closes #679
