### PR TITLE
fix(movers): clamp a near-total dominance share below a flat 100

### DIFF
--- a/src/movers.mjs
+++ b/src/movers.mjs
@@ -97,7 +97,13 @@ const SORT_KEY = {
 function pctShare(part, total) {
   if (!Number.isFinite(part) || !Number.isFinite(total) || total <= 0)
     return null;
-  return Math.round((part / total) * 100 * 100) / 100;
+  const pct = Math.round((part / total) * 100 * 100) / 100;
+  // A sub-total share must not round up to a flat 100 while other subnets still
+  // hold stake/emission — that would report a lone subnet as owning the whole
+  // network. Clamp to the largest 2dp value below 100, the same anti-overstatement
+  // guard formatUptimePercent and chain-transfer-pairs' top_pair_share apply. Only
+  // a genuine part === total (single-subnet network) keeps an exact 100.
+  return pct >= 100 && part < total ? 99.99 : pct;
 }
 
 // Build the per-subnet mover scorecards from the start + end snapshot aggregates and rank

--- a/tests/movers.test.mjs
+++ b/tests/movers.test.mjs
@@ -267,6 +267,38 @@ describe("movers dominance shares", () => {
     assert.equal(m[0].stake_share_pct, null);
     assert.equal(m[0].emission_share_pct, null);
   });
+
+  test("a near-total share does not round up to a flat 100 while another subnet holds stake", () => {
+    // Subnet 1 holds 249990/250000 = 99.996% of network stake; subnet 2 still
+    // holds the remaining 10 TAO. The 2dp rounding of 99.996 lands on 100.00,
+    // which would report subnet 1 as owning the ENTIRE network — clamp it below.
+    const near = { neurons: 1, validators: 0, stake: 249990, emission: 249990 };
+    const rest = { neurons: 1, validators: 0, stake: 10, emission: 10 };
+    const m = computeMovers(
+      [agg(1, "s", near), agg(2, "s", rest)],
+      [agg(1, "e", near), agg(2, "e", rest)],
+      { sort: "stake" },
+    );
+    const s1 = m.find((x) => x.netuid === 1);
+    const s2 = m.find((x) => x.netuid === 2);
+    // 249990/250000 = 99.996% -> 2dp rounds to 100.00 without the clamp.
+    assert.ok(s1.stake_share_pct < 100, "near-total share must stay below 100");
+    assert.equal(s1.stake_share_pct, 99.99);
+    assert.equal(s1.emission_share_pct, 99.99);
+    // subnet 2's 0.004% rounds to 0.00 at 2dp, but it is a distinct subnet that
+    // holds real stake — which is exactly why subnet 1 must not read as 100%.
+    assert.equal(s2.stake_share_pct, 0);
+  });
+
+  test("a genuine single-subnet network keeps an exact 100 share", () => {
+    const m = computeMovers(
+      [agg(1, "s", { neurons: 1, validators: 0, stake: 100, emission: 5 })],
+      [agg(1, "e", { neurons: 1, validators: 0, stake: 100, emission: 5 })],
+      { sort: "stake" },
+    );
+    assert.equal(m[0].stake_share_pct, 100);
+    assert.equal(m[0].emission_share_pct, 100);
+  });
 });
 
 describe("movers network summary", () => {


### PR DESCRIPTION
## What

`pctShare` in the subnet-movers leaderboard rounds each subnet's stake/emission share of the network total to 2 dp, but never guarded the round-up boundary:

```js
return Math.round((part / total) * 100 * 100) / 100;
```

A subnet holding **99.996%** of network stake — with other subnets still holding the remaining fraction — rounds to a flat **100.00**, reporting a lone subnet as owning the **entire** network in `stake_share_pct` / `emission_share_pct`.

## Concrete case

Two subnets at the end snapshot: subnet 1 holds 249990 TAO, subnet 2 holds 10 TAO (network total 250000).

- Subnet 1's true share is 99.996%.
- `Math.round(99.996 * 100) / 100 = 10000 / 100 = 100.00`
- **Before:** `stake_share_pct: 100` (overstates subnet 1 as the whole network)
- **After:** `stake_share_pct: 99.99`

## Fix

Clamp a sub-total share that rounds to `>= 100` down to the largest 2 dp value below 100 — the same anti-overstatement guard already applied by `formatUptimePercent` (badge.svg) and, as of #2971, `chain-transfer-pairs`' `top_pair_share`. Only a genuine `part === total` (single-subnet network) keeps an exact `100`.

This is an inline clamp (no new shared helper), matching the existing `formatUptimePercent` / `stability_score` style in the codebase.

## Tests

- New: a near-total share (99.996%) with another subnet present clamps to `99.99` for both `stake_share_pct` and `emission_share_pct` — fails on the old code, passes with the fix.
- New: a genuine single-subnet network keeps an exact `100`.
- Existing dominance-share tests (89.29 / 10.71, null-on-zero-total, etc.) still pass (31/31).

Source + tests only — no schema/contract/generated-artifact changes. `eslint` clean, `prettier` clean, 100% patch coverage of the changed lines.
