### PR TITLE
feat(registry): add SN68 NOVA Submission Archive data-artifact

### DIFF
--- a/registry/subnets/nova.json
+++ b/registry/subnets/nova.json
@@ -1,0 +1,32 @@
+{
+  "categories": [],
+  "curation": {
+    "level": "community-seeded",
+    "review_state": "unreviewed"
+  },
+  "name": "NOVA",
+  "netuid": 68,
+  "schema_version": 1,
+  "slug": "sn-68",
+  "status": "active",
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-68-submission-archive",
+      "kind": "data-artifact",
+      "name": "NOVA Submission Archive (Hugging Face)",
+      "notes": "Public Hugging Face dataset of previously submitted sequences and scores, described as \"our Submission Archive HuggingFace dataset\" in the official NOVA docs.",
+      "provider": "nova",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://github.com/metanova-labs/nova/blob/16da5da15919ff3757b82a5980cf59460335d23e/docs/nanobody_stragegy_guide.md#L197"
+      ],
+      "url": "https://huggingface.co/datasets/Metanova/Submission-Archive"
+    }
+  ]
+}


### PR DESCRIPTION
## Add or update a subnet surface

SN68 (NOVA) had no `registry/subnets/` manifest yet, so this PR scaffolds `registry/subnets/nova.json` via `npm run subnet:new` and appends one community `data-artifact` surface — one new file, nothing else.

## Summary

NOVA's validators archive miners' submitted sequences and scores to a public HuggingFace dataset. The official `metanova-labs/nova` docs describe it as **"our Submission Archive HuggingFace dataset"**, and the validator code (`neurons/validator/save_data.py`) uploads to it. It's a live, public data artifact (100k+ downloads, updated regularly) and SN68 had no data-artifact surface registered.

## Surface

- Netuid: 68
- Kind: data-artifact
- Public URL: https://huggingface.co/datasets/Metanova/Submission-Archive
- Source URL (proves the claim): https://github.com/metanova-labs/nova/blob/main/docs/nanobody_stragegy_guide.md
- Provider slug: nova

The docs guide (line ~197) links the dataset as "our Submission Archive HuggingFace dataset," establishing subnet ownership.

## Checklist

- [x] One new `registry/subnets/nova.json` file: `subnet:new` scaffold plus one community surface; no other files.
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public and read-only-safe; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [ ] Links a tracked issue — issue creation is restricted for non-collaborators; judged on its own merit.

## Validation

- [x] `npm run validate:surface -- registry/subnets/nova.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate` (full suite, green)
