### PR TITLE
fix(api): sum account portfolio totals in exact rao space

### DIFF
--- a/src/account-portfolio.mjs
+++ b/src/account-portfolio.mjs
@@ -20,6 +20,20 @@ function round9(value) {
   return Math.round(value * SCALE) / SCALE;
 }
 
+// Sum in rao-integer BigInt space, not float space -- accumulating the wallet's
+// per-subnet stake/emission with plain `+=` compounds rounding error across the
+// positions even when each value is itself rao-exact, so convert each addend to
+// integer rao, sum the integers, and convert back once at the end. Mirrors the
+// toRaoBig/raoBigToTao pattern in concentration.mjs / counterparties.mjs (#2933).
+function toRaoBig(tao) {
+  const rao = Math.round(tao * SCALE);
+  return Number.isFinite(rao) ? BigInt(rao) : 0n;
+}
+
+function raoBigToTao(rao) {
+  return Number(rao / 1_000_000_000n) + Number(rao % 1_000_000_000n) / SCALE;
+}
+
 // Coerce a D1 numeric cell (number, numeric string, or null) to a finite number.
 function toNumber(value) {
   const n = Number(value);
@@ -69,8 +83,8 @@ export function buildAccountPortfolio(rows, ss58) {
   const positions = [];
   const netuids = new Set();
   let validatorCount = 0;
-  let totalStake = 0;
-  let totalEmission = 0;
+  let totalStakeRao = 0n;
+  let totalEmissionRao = 0n;
   let capturedAt = null;
   for (const row of list) {
     const netuid = toInt(row?.netuid);
@@ -84,8 +98,8 @@ export function buildAccountPortfolio(rows, ss58) {
     const emission = toNumber(row?.emission_tao);
     const isValidator = Number(row?.validator_permit) === 1;
     if (isValidator) validatorCount += 1;
-    totalStake += stake;
-    totalEmission += emission;
+    totalStakeRao += toRaoBig(stake);
+    totalEmissionRao += toRaoBig(emission);
     positions.push({
       netuid,
       uid: toInt(row?.uid),
@@ -102,6 +116,9 @@ export function buildAccountPortfolio(rows, ss58) {
   }
   // Biggest position first; tie-break by netuid for a stable order.
   positions.sort((a, b) => b.stake_tao - a.stake_tao || a.netuid - b.netuid);
+  // Convert the rao-integer accumulators back to TAO once, at the end.
+  const totalStake = raoBigToTao(totalStakeRao);
+  const totalEmission = raoBigToTao(totalEmissionRao);
   return {
     schema_version: 1,
     ss58,

--- a/tests/account-portfolio.test.mjs
+++ b/tests/account-portfolio.test.mjs
@@ -64,6 +64,50 @@ describe("buildAccountPortfolio", () => {
     assert.equal(out.captured_at, new Date(1_750_000_000_000).toISOString());
   });
 
+  test("sums the wallet totals in exact rao space, not float", () => {
+    // A wallet registered across 100 subnets, each position a 9-dp stake whose
+    // scaled rao is exactly representable. Summing them in float TAO space drifts
+    // (the running sum crosses 2^53 scaled), so the naive `+=` reports
+    // 12345678.90123447 instead of the true integer-rao total 12345678.9012345.
+    const stake = 123456.789012345;
+    const rows = Array.from({ length: 100 }, (_, i) => ({
+      netuid: i + 1,
+      uid: i,
+      stake_tao: stake,
+      emission_tao: 0,
+      validator_permit: 0,
+      active: 1,
+      captured_at: 1_750_000_000_000,
+    }));
+    const out = buildAccountPortfolio(rows, SS58);
+    assert.equal(out.total_stake_tao, 12345678.9012345);
+    // The naive float accumulation would have produced this drifted value.
+    let floatSum = 0;
+    for (const row of rows) floatSum += row.stake_tao;
+    assert.notEqual(Math.round(floatSum * 1e9) / 1e9, 12345678.9012345);
+  });
+
+  test("a huge stake that overflows the rao scale stays finite (no BigInt throw)", () => {
+    // toRaoBig clamps a non-finite scaled value to 0n so a stake so large that
+    // stake * 1e9 overflows to Infinity drops to 0 rather than throwing on
+    // BigInt(Infinity) — keeping the wallet totals finite JSON.
+    const out = buildAccountPortfolio(
+      [
+        {
+          netuid: 1,
+          uid: 0,
+          stake_tao: Number.MAX_VALUE,
+          emission_tao: 0,
+          validator_permit: 0,
+          active: 1,
+        },
+      ],
+      SS58,
+    );
+    assert.equal(out.total_stake_tao, 0);
+    assert.equal(out.overall_yield, null);
+  });
+
   test("positions carry per-position economics + yield, biggest stake first", () => {
     const out = buildAccountPortfolio(ROWS, SS58);
     assert.equal(out.positions[0].netuid, 7); // 1000 stake sorts first


### PR DESCRIPTION
## What

`buildAccountPortfolio` accumulated a wallet's cross-subnet stake and emission with float `+=`:

```js
totalStake += stake;
totalEmission += emission;
```

Even when each per-subnet value is itself rao-exact, summing in float TAO space compounds IEEE-754 error across the positions. A wallet registered across many subnets can therefore report `total_stake_tao` / `total_emission_tao` — and the derived `overall_yield` — off by several rao from the true integer-rao total (e.g. 100 positions of `123456.789012345` TAO sum to `12345678.90123447` in float vs the exact `12345678.9012345`).

## Fix

Accumulate in integer-rao BigInt space and convert back to TAO once at the end, mirroring the same treatment already in `concentration.mjs` and `counterparties.mjs`:

```js
totalStakeRao += toRaoBig(stake);
totalEmissionRao += toRaoBig(emission);
// ...
const totalStake = raoBigToTao(totalStakeRao);
```

`toRaoBig` clamps a non-finite scaled value to `0n`, so an overflowing stake stays finite JSON instead of throwing on `BigInt(Infinity)`.

## Tests

Two regression tests added:
- 100 positions summing to a value the naive float `+=` drifts on — asserts the rao-exact total and that the float sum differs.
- An overflowing (`Number.MAX_VALUE`) stake stays finite (`total_stake_tao === 0`) rather than throwing.

Source + tests only — no schema/contract/generated-artifact changes. `eslint` clean, `prettier` clean, 12/12 tests pass, 100% patch coverage.
