### PR TITLE
feat(mcp): add get_curation_states tool mirroring the curation route

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -301,6 +301,25 @@ if (existsSync(gapsArtifactPath)) {
   );
 }
 
+// curation.json is an R2-only artifact staged into the cold env only after
+// `npm run build`; exercise the happy path when present, else the not_found
+// guard loadArtifactData maps.
+const curationPath = artifactFilePath("curation.json");
+if (existsSync(curationPath)) {
+  const curationStates = await callOk("get_curation_states", {});
+  assert.ok(
+    Array.isArray(curationStates.curation),
+    "get_curation_states must return curation[]",
+  );
+} else {
+  const curationCold = await call("get_curation_states", {});
+  assert.equal(
+    curationCold.isError,
+    true,
+    "get_curation_states must isError when the curation artifact is absent",
+  );
+}
+
 // Economic opportunity boards project from the committed economics.json in the
 // cold local env; assert the call succeeds and returns the economic boards.
 const opportunities = await callOk("find_subnet_opportunities", { limit: 5 });

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -226,7 +226,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.24.0";
+export const MCP_SERVER_VERSION = "1.25.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -4563,6 +4563,26 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_curation_states",
+    title: "Get per-subnet curation states",
+    description:
+      "Fetch the network-wide curation-state report: for every subnet its " +
+      "netuid, slug, name, resolved coverage_level, surface_count and " +
+      "candidate_count, its list of missing surface kinds, and the curation " +
+      "metadata block (curation level, review_state, reviewed_at/verified_at " +
+      "timestamps, source_count, and gap_notes). Use it to see, across the " +
+      "whole registry, which subnets are maintainer-reviewed vs merely observed " +
+      "and how well each is curated. Mirrors GET /api/v1/curation.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadArtifactData(ctx, "/metagraph/curation.json");
+    },
+  },
+  {
     name: "find_subnet_opportunities",
     title: "Rank subnets by economic opportunity",
     description:
@@ -6515,6 +6535,47 @@ const TOOL_OUTPUT_SCHEMAS = {
       name: NULLABLE_STRING,
       priorities: { type: "array", items: { type: "object" } },
       enrichment_queue: { type: "array", items: { type: "object" } },
+    },
+  },
+  get_curation_states: {
+    type: "object",
+    additionalProperties: true,
+    required: ["curation"],
+    properties: {
+      schema_version: { type: "integer" },
+      generated_at: NULLABLE_STRING,
+      curation: objectItems({
+        netuid: { type: "integer" },
+        slug: { type: "string" },
+        name: { type: "string" },
+        coverage_level: NULLABLE_STRING,
+        surface_count: NULLABLE_INT,
+        candidate_count: NULLABLE_INT,
+        gap_count: NULLABLE_INT,
+        // Nested Gaps object: resolved missing/supported surface kinds + notes.
+        gaps: {
+          type: "object",
+          additionalProperties: true,
+          properties: {
+            missing_kinds: { type: "array" },
+            supported_kinds: { type: "array" },
+            gap_notes: { type: "array" },
+          },
+        },
+        // Nested CurationMetadata: the resolved review posture for this subnet.
+        curation: {
+          type: "object",
+          additionalProperties: true,
+          properties: {
+            level: NULLABLE_STRING,
+            review_state: NULLABLE_STRING,
+            reviewed_at: NULLABLE_STRING,
+            verified_at: NULLABLE_STRING,
+            source_count: NULLABLE_INT,
+            gap_notes: { type: "array" },
+          },
+        },
+      }),
     },
   },
   find_subnet_for_task: {

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.24.0");
+    assert.equal(MCP_SERVER_VERSION, "1.25.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.24.0");
+    assert.equal(MCP_SERVER_VERSION, "1.25.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.24.0");
+    assert.equal(MCP_SERVER_VERSION, "1.25.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1487,6 +1487,47 @@ describe("MCP tools (injected deps)", () => {
     assert.equal(res.body.result.isError, true);
   });
 
+  test("get_curation_states returns the network-wide curation artifact", async () => {
+    const deps = makeDeps({
+      "/metagraph/curation.json": {
+        schema_version: 1,
+        curation: [
+          {
+            netuid: 7,
+            slug: "allways",
+            name: "Allways",
+            coverage_level: "callable",
+            surface_count: 4,
+            candidate_count: 1,
+            gaps: {
+              missing_kinds: ["docs"],
+              supported_kinds: [],
+              gap_notes: [],
+            },
+            curation: {
+              level: "verified",
+              review_state: "maintainer-reviewed",
+              source_count: 3,
+              gap_notes: ["Docs pending official confirmation."],
+            },
+          },
+        ],
+      },
+    });
+    const res = await callTool("get_curation_states", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.curation.length, 1);
+    assert.equal(out.curation[0].netuid, 7);
+    assert.equal(out.curation[0].curation.review_state, "maintainer-reviewed");
+    assert.equal(out.curation[0].curation.level, "verified");
+  });
+
+  test("get_curation_states is not_found when the artifact is missing", async () => {
+    const res = await callTool("get_curation_states", {});
+    assert.equal(res.body.result.isError, true);
+    assert.equal(res.body.result.structuredContent.error.code, "not_found");
+  });
+
   const opportunityDeps = makeDeps({
     "/metagraph/economics.json": {
       captured_at: "2026-06-20T00:00:00Z",

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.24.0");
+    assert.equal(MCP_SERVER_VERSION, "1.25.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.24.0");
+    assert.equal(MCP_SERVER_VERSION, "1.25.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
Exposes the network-wide curation-state report (`GET /api/v1/curation`) as an MCP tool so an agent can see, across the whole registry, which subnets are maintainer-reviewed vs merely observed and how well each is curated. For every subnet it returns netuid/slug/name, resolved coverage_level, surface_count and candidate_count, the nested Gaps object (missing/supported surface kinds), and the curation metadata block (level, review_state, reviewed_at/verified_at, source_count, gap_notes).

Self-contained: straight `loadArtifactData` read of the curation artifact (no D1, no schema regen). Registers the tool + a typed output schema, a build-gated `validate-mcp` assertion (happy path when staged, `not_found` guard when cold), the MCP server/registry version bump to 1.25.0 with all pinned version assertions updated, and unit tests for the populated and missing-artifact paths.

`npm run validate:mcp` passes (89 tools); full mcp-server + version-pin suites green.