### PR TITLE
feat(registry): enrich SN14 Cacheon — add current-leader subnet-api surface

### DIFF
--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -186,6 +186,25 @@
       },
       "source_urls": ["https://cacheon.ai/docs/miners/api-contract"],
       "url": "https://api.cacheon.ai/api/status"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-subnet-api-api-cacheon-ai",
+      "kind": "subnet-api",
+      "name": "Cacheon current-leader API",
+      "notes": "Public read-only GET returning the subnet's current leader (uid/hotkey). Documented in the subnet's own OpenAPI (api.cacheon.ai/openapi.json, 'Cacheon Monitoring API'); same host as the existing openapi + subnet-api surfaces.",
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dhgoal"
+      },
+      "source_urls": [
+        "https://api.cacheon.ai/openapi.json",
+        "https://cacheon.ai/docs/miners/api-contract"
+      ],
+      "url": "https://api.cacheon.ai/api/leader"
     }
   ],
   "website_url": "https://cacheon.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one verified public surface to `registry/subnets/cacheon.json` (SN14 Cacheon): the public **current-leader** endpoint.

*No open enrichment issue exists for this; standalone surface addition under the surface-enrichment epic #427.*

## Surface
- Netuid: 14 · Kind: `subnet-api` · Provider: `cacheon` (already registered)
- Public URL: https://api.cacheon.ai/api/leader

### Source proof (first-party)
Documented in Cacheon's own OpenAPI spec ([`api.cacheon.ai/openapi.json`](https://api.cacheon.ai/openapi.json), "Cacheon Monitoring API", read-only), and `api.cacheon.ai` already backs the subnet's existing `openapi` + `subnet-api` (`/api/status`) surfaces in this manifest. Verified live (HTTP 200, no-auth JSON — the subnet's current leader uid/hotkey).

## Checklist
- [x] Appends to exactly one `registry/subnets/<slug>.json` (append-only, single file)
- [x] Generated via `npm run surface:add` — `authority: community`, `review.state: community-submitted`
- [x] `url` public + read-only; documented in the subnet's own OpenAPI on an already-trusted host
- [x] Provider `cacheon` already registered (no debut file); distinct from the existing `/api/status` surface
- [x] Public-safe: no secrets/private URLs/generated artifacts

## Validation
- [x] `npm run validate:surface` → passed
- [x] `npm run scan:public-safety` → passed
