### PR TITLE
feat(registry): enrich SN18 Zeus — dashboard and BOREAS forecast endpoints

### DIFF
--- a/registry/subnets/sn-18.json
+++ b/registry/subnets/sn-18.json
@@ -49,6 +49,70 @@
         "https://api.zeussubnet.com/openapi.json"
       ],
       "url": "https://api.zeussubnet.com/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-18-zeus-dashboard",
+      "kind": "dashboard",
+      "name": "Zeus dashboard",
+      "notes": "Official Zeus subnet dashboard, linked from the Zeus website navigation (href=\"/dashboard\" on www.zeussubnet.com).",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "zeus",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": ["https://www.zeussubnet.com/"],
+      "url": "https://www.zeussubnet.com/dashboard"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-18-zeus-forecast-point",
+      "kind": "subnet-api",
+      "name": "Zeus BOREAS point forecast",
+      "notes": "Public BOREAS Edge API point-forecast endpoint (lat/lon -> environmental-variable forecast), documented in the Zeus OpenAPI spec. Requires an X-API-Key, so the probe is disabled.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET"
+      },
+      "provider": "zeus",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": ["https://api.zeussubnet.com/openapi.json"],
+      "url": "https://api.zeussubnet.com/v1/forecast/point"
+    },
+    {
+      "auth_required": true,
+      "authority": "community",
+      "id": "sn-18-zeus-forecast-area",
+      "kind": "subnet-api",
+      "name": "Zeus BOREAS area forecast",
+      "notes": "Public BOREAS Edge API area-forecast endpoint (bounding box -> gridded environmental forecast), documented in the Zeus OpenAPI spec. Requires an X-API-Key, so the probe is disabled.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "GET"
+      },
+      "provider": "zeus",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": ["https://api.zeussubnet.com/openapi.json"],
+      "url": "https://api.zeussubnet.com/v1/forecast/area"
     }
   ],
   "website_url": "https://www.zeussubnet.com/"


### PR DESCRIPTION
## Summary

Enriches **SN18 Zeus** (climate/environmental forecasting) with three verified, owner-matched community surfaces in one **append-only** diff. All live on official Zeus (Orpheus-AI) properties and complement the existing `/v1/meta` + OpenAPI surfaces.

| kind | url | proof / notes |
|------|-----|---------------|
| `dashboard` | https://www.zeussubnet.com/dashboard | linked from the Zeus homepage nav (`href="/dashboard"`) |
| `subnet-api` | https://api.zeussubnet.com/v1/forecast/point | documented in the Zeus OpenAPI spec; X-API-Key required |
| `subnet-api` | https://api.zeussubnet.com/v1/forecast/area | documented in the Zeus OpenAPI spec; X-API-Key required |

## Verification

- **dashboard** — `GET https://www.zeussubnet.com/dashboard` → 200 HTML; the official website (`www.zeussubnet.com`, SN18's registered `website_url`) links it directly in its nav (`href="/dashboard"`). Probe enabled (HEAD/html).
- **forecast endpoints** — both are documented in the already-listed public OpenAPI spec (`https://api.zeussubnet.com/openapi.json`) under `/v1/forecast/point` and `/v1/forecast/area`, returning gridded environmental-variable forecasts (the subnet's core product — **not** liveness/health probes). They require an `X-API-Key`, so each carries `auth_required: true` with `probe.enabled: false`, matching the existing authed `subnet-api` convention already in the registry (e.g. gopher / data-universe).

## Qualifies

- **Owner-matched** — `zeussubnet.com` / `api.zeussubnet.com` are Zeus's official domains (registered website + source repo `Orpheus-AI/Zeus`).
- **Non-duplicate** — none overlap the two existing surfaces; the OpenAPI spec names the two forecast operations distinctly.
- **Append-only single-file diff** — 64 insertions, 0 deletions to `registry/subnets/sn-18.json`; existing surface ordering untouched.

`npm run validate:surface -- registry/subnets/sn-18.json` → passed (5 surfaces). `scan:public-safety` + `format:check` pass.