### PR TITLE
feat(mcp): add get_endpoint_pools tool mirroring the endpoint-pools route

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -607,6 +607,24 @@ assert.ok(
     Array.isArray(rpcUsageCold.buckets),
   "get_rpc_usage must return window + endpoints[] + buckets[] on cold D1",
 );
+// endpoint-pools.json is an R2-only artifact staged into the cold env only
+// after `npm run build`; exercise the happy path when present, else assert the
+// not_found guard loadArtifactData maps.
+const endpointPoolsPath = artifactFilePath("endpoint-pools.json");
+if (existsSync(endpointPoolsPath)) {
+  const endpointPools = await callOk("get_endpoint_pools", {});
+  assert.ok(
+    Array.isArray(endpointPools.pools),
+    "get_endpoint_pools must return pools[]",
+  );
+} else {
+  const endpointPoolsCold = await call("get_endpoint_pools", {});
+  assert.equal(
+    endpointPoolsCold.isError,
+    true,
+    "get_endpoint_pools must isError when the endpoint-pools artifact is absent",
+  );
+}
 const healthTrendsCold = await callOk("get_health_trends", {});
 assert.ok(
   healthTrendsCold.windows?.["7d"] &&

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -208,7 +208,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.22.0";
+export const MCP_SERVER_VERSION = "1.23.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -4238,6 +4238,27 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_endpoint_pools",
+    title: "Get generalized endpoint pool scores",
+    description:
+      "Fetch the generalized endpoint pool scorecard: the ranked pools of " +
+      "monitored public surfaces, each provider's aggregate score board " +
+      "(endpoint/monitored/ok/failed/degraded counts, pool-eligible count, and " +
+      "the average + operational scores), the eligibility policy that decides " +
+      "which endpoints qualify (required status, eligible layers, public-safe " +
+      "and no-auth requirements), and the read-only RPC proxy contract. Use it " +
+      "to see which providers and endpoints are healthy enough to route to. " +
+      "Mirrors GET /api/v1/endpoint-pools.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadArtifactData(ctx, "/metagraph/endpoint-pools.json");
+    },
+  },
+  {
     name: "get_best_rpc_endpoint",
     title: "Get the best Bittensor RPC endpoint",
     description:
@@ -6171,6 +6192,29 @@ const TOOL_OUTPUT_SCHEMAS = {
       endpoints: RPC_USAGE_ENDPOINTS,
       networks: RPC_USAGE_NETWORKS,
       buckets: RPC_USAGE_BUCKETS,
+    },
+  },
+  get_endpoint_pools: {
+    type: "object",
+    additionalProperties: true,
+    required: ["pools"],
+    properties: {
+      schema_version: { type: "integer" },
+      generated_at: NULLABLE_STRING,
+      pools: { type: "array", items: { type: "object" } },
+      provider_scores: objectItems({
+        provider: { type: "string" },
+        endpoint_count: NULLABLE_INT,
+        monitored_count: NULLABLE_INT,
+        ok_count: NULLABLE_INT,
+        failed_count: NULLABLE_INT,
+        degraded_count: NULLABLE_INT,
+        pool_eligible_count: NULLABLE_INT,
+        average_score: NULLABLE_INT,
+        operational_score: NULLABLE_INT,
+      }),
+      eligibility_policy: { type: ["object", "null"] },
+      disabled_proxy_contract: { type: ["object", "null"] },
     },
   },
   list_subnet_apis: {

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.22.0");
+    assert.equal(MCP_SERVER_VERSION, "1.23.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.22.0");
+    assert.equal(MCP_SERVER_VERSION, "1.23.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -9212,6 +9212,41 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(res.body.result.structuredContent.providers[0].status, "ok");
   });
 
+  test("get_endpoint_pools returns the endpoint pool scorecard artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/endpoint-pools.json": {
+        schema_version: 1,
+        pools: [{ layer: "application", endpoint_count: 5 }],
+        provider_scores: [
+          {
+            provider: "datura",
+            endpoint_count: 4,
+            monitored_count: 4,
+            ok_count: 3,
+            failed_count: 1,
+            degraded_count: 0,
+            pool_eligible_count: 3,
+            average_score: 82,
+            operational_score: 90,
+          },
+        ],
+        eligibility_policy: { required_status: "ok" },
+      },
+    });
+    const res = await callTool("get_endpoint_pools", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.pools[0].layer, "application");
+    assert.equal(out.provider_scores[0].provider, "datura");
+    assert.equal(out.provider_scores[0].operational_score, 90);
+    assert.equal(out.eligibility_policy.required_status, "ok");
+  });
+
+  test("get_endpoint_pools is not_found when the artifact is missing", async () => {
+    const res = await callTool("get_endpoint_pools", {});
+    assert.equal(res.body.result.isError, true);
+    assert.equal(res.body.result.structuredContent.error.code, "not_found");
+  });
+
   test("get_freshness overlays the live prober run onto surface-health", async () => {
     const deps = makeDeps(
       {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.22.0");
+    assert.equal(MCP_SERVER_VERSION, "1.23.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {


### PR DESCRIPTION
Exposes the generalized endpoint pool scorecard (`GET /api/v1/endpoint-pools`) as an MCP tool so an agent can see which providers and endpoints are healthy enough to route to — the ranked pools of monitored public surfaces, each providers aggregate score board (endpoint/monitored/ok/failed/degraded/pool-eligible counts plus average + operational scores), the eligibility policy, and the read-only RPC proxy contract.

Self-contained: straight `loadArtifactData` read of the endpoint-pools artifact (no D1, no schema regen). Registers the tool + a typed output schema, a build-gated `validate-mcp` assertion (happy path when the artifact is staged, `not_found` guard when cold), the MCP server/registry version bump to 1.23.0 with the pinned assertion updated, and unit tests for the populated and missing-artifact paths.

`npm run validate:mcp` passes (85 tools); full `mcp-server` + `global-operational-health` suites green.