### PR TITLE
fix(subnet-yield): sum stake/emission in exact rao space, not float

### DIFF
--- a/src/subnet-yield.mjs
+++ b/src/subnet-yield.mjs
@@ -21,6 +21,20 @@ function toNumber(value) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+// Sum a subnet's per-UID stake_tao/emission_tao in rao-integer BigInt space, not
+// float space -- a subnet's neuron set is often hundreds to thousands of rows, and
+// plain `+=` float accumulation compounds rounding error across the sum even when
+// each individual value is itself exact (metagraphed#2922, the per-subnet analog of
+// the network-wide chain-yield fix in #2933; mirrors the toRao pattern proven in
+// src/account-balance.mjs for #2070). Convert back to TAO only once, at the end.
+// Callers always pass an already-finite toNumber() result, so no isFinite guard here.
+function toRaoBig(tao) {
+  return BigInt(Math.round(tao * 1e9));
+}
+function raoBigToTao(rao) {
+  return Number(rao / 1_000_000_000n) + Number(rao % 1_000_000_000n) / 1e9;
+}
+
 // A non-negative integer uid, or null for a malformed/absent cell (Number(null) === 0,
 // so guard null explicitly rather than coercing it to uid 0).
 function normalizedUid(value) {
@@ -79,8 +93,8 @@ function median(ascending) {
 export function buildSubnetYield(rows, netuid) {
   const list = Array.isArray(rows) ? rows : [];
   const neurons = [];
-  let totalStake = 0;
-  let totalEmission = 0;
+  let totalStakeRao = 0n;
+  let totalEmissionRao = 0n;
   let validatorCount = 0;
   let capturedAt = null;
   let blockNumber = null;
@@ -102,8 +116,8 @@ export function buildSubnetYield(rows, netuid) {
     // Match the sibling neuron formatter's SQLite 0/1 convention: only an integer 1
     // is a validator, so a numeric-string "0" cannot slip through as truthy.
     const isValidator = Number(row?.validator_permit) === 1;
-    totalStake += stake;
-    totalEmission += emission;
+    totalStakeRao += toRaoBig(stake);
+    totalEmissionRao += toRaoBig(emission);
     if (isValidator) validatorCount += 1;
     neurons.push({
       uid,
@@ -114,6 +128,10 @@ export function buildSubnetYield(rows, netuid) {
       yield: computeYieldValue(emission, stake),
     });
   }
+
+  // Convert the exact rao-space accumulators back to TAO once, at the end.
+  const totalStake = raoBigToTao(totalStakeRao);
+  const totalEmission = raoBigToTao(totalEmissionRao);
 
   // Distribution over the UIDs that actually have a defined yield (stake > 0).
   const definedYields = neurons

--- a/tests/subnet-yield.test.mjs
+++ b/tests/subnet-yield.test.mjs
@@ -68,6 +68,34 @@ describe("buildSubnetYield", () => {
     assert.equal(u3.role, "miner");
   });
 
+  test("sums thousands of UIDs in exact rao space, not compounding float error (#2922)", () => {
+    // Each UID's stake/emission carries a real sub-TAO fractional component (not a
+    // round number) -- plain `+=` float accumulation across a large neuron set would
+    // drift from the true sum. Summing in rao BigInt space (the per-subnet analog of
+    // the network-wide chain-yield fix #2933) must not.
+    const rows = [];
+    let expectedStakeRao = 0n;
+    let expectedEmissionRao = 0n;
+    for (let i = 0; i < 5000; i += 1) {
+      const stakeTao = 1234.987654321 + i * 0.000000001;
+      const emissionTao = 12.345678901 + i * 0.000000001;
+      rows.push(neuron(i, { stake: stakeTao, emission: emissionTao }));
+      expectedStakeRao += BigInt(Math.round(stakeTao * 1e9));
+      expectedEmissionRao += BigInt(Math.round(emissionTao * 1e9));
+    }
+    const raoToTao = (rao) =>
+      Number(rao / 1_000_000_000n) + Number(rao % 1_000_000_000n) / 1e9;
+    const d = buildSubnetYield(rows, 7);
+    assert.equal(
+      d.total_stake_tao,
+      Math.round(raoToTao(expectedStakeRao) * 1e9) / 1e9,
+    );
+    assert.equal(
+      d.total_emission_tao,
+      Math.round(raoToTao(expectedEmissionRao) * 1e9) / 1e9,
+    );
+  });
+
   test("computes mean, conventional median, and nearest-rank percentiles", () => {
     const d = buildSubnetYield(set, 7);
     assert.equal(d.mean_yield, 0.25); // (0.1+0.2+0.3+0.4)/4


### PR DESCRIPTION
## Summary

- `buildSubnetYield` accumulated a subnet's per-UID `stake_tao` / `emission_tao` with plain float `+=`. A subnet's neuron set is often hundreds to thousands of rows, so IEEE-754 rounding error compounds across the accumulation even when each individual value is itself exact — `total_stake_tao`, `total_emission_tao`, and the derived `subnet_yield` ratio drift from the true sum.

## What Changed

- Sum `stake_tao` / `emission_tao` in **rao-integer BigInt space** (`toRaoBig` / `raoBigToTao`) and convert back to TAO once, at the end. This is the per-subnet analog of the network-wide `chain-yield` fix (#2933 / #2922) and the `toRao` pattern already proven in `src/account-balance.mjs` (#2070). Per-UID values and the output schema are unchanged; only the accumulation is now exact.
- Add a regression test summing 5000 fractional-TAO rows and asserting the exact rao-space `total_stake_tao` / `total_emission_tao` (the naive float sum drifts and would fail this).

## Registry Safety

- [x] No secrets, PATs, wallet data, private/ private URLs, or validator-local state.
- [x] No generated artifacts changed — pure `src/` computation + test.
- [x] No public API/OpenAPI/schema shape change (only numeric precision of computed values).

## Validation

- [x] `vitest run tests/subnet-yield.test.mjs` — 18/18 pass, including the new `#2922` rao-space regression test.
- [x] `eslint` + `prettier --check` on the changed files — clean.
- [x] `git diff --check` — clean.

Two files changed, +50/−4, no generated artifacts touched.
