### PR TITLE
fix(api): vary JSON responses by Accept

### DIFF
--- a/tests/responses-envelope.test.mjs
+++ b/tests/responses-envelope.test.mjs
@@ -23,6 +23,12 @@ test("linkHeader joins entries into an RFC 8288 header value", () => {
   assert.equal(linkHeader([]), "");
 });
 
+test("envelopeResponse marks JSON envelopes as varying by Accept", async () => {
+  const payload = { data: { ok: 1 }, meta: { contract_version: "test" } };
+  const res = await envelopeResponse(reqWith(null), payload, "standard");
+  assert.equal(res.headers.get("vary"), "Accept, Accept-Encoding");
+});
+
 test("envelopeResponse applies extra headers and skips null values", async () => {
   const payload = { data: { ok: 1 }, meta: { contract_version: "test" } };
   const res = await envelopeResponse(reqWith(null), payload, "standard", {

--- a/workers/http.mjs
+++ b/workers/http.mjs
@@ -57,7 +57,7 @@ export function apiHeaders(cacheProfile) {
   headers.set("content-type", JSON_CONTENT_TYPE);
   headers.set("x-content-type-options", "nosniff");
   headers.set("x-metagraph-cache-profile", cacheProfile);
-  headers.set("vary", "Accept-Encoding");
+  headers.set("vary", "Accept, Accept-Encoding");
   return headers;
 }
 


### PR DESCRIPTION
### Motivation

- CSV-capable analytics routes can return either JSON or CSV for the same URL depending on `Accept` negotiation, so JSON responses must advertise `Vary: Accept` to avoid shared caches serving JSON to subsequent CSV requests.
- The change fixes HTTP content-negotiation correctness for cacheable JSON envelopes without altering existing CSV behavior.

### Description

- Update the shared JSON response header builder `apiHeaders()` to include `Accept` in the `Vary` header so JSON envelopes emit `Vary: Accept, Accept-Encoding` (`workers/http.mjs`).
- Add a regression test asserting the JSON envelope `Vary` value (`tests/responses-envelope.test.mjs`).

### Testing

- Ran `npm test -- --run tests/responses-envelope.test.mjs tests/csv.test.mjs` and both test files passed.
- Ran targeted route/unit tests with `npm test -- --run tests/request-handlers-entities.test.mjs tests/analytics-edge-cache.test.mjs --testNamePattern "CSV requests use distinct neuron-tier cache keys|handleGlobalValidators|subnet metagraph|subnet validators|subnet movers|Accept: text/csv negotiates CSV"` and the selected tests passed.
- Ran `npm run lint` and `npm run format:check` and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a488d18ed34832cb14495de49f9c5bf)