### PR TITLE
fix(d1): cut retention windows after hitting D1's 10GB cap (production outage)

### DIFF
--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -197,9 +197,14 @@ def push(url, payload):
             resp.read()
         return True
     except urllib.error.HTTPError as e:
+        try:
+            body = e.read().decode("utf-8", "replace")[:500]
+        except Exception:
+            body = "<no body>"
         log.warning(
-            "ingest push rejected (HTTP %s) — poller backstop will cover this gap",
+            "ingest push rejected (HTTP %s): %s — poller backstop will cover this gap",
             e.code,
+            body,
         )
         return False
     except urllib.error.URLError as e:

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -15,9 +15,19 @@ import {
   buildAccountExtrinsics,
 } from "./extrinsics.mjs";
 
-// D1 safety-valve: 365-day retention prevents unbounded growth before the
-// Postgres cold tier (#1519) ships. pruneAccountEvents runs in HEALTH_PRUNE_CRON.
-export const EVENT_RETENTION_MS = 365 * 24 * 60 * 60 * 1000;
+// D1 safety-valve, ORIGINALLY 365 days ("prevents unbounded growth before the
+// Postgres cold tier (#1519) ships") -- but #1519 never shipped, and real
+// ingestion volume (measured 2026-07-04: ~1.3M rows/day, steady) meant 365 days
+// of retention never actually got old enough to prune (the table is younger
+// than that), so this "safety valve" never engaged and the table grew until
+// it hit D1's hard, unraisable 10GB-per-database cap in production (a live
+// outage: every write into this D1 failed with D1_ERROR: Exceeded maximum DB
+// size). 3 days is what the measured ingestion rate can sustainably fit with
+// real headroom under 10GB across all tables sharing this database -- this is
+// an emergency-driven number, not an arbitrary product decision; raise it only
+// once the raw/long-history chain data lives in Postgres (self-hosted, no cap)
+// instead of D1, per ADR 0013's own "demote/retire D1" end state.
+export const EVENT_RETENTION_MS = 3 * 24 * 60 * 60 * 1000;
 
 // Columns written to account_events — THE load contract. scripts/fetch-events.py
 // emits rows with exactly these keys; loadStagedEvents binds them in this order.

--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -99,13 +99,24 @@ export async function rollupNeuronDaily(env, { now = Date.now() } = {}) {
   return { rolled: true, rows: res?.meta?.changes ?? null };
 }
 
