### PR TITLE
fix(extrinsics): reject blank chain-position cells that coerce to 0

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -61,6 +61,8 @@ function toIso(ms) {
 // blocks.mjs in #2435.
 function toChainPosition(value) {
   if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isInteger(n) && n >= 0 ? n : null;
 }

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -423,6 +423,27 @@ test("formatExtrinsic rejects negative or non-integer chain-position cells to nu
   );
 });
 
+test("formatExtrinsic rejects blank chain-position cells that coerce to 0", () => {
+  // Mirrors the blank-cell guard in blocks.mjs (#2947): Number("") and
+  // Number("   ") are 0, which would fabricate genesis block / index 0.
+  for (const blank of ["", "   "]) {
+    const out = formatExtrinsic({
+      block_number: blank,
+      extrinsic_index: blank,
+    });
+    assert.equal(
+      out.block_number,
+      null,
+      `block_number for ${JSON.stringify(blank)}`,
+    );
+    assert.equal(
+      out.extrinsic_index,
+      null,
+      `extrinsic_index for ${JSON.stringify(blank)}`,
+    );
+  }
+});
+
 test("buildExtrinsic wraps a row + is schema-stable when absent (#1345)", () => {
   const hash = `0x${"a".repeat(64)}`;
   const out = buildExtrinsic(


### PR DESCRIPTION
## Summary

Reject blank D1 chain-position cells in extrinsic formatting so empty strings and whitespace-only values return `null` instead of coercing to block `0` / index `0`.

## What Changed

- Add a trim guard to `toChainPosition()` in `src/extrinsics.mjs`, matching the pattern merged in blocks.mjs (#2947).
- Add regression coverage in `tests/extrinsics.test.mjs` for `block_number` and `extrinsic_index`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/extrinsics.test.mjs` (57 passed)
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Sibling fix to the merged #2947 blocks blank-cell guard.
