### PR TITLE
fix(transfer-pairs): reject blank last_block cells that coerce to 0

### DIFF
--- a/src/chain-transfer-pairs.mjs
+++ b/src/chain-transfer-pairs.mjs
@@ -26,6 +26,8 @@ function toCount(value) {
 
 function toBlockNumber(value) {
   if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isSafeInteger(n) && n >= 0 ? n : null;
 }

--- a/tests/chain-transfer-pairs.test.mjs
+++ b/tests/chain-transfer-pairs.test.mjs
@@ -138,6 +138,8 @@ describe("buildChainTransferPairs", () => {
           ...pair("5K", "5L", 1),
           last_observed_at: 8640000000000001,
         },
+        pair("5M", "5N", 1, 1, ""),
+        pair("5O", "5P", 1, 1, "   "),
       ],
     });
     assert.equal(d.pairs[0].last_block, null);
@@ -146,6 +148,8 @@ describe("buildChainTransferPairs", () => {
     assert.equal(d.pairs[3].last_observed_at, null);
     assert.equal(d.pairs[4].last_observed_at, null);
     assert.equal(d.pairs[5].last_observed_at, null);
+    assert.equal(d.pairs[6].last_block, null);
+    assert.equal(d.pairs[7].last_block, null);
   });
 
   test("rounds TAO volume and normalizes unknown sort values", () => {


### PR DESCRIPTION
## Summary

Reject blank D1 `last_block` cells in chain transfer-pair formatting so empty strings and whitespace-only values return `null` instead of coercing to block `0`.

## What Changed

- Add a trim guard to `toBlockNumber()` in `src/chain-transfer-pairs.mjs`, matching the pattern merged in blocks.mjs (#2947) and extrinsics.mjs (#2974).
- Extend the malformed-evidence regression in `tests/chain-transfer-pairs.test.mjs` for blank `last_block` cells.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/chain-transfer-pairs.test.mjs` (16 passed)
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Sibling fix to the merged #2947 / #2974 blank-cell guards.
