### PR TITLE
fix(api): floor the global-validators limit at 0 so limit=0 returns empty

### DIFF
--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -279,8 +279,11 @@ export function buildGlobalValidators(
     ? sort
     : DEFAULT_GLOBAL_VALIDATOR_SORT;
   const flooredLimit = Math.floor(Number(limit));
+  // Floor the limit at 0, not 1, so an explicit limit=0 returns an empty
+  // leaderboard rather than being silently bumped up to a single validator.
+  // Mirrors the chain-turnover / chain-stake-flow / chain-weights (#2984) clamp.
   const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(1, Math.min(flooredLimit, GLOBAL_VALIDATOR_LIMIT_MAX))
+    ? Math.max(0, Math.min(flooredLimit, GLOBAL_VALIDATOR_LIMIT_MAX))
     : GLOBAL_VALIDATOR_LIMIT_DEFAULT;
   const validatorsByHotkey = new Map();
   let latestCapturedAt = null;

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -393,13 +393,16 @@ describe("metagraph-neurons builders", () => {
     assert.equal(empty.validator_count, 0);
     assert.deepEqual(empty.validators, []);
 
+    // An explicit limit of 0 yields an EMPTY leaderboard (not a bumped-up single
+    // row), matching the chain-turnover / chain-stake-flow / chain-weights (#2984)
+    // floor-at-0 convention. validator_count still reports the full set.
     const clamped = buildGlobalValidators(
       [{ ...ROW, netuid: 7, uid: 0, hotkey: "hk-a" }],
       { limit: 0 },
     );
-    assert.equal(clamped.limit, 1);
+    assert.equal(clamped.limit, 0);
     assert.equal(clamped.validator_count, 1);
-    assert.equal(clamped.validators.length, 1);
+    assert.equal(clamped.validators.length, 0);
   });
 
   test("buildGlobalValidators handles sparse identity rows and trust sorting", () => {


### PR DESCRIPTION
## What

`buildGlobalValidators` (the `GET /api/v1/validators` leaderboard) normalizes its `limit` with a floor of **1**:

```js
const normalizedLimit = Number.isFinite(flooredLimit)
  ? Math.max(1, Math.min(flooredLimit, GLOBAL_VALIDATOR_LIMIT_MAX))
  : GLOBAL_VALIDATOR_LIMIT_DEFAULT;
```

So an **explicit `limit=0`** is silently bumped up to `1`, returning a single validator instead of an empty leaderboard.

## Why it's a bug

The rest of the codebase floors these leaderboard limits at **0** so `limit=0` returns an empty result: `chain-turnover.mjs` and `chain-stake-flow.mjs` already do, and `chain-weights.mjs` was just fixed to match in #2984 ("clamp limit floor to 0 instead of 1"). `buildGlobalValidators` is the remaining outlier.

## Concrete case

`buildGlobalValidators([oneValidatorRow], { limit: 0 })`:

- **Before:** `limit: 1`, `validators.length: 1` (one row leaks through)
- **After:** `limit: 0`, `validators.length: 0` (empty leaderboard)
- `validator_count` still reports the full set (`1`) either way.

## Fix

Floor the limit at `0` (`Math.max(0, …)`), mirroring the sibling chain builders / #2984. The existing "normalizes direct-call options" test asserted the old bumped-up behavior (`limit: 0 → 1`); it's updated to assert the empty-leaderboard behavior the convention now requires.

## Tests

- Updated the `limit: 0` case to assert `limit === 0` and `validators.length === 0` (with `validator_count === 1`). This fails on the old `Math.max(1, …)` and passes with the fix.
- Full suite still green (52/52).

Source + tests only — no schema/contract/generated-artifact changes. `eslint` clean, `prettier` clean, 100% patch coverage of the changed line.
