### PR TITLE
feat(api): add ?format=csv to GET /api/v1/subnets/{netuid}/events and /accounts/{ss58}/events (#2533)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -79,7 +79,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
+        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). Pass ?format=csv to download the page as CSV. */
         get: operations["accountEvents"];
         put?: never;
         post?: never;
@@ -1541,7 +1541,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. */
+        /** Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. Pass ?format=csv to download the page as CSV. */
         get: operations["subnetEvents"];
         put?: never;
         post?: never;
@@ -6768,6 +6768,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -6777,7 +6779,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -6831,6 +6833,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountEventsArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index
+                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,,2026-07-03T00:00:00.000Z,2
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -18700,6 +18707,8 @@ export interface operations {
                 block_end?: number;
                 limit?: number;
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -18709,7 +18718,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -18763,6 +18772,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetEventsArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index
+                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,,2026-07-03T00:00:00.000Z,2
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4970,7 +4970,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/events.json",
       "cache": "short",
-      "description": "Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset.",
+      "description": "Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. Pass ?format=csv to download the page as CSV.",
       "id": "subnet-events",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/events",
@@ -5011,6 +5011,17 @@
           "schema": {
             "minimum": 0,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]
@@ -5148,7 +5159,7 @@
     {
       "artifact_path": "/metagraph/accounts/{ss58}/events.json",
       "cache": "short",
-      "description": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+      "description": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). Pass ?format=csv to download the page as CSV.",
       "id": "account-events",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/events",
@@ -5201,6 +5212,17 @@
         {
           "name": "cursor",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
             "type": "string"
           }
         }

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -570,7 +570,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "First-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, served live from the account_events D1 tier filtered by netuid at /api/v1/subnets/{netuid}/events (no static file).",
+      "description": "First-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, served live from the account_events D1 tier filtered by netuid at /api/v1/subnets/{netuid}/events; pass ?format=csv to download the page as CSV (no static file).",
       "id": "subnet-events",
       "path": "/metagraph/subnets/{netuid}/events.json",
       "schema_ref": "#/components/schemas/SubnetEventsArtifact",
@@ -624,7 +624,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events (no static file).",
+      "description": "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events; pass ?format=csv to download the page as CSV (no static file).",
       "id": "account-events",
       "path": "/metagraph/accounts/{ss58}/events.json",
       "schema_ref": "#/components/schemas/AccountEventsArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -18230,6 +18230,19 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -18291,9 +18304,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index\r\n8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,,2026-07-03T00:00:00.000Z,2",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -18350,7 +18369,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+        "summary": "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). Pass ?format=csv to download the page as CSV.",
         "tags": [
           "accounts",
           "analytics"
@@ -36368,6 +36387,19 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -36429,9 +36461,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index\r\n8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,,2026-07-03T00:00:00.000Z,2",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -36488,7 +36526,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset.",
+        "summary": "Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. Pass ?format=csv to download the page as CSV.",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -79,7 +79,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). */
+        /** Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). Pass ?format=csv to download the page as CSV. */
         get: operations["accountEvents"];
         put?: never;
         post?: never;
@@ -1541,7 +1541,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. */
+        /** Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. Pass ?format=csv to download the page as CSV. */
         get: operations["subnetEvents"];
         put?: never;
         post?: never;
