### PR TITLE
fix(api): ensure JSON responses vary on Accept for account CSV-negotiated routes

### DIFF
--- a/tests/account-routes.test.mjs
+++ b/tests/account-routes.test.mjs
@@ -4,8 +4,8 @@ import { handleRequest } from "../workers/api.mjs";
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
-function req(path) {
-  return new Request(`https://api.metagraph.sh${path}`);
+function req(path, init) {
+  return new Request(`https://api.metagraph.sh${path}`, init);
 }
 
 // A D1 mock that routes by SQL shape so the account handlers (#1347/#1847) get
@@ -242,6 +242,19 @@ test("GET /accounts/{ss58}/extrinsics is schema-stable when D1 is cold (never 40
   assert.equal(Array.isArray(body.data.extrinsics), true);
 });
 
+test("GET /accounts/{ss58}/extrinsics JSON varies on Accept when CSV is negotiated by header", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/extrinsics`, {
+      headers: { accept: "application/json" },
+    }),
+    {},
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("vary"), "Accept, Accept-Encoding");
+  assert.match(res.headers.get("content-type"), /^application\/json/);
+});
+
 test("GET /accounts/{ss58}/extrinsics?format=csv exports extrinsic_id/block_number/call_module columns (#2534)", async () => {
   const env = dbWith({
     extrinsics: [
@@ -361,6 +374,19 @@ test("GET /accounts/{ss58}/transfers is schema-stable when D1 is cold (never 404
   assert.equal(body.data.ss58, SS58);
   assert.equal(body.data.transfer_count, 0);
   assert.equal(Array.isArray(body.data.transfers), true);
+});
+
+test("GET /accounts/{ss58}/transfers JSON varies on Accept when CSV is negotiated by header", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/transfers`, {
+      headers: { accept: "application/json" },
+    }),
+    {},
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("vary"), "Accept, Accept-Encoding");
+  assert.match(res.headers.get("content-type"), /^application\/json/);
 });
 
 test("GET /accounts/{ss58}/transfers?direction=sent&format=csv filters direction and exports from/to/amount_tao columns (#2534)", async () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1190,9 +1190,11 @@ async function accountEnvelopeResponse(
   request,
   payload,
   cacheProfile = "short",
+  extraHeaders = {},
 ) {
   return envelopeResponse(request, payload, cacheProfile, {
     [X_METAGRAPH_ARTIFACT_SOURCE_HEADER]: payload.meta.source,
+    ...extraHeaders,
   });
 }
 
@@ -1512,6 +1514,7 @@ export async function handleAccountExtrinsics(request, env, ss58, url) {
       ),
     },
     "short",
+    { vary: "Accept, Accept-Encoding" },
   );
 }
 
@@ -1586,6 +1589,7 @@ export async function handleAccountTransfers(request, env, ss58, url) {
       ),
     },
     "short",
+    { vary: "Accept, Accept-Encoding" },
   );
 }
 


### PR DESCRIPTION
### Motivation
- Two account routes (`/api/v1/accounts/{ss58}/extrinsics` and `/api/v1/accounts/{ss58}/transfers`) were added to negotiate CSV using the `Accept` header, but their JSON path used shared `apiHeaders()` which only set `Vary: Accept-Encoding`, allowing a shared cache to serve the wrong representation to later `Accept: text/csv` requests.

### Description
- Allow `accountEnvelopeResponse` to accept and forward route-specific headers by adding an `extraHeaders` parameter and spreading it into the downstream `envelopeResponse` call.
- Ensure the JSON responses for `handleAccountExtrinsics` and `handleAccountTransfers` include `{ vary: "Accept, Accept-Encoding" }` so shared caches are informed about `Accept`-based representation selection.
- Update the test helper `req()` signature in `tests/account-routes.test.mjs` and add regression tests that assert the JSON responses for both account routes now set `Vary: Accept, Accept-Encoding`.
- Keep formatting and style consistent (ran `prettier` and `eslint` checks).

### Testing
- Ran the focused test file with `npm test -- tests/account-routes.test.mjs`, and all tests passed (`20 passed`).
- Ran formatting check with `npm run format:check` and lint with `npm run lint`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a488bbb82c8832c86f1689d2272149a)