### PR TITLE
fix(blocks): ignore invalid summary timestamps

### DIFF
--- a/src/blocks-summary.mjs
+++ b/src/blocks-summary.mjs
@@ -49,6 +49,12 @@ function toInt(value) {
   return null;
 }
 
+function toTimestamp(value) {
+  const ms = toInt(value);
+  if (ms == null) return null;
+  return Number.isFinite(new Date(ms).getTime()) ? ms : null;
+}
+
 // A nullable count cell (extrinsic_count / event_count) coerced to a finite,
 // non-negative integer, defaulting to 0 — a block with an absent count carried 0
 // of that thing, which must not poison the totals or the mean.
@@ -96,7 +102,7 @@ export function buildBlocksSummary(rows) {
     if (blockNumber == null) continue;
     blocks.push({
       block_number: blockNumber,
-      observed_at: toInt(row?.observed_at),
+      observed_at: toTimestamp(row?.observed_at),
       author: typeof row?.author === "string" && row.author ? row.author : null,
       extrinsic_count: toCount(row?.extrinsic_count),
       event_count: toCount(row?.event_count),

--- a/tests/blocks-summary.test.mjs
+++ b/tests/blocks-summary.test.mjs
@@ -174,6 +174,18 @@ describe("buildBlocksSummary", () => {
     assert.equal(out.block_time, null);
   });
 
+  test("drops out-of-range observed_at cells instead of throwing", () => {
+    const observed = 1_750_000_000_000;
+    const out = buildBlocksSummary([
+      { block_number: 1, observed_at: "8640000000000001" },
+      { block_number: 2, observed_at: observed },
+    ]);
+    assert.equal(out.block_count, 2);
+    assert.equal(out.first_observed_at, new Date(observed).toISOString());
+    assert.equal(out.last_observed_at, new Date(observed).toISOString());
+    assert.equal(out.block_time, null);
+  });
+
   test("cold/empty store → schema-stable zeroed card", () => {
     const out = buildBlocksSummary([]);
     assert.equal(out.block_count, 0);


### PR DESCRIPTION
## Summary

- Ignore out-of-range `observed_at` cells when shaping `/api/v1/blocks/summary`.
- Prevent `RangeError: Invalid time value` from a corrupt D1 timestamp while preserving valid block rows.

## What Changed

- Added timestamp-specific coercion in `src/blocks-summary.mjs` that verifies JS `Date` range before storing `observed_at`.
- Added a regression test for an out-of-range numeric-string `observed_at` beside a valid timestamp.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm.cmd test -- tests/blocks-summary.test.mjs`
- [x] `npx.cmd prettier --check src/blocks-summary.mjs tests/blocks-summary.test.mjs`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`

## Issue Link

No linked issue. This is a small self-contained regression fix with the repro, expected behavior, and validation documented above.
