### PR TITLE
feat(registry): add SN78 Vocence API surfaces (#590)

### DIFF
--- a/registry/subnets/vocence.json
+++ b/registry/subnets/vocence.json
@@ -1,0 +1,54 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "Vocence",
+  "netuid": 78,
+  "schema_version": 1,
+  "slug": "sn-78",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-78-vocence-subnet-api",
+      "kind": "subnet-api",
+      "name": "Vocence developer API health endpoint",
+      "notes": "Public health endpoint for the official Vocence developer API.",
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "daedalus-icarus"
+      },
+      "source_urls": [
+        "https://api.vocence.ai/openapi.json",
+        "https://github.com/vocence-78/vocence/blob/master/vocence/gateway/http/service/endpoints/status.py"
+      ],
+      "url": "https://api.vocence.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-78-vocence-openapi",
+      "kind": "openapi",
+      "name": "Vocence Developer API OpenAPI",
+      "notes": "Official machine-readable OpenAPI spec for the Vocence developer API.",
+      "provider": "vocence",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "daedalus-icarus"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.vocence.ai/openapi.json",
+      "source_urls": [
+        "https://www.vocence.ai/docs/api",
+        "https://github.com/vocence-78/vocence/blob/master/vocence/gateway/http/service/app.py"
+      ],
+      "url": "https://api.vocence.ai/openapi.json"
+    }
+  ]
+}


### PR DESCRIPTION
## Add or update a subnet surface

This PR adds the missing SN78 Vocence manifest and appends the two public surfaces tracked by #590.

## Surface

- Netuid: `78`
- Kind: `subnet-api`, `openapi`
- Public URL: `https://api.vocence.ai/health`, `https://api.vocence.ai/openapi.json`
- Source URL (proves the claim): `https://api.vocence.ai/openapi.json`, `https://www.vocence.ai/docs/api`, `https://github.com/vocence-78/vocence/blob/master/vocence/gateway/http/service/app.py`, `https://github.com/vocence-78/vocence/blob/master/vocence/gateway/http/service/endpoints/status.py`
- Provider slug: `vocence`

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest, or a `subnet:new` scaffold plus surface(s) for a missing manifest (optionally plus one `registry/providers/*.json` for a debut provider).
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #<n>`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass. Base-layer RPC/WSS/archive, authenticated surfaces, unknown providers, and identity disputes route to manual review.

## Validation

- [x] `npm run validate:surface -- registry/subnets/vocence.json`
- [x] `npm run scan:public-safety`

Closes #590
