### PR TITLE
fix(api): coerce identity-history cache stamps

### DIFF
--- a/tests/chain-identity-history.test.mjs
+++ b/tests/chain-identity-history.test.mjs
@@ -27,6 +27,13 @@ describe("readIdentityHistoryCacheStamp", () => {
     assert.equal(stamp, "1700000000000");
   });
 
+  test("coerces D1 numeric-string observed_at stamps", async () => {
+    const stamp = await readIdentityHistoryCacheStamp(
+      envWith([{ observed_at: "1700000000000" }]),
+    );
+    assert.equal(stamp, "1700000000000");
+  });
+
   test("returns null when the store is cold or the stamp is non-positive/non-integer", async () => {
     assert.equal(
       await readIdentityHistoryCacheStamp(envWith([{ observed_at: null }])),

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -372,10 +372,7 @@ export async function readIdentityHistoryCacheStamp(env) {
     [],
   );
   if (hasD1FallbackRows(rows)) return null;
-  const observedAt = rows[0]?.observed_at;
-  return Number.isInteger(observedAt) && observedAt > 0
-    ? String(observedAt)
-    : null;
+  return coerceCapturedAtStamp(rows[0]?.observed_at);
 }
 
 // Edge-cache stamp for routes derived from the neuron_daily rollup (the daily-snapshot tier), NOT


### PR DESCRIPTION
### Motivation
- The network identity-history edge-cache stamp resolver accepted only integer-typed `MAX(observed_at)` values, but D1 often returns numeric strings which caused the resolver to return `null` and disabled edge caching for a public route. 
- Restoring numeric-string coercion prevents repeated, unnecessary D1 feed queries for unauthenticated requests and reduces cost/amplification risk.

### Description
- Replace the inline `Number.isInteger` guard in `readIdentityHistoryCacheStamp` with the existing `coerceCapturedAtStamp` helper so numeric-string `observed_at` values are coerced to stable non-null stamps (`workers/request-handlers/analytics.mjs`).
- Add a focused regression test that verifies the resolver coerces D1 numeric-string `observed_at` aggregates to a string stamp (`tests/chain-identity-history.test.mjs`).
- No API schema or contract changes were made.

### Testing
- Ran the focused unit tests with `npm test -- tests/chain-identity-history.test.mjs`, and all tests passed (`21 passed`).
- Ran `npm run lint` and `npm run format:check`, both succeeded. 
- Ran `npm run build` and then `npm run validate:api`, and `validate:api` passed after the build produced the required local artifact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48886e97b4832ca72bd53af03f883b)