### PR TITLE
feat(registry): add SN38 ChronoLLM ChronoGPT models data-artifact

### DIFF
--- a/registry/subnets/chronollm.json
+++ b/registry/subnets/chronollm.json
@@ -25,6 +25,22 @@
       },
       "source_urls": ["https://github.com/chronollm/sn38/blob/main/README.md"],
       "url": "https://github.com/chronollm/sn38/blob/main/docs/miner.md"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-38-chronogpt-models",
+      "kind": "data-artifact",
+      "name": "ChronoGPT models (HuggingFace)",
+      "notes": "Official ChronoGPT collection on HuggingFace (per-year chrono-gpt-v1 models), listed as \"ChronoGPT models\" in the official ChronoLLM README.",
+      "provider": "tao-colosseum",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": ["https://github.com/chronollm/sn38/blob/main/README.md"],
+      "url": "https://huggingface.co/collections/manelalab/chronogpt-67c878a02139875341ca9d3b"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/chronollm.json` (SN38 ChronoLLM). Append-only; no other files changed.

## Summary

SN38 (ChronoLLM) had no `data-artifact` surface registered. The subnet's core deliverable is a per-year collection of ChronoGPT language models, published on HuggingFace and listed as **"ChronoGPT models"** in the official `chronollm/sn38` README's Links table. This adds that collection as a `data-artifact` surface.

## Surface

- Netuid: 38
- Kind: data-artifact
- Public URL: https://huggingface.co/manelalab
- Source URL (proves the claim): https://github.com/chronollm/sn38/blob/main/README.md
- Provider slug: tao-colosseum

The README's "Links" section explicitly maps `ChronoGPT models → huggingface.co/manelalab`, and the org hosts the per-year `chrono-bert-v1-<year>` models matching the subnet's design. Provider follows existing precedent for the subnet's `chronollm/sn38` docs/source-repo surfaces.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file (append-only).
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public and read-only-safe; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [ ] Links a tracked issue — no open enrichment issue exists for SN38 data-artifact; judged on its own merit.

## Validation

- [x] `npm run validate:surface -- registry/subnets/chronollm.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate` (full suite, green)
