### PR TITLE
fix(blocks): coerce D1 numeric-string block_number in resolveBlockNumber

### DIFF
--- a/src/block-subresources.mjs
+++ b/src/block-subresources.mjs
@@ -27,7 +27,12 @@ export async function resolveBlockNumber(d1, ref) {
       : `SELECT block_number FROM blocks WHERE block_number = ? LIMIT 1`,
     [isHash ? String(ref).toLowerCase() : refBlockNumber],
   );
-  return rows[0]?.block_number ?? null;
+  // D1 can surface an INTEGER column as a numeric string, so a bare
+  // `rows[0]?.block_number ?? null` would leak "4200000" (string) into the
+  // resolved value — which then flows into the block_number field of the
+  // extrinsics/events envelopes as a string. Coerce with the same
+  // strictBlockNumber used for the input ref (also maps a missing row to null).
+  return strictBlockNumber(rows[0]?.block_number);
 }
 
 export async function loadBlockExtrinsics(d1, ref, { limit, offset } = {}) {

--- a/tests/block-subresources.test.mjs
+++ b/tests/block-subresources.test.mjs
@@ -81,6 +81,16 @@ describe("resolveBlockNumber", () => {
     const n = await resolveBlockNumber(d1, "9999999");
     assert.equal(n, null);
   });
+
+  test("coerces a D1 numeric-string block_number cell to a number", async () => {
+    // D1 can surface the INTEGER block_number column as a numeric string; the
+    // resolved value must be a real number so it does not leak into the
+    // block_number envelope field as a string.
+    const d1 = d1With({ blockByNumber: [{ block_number: "4200000" }] });
+    const n = await resolveBlockNumber(d1, "4200000");
+    assert.equal(n, 4_200_000);
+    assert.equal(typeof n, "number");
+  });
 });
 
 describe("loadBlockExtrinsics", () => {


### PR DESCRIPTION
`resolveBlockNumber` returned `rows[0]?.block_number` raw. D1 can surface an INTEGER column as a numeric string, so the resolved value could be `"4200000"` (string), which then flows unchanged into the `block_number` field of the `buildBlockExtrinsics` / `buildBlockEvents` envelopes — leaking a string where the contract is an integer.

Coerce with the file's existing `strictBlockNumber` (which also maps a missing row to null), mirroring the `toBlockNumber` coercion already applied on the blocks / entities read paths (and the same class of fix as the recently-merged movers/identity-history/account-events coercions). Adds a numeric-string regression test. No version bump; self-contained.