### PR TITLE
fix(streamer): fail fast on ingest auth errors

### DIFF
--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -197,6 +197,13 @@ def push(url, payload):
             resp.read()
         return True
     except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            log.error(
+                "ingest push rejected (HTTP %s) — auth/token misconfiguration; "
+                "exiting so this does not silently retry forever",
+                e.code,
+            )
+            sys.exit(1)
         log.warning(
             "ingest push rejected (HTTP %s) — poller backstop will cover this gap",
             e.code,

--- a/scripts/test_stream_events.py
+++ b/scripts/test_stream_events.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Unit tests for the realtime streamer's ingest-push auth handling (#2687).
+
+stream-events.py is hyphenated, so it is loaded by path the same way
+test_fetch_events.py loads fetch-events.py — no package rename needed. `push()`
+is exercised with `urlopen` mocked; nothing here touches the network.
+
+    python3 scripts/test_stream_events.py          # standalone (CI-friendly)
+    python3 -m unittest scripts.test_stream_events # via the unittest runner
+    python3 -m pytest scripts/test_stream_events.py # if pytest is available
+"""
+import importlib.util
+import os
+import unittest
+import urllib.error
+from unittest.mock import patch
+
+_SE_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "stream-events.py"
+)
+_spec = importlib.util.spec_from_file_location("stream_events_under_test", _SE_PATH)
+_se = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_se)
+
+
+def _http_error(code):
+    return urllib.error.HTTPError(
+        url="https://api.metagraph.sh/api/v1/internal/events",
+        code=code,
+        msg="error",
+        hdrs=None,
+        fp=None,
+    )
+
+
+class PushAuthFatalTest(unittest.TestCase):
+    def test_401_exits_instead_of_retrying(self):
+        with patch.object(_se.urllib.request, "urlopen", side_effect=_http_error(401)):
+            with self.assertRaises(SystemExit):
+                _se.push("https://api.metagraph.sh/api/v1/internal/events", {})
+
+    def test_403_exits_instead_of_retrying(self):
+        with patch.object(_se.urllib.request, "urlopen", side_effect=_http_error(403)):
+            with self.assertRaises(SystemExit):
+                _se.push("https://api.metagraph.sh/api/v1/internal/events", {})
+
+    def test_other_http_error_is_transient_not_fatal(self):
+        with patch.object(_se.urllib.request, "urlopen", side_effect=_http_error(500)):
+            result = _se.push("https://api.metagraph.sh/api/v1/internal/events", {})
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- `scripts/stream-events.py`'s `push()` now treats an HTTP 401/403 from the ingest endpoint as fatal (logs ERROR, exits) instead of a transient error (logs WARNING, returns `False`, keeps going).

## What Changed

- Added a dedicated branch in `push()`'s `except urllib.error.HTTPError` handler: `e.code in (401, 403)` now exits the process, mirroring the existing TLS/certificate-verification-failure branch in the same function (same file, a few lines below) that already treats a cert/MITM failure as fatal rather than a silently-swallowed transient blip.
- Added `scripts/test_stream_events.py` (stdlib `unittest`, loaded by path the same way `scripts/test_fetch_events.py` loads `fetch-events.py`) covering: 401 exits, 403 exits, and a non-auth HTTP error (500) still returns `False` without exiting.

## Why

If `METAGRAPH_EVENTS_INGEST_SECRET` is ever wrong, unset, or rotated without updating the Railway deployment, every realtime push 401/403s. Before this change the streamer just logs a WARNING and keeps subscribing/decoding blocks forever — nothing pages, nothing crash-loops, nothing looks down. The only thing actually landing realtime events during that window is the CI poller backstop, so the failure mode is a full, silent regression to poller-only latency. This makes the failure loud and immediate instead, consistent with how the function already treats TLS failures on this same secret-bearing endpoint.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — no schema/API surface touched.)

## Validation

- [x] `python scripts/test_stream_events.py` (3 passed)
- [x] `npm run lint`
- [x] `npm run validate`
- [x] `npm test` (pre-existing unrelated local failures only; see note)
- [x] `git diff --check`
- [ ] `npm run validate:schemas` / `validate:api` / `validate:openapi` / `validate:types` / `validate:artifact-budgets` / `validate:docs` / `validate:intake` / `validate:workflows` / `worker:test` / `test:coverage` / `scan:public-safety` — not applicable, this PR only touches `scripts/stream-events.py` (Python, no JS/contract/registry surface)

Note on `npm test`: 24 pre-existing failures across 12 files (r2-upload execFileSync path handling, a candidate-path regex expecting `/` on a Windows checkout, and a slow enum-error test hitting the default 5s timeout) reproduce identically on a clean `main` checkout in this environment and are unrelated to this change, which only touches a Python script with zero JS test coverage.

## Issue Link

No linked issue — this is a small, self-contained fix with the repro, impact, and expected behavior documented above.