### PR TITLE
fix(chain-transfer-pairs): clamp top_pair_share so a sub-1 dominance never rounds to 100%

### DIFF
--- a/src/chain-transfer-pairs.mjs
+++ b/src/chain-transfer-pairs.mjs
@@ -39,6 +39,20 @@ function toNonNegativeTao(value) {
   return Math.max(0, roundTao(value));
 }
 
+// Round a 0..1 dominance ratio to a stable precision WITHOUT letting a
+// sub-perfect value round up to an exact 1 — the same anti-overstatement guard
+// the sibling concentration/turnover ratios apply (roundRatio in
+// src/concentration.mjs, round in src/chain-turnover.mjs). top_pair_volume_tao is
+// the full-window MAX corridor and total_volume_tao the full-window SUM, so a
+// near-monopoly (e.g. 249990/250000 = 0.99996, with other pairs still present in
+// unique_pairs/pairs[]) must not surface as a flat 1 ("100% of volume"). A
+// genuine single-corridor window where top == total keeps a true 1.
+function roundShare(value, dp = 4) {
+  const factor = 10 ** dp;
+  const rounded = Math.round(value * factor) / factor;
+  return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
+}
+
 function toIso(value) {
   if (value == null) return null;
   const n = Number(value);
@@ -97,9 +111,7 @@ export function buildChainTransferPairs({
     ? toNonNegativeTao(totals.top_pair_volume_tao)
     : returnedTopPairVolume;
   const topPairShare =
-    totalVolume > 0
-      ? Math.round((topPairVolume / totalVolume) * 10000) / 10000
-      : null;
+    totalVolume > 0 ? roundShare(topPairVolume / totalVolume) : null;
 
   return {
     schema_version: 1,

--- a/tests/chain-transfer-pairs.test.mjs
+++ b/tests/chain-transfer-pairs.test.mjs
@@ -62,6 +62,37 @@ describe("buildChainTransferPairs", () => {
     assert.equal(d.pairs[0].last_observed_at, "2026-07-03T00:00:00.000Z");
   });
 
+  test("clamps a near-monopoly top-pair share below a flat 1 when other pairs exist", () => {
+    // top_pair_volume_tao (full-window MAX) is 99.996% of total_volume_tao
+    // (full-window SUM) but a second corridor exists — the share must not round
+    // up to a flat 1 ("100% of volume") while unique_pairs/pairs[] show > 1.
+    const d = buildChainTransferPairs({
+      totals: {
+        total_volume_tao: 250000,
+        top_pair_volume_tao: 249990,
+        transfer_count: 10,
+        unique_pairs: 2,
+      },
+      pairs: [pair("5A", "5B", 249990), pair("5C", "5D", 10)],
+    });
+    assert.equal(d.unique_pairs, 2);
+    assert.ok(d.top_pair_share < 1, "share must be strictly below 1");
+    assert.equal(d.top_pair_share, 0.9999);
+  });
+
+  test("keeps a genuine single-corridor top-pair share at exactly 1", () => {
+    const d = buildChainTransferPairs({
+      totals: {
+        total_volume_tao: 100,
+        top_pair_volume_tao: 100,
+        transfer_count: 3,
+        unique_pairs: 1,
+      },
+      pairs: [pair("5A", "5B", 100)],
+    });
+    assert.equal(d.top_pair_share, 1);
+  });
+
   test("reports a zero top-pair share when totals exist but no pair rows survive", () => {
     const d = buildChainTransferPairs({
       totals: { total_volume_tao: 10, transfer_count: 1, unique_pairs: 1 },


### PR DESCRIPTION
## Summary

Clamp `top_pair_share` in the `/api/v1/chain/transfer-pairs` card so a sub-perfect dominance ratio can never round up to a flat `1` (a reported "100% of network transfer volume") while other corridors demonstrably exist.

`buildChainTransferPairs` computed the share with a bare `Math.round((topPairVolume / totalVolume) * 10000) / 10000`. `top_pair_volume_tao` is the full-window MAX corridor and `total_volume_tao` the full-window SUM, so the ratio is `< 1` whenever more than one pair exists — but a near-monopoly (e.g. `249990 / 250000 = 0.99996`) rounds up to exactly `1`, contradicting the same response's `unique_pairs: 2` and its second `pairs[]` entry.

Every sibling concentration/dominance ratio already guards against this: `roundRatio` in `src/concentration.mjs` and `round` in `src/chain-turnover.mjs` both apply the "a sub-1 value must not round to 1" clamp, and concentration.mjs's comment calls it "the same anti-overstatement guard the turnover/chain-activity ratios apply." `chain-transfer-pairs` was the one dominance ratio missing it.

## What Changed

- Added a local `roundShare` helper mirroring the sibling `round`/`roundRatio` idiom (dp=4, same precision as before): a value that rounds to `1` while being strictly `< 1` clamps to `0.9999`; a genuine `1` (single-corridor window where `top == total`) stays `1`.
- Routed `top_pair_share` through it. No response-shape or OpenAPI change — same field, same precision, correct value at the boundary.
- Regression tests: a 99.996% near-monopoly with a second pair now yields `0.9999` (`< 1`); a true single corridor stays `1`. Existing `0.55` / `0.3333` / `0.8` / `0` / `null` cases are unchanged.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — value correctness only.)

## Validation

- [x] `npx vitest run tests/chain-transfer-pairs.test.mjs`
- [x] `npm run lint` · `npm run format:check`
- [x] `git diff --check`
