### PR TITLE
fix(staging): return load_failed for sidecar batch writes

### DIFF
--- a/tests/load-staged-blocks-extrinsics.test.mjs
+++ b/tests/load-staged-blocks-extrinsics.test.mjs
@@ -310,7 +310,9 @@ for (const c of cases) {
       delete: async (k) => deleted.push(k),
       batchThrows: true,
     });
-    await assert.rejects(c.load(env));
+    const r = await c.load(env);
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "load_failed");
     assert.deepEqual(puts, [], "no remainder written on failure");
     assert.deepEqual(deleted, [], "object NOT deleted — re-drains next tick");
   });

--- a/tests/load-staged-events.test.mjs
+++ b/tests/load-staged-events.test.mjs
@@ -360,7 +360,9 @@ test("loadStagedEvents leaves the file intact if a D1 batch throws (no drop on c
       },
     },
   };
-  await assert.rejects(loadStagedEvents(env));
+  const r = await loadStagedEvents(env);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "load_failed");
   assert.deepEqual(puts, [], "no remainder written on failure");
   assert.deepEqual(
     deleted,

--- a/workers/request-handlers/staging.mjs
+++ b/workers/request-handlers/staging.mjs
@@ -137,6 +137,12 @@ async function signedExtrinsicEnvelope(signingKey, rows) {
   };
 }
 
+async function runStagedBatches(db, statements, statementsPerBatch) {
+  for (let i = 0; i < statements.length; i += statementsPerBatch) {
+    await db.batch(statements.slice(i, i + statementsPerBatch));
+  }
+}
+
 function utf8Bytes(value) {
   return new TextEncoder().encode(value);
 }
@@ -530,8 +536,10 @@ export async function loadStagedEvents(env) {
       : [];
   const statements = eventInsertStatements(db, batch);
   const STMTS_PER_BATCH = 50;
-  for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
-    await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
+  try {
+    await runStagedBatches(db, statements, STMTS_PER_BATCH);
+  } catch {
+    return { ok: false, reason: "load_failed" };
   }
   if (remainder.length) {
     await bucket.put(
@@ -608,8 +616,10 @@ export async function loadStagedBlocks(env) {
       : [];
   const statements = blockInsertStatements(db, batch);
   const STMTS_PER_BATCH = 50;
-  for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
-    await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
+  try {
+    await runStagedBatches(db, statements, STMTS_PER_BATCH);
+  } catch {
+    return { ok: false, reason: "load_failed" };
   }
   if (remainder.length) {
     await bucket.put(
@@ -688,8 +698,10 @@ export async function loadStagedExtrinsics(env) {
       : [];
   const statements = extrinsicInsertStatements(db, batch);
   const STMTS_PER_BATCH = 50;
-  for (let i = 0; i < statements.length; i += STMTS_PER_BATCH) {
-    await db.batch(statements.slice(i, i + STMTS_PER_BATCH));
+  try {
+    await runStagedBatches(db, statements, STMTS_PER_BATCH);
+  } catch {
+    return { ok: false, reason: "load_failed" };
   }
   if (remainder.length) {
     await bucket.put(


### PR DESCRIPTION
## Summary

- Return structured `load_failed` results when staged account-event, block, or extrinsic sidecar drains hit a D1 batch-write failure.
- Preserve the staged R2 object for retry without rewriting a remainder or deleting the file.

## What Changed

- Added a shared staged-batch runner in `workers/request-handlers/staging.mjs`.
- Wrapped sidecar staged writes so D1 batch exceptions return `{ ok: false, reason: "load_failed" }`.
- Updated event/block/extrinsic staged-loader regression tests for the recoverable failure contract.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm.cmd test -- tests/load-staged-events.test.mjs tests/load-staged-blocks-extrinsics.test.mjs tests/health-prober.test.mjs`
- [x] `npx.cmd prettier --check workers/request-handlers/staging.mjs tests/load-staged-events.test.mjs tests/load-staged-blocks-extrinsics.test.mjs`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`

## Issue Link

No linked issue. This is a small self-contained regression fix with the repro, expected behavior, and validation documented above.
