### PR TITLE
fix(counterparties): sum transfer amounts in exact rao space, not float

### DIFF
--- a/src/counterparties.mjs
+++ b/src/counterparties.mjs
@@ -38,6 +38,26 @@ function round(value, dp = 9) {
   return Math.round(value * factor) / factor;
 }
 
+// Sum in rao-integer BigInt space, not float space -- accumulating TAO amounts
+// with plain `+=` compounds rounding error across the scan (up to thousands of
+// transfers) even when each individual value is itself exact, so convert each
+// addend to integer rao, sum the integers, and convert back once at the end.
+// Mirrors the toRaoBig/raoBigToTao pattern established in concentration.mjs /
+// chain-yield.mjs (#2933).
+function toRaoBig(tao) {
+  // Guard the post-multiply value (not just `tao`): a huge-but-finite TAO amount
+  // like Number.MAX_VALUE overflows `tao * 1e9` to Infinity, and BigInt(Infinity)
+  // throws — so clamp a non-finite rao to 0n, preserving the old round()-based
+  // defensive behaviour that dropped an overflowing sum to 0 rather than leaking
+  // Infinity/NaN into the JSON.
+  const rao = Math.round(tao * 1e9);
+  return Number.isFinite(rao) ? BigInt(rao) : 0n;
+}
+
+function raoBigToTao(rao) {
+  return Number(rao / 1_000_000_000n) + Number(rao % 1_000_000_000n) / 1e9;
+}
+
 function nullableNumber(value) {
   if (value == null || value === "") return null;
   const n = typeof value === "number" ? value : Number(value);
@@ -71,8 +91,8 @@ function toIso(value) {
 export function buildCounterparties(rows, ss58, { limit = 20 } = {}) {
   const list = Array.isArray(rows) ? rows : [];
   const byParty = new Map();
-  let totalSent = 0;
-  let totalReceived = 0;
+  let totalSentRao = 0n;
+  let totalReceivedRao = 0n;
   for (const row of list) {
     const from = row?.hotkey;
     const to = row?.coldkey;
@@ -97,17 +117,19 @@ export function buildCounterparties(rows, ss58, { limit = 20 } = {}) {
       received = amount;
     }
     if (party == null) continue;
-    totalSent += sent;
-    totalReceived += received;
+    const sentRao = toRaoBig(sent);
+    const receivedRao = toRaoBig(received);
+    totalSentRao += sentRao;
+    totalReceivedRao += receivedRao;
     const entry = byParty.get(party) ?? {
       address: party,
-      sent: 0,
-      received: 0,
+      sentRao: 0n,
+      receivedRao: 0n,
       count: 0,
       lastBlock: null,
     };
-    entry.sent += sent;
-    entry.received += received;
+    entry.sentRao += sentRao;
+    entry.receivedRao += receivedRao;
     entry.count += 1;
     // `row` is non-null here (it produced a party), so no optional chain needed.
     // Coerce the cell (D1 can return an INTEGER column as a numeric string) so a
@@ -123,9 +145,9 @@ export function buildCounterparties(rows, ss58, { limit = 20 } = {}) {
   const ranked = [...byParty.values()]
     .map((entry) => ({
       address: entry.address,
-      sent_tao: round(entry.sent),
-      received_tao: round(entry.received),
-      net_tao: round(entry.received - entry.sent),
+      sent_tao: raoBigToTao(entry.sentRao),
+      received_tao: raoBigToTao(entry.receivedRao),
+      net_tao: raoBigToTao(entry.receivedRao - entry.sentRao),
       transfer_count: entry.count,
       last_block: entry.lastBlock,
     }))
@@ -146,8 +168,8 @@ export function buildCounterparties(rows, ss58, { limit = 20 } = {}) {
     counterparty_count: byParty.size,
     transfers_scanned: list.length,
     scan_capped: list.length >= COUNTERPARTIES_SCAN_CAP,
-    total_sent_tao: round(totalSent),
-    total_received_tao: round(totalReceived),
+    total_sent_tao: raoBigToTao(totalSentRao),
+    total_received_tao: raoBigToTao(totalReceivedRao),
     counterparties: ranked.slice(0, cap),
   };
 }
@@ -163,8 +185,8 @@ export function buildCounterpartyRelationship(
 ) {
   const list = Array.isArray(rows) ? rows : [];
   const transfers = [];
-  let totalSent = 0;
-  let totalReceived = 0;
+  let totalSentRao = 0n;
+  let totalReceivedRao = 0n;
   let firstBlock = null;
   let lastBlock = null;
   let firstObserved = null;
@@ -181,8 +203,8 @@ export function buildCounterpartyRelationship(
 
     const amount = nullableNumber(row.amount_tao);
     if (amount == null) continue;
-    if (sent) totalSent += amount;
-    if (received) totalReceived += amount;
+    if (sent) totalSentRao += toRaoBig(amount);
+    if (received) totalReceivedRao += toRaoBig(amount);
 
     const block = nullableInteger(row.block_number);
     if (block != null) {
@@ -218,9 +240,9 @@ export function buildCounterpartyRelationship(
     transfer_count: transfers.length,
     transfers_scanned: list.length,
     scan_capped: scanCapped,
-    total_sent_tao: round(totalSent),
-    total_received_tao: round(totalReceived),
-    net_tao: round(totalReceived - totalSent),
+    total_sent_tao: raoBigToTao(totalSentRao),
+    total_received_tao: raoBigToTao(totalReceivedRao),
+    net_tao: raoBigToTao(totalReceivedRao - totalSentRao),
     // Oldest block/timestamp are unknowable when the newest-first scan was truncated.
     first_block: scanCapped ? null : firstBlock,
     last_block: lastBlock,

--- a/tests/counterparties.test.mjs
+++ b/tests/counterparties.test.mjs
@@ -138,9 +138,55 @@ describe("buildCounterparties", () => {
     assert.equal(data.counterparty_count, COUNTERPARTIES_SCAN_CAP);
     assert.equal(data.counterparties.length, 10);
   });
+
+  test("sums amounts in exact rao space, not float (no accumulated drift)", () => {
+    // 1000 transfers of a 9-dp amount whose scaled rao is exactly representable
+    // (123456.789012345 * 1e9 = 123456789012345 < 2^53). Summing them in float
+    // TAO space drifts (the running sum crosses 2^53 scaled), so the naive
+    // `+=` version reports 123456789.012343466 — off by 1535 rao from the true
+    // integer-rao total 123456789.012345. Mirrors #2933.
+    const amount = 123456.789012345;
+    const rows = Array.from({ length: 1000 }, (_, i) => ({
+      hotkey: ME,
+      coldkey: "A",
+      amount_tao: amount,
+      block_number: i + 1,
+    }));
+    const data = buildCounterparties(rows, ME, { limit: 5 });
+    // Exact: 1000 * round(amount * 1e9) rao = 123456789012345000 rao.
+    assert.equal(data.total_sent_tao, 123456789.012345);
+    assert.equal(data.counterparties[0].sent_tao, 123456789.012345);
+    // The naive float accumulation would have produced this drifted value.
+    let floatSum = 0;
+    for (const row of rows) floatSum += row.amount_tao;
+    assert.notEqual(Math.round(floatSum * 1e9) / 1e9, 123456789.012345);
+  });
 });
 
 describe("buildCounterpartyRelationship", () => {
+  test("sums amounts in exact rao space, not float (no accumulated drift)", () => {
+    // Same drift construction as buildCounterparties: 1000 sends of a 9-dp amount
+    // whose float running-sum drifts past rao precision. The rao-exact total is
+    // 123456789.012345; the naive `+=` version drifts to 123456789.012343466.
+    const amount = 123456.789012345;
+    const rows = Array.from({ length: 1000 }, (_, i) => ({
+      block_number: i + 1,
+      event_index: 0,
+      hotkey: ME,
+      coldkey: "A",
+      netuid: 1,
+      amount_tao: amount,
+      observed_at: 1_700_000_000_000,
+    }));
+    const data = buildCounterpartyRelationship(rows, ME, "A", { limit: 5 });
+    assert.equal(data.total_sent_tao, 123456789.012345);
+    // All 1000 rows are sends (ME → A), so net = received - sent is negative.
+    assert.equal(data.net_tao, -123456789.012345);
+    let floatSum = 0;
+    for (const row of rows) floatSum += row.amount_tao;
+    assert.notEqual(Math.round(floatSum * 1e9) / 1e9, 123456789.012345);
+  });
+
   test("cold / empty / non-array rows yield a schema-stable empty relationship", () => {
     for (const rows of [[], null, undefined]) {
       const data = buildCounterpartyRelationship(rows, ME, "A", {});


### PR DESCRIPTION
## What

`buildCounterparties` and `buildCounterpartyRelationship` accumulated `amount_tao` with float `+=` across up to `COUNTERPARTIES_SCAN_CAP` (5000) transfers and rounded only at the end — so the running sum compounds IEEE-754 error even when each individual transfer amount is itself rao-exact.

## Impact

The per-counterparty and total `sent_tao` / `received_tao` / `net_tao` on `GET /api/v1/accounts/{ss58}/counterparties` (and the relationship-detail route) can drift by many rao under a busy account. Concrete: **1000 sends of `123456.789012345` TAO** reports `123456789.012343466` instead of the true `123456789.012345` — **1535 rao off**.

## Fix

Convert each addend to integer rao, accumulate in `BigInt`, and convert back once at the end — the `toRaoBig`/`raoBigToTao` pattern already established for the same bug class in `concentration.mjs` / `chain-yield.mjs` / `metagraph-neurons.mjs` (#2933). `toRaoBig` guards the post-multiply value so a huge/overflowing amount (e.g. `Number.MAX_VALUE`) clamps to `0n` rather than throwing on `BigInt(Infinity)` — preserving the existing defensive-overflow behaviour (the `Number.MAX_VALUE` test still passes).

This is a distinct site from the merged #2933 (which fixed concentration/chain-yield/metagraph-neurons) and from the in-flight #2937 (subnet-yield) — counterparties was untouched.

## Tests

Adds a regression to each builder: 1000 transfers of a 9-dp amount whose float running-sum drifts, asserting the output equals the exact integer-rao total **and** that the naive float accumulation would not. All existing counterparties tests (including the defensive-overflow guard) still pass. Pure builder change — no schema/contract/artifact change.
