### PR TITLE
fix(api): use indexed neuron_daily cache stamp

### DIFF
--- a/tests/chain-turnover.test.mjs
+++ b/tests/chain-turnover.test.mjs
@@ -454,7 +454,7 @@ describe("readNeuronDailyCacheStamp", () => {
     },
   });
 
-  test("reads MAX(captured_at) from neuron_daily and returns it as a string", async () => {
+  test("reads the indexed latest snapshot_date from neuron_daily", async () => {
     let seenSql;
     const env = {
       METAGRAPH_HEALTH_DB: {
@@ -464,7 +464,7 @@ describe("readNeuronDailyCacheStamp", () => {
             bind: () => ({
               all: () =>
                 Promise.resolve({
-                  results: [{ captured_at: 1_700_000_000_000 }],
+                  results: [{ snapshot_date: "2026-06-27" }],
                 }),
             }),
           };
@@ -472,13 +472,15 @@ describe("readNeuronDailyCacheStamp", () => {
       },
     };
     const stamp = await readNeuronDailyCacheStamp(env);
-    assert.equal(stamp, "1700000000000");
+    assert.equal(stamp, "2026-06-27");
     assert.match(seenSql, /FROM neuron_daily/); // the correct source table, not `neurons`
+    assert.match(seenSql, /ORDER BY snapshot_date DESC LIMIT 1/);
+    assert.doesNotMatch(seenSql, /captured_at/);
   });
 
-  test("returns null for a non-integer captured_at", async () => {
+  test("returns null for a missing snapshot_date", async () => {
     assert.equal(
-      await readNeuronDailyCacheStamp(stampEnv([{ captured_at: null }])),
+      await readNeuronDailyCacheStamp(stampEnv([{ snapshot_date: null }])),
       null,
     );
   });
@@ -494,9 +496,9 @@ describe("chain/turnover edge cache", () => {
     globalThis.caches = originalCaches;
   });
 
-  // The neuron_daily captured_at the stamp query returns — mutated mid-test to simulate a rollup
-  // refresh. Every SELECT the stamp resolver runs is recorded so the test can assert the stamp
-  // reads neuron_daily (its actual source table), not the live neurons tier.
+  // The latest neuron_daily snapshot_date the stamp query returns — mutated mid-test to simulate a
+  // rollup refresh. Every SELECT the stamp resolver runs is recorded so the test can assert the
+  // stamp reads neuron_daily (its actual source table), not the live neurons tier.
   function turnoverEnv(state) {
     return {
       ...createLocalArtifactEnv(),
@@ -505,12 +507,12 @@ describe("chain/turnover edge cache", () => {
           return {
             bind: () => ({
               all: () => {
-                // The busting stamp query hits MAX(captured_at); the window boundary hits
-                // MIN(snapshot_date); the rest is the validator read.
-                if (/MAX\(captured_at\)/.test(sql)) {
+                // The busting stamp query uses the indexed latest snapshot_date; the window
+                // boundary hits MIN(snapshot_date); the rest is the validator read.
+                if (/ORDER BY snapshot_date DESC LIMIT 1/.test(sql)) {
                   state.stampSql = sql;
                   return Promise.resolve({
-                    results: [{ captured_at: state.capturedAt }],
+                    results: [{ snapshot_date: state.snapshotDate }],
                   });
                 }
                 if (/MIN\(snapshot_date\)/.test(sql)) {
@@ -541,7 +543,7 @@ describe("chain/turnover edge cache", () => {
         },
       },
     };
-    const state = { capturedAt: 1_700_000_000_000, stampSql: null };
+    const state = { snapshotDate: "2026-06-27", stampSql: null };
     const env = turnoverEnv(state);
     const call = () =>
       handleRequest(
@@ -563,9 +565,9 @@ describe("chain/turnover edge cache", () => {
     await call();
     assert.equal(store.size, 1);
 
-    // Simulate a neuron_daily rollup refresh: a new captured_at -> a new stamp -> a new cache key,
-    // so the stale entry is not reused and the artifact is recomputed and re-cached.
-    state.capturedAt = 1_700_000_600_000;
+    // Simulate a neuron_daily rollup refresh: a new snapshot_date -> a new stamp -> a new
+    // cache key, so the stale entry is not reused and the artifact is recomputed and re-cached.
+    state.snapshotDate = "2026-06-28";
     const refreshed = await call();
     assert.equal(refreshed.status, 200);
     assert.equal(store.size, 2); // busted: a second cache entry under the new stamp

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -381,21 +381,19 @@ export async function readIdentityHistoryCacheStamp(env) {
 }
 
 // Edge-cache stamp for routes derived from the neuron_daily rollup (the daily-snapshot tier), NOT
-// the live `neurons` tier: reads MAX(captured_at) from neuron_daily so the stamp advances exactly
-// when a new daily snapshot lands, invalidating the cached artifact on that refresh rather than on
-// the more-frequent live-neurons cadence. Used by neuron_daily-derived network routes (e.g.
-// /chain/turnover) whose data source is neuron_daily, not neurons.
+// the live `neurons` tier. Use the indexed snapshot_date column so every public cache lookup can
+// resolve freshness with an index-backed tail read instead of scanning the large rollup table.
+// Used by neuron_daily-derived network routes (e.g. /chain/turnover) whose data source is
+// neuron_daily, not neurons.
 export async function readNeuronDailyCacheStamp(env) {
   const rows = await d1All(
     env,
-    "SELECT MAX(captured_at) AS captured_at FROM neuron_daily",
+    "SELECT snapshot_date FROM neuron_daily ORDER BY snapshot_date DESC LIMIT 1",
     [],
   );
   if (hasD1FallbackRows(rows)) return null;
-  const capturedAt = rows[0]?.captured_at;
-  return Number.isInteger(capturedAt) && capturedAt > 0
-    ? String(capturedAt)
-    : null;
+  const snapshotDate = rows[0]?.snapshot_date;
+  return typeof snapshotDate === "string" && snapshotDate ? snapshotDate : null;
 }
 
 export function withNeuronsEdgeCache(


### PR DESCRIPTION
### Motivation
- The chain turnover route used an unindexed `MAX(captured_at)` over the large `neuron_daily` rollup as its edge-cache freshness resolver, which forces a full-table D1 scan on every cached GET and creates an unauthenticated availability amplification vector. 
- Resolve freshness with an index-backed read so public cache lookups can determine staleness without scanning millions of rows.

### Description
- Replace the freshness resolver in `workers/request-handlers/analytics.mjs` to use `SELECT snapshot_date FROM neuron_daily ORDER BY snapshot_date DESC LIMIT 1` and return the latest `snapshot_date` string instead of `MAX(captured_at)`.
- Update `tests/chain-turnover.test.mjs` to assert the new indexed tail-read query, adjust fixtures to mutate `snapshot_date` for cache-busting, and rename/align the stamp-related assertions accordingly.
- Preserve existing cache semantics: the stamp still advances when the daily rollup refreshes and continues to bust the edge cache only on genuine neuron_daily updates.

### Testing
- Ran the targeted unit tests with `npm test -- --run tests/chain-turnover.test.mjs` and all tests in that file passed. 
- Ran `npm run build`, `npm run lint`, `npm run format:check`, and `npm run validate:api`, each of which completed successfully. 
- Verified `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4887aec9ac832cb2b3c266873958d9)