### PR TITLE
fix(tests): update stale MCP_SERVER_VERSION assertion

### DIFF
--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.22.0");
+    assert.equal(MCP_SERVER_VERSION, "1.23.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- \`tests/curation-mcp.test.mjs\` hardcoded \`MCP_SERVER_VERSION\` as \`"1.22.0"\`. A subsequent MCP feature PR (#2840, direction filter on \`get_account_stake_flow\`) bumped the real constant to \`"1.23.0"\` without updating this assertion, breaking CI on \`main\` for anything that rebases past it — currently blocking #2928.

## Test plan
- [x] \`npx vitest run tests/curation-mcp.test.mjs\` — 26/26 pass locally