### PR TITLE
fix(api): sum network-wide stake/emission in exact rao space, not float

### DIFF
--- a/src/chain-yield.mjs
+++ b/src/chain-yield.mjs
@@ -31,6 +31,20 @@ function toNumber(value) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+// Sum in rao-integer BigInt space, not float space -- summing potentially
+// thousands of network-wide stake_tao/emission_tao floats with plain `+=`
+// compounds rounding error across the accumulation even when each individual
+// value is itself exact (metagraphed#2922, mirrors the toRao pattern already
+// proven in src/account-balance.mjs for #2070). Convert back to TAO only
+// once, at the very end.
+function toRaoBig(taoValue) {
+  const n = Number(taoValue);
+  return Number.isFinite(n) ? BigInt(Math.round(n * 1e9)) : 0n;
+}
+function raoBigToTao(rao) {
+  return Number(rao / 1_000_000_000n) + Number(rao % 1_000_000_000n) / 1e9;
+}
+
 // Coerce a D1 netuid cell to a non-negative integer, or null. Accept ONLY a real
 // number or an all-digits string: a bare Number() would turn "", null, or false
 // into a valid subnet 0 (Number("") === Number(null) === Number(false) === 0), so
@@ -114,10 +128,10 @@ export function buildChainYield(rows) {
   const list = Array.isArray(rows) ? rows : [];
   let capturedAt = null;
   let validatorCount = 0;
-  let totalStake = 0;
-  let totalEmission = 0;
-  let validatorStake = 0;
-  let validatorEmission = 0;
+  let totalStakeRao = 0n;
+  let totalEmissionRao = 0n;
+  let validatorStakeRao = 0n;
+  let validatorEmissionRao = 0n;
   const netuids = new Set();
   const yields = [];
   for (const row of list) {
@@ -132,18 +146,24 @@ export function buildChainYield(rows) {
     // Match the neuron formatter's SQLite 0/1 convention: only an integer 1 is a
     // validator, so a numeric-string "0" cannot slip through as truthy.
     const isValidator = Number(row?.validator_permit) === 1;
-    totalStake += stake;
-    totalEmission += emission;
+    const stakeRao = toRaoBig(stake);
+    const emissionRao = toRaoBig(emission);
+    totalStakeRao += stakeRao;
+    totalEmissionRao += emissionRao;
     if (isValidator) {
       validatorCount += 1;
-      validatorStake += stake;
-      validatorEmission += emission;
+      validatorStakeRao += stakeRao;
+      validatorEmissionRao += emissionRao;
     }
     const value = computeYieldValue(emission, stake);
     if (value != null) yields.push(value);
   }
-  const minerStake = totalStake - validatorStake;
-  const minerEmission = totalEmission - validatorEmission;
+  const totalStake = raoBigToTao(totalStakeRao);
+  const totalEmission = raoBigToTao(totalEmissionRao);
+  const validatorStake = raoBigToTao(validatorStakeRao);
+  const validatorEmission = raoBigToTao(validatorEmissionRao);
+  const minerStake = raoBigToTao(totalStakeRao - validatorStakeRao);
+  const minerEmission = raoBigToTao(totalEmissionRao - validatorEmissionRao);
   return {
     schema_version: 1,
     subnet_count: netuids.size,

--- a/src/chain-yield.mjs
+++ b/src/chain-yield.mjs
@@ -36,10 +36,10 @@ function toNumber(value) {
 // compounds rounding error across the accumulation even when each individual
 // value is itself exact (metagraphed#2922, mirrors the toRao pattern already
 // proven in src/account-balance.mjs for #2070). Convert back to TAO only
-// once, at the very end.
-function toRaoBig(taoValue) {
-  const n = Number(taoValue);
-  return Number.isFinite(n) ? BigInt(Math.round(n * 1e9)) : 0n;
+// once, at the very end. Callers always pass an already-finite toNumber()
+// result, so no isFinite guard here.
+function toRaoBig(tao) {
+  return BigInt(Math.round(tao * 1e9));
 }
 function raoBigToTao(rao) {
   return Number(rao / 1_000_000_000n) + Number(rao % 1_000_000_000n) / 1e9;

--- a/src/concentration.mjs
+++ b/src/concentration.mjs
@@ -36,6 +36,20 @@ function roundRatio(value, dp = 6) {
   return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
 }
 
+// Sum in rao-integer BigInt space, not float space -- summing potentially
+// thousands of network-wide stake_tao/emission_tao floats (per controlling
+// entity, or as a distribution total) with plain `+=` compounds rounding error
+// across the accumulation even when each individual value is itself exact
+// (metagraphed#2922, mirrors the toRaoBig pattern in src/chain-yield.mjs and
+// src/metagraph-neurons.mjs). Convert back to TAO only once, at the very end.
+function toRaoBig(taoValue) {
+  const n = typeof taoValue === "number" ? taoValue : Number(taoValue);
+  return Number.isFinite(n) ? BigInt(Math.round(n * 1e9)) : 0n;
+}
+function raoBigToTao(rao) {
+  return Number(rao / 1_000_000_000n) + Number(rao % 1_000_000_000n) / 1e9;
+}
+
 function epochMsStamp(ms) {
   if (!Number.isFinite(ms) || ms <= 0) return null;
   const date = new Date(ms);
@@ -152,7 +166,12 @@ export function computeConcentration(values) {
   const positives = positiveValues(Array.isArray(values) ? values : []);
   const holders = positives.length;
   if (holders === 0) return null;
-  const total = positives.reduce((sum, v) => sum + v, 0);
+  // The distribution total is the ratio denominator for every metric below
+  // (gini/hhi/entropy/topShares) -- summing potentially thousands of holders'
+  // values in rao-BigInt space, not plain float `+=`, keeps it exact (#2922).
+  const total = raoBigToTao(
+    positives.reduce((sum, v) => sum + toRaoBig(v), 0n),
+  );
   if (total <= 0) return null;
   const ascending = [...positives].sort((a, b) => a - b);
   const descending = [...positives].sort((a, b) => b - a);
@@ -171,32 +190,30 @@ export function computeConcentration(values) {
   };
 }
 
-// Coerce one raw cell to a finite number (or 0) for summation — when totaling a
-// coldkey's UIDs a non-finite cell must contribute 0, not poison the sum.
-function numeric(value) {
-  const n = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(n) ? n : 0;
-}
-
 // Collapse a subnet's UID rows into one holder per controlling entity (coldkey),
 // summing stake + emission across all of an entity's hotkeys. A row with no
 // coldkey becomes its own singleton entity (a fresh object key), so the entity
-// count never under-counts unknown owners. Returns per-entity value arrays + the
-// distinct-entity count, all consistent.
+// count never under-counts unknown owners. Sums in rao-BigInt space per entity
+// (network-wide, potentially thousands of UIDs collapsing into one coldkey's
+// total) and converts to TAO once per entity, not per row (#2922). Returns
+// per-entity value arrays + the distinct-entity count, all consistent.
 function groupByEntity(rows) {
-  const stake = new Map();
-  const emission = new Map();
+  const stakeRao = new Map();
+  const emissionRao = new Map();
   for (const row of rows) {
     const hasColdkey =
       typeof row?.coldkey === "string" && row.coldkey.length > 0;
     const key = hasColdkey ? row.coldkey : {};
-    stake.set(key, (stake.get(key) ?? 0) + numeric(row?.stake_tao));
-    emission.set(key, (emission.get(key) ?? 0) + numeric(row?.emission_tao));
+    stakeRao.set(key, (stakeRao.get(key) ?? 0n) + toRaoBig(row?.stake_tao));
+    emissionRao.set(
+      key,
+      (emissionRao.get(key) ?? 0n) + toRaoBig(row?.emission_tao),
+    );
   }
   return {
-    stake: [...stake.values()],
-    emission: [...emission.values()],
-    count: stake.size,
+    stake: [...stakeRao.values()].map(raoBigToTao),
+    emission: [...emissionRao.values()].map(raoBigToTao),
+    count: stakeRao.size,
   };
 }
 

--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -85,6 +85,21 @@ function roundTao(value) {
   return Math.round(numberOrZero(value) * RAO_PER_TAO) / RAO_PER_TAO;
 }
 
+// Sum in rao-integer BigInt space, not float space -- summing every validator
+// UID's stake_tao/emission_tao per hotkey (network-wide, unbounded) with plain
+// `+=` compounds rounding error across the accumulation even when each
+// individual value is itself exact (metagraphed#2922, mirrors the toRaoBig
+// pattern in src/chain-yield.mjs and the toRao helper proven in
+// src/account-balance.mjs for #2070). Convert back to TAO only once, at the
+// very end.
+function toRaoBig(taoValue) {
+  const n = Number(taoValue);
+  return Number.isFinite(n) ? BigInt(Math.round(n * RAO_PER_TAO)) : 0n;
+}
+function raoBigToTao(rao) {
+  return Number(rao / 1_000_000_000n) + Number(rao % 1_000_000_000n) / 1e9;
+}
+
 function round(value, dp = 6) {
   if (value == null || !Number.isFinite(value)) return null;
   const factor = 10 ** dp;
@@ -221,8 +236,8 @@ function buildGlobalValidatorEntry(entry) {
     coldkey_count: entry.coldkeys.size,
     subnet_count: entry.netuids.size,
     uid_count: entry.uidCount,
-    total_stake_tao: roundTao(entry.stakeTotal),
-    total_emission_tao: roundTao(entry.emissionTotal),
+    total_stake_tao: roundTao(raoBigToTao(entry.stakeTotalRao)),
+    total_emission_tao: roundTao(raoBigToTao(entry.emissionTotalRao)),
     avg_validator_trust: round(avgTrust),
     max_validator_trust: round(entry.maxValidatorTrust),
     latest_captured_at: toIso(entry.latestCapturedAt),
@@ -232,10 +247,16 @@ function buildGlobalValidatorEntry(entry) {
 }
 
 function applyStakeDominance(validators) {
-  const networkStakeTotal = validators.reduce(
-    (sum, entry) => sum + numberOrZero(entry.total_stake_tao),
-    0,
+  // Same rao-BigInt treatment as the per-hotkey accumulation above: summing
+  // every validator's already-rounded total_stake_tao (one per hotkey,
+  // network-wide) with plain `+=` reintroduces the same float-compounding risk
+  // this fix removed upstream. total_stake_tao is already rao-precision here
+  // (roundTao'd from an exact BigInt sum), so re-deriving its rao value is exact.
+  const networkStakeRao = validators.reduce(
+    (sum, entry) => sum + toRaoBig(entry.total_stake_tao),
+    0n,
   );
+  const networkStakeTotal = raoBigToTao(networkStakeRao);
   if (!(networkStakeTotal > 0) || !Number.isFinite(networkStakeTotal)) {
     return validators.map((entry) => ({ ...entry, stake_dominance: null }));
   }
@@ -286,8 +307,8 @@ export function buildGlobalValidators(
         coldkeys: new Map(),
         netuids: new Set(),
         uidCount: 0,
-        stakeTotal: 0,
-        emissionTotal: 0,
+        stakeTotalRao: 0n,
+        emissionTotalRao: 0n,
         validatorTrustTotal: 0,
         validatorTrustCount: 0,
         maxValidatorTrust: null,
@@ -305,8 +326,8 @@ export function buildGlobalValidators(
     }
     entry.netuids.add(netuid);
     entry.uidCount += 1;
-    entry.stakeTotal += stake;
-    entry.emissionTotal += emission;
+    entry.stakeTotalRao += toRaoBig(stake);
+    entry.emissionTotalRao += toRaoBig(emission);
     if (trust != null) {
       entry.validatorTrustTotal += trust;
       entry.validatorTrustCount += 1;

--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -91,10 +91,10 @@ function roundTao(value) {
 // individual value is itself exact (metagraphed#2922, mirrors the toRaoBig
 // pattern in src/chain-yield.mjs and the toRao helper proven in
 // src/account-balance.mjs for #2070). Convert back to TAO only once, at the
-// very end.
-function toRaoBig(taoValue) {
-  const n = Number(taoValue);
-  return Number.isFinite(n) ? BigInt(Math.round(n * RAO_PER_TAO)) : 0n;
+// very end. Callers always pass an already-finite numberOrZero()/roundTao()
+// result, so no isFinite guard here.
+function toRaoBig(tao) {
+  return BigInt(Math.round(tao * RAO_PER_TAO));
 }
 function raoBigToTao(rao) {
   return Number(rao / 1_000_000_000n) + Number(rao % 1_000_000_000n) / 1e9;

--- a/tests/chain-concentration.test.mjs
+++ b/tests/chain-concentration.test.mjs
@@ -68,6 +68,38 @@ describe("buildChainConcentration", () => {
     assert.equal(out.validator_stake.total, 30);
   });
 
+  test("sums one coldkey's per-UID stake and the network total in exact rao space (#2922)", () => {
+    // groupByEntity's per-entity pre-sum and computeConcentration's own
+    // distribution total both now accumulate in rao-BigInt space rather than
+    // plain float `+=` (metagraphed#2922). The `total` field is only surfaced
+    // at 4dp, so a handful of thousand rows won't visibly drift past that
+    // rounding either way -- this asserts the rao-exact value the BigInt path
+    // is now guaranteed to produce, rather than relying on rounding to mask
+    // (or reveal) any accumulation error.
+    const rows = [];
+    let expectedTotalRao = 0n;
+    for (let i = 0; i < 5000; i += 1) {
+      const stakeTao = 1234.987654321 + i * 0.000000001;
+      rows.push({
+        stake_tao: stakeTao,
+        emission_tao: 0,
+        coldkey: "ck-precision",
+        validator_permit: 0,
+        netuid: i,
+      });
+      expectedTotalRao += BigInt(Math.round(stakeTao * 1e9));
+    }
+    const out = buildChainConcentration(rows);
+    const expectedTotal =
+      Number(expectedTotalRao / 1_000_000_000n) +
+      Number(expectedTotalRao % 1_000_000_000n) / 1e9;
+    const rounded = Math.round(expectedTotal * 1e4) / 1e4; // computeConcentration rounds `total` to 4dp
+    // one coldkey -> one entity, so the entity total equals the per-UID total.
+    assert.equal(out.stake.total, rounded);
+    assert.equal(out.entity_stake.total, rounded);
+    assert.equal(out.entity_stake.holders, 1);
+  });
+
   test("takes the newest captured_at across mixed epoch-ms / ISO stamps", () => {
     const out = buildChainConcentration([
       { stake_tao: 5, coldkey: "a", netuid: 1, captured_at: 1_700_000_000_000 },

--- a/tests/chain-yield.test.mjs
+++ b/tests/chain-yield.test.mjs
@@ -165,6 +165,30 @@ describe("buildChainYield", () => {
     assert.equal(out.distribution, null);
   });
 
+  test("sums thousands of rows in exact rao space, not compounding float error (#2922)", () => {
+    // Each row's stake carries a real sub-TAO fractional component (not a
+    // round number) -- plain `+=` float accumulation across many rows would
+    // drift from the true sum. Summing in rao BigInt space must not.
+    const rows = [];
+    let expectedTotalRao = 0n;
+    for (let i = 0; i < 5000; i += 1) {
+      const stakeTao = 1234.987654321 + i * 0.000000001;
+      rows.push({
+        validator_permit: 0,
+        stake_tao: stakeTao,
+        emission_tao: 0,
+        netuid: i % 129,
+        captured_at: 1_750_000_000_000,
+      });
+      expectedTotalRao += BigInt(Math.round(stakeTao * 1e9));
+    }
+    const out = buildChainYield(rows);
+    const expectedTotal =
+      Number(expectedTotalRao / 1_000_000_000n) +
+      Number(expectedTotalRao % 1_000_000_000n) / 1e9;
+    assert.equal(out.total_stake_tao, Math.round(expectedTotal * 1e9) / 1e9);
+  });
+
   test("loadChainYield issues one un-filtered SELECT and shapes it", async () => {
     let seen;
     const d1 = async (sql, params) => {

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -646,6 +646,35 @@ describe("metagraph-neurons builders", () => {
     );
   });
 
+  test("sums a hotkey's per-UID stake in exact rao space, not compounding float error (#2922)", () => {
+    // One hotkey validating on thousands of subnets, each contributing a real
+    // sub-TAO fractional stake -- plain `+=` float accumulation across many
+    // rows would drift from the true sum. Summing in rao BigInt space must not.
+    const rows = [];
+    let expectedTotalRao = 0n;
+    for (let i = 0; i < 5000; i += 1) {
+      const stakeTao = 1234.987654321 + i * 0.000000001;
+      rows.push({
+        ...ROW,
+        netuid: i,
+        uid: 0,
+        hotkey: "hk-precision",
+        stake_tao: stakeTao,
+        emission_tao: 0,
+      });
+      expectedTotalRao += BigInt(Math.round(stakeTao * 1e9));
+    }
+    const data = buildGlobalValidators(rows, {
+      sort: "total_stake",
+      limit: 10,
+    });
+    const expectedTotal =
+      Number(expectedTotalRao / 1_000_000_000n) +
+      Number(expectedTotalRao % 1_000_000_000n) / 1e9;
+    const entry = data.validators.find((v) => v.hotkey === "hk-precision");
+    assert.equal(entry.total_stake_tao, Math.round(expectedTotal * 1e9) / 1e9);
+  });
+
   test("builders drop malformed rows and count only real neurons", () => {
     // A null/non-object row can't be a Neuron, so it must not leak into the
     // array — and the count tracks the array (neuron_count === neurons.length),


### PR DESCRIPTION
## Summary

Phase 2 of the u128 precision-loss remediation roadmap (#2588). Three JS-side
network-wide aggregation sites accumulate `stake_tao`/`emission_tao` across
potentially thousands of rows with plain float `+=`, which compounds rounding
error across the accumulation even when each individual cell is itself exact
(SQLite `REAL`/JS `Number` is only exact up to `2^53-1`, ~9M TAO at 1e9
rao/TAO — long before that ceiling, repeated float addition drifts from the
true sum).

Fixed by summing in rao-integer `BigInt` space and converting back to a TAO
float only once, at the very end — the same pattern already proven in
`src/account-balance.mjs`'s `toRao()` helper for #2070:

- **`src/chain-yield.mjs`** — `buildChainYield`'s `totalStake`/`totalEmission`/
  `validatorStake`/`validatorEmission` accumulators (network-wide, every
  subnet's neurons in one pass).
- **`src/metagraph-neurons.mjs`** — `buildGlobalValidators`'s per-hotkey
  `stakeTotal`/`emissionTotal` accumulators, and `applyStakeDominance`'s
  `networkStakeTotal` denominator (summed across every hotkey network-wide).
- **`src/concentration.mjs`** — `groupByEntity`'s per-entity pre-sum (a
  coldkey's UIDs collapsed network-wide) and `computeConcentration`'s own
  distribution `total`. Note: this file's `total` is only ever surfaced at
  4dp, so the compounding error doesn't cross that rounding threshold at
  realistic row counts today — this fix is about closing the gap at the
  source for consistency with the other two files, not a currently-visible
  bug in this file's output.

**Intentionally not touched** (per #2922's own scope): SQL-engine-level
`SUM()` sites — `src/movers.mjs`, `workers/request-handlers/entities.mjs`
(`handleSubnetHistory`), `src/mcp-server.mjs` (`loadSubnetHistory`), and
`src/chain-transfers.mjs`. SQLite computes `SUM()` in floating point inside
the database engine before any JS runs, so a BigInt change on this side can't
fix those — that's a separate architecture/schema decision.

## Test plan
- [x] New regression tests in `tests/chain-yield.test.mjs`,
      `tests/metagraph-neurons.test.mjs`, and `tests/chain-concentration.test.mjs`
      — each sums 5,000 rows carrying a real sub-TAO fractional stake and
      asserts the output matches an independently-computed exact BigInt sum.
- [x] Manually confirmed the old plain-float `+=` approach diverges from the
      correct sum for `chain-yield.mjs`/`metagraph-neurons.mjs`
      (`6174938.284102502` vs the correct `6174938.2841025` at rao/9dp
      precision) — proving those two tests are meaningful regression guards.
- [x] `npx vitest run` on all four touched test files — 114/114 passing (all
      pre-existing tests pass unchanged; no output-shape changes).
- [x] `npx eslint` / `npx prettier --check` clean on all touched files.