### PR TITLE
fix(webhooks): classify unsafe DNS resolver errors

### DIFF
--- a/scripts/dispatch-webhooks.mjs
+++ b/scripts/dispatch-webhooks.mjs
@@ -246,7 +246,9 @@ async function resolvePublicAddressRecords(hostname) {
     records.length === 0 ||
     records.some((record) => !isPublicWebhookAddress(record.address))
   ) {
-    throw new Error("unsafe webhook DNS result");
+    const error = new Error("unsafe webhook DNS result");
+    error.code = "UNSAFE_WEBHOOK_DNS_RESULT";
+    throw error;
   }
   return records;
 }

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -158,6 +158,13 @@ export function isPublicWebhookUrl(value) {
 // Splitting the transient resolver failure out from a genuine "unsafe" verdict is
 // what lets deliverChangeEvent park + retry it instead of silently dropping an
 // owed at-least-once delivery when DNS momentarily fails during a sweep.
+function isUnsafeWebhookDnsError(error) {
+  return (
+    error?.code === "UNSAFE_WEBHOOK_DNS_RESULT" ||
+    error?.message === "unsafe webhook DNS result"
+  );
+}
+
 export async function resolvedWebhookUrlStatus(value, resolveHostnames) {
   if (!isPublicWebhookUrl(value)) return "unsafe";
   if (typeof resolveHostnames !== "function") return "ok";
@@ -171,8 +178,8 @@ export async function resolvedWebhookUrlStatus(value, resolveHostnames) {
   let addresses;
   try {
     addresses = await resolveHostnames(host);
-  } catch {
-    return "resolve-error";
+  } catch (error) {
+    return isUnsafeWebhookDnsError(error) ? "unsafe" : "resolve-error";
   }
   const allPublic =
     Array.isArray(addresses) &&

--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -514,6 +514,21 @@ describe("deliverChangeEvent", () => {
     assert.equal(out.reason, "unsafe-url");
   });
 
+  test("skips when the resolver throws an unsafe DNS result", async () => {
+    const out = await deliverChangeEvent({
+      subscription: base,
+      event,
+      fetchFn: async () => new Response("", { status: 200 }),
+      resolveHostnames: async () => {
+        const error = new Error("unsafe webhook DNS result");
+        error.code = "UNSAFE_WEBHOOK_DNS_RESULT";
+        throw error;
+      },
+    });
+    assert.equal(out.status, "skipped");
+    assert.equal(out.reason, "unsafe-url");
+  });
+
   test("returns a retryable failure (not a drop) when the resolver throws", async () => {
     // A transient DNS failure (resolver throws, e.g. EAI_AGAIN) must NOT be a
     // terminal "skipped" — that would delete the parked record on the redelivery

--- a/tests/webhooks-redelivery.test.mjs
+++ b/tests/webhooks-redelivery.test.mjs
@@ -367,6 +367,26 @@ describe("dispatchWithRedelivery", () => {
     assert.deepEqual(await keysOf(), []);
   });
 
+  test("an unsafe DNS result on the sweep drops the parked record", async () => {
+    store = makeStore();
+    await run({ event: event7, now: () => T0, fetchFn: fail503 });
+    assert.equal((await keysOf()).length, 1);
+
+    const { redelivered } = await run({
+      event: event9,
+      now: () => "2026-06-22T00:00:05.000Z",
+      fetchFn: ok200,
+      resolveHostnames: async () => {
+        const error = new Error("unsafe webhook DNS result");
+        error.code = "UNSAFE_WEBHOOK_DNS_RESULT";
+        throw error;
+      },
+    });
+    assert.equal(redelivered.length, 1);
+    assert.equal(redelivered[0].status, "skipped");
+    assert.equal((await keysOf()).length, 0);
+  });
+
   test("a transient resolver failure on the sweep re-parks (does NOT drop) the record", async () => {
     store = makeStore();
     // Park event7 with a 503 (no resolver → resolves "ok", delivery is attempted).


### PR DESCRIPTION
### Motivation
- The webhook DNS tri-state classifier treated every resolver throw as a transient `resolve-error`, but the production resolver throws for unsafe/non-public DNS answers, causing unsafe endpoints to be parked and retried instead of being dropped. This weakens the safety boundary and creates persistent redelivery churn.

### Description
- Add `isUnsafeWebhookDnsError()` and update `resolvedWebhookUrlStatus()` to map errors explicitly tagged as production unsafe DNS results to the terminal `"unsafe"` outcome instead of `"resolve-error"`.
- Tag the resolver-thrown unsafe result in `scripts/dispatch-webhooks.mjs` with `error.code = "UNSAFE_WEBHOOK_DNS_RESULT"` so the classifier can distinguish unsafe answers from transient resolver failures.
- Update dispatcher logic to keep transient resolver throws retryable while treating resolver-thrown unsafe DNS answers as terminal `skipped/unsafe-url` outcomes.
- Add regression tests in `tests/webhooks-core.test.mjs` and `tests/webhooks-redelivery.test.mjs` to cover resolver throws that are unsafe and ensure they are not parked for redelivery.

### Testing
- Ran linter: `npm run lint -- --max-warnings=0` and it passed with no warnings.
- Ran targeted unit tests: `npx vitest run tests/webhooks-core.test.mjs tests/webhooks-redelivery.test.mjs --testNamePattern 'unsafe DNS|resolver throws|transient resolver failure on the sweep|DNS resolves to a private address'` and the targeted tests passed.
- Ran the full unit suite for the modified files: `npx vitest run tests/webhooks-core.test.mjs tests/webhooks-redelivery.test.mjs` and both test files passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4748af6260832c91c6f6d4314938bc)