### PR TITLE
fix(block-subresources): coerce D1 string block_number in resolveBlockNumber

### DIFF
--- a/src/block-subresources.mjs
+++ b/src/block-subresources.mjs
@@ -27,7 +27,14 @@ export async function resolveBlockNumber(d1, ref) {
       : `SELECT block_number FROM blocks WHERE block_number = ? LIMIT 1`,
     [isHash ? String(ref).toLowerCase() : refBlockNumber],
   );
-  return rows[0]?.block_number ?? null;
+  // Coerce the resolved cell: some D1 read paths return the INTEGER block_number
+  // as a string, and this height flows straight into the envelope block_number of
+  // both buildBlockExtrinsics/buildBlockEvents. Without coercion the top-level
+  // field leaks as a JSON string while the nested rows (formatAccountEvent /
+  // formatExtrinsic) coerce theirs — an inconsistent, off-contract payload.
+  // strictBlockNumber accepts a real integer or an all-digits string and rejects
+  // anything else to null, matching the "unknown ref → null block_number" shape.
+  return strictBlockNumber(rows[0]?.block_number);
 }
 
 export async function loadBlockExtrinsics(d1, ref, { limit, offset } = {}) {

--- a/tests/block-subresources.test.mjs
+++ b/tests/block-subresources.test.mjs
@@ -81,6 +81,24 @@ describe("resolveBlockNumber", () => {
     const n = await resolveBlockNumber(d1, "9999999");
     assert.equal(n, null);
   });
+
+  test("coerces a string-typed D1 block_number to an integer", async () => {
+    // Some D1 read paths return the INTEGER block_number as a string; the
+    // resolved height must be a number so the envelope field is not off-contract.
+    const numericRef = await resolveBlockNumber(
+      d1With({ blockByNumber: [{ block_number: "4200000" }] }),
+      "4200000",
+    );
+    assert.equal(numericRef, 4_200_000);
+    assert.equal(typeof numericRef, "number");
+
+    const hashRef = await resolveBlockNumber(
+      d1With({ blockByHash: [{ block_number: "4200000" }] }),
+      "0x" + "a".repeat(64),
+    );
+    assert.equal(hashRef, 4_200_000);
+    assert.equal(typeof hashRef, "number");
+  });
 });
 
 describe("loadBlockExtrinsics", () => {


### PR DESCRIPTION
## Summary

Coerce the D1-resolved `block_number` in `resolveBlockNumber` so the block sub-resource envelopes emit an integer, not a string.

Some D1 read paths return the INTEGER `blocks.block_number` as a string. `resolveBlockNumber` returned that cell raw, and the height flows straight into the top-level `block_number` of both `buildBlockExtrinsics` and `buildBlockEvents` — so `GET /api/v1/blocks/{ref}/extrinsics` and `/events` (and the MCP block-explorer tools) could emit `block_number` as a JSON string while the nested `events[*].block_number` are coerced to integers by `formatAccountEvent`/`formatExtrinsic`. The result is an internally inconsistent, off-contract payload.

## What Changed

- `resolveBlockNumber` routes the resolved cell through the file's existing `strictBlockNumber` helper (accepts a real integer or an all-digits string, rejects anything else to `null`), so both builders always emit an integer or `null` — matching the "unknown ref → null block_number" shape. No response-shape or OpenAPI change.
- Regression tests: a string-typed `block_number` from both the numeric-ref and hash-ref reads now resolves to the integer `4200000` (`typeof === "number"`); the existing numeric-cell and missing-row cases still hold.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — ordering/typing only.)

## Validation

- [x] `npx vitest run tests/block-subresources.test.mjs`
- [x] `npm test` (full suite)
- [x] `npm run lint` · `npm run format:check`
- [x] `git diff --check`
