### PR TITLE
fix(streamer): fail fast on ingest auth errors

### DIFF
--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -12,8 +12,10 @@ is covered for free.
 Production behavior:
   * Structured, leveled logging (timestamp + level). The per-block line is DEBUG
     (quiet by default); a periodic INFO summary shows liveness without flooding.
-  * A failed ingest POST is logged + skipped (the poller backstop covers it) — it
-    does NOT tear down the subscription.
+  * A transient failed ingest POST is logged + skipped (the poller backstop covers
+    it) — it does NOT tear down the subscription. An ingest auth rejection
+    (401/403) or a TLS/certificate verification failure is NOT transient: both are
+    logged at ERROR and exit the process instead.
   * Exponential backoff + jitter on RPC reconnect; SIGTERM/SIGINT graceful stop.
 
 Deployed on Railway (config-as-code via railway.json); see docs/realtime-streamer.md.
@@ -176,10 +178,11 @@ def decode_head(s, block_number):
 def push(url, payload):
     """POST a JSON payload to an ingest endpoint. Returns True on success; logs WARN
     + returns False on a transient network failure (the CI poller backstop covers
-    the gap). A TLS/certificate verification failure is NOT a transient blip — it's
-    logged at ERROR and the process exits, so a possible MITM on the secret-bearing
-    POST is surfaced (Railway restarts a transient one; a persistent one crash-loops
-    to the retry cap + goes visibly down) rather than silently swallowed."""
+    the gap). Neither an ingest auth rejection (401/403 — token misconfigured or
+    rotated) nor a TLS/certificate verification failure is a transient blip — both
+    are logged at ERROR and the process exits, so a persistent failure is surfaced
+    (Railway restarts a transient one; a persistent one crash-loops to the retry
+    cap + goes visibly down) rather than silently swallowed forever."""
     req = urllib.request.Request(
         url,
         data=json.dumps(payload).encode(),
@@ -201,6 +204,14 @@ def push(url, payload):
             body = e.read().decode("utf-8", "replace")[:500]
         except Exception:
             body = "<no body>"
+        if e.code in (401, 403):
+            log.error(
+                "ingest push rejected (HTTP %s): %s — auth/token misconfiguration; "
+                "exiting so this does not silently retry forever",
+                e.code,
+                body,
+            )
+            sys.exit(1)
         log.warning(
             "ingest push rejected (HTTP %s): %s — poller backstop will cover this gap",
             e.code,

--- a/scripts/test_stream_events.py
+++ b/scripts/test_stream_events.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Unit tests for the realtime streamer's ingest-push auth handling (#2687).
+
+stream-events.py is hyphenated, so it is loaded by path the same way
+test_fetch_events.py loads fetch-events.py — no package rename needed. `push()`
+is exercised with `urlopen` mocked; nothing here touches the network.
+
+    python3 scripts/test_stream_events.py          # standalone (CI-friendly)
+    python3 -m unittest scripts.test_stream_events # via the unittest runner
+    python3 -m pytest scripts/test_stream_events.py # if pytest is available
+"""
+import importlib.util
+import os
+import unittest
+import urllib.error
+from unittest.mock import patch
+
+_SE_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "stream-events.py"
+)
+_spec = importlib.util.spec_from_file_location("stream_events_under_test", _SE_PATH)
+_se = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_se)
+
+
+def _http_error(code):
+    return urllib.error.HTTPError(
+        url="https://api.metagraph.sh/api/v1/internal/events",
+        code=code,
+        msg="error",
+        hdrs=None,
+        fp=None,
+    )
+
+
+class PushAuthFatalTest(unittest.TestCase):
+    def test_401_exits_instead_of_retrying(self):
+        with patch.object(_se.urllib.request, "urlopen", side_effect=_http_error(401)):
+            with self.assertRaises(SystemExit):
+                _se.push("https://api.metagraph.sh/api/v1/internal/events", {})
+
+    def test_403_exits_instead_of_retrying(self):
+        with patch.object(_se.urllib.request, "urlopen", side_effect=_http_error(403)):
+            with self.assertRaises(SystemExit):
+                _se.push("https://api.metagraph.sh/api/v1/internal/events", {})
+
+    def test_other_http_error_is_transient_not_fatal(self):
+        with patch.object(_se.urllib.request, "urlopen", side_effect=_http_error(500)):
+            result = _se.push("https://api.metagraph.sh/api/v1/internal/events", {})
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_stream_events.py
+++ b/scripts/test_stream_events.py
@@ -36,13 +36,15 @@ def _http_error(code):
 class PushAuthFatalTest(unittest.TestCase):
     def test_401_exits_instead_of_retrying(self):
         with patch.object(_se.urllib.request, "urlopen", side_effect=_http_error(401)):
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(SystemExit) as cm:
                 _se.push("https://api.metagraph.sh/api/v1/internal/events", {})
