### PR TITLE
feat(registry): enrich SN43 Graphite — add coverage stats data-artifact

### DIFF
--- a/registry/subnets/graphite.json
+++ b/registry/subnets/graphite.json
@@ -137,6 +137,24 @@
         "https://api.graphite-ai.net/docs"
       ],
       "url": "https://api.graphite-ai.net/api/v1/stats/subnet"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-43-graphite-ai-coverage-stats",
+      "kind": "data-artifact",
+      "name": "Graphite coverage stats",
+      "provider": "graphite-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "statxc"
+      },
+      "source_urls": [
+        "https://api.graphite-ai.net/openapi.json",
+        "https://api.graphite-ai.net/docs"
+      ],
+      "url": "https://api.graphite-ai.net/api/v1/stats/coverage"
     }
   ],
   "website_url": "https://graphite-ai.net/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one verified public surface to `registry/subnets/graphite.json` (SN43): the knowledge-graph coverage stats endpoint on Graphite's official API host.

## Surface

- Netuid: `43`
- Kind: `data-artifact`
- Public URL: `https://api.graphite-ai.net/api/v1/stats/coverage`
- Source URL (proves the claim):
  - `https://api.graphite-ai.net/openapi.json`
  - `https://api.graphite-ai.net/docs`
- Provider slug: `graphite-ai`

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest.
- [x] Generated with `npm run surface:add` and finalized as a single append in that same file.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.

## Validation

- [x] `npm run validate:surface -- registry/subnets/graphite.json`
- [x] `npm run scan:public-safety`

Refs #427
