### PR TITLE
feat(registry): enrich SN4 Targon — Python SDK and stats dashboard

### DIFF
--- a/registry/subnets/targon.json
+++ b/registry/subnets/targon.json
@@ -123,6 +123,55 @@
         "timeout_ms": 10000
       },
       "review": { "state": "community-submitted", "submitted_by": "nickmopen" }
+    },
+    {
+      "id": "sn-4-targon-sdk",
+      "name": "Targon Python SDK",
+      "kind": "sdk",
+      "url": "https://github.com/manifold-inc/targon-sdk",
+      "provider": "targon",
+      "authority": "community",
+      "auth_required": false,
+      "public_safe": true,
+      "source_urls": [
+        "https://pypi.org/project/targon-sdk/",
+        "https://github.com/manifold-inc/targon-sdk/blob/main/README.md"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Official Targon Python SDK (PyPI: targon-sdk) by manifold-inc for interacting with Targon rentals and serverless. Same manifold-inc org as the registered official source repository."
+    },
+    {
+      "id": "sn-4-targon-stats-dashboard",
+      "name": "Targon Stats dashboard",
+      "kind": "dashboard",
+      "url": "https://stats.targon.com/",
+      "provider": "targon",
+      "authority": "community",
+      "auth_required": false,
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/manifold-inc/targon/blob/main/targon/cli/get/errors.go"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "html",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Official Targon Stats dashboard (page title \"Targon Stats\"). Its first-party ownership is proven by the official manifold-inc/targon CLI source, which names https://stats.targon.com as a default endpoint host."
     }
   ],
   "social": { "x": "https://x.com/targoncompute" },


### PR DESCRIPTION
## Summary

Appends two verified, owner-matched community surfaces to **SN4 Targon** — **append-only**, mirroring the existing inventory surface's field order and `probe` blocks (no manifest reordering).

| kind | url | first-party proof |
|------|-----|-------------------|
| `sdk` | https://github.com/manifold-inc/targon-sdk | https://pypi.org/project/targon-sdk/ (`targon-sdk` v1.0.0) |
| `dashboard` | https://stats.targon.com/ | manifold-inc/targon CLI source names `stats.targon.com` as a default endpoint host |

## Verification

- **Python SDK** — `targon-sdk` on PyPI (v1.0.0, "Targon SDK to interact with Targon rentals and serverless"); repo `manifold-inc/targon-sdk`, the same `manifold-inc` org as SN4's registered official `source_repo` (`manifold-inc/targon`).
- **stats dashboard** — https://stats.targon.com/ returns `<title>Targon Stats</title>`; first-party ownership is proven by the official `manifold-inc/targon` CLI source ([`targon/cli/get/errors.go`](https://github.com/manifold-inc/targon/blob/main/targon/cli/get/errors.go)), which hard-codes `https://stats.targon.com/...` as a default endpoint.

## Qualifies

- **Owner-matched, live, public-safe** — both URLs probe reachable; both carry `probe` blocks.
- **Non-duplicate** — neither overlaps an existing surface.
- **Append-only single-file diff** — 49 insertions, 0 deletions to `registry/subnets/targon.json`.

`validate:surface` → passed (7 surfaces). `scan:public-safety` + `format:check` pass.