### PR TITLE
fix(chain-weights): clamp limit floor to 0 instead of 1

### DIFF
--- a/src/chain-weights.mjs
+++ b/src/chain-weights.mjs
@@ -106,7 +106,7 @@ export function buildChainWeights(
   const list = Array.isArray(subnetRows) ? subnetRows : [];
   const flooredLimit = Math.floor(Number(limit));
   const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(1, Math.min(flooredLimit, CHAIN_WEIGHTS_LIMIT_MAX))
+    ? Math.max(0, Math.min(flooredLimit, CHAIN_WEIGHTS_LIMIT_MAX))
     : CHAIN_WEIGHTS_LIMIT_DEFAULT;
   const observedAt = toIso(networkDistinct?.newest_observed);
 

--- a/tests/chain-weights.test.mjs
+++ b/tests/chain-weights.test.mjs
@@ -98,6 +98,16 @@ describe("buildChainWeights", () => {
     assert.equal(data.intensity_distribution.count, 3);
   });
 
+  test("limit of 0 yields an empty leaderboard, not a single row", () => {
+    const data = buildChainWeights(SUBNETS, {
+      window: "7d",
+      limit: 0,
+      networkDistinct: NETWORK,
+    });
+    assert.equal(data.subnets.length, 0);
+    assert.equal(data.subnet_count, 3);
+  });
+
   test("limit above the max clamps; a non-numeric limit uses the default", () => {
     const big = buildChainWeights(SUBNETS, {
       window: "7d",


### PR DESCRIPTION
## Summary
- `buildChainWeights` normalized a `limit` of `0` up to `1` (`Math.max(1, ...)`), so requesting an empty leaderboard silently returned one row instead of `[]`.
- Sibling rollup builders (`chain-turnover.mjs`, `chain-stake-flow.mjs`) already clamp the floor to `0`; `chain-weights.mjs` was the one outlier from that shared pattern.
- `buildChainWeights` is exported and documented as a pure shaping function for direct/unit-test callers, so a `limit: 0` caller silently got a schema-inconsistent single-row result instead of the empty array the sibling modules guarantee.

## Test plan
- [x] New unit test: `buildChainWeights` with `limit: 0` returns `subnets: []` (`subnet_count` unaffected)
- [x] `npm run lint`
- [x] `npm run validate`
- [x] `npx vitest run tests/chain-weights.test.mjs` (22 passed)
