### PR TITLE
feat(registry): add SN33 ReadyAI health API

### DIFF
--- a/registry/subnets/readyai.json
+++ b/registry/subnets/readyai.json
@@ -156,6 +156,22 @@
       "schema_url": "https://api.readyai.ai/openapi.json",
       "source_urls": ["https://readyai.ai/docs"],
       "url": "https://api.readyai.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-33-readyai-subnet-api",
+      "kind": "subnet-api",
+      "name": "ReadyAI health API",
+      "notes": "Public no-auth health endpoint documented by the ReadyAI OpenAPI schema.",
+      "provider": "readyai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "oktofeesh1"
+      },
+      "source_urls": ["https://api.readyai.ai/openapi.json"],
+      "url": "https://api.readyai.ai/health"
     }
   ],
   "website_url": "https://readyai.ai/"


### PR DESCRIPTION
## Summary
Adds a public no-auth ReadyAI API endpoint to the SN33 registry entry.

Refs #1282

## What changed
- Added `https://api.readyai.ai/health` as a community `subnet-api` surface.
- Used the live ReadyAI OpenAPI schema as the source proof for the endpoint.

## Why
SN33 has a live OpenAPI schema already registered, but the registry did not include a concrete public API endpoint from that schema.

## Validation
- `git diff --check`
- `npm run validate:surface -- registry/subnets/readyai.json`
- `npm run scan:public-safety`
- `npm run build`
- `npm run validate`
- Confirmed `https://api.readyai.ai/health`, `https://api.readyai.ai/openapi.json`, and `https://api.readyai.ai/docs` return HTTP 200.

## Notes
- The current public ReadyAI OpenAPI schema does not document a no-auth SSE route, so this PR does not claim to close the full SSE portion of #1282.
- Reverted deploy-owned build artifacts before committing; this PR intentionally changes only `registry/subnets/readyai.json`.