@@ -6768,6 +6768,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -6777,7 +6779,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -6831,6 +6833,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountEventsArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index
+                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,,2026-07-03T00:00:00.000Z,2
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -18700,6 +18707,8 @@ export interface operations {
                 block_end?: number;
                 limit?: number;
                 offset?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -18709,7 +18718,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -18763,6 +18772,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetEventsArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index
+                     *     8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,,2026-07-03T00:00:00.000Z,2
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -998,7 +998,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "subnet-events",
     "/metagraph/subnets/{netuid}/events.json",
-    "First-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, served live from the account_events D1 tier filtered by netuid at /api/v1/subnets/{netuid}/events (no static file).",
+    "First-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, served live from the account_events D1 tier filtered by netuid at /api/v1/subnets/{netuid}/events; pass ?format=csv to download the page as CSV (no static file).",
     "SubnetEventsArtifact",
   ),
   artifact(
@@ -1034,7 +1034,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "account-events",
     "/metagraph/accounts/{ss58}/events.json",
-    "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events (no static file).",
+    "Paginated first-party chain-event history for one account (hotkey or coldkey), served live from the account_events D1 tier at /api/v1/accounts/{ss58}/events; pass ?format=csv to download the page as CSV (no static file).",
     "AccountEventsArtifact",
   ),
   artifact(
@@ -2039,16 +2039,16 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/events",
     "/metagraph/subnets/{netuid}/events.json",
-    "Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset.",
+    "Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events D1 tier filtered by netuid. Optional ?kind= filter and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset. Pass ?format=csv to download the page as CSV.",
     "short",
     ["subnets", "analytics"],
-    [
+    csvRouteQuery([
       { name: "kind", schema: { type: "string" } },
       { name: "block_start", schema: { type: "integer", minimum: 0 } },
       { name: "block_end", schema: { type: "integer", minimum: 0 } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
-    ],
+    ]),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(
@@ -2134,10 +2134,10 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/events",
     "/metagraph/accounts/{ss58}/events.json",
-    "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851).",
+    "Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first. Optional ?kind= filter, ?netuid= to scope to one subnet, and ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging (#1851). Pass ?format=csv to download the page as CSV.",
     "short",
     ["accounts", "analytics"],
-    [
+    csvRouteQuery([
       { name: "kind", schema: { type: "string" } },
       { name: "netuid", schema: { type: "integer", minimum: 0 } },
       { name: "block_start", schema: { type: "integer", minimum: 0 } },
@@ -2145,7 +2145,7 @@ export const API_ROUTES = [
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "cursor", schema: { type: "string" } },
-    ],
+    ]),
     [{ name: "ss58", schema: { type: "string" } }],
   ),
   route(

--- a/src/csv-route-examples.mjs
+++ b/src/csv-route-examples.mjs
@@ -1,9 +1,18 @@
 // Supplemental OpenAPI CSV examples for routes whose handlers live outside
 // analytics-routes.mjs. Kept in a dedicated module so parallel CSV PRs can add
 // examples without contending on the csvExampleForRoute if-chain in contracts.mjs.
+// Shared header/example for the two event-stream feeds (subnet + account), which
+// serialize the same formatAccountEvent row shape.
+const EVENTS_CSV_EXAMPLE = [
+  "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index",
+  "8454388,3,StakeAdded,5Hotkey_sample,5Coldkey_sample,7,3,12.5,,2026-07-03T00:00:00.000Z,2",
+].join("\r\n");
+
 export const ROUTE_CSV_EXAMPLES = {
   "subnet-yield": [
     "uid,hotkey,role,stake_tao,emission_tao,yield,vs_median",
     "0,hk_sample,validator,1000,22.1,0.0221,above",
   ].join("\r\n"),
+  "subnet-events": EVENTS_CSV_EXAMPLE,
+  "account-events": EVENTS_CSV_EXAMPLE,
 };

--- a/tests/account-routes.test.mjs
+++ b/tests/account-routes.test.mjs
@@ -156,6 +156,56 @@ test("GET /accounts/{ss58}/events rejects an unsupported query param", async () 
   assert.equal(res.status, 400);
 });
 
+const EVENTS_CSV_HEADER =
+  "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index";
+
+test("GET /accounts/{ss58}/events?format=csv streams the event rows as CSV", async () => {
+  const env = dbWith({
+    events: [
+      {
+        block_number: 200,
+        event_index: 1,
+        event_kind: "StakeAdded",
+        hotkey: SS58,
+        coldkey: null,
+        netuid: 7,
+        uid: 3,
+        amount_tao: 2.0,
+        observed_at: 1750009000000,
+      },
+    ],
+  });
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/events?format=csv&kind=StakeAdded`),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  assert.match(
+    res.headers.get("content-disposition") ?? "",
+    /attachment; filename="/,
+  );
+  const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines[0], EVENTS_CSV_HEADER);
+  assert.equal(lines.length, 2);
+  const cells = lines[1].split(",");
+  assert.equal(cells[0], "200"); // block_number
+  assert.equal(cells[2], "StakeAdded"); // event_kind
+  assert.equal(cells[7], "2"); // amount_tao
+});
+
+test("GET /accounts/{ss58}/events?format=csv emits a header-only CSV when cold", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/events?format=csv`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  assert.equal((await res.text()).trim(), EVENTS_CSV_HEADER);
+});
+
 test("GET /accounts/{ss58}/subnets returns the cross-subnet footprint (#1347)", async () => {
   const env = dbWith({
     registrations: [

--- a/tests/subnet-events.test.mjs
+++ b/tests/subnet-events.test.mjs
@@ -87,6 +87,56 @@ test("GET /subnets/{netuid}/events rejects an unsupported query param", async ()
   assert.equal(res.status, 400);
 });
 
+const EVENTS_CSV_HEADER =
+  "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index";
+
+test("GET /subnets/{netuid}/events?format=csv streams the event rows as CSV", async () => {
+  const env = dbWith({ events: [ROW] });
+  const res = await handleRequest(
+    req("/api/v1/subnets/7/events?format=csv"),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  assert.match(
+    res.headers.get("content-disposition") ?? "",
+    /attachment; filename="/,
+  );
+  const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines[0], EVENTS_CSV_HEADER);
+  assert.equal(lines.length, 2);
+  const cells = lines[1].split(",");
+  assert.equal(cells[0], "4000200"); // block_number
+  assert.equal(cells[2], "NeuronRegistered"); // event_kind
+  assert.equal(cells[5], "7"); // netuid
+});
+
+test("GET /subnets/{netuid}/events?kind=&format=csv keeps the CSV shape when filtering", async () => {
+  const env = dbWith({ events: [{ ...ROW, event_kind: "WeightsSet" }] });
+  const res = await handleRequest(
+    req("/api/v1/subnets/7/events?kind=WeightsSet&format=csv"),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines[0], EVENTS_CSV_HEADER);
+  assert.equal(lines[1].split(",")[2], "WeightsSet");
+});
+
+test("GET /subnets/{netuid}/events?format=csv emits a header-only CSV when cold", async () => {
+  const res = await handleRequest(
+    req("/api/v1/subnets/7/events?format=csv"),
+    {},
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  assert.equal((await res.text()).trim(), EVENTS_CSV_HEADER);
+});
+
 test("GET /subnets/{netuid}/events is schema-stable when D1 is cold (never 404)", async () => {
   const res = await handleRequest(req("/api/v1/subnets/7/events"), {}, {});
   assert.equal(res.status, 200);

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -242,6 +242,21 @@ const ACCOUNT_TRANSFERS_CSV_COLUMNS = [
   "direction",
   "observed_at",
 ];
+// Shared column order for the subnet + account event-stream feeds — the
+// formatAccountEvent row shape, stable so a CSV consumer's columns never shift.
+const EVENTS_CSV_COLUMNS = [
+  "block_number",
+  "event_index",
+  "event_kind",
+  "hotkey",
+  "coldkey",
+  "netuid",
+  "uid",
+  "amount_tao",
+  "alpha_amount",
+  "observed_at",
+  "extrinsic_index",
+];
 
 function validateResponseFormat(url) {
   const raw = url.searchParams.get("format");
@@ -1267,7 +1282,7 @@ export async function handleAccount(request, env, ss58) {
 // GET /api/v1/accounts/{ss58}/events: paginated event history (newest first),
 // optional ?kind= filter, ?limit (<=1000) / ?offset.
 export async function handleAccountEvents(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "kind",
     "netuid",
     "block_start",
@@ -1275,6 +1290,7 @@ export async function handleAccountEvents(request, env, ss58, url) {
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   // Optional block-height range filter, parity with the extrinsics and
@@ -1317,6 +1333,15 @@ export async function handleAccountEvents(request, env, ss58, url) {
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.events,
+      "account-events",
+      "short",
+      request,
+      EVENTS_CSV_COLUMNS,
+    );
+  }
   return accountEnvelopeResponse(
     request,
     {
@@ -1695,13 +1720,14 @@ export async function handleAccountPortfolio(request, env, ss58) {
 // ?kind= filter; ?limit (<=1000)/?offset. Cold/absent store → schema-stable zero
 // (never 404), mirroring handleAccountEvents.
 export async function handleSubnetEvents(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "kind",
     "block_start",
     "block_end",
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const kind = url.searchParams.get("kind");
@@ -1736,6 +1762,15 @@ export async function handleSubnetEvents(request, env, netuid, url) {
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
   });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.events,
+      "subnet-events",
+      "short",
+      request,
+      EVENTS_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

Add `?format=csv` (and `Accept: text/csv`) negotiation to the two first-party chain-event feeds — `GET /api/v1/subnets/{netuid}/events` and `GET /api/v1/accounts/{ss58}/events` — mirroring the account-extrinsics/transfers CSV branch (#2846). Both routes serialize the current page's `events` array to CSV with stable column headers; the JSON envelope is unchanged when CSV is not requested.

Closes #2533

## What Changed

- `workers/request-handlers/entities.mjs`: a shared `EVENTS_CSV_COLUMNS` order (the `formatAccountEvent` row shape) plus a `csvRequested(...)` → `csvResponse(data.events, ...)` branch in `handleAccountEvents` and `handleSubnetEvents`, before the JSON envelope. Both handlers now validate via `validateEntityQuery` with `format` allowed (rejecting `?format=xml`). These routes are served direct (no edge cache — the code comment notes this), so no cache-key variant is needed; `csvResponse` sets its own `text/csv` + `content-disposition` + weak ETag.
- `src/contracts.mjs`: wrapped the `subnet-events` and `account-events` route query params in `csvRouteQuery(...)` (adds the `format` param + `text/csv` response to the OpenAPI), and noted `?format=csv` in both route + artifact descriptions.
- `src/csv-route-examples.mjs`: a shared `EVENTS_CSV_EXAMPLE` for both route ids (the dedicated module the repo keeps for CSV examples so parallel CSV PRs don't contend on the `contracts.mjs` if-chain).
- Regenerated + committed the derived contract artifacts (`npm run build`): `openapi.json`, `contracts.json`, `api-index.json`, `types.d.ts`, `generated/metagraphed-api.d.ts`. Per repo policy, `public/metagraph/r2-manifest.json` and `public/metagraph/schemas/index.json` are intentionally NOT included (deploy/publish-pipeline-owned).
- Tests: `?format=csv` emits the header + a data row; `?kind=…&format=csv` keeps the CSV shape while filtering; a cold/empty store emits a header-only CSV.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts (`npm run build`), not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed (r2-manifest.json / schemas/index.json excluded).
- [x] Public API/OpenAPI/schema changes are intentional and documented (new `format` param + `text/csv` response on the two event routes).

## Validation

- [x] `npm run build` (regenerated + committed OpenAPI/types/contracts)
- [x] `npm run validate` · `validate:contract-drift` · `validate:openapi` · `validate:api` · `validate:schemas` · `validate:types` · `validate:docs`
- [x] `npx vitest run tests/subnet-events.test.mjs tests/account-routes.test.mjs tests/contracts.test.mjs tests/csv.test.mjs`
- [x] `npm run lint` · `npm run format:check` · `git diff --check`
