### PR TITLE
fix(scan): flag a bare npm access token in public-safety scan

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -32,6 +32,14 @@ const patterns = [
     name: "gitlab personal access token",
     regex: /glpat-[A-Za-z0-9_-]{20,}/,
   },
+  // npm access token: the fixed `npm_` prefix + 36 base62 chars is the documented
+  // format for automation / granular / publish tokens. A leaked npm token grants
+  // publish rights to a package (a supply-chain risk) and its distinctive prefix is
+  // matched by none of the other token rules above (`gh`/`glpat-`/`sk-`/`xox`).
+  {
+    name: "npm access token",
+    regex: /npm_[A-Za-z0-9]{36}/,
+  },
   { name: "openai-style token", regex: /sk-[A-Za-z0-9]{20,}/ },
   { name: "slack-style token", regex: /xox[baprs]-[A-Za-z0-9-]+/ },
   // AWS access key id: AKIA (long-term) / ASIA (temporary STS) + 16 upper-alnum.

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -233,6 +233,20 @@ describe("captured-fixture body scan", () => {
     );
   });
 
+  test("flags a bare npm access token", async () => {
+    // The fixed `npm_` prefix + 36 base62 chars is the documented automation /
+    // granular token format; a leaked one grants package publish rights (a supply-
+    // chain risk) and none of the other token rules catch it. Assemble the prefix +
+    // shared body at runtime so the source never commits a contiguous token literal.
+    const token = `npm_${"abcdefghijklmnopqrstuvwxyz0123456789"}`; // npm_ + 36 chars
+    await fs.writeFile(TEST_PUBLIC_PATH, `${token}\n`, "utf8");
+    const output = runScanOutput();
+    assert.ok(
+      output.includes(`${TEST_PUBLIC_FILE}:1: npm access token`),
+      `npm access token must be flagged; got:\n${output}`,
+    );
+  });
+
   test("flags a link-local cloud-metadata URL as a private/loopback leak", async () => {
     // 169.254.169.254 is the AWS/GCP metadata endpoint — the canonical SSRF /
     // credential-theft target and unsafe per lib.mjs isUnsafeUrl, so a leaked URL


### PR DESCRIPTION
## Summary

- The public-safety scan flags GitHub, GitLab, AWS, Google, and OpenAI/Slack credentials, but a leaked **npm access token** slips through: none of the existing token rules match the `npm_` prefix. A leaked automation / granular / publish token grants package publish rights (a supply-chain risk) and could land in a scanned public artifact undetected.

## What Changed

- Add an `npm access token` rule to `scripts/scan-public-safety.mjs`, placed right after the github/gitlab token rules it mirrors: the fixed `npm_` prefix + 36 base62 chars is npm's documented token format (`/npm_[A-Za-z0-9]{36}/`) — a distinctive prefix with no false-positive surface, matching how the AWS (`AKIA`/`ASIA`) and Google (`AIza`) rules are scoped to their fixed prefixes.
- Add a regression test in `tests/public-safety.test.mjs` alongside the existing GitHub/GitLab/AWS/Google cases, assembling the token from prefix + body at runtime so the source never commits a contiguous token-shaped literal.

## Registry Safety

- [x] No secrets, PATs, wallet data, private/localhost URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes (scanner script + test only).

## Validation

- [x] `npm run scan:public-safety` — passes, no new findings (the new rule is false-positive-clean on the tree).
- [x] `vitest run tests/public-safety.test.mjs` — the new `flags a bare npm access token` test passes.
- [x] `eslint` + `prettier --check` on the changed files — clean.
- [x] `git diff --check` — clean.

Two files changed, +22 lines, no generated artifacts touched.
