### PR TITLE
feat(registry): enrich SN96 Verathos — add circulating-supply subnet-api surface

### DIFF
--- a/registry/subnets/verathos.json
+++ b/registry/subnets/verathos.json
@@ -271,6 +271,25 @@
         "https://verathos.ai/openapi.json"
       ],
       "url": "https://verathos.ai/api/models/presets"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-subnet-api",
+      "kind": "subnet-api",
+      "name": "Verathos circulating-supply API",
+      "notes": "Public no-auth GET returning the subnet's circulating supply. Documented in the subnet's own OpenAPI (api.verathos.ai/openapi.json); same host as the existing subnet-api (/v1/models) surface.",
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dhgoal"
+      },
+      "source_urls": [
+        "https://api.verathos.ai/openapi.json",
+        "https://verathos.ai/docs"
+      ],
+      "url": "https://api.verathos.ai/v1/supply/circulating"
     }
   ],
   "website_url": "https://verathos.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one verified public surface to `registry/subnets/verathos.json` (SN96 Verathos): the public **circulating-supply** endpoint.

*No open enrichment issue exists for this; standalone surface addition under the surface-enrichment epic #427.*

## Surface
- Netuid: 96 · Kind: `subnet-api` · Provider: `verathos` (already registered)
- Public URL: https://api.verathos.ai/v1/supply/circulating

### Source proof (first-party)
Documented in Verathos' own OpenAPI spec ([`api.verathos.ai/openapi.json`](https://api.verathos.ai/openapi.json), path `/v1/supply/circulating` → "Supply Circulating", no security), and `api.verathos.ai` already backs the subnet's existing `subnet-api` (`/v1/models`) surface in this manifest. Verified live (HTTP 200, no-auth — circulating-supply value).

## Checklist
- [x] Appends to exactly one `registry/subnets/<slug>.json` (append-only, single file)
- [x] Generated via `npm run surface:add` — `authority: community`, `review.state: community-submitted`
- [x] `url` public + no-auth; documented in the subnet's own OpenAPI on an already-trusted host
- [x] Provider `verathos` already registered (no debut file); distinct from the existing `/v1/models` surface
- [x] Public-safe: no secrets/private URLs/generated artifacts

## Validation
- [x] `npm run validate:surface` → passed
- [x] `npm run scan:public-safety` → passed
