### PR TITLE
fix(api): index account events netuid filter

### DIFF
--- a/migrations/0034_account_events_account_netuid_indexes.sql
+++ b/migrations/0034_account_events_account_netuid_indexes.sql
@@ -1,0 +1,8 @@
+-- Make the public account-events ?netuid filter index-satisfiable for each
+-- account branch. The feed query pins its hotkey/coldkey branch indexes to avoid
+-- an OR-across-columns scan; without netuid in those forced indexes, an absent or
+-- rare netuid must walk the account's retained history before returning no rows.
+CREATE INDEX IF NOT EXISTS idx_account_events_hotkey_netuid
+  ON account_events (hotkey, netuid, block_number);
+CREATE INDEX IF NOT EXISTS idx_account_events_coldkey_netuid
+  ON account_events (coldkey, netuid, block_number);

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -812,13 +812,26 @@ export function buildAccountTransfers(
 // loadAccountTransfers' both-direction feed).
 const ACCOUNT_EVENT_HOTKEY_INDEX = "idx_account_events_hotkey";
 const ACCOUNT_EVENT_COLDKEY_INDEX = "idx_account_events_coldkey";
+const ACCOUNT_EVENT_HOTKEY_NETUID_INDEX = "idx_account_events_hotkey_netuid";
+const ACCOUNT_EVENT_COLDKEY_NETUID_INDEX = "idx_account_events_coldkey_netuid";
 
-function accountEventIndexedUnion(select, filters = "", filterParams = []) {
+function accountEventIndexedUnion(
+  select,
+  filters = "",
+  filterParams = [],
+  { netuidFiltered = false } = {},
+) {
   const branchFilters = filters ? ` ${filters}` : "";
+  const hotkeyIndex = netuidFiltered
+    ? ACCOUNT_EVENT_HOTKEY_NETUID_INDEX
+    : ACCOUNT_EVENT_HOTKEY_INDEX;
+  const coldkeyIndex = netuidFiltered
+    ? ACCOUNT_EVENT_COLDKEY_NETUID_INDEX
+    : ACCOUNT_EVENT_COLDKEY_INDEX;
   return {
     sql:
-      `(SELECT ${select} FROM account_events INDEXED BY ${ACCOUNT_EVENT_HOTKEY_INDEX} WHERE hotkey = ?${branchFilters}` +
-      ` UNION ALL SELECT ${select} FROM account_events INDEXED BY ${ACCOUNT_EVENT_COLDKEY_INDEX} WHERE coldkey = ? AND (hotkey IS NULL OR hotkey <> ?)${branchFilters})`,
+      `(SELECT ${select} FROM account_events INDEXED BY ${hotkeyIndex} WHERE hotkey = ?${branchFilters}` +
+      ` UNION ALL SELECT ${select} FROM account_events INDEXED BY ${coldkeyIndex} WHERE coldkey = ? AND (hotkey IS NULL OR hotkey <> ?)${branchFilters})`,
     paramsFor(ss58) {
       return [ss58, ...filterParams, ss58, ss58, ...filterParams];
     },
@@ -983,6 +996,7 @@ export async function loadAccountEvents(
     ACCOUNT_EVENT_COLUMNS,
     filterParts.join(" "),
     filterParams,
+    { netuidFiltered: netuid != null },
   );
   const params = [...union.paramsFor(ss58), lim];
   let sql = `SELECT * FROM ${union.sql} ORDER BY block_number DESC, event_index DESC LIMIT ?`;

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -1412,6 +1412,8 @@ test("loadAccountEvents applies the ?netuid filter as a bound param on both bran
   );
   assert.ok(/AND netuid = \?/.test(captured.sql));
   assert.equal(captured.sql.match(/AND netuid = \?/g)?.length, 2);
+  assert.match(captured.sql, /INDEXED BY idx_account_events_hotkey_netuid/);
+  assert.match(captured.sql, /INDEXED BY idx_account_events_coldkey_netuid/);
   assert.deepEqual(captured.params, ["5Hk", 7, "5Hk", "5Hk", 7, 100, 0]);
 });
 
@@ -1426,6 +1428,10 @@ test("loadAccountEvents omits netuid filter when absent", async () => {
     {},
   );
   assert.ok(!/AND netuid = \?/.test(captured.sql));
+  assert.match(captured.sql, /INDEXED BY idx_account_events_hotkey/);
+  assert.match(captured.sql, /INDEXED BY idx_account_events_coldkey/);
+  assert.doesNotMatch(captured.sql, /idx_account_events_hotkey_netuid/);
+  assert.doesNotMatch(captured.sql, /idx_account_events_coldkey_netuid/);
 });
 
 test("loadAccountEvents short-circuits an inverted block range before D1", async () => {


### PR DESCRIPTION
### Motivation
- The public `/api/v1/accounts/{ss58}/events` route accepted a `?netuid=` filter that became a residual predicate on a query that forces the hotkey/coldkey indexes, which can force expensive D1/SQLite scans for rare or nonexistent `netuid` values and enable availability/cost-amplification attacks.

### Description
- Add a migration `migrations/0034_account_events_account_netuid_indexes.sql` that creates composite indexes `idx_account_events_hotkey_netuid` and `idx_account_events_coldkey_netuid` on `(hotkey, netuid, block_number)` and `(coldkey, netuid, block_number)`, respectively.
- Update `accountEventIndexedUnion` in `src/account-events.mjs` to choose the composite hotkey/coldkey indexes when the caller indicates the union is netuid-filtered, and leave existing indexes in place for unfiltered reads.
- Pass a `netuidFiltered` flag from `loadAccountEvents` when `?netuid=` is present so the query is routed to the composite indexes only for netuid-scoped requests.
- Add/adjust test assertions in `tests/account-events.test.mjs` to assert use of the composite indexes when `?netuid=` is supplied and to assert legacy index use when the filter is absent.

### Testing
- Ran `npm run validate:migrations` which succeeded and validated migration sequencing; the new migration was accepted.
- Ran `npm run build` and `npm run validate` which completed without errors and reported the project artifacts built successfully.
- Ran `prettier --check` on modified files which passed formatting checks.
- Ran targeted unit tests: `tests/account-events.test.mjs` assertions for `loadAccountEvents` (netuid present/absent + indexed-union behavior) passed, and `tests/request-handlers-entities.test.mjs` netuid-related tests passed; all targeted tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a488ae68854832c821b825e2e97126b)