### PR TITLE
feat(api): add CSV export (?format=csv) to /api/v1/chain/stake-flow

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -10252,6 +10252,8 @@ export interface operations {
             query?: {
                 window?: "7d" | "30d";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the per-subnet capital-flow leaderboard as text/csv; `json` (default) keeps the response envelope (which also carries the network rollup + net-flow distribution). */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10259,7 +10261,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -10338,6 +10340,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainStakeFlowArtifact"];
                     };
+                    /**
+                     * @example netuid,total_staked_tao,total_unstaked_tao,net_flow_tao,gross_flow_tao,stake_events,unstake_events,direction
+                     *     1,100,30,70,130,5,2,inflow
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -6128,6 +6128,17 @@
             "minimum": 1,
             "type": "integer"
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the per-subnet capital-flow leaderboard as text/csv; `json` (default) keeps the response envelope (which also carries the network rollup + net-flow distribution).",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -22908,6 +22908,19 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the per-subnet capital-flow leaderboard as text/csv; `json` (default) keeps the response envelope (which also carries the network rollup + net-flow distribution).",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -22994,9 +23007,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,total_staked_tao,total_unstaked_tao,net_flow_tao,gross_flow_tao,stake_events,unstake_events,direction\r\n1,100,30,70,130,5,2,inflow",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -10252,6 +10252,8 @@ export interface operations {
             query?: {
                 window?: "7d" | "30d";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the per-subnet capital-flow leaderboard as text/csv; `json` (default) keeps the response envelope (which also carries the network rollup + net-flow distribution). */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10259,7 +10261,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -10338,6 +10340,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainStakeFlowArtifact"];
                     };
