### PR TITLE
fix(analytics): coerce D1 string-typed netuid at Map-key sites (strict, no subnet 0)

### DIFF
--- a/src/analytics-live.mjs
+++ b/src/analytics-live.mjs
@@ -64,7 +64,19 @@ export function profilesProjectionFromRows(profiles) {
 export function growthRowsFromSamples(growthSamples) {
   const growthByNetuid = new Map();
   for (const row of growthSamples || []) {
-    const entry = growthByNetuid.get(row.netuid) || {
+    // D1 can hand the INTEGER netuid back as a numeric string on this GROUP BY
+    // read path; the emitted netuid keys the integer-keyed subnetMeta map in
+    // formatLeaderboards, so a raw string netuid drops the fastest-growing entry's
+    // slug/name metadata. Accept only a real number or an all-digits string so a
+    // blank/null/false cell is dropped, never read as subnet 0.
+    const netuid =
+      typeof row.netuid === "number"
+        ? row.netuid
+        : typeof row.netuid === "string" && /^\d+$/.test(row.netuid)
+          ? Number(row.netuid)
+          : null;
+    if (netuid == null || !Number.isInteger(netuid) || netuid < 0) continue;
+    const entry = growthByNetuid.get(netuid) || {
       first: null,
       last: null,
     };
@@ -83,7 +95,7 @@ export function growthRowsFromSamples(growthSamples) {
       if (entry.first == null) entry.first = score;
       entry.last = score;
     }
-    growthByNetuid.set(row.netuid, entry);
+    growthByNetuid.set(netuid, entry);
   }
   return [...growthByNetuid.entries()].map(([netuid, entry]) => ({
     netuid,

--- a/src/subnet-identity-history.mjs
+++ b/src/subnet-identity-history.mjs
@@ -140,6 +140,21 @@ async function runStatementBatches(db, statements) {
   }
 }
 
+// D1 hands INTEGER columns back as numeric strings on GROUP BY / JOIN read paths
+// (the convention account-events.mjs and analytics-routes.mjs coerce for). Accept
+// ONLY a real number or an all-digits string so a blank/null/false cell is rejected
+// rather than read as a valid subnet 0 (Number("") === Number(null) === 0). A raw
+// string key otherwise silently misses the integer netuid the callers look up by.
+function rowNetuid(value) {
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    return Number(value);
+  }
+  return null;
+}
+
 async function latestIdentityHashes(db) {
   const res = await db
     .prepare(
@@ -152,9 +167,12 @@ async function latestIdentityHashes(db) {
        ) latest ON h.netuid = latest.netuid AND h.id = latest.max_id`,
     )
     .all();
-  return new Map(
-    (res?.results || []).map((row) => [row.netuid, row.identity_hash]),
-  );
+  const map = new Map();
+  for (const row of res?.results || []) {
+    const netuid = rowNetuid(row.netuid);
+    if (netuid != null) map.set(netuid, row.identity_hash);
+  }
+  return map;
 }
 
 async function latestBlockNumber(db) {
@@ -298,8 +316,13 @@ export async function loadPreviouslyKnownAsForNetuids(d1, entries) {
   );
   const grouped = new Map();
   for (const row of rows || []) {
-    let list = grouped.get(row.netuid);
-    if (!list) grouped.set(row.netuid, (list = []));
+    // Coerce so the group keys on the same integer the caller and currentByNetuid
+    // use — a raw string key both drops the alias from the agent-catalog lookup
+    // and lets the current name leak into the history.
+    const netuid = rowNetuid(row.netuid);
+    if (netuid == null) continue;
+    let list = grouped.get(netuid);
+    if (!list) grouped.set(netuid, (list = []));
     list.push(row);
   }
   const out = new Map();

--- a/tests/analytics-live.test.mjs
+++ b/tests/analytics-live.test.mjs
@@ -179,6 +179,23 @@ describe("analytics-live projections", () => {
       [{ netuid: 7, delta: 60 }],
     );
   });
+
+  test("growthRowsFromSamples emits an integer netuid; drops blank/null/non-numeric", () => {
+    // D1 hands the INTEGER netuid back as the string "5"; the emitted netuid keys
+    // the integer-keyed subnetMeta map in formatLeaderboards, so it must be an
+    // integer. Blank/null/non-numeric cells are dropped, never read as subnet 0.
+    const rows = growthRowsFromSamples([
+      { netuid: "5", completeness_score: 20 },
+      { netuid: "5", completeness_score: 50 },
+      { netuid: "", completeness_score: 9 }, // blank → dropped (not subnet 0)
+      { netuid: null, completeness_score: 9 }, // dropped
+      { netuid: false, completeness_score: 9 }, // dropped
+      { netuid: "abc", completeness_score: 9 }, // non-numeric → dropped
+      { netuid: -1, completeness_score: 9 }, // negative → dropped
+    ]);
+    assert.deepEqual(rows, [{ netuid: 5, delta: 30 }]);
+    assert.equal(typeof rows[0].netuid, "number");
+  });
 });
 
 describe("analytics-live loaders", () => {

--- a/tests/subnet-identity-history.test.mjs
+++ b/tests/subnet-identity-history.test.mjs
@@ -550,6 +550,51 @@ describe("recordSubnetIdentityChanges", () => {
     assert.equal(result.rows, 0);
   });
 
+  test("skips unchanged when D1 returns a string netuid; ignores blank cells", async () => {
+    // D1 hands the INTEGER netuid back as the string "7"; the dedup map must key
+    // on 7 so the integer profile.netuid lookup hits — otherwise the cron re-inserts
+    // an identical row every run (unbounded growth). A blank netuid cell must be
+    // dropped, not coerced to a valid subnet 0.
+    const snapshot = identitySnapshotFromProfile({
+      netuid: 7,
+      symbol: "T",
+      native_identity: { subnet_name: "Subnet" },
+    });
+    const hash = await identityHash(snapshot);
+    const db = {
+      prepare() {
+        return {
+          bind() {
+            return this;
+          },
+          all: async () => ({
+            results: [
+              { netuid: "", identity_hash: "junk" }, // blank → ignored
+              { netuid: "7", identity_hash: hash }, // string netuid → key on 7
+            ],
+          }),
+        };
+      },
+      batch: async () => {
+        throw new Error("should not write for an unchanged identity");
+      },
+    };
+    const result = await recordSubnetIdentityChanges(
+      {},
+      {
+        profiles: [
+          {
+            netuid: 7,
+            symbol: "T",
+            native_identity: { subnet_name: "Subnet" },
+          },
+        ],
+        db,
+      },
+    );
+    assert.equal(result.rows, 0);
+  });
+
   test("returns unavailable when profiles are missing", async () => {
     assert.deepEqual(await recordSubnetIdentityChanges({}, { profiles: [] }), {
       recorded: false,
@@ -842,6 +887,28 @@ describe("loadPreviouslyKnownAsForNetuids", () => {
     ]);
     assert.deepEqual(map.get(86), ["MIAO"]);
     assert.deepEqual(map.get(7), ["Old7"]);
+  });
+
+  test("coerces string netuid to int; rejects blank/null/non-numeric (never subnet 0)", async () => {
+    // D1 hands the INTEGER netuid back as the string "1"; the map must key on the
+    // integer 1 so the caller's aliasMap.get(1) hits and the current name is
+    // excluded. Blank/null/non-numeric cells must be dropped, NOT coerced to a
+    // valid subnet 0 (Number("") === Number(null) === 0).
+    const d1 = async () => [
+      { netuid: "1", subnet_name: "OldName", observed_at: 1000 },
+      { netuid: "1", subnet_name: "CurrentName", observed_at: 2000 },
+      { netuid: "", subnet_name: "Blank", observed_at: 3000 }, // dropped
+      { netuid: null, subnet_name: "Null", observed_at: 4000 }, // dropped
+      { netuid: "bad", subnet_name: "Junk", observed_at: 5000 }, // dropped
+      { netuid: -5, subnet_name: "Neg", observed_at: 6000 }, // negative num → dropped
+    ];
+    const map = await loadPreviouslyKnownAsForNetuids(d1, [
+      { netuid: 1, name: "CurrentName" },
+    ]);
+    assert.deepEqual(map.get(1), ["OldName"]); // attached under int key
+    assert.equal(map.get("1"), undefined);
+    assert.equal(map.get(0), undefined); // blank/null were NOT read as subnet 0
+    assert.ok(!(map.get(1) || []).includes("CurrentName")); // current excluded
   });
 
   test("merges multiple rows for the same netuid", async () => {


### PR DESCRIPTION
## Summary

D1 hands INTEGER columns back as numeric strings on GROUP BY / JOIN read paths (the convention `account-events.mjs` and `analytics-routes.mjs` coerce for). Three sites keyed a `Map` on the raw string netuid while callers looked it up with an integer, so the lookups silently missed:

- **`src/subnet-identity-history.mjs` `latestIdentityHashes`** — the `recordSubnetIdentityChanges` dedup guard never fired, so the hourly identity-change cron re-inserted an identical row for **every subnet every run** (unbounded growth of the append-only `subnet_identity_history` table).
- **`src/subnet-identity-history.mjs` `loadPreviouslyKnownAsForNetuids`** — `previously_known_as` was **never attached** to agent-catalog subnets **and** the current name **leaked** into the alias list.
- **`src/analytics-live.mjs` `growthRowsFromSamples`** — the fastest-growing leaderboard lost each entry's slug/name metadata (integer-keyed `subnetMeta` join missed).

## Fix

The coercion accepts **only** a real number or an all-digits string, so a blank/null/false cell is rejected outright rather than read as a valid subnet 0 (`Number("") === Number(null) === Number(false) === 0`). Regression tests cover the string-netuid path plus the blank/null/non-numeric/negative rejection cases.

```
npm run lint
npx vitest run tests/subnet-identity-history.test.mjs tests/analytics-live.test.mjs
```

No schema/route/contract change → no artifact regeneration.
