### PR TITLE
fix(data-api): add chain-events CSV export (#2530)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -402,7 +402,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs. */
+        /** Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Pass ?format=csv to download the filtered event rows as CSV. Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs. */
         get: operations["chainEventsFeed"];
         put?: never;
         post?: never;
@@ -9079,6 +9079,8 @@ export interface operations {
                 cursor?: string;
                 before?: number;
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -9086,7 +9088,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -9139,6 +9141,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainEventsFeedArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,pallet,method,args,phase,extrinsic_index,observed_at
+                     *     123,0,System,ExtrinsicSuccess,"{""x"":1}",ApplyExtrinsic,2,100
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -2,8 +2,8 @@
   "$schema": "https://api.metagraph.sh/.well-known/agent-skills/schema.json",
   "skills": [
     {
-      "description": "Use when a developer asks what a Bittensor subnet does, whether it's up right now, or how to call/integrate its API — e.g. \"which subnet does image generation\", \"is subnet 7 healthy\", \"how do I call the Chutes API\", \"build on a Bittensor subnet\". Backed by metagraphed (api.metagraph.sh), the live operational + integration registry for ~129 subnets.",
-      "digest": "sha256:202192843c32bc7efdc7313d1b78974014ae64b4f6b6c5b8823de49775bde4b2",
+      "description": "The bittensor agent skill.",
+      "digest": "sha256:a406d66075804cbc5dbeae4c7c089e8f93ad66cc5221a4951e0d9260ce8831e3",
       "name": "bittensor",
       "type": "skill-md",
       "url": "https://api.metagraph.sh/skills/bittensor/SKILL.md"

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5661,7 +5661,7 @@
     {
       "artifact_path": "/metagraph/chain-events.json",
       "cache": "short",
-      "description": "Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs.",
+      "description": "Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Pass ?format=csv to download the filtered event rows as CSV. Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs.",
       "id": "chain-events-feed",
       "method": "GET",
       "path": "/api/v1/chain-events",
@@ -5719,6 +5719,17 @@
             "maximum": 200,
             "minimum": 1,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -21361,6 +21361,19 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -21421,9 +21434,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,event_index,pallet,method,args,phase,extrinsic_index,observed_at\r\n123,0,System,ExtrinsicSuccess,\"{\"\"x\"\":1}\",ApplyExtrinsic,2,100",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -21480,7 +21499,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs.",
+        "summary": "Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Pass ?format=csv to download the filtered event rows as CSV. Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs.",
         "tags": [
           "chain",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -402,7 +402,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs. */
+        /** Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Pass ?format=csv to download the filtered event rows as CSV. Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs. */
         get: operations["chainEventsFeed"];
         put?: never;
         post?: never;
@@ -9079,6 +9079,8 @@ export interface operations {
                 cursor?: string;
                 before?: number;
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -9086,7 +9088,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -9139,6 +9141,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainEventsFeedArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,pallet,method,args,phase,extrinsic_index,observed_at
+                     *     123,0,System,ExtrinsicSuccess,"{""x"":1}",ApplyExtrinsic,2,100
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2359,10 +2359,10 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/chain-events",
     "/metagraph/chain-events.json",
-    "Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs.",
+    "Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Pass ?format=csv to download the filtered event rows as CSV. Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs.",
     "short",
     ["chain", "analytics"],
-    [
+    csvRouteQuery([
       { name: "pallet", schema: { type: "string", maxLength: 64 } },
       { name: "method", schema: { type: "string", maxLength: 64 } },
       { name: "block", schema: { type: "integer", minimum: 0 } },
@@ -2379,7 +2379,7 @@ export const API_ROUTES = [
       },
       { name: "before", schema: { type: "integer", minimum: 0 } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 200 } },
-    ],
+    ]),
     [],
   ),
   route(

--- a/src/csv-route-examples.mjs
+++ b/src/csv-route-examples.mjs
@@ -2,6 +2,10 @@
 // analytics-routes.mjs. Kept in a dedicated module so parallel CSV PRs can add
 // examples without contending on the csvExampleForRoute if-chain in contracts.mjs.
 export const ROUTE_CSV_EXAMPLES = {
+  "chain-events-feed": [
+    "block_number,event_index,pallet,method,args,phase,extrinsic_index,observed_at",
+    '123,0,System,ExtrinsicSuccess,"{""x"":1}",ApplyExtrinsic,2,100',
+  ].join("\r\n"),
   "subnet-yield": [
     "uid,hotkey,role,stake_tao,emission_tao,yield,vs_median",
     "0,hk_sample,validator,1000,22.1,0.0221,above",

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4,26 +4,15 @@
 import { beforeEach, test, expect, vi } from "vitest";
 
 const sqlCalls = vi.hoisted(() => []);
+const mockRows = vi.hoisted(() => []);
 
 vi.mock("postgres", () => ({
   default: () => {
-    const rows = [
-      {
-        block_number: "123",
-        event_index: 0,
-        pallet: "System",
-        method: "ExtrinsicSuccess",
-        args: { x: 1 },
-        phase: "ApplyExtrinsic",
-        extrinsic_index: 2,
-        observed_at: "100",
-      },
-    ];
     // Every tagged-template call (top-level query OR nested fragment) resolves to rows;
     // the handler awaits the outer query and ignores interpolated fragment values.
     const sql = (strings, ...values) => {
       sqlCalls.push({ text: Array.from(strings).join("?"), values });
-      return Promise.resolve(rows);
+      return Promise.resolve(mockRows);
     };
     sql.end = () => Promise.resolve();
     return sql;
@@ -39,6 +28,16 @@ const queryText = () => sqlCalls.map((call) => call.text).join("\n");
 
 beforeEach(() => {
   sqlCalls.length = 0;
+  mockRows.splice(0, mockRows.length, {
+    block_number: "123",
+    event_index: 0,
+    pallet: "System",
+    method: "ExtrinsicSuccess",
+    args: { x: 1 },
+    phase: "ApplyExtrinsic",
+    extrinsic_index: 2,
+    observed_at: "100",
+  });
 });
 
 test("GET /api/v1/blocks/:n/chain-events returns the block's events", async () => {
@@ -68,6 +67,39 @@ test("GET /api/v1/chain-events returns the feed with a cursor (filters + before)
   expect(typeof body.events[0].block_number).toBe("number");
   expect(body.events[0].observed_at).toBe(100);
   expect(typeof body.events[0].observed_at).toBe("number");
+});
+
+test("GET /api/v1/chain-events?format=csv exports chain-event rows (#2530)", async () => {
+  const res = await req("/api/v1/chain-events?format=csv&limit=1");
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-type")).toMatch(/^text\/csv/);
+  expect(res.headers.get("content-disposition")).toBe(
+    'attachment; filename="chain-events.csv"',
+  );
+  expect(await res.text()).toBe(
+    [
+      "block_number,event_index,pallet,method,args,phase,extrinsic_index,observed_at",
+      '123,0,System,ExtrinsicSuccess,"{""x"":1}",ApplyExtrinsic,2,100',
+    ].join("\r\n"),
+  );
+});
+
+test("GET /api/v1/chain-events?pallet=Balances&format=csv binds the pallet filter (#2530)", async () => {
+  const res = await req("/api/v1/chain-events?pallet=Balances&format=csv");
+  expect(res.status).toBe(200);
+  expect(await res.text()).toContain("block_number,event_index,pallet,method");
+  expect(queryText()).toContain("AND pallet =");
+  expect(sqlCalls.flatMap((call) => call.values)).toContain("Balances");
+});
+
+test("GET /api/v1/chain-events?format=csv emits a header-only cold export (#2530)", async () => {
+  mockRows.length = 0;
+  const res = await req("/api/v1/chain-events?format=csv");
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-type")).toMatch(/^text\/csv/);
+  expect(await res.text()).toBe(
+    "block_number,event_index,pallet,method,args,phase,extrinsic_index,observed_at",
+  );
 });
 
 test("chain-events cursor seeks by block_number and event_index", async () => {

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -99,6 +99,41 @@ describe("Worker runtime", () => {
     assert.equal(body.meta.source, "data-worker-postgres");
   });
 
+  test("passes DATA_API chain-events CSV exports through without an envelope", async () => {
+    const response = await handleRequest(
+      new Request("https://metagraph.sh/api/v1/chain-events?format=csv"),
+      {
+        ...env,
+        DATA_API: {
+          fetch() {
+            return new Response(
+              "block_number,event_index,pallet,method\r\n123,0,System,Event",
+              {
+                status: 200,
+                headers: {
+                  "content-type": "text/csv; charset=utf-8",
+                  "content-disposition":
+                    'attachment; filename="chain-events.csv"',
+                },
+              },
+            );
+          },
+        },
+      },
+      {},
+    );
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      response.headers.get("content-disposition"),
+      'attachment; filename="chain-events.csv"',
+    );
+    assert.equal(
+      await response.text(),
+      "block_number,event_index,pallet,method\r\n123,0,System,Event",
+    );
+  });
+
   test("forwards a GET to DATA_API for a HEAD chain-events probe (not a 405)", async () => {
     // DATA_API is GET-only. A HEAD probe must still get the bodiless 200 that
     // every other GET route returns for HEAD — not the data Worker's 405 — so

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -881,8 +881,10 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
 // envelope so /api/v1/chain-events* matches the OpenAPI contract (typed `data`
 // payload + ETag/cache headers) like every other route. The MCP get_chain_activity
 // tool calls DATA_API directly and keeps consuming the bare shape — only this
-// public REST path is enveloped. 503 when the binding is absent (e.g. a preview
-// deploy without the data Worker); upstream non-2xx maps to a clean error envelope.
+// public REST JSON path is enveloped. CSV exports are already final responses
+// from DATA_API, so pass them through. 503 when the binding is absent (e.g. a
+// preview deploy without the data Worker); upstream non-2xx maps to a clean error
+// envelope.
 async function handleChainEventsProxy(request, env, url) {
   if (!env.DATA_API) {
     return errorResponse(
@@ -901,6 +903,12 @@ async function handleChainEventsProxy(request, env, url) {
       ? new Request(request.url, { method: "GET", headers: request.headers })
       : request,
   );
+  if (/^text\/csv\b/i.test(upstream.headers.get("content-type") || "")) {
+    return new Response(request.method === "HEAD" ? null : upstream.body, {
+      status: upstream.status,
+      headers: upstream.headers,
+    });
+  }
   let body;
   try {
     body = await upstream.json();

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -11,13 +11,29 @@
 // closed via ctx.waitUntil so it never blocks the response.
 import postgres from "postgres";
 import { decodeCursor, encodeCursor } from "../src/cursor.mjs";
+import { csvRequested, csvResponse } from "./csv.mjs";
 
 const MAX_LIMIT = 200;
 const DEFAULT_LIMIT = 50;
 const FILTER_PATTERN = /^[A-Za-z][A-Za-z0-9_]{0,63}$/;
+const CHAIN_EVENTS_CSV_COLUMNS = [
+  "block_number",
+  "event_index",
+  "pallet",
+  "method",
+  "args",
+  "phase",
+  "extrinsic_index",
+  "observed_at",
+];
 
 function validEventFilter(value) {
   return value == null || value === "" || FILTER_PATTERN.test(value);
+}
+
+function validResponseFormat(params) {
+  const format = params.get("format");
+  return format == null || /^(?:json|csv)$/i.test(format);
 }
 
 function json(data, status = 200) {
@@ -117,6 +133,9 @@ export default {
       // cursor is the lossless keyset over (block_number,event_index); before is
       // retained as the legacy block_number-only cursor for existing callers.
       if (url.pathname === "/api/v1/chain-events") {
+        if (!validResponseFormat(url.searchParams)) {
+          return json({ error: "format must be json or csv" }, 400);
+        }
         const limit = clampLimit(url.searchParams.get("limit"));
         const pallet = url.searchParams.get("pallet");
         const method = url.searchParams.get("method");
@@ -168,11 +187,21 @@ export default {
         const nextCursor = last
           ? encodeCursor([nextBlock, numberOrNull(last.event_index)])
           : null;
+        const events = rows.map(coerceEvent);
+        if (csvRequested(url, request)) {
+          return csvResponse(
+            events,
+            "chain-events",
+            "short",
+            request,
+            CHAIN_EVENTS_CSV_COLUMNS,
+          );
+        }
         return json({
           count: rows.length,
           next_before: nextBlock,
           next_cursor: nextCursor,
-          events: rows.map(coerceEvent),
+          events,
         });
       }
 


### PR DESCRIPTION
## Summary

Adds CSV export support for `GET /api/v1/chain-events` via `?format=csv`, including filtered event rows, header-only cold exports, public API passthrough, and regenerated contract/OpenAPI artifacts.

Fixes #2530

## Validation

- `npm test -- tests/data-api.test.mjs`
- `npm test -- tests/worker-runtime.test.mjs -t "passes DATA_API chain-events CSV"`
- `npm run build`
- `npm run lint`
- `npm run validate:api`
- `npm run validate:openapi`
- `npm run validate:contract-drift`
- `npm run scan:public-safety`
- `git diff --check`
- `npx prettier --check src/contracts.mjs src/csv-route-examples.mjs tests/data-api.test.mjs tests/worker-runtime.test.mjs workers/api.mjs workers/data-api.mjs`