### PR TITLE
feat(registry): add SN51 lium.io openapi surface (#462)

### DIFF
--- a/registry/providers/lium-io.json
+++ b/registry/providers/lium-io.json
@@ -1,0 +1,10 @@
+{
+  "authority": "community",
+  "github_url": "https://github.com/Datura-ai/lium-io",
+  "id": "lium-io",
+  "kind": "subnet-team",
+  "name": "lium.io",
+  "public_notes": "",
+  "schema_version": 1,
+  "website_url": "https://lium.io/"
+}

--- a/registry/subnets/lium-io.json
+++ b/registry/subnets/lium-io.json
@@ -1,0 +1,34 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "lium.io",
+  "netuid": 51,
+  "schema_version": 1,
+  "slug": "sn-51",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-51-lium-io-openapi",
+      "kind": "openapi",
+      "name": "lium.io Lium Backend API",
+      "provider": "lium-io",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "daedalus-icarus"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://lium.io/api/openapi.json",
+      "source_urls": [
+        "https://lium.io/",
+        "https://github.com/Datura-ai/lium-io/blob/main/README.md"
+      ],
+      "url": "https://lium.io/api/openapi.json"
+    }
+  ]
+}


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends or updates surface(s) on exactly one subnet manifest — `registry/subnets/<slug>.json`. If the manifest did not exist on the base branch, this PR may include the required `subnet:new` scaffold fields in that same new file.

## Surface

- Netuid: `51`
- Kind: `openapi`
- Public URL: `https://lium.io/api/openapi.json`
- Source URL (proves the claim): `https://lium.io/`, `https://github.com/Datura-ai/lium-io/blob/main/README.md`
- Provider slug: `lium-io`

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file: append-only for an existing manifest, or a `subnet:new` scaffold plus surface(s) for a missing manifest (optionally plus one `registry/providers/*.json` for a debut provider).
- [x] Generated with `npm run surface:add` — lands `authority: community` and `review.state: community-submitted`.
- [x] The `url` is public and safe for read-only probes; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no auth-only/credentialed flows, secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue (`Closes #<n>`).

## Gate Expectations

Public-safe surfaces can be AI-reviewed by the private Metagraphed gate and may be merged automatically after public checks pass. Base-layer RPC/WSS/archive, authenticated surfaces, unknown providers, and identity disputes route to manual review.

## Validation

- [x] `npm run validate:surface -- registry/subnets/lium-io.json`
- [x] `npm run scan:public-safety`

Closes #462