### PR TITLE
fix(api): show a renamed surface's current alias in the uptime series

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1125,10 +1125,22 @@ export function formatUptime({
     const key = surfaceLookupKey(row);
     if (!key) continue;
     const entry = bySurface.get(key) || {
-      surface_id: row.surface_id,
+      surface_id: null,
+      surface_id_day: null,
       days: [],
     };
-    entry.surface_id = row.surface_id || entry.surface_id;
+    // Resolve the display alias to the surface_id from the LATEST day: the loader
+    // returns rows newest-first (ORDER BY day DESC), so a blind last-writer wins
+    // would leave a renamed surface showing its OLDEST (stale) alias. Track the
+    // day the alias came from and only adopt a row whose day is newer.
+    if (
+      row.surface_id &&
+      (entry.surface_id_day == null ||
+        String(row.day).localeCompare(entry.surface_id_day) > 0)
+    ) {
+      entry.surface_id = row.surface_id;
+      entry.surface_id_day = String(row.day);
+    }
     entry.days.push({
       day: row.day,
       samples: Number(row.samples) || 0,

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -2356,6 +2356,70 @@ describe("formatUptime (daily uptime history)", () => {
     assert.equal(out.reliability.surface_count, 1);
   });
 
+  test("resolves a renamed surface_id to the newest day's alias in query order", () => {
+    // The loader returns rows newest-first (ORDER BY day DESC). A renamed surface
+    // shares one stable surface_key but carries a different surface_id per day;
+    // the displayed alias must be the CURRENT one (newest day), never the oldest
+    // row that happens to be processed last.
+    const out = formatUptime({
+      netuid: 7,
+      window: "90d",
+      rows: [
+        {
+          surface_id: "7:api:new",
+          surface_key: "srf-api0000000000",
+          day: "2026-06-13",
+          samples: 100,
+          ok_count: 100,
+          uptime_ratio: 1,
+          avg_latency_ms: 40,
+          status: "ok",
+        },
+        {
+          surface_id: "7:api:old",
+          surface_key: "srf-api0000000000",
+          day: "2026-06-12",
+          samples: 100,
+          ok_count: 80,
+          uptime_ratio: 0.8,
+          avg_latency_ms: 60,
+          status: "degraded",
+        },
+      ],
+    });
+    assert.equal(out.surfaces.length, 1);
+    assert.equal(out.surfaces[0].surface_id, "7:api:new");
+  });
+
+  test("falls back past a newest-day row with no surface_id to the latest labelled alias", () => {
+    // Newest-first rows where the current day's alias is missing: keep the most
+    // recent non-empty surface_id rather than clobbering it to null.
+    const out = formatUptime({
+      netuid: 7,
+      window: "90d",
+      rows: [
+        {
+          surface_id: null,
+          surface_key: "srf-api0000000000",
+          day: "2026-06-13",
+          samples: 100,
+          ok_count: 100,
+          status: "ok",
+        },
+        {
+          surface_id: "7:api:labelled",
+          surface_key: "srf-api0000000000",
+          day: "2026-06-12",
+          samples: 100,
+          ok_count: 90,
+          status: "ok",
+        },
+      ],
+    });
+    assert.equal(out.surfaces.length, 1);
+    assert.equal(out.surfaces[0].surface_id, "7:api:labelled");
+  });
+
   test("returns an empty series + null reliability for no rows", () => {
     const out = formatUptime({ netuid: 7, window: "1y", rows: [] });
     assert.deepEqual(out.surfaces, []);


### PR DESCRIPTION
## What

`formatUptime` (the `/…/uptime` daily series) resolved each surface's display `surface_id` by overwriting it on **every** row:

```js
entry.surface_id = row.surface_id || entry.surface_id;
```

`loadSubnetUptime` feeds the rows in the loader's query order, which is newest-first:

```sql
SELECT MAX(surface_id) AS surface_id, COALESCE(surface_key, surface_id) AS surface_key, day, …
FROM surface_uptime_daily
WHERE netuid = ? AND day >= ?
GROUP BY COALESCE(surface_key, surface_id), day
… ORDER BY day DESC
```

For a surface **renamed mid-window** — one stable `surface_key`, a different `surface_id` on each side of the rename boundary — the last row processed is therefore the **oldest** day. Last-writer-wins leaves the whole series labelled with the **stale** alias instead of the current one.

## Concrete case

Rows as returned by the query (newest-first):

| day | surface_id | surface_key |
|-----|-----------|-------------|
| 2026-06-13 | `7:api:new` | `srf-api0000000000` |
| 2026-06-12 | `7:api:old` | `srf-api0000000000` |

- **Expected:** `surface_id: "7:api:new"` (the current alias)
- **Before this fix:** `surface_id: "7:api:old"` (the oldest row, processed last)

## Fix

Track the day each candidate alias came from and only adopt a row whose `day` is newer, so the displayed `surface_id` is the newest-day alias **regardless of row order**. `surface_id_day` is internal to the grouping accumulator and is never emitted — the output schema is unchanged.

## Why the existing test didn't catch it

The `"groups renamed uptime rows by stable surface_key"` test already asserts `surface_id === "7:api:new"`, but it feeds its two rows in **ascending** day order (old first) — the reverse of the real `ORDER BY day DESC` query — so the buggy last-writer-wins happened to land on the newer row. This PR adds a regression that feeds the rows in the actual newest-first query order.

## Tests

- New: renamed surface in newest-first (query) order resolves to the current alias (`7:api:new`). Fails on the old code, passes with the fix.
- New: a newest-day row with no `surface_id` falls back to the most-recent labelled alias rather than clobbering to null.
- Existing rename/grouping tests still pass (139/139).

Source + tests only — no schema/contract/generated-artifact changes. `eslint` clean, `prettier` clean, 100% patch coverage of the changed lines.