-// D1 keeps a bounded hot window; older days live only in the R2 cold archive
-// (written BEFORE any prune). 400 days (~13 months) keeps a ROLLING 1-year history
-// permanently D1-served — "1 year ago" is always ≤ 400 days old, so every
-// 7d/30d/90d/1y query is answered from D1 with zero R2 fallthrough. At the measured
-// ~7.8 MB/day this caps the table ~3.1 GB — comfortably under D1's 10 GB limit.
-// Only >13-month deep history ages into the R2 cold tier (served later by PR-A2b).
-export const NEURON_DAILY_RETENTION_DAYS = 400;
+// D1 keeps a bounded hot window; older days are written to the R2 cold archive
+// BEFORE any prune (coldArchiveKey below), but -- confirmed 2026-07-04 -- nothing
+// in this codebase actually READS from that archive yet ("served later by
+// PR-A2b" below was never shipped). So today, once a day ages out of this
+// window, it's genuinely gone from query results, not "falls back to R2".
+//
+// Was 400 days (~13 months, sized so "1y ago" is always in-window) under the
+// assumption neuron_daily alone would stay ~3.1 GB -- true in isolation, but D1's
+// 10 GB cap is shared across every table (account_events independently grew to
+// dominate it), and the combined total hit the hard, unraisable per-database
+// limit in production (a live outage: every D1 write failed with D1_ERROR:
+// Exceeded maximum DB size). Cut to 90 days as part of the emergency fix --
+// this is a real, known tradeoff (1y-lookback neuron queries lose data between
+// 90-400 days old until PR-A2b's read path ships, or the account_events cut
+// (see EVENT_RETENTION_MS) buys enough headroom to raise this again), accepted
+// because the write outage is the more severe problem. Raise this once the raw
+// chain data moves to self-hosted Postgres (no cap) per ADR 0013, not before.
+export const NEURON_DAILY_RETENTION_DAYS = 90;
 
 // R2 cold-archive key: one immutable gzip-NDJSON object per subnet per UTC day.
 export function coldArchiveKey(netuid, day) {

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -954,10 +954,19 @@ describe("R2 cold archive + prune (PR-A2)", () => {
     assert.ok(res.rows >= 1);
   });
 
-  test("retention window covers a rolling 1-year history (>= 365 days)", () => {
+  test("retention window is bounded to a sustainable D1 footprint (2026-07-04 emergency cut)", () => {
+    // Was >= 365 (a rolling 1-year window fully D1-served). Cut to 90 as part of
+    // an emergency fix after D1 hit its hard, unraisable 10GB-per-database cap
+    // in production (metagraphed's D1 shares its 10GB budget across every
+    // table; account_events' own growth was the larger contributor, but both
+    // needed cutting for real headroom). The R2 cold-archive read fallback this
+    // window's original design assumed ("PR-A2b") was never implemented, so
+    // 1y-lookback neuron queries now have a real gap between 90-400 days old --
+    // a known, accepted tradeoff, not an oversight. Raise this again once the
+    // raw chain data lives in self-hosted Postgres (no cap) instead of D1.
     assert.ok(
-      NEURON_DAILY_RETENTION_DAYS >= 365,
-      "1y window must stay D1-served",
+      NEURON_DAILY_RETENTION_DAYS >= 90 && NEURON_DAILY_RETENTION_DAYS <= 400,
+      "retention should stay in the sustainable 90-400 day range until D1's role shrinks",
     );
   });
 });


### PR DESCRIPTION
## Summary

**Live production outage, discovered 2026-07-04**: `metagraphed-health` (D1) hit Cloudflare's hard, unraisable 10GB-per-database limit β€” every write into it (the streamer, the poller, anything) has been failing with `D1_ERROR: Exceeded maximum DB size`. Confirmed via live Worker log tailing (`wrangler tail`), not guessed.

Root cause: neither retention window had ever actually triggered a prune.
- `EVENT_RETENTION_MS` (365 days) had no measured-rate validation behind it β€” just "prevents unbounded growth." Measured today: `account_events` ingests ~1.3M rows/day steady. 365 days of that was never going to fit in 10GB.
- `NEURON_DAILY_RETENTION_DAYS` (400) *was* validated β€” but only against `neuron_daily`'s own footprint in isolation (~3.1GB estimated). D1's 10GB cap is shared across every table in the database, and `account_events`' independent growth pushed the combined total over the edge.

## Changes

- `EVENT_RETENTION_MS`: 365d β†’ 3d
- `NEURON_DAILY_RETENTION_DAYS`: 400 β†’ 90
- `scripts/stream-events.py`: logs the response body (not just the HTTP status) on an ingest push rejection β€” this is what surfaced the real `D1_ERROR` instead of a bare "HTTP 500" that took real investigation to unmask.

Both numbers are emergency-driven, sustainable-footprint values, not new product targets β€” documented in-line with the reasoning and the path to raising them again (once the raw chain data lives in self-hosted Postgres, which has no such cap, per ADR 0013).

**Known, accepted tradeoff**: the R2 cold-archive read fallback `neuron_daily`'s original 400-day design assumed ("PR-A2b") was never actually implemented (confirmed β€” grepped the whole codebase, only the write path exists). So cutting to 90 days means 1-year-lookback neuron queries have a real gap between 90-400 days old until that read path ships or headroom allows raising retention again. Accepted because the active write outage is the more severe problem right now.

## Also in progress (not part of this PR)
- Manually pruning existing rows past the new cutoffs directly against production D1 (in progress in parallel, to free space immediately rather than waiting for the next hourly cron tick).
- Standing up a Cloudflare Tunnel + Workers VPC service on the self-hosted indexer node, for the separate (not-yet-merged) work of moving the *live-reads* off Railway's Postgres entirely (#2956).

## Test plan
- [x] `npx vitest run tests/neuron-history.test.mjs tests/account-events.test.mjs` β€” 164/164 passing, including an updated test that previously hard-asserted `NEURON_DAILY_RETENTION_DAYS >= 365` (now asserts the new, documented sustainable range with the tradeoff explained inline).
- [x] `eslint` / `prettier --check` clean on all touched files.