### PR TITLE
fix(data-api): deterministic tie-break for chain-events/stats ranking

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -164,6 +164,17 @@ test("chain-events/stats returns the activity aggregate with a clamped window", 
   ).toBe(1000);
 });
 
+test("chain-events/stats ranks with a deterministic tie-break on the group key", async () => {
+  const res = await req("/api/v1/chain-events/stats?blocks=500");
+  expect(res.status).toBe(200);
+  // count is non-unique; the ranking must tie-break on the GROUP BY key so the
+  // order and the LIMIT 100 boundary membership are stable across identical
+  // requests rather than left to Postgres' unordered equal-count grouping.
+  const stats = sqlCalls.at(-1).text;
+  expect(stats).toContain("ORDER BY count DESC, pallet ASC, method ASC");
+  expect(stats).not.toMatch(/ORDER BY count DESC\s+LIMIT/);
+});
+
 test("chain-events/stats floors fractional blocks before binding", async () => {
   const res = await req("/api/v1/chain-events/stats?blocks=1.5");
   expect(res.status).toBe(200);

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -181,12 +181,18 @@ export default {
       // 1000, capped 5000). Bounded window + capped output keep it index-cheap.
       if (url.pathname === "/api/v1/chain-events/stats") {
         const blocks = clampStatsBlocks(url.searchParams.get("blocks"));
+        // count is a non-unique sort key, so ORDER BY count alone leaves ties
+        // unordered — and over Hyperdrive's pooled connections (prepare:false)
+        // Postgres can plan/scan identical requests differently, reshuffling
+        // equal-count groups and flipping which groups survive LIMIT 100 at the
+        // boundary. Tie-break on the GROUP BY key (unique per row) for a total,
+        // stable order, matching the keyset orders on the sibling queries above.
         const rows = await sql`
           SELECT pallet, method, count(*)::int AS count
           FROM chain_events
           WHERE block_number > (SELECT max(block_number) FROM chain_events) - ${blocks}
           GROUP BY pallet, method
-          ORDER BY count DESC
+          ORDER BY count DESC, pallet ASC, method ASC
           LIMIT 100`;
         return json({
           window_blocks: blocks,


### PR DESCRIPTION
## Summary

Give the `/api/v1/chain-events/stats` activity aggregate a deterministic tie-break so its ranking and `LIMIT 100` boundary are stable across identical requests.

The query ranked `pallet.method` groups with `ORDER BY count DESC` and no tie-break. `count` is a non-unique sort key, and this Worker runs over Hyperdrive with `prepare: false` / `fetch_types: false` across pooled connections, so Postgres gives no ordering guarantee among equal-count groups — identical requests can return the tied groups in a different order, and when more than 100 distinct groups exist the ones sitting at the boundary count are non-deterministically included or excluded (`groups` stays 100 but *which* 100 flips between calls). The sibling queries in this file are already total orders (`/blocks/:n/chain-events` on unique `event_index`, `/chain-events` on the `(block_number, event_index)` keyset); `stats` was the one aggregate left without one.

## What Changed

- `ORDER BY count DESC` → `ORDER BY count DESC, pallet ASC, method ASC` on the stats aggregate. `(pallet, method)` is the `GROUP BY` key and thus unique per row, giving a total order — both the ordering and the `LIMIT 100` membership are now stable. No response-shape or OpenAPI change.
- Regression test asserting the deterministic tie-break ordering on the stats query.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — ordering only.)

## Validation

- [x] `npx vitest run tests/data-api.test.mjs`
- [x] `npm run lint` · `npm run format:check`
- [x] `git diff --check`
