### PR TITLE
feat(registry): enrich SN90 DegenBrain — add statement-test-progress subnet-api surface

### DIFF
--- a/registry/subnets/degenbrain.json
+++ b/registry/subnets/degenbrain.json
@@ -126,6 +126,25 @@
         "https://api.subnet90.com/openapi.json"
       ],
       "url": "https://api.subnet90.com/api/resolutions"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-90-degenbrain-subnet-api-api-subnet90-com",
+      "kind": "subnet-api",
+      "name": "DegenBrain statement-test progress API",
+      "notes": "Public no-auth GET returning statement/chunk processing progress for the DegenBrain eval pipeline. Documented in the subnet's own OpenAPI (api.subnet90.com/openapi.json, 'Brain-API'); same host as the existing subnet-api surfaces. Response is aggregate counts only (no account/key material).",
+      "provider": "degenbrain",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dhgoal"
+      },
+      "source_urls": [
+        "https://api.subnet90.com/openapi.json",
+        "https://subnet90.com/"
+      ],
+      "url": "https://api.subnet90.com/api/test/progress"
     }
   ],
   "website_url": "https://subnet90.com/"


### PR DESCRIPTION
## Add a subnet surface

Appends one verified public surface to `registry/subnets/degenbrain.json` (SN90 DegenBrain): the public statement-test progress endpoint.

- Netuid: 90 · Kind: `subnet-api` · Provider: `degenbrain` (registered)
- URL: https://api.subnet90.com/api/test/progress

**Source proof:** documented in DegenBrain's own OpenAPI ([`api.subnet90.com/openapi.json`](https://api.subnet90.com/openapi.json), path `/api/test/progress`, no security); same host as the existing `subnet-api` surfaces. Verified live (HTTP 200, no-auth, aggregate counts only — no account/key material).

- [x] Single-file append-only; `authority: community`
- [x] `validate:surface` + `scan:public-safety` pass
- [x] Provider registered; not a duplicate; public-safe

*No open enrichment issue; standalone addition under epic #427.*