### PR TITLE
feat(registry): enrich SN19 BlockMachine — add current-epoch snapshot

### DIFF
--- a/registry/subnets/blockmachine.json
+++ b/registry/subnets/blockmachine.json
@@ -146,6 +146,24 @@
         "https://api.blockmachine.io/openapi.json"
       ],
       "url": "https://api.blockmachine.io/epochs/latest-finalized"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-19-blockmachine-data-artifact-api-blockmachine-io",
+      "kind": "data-artifact",
+      "name": "BlockMachine current-epoch snapshot",
+      "provider": "blockmachine",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "statxc"
+      },
+      "source_urls": [
+        "https://blockmachine.io/",
+        "https://api.blockmachine.io/openapi.json"
+      ],
+      "url": "https://api.blockmachine.io/epochs/current"
     }
   ],
   "website_url": "https://blockmachine.io/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one verified public surface to `registry/subnets/blockmachine.json` (SN19): the live current-epoch snapshot documented on BlockMachine's official API host.

## Surface

- Netuid: `19`
- Kind: `data-artifact`
- Public URL: `https://api.blockmachine.io/epochs/current`
- Source URL (proves the claim):
  - `https://blockmachine.io/`
  - `https://api.blockmachine.io/openapi.json`
- Provider slug: `blockmachine`

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest.
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.

## Validation

- [x] `npm run validate:surface -- registry/subnets/blockmachine.json`
- [x] `npm run scan:public-safety`

Refs #427