+        self.assertEqual(cm.exception.code, 1)
 
     def test_403_exits_instead_of_retrying(self):
         with patch.object(_se.urllib.request, "urlopen", side_effect=_http_error(403)):
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(SystemExit) as cm:
                 _se.push("https://api.metagraph.sh/api/v1/internal/events", {})
+        self.assertEqual(cm.exception.code, 1)
 
     def test_other_http_error_is_transient_not_fatal(self):
         with patch.object(_se.urllib.request, "urlopen", side_effect=_http_error(500)):


### PR DESCRIPTION
## Summary

- `scripts/stream-events.py`'s `push()` now treats an HTTP 401/403 from the ingest endpoint as fatal (logs ERROR, exits) instead of a transient error (logs WARNING, returns `False`, keeps going).

## What Changed

- Added a dedicated branch in `push()`'s `except urllib.error.HTTPError` handler: `e.code in (401, 403)` now exits the process, mirroring the existing TLS/certificate-verification-failure branch in the same function that already treats a cert/MITM failure as fatal rather than a silently-swallowed transient blip.
- Updated the module and `push()` docstrings, which previously described every failed ingest POST as non-fatal — they now note that an auth rejection (like a TLS failure) exits instead.
- Added `scripts/test_stream_events.py` (stdlib `unittest`, loaded by path the same way `scripts/test_fetch_events.py` loads `fetch-events.py`) covering: 401 exits with code 1, 403 exits with code 1, and a non-auth HTTP error (500) still returns `False` without exiting.

(Rebased on current `main` — a prior PR for this same branch was auto-closed for a base conflict against a separately-merged change that added ingest error-body logging to this same function; that change and this one are combined cleanly here.)

## Why

If `METAGRAPH_EVENTS_INGEST_SECRET` is ever wrong, unset, or rotated without updating the Railway deployment, every realtime push 401/403s. Before this change the streamer just logs a WARNING and keeps subscribing/decoding blocks forever — nothing pages, nothing crash-loops, nothing looks down. The only thing actually landing realtime events during that window is the CI poller backstop, so the failure mode is a full, silent regression to poller-only latency. This makes the failure loud and immediate instead, consistent with how the function already treats TLS failures on this same secret-bearing endpoint.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — no schema/API surface touched.)

## Validation

- [x] `python scripts/test_stream_events.py` (3 passed)
- [x] `npm run lint`
- [x] `git diff --check`
- [ ] `npm run validate` / `validate:schemas` / `validate:api` / `validate:openapi` / `validate:types` / `validate:artifact-budgets` / `validate:docs` / `validate:intake` / `validate:workflows` / `worker:test` / `test:coverage` / `scan:public-safety` — not applicable, this PR only touches `scripts/stream-events.py` and its Python test (no JS/contract/registry surface)

## Issue Link

No linked issue — small, self-contained fix with the repro, impact, and expected behavior documented above.