### PR TITLE
feat(api): add ?format=csv to subnet-events and account-events feeds

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -6719,6 +6719,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the event history as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -6728,7 +6730,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -6782,6 +6784,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountEventsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -18517,6 +18524,8 @@ export interface operations {
                 block_end?: number;
                 limit?: number;
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the event stream as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -18526,7 +18535,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -18580,6 +18589,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetEventsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5005,6 +5005,17 @@
             "minimum": 0,
             "type": "integer"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the event stream as text/csv; `json` (default) keeps the response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -5194,6 +5205,17 @@
         {
           "name": "cursor",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the event history as text/csv; `json` (default) keeps the response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
             "type": "string"
           }
         }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -18076,6 +18076,19 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the event history as text/csv; `json` (default) keeps the response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -18137,9 +18150,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -36041,6 +36060,19 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the event stream as text/csv; `json` (default) keeps the response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -36102,9 +36134,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6719,6 +6719,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the event history as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -6728,7 +6730,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -6782,6 +6784,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountEventsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -18517,6 +18524,8 @@ export interface operations {
                 block_end?: number;
                 limit?: number;
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the event stream as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -18526,7 +18535,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -18580,6 +18589,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetEventsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2036,13 +2036,25 @@ export const API_ROUTES = [
     "Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset.",
     "short",
     ["subnets", "analytics"],
-    [
-      { name: "kind", schema: { type: "string" } },
-      { name: "block_start", schema: { type: "integer", minimum: 0 } },
-      { name: "block_end", schema: { type: "integer", minimum: 0 } },
-      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
-      { name: "offset", schema: { type: "integer", minimum: 0 } },
-    ],
+    {
+      csvResponse: true,
+      parameters: [
+        { name: "kind", schema: { type: "string" } },
+        { name: "block_start", schema: { type: "integer", minimum: 0 } },
+        { name: "block_end", schema: { type: "integer", minimum: 0 } },
+        {
+          name: "limit",
+          schema: { type: "integer", minimum: 1, maximum: 1000 },
+        },
+        { name: "offset", schema: { type: "integer", minimum: 0 } },
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the event stream as text/csv; `json` (default) keeps the response envelope.",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(
@@ -2131,15 +2143,27 @@ export const API_ROUTES = [
     "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
     "short",
     ["accounts", "analytics"],
-    [
-      { name: "kind", schema: { type: "string" } },
-      { name: "netuid", schema: { type: "integer", minimum: 0 } },
-      { name: "block_start", schema: { type: "integer", minimum: 0 } },
-      { name: "block_end", schema: { type: "integer", minimum: 0 } },
-      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
-      { name: "offset", schema: { type: "integer", minimum: 0 } },
-      { name: "cursor", schema: { type: "string" } },
-    ],
+    {
+      csvResponse: true,
+      parameters: [
+        { name: "kind", schema: { type: "string" } },
+        { name: "netuid", schema: { type: "integer", minimum: 0 } },
+        { name: "block_start", schema: { type: "integer", minimum: 0 } },
+        { name: "block_end", schema: { type: "integer", minimum: 0 } },
+        {
+          name: "limit",
+          schema: { type: "integer", minimum: 1, maximum: 1000 },
+        },
+        { name: "offset", schema: { type: "integer", minimum: 0 } },
+        { name: "cursor", schema: { type: "string" } },
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the event history as text/csv; `json` (default) keeps the response envelope.",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [{ name: "ss58", schema: { type: "string" } }],
   ),
   route(

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -5259,3 +5259,65 @@ describe("canonicalSubnetHistoryCachePath", () => {
 // Fixture documentation: each factory above mirrors the D1 column contracts used
 // by workers/request-handlers/entities.mjs. When adding a new handler test,
 // prefer reusing these rows so formatters stay aligned with production schemas.
+
+// --- account-events CSV export (#2533) --------------------------------------
+describe("handleAccountEvents CSV export", () => {
+  const ACCOUNT_EVENTS_CSV_HEADER =
+    "block_number,event_index,event_kind,netuid,uid,hotkey,coldkey,amount_tao,alpha_amount,observed_at,extrinsic_index";
+
+  test("?format=csv exports the event history as CSV", async () => {
+    const { env } = dbWith({ accountEvents: [accountEventRow()] });
+    const res = await handleAccountEvents(
+      req(`/api/v1/accounts/${SS58}/events`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(lines[0], ACCOUNT_EVENTS_CSV_HEADER);
+    assert.ok(lines[1].includes("StakeAdded"));
+  });
+
+  test("Accept: text/csv negotiates CSV on the account-events feed", async () => {
+    const { env } = dbWith({ accountEvents: [accountEventRow()] });
+    const res = await handleAccountEvents(
+      new Request(`https://api.metagraph.sh/api/v1/accounts/${SS58}/events`, {
+        headers: { accept: "text/csv" },
+      }),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events`),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+  });
+
+  test("?kind=StakeAdded&format=csv filters and emits CSV", async () => {
+    const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
+    const res = await handleAccountEvents(
+      req(`/api/v1/accounts/${SS58}/events`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events?kind=StakeAdded&format=csv`),
+    );
+    assert.equal(res.status, 200);
+    const sql = captures.sql.find((s) => /FROM account_events/.test(s));
+    assert.ok(/event_kind = \?/.test(sql));
+    assert.ok((await res.text()).includes("StakeAdded"));
+  });
+
+  test("?format=csv on a cold DB emits a header-only export", async () => {
+    const res = await handleAccountEvents(
+      req(`/api/v1/accounts/${SS58}/events`),
+      emptyEnv(),
+      SS58,
+      url(`/api/v1/accounts/${SS58}/events?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(lines[0], ACCOUNT_EVENTS_CSV_HEADER);
+    assert.equal(lines.length, 1);
+  });
+});

--- a/tests/subnet-events.test.mjs
+++ b/tests/subnet-events.test.mjs
@@ -138,3 +138,48 @@ test("GET /subnets/{netuid}/event-summary rejects bad window", async () => {
   );
   assert.equal(res.status, 400);
 });
+
+// --- CSV export (#2533) ------------------------------------------------------
+const SUBNET_EVENTS_CSV_HEADER =
+  "block_number,event_index,event_kind,netuid,uid,hotkey,coldkey,amount_tao,alpha_amount,observed_at,extrinsic_index";
+
+test("GET /subnets/{netuid}/events?format=csv exports the stream as CSV", async () => {
+  const env = dbWith({ events: [ROW] });
+  const res = await handleRequest(
+    req("/api/v1/subnets/7/events?format=csv"),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /^text\/csv/);
+  const lines = (await res.text()).split("\r\n");
+  assert.equal(lines[0], SUBNET_EVENTS_CSV_HEADER);
+  assert.ok(lines[1].includes("NeuronRegistered"));
+  assert.ok(lines[1].includes(",7,"));
+});
+
+test("GET /subnets/{netuid}/events?kind=WeightsSet&format=csv filters + emits CSV", async () => {
+  const env = dbWith({ events: [{ ...ROW, event_kind: "WeightsSet" }] });
+  const res = await handleRequest(
+    req("/api/v1/subnets/7/events?kind=WeightsSet&format=csv"),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /^text\/csv/);
+  const text = await res.text();
+  assert.equal(text.split("\r\n")[0], SUBNET_EVENTS_CSV_HEADER);
+  assert.ok(text.includes("WeightsSet"));
+});
+
+test("GET /subnets/{netuid}/events?format=csv on a cold DB is header-only", async () => {
+  const res = await handleRequest(
+    req("/api/v1/subnets/7/events?format=csv"),
+    dbWith({}),
+    {},
+  );
+  assert.equal(res.status, 200);
+  const lines = (await res.text()).split("\r\n");
+  assert.equal(lines[0], SUBNET_EVENTS_CSV_HEADER);
+  assert.equal(lines.length, 1);
+});

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1266,6 +1266,23 @@ export async function handleAccount(request, env, ss58) {
 
 // GET /api/v1/accounts/{ss58}/events: paginated event history (newest first),
 // optional ?kind= filter, ?limit (<=1000) / ?offset.
+// Column order for the CSV export of the first-party chain-event streams
+// (subnet-events + account-events), mirroring the account_events row shape
+// (src/account-events.mjs formatAccountEvent).
+const EVENT_CSV_COLUMNS = [
+  "block_number",
+  "event_index",
+  "event_kind",
+  "netuid",
+  "uid",
+  "hotkey",
+  "coldkey",
+  "amount_tao",
+  "alpha_amount",
+  "observed_at",
+  "extrinsic_index",
+];
+
 export async function handleAccountEvents(request, env, ss58, url) {
   const validationError = validateQueryParams(url, [
     "kind",
@@ -1275,6 +1292,7 @@ export async function handleAccountEvents(request, env, ss58, url) {
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   // Optional block-height range filter, parity with the extrinsics and
@@ -1317,6 +1335,15 @@ export async function handleAccountEvents(request, env, ss58, url) {
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.events,
+      "account-events",
+      "short",
+      request,
+      EVENT_CSV_COLUMNS,
+    );
+  }
   return accountEnvelopeResponse(
     request,
     {
@@ -1702,6 +1729,7 @@ export async function handleSubnetEvents(request, env, netuid, url) {
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const kind = url.searchParams.get("kind");
@@ -1736,6 +1764,15 @@ export async function handleSubnetEvents(request, env, netuid, url) {
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.events,
+      "subnet-events",
+      "short",
+      request,
+      EVENT_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## What

Adds `?format=csv` (and `Accept: text/csv` negotiation) to the two first-party
chain-event stream endpoints, reusing the shared CSV branch already wired into
the other entity feeds:

- `GET /api/v1/subnets/{netuid}/events`
- `GET /api/v1/accounts/{ss58}/events`

When `format=csv` (or an `Accept: text/csv` header) is supplied, the handler
streams the `events` array as `text/csv` with a stable column order matching the
`account_events` row shape; the default JSON envelope is unchanged. `format` is
added to each route's query allowlist and the OpenAPI contract (regenerated
`openapi.json` + generated types committed).

## Why

Brings the event feeds in line with the CSV-exportable entity endpoints so the
chain-event history can be pulled straight into spreadsheets / data tooling
without a JSON post-processing step.

## Tests

Added coverage on both routes: `format=csv` export, `Accept: text/csv`
negotiation, `kind=` filter + CSV, and a header-only export on a cold DB. Full
suite green; `validate:contract-drift`, lint, and prettier pass.

Closes #2533