### PR TITLE
feat(registry): add SN22 Desearch Search Evals data-artifact

### DIFF
--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -241,6 +241,24 @@
       "schema_url": "https://api.desearch.ai/openapi.json",
       "source_urls": ["https://www.desearch.ai/docs"],
       "url": "https://api.desearch.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-22-desearch-search-evals",
+      "kind": "data-artifact",
+      "name": "Desearch Search Evals (Hugging Face)",
+      "notes": "Public CC-BY-4.0 Hugging Face dataset of Desearch search-quality evaluations, published and documented in the official Desearch-ai/desearch-search-evals repo.",
+      "provider": "desearch",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://github.com/Desearch-ai/desearch-search-evals/blob/cfd3c83b553f6fa61e4fe71b08d46dcbb098b8d5/README.md#L56"
+      ],
+      "url": "https://huggingface.co/datasets/desearch/desearch-search-evals"
     }
   ],
   "website_url": "https://www.desearch.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/desearch.json` (SN22 Desearch). Append-only; no other files changed.

## Summary

SN22 (Desearch) had no `data-artifact` surface. Desearch publishes a public CC-BY-4.0 Hugging Face dataset of its search-quality evaluations, `desearch/desearch-search-evals`. The official `Desearch-ai/desearch-search-evals` repo badges and documents this exact dataset (README line 56, `load_dataset("desearch/desearch-search-evals", ...)`), establishing first-party ownership.

## Surface

- Netuid: 22
- Kind: data-artifact
- Public URL: https://huggingface.co/datasets/desearch/desearch-search-evals
- Source URL (proves the claim): https://github.com/Desearch-ai/desearch-search-evals/blob/cfd3c83b553f6fa61e4fe71b08d46dcbb098b8d5/README.md#L56
- Provider slug: desearch

Commit-pinned line anchor points to the exact README line documenting the dataset.

## No linked issue (rationale)

This is an intentional no-issue PR. There is no open enrichment issue tracking the SN22 data-artifact gap, and issue creation on this repo is restricted to collaborators, so one cannot be filed. The change is a single, self-contained, self-proving surface append — the public dataset URL plus the first-party source URL fully establish and verify the claim, so it stands on its own merit without a tracking issue.

## Checklist

- [x] Changes exactly one `registry/subnets/desearch.json` file (append-only).
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public and read-only-safe; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] No linked issue — rationale provided above (issue creation restricted; self-proving surface).

## Validation

- [x] `npm run validate:surface -- registry/subnets/desearch.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate` (full suite, green)