### PR TITLE
fix(health): coerce D1 string-typed netuid in live surface_status fallback

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1291,21 +1291,38 @@ function isoFromMs(ms) {
   return Number.isFinite(date.getTime()) ? date.toISOString() : null;
 }
 
+// D1 can hand the INTEGER netuid column back as a numeric string on this
+// `surface_status` read path; the emitted netuid both groups the per-subnet
+// `subnets` summary (Map key) and rides into the response contract, so a raw
+// string netuid would splinter a subnet's surfaces across two group keys and
+// ship a string where every other route ships a number. Accept only a real
+// number or an all-digits string so a blank/null cell is dropped rather than
+// read as valid subnet 0 (Number("") === Number(null) === 0).
+function normalizedNetuid(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const netuid = Number(value);
+  return Number.isSafeInteger(netuid) && netuid >= 0 ? netuid : null;
+}
+
 function liveFromD1Rows(rows) {
-  const surfaces = rows.map((r) => ({
-    surface_id: r.surface_id,
-    surface_key: r.surface_key ?? null,
-    netuid: r.netuid,
-    kind: r.kind,
-    provider: r.provider,
-    url: r.url,
-    status: normalizeProbeStatus(r.status),
-    classification: r.classification,
-    latency_ms: Number.isFinite(r.latency_ms) ? r.latency_ms : null,
-    status_code: Number.isInteger(r.status_code) ? r.status_code : null,
-    last_checked: isoFromMs(r.last_checked),
-    last_ok: isoFromMs(r.last_ok),
-  }));
+  const surfaces = rows
+    .map((r) => ({ ...r, netuid: normalizedNetuid(r.netuid) }))
+    .filter((r) => r.netuid != null)
+    .map((r) => ({
+      surface_id: r.surface_id,
+      surface_key: r.surface_key ?? null,
+      netuid: r.netuid,
+      kind: r.kind,
+      provider: r.provider,
+      url: r.url,
+      status: normalizeProbeStatus(r.status),
+      classification: r.classification,
+      latency_ms: Number.isFinite(r.latency_ms) ? r.latency_ms : null,
+      status_code: Number.isInteger(r.status_code) ? r.status_code : null,
+      last_checked: isoFromMs(r.last_checked),
+      last_ok: isoFromMs(r.last_ok),
+    }));
   const byNetuid = new Map();
   for (const row of surfaces) {
     const group = byNetuid.get(row.netuid) || [];

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -1369,6 +1369,73 @@ describe("resolveLiveHealth (KV → D1 → null)", () => {
     assert.match(live.surfaces[0].last_ok, /^20\d\d-/);
   });
 
+  test("D1 fallback coerces a string netuid and drops a blank one (never subnet 0)", async () => {
+    // D1 hands the INTEGER netuid column back as "7" on this read path; the
+    // emitted netuid both keys the per-subnet summary Map and rides into the
+    // response, so a raw string would splinter one subnet's rows across two
+    // group keys. A blank cell must be dropped, not coerced to subnet 0.
+    const db = d1With([
+      {
+        surface_id: "7:subnet-api:a",
+        surface_key: "srf-strnetuid0000a",
+        netuid: "7",
+        kind: "subnet-api",
+        provider: "a",
+        url: "https://a",
+        status: "ok",
+        classification: "up",
+        latency_ms: 10,
+        status_code: 200,
+        last_checked: 1_700_000_000_000,
+        last_ok: 1_700_000_000_000,
+      },
+      {
+        surface_id: "7:subnet-api:b",
+        surface_key: "srf-strnetuid0000b",
+        netuid: 7,
+        kind: "subnet-api",
+        provider: "b",
+        url: "https://b",
+        status: "ok",
+        classification: "up",
+        latency_ms: 20,
+        status_code: 200,
+        last_checked: 1_700_000_000_000,
+        last_ok: 1_700_000_000_000,
+      },
+      {
+        surface_id: "blank:subnet-api:c",
+        surface_key: "srf-blanknetuid00c",
+        netuid: "",
+        kind: "subnet-api",
+        provider: "c",
+        url: "https://c",
+        status: "ok",
+        classification: "up",
+        latency_ms: 5,
+        status_code: 200,
+        last_checked: 1_700_000_000_000,
+        last_ok: 1_700_000_000_000,
+      },
+    ]);
+    const live = await resolveLiveHealth({
+      readHealthKv: async () => null,
+      env: {},
+      db,
+      now: () => 1_700_000_600_000,
+    });
+    assert.deepEqual(
+      live.surfaces.map((s) => s.surface_id),
+      ["7:subnet-api:a", "7:subnet-api:b"],
+    );
+    assert.equal(typeof live.surfaces[0].netuid, "number");
+    assert.equal(live.surfaces[0].netuid, 7);
+    // Both surfaces land in the SAME subnet-7 group, not two separate rows.
+    assert.equal(live.subnets.length, 1);
+    assert.equal(live.subnets[0].netuid, 7);
+    assert.equal(live.subnets[0].surface_count, 2);
+  });
+
   test("D1 fallback folds unrecognized surface status into unknown in global status_counts", async () => {
     const now = 1_700_000_600_000;
     const db = {


### PR DESCRIPTION
## Summary

- `src/health-serving.mjs`'s `liveFromD1Rows()` (the D1 fallback path `resolveLiveHealth()` uses when KV `health:current` is cold) now coerces the `surface_status.netuid` D1 column to a real integer, dropping a blank/null cell instead of silently reading it as subnet 0 or shipping a string.

## What Changed

- Added `normalizedNetuid(value)` to `src/health-serving.mjs`, matching the convention already used in `src/movers.mjs`, `src/chain-turnover.mjs`, `src/chain-weights.mjs`, `src/account-stake-flow.mjs`, `src/chain-stake-flow.mjs`, and (most recently, #2938) `src/analytics-live.mjs` / `src/subnet-identity-history.mjs`: accept only a real number or an all-digits string, reject blank/null (never coerce to subnet 0 via `Number("") === 0`).
- `liveFromD1Rows()` now coerces + drops any row whose `netuid` doesn't survive that check, before it ever reaches the per-subnet grouping `Map` or the response.
- Added a regression test in `tests/health-serving.test.mjs` covering: a string `"7"` netuid coerces to the number `7` and groups with a sibling `netuid: 7` row under one subnet-7 summary (not split across two group keys), and a blank `netuid: ""` row is dropped entirely rather than surfacing as subnet 0.

## Why

D1/SQLite can hand an `INTEGER` column back as a numeric string on this read path (the same class of issue #2938, #2641, #2474, #2728 fixed elsewhere in this codebase). Here the emitted `netuid` is used as a `Map` key to group surfaces into the per-subnet `subnets` summary AND rides directly into the live-health API response. A raw string netuid would:
- Splinter one subnet's surfaces across two different group keys (`7` vs `"7"`) if any row for that subnet ever came back typed differently, corrupting the `subnets[]` summary counts for that subnet.
- Ship a string `netuid` in the API response where every sibling live-health route ships a number, an inconsistent contract for API consumers.

This file was untouched by #2938 (which covered `analytics-live.mjs` and `subnet-identity-history.mjs` only), so this specific D1 read path was still exposed.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — internal D1-row shaping only, no contract change.)

## Validation

- [x] `npx vitest run tests/health-serving.test.mjs` (138 passed)
- [x] `npm run lint`
- [x] `npx prettier --check src/health-serving.mjs tests/health-serving.test.mjs`
- [x] `npm run validate`
- [x] `npm test` (pre-existing unrelated local failures only, reproduce identically on a clean `main` checkout in this environment: Windows execFileSync/path-separator issues in `tests/r2-upload.test.mjs` + `tests/script-utils.test.mjs`, and a slow enum-error test hitting the default 5s timeout in `tests/validate-error-messages.test.mjs`)
- [x] `git diff --check`
- [ ] `npm run validate:schemas` / `validate:api` / `validate:openapi` / `validate:types` / `validate:artifact-budgets` / `validate:docs` / `validate:intake` / `validate:workflows` / `worker:test` / `test:coverage` / `scan:public-safety` — not applicable, no schema/contract/registry surface touched

## Issue Link

No linked issue — small, self-contained fix with the repro, impact, and expected behavior documented above.