### PR TITLE
fix(blocks): reject blank integer cells that coerce to block 0

### DIFF
--- a/src/blocks.mjs
+++ b/src/blocks.mjs
@@ -44,6 +44,8 @@ function toIso(ms) {
 // and the `nullableInteger` coercion added to counterparties in #2414.
 function toBlockNumber(value) {
   if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isInteger(n) && n >= 0 ? n : null;
 }

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -231,6 +231,23 @@ test("formatBlock rejects a negative or non-integer block_number cell to null", 
   assert.equal(formatBlock({ block_number: "abc" }).block_number, null);
 });
 
+test("formatBlock rejects blank integer cells that coerce to 0 (not block 0)", () => {
+  // Mirrors the blank-cell guard in account-events.mjs (#2897): Number("") and
+  // Number("   ") are 0, which would fabricate genesis height / counts.
+  for (const blank of ["", "   "]) {
+    const out = formatBlock({
+      block_number: blank,
+      extrinsic_count: blank,
+      event_count: blank,
+      spec_version: blank,
+    });
+    assert.equal(out.block_number, null, `block_number for ${JSON.stringify(blank)}`);
+    assert.equal(out.extrinsic_count, null, `extrinsic_count for ${JSON.stringify(blank)}`);
+    assert.equal(out.event_count, null, `event_count for ${JSON.stringify(blank)}`);
+    assert.equal(out.spec_version, null, `spec_version for ${JSON.stringify(blank)}`);
+  }
+});
+
 test("loadBlock resolves neighbors when D1 returns a string-typed block_number (#1853)", async () => {
   // D1 can return the INTEGER block_number as a numeric string. The neighbor
   // guard must coerce the resolved anchor (like formatBlock) before the MAX/MIN

--- a/tests/blocks.test.mjs
+++ b/tests/blocks.test.mjs
@@ -241,10 +241,26 @@ test("formatBlock rejects blank integer cells that coerce to 0 (not block 0)", (
       event_count: blank,
       spec_version: blank,
     });
-    assert.equal(out.block_number, null, `block_number for ${JSON.stringify(blank)}`);
-    assert.equal(out.extrinsic_count, null, `extrinsic_count for ${JSON.stringify(blank)}`);
-    assert.equal(out.event_count, null, `event_count for ${JSON.stringify(blank)}`);
-    assert.equal(out.spec_version, null, `spec_version for ${JSON.stringify(blank)}`);
+    assert.equal(
+      out.block_number,
+      null,
+      `block_number for ${JSON.stringify(blank)}`,
+    );
+    assert.equal(
+      out.extrinsic_count,
+      null,
+      `extrinsic_count for ${JSON.stringify(blank)}`,
+    );
+    assert.equal(
+      out.event_count,
+      null,
+      `event_count for ${JSON.stringify(blank)}`,
+    );
+    assert.equal(
+      out.spec_version,
+      null,
+      `spec_version for ${JSON.stringify(blank)}`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

Reject blank D1 integer cells in block formatting so empty strings and whitespace-only values return `null` instead of coercing to block `0` / zero counts.

## What Changed

- Add a trim guard to `toBlockNumber()` in `src/blocks.mjs`, matching the pattern already used in `account-events.mjs` (#2897).
- Add regression coverage in `tests/blocks.test.mjs` for `block_number`, `extrinsic_count`, `event_count`, and `spec_version`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/blocks.test.mjs` (72 passed)
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. This is a small defensive coercion fix aligned with the existing #2897 pattern.
