### PR TITLE
fix(analytics): coerce D1 numeric-string cache stamps in two readers

### DIFF
--- a/tests/chain-identity-history.test.mjs
+++ b/tests/chain-identity-history.test.mjs
@@ -42,6 +42,18 @@ describe("readIdentityHistoryCacheStamp", () => {
   test("returns null when D1 is unbound (fallback rows)", async () => {
     assert.equal(await readIdentityHistoryCacheStamp({}), null);
   });
+
+  test("coerces a D1 numeric-string observed_at cell", async () => {
+    // D1 MAX(observed_at) commonly surfaces as a numeric string; a bare
+    // Number.isInteger guard would treat it as invalid and always return null,
+    // so the identity-history edge cache would never bust on new data.
+    assert.equal(
+      await readIdentityHistoryCacheStamp(
+        envWith([{ observed_at: "1700000000000" }]),
+      ),
+      "1700000000000",
+    );
+  });
 });
 
 // A network feed: identity changes from two subnets, newest first (the loader

--- a/tests/chain-turnover.test.mjs
+++ b/tests/chain-turnover.test.mjs
@@ -483,6 +483,18 @@ describe("readNeuronDailyCacheStamp", () => {
     );
   });
 
+  test("coerces a D1 numeric-string captured_at cell", async () => {
+    // D1 MAX(captured_at) commonly surfaces as a numeric string; a bare
+    // Number.isInteger guard would treat it as invalid and always return null,
+    // so the neuron_daily edge cache would never bust on a new daily snapshot.
+    assert.equal(
+      await readNeuronDailyCacheStamp(
+        stampEnv([{ captured_at: "1700000000000" }]),
+      ),
+      "1700000000000",
+    );
+  });
+
   test("returns null when the D1 read degrades to the empty fallback", async () => {
     assert.equal(await readNeuronDailyCacheStamp({}), null); // no METAGRAPH_HEALTH_DB
   });

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -372,10 +372,10 @@ export async function readIdentityHistoryCacheStamp(env) {
     [],
   );
   if (hasD1FallbackRows(rows)) return null;
-  const observedAt = rows[0]?.observed_at;
-  return Number.isInteger(observedAt) && observedAt > 0
-    ? String(observedAt)
-    : null;
+  // D1 MAX(observed_at) is INTEGER but often surfaces as a numeric string;
+  // coerce before the integer guard (like readNeuronsCacheStamp) so the stamp
+  // is not always null and the identity-history edge cache actually busts.
+  return coerceCapturedAtStamp(rows[0]?.observed_at);
 }
 
 // Edge-cache stamp for routes derived from the neuron_daily rollup (the daily-snapshot tier), NOT
@@ -390,10 +390,10 @@ export async function readNeuronDailyCacheStamp(env) {
     [],
   );
   if (hasD1FallbackRows(rows)) return null;
-  const capturedAt = rows[0]?.captured_at;
-  return Number.isInteger(capturedAt) && capturedAt > 0
-    ? String(capturedAt)
-    : null;
+  // D1 MAX(captured_at) is INTEGER but often surfaces as a numeric string;
+  // coerce before the integer guard (like readNeuronsCacheStamp) so the stamp
+  // is not always null and the neuron_daily edge cache actually busts.
+  return coerceCapturedAtStamp(rows[0]?.captured_at);
 }
 
 export function withNeuronsEdgeCache(


### PR DESCRIPTION
`readIdentityHistoryCacheStamp` (`MAX(observed_at)`) and `readNeuronDailyCacheStamp` (`MAX(captured_at)`) guarded the D1 cell with a bare `Number.isInteger` before `String()`-ifying it. D1 commonly surfaces an INTEGER aggregate as a numeric string, so the guard was **always false** and both readers **always returned null** — meaning the identity-history and neuron_daily edge caches never busted on new data (stale reads until the next unrelated invalidation).

Route both through the existing `coerceCapturedAtStamp` helper, exactly as `readNeuronsCacheStamp` / `readSubnetNeuronsCacheStamp` already do (the sibling fix merged as #2900). Adds a numeric-string regression test to each reader's suite. No version bump; self-contained.