### PR TITLE
fix(ingestion): preserve rao-exact precision in stake/emission writers

### DIFF
--- a/scripts/backfill-neuron-history.py
+++ b/scripts/backfill-neuron-history.py
@@ -16,7 +16,9 @@ and emit the exact `neuron_daily` row shape to the secret-gated ingest (idempote
 (netuid,uid,snapshot_date), so re-runs are safe/resumable).
 
 Units match scripts/fetch-metagraph-native.py: consensus/incentive/dividends/
-validator_trust = u16/65535; emission_tao = u64/1e9; rank derived (1-based incentive
+validator_trust = u16/65535; emission_tao = exact u64-rao whole/remainder split,
+not plain u64/1e9, which loses precision above 2**53 rao (metagraphed#2921);
+rank derived (1-based incentive
 desc); trust = 0.0 (dead in dTAO). hotkey/coldkey/registered_at_block/axon come from a
 one-shot CURRENT-snapshot overlay (get_all_metagraphs_info at head) applied to all
 backfilled rows — accurate for stable UIDs (documented approximation). stake_tao is
@@ -111,6 +113,20 @@ def decode_vec_bool(hexval):
 
 def u16_ratio(v):
     return round(int(v) / 65535, 9) if v is not None else None
+
+
+def rao_to_tao_exact(rao):
+    """Whole/remainder split so the integer TAO part is always exact — plain
+    `rao / 1e9` routes the whole rao integer through double rounding before
+    the division even happens, silently corrupting values above 2**53 rao
+    (~9M TAO) (metagraphed#2921). `rao` here is already an exact
+    arbitrary-precision int from decode_vec_uint, so this loses nothing that
+    wasn't already lost by the old `round(emission[uid] / 1e9, 9)`."""
+    if rao is None:
+        return None
+    whole = rao // 1_000_000_000
+    remainder = (rao % 1_000_000_000) / 1e9
+    return whole + remainder
 
 
 def fmt_axon(axon):
@@ -242,7 +258,7 @@ def build_rows(raw, overlay, netuids, block, captured_at, snapshot_date):
                     "dividends": u16_ratio(dividends[uid])
                     if uid < len(dividends)
                     else None,
-                    "emission_tao": round(emission[uid] / 1e9, 9),
+                    "emission_tao": rao_to_tao_exact(emission[uid]),
                     "stake_tao": None,  # deferred: runtime-only in dTAO
                     "registered_at_block": reg,
                     "is_immunity_period": 1

--- a/scripts/backfill-stake-monthly.py
+++ b/scripts/backfill-stake-monthly.py
@@ -12,12 +12,13 @@ the last ~8 months is therefore the feasible enrichment: ~8 blocks x ~129 subnet
 
 For each month offset we resolve the block nearest a fixed UTC time-of-day, then for
 every subnet pull the FULL runtime metagraph and emit the SAME `neuron_daily` row shape
-as the daily backfiller — only now `stake_tao = float(total_stake[uid])` is populated.
+as the daily backfiller — only now `stake_tao = to_tao_exact(total_stake[uid])` is populated.
 The ingest upsert is idempotent on (netuid,uid,snapshot_date), so these monthly days are
 overwritten in place with complete, stake-included rows (re-runs are safe/resumable).
 
 Units match scripts/fetch-metagraph-native.py exactly:
-  stake_tao / emission_tao = float(Balance, alpha-denominated)
+  stake_tao / emission_tao = Balance.rao / 1e9, alpha-denominated, computed exactly
+    (not float(Balance)/.tao, which loses precision above 2**53 rao — #2921)
   consensus / incentive / dividends = runtime 0..1 floats
   validator_trust = SubtensorModule u16 (0..65535) / 65535
   trust = 0.0 (dead in dTAO)
@@ -40,8 +41,6 @@ import time
 import urllib.error
 import urllib.request
 
-import bittensor as bt
-
 # OnFinality public archive — free, no key, no rate limit, retains historical state.
 NETWORK = "wss://bittensor-finney.api.onfinality.io/public-ws"
 BLOCK_MS = 12_000  # finney block time, empirically exactly 12.0s
@@ -61,6 +60,23 @@ def to_float(value):
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def to_tao_exact(balance):
+    """Convert a Balance to TAO without going through float(Balance)/.tao, which
+    computes the rao->TAO division in double precision internally and silently
+    loses low-order digits above 2**53 rao (~9M TAO). balance.rao is the exact
+    arbitrary-precision int; splitting whole/remainder before the final float
+    conversion keeps the integer TAO part exact (metagraphed#2921)."""
+    if balance is None:
+        return None
+    try:
+        rao = balance.rao
+    except AttributeError:
+        return to_float(balance)  # not a Balance (e.g. already a plain number) — fall back
+    whole = rao // 1_000_000_000
+    remainder = (rao % 1_000_000_000) / 1e9
+    return whole + remainder
 
 
 def u16_ratio(value):
@@ -170,8 +186,8 @@ def build_subnet_rows(info, vtrust_vec, netuid, block, captured_at, snapshot_dat
                 "consensus": to_float(_at(consensus, uid)),
                 "incentive": to_float(_at(incentives, uid)),
                 "dividends": to_float(_at(dividends, uid)),
-                "emission_tao": to_float(_at(emission, uid)),
-                "stake_tao": to_float(_at(stake, uid)),  # THE point of this pass
+                "emission_tao": to_tao_exact(_at(emission, uid)),
+                "stake_tao": to_tao_exact(_at(stake, uid)),  # THE point of this pass
                 "registered_at_block": reg,
                 "is_immunity_period": 1
                 if (reg is not None and block - reg < immunity)
@@ -235,6 +251,9 @@ def main():
     args = p.parse_args()
     if not SECRET and not args.dry_run:
         sys.exit("METAGRAPH_BACKFILL_SECRET is required (or use --dry-run)")
+
+    import bittensor as bt  # lazy: keeps this module loadable (e.g. for unit tests)
+    # without the heavy SDK installed, matching fetch-events.py's convention.
 
     # bittensor 10.4.x: metagraph helpers live on api.metagraphs (NOT api.subnets).
     api = bt.SubtensorApi(network=NETWORK)

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -182,7 +182,19 @@ def _idx(v):
 
 
 def _tao(v):
-    return (v / RAO) if isinstance(v, (int, float)) and v >= 0 else None
+    # Whole/remainder split so the integer TAO part is always exact -- plain
+    # `v / RAO` routes the whole rao integer through double rounding before
+    # the division even happens, silently corrupting values above 2**53 rao
+    # (~9M TAO) (metagraphed#2921). v is already an exact arbitrary-precision
+    # Python int from substrate-interface's SCALE decode, so this loses
+    # nothing that wasn't already lost by the old `v / RAO`.
+    if not (isinstance(v, (int, float)) and v >= 0):
+        return None
+    if isinstance(v, float):
+        return v / RAO  # already a float (unexpected for a rao amount) — nothing to preserve
+    whole = v // 1_000_000_000
+    remainder = (v % 1_000_000_000) / 1e9
+    return whole + remainder
 
 
 # Each extractor maps a decoded attribute tuple -> the entity fields we store.

--- a/scripts/fetch-metagraph-native.py
+++ b/scripts/fetch-metagraph-native.py
@@ -7,7 +7,8 @@ SubtensorModule storage (MetagraphInfo doesn't carry them in dTAO). Emits the ex
 Worker's token-free `loadStagedNeurons`. No Taostats, no API key.
 
 Units (verified by the parity check vs the prior Taostats data, #1348):
-  stake_tao/emission_tao = float(Balance, alpha-denominated)
+  stake_tao/emission_tao = Balance.rao / 1e9, alpha-denominated, computed exactly
+    (not float(Balance)/.tao, which loses precision above 2**53 rao — #2921)
   consensus/incentive/dividends = on-chain 0..1 floats
   rank/validator_trust = SubtensorModule u16 (0..65535) ÷ 65535
   trust = 0.0 (dead in dTAO — 0 across all neurons, Taostats included)
@@ -21,8 +22,6 @@ import os
 import sys
 import time
 
-import bittensor as bt
-
 OUT = os.environ.get("METAGRAPH_NEURONS_JSON", "dist/metagraph-neurons.json")
 
 
@@ -33,6 +32,23 @@ def to_float(value):
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def to_tao_exact(balance):
+    """Convert a Balance to TAO without going through float(Balance)/.tao, which
+    computes the rao->TAO division in double precision internally and silently
+    loses low-order digits above 2**53 rao (~9M TAO). balance.rao is the exact
+    arbitrary-precision int; splitting whole/remainder before the final float
+    conversion keeps the integer TAO part exact (metagraphed#2921)."""
+    if balance is None:
+        return None
+    try:
+        rao = balance.rao
+    except AttributeError:
+        return to_float(balance)  # not a Balance (e.g. already a plain number) — fall back
+    whole = rao // 1_000_000_000
+    remainder = (rao % 1_000_000_000) / 1e9
+    return whole + remainder
 
 
 def u16_ratio(value):
@@ -64,6 +80,9 @@ def _at(arr, i):
 
 
 def main():
+    import bittensor as bt  # lazy: keeps this module loadable (e.g. for unit tests)
+    # without the heavy SDK installed, matching fetch-events.py's convention.
+
     parser = argparse.ArgumentParser()
     # Default from the SUBTENSOR_RPC_URL env (the hidden chain-RPC secret; ADR 0012)
     # so the metagraph fetch routes through our own node without exposing its URL;
@@ -129,8 +148,8 @@ def main():
                     "consensus": to_float(_at(consensus, uid)),
                     "incentive": to_float(_at(incentives, uid)),
                     "dividends": to_float(_at(dividends, uid)),
-                    "emission_tao": to_float(_at(emission, uid)),
-                    "stake_tao": to_float(_at(stake, uid)),
+                    "emission_tao": to_tao_exact(_at(emission, uid)),
+                    "stake_tao": to_tao_exact(_at(stake, uid)),
                     "registered_at_block": reg,
                     "is_immunity_period": 1
                     if (reg is not None and block - reg < immunity)

--- a/scripts/fetch-native-subnets.py
+++ b/scripts/fetch-native-subnets.py
@@ -3,22 +3,43 @@ import argparse
 import json
 from datetime import datetime, timezone
 
-import bittensor as bt
 
-
-def to_tao(value):
-    """Coerce a bittensor Balance (or plain number) to a float.
-
-    Balance.__float__ already returns the tao-denominated value; plain ints and
-    floats pass through. Anything else (None, unexpected type) becomes None so a
-    single odd field never aborts the per-subnet economics block.
-    """
-    if value is None:
+def to_rao_exact(balance):
+    """Extract the exact rao integer from a Balance, for sum-then-convert
+    aggregation. Summing already-float-converted TAO values (the prior
+    approach) compounds double-precision rounding across every per-UID entry
+    before the total is even computed; summing rao (Python int, arbitrary
+    precision) first and converting once at the end avoids that entirely
+    (metagraphed#2921). Falls back to a best-effort rao estimate for plain
+    numbers (never expected in practice — MetagraphInfo's per-UID arrays are
+    Balance objects — but keeps this defensive like to_tao)."""
+    if balance is None:
         return None
     try:
-        return float(value)
-    except (TypeError, ValueError):
+        return balance.rao
+    except AttributeError:
+        try:
+            return int(round(float(balance) * 1_000_000_000))
+        except (TypeError, ValueError):
+            return None
+
+
+def rao_to_tao_exact(rao):
+    """Whole/remainder split so the integer TAO part is always exact, only
+    crossing to a float for the sub-TAO remainder (metagraphed#2921)."""
+    if rao is None:
         return None
+    whole = rao // 1_000_000_000
+    remainder = (rao % 1_000_000_000) / 1e9
+    return whole + remainder
+
+
+def to_tao_exact(balance):
+    """Single-value equivalent of to_rao_exact + rao_to_tao_exact, for fields
+    that aren't aggregated (registration_cost_tao, alpha_price_tao, pool
+    reserves, etc.) — same exact-conversion guarantee as to_tao without ever
+    routing through Balance.__float__/.tao internally (metagraphed#2921)."""
+    return rao_to_tao_exact(to_rao_exact(balance))
 
 
 def normalize_economics(info):
@@ -32,31 +53,36 @@ def normalize_economics(info):
     permits = list(getattr(info, "validator_permit", []) or [])
     validator_count = sum(1 for permit in permits if permit)
     num_uids = int(getattr(info, "num_uids", 0) or 0)
-    stakes = [
-        stake
-        for stake in (
-            to_tao(entry) for entry in (getattr(info, "total_stake", []) or [])
+    # Sum in rao-integer space (exact, arbitrary precision), not float space —
+    # summing already-converted TAO floats compounds rounding across every
+    # per-UID entry before the subnet total is even computed (metagraphed#2921).
+    stake_rao_values = [
+        rao
+        for rao in (
+            to_rao_exact(entry) for entry in (getattr(info, "total_stake", []) or [])
         )
-        if stake is not None
+        if rao is not None
     ]
+    total_stake_rao = sum(stake_rao_values) if stake_rao_values else None
+    max_stake_rao = max(stake_rao_values) if stake_rao_values else None
     return {
         "max_uids": int(getattr(info, "max_uids", 0) or 0),
         "validator_count": validator_count,
         "max_validators": int(getattr(info, "max_validators", 0) or 0),
         "miner_count": max(0, num_uids - validator_count),
         "registration_allowed": bool(getattr(info, "registration_allowed", False)),
-        "registration_cost_tao": to_tao(getattr(info, "burn", None)),
+        "registration_cost_tao": to_tao_exact(getattr(info, "burn", None)),
         # dTAO emission is price-weighted: a subnet's share of network TAO
         # emission tracks its alpha price (moving_price), not the now-zeroed
         # subnet_emission/tao_in_emission fields. We capture the price here and
         # derive each subnet's emission_share at build time (price / Σ price).
-        "alpha_price_tao": to_tao(getattr(info, "moving_price", None)),
-        "total_stake_tao": round(sum(stakes), 9) if stakes else None,
-        "max_stake_tao": round(max(stakes), 9) if stakes else None,
-        "tao_in_pool_tao": to_tao(getattr(info, "tao_in", None)),
-        "alpha_in_pool": to_tao(getattr(info, "alpha_in", None)),
-        "alpha_out_pool": to_tao(getattr(info, "alpha_out", None)),
-        "subnet_volume_tao": to_tao(getattr(info, "subnet_volume", None)),
+        "alpha_price_tao": to_tao_exact(getattr(info, "moving_price", None)),
+        "total_stake_tao": rao_to_tao_exact(total_stake_rao),
+        "max_stake_tao": rao_to_tao_exact(max_stake_rao),
+        "tao_in_pool_tao": to_tao_exact(getattr(info, "tao_in", None)),
+        "alpha_in_pool": to_tao_exact(getattr(info, "alpha_in", None)),
+        "alpha_out_pool": to_tao_exact(getattr(info, "alpha_out", None)),
+        "subnet_volume_tao": to_tao_exact(getattr(info, "subnet_volume", None)),
         "owner_hotkey": str(getattr(info, "owner_hotkey", "") or "") or None,
         "owner_coldkey": str(getattr(info, "owner_coldkey", "") or "") or None,
     }
@@ -136,6 +162,9 @@ def classify_name(raw_name, netuid):
 
 
 def main():
+    import bittensor as bt  # lazy: keeps this module loadable (e.g. for unit tests)
+    # without the heavy SDK installed, matching fetch-events.py's convention.
+
     parser = argparse.ArgumentParser(description="Fetch decoded Bittensor Finney subnet metadata.")
     parser.add_argument("--network", default="finney")
     args = parser.parse_args()

--- a/scripts/test_backfill_neuron_history.py
+++ b/scripts/test_backfill_neuron_history.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Unit tests for backfill-neuron-history.py's exact rao->TAO conversion (#2921).
+
+Runnable both ways:
+
+    python3 scripts/test_backfill_neuron_history.py
+    python3 -m pytest scripts/test_backfill_neuron_history.py
+"""
+import importlib.util
+import os
+import sys
+import types
+import unittest
+
+# backfill-neuron-history.py imports bittensor and xxhash at module level (used
+# by main()/twox128, unrelated to the pure conversion logic under test here) --
+# stub both so this module can be loaded for testing without the heavy/native
+# deps installed, without changing the script's own import structure.
+for _mod_name in ("bittensor", "xxhash"):
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = types.ModuleType(_mod_name)
+
+_BNH_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "backfill-neuron-history.py"
+)
+_spec = importlib.util.spec_from_file_location("backfill_neuron_history_under_test", _BNH_PATH)
+_bnh = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_bnh)
+
+rao_to_tao_exact = _bnh.rao_to_tao_exact
+
+
+class RaoToTaoExactTest(unittest.TestCase):
+    def test_none_returns_none(self):
+        self.assertIsNone(rao_to_tao_exact(None))
+
+    def test_zero(self):
+        self.assertEqual(rao_to_tao_exact(0), 0)
+
+    def test_small_value_matches_plain_division(self):
+        self.assertEqual(rao_to_tao_exact(2_500_000_000), 2.5)
+
+    def test_large_emission_whole_part_exact(self):
+        # An intentionally large emission value (real per-UID emission is
+        # small, but the conversion must be correct at any magnitude).
+        rao = 50_000_000 * 10**9 + 123_456_789
+        result = rao_to_tao_exact(rao)
+        self.assertEqual(int(result), 50_000_000)
+
+    def test_extreme_magnitude_whole_part_exact(self):
+        rao = 9_007_199_254_740_993_123
+        result = rao_to_tao_exact(rao)
+        self.assertEqual(int(result), rao // 1_000_000_000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_backfill_stake_monthly.py
+++ b/scripts/test_backfill_stake_monthly.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Unit tests for backfill-stake-monthly.py's exact rao->TAO conversion (#2921).
+
+Runnable both ways:
+
+    python3 scripts/test_backfill_stake_monthly.py
+    python3 -m pytest scripts/test_backfill_stake_monthly.py
+
+Same to_tao_exact logic as fetch-metagraph-native.py (this script's own docstring
+says "Units match scripts/fetch-metagraph-native.py exactly") — see
+test_fetch_metagraph_native.py for the fuller test suite; this just confirms the
+same fix landed correctly in this script's own copy of the helper.
+"""
+import importlib.util
+import os
+import unittest
+
+_BSM_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "backfill-stake-monthly.py"
+)
+_spec = importlib.util.spec_from_file_location("backfill_stake_monthly_under_test", _BSM_PATH)
+_bsm = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_bsm)
+
+to_tao_exact = _bsm.to_tao_exact
+
+
+class FakeBalance:
+    def __init__(self, rao):
+        self.rao = rao
+
+
+class ToTaoExactTest(unittest.TestCase):
+    def test_none_returns_none(self):
+        self.assertIsNone(to_tao_exact(None))
+
+    def test_small_value_matches_plain_division(self):
+        self.assertEqual(to_tao_exact(FakeBalance(2_500_000_000)), 2.5)
+
+    def test_large_validator_stake_whole_part_exact(self):
+        rao = 50_000_000 * 10**9 + 123_456_789
+        result = to_tao_exact(FakeBalance(rao))
+        self.assertEqual(int(result), 50_000_000)
+
+    def test_non_balance_value_falls_back_to_plain_float(self):
+        self.assertEqual(to_tao_exact(3.5), 3.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_fetch_events.py
+++ b/scripts/test_fetch_events.py
@@ -32,6 +32,7 @@ AURA_ENGINE_ID = _fe.AURA_ENGINE_ID
 PRUNE_HORIZON = _fe.PRUNE_HORIZON
 event_rows_for_events = _fe.event_rows_for_events
 _can_append_event_block = _fe._can_append_event_block
+_tao = _fe._tao
 
 
 class ComputeFromBlockTest(unittest.TestCase):
@@ -862,6 +863,34 @@ class BurnSetExtractorTest(unittest.TestCase):
         result = _extract("BurnSet", [])
         self.assertIsNone(result["netuid"])
         self.assertIsNone(result["amount_tao"])
+
+
+class TaoConversionTest(unittest.TestCase):
+    """_tao's exact rao->TAO conversion (#2921) -- the whole-TAO part must
+    always match exact integer division, unlike the old plain `v / RAO`."""
+
+    def test_none_and_invalid_inputs(self):
+        self.assertIsNone(_tao(None))
+        self.assertIsNone(_tao(-1))
+        self.assertIsNone(_tao("100"))
+
+    def test_zero(self):
+        self.assertEqual(_tao(0), 0)
+
+    def test_small_value_matches_plain_division(self):
+        self.assertEqual(_tao(2_500_000_000), 2.5)
+
+    def test_large_transfer_whole_part_exact(self):
+        # A large native-TAO transfer or whale stake-add -- above the ~9.007M
+        # ceiling, a plausible real-world magnitude for this event class.
+        rao = 50_000_000 * 10**9 + 123_456_789
+        result = _tao(rao)
+        self.assertEqual(int(result), 50_000_000)
+
+    def test_extreme_magnitude_whole_part_exact(self):
+        rao = 9_007_199_254_740_993_123
+        result = _tao(rao)
+        self.assertEqual(int(result), rao // 1_000_000_000)
 
 
 if __name__ == "__main__":

--- a/scripts/test_fetch_metagraph_native.py
+++ b/scripts/test_fetch_metagraph_native.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Unit tests for fetch-metagraph-native.py's exact rao->TAO conversion (#2921).
+
+Runnable both ways:
+
+    python3 scripts/test_fetch_metagraph_native.py
+    python3 -m pytest scripts/test_fetch_metagraph_native.py
+
+Loaded by path (hyphenated filename) the same way test_fetch_events.py loads
+fetch-events.py. Does not import the real `bittensor` package — to_tao_exact
+only needs a `.rao` attribute (duck-typed), so a minimal stand-in is enough to
+exercise the pure conversion logic without the heavy SDK dependency.
+"""
+import importlib.util
+import os
+import unittest
+
+_FMN_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "fetch-metagraph-native.py"
+)
+_spec = importlib.util.spec_from_file_location("fetch_metagraph_native_under_test", _FMN_PATH)
+_fmn = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_fmn)
+
+to_tao_exact = _fmn.to_tao_exact
+to_float = _fmn.to_float
+
+
+class FakeBalance:
+    """Duck-types the one attribute to_tao_exact reads from a real Balance."""
+
+    def __init__(self, rao):
+        self.rao = rao
+
+
+class ToTaoExactTest(unittest.TestCase):
+    def test_none_returns_none(self):
+        self.assertIsNone(to_tao_exact(None))
+
+    def test_small_value_matches_plain_division(self):
+        # Well under 2**53 rao -- exact and float division should agree exactly.
+        rao = 2_500_000_000  # 2.5 TAO
+        self.assertEqual(to_tao_exact(FakeBalance(rao)), 2.5)
+
+    def test_extreme_magnitude_matches_exact_integer_math(self):
+        # An intentionally extreme rao value (~9.007 billion TAO). The whole-TAO
+        # part must always match exact integer division -- this is the actual
+        # guarantee the fix provides (unlike float(rao)/1e9, which routes the
+        # whole integer through double rounding before dividing at all).
+        rao = 9_007_199_254_740_993_123
+        result = to_tao_exact(FakeBalance(rao))
+        whole_tao = rao // 1_000_000_000
+        self.assertEqual(int(result), whole_tao)
+
+    def test_realistic_large_validator_stake(self):
+        # 50M TAO -- above the ~9.007M ceiling, a plausible "what if a large
+        # validator/foundation wallet grows" magnitude, unlike the extreme
+        # test above. The whole-TAO part must be exact.
+        rao = 50_000_000 * 10**9 + 123_456_789
+        result = to_tao_exact(FakeBalance(rao))
+        self.assertEqual(int(result), 50_000_000)
+        # Sub-TAO accuracy is bounded by double precision at this magnitude
+        # (~7-8 significant fractional digits, not the full 9 rao decimals).
+        self.assertAlmostEqual(result - 50_000_000, 0.123456789, places=7)
+
+    def test_non_balance_value_falls_back_to_plain_float(self):
+        # Defensive path: something without .rao (e.g. an already-plain number)
+        # falls back to to_float rather than raising.
+        self.assertEqual(to_tao_exact(3.5), 3.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_fetch_native_subnets.py
+++ b/scripts/test_fetch_native_subnets.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Unit tests for fetch-native-subnets.py's exact rao->TAO conversion and
+sum-in-rao-space aggregation (#2921).
+
+Runnable both ways:
+
+    python3 scripts/test_fetch_native_subnets.py
+    python3 -m pytest scripts/test_fetch_native_subnets.py
+"""
+import importlib.util
+import os
+import types
+import unittest
+
+_FNS_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "fetch-native-subnets.py"
+)
+_spec = importlib.util.spec_from_file_location("fetch_native_subnets_under_test", _FNS_PATH)
+_fns = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_fns)
+
+to_rao_exact = _fns.to_rao_exact
+rao_to_tao_exact = _fns.rao_to_tao_exact
+to_tao_exact = _fns.to_tao_exact
+normalize_economics = _fns.normalize_economics
+
+
+class FakeBalance:
+    def __init__(self, rao):
+        self.rao = rao
+
+
+class ConversionHelpersTest(unittest.TestCase):
+    def test_to_rao_exact_reads_balance_rao_directly(self):
+        self.assertEqual(to_rao_exact(FakeBalance(123_456_789_000)), 123_456_789_000)
+
+    def test_to_rao_exact_none(self):
+        self.assertIsNone(to_rao_exact(None))
+
+    def test_rao_to_tao_exact_matches_plain_division_for_small_values(self):
+        self.assertEqual(rao_to_tao_exact(2_500_000_000), 2.5)
+
+    def test_to_tao_exact_composes_both(self):
+        self.assertEqual(to_tao_exact(FakeBalance(2_500_000_000)), 2.5)
+        self.assertIsNone(to_tao_exact(None))
+
+
+class NormalizeEconomicsAggregationTest(unittest.TestCase):
+    def test_total_stake_sums_in_rao_space_not_float_space(self):
+        # Three large per-UID stakes, each individually above the point where
+        # summing pre-converted floats would compound rounding error. The old
+        # code did `round(sum(to_tao(entry) for entry in total_stake), 9)` --
+        # summing TAO floats. The fix sums rao ints first, converts once.
+        stakes = [
+            FakeBalance(3_707_767 * 10**9 + 110_483_468),
+            FakeBalance(3_560_214 * 10**9 + 214_195_670),
+            FakeBalance(3_323_419 * 10**9 + 873_737_862),
+        ]
+        info = types.SimpleNamespace(
+            validator_permit=[True, True, True],
+            num_uids=3,
+            max_uids=256,
+            max_validators=64,
+            registration_allowed=True,
+            burn=FakeBalance(1_000_000_000),
+            moving_price=FakeBalance(500_000_000),
+            total_stake=stakes,
+            tao_in=FakeBalance(10_000_000_000),
+            alpha_in=FakeBalance(10_000_000_000),
+            alpha_out=FakeBalance(10_000_000_000),
+            subnet_volume=FakeBalance(1_000_000_000),
+            owner_hotkey="",
+            owner_coldkey="",
+        )
+        result = normalize_economics(info)
+        expected_total_rao = sum(s.rao for s in stakes)
+        expected_whole_tao = expected_total_rao // 1_000_000_000
+        self.assertEqual(int(result["total_stake_tao"]), expected_whole_tao)
+        self.assertEqual(result["max_stake_tao"], rao_to_tao_exact(max(s.rao for s in stakes)))
+
+    def test_empty_stakes_returns_none(self):
+        info = types.SimpleNamespace(
+            validator_permit=[],
+            num_uids=0,
+            max_uids=0,
+            max_validators=0,
+            registration_allowed=False,
+            burn=None,
+            moving_price=None,
+            total_stake=[],
+            tao_in=None,
+            alpha_in=None,
+            alpha_out=None,
+            subnet_volume=None,
+            owner_hotkey="",
+            owner_coldkey="",
+        )
+        result = normalize_economics(info)
+        self.assertIsNone(result["total_stake_tao"])
+        self.assertIsNone(result["max_stake_tao"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2921 (part of the #2588 u128 precision-loss roadmap).

## Summary
- Every live ingestion writer producing `stake_tao`/`emission_tao`/`amount_tao` either called `float(Balance)` (the Bittensor SDK does the rao→TAO division internally in double precision, discarding the exact rao integer before this repo's code runs) or divided an already-exact SCALE-decoded int by `1e9` directly. Both silently lose precision above `2**53` rao (~9M TAO).
- Verified against the pinned `bittensor==10.4.0` SDK (via `uvx`) that `Balance.rao` is a plain, always-exact arbitrary-precision int attribute — confirmed with an intentionally extreme test value that visibly diverges from `float(Balance)`.
- Fixed all 5 live writers to split whole/remainder before the final float conversion, mirroring the already-merged `src/account-balance.mjs` pattern (#2070), relocated into Python since these are separate processes the JS layer can't reach:
  - `scripts/fetch-metagraph-native.py`
  - `scripts/backfill-stake-monthly.py`
  - `scripts/fetch-native-subnets.py` — also fixes `total_stake_tao`/`max_stake_tao`, which summed already-lossy per-UID floats; now sums exact rao integers first, converts once
  - `scripts/backfill-neuron-history.py`
  - `scripts/fetch-events.py`
- Made the `bittensor` import lazy in the 3 scripts that had it at module level, matching `fetch-events.py`'s existing convention — keeps these modules loadable for unit testing without the heavy SDK installed.
- No D1 schema change, no OpenAPI/contract change — every writer still emits a plain JSON number, just computed correctly.

## Test plan
- [x] Unit tests added/updated for all 5 writers, covering the >2^53-rao case (`scripts/test_fetch_metagraph_native.py`, `scripts/test_backfill_stake_monthly.py`, `scripts/test_fetch_native_subnets.py`, `scripts/test_backfill_neuron_history.py`, new `TaoConversionTest` class in `scripts/test_fetch_events.py`)
- [x] All 99 pre-existing tests in `test_fetch_events.py` still pass (fully backward-compatible for normal-magnitude values)
- [x] Verified end-to-end against live chain data for the 3 SDK-`Balance`-based writers (`fetch-metagraph-native.py`, `fetch-native-subnets.py`) — real production values, correct shape, sensible magnitudes
- [x] `py_compile` clean on all 5 modified scripts