+                    /**
+                     * @example netuid,total_staked_tao,total_unstaked_tao,net_flow_tao,gross_flow_tao,stake_events,unstake_events,direction
+                     *     1,100,30,70,130,5,2,inflow
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2568,10 +2568,22 @@ export const API_ROUTES = [
     "Fetch network-wide cross-subnet capital flow over a 7d or 30d window: every subnet that moved stake in the window ranked by net StakeAdded minus StakeRemoved TAO (subnets with no stake events in the window are excluded) (biggest net inflow first, ?limit <=100), with per-subnet staked/unstaked/net/gross totals and a direction label, a network rollup, and a distribution (count, mean, min, p25, median, p75, p90, max) of the per-subnet net flow. Computed live from the account_events stake stream; schema-stable zeros + empty leaderboard when cold.",
     "short",
     ["chain", "analytics"],
-    [
-      { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
-      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
-    ],
+    {
+      csvResponse: true,
+      parameters: [
+        { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
+        {
+          name: "limit",
+          schema: { type: "integer", minimum: 1, maximum: 100 },
+        },
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the per-subnet capital-flow leaderboard as text/csv; `json` (default) keeps the response envelope (which also carries the network rollup + net-flow distribution).",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [],
   ),
   route(
@@ -3464,6 +3476,14 @@ function csvExampleForRoute(entry) {
     return [
       "day,extrinsic_count,total_fee_tao,avg_fee_tao,median_fee_tao,total_tip_tao,avg_tip_tao,median_tip_tao",
       "2026-07-01,15000,42.5,0.002833,0.0025,0,0,0",
+    ].join("\r\n");
+  }
+  if (entry.id === "chain-stake-flow") {
+    // The row-shaped per-subnet leaderboard (data.subnets); the network rollup +
+    // net_flow_distribution stay JSON-only, mirroring chain-fees' top_fee_payers.
+    return [
+      "netuid,total_staked_tao,total_unstaked_tao,net_flow_tao,gross_flow_tao,stake_events,unstake_events,direction",
+      "1,100,30,70,130,5,2,inflow",
     ].join("\r\n");
   }
   if (entry.id === "blocks-feed") {

--- a/tests/chain-stake-flow.test.mjs
+++ b/tests/chain-stake-flow.test.mjs
@@ -338,6 +338,71 @@ describe("GET /api/v1/chain/stake-flow", () => {
     const res = await handleRequest(req("?limit=0"), stakeFlowEnv([]), {});
     assert.equal(res.status, 400);
   });
+
+  test("exports the per-subnet leaderboard as CSV with ?format=csv", async () => {
+    const res = await handleRequest(
+      req("?window=7d&format=csv"),
+      stakeFlowEnv(ROWS),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    assert.match(
+      res.headers.get("content-disposition"),
+      /attachment; filename="chain-stake-flow\.csv"/,
+    );
+    const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(
+      lines[0],
+      "netuid,total_staked_tao,total_unstaked_tao,net_flow_tao,gross_flow_tao,stake_events,unstake_events,direction",
+    );
+    // Biggest net inflow first: netuid 1 (net +70) leads, then 3 (0), then 2 (-60).
+    assert.equal(lines.length, 4); // header + 3 subnet rows
+    assert.equal(lines[1], "1,100,30,70,130,5,2,inflow");
+  });
+
+  test("honors Accept: text/csv the same as ?format=csv", async () => {
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/chain/stake-flow", {
+        headers: { accept: "text/csv" },
+      }),
+      stakeFlowEnv(ROWS),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+  });
+
+  test("emits a header-only CSV on a cold store", async () => {
+    const res = await handleRequest(req("?format=csv"), stakeFlowEnv([]), {});
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    assert.equal(
+      (await res.text()).trim(),
+      "netuid,total_staked_tao,total_unstaked_tao,net_flow_tao,gross_flow_tao,stake_events,unstake_events,direction",
+    );
+  });
+
+  test("serves a CSV HEAD probe with the CSV headers and no body", async () => {
+    const res = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/chain/stake-flow?format=csv",
+        {
+          method: "HEAD",
+        },
+      ),
+      stakeFlowEnv(ROWS),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    assert.equal(await res.text(), ""); // HEAD carries no body
+  });
+
+  test("rejects an unsupported format value with 400", async () => {
+    const res = await handleRequest(req("?format=xml"), stakeFlowEnv([]), {});
+    assert.equal(res.status, 400);
+  });
 });
 
 describe("chain/stake-flow edge cache", () => {

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -747,6 +747,19 @@ const CHAIN_FEES_CSV_COLUMNS = [
   "avg_tip_tao",
   "median_tip_tao",
 ];
+// The stake-flow CSV exports the per-subnet capital-flow leaderboard (data.subnets)
+// — the row-shaped table, mirroring chain-signers; the network rollup and
+// net_flow_distribution stay JSON-only in the envelope.
+const CHAIN_STAKE_FLOW_CSV_COLUMNS = [
+  "netuid",
+  "total_staked_tao",
+  "total_unstaked_tao",
+  "net_flow_tao",
+  "gross_flow_tao",
+  "stake_events",
+  "unstake_events",
+  "direction",
+];
 
 // Daily network-activity aggregates over the first-party chain D1 tiers (#1987):
 // per-UTC-day extrinsic/event/block counts, success rate, and unique signers —
@@ -1074,13 +1087,16 @@ export async function handleChainTransferPairs(request, env, url, ctx = {}) {
 // distribution. The network companion to /api/v1/subnets/{netuid}/stake-flow; edge-cached like
 // the sibling chain-transfers route (account_events-derived, analytics cron freshness).
 export async function handleChainStakeFlow(request, env, url, ctx = {}) {
-  const { label, days, error } = analyticsWindow(url, ["limit"]);
+  const { label, days, error } = analyticsWindow(url, ["limit", "format"]);
   if (error) return analyticsQueryError(error);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { limit, error: limitError } = parseLimitParam(url, {
     defaultLimit: CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
     maxLimit: CHAIN_STAKE_FLOW_LIMIT_MAX,
   });
   if (limitError) return analyticsQueryError(limitError);
+  const csv = csvRequested(url, request);
 
   // Normalize HEAD probes through the GET cache key so they cannot bypass the edge cache and
   // repeatedly force the network-wide account_events aggregation (mirrors chain-transfers).
@@ -1099,6 +1115,17 @@ export async function handleChainStakeFlow(request, env, url, ctx = {}) {
         windowDays: days,
         limit,
       });
+      // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
+      // net_flow_distribution stay JSON-only (mirrors chain-fees' top_fee_payers).
+      if (csv) {
+        return csvResponse(
+          data.subnets,
+          "chain-stake-flow",
+          "short",
+          cacheRequest,
+          CHAIN_STAKE_FLOW_CSV_COLUMNS,
+        );
+      }
       return envelopeResponse(
         cacheRequest,
         {
@@ -1112,7 +1139,7 @@ export async function handleChainStakeFlow(request, env, url, ctx = {}) {
         "short",
       );
     },
-    canonicalAnalyticsCacheRoute(url, ["limit"]),
+    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })


### PR DESCRIPTION
## Summary

The sibling chain-analytics leaderboards `/api/v1/chain/activity`, `/chain/calls`, `/chain/signers`, and `/chain/fees` already stream `text/csv` via `?format=csv` (or `Accept: text/csv`), but `/api/v1/chain/stake-flow` did not. This adds the same affordance so the per-subnet cross-subnet capital-flow board can be pulled into a spreadsheet without hand-converting the JSON envelope — closing a consistency gap in the chain family rather than introducing a new pattern (mirrors the recently-merged CSV exports on `/subnets/{netuid}/trajectory` and `/subnets/{netuid}/yield`).

## What Changed

- **`workers/request-handlers/analytics.mjs`** — `handleChainStakeFlow` now accepts `format`, validates it (`validateFormatParam`), and when CSV is requested returns `csvResponse(data.subnets, "chain-stake-flow", "short", …, CHAIN_STAKE_FLOW_CSV_COLUMNS)`; the `format=csv` variant gets its own edge-cache key. Implementation copied structurally from `handleChainSigners` / `handleChainFees`.
- **`src/contracts.mjs`** — the `chain-stake-flow` route gains the `csvResponse: true` + `format` query parameter (same shape as `chain-fees`), plus a worked CSV example in `csvExampleForRoute`.
- CSV exports the row-shaped `data.subnets` leaderboard: `netuid,total_staked_tao,total_unstaked_tao,net_flow_tao,gross_flow_tao,stake_events,unstake_events,direction`. The network rollup (`data.network`) and `net_flow_distribution` stay JSON-only, exactly as `/chain/fees` keeps `top_fee_payers` JSON-only.
- Regenerated contract artifacts (`public/metagraph/openapi.json`, `types.d.ts`, `api-index.json`, `generated/metagraphed-api.d.ts`) committed from `npm run build`; deploy-owned / content-derived artifacts reverted against `upstream/main`.
- **`tests/chain-stake-flow.test.mjs`** — added coverage: `?format=csv` header + rows, `Accept: text/csv`, header-only CSV on a cold store, a CSV `HEAD` probe (no body), and a `400` on an unsupported `format`.

No data-shape change; the JSON envelope is byte-for-byte unchanged when CSV is not requested.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts (`npm run build`), not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed (`r2-manifest.json` / `schemas/index.json` / `operational-surfaces.json` reverted to `upstream/main`).
- [x] Public API/OpenAPI/schema changes are intentional and documented above.

## Validation

Run locally (Windows; Node 22):

- [x] `npm run validate`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi` + `validate:openapi-examples`
- [x] `npm run validate:types`
- [x] `npm run validate:contract-drift` + `validate:generated-client` + `validate:committed-seed` + `validate:schema-enums`
- [x] `npm run validate:mcp` · `validate:client-sdk-sync` · `validate:artifact-budgets` · `validate:docs`
- [x] `npm run worker:test`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
- [x] `eslint` + `prettier --check` on the changed files (clean)
- [x] `vitest run` on the affected suites — 355 passing, including the new CSV tests

Note: the full `test:coverage` / `format:check .` were not run whole-repo because this box is Windows and a handful of suites shell out to Linux-only tooling (`wrangler`/`pg_dump`) and prettier flags CRLF on files unrelated to this change; the committed blobs are LF-normalized and the CI Linux runner covers the full suite.

No linked issue: issue creation on this repo returned 404 for the available account, and a linked issue is optional per `CONTRIBUTING.md` (a PR is judged on its own merit).