### PR TITLE
feat(api): add account event-summary endpoint

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -72,6 +72,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/accounts/{ss58}/event-summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch a windowed event summary for one account (hotkey or coldkey): account_events counts by kind and coarse category, distinct hotkey/coldkey counts, TAO/alpha sums where applicable, subnet footprint, first/last evidence bounds, plus a newest-first evidence slice. ?window=7d|30d|90d (default 30d); optional ?netuid= scopes to one subnet; ?limit caps recent_events (default 10, max 50). Computed live from the account_events D1 tier. */
+        get: operations["accountEventSummary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/accounts/{ss58}/events": {
         parameters: {
             query?: never;
@@ -2083,6 +2100,27 @@ export interface components {
             offset?: number;
             schema_version: number;
             ss58: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** @description Windowed event summary for one account (hotkey or coldkey): account_events counts by kind and coarse category, distinct hotkey/coldkey counts, TAO/alpha sums where applicable, subnet footprint, first/last evidence bounds, and a small newest-first evidence slice. Served live at /api/v1/accounts/{ss58}/event-summary (no static file). */
+        AccountEventSummaryArtifact: {
+            categories: components["schemas"]["SubnetEventCategorySummary"][];
+            category_count: number;
+            event_kinds: components["schemas"]["SubnetEventKindSummary"][];
+            kind_count: number;
+            limit: number;
+            netuid: number | null;
+            /** Format: date-time */
+            observed_at: string | null;
+            recent_event_count: number;
+            recent_events: components["schemas"]["AccountEvent"][];
+            schema_version: number;
+            ss58: string;
+            subnet_count: number;
+            total_events: number;
+            /** @enum {string} */
+            window: "7d" | "30d" | "90d";
         } & {
             [key: string]: unknown;
         };
@@ -6710,6 +6748,155 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountCounterpartiesArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    accountEventSummary: {
+        parameters: {
+            query?: {
+                window?: "7d" | "30d" | "90d";
+                netuid?: number;
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                ss58: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "categories": [
+                     *           {
+                     *             "alpha_amount": 0.5,
+                     *             "amount_tao": 0.5,
+                     *             "category": "registration",
+                     *             "event_count": 1,
+                     *             "first_block": 5000000,
+                     *             "first_observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "kind_count": 1,
+                     *             "last_block": 5000000,
+                     *             "last_observed_at": "2026-06-01T00:00:00.000Z"
+                     *           }
+                     *         ],
+                     *         "category_count": 1,
+                     *         "event_kinds": [
+                     *           {
+                     *             "alpha_amount": 0.5,
+                     *             "amount_tao": 0.5,
+                     *             "category": "registration",
+                     *             "coldkey_count": 1,
+                     *             "event_count": 1,
+                     *             "event_kind": "example",
+                     *             "first_block": 5000000,
+                     *             "first_observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "hotkey_count": 1,
+                     *             "last_block": 5000000,
+                     *             "last_observed_at": "2026-06-01T00:00:00.000Z"
+                     *           }
+                     *         ],
+                     *         "kind_count": 1,
+                     *         "limit": 1,
+                     *         "netuid": 7,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "recent_event_count": 1,
+                     *         "recent_events": [
+                     *           {
+                     *             "block_number": 5000000,
+                     *             "event_kind": "example"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                     *         "subnet_count": 1,
+                     *         "total_events": 1,
+                     *         "window": "7d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-29.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["AccountEventSummaryArtifact"];
                     };
                 };
             };

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -492,6 +492,13 @@
     },
     {
       "contract_version": "2026-07-03.2",
+      "id": "account-event-summary",
+      "path": "/metagraph/accounts/{ss58}/event-summary.json",
+      "schema_ref": "#/components/schemas/AccountEventSummaryArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "contract_version": "2026-07-03.2",
       "id": "account-history",
       "path": "/metagraph/accounts/{ss58}/history.json",
       "schema_ref": "#/components/schemas/AccountHistoryArtifact",
@@ -5202,6 +5209,45 @@
           "name": "cursor",
           "schema": {
             "type": "string"
+          }
+        }
+      ]
+    },
+    {
+      "artifact_path": "/metagraph/accounts/{ss58}/event-summary.json",
+      "cache": "short",
+      "description": "Fetch a windowed event summary for one account (hotkey or coldkey): account_events counts by kind and coarse category, distinct hotkey/coldkey counts, TAO/alpha sums where applicable, subnet footprint, first/last evidence bounds, plus a newest-first evidence slice. ?window=7d|30d|90d (default 30d); optional ?netuid= scopes to one subnet; ?limit caps recent_events (default 10, max 50). Computed live from the account_events D1 tier.",
+      "id": "account-event-summary",
+      "method": "GET",
+      "path": "/api/v1/accounts/{ss58}/event-summary",
+      "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
+      "query_parameters": [
+        {
+          "name": "window",
+          "schema": {
+            "enum": [
+              "7d",
+              "30d",
+              "90d"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 50,
+            "minimum": 1,
+            "type": "integer"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -633,6 +633,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
+      "description": "Windowed event summary for one account (hotkey or coldkey): account_events counts by kind and coarse category, distinct hotkey/coldkey counts, TAO/alpha sums where applicable, subnet footprint, first/last evidence bounds, and a small newest-first evidence slice, served live from D1 at /api/v1/accounts/{ss58}/event-summary (no static file).",
+      "id": "account-event-summary",
+      "path": "/metagraph/accounts/{ss58}/event-summary.json",
+      "schema_ref": "#/components/schemas/AccountEventSummaryArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-07-03.2",
       "description": "Durable per-day activity series for one account (hotkey-keyed, newest day first), served live from the account_events_daily rollup at /api/v1/accounts/{ss58}/history (no static file).",
       "id": "account-history",
       "path": "/metagraph/accounts/{ss58}/history.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -516,6 +516,101 @@
         ],
         "type": "object"
       },
+      "AccountEventSummaryArtifact": {
+        "additionalProperties": true,
+        "description": "Windowed event summary for one account (hotkey or coldkey): account_events counts by kind and coarse category, distinct hotkey/coldkey counts, TAO/alpha sums where applicable, subnet footprint, first/last evidence bounds, and a small newest-first evidence slice. Served live at /api/v1/accounts/{ss58}/event-summary (no static file).",
+        "properties": {
+          "categories": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetEventCategorySummary"
+            },
+            "type": "array"
+          },
+          "category_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "event_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetEventKindSummary"
+            },
+            "type": "array"
+          },
+          "kind_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "limit": {
+            "maximum": 50,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "observed_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "recent_event_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "recent_events": {
+            "items": {
+              "$ref": "#/components/schemas/AccountEvent"
+            },
+            "type": "array"
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "ss58": {
+            "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
+            "type": "string"
+          },
+          "subnet_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total_events": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "window": {
+            "enum": [
+              "7d",
+              "30d",
+              "90d"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema_version",
+          "ss58",
+          "netuid",
+          "window",
+          "observed_at",
+          "total_events",
+          "kind_count",
+          "category_count",
+          "subnet_count",
+          "recent_event_count",
+          "limit",
+          "categories",
+          "event_kinds",
+          "recent_events"
+        ],
+        "type": "object"
+      },
       "AccountExtrinsicsArtifact": {
         "additionalProperties": true,
         "description": "Paginated extrinsics this account signed (#1844), newest first, from the extrinsics D1 tier. Matched by the extrinsic signer only — not the hotkey or coldkey union the event routes use. Page with limit/offset or follow next_cursor, the opaque keyset token emitted on full pages. Served live at /api/v1/accounts/{ss58}/extrinsics (no static file).",
@@ -18151,6 +18246,209 @@
           }
         },
         "summary": "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present.",
+        "tags": [
+          "accounts",
+          "analytics"
+        ]
+      }
+    },
+    "/api/v1/accounts/{ss58}/event-summary": {
+      "get": {
+        "operationId": "accountEventSummary",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ss58",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "window",
+            "required": false,
+            "schema": {
+              "enum": [
+                "7d",
+                "30d",
+                "90d"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 50,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "categories": [
+                      {
+                        "alpha_amount": 0.5,
+                        "amount_tao": 0.5,
+                        "category": "registration",
+                        "event_count": 1,
+                        "first_block": 5000000,
+                        "first_observed_at": "2026-06-01T00:00:00.000Z",
+                        "kind_count": 1,
+                        "last_block": 5000000,
+                        "last_observed_at": "2026-06-01T00:00:00.000Z"
+                      }
+                    ],
+                    "category_count": 1,
+                    "event_kinds": [
+                      {
+                        "alpha_amount": 0.5,
+                        "amount_tao": 0.5,
+                        "category": "registration",
+                        "coldkey_count": 1,
+                        "event_count": 1,
+                        "event_kind": "example",
+                        "first_block": 5000000,
+                        "first_observed_at": "2026-06-01T00:00:00.000Z",
+                        "hotkey_count": 1,
+                        "last_block": 5000000,
+                        "last_observed_at": "2026-06-01T00:00:00.000Z"
+                      }
+                    ],
+                    "kind_count": 1,
+                    "limit": 1,
+                    "netuid": 7,
+                    "observed_at": "2026-06-01T00:00:00.000Z",
+                    "recent_event_count": 1,
+                    "recent_events": [
+                      {
+                        "block_number": 5000000,
+                        "event_kind": "example"
+                      }
+                    ],
+                    "schema_version": 1,
+                    "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                    "subnet_count": 1,
+                    "total_events": 1,
+                    "window": "7d"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-29.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AccountEventSummaryArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch a windowed event summary for one account (hotkey or coldkey): account_events counts by kind and coarse category, distinct hotkey/coldkey counts, TAO/alpha sums where applicable, subnet footprint, first/last evidence bounds, plus a newest-first evidence slice. ?window=7d|30d|90d (default 30d); optional ?netuid= scopes to one subnet; ?limit caps recent_events (default 10, max 50). Computed live from the account_events D1 tier.",
         "tags": [
           "accounts",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -72,6 +72,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/accounts/{ss58}/event-summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch a windowed event summary for one account (hotkey or coldkey): account_events counts by kind and coarse category, distinct hotkey/coldkey counts, TAO/alpha sums where applicable, subnet footprint, first/last evidence bounds, plus a newest-first evidence slice. ?window=7d|30d|90d (default 30d); optional ?netuid= scopes to one subnet; ?limit caps recent_events (default 10, max 50). Computed live from the account_events D1 tier. */
+        get: operations["accountEventSummary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/accounts/{ss58}/events": {
         parameters: {
             query?: never;
@@ -2083,6 +2100,27 @@ export interface components {
             offset?: number;
             schema_version: number;
             ss58: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** @description Windowed event summary for one account (hotkey or coldkey): account_events counts by kind and coarse category, distinct hotkey/coldkey counts, TAO/alpha sums where applicable, subnet footprint, first/last evidence bounds, and a small newest-first evidence slice. Served live at /api/v1/accounts/{ss58}/event-summary (no static file). */
+        AccountEventSummaryArtifact: {
+            categories: components["schemas"]["SubnetEventCategorySummary"][];
+            category_count: number;
+            event_kinds: components["schemas"]["SubnetEventKindSummary"][];
+            kind_count: number;
+            limit: number;
+            netuid: number | null;
+            /** Format: date-time */
+            observed_at: string | null;
+            recent_event_count: number;
+            recent_events: components["schemas"]["AccountEvent"][];
+            schema_version: number;
+            ss58: string;
+            subnet_count: number;
+            total_events: number;
+            /** @enum {string} */
+            window: "7d" | "30d" | "90d";
         } & {
             [key: string]: unknown;
         };
@@ -6710,6 +6748,155 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountCounterpartiesArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    accountEventSummary: {
+        parameters: {
+            query?: {
+                window?: "7d" | "30d" | "90d";
+                netuid?: number;
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                ss58: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "categories": [
+                     *           {
+                     *             "alpha_amount": 0.5,
+                     *             "amount_tao": 0.5,
+                     *             "category": "registration",
+                     *             "event_count": 1,
+                     *             "first_block": 5000000,
+                     *             "first_observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "kind_count": 1,
+                     *             "last_block": 5000000,
+                     *             "last_observed_at": "2026-06-01T00:00:00.000Z"
+                     *           }
+                     *         ],
+                     *         "category_count": 1,
+                     *         "event_kinds": [
+                     *           {
+                     *             "alpha_amount": 0.5,
+                     *             "amount_tao": 0.5,
+                     *             "category": "registration",
+                     *             "coldkey_count": 1,
+                     *             "event_count": 1,
+                     *             "event_kind": "example",
+                     *             "first_block": 5000000,
+                     *             "first_observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "hotkey_count": 1,
+                     *             "last_block": 5000000,
+                     *             "last_observed_at": "2026-06-01T00:00:00.000Z"
+                     *           }
+                     *         ],
+                     *         "kind_count": 1,
+                     *         "limit": 1,
+                     *         "netuid": 7,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "recent_event_count": 1,
+                     *         "recent_events": [
+                     *           {
+                     *             "block_number": 5000000,
+                     *             "event_kind": "example"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+                     *         "subnet_count": 1,
+                     *         "total_events": 1,
+                     *         "window": "7d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-29.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["AccountEventSummaryArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -502,6 +502,101 @@
         ],
         "type": "object"
       },
+      "AccountEventSummaryArtifact": {
+        "additionalProperties": true,
+        "description": "Windowed event summary for one account (hotkey or coldkey): account_events counts by kind and coarse category, distinct hotkey/coldkey counts, TAO/alpha sums where applicable, subnet footprint, first/last evidence bounds, and a small newest-first evidence slice. Served live at /api/v1/accounts/{ss58}/event-summary (no static file).",
+        "properties": {
+          "categories": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetEventCategorySummary"
+            },
+            "type": "array"
+          },
+          "category_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "event_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetEventKindSummary"
+            },
+            "type": "array"
+          },
+          "kind_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "limit": {
+            "maximum": 50,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "observed_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "recent_event_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "recent_events": {
+            "items": {
+              "$ref": "#/components/schemas/AccountEvent"
+            },
+            "type": "array"
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "ss58": {
+            "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$",
+            "type": "string"
+          },
+          "subnet_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total_events": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "window": {
+            "enum": [
+              "7d",
+              "30d",
+              "90d"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema_version",
+          "ss58",
+          "netuid",
+          "window",
+          "observed_at",
+          "total_events",
+          "kind_count",
+          "category_count",
+          "subnet_count",
+          "recent_event_count",
+          "limit",
+          "categories",
+          "event_kinds",
+          "recent_events"
+        ],
+        "type": "object"
+      },
       "AccountExtrinsicsArtifact": {
         "additionalProperties": true,
         "description": "Paginated extrinsics this account signed (#1844), newest first, from the extrinsics D1 tier. Matched by the extrinsic signer only — not the hotkey or coldkey union the event routes use. Page with limit/offset or follow next_cursor, the opaque keyset token emitted on full pages. Served live at /api/v1/accounts/{ss58}/extrinsics (no static file).",

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -2066,6 +2066,57 @@
           }
         }
       },
+      "AccountEventSummaryArtifact": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Windowed event summary for one account (hotkey or coldkey): account_events counts by kind and coarse category, distinct hotkey/coldkey counts, TAO/alpha sums where applicable, subnet footprint, first/last evidence bounds, and a small newest-first evidence slice. Served live at /api/v1/accounts/{ss58}/event-summary (no static file).",
+        "required": [
+          "schema_version",
+          "ss58",
+          "netuid",
+          "window",
+          "observed_at",
+          "total_events",
+          "kind_count",
+          "category_count",
+          "subnet_count",
+          "recent_event_count",
+          "limit",
+          "categories",
+          "event_kinds",
+          "recent_events"
+        ],
+        "properties": {
+          "schema_version": { "type": "integer" },
+          "ss58": {
+            "type": "string",
+            "pattern": "^[1-9A-HJ-NP-Za-km-z]{47,48}$"
+          },
+          "netuid": { "type": ["integer", "null"], "minimum": 0 },
+          "window": { "type": "string", "enum": ["7d", "30d", "90d"] },
+          "observed_at": { "type": ["string", "null"], "format": "date-time" },
+          "total_events": { "type": "integer", "minimum": 0 },
+          "kind_count": { "type": "integer", "minimum": 0 },
+          "category_count": { "type": "integer", "minimum": 0 },
+          "subnet_count": { "type": "integer", "minimum": 0 },
+          "recent_event_count": { "type": "integer", "minimum": 0 },
+          "limit": { "type": "integer", "minimum": 1, "maximum": 50 },
+          "categories": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubnetEventCategorySummary"
+            }
+          },
+          "event_kinds": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/SubnetEventKindSummary" }
+          },
+          "recent_events": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AccountEvent" }
+          }
+        }
+      },
       "AccountExtrinsicsArtifact": {
         "type": "object",
         "additionalProperties": true,

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -328,6 +328,7 @@ const checks = [
   ],
   [
     "/api/v1/subnets/7/event-summary",
+    "/api/v1/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5/event-summary",
     (body) => {
       assert.equal(body.data.netuid, 7);
       assert.equal(Array.isArray(body.data.categories), true);

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -41,6 +41,7 @@ const COMPUTED_ARTIFACTS = new Set([
   "subnet-validators",
   "subnet-events",
   "subnet-event-summary",
+  "account-event-summary",
   "subnet-neuron-history",
   "subnet-history",
   "subnet-identity-history",

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -526,15 +526,8 @@ function mergeObserved(existing, next, choose) {
   return choose(existing, nextValue);
 }
 
-// Windowed event summary for one subnet: compact kind/category counts plus a
-// small newest-first evidence slice. This complements /subnets/{netuid}/events,
-// which exposes the raw paginated feed.
-export function buildSubnetEventSummary(
-  kindRows,
-  recentRows,
-  netuid,
-  { window, limit } = {},
-) {
+// Shared windowed summary payload for subnet- and account-scoped event summaries.
+function summarizeEventRows(kindRows, recentRows, { window, limit } = {}) {
   const eventKinds = [];
   const categories = new Map();
   let latestObserved = null;
@@ -628,7 +621,6 @@ export function buildSubnetEventSummary(
   }
   return {
     schema_version: 1,
-    netuid,
     window: window ?? null,
     observed_at: toIso(latestObserved),
     total_events: eventKinds.reduce((sum, row) => sum + row.event_count, 0),
@@ -641,6 +633,50 @@ export function buildSubnetEventSummary(
     recent_events: recentEvents,
   };
 }
+
+// Windowed event summary for one subnet: compact kind/category counts plus a
+// small newest-first evidence slice. This complements /subnets/{netuid}/events,
+// which exposes the raw paginated feed.
+export function buildSubnetEventSummary(
+  kindRows,
+  recentRows,
+  netuid,
+  { window, limit } = {},
+) {
+  return {
+    ...summarizeEventRows(kindRows, recentRows, { window, limit }),
+    netuid,
+  };
+}
+
+// Windowed event summary for one account (hotkey or coldkey): the dashboard-
+// friendly companion to /accounts/{ss58}/events.
+export function buildAccountEventSummary(
+  kindRows,
+  recentRows,
+  ss58,
+  { window, limit, netuid, subnet_count } = {},
+) {
+  return {
+    ...summarizeEventRows(kindRows, recentRows, { window, limit }),
+    ss58,
+    netuid: netuid ?? null,
+    subnet_count: subnet_count ?? 0,
+  };
+}
+
+const EVENT_SUMMARY_AGG_COLUMNS =
+  "event_kind, hotkey, coldkey, netuid, amount_tao, alpha_amount, block_number, observed_at";
+
+const EVENT_SUMMARY_KIND_AGG_SQL =
+  "SELECT event_kind, COUNT(*) AS event_count, " +
+  "COUNT(DISTINCT hotkey) AS hotkey_count, " +
+  "COUNT(DISTINCT coldkey) AS coldkey_count, " +
+  "COALESCE(SUM(amount_tao), 0) AS amount_tao, " +
+  "COALESCE(SUM(alpha_amount), 0) AS alpha_amount, " +
+  "MIN(block_number) AS first_block, MAX(block_number) AS last_block, " +
+  "MIN(observed_at) AS first_observed_at, MAX(observed_at) AS last_observed_at " +
+  "FROM";
 
 export async function loadSubnetEventSummary(
   d1,
@@ -683,6 +719,67 @@ export async function loadSubnetEventSummary(
   return buildSubnetEventSummary(kindRows, recentRows, netuid, {
     window: effectiveWindowLabel,
     limit: lim,
+  });
+}
+
+export async function loadAccountEventSummary(
+  d1,
+  ss58,
+  {
+    windowLabel = DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW,
+    limit = SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+    netuid = null,
+  } = {},
+) {
+  const effectiveWindowLabel = Object.hasOwn(
+    SUBNET_EVENT_SUMMARY_WINDOWS,
+    windowLabel,
+  )
+    ? windowLabel
+    : DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW;
+  const days = SUBNET_EVENT_SUMMARY_WINDOWS[effectiveWindowLabel];
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  const lim = clampLimit(limit, {
+    defaultLimit: SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+    maxLimit: SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+  });
+  const filterParts = ["AND observed_at >= ?"];
+  const filterParams = [cutoff];
+  if (netuid != null) {
+    filterParts.push("AND netuid = ?");
+    filterParams.push(netuid);
+  }
+  const filters = filterParts.join(" ");
+  const union = accountEventIndexedUnion(
+    EVENT_SUMMARY_AGG_COLUMNS,
+    filters,
+    filterParams,
+    { netuidFiltered: netuid != null },
+  );
+  const params = union.paramsFor(ss58);
+  const kindRows = await d1(
+    `${EVENT_SUMMARY_KIND_AGG_SQL} (${union.sql}) GROUP BY event_kind ORDER BY event_count DESC, event_kind ASC`,
+    params,
+  );
+  const subnetRows = await d1(
+    `SELECT COUNT(DISTINCT netuid) AS subnet_count FROM (${union.sql}) WHERE netuid IS NOT NULL`,
+    params,
+  );
+  const recentUnion = accountEventIndexedUnion(
+    ACCOUNT_EVENT_COLUMNS,
+    filters,
+    filterParams,
+    { netuidFiltered: netuid != null },
+  );
+  const recentRows = await d1(
+    `SELECT * FROM ${recentUnion.sql} ORDER BY block_number DESC, event_index DESC LIMIT ?`,
+    [...recentUnion.paramsFor(ss58), lim],
+  );
+  return buildAccountEventSummary(kindRows, recentRows, ss58, {
+    window: effectiveWindowLabel,
+    limit: lim,
+    netuid,
+    subnet_count: toCount(subnetRows[0]?.subnet_count),
   });
 }
 

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -65,6 +65,7 @@ export const R2_ONLY_PATTERNS = [
   /^subnets\/(?:\d+|\{netuid\})\/events\.json$/,
   // Per-subnet event summary: computed live from account_events.
   /^subnets\/(?:\d+|\{netuid\})\/event-summary\.json$/,
+  /^accounts\/(?:\{ss58\}|[1-9A-HJ-NP-Za-km-z]{47,48})\/event-summary\.json$/,
   // Account entity tiers (#1347): computed live from account_events + neurons at
   // /api/v1/accounts/{ss58}(/events|/subnets) — never written as files.
   /^accounts\/(?:[1-9A-HJ-NP-Za-km-z]{47,48}|\{ss58\})\.json$/,

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1038,6 +1038,12 @@ export const PUBLIC_ARTIFACTS = [
     "AccountEventsArtifact",
   ),
   artifact(
+    "account-event-summary",
+    "/metagraph/accounts/{ss58}/event-summary.json",
+    "Windowed event summary for one account (hotkey or coldkey): account_events counts by kind and coarse category, distinct hotkey/coldkey counts, TAO/alpha sums where applicable, subnet footprint, first/last evidence bounds, and a small newest-first evidence slice, served live from D1 at /api/v1/accounts/{ss58}/event-summary (no static file).",
+    "AccountEventSummaryArtifact",
+  ),
+  artifact(
     "account-history",
     "/metagraph/accounts/{ss58}/history.json",
     "Durable per-day activity series for one account (hotkey-keyed, newest day first), served live from the account_events_daily rollup at /api/v1/accounts/{ss58}/history (no static file).",
@@ -2145,6 +2151,24 @@ export const API_ROUTES = [
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "cursor", schema: { type: "string" } },
+    ],
+    [{ name: "ss58", schema: { type: "string" } }],
+  ),
+  route(
+    "account-event-summary",
+    "GET",
+    "/api/v1/accounts/{ss58}/event-summary",
+    "/metagraph/accounts/{ss58}/event-summary.json",
+    "Fetch a windowed event summary for one account (hotkey or coldkey): account_events counts by kind and coarse category, distinct hotkey/coldkey counts, TAO/alpha sums where applicable, subnet footprint, first/last evidence bounds, plus a newest-first evidence slice. ?window=7d|30d|90d (default 30d); optional ?netuid= scopes to one subnet; ?limit caps recent_events (default 10, max 50). Computed live from the account_events D1 tier.",
+    "short",
+    ["accounts", "analytics"],
+    [
+      {
+        name: "window",
+        schema: { type: "string", enum: ["7d", "30d", "90d"] },
+      },
+      { name: "netuid", schema: { type: "integer", minimum: 0 } },
+      { name: "limit", schema: { type: "integer", minimum: 1, maximum: 50 } },
     ],
     [{ name: "ss58", schema: { type: "string" } }],
   ),

--- a/tests/account-event-summary.test.mjs
+++ b/tests/account-event-summary.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+function req(path) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+function dbWith({ summaryKinds, summaryRecent, subnetCount } = {}) {
+  return {
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              async all() {
+                if (/COUNT\(DISTINCT netuid\)/.test(sql)) {
+                  return { results: [{ subnet_count: subnetCount ?? 0 }] };
+                }
+                if (/GROUP BY event_kind/.test(sql)) {
+                  return { results: summaryKinds || [] };
+                }
+                if (
+                  /observed_at >= \?/.test(sql) &&
+                  /ORDER BY block_number DESC, event_index DESC LIMIT \?/.test(
+                    sql,
+                  )
+                ) {
+                  return { results: summaryRecent || [] };
+                }
+                return { results: [] };
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+test("GET /accounts/{ss58}/event-summary returns windowed kind aggregates", async () => {
+  const env = dbWith({
+    subnetCount: 1,
+    summaryKinds: [
+      {
+        event_kind: "StakeAdded",
+        event_count: 2,
+        hotkey_count: 1,
+        coldkey_count: 1,
+        amount_tao: 3,
+        alpha_amount: 0.5,
+        first_block: 4_000_100,
+        last_block: 4_000_200,
+        first_observed_at: 1_750_008_000_000,
+        last_observed_at: 1_750_009_000_000,
+      },
+    ],
+    summaryRecent: [
+      {
+        block_number: 4_000_200,
+        event_index: 2,
+        event_kind: "NeuronRegistered",
+        hotkey: SS58,
+        coldkey: null,
+        netuid: 7,
+        uid: 3,
+        amount_tao: null,
+        observed_at: 1_750_009_000_000,
+      },
+    ],
+  });
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/event-summary?window=7d&limit=3`),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.data.ss58, SS58);
+  assert.equal(body.data.window, "7d");
+  assert.equal(body.data.subnet_count, 1);
+  assert.equal(body.data.total_events, 2);
+  assert.equal(body.data.event_kinds[0].category, "stake");
+  assert.equal(body.data.recent_events[0].event_kind, "NeuronRegistered");
+  assert.equal(
+    body.meta.artifact_path,
+    `/metagraph/accounts/${SS58}/event-summary.json`,
+  );
+});
+
+test("GET /accounts/{ss58}/event-summary rejects bad window", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/event-summary?window=1y`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 400);
+});
+
+test("GET /accounts/{ss58}/event-summary is schema-stable when D1 is cold", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/event-summary`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.ss58, SS58);
+  assert.equal(body.data.total_events, 0);
+  assert.equal(body.data.subnet_count, 0);
+  assert.deepEqual(body.data.recent_events, []);
+});

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -13,11 +13,13 @@ import {
   buildAccountSummary,
   buildAccountEvents,
   buildSubnetEventSummary,
+  buildAccountEventSummary,
   buildAccountSubnets,
   loadAccountSummary,
   loadAccountEvents,
   loadSubnetEvents,
   loadSubnetEventSummary,
+  loadAccountEventSummary,
   loadAccountHistory,
   loadAccountExtrinsics,
   loadAccountSubnets,
@@ -1683,6 +1685,71 @@ test("loadSubnetEventSummary falls back to the default direct-call window", asyn
   const expectedCutoff = Date.now() - 30 * 24 * 60 * 60 * 1000;
   assert.ok(Math.abs(cutoff - expectedCutoff) < 1000);
   assert.equal(out.window, "30d");
+});
+
+test("buildAccountEventSummary mirrors subnet summary shape with ss58 footprint", () => {
+  const ss58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+  const out = buildAccountEventSummary(
+    [
+      {
+        event_kind: "StakeAdded",
+        event_count: 2,
+        hotkey_count: 1,
+        coldkey_count: 1,
+        amount_tao: 3,
+        alpha_amount: 0,
+        first_block: 100,
+        last_block: 200,
+        first_observed_at: 1_750_000_000_000,
+        last_observed_at: 1_750_001_000_000,
+      },
+    ],
+    [
+      {
+        block_number: 200,
+        event_index: 1,
+        event_kind: "StakeAdded",
+        hotkey: ss58,
+        coldkey: null,
+        netuid: 7,
+        uid: 1,
+        amount_tao: 1.5,
+        observed_at: 1_750_001_000_000,
+      },
+    ],
+    ss58,
+    { window: "7d", limit: 5, netuid: null, subnet_count: 1 },
+  );
+  assert.equal(out.ss58, ss58);
+  assert.equal(out.netuid, null);
+  assert.equal(out.subnet_count, 1);
+  assert.equal(out.total_events, 2);
+  assert.equal(out.event_kinds[0].category, "stake");
+});
+
+test("loadAccountEventSummary uses indexed union seeks and optional netuid filter", async () => {
+  const ss58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+  const calls = [];
+  const out = await loadAccountEventSummary(
+    async (sql, params) => {
+      calls.push({ sql, params });
+      if (/COUNT\(DISTINCT netuid\)/.test(sql)) {
+        return [{ subnet_count: 2 }];
+      }
+      if (/GROUP BY event_kind/.test(sql)) {
+        return [{ event_kind: "Transfer", event_count: 4 }];
+      }
+      return [{ block_number: 10, event_index: 0, event_kind: "Transfer" }];
+    },
+    ss58,
+    { windowLabel: "7d", limit: 3, netuid: 7 },
+  );
+  assert.equal(calls.length, 3);
+  assert.match(calls[0].sql, /INDEXED BY idx_account_events_hotkey_netuid/);
+  assert.match(calls[0].sql, /AND netuid = \?/);
+  assert.equal(out.netuid, 7);
+  assert.equal(out.subnet_count, 2);
+  assert.equal(out.total_events, 4);
 });
 
 test("loadAccountEvents emits a next_cursor only on a full page", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -78,6 +78,7 @@ import {
   handleSubnetValidators,
   handleSubnetEventSummary,
   handleSubnetEvents,
+  handleAccountEventSummary,
   handleNeuronHistory,
   handleSubnetHistory,
   handleSubnetIdentityHistory,
@@ -285,6 +286,7 @@ import {
   SUBNET_VALIDATORS_PATH_PATTERN,
   SUBNET_EVENT_SUMMARY_PATH_PATTERN,
   SUBNET_EVENTS_PATH_PATTERN,
+  ACCOUNT_EVENT_SUMMARY_PATH_PATTERN,
   TRAJECTORY_PATH_PATTERN,
   SUBNET_CONCENTRATION_PATH_PATTERN,
   SUBNET_CONCENTRATION_HISTORY_PATH_PATTERN,
@@ -1595,6 +1597,17 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         request,
         env,
         accountHistoryMatch[1],
+        resolved.url,
+      );
+    }
+    const accountEventSummaryMatch = ACCOUNT_EVENT_SUMMARY_PATH_PATTERN.exec(
+      resolved.url.pathname,
+    );
+    if (accountEventSummaryMatch) {
+      return handleAccountEventSummary(
+        request,
+        env,
+        accountEventSummaryMatch[1],
         resolved.url,
       );
     }

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -89,6 +89,8 @@ export const ACCOUNT_PATH_PATTERN =
   /^\/api\/v1\/accounts\/([1-9A-HJ-NP-Za-km-z]{47,48})$/;
 export const ACCOUNT_EVENTS_PATH_PATTERN =
   /^\/api\/v1\/accounts\/([1-9A-HJ-NP-Za-km-z]{47,48})\/events$/;
+export const ACCOUNT_EVENT_SUMMARY_PATH_PATTERN =
+  /^\/api\/v1\/accounts\/([1-9A-HJ-NP-Za-km-z]{47,48})\/event-summary$/;
 // Per-account daily-history series (#1854): the durable per-day activity from the
 // account_events_daily rollup. Dispatched BEFORE the bare ACCOUNT_PATH_PATTERN.
 export const ACCOUNT_HISTORY_PATH_PATTERN =

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -71,6 +71,7 @@ import {
   loadAccountEvents,
   loadSubnetEvents,
   loadSubnetEventSummary,
+  loadAccountEventSummary,
   loadAccountExtrinsics,
   loadAccountTransfers,
   loadAccountSubnets,
@@ -1789,6 +1790,58 @@ export async function handleSubnetEventSummary(request, env, netuid, url) {
       meta: await accountMeta(
         env,
         `/metagraph/subnets/${netuid}/event-summary.json`,
+        data.observed_at,
+      ),
+    },
+    "short",
+  );
+}
+
+// GET /api/v1/accounts/{ss58}/event-summary: compact windowed account_events
+// aggregates by kind/category plus a small newest-first evidence slice. This is
+// the dashboard-friendly companion to the raw /events feed.
+export async function handleAccountEventSummary(request, env, ss58, url) {
+  const validationError = validateQueryParams(url, [
+    "window",
+    "limit",
+    "netuid",
+  ]);
+  if (validationError) return analyticsQueryError(validationError);
+  const windowLabel =
+    url.searchParams.get("window") ?? DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW;
+  if (
+    !Object.prototype.hasOwnProperty.call(
+      SUBNET_EVENT_SUMMARY_WINDOWS,
+      windowLabel,
+    )
+  ) {
+    return analyticsQueryError({
+      parameter: "window",
+      message: `window must be one of ${Object.keys(SUBNET_EVENT_SUMMARY_WINDOWS).join(", ")}.`,
+    });
+  }
+  const parsedLimit = parseLimitParam(url, {
+    defaultLimit: SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+    maxLimit: SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+  });
+  if (parsedLimit.error) return analyticsQueryError(parsedLimit.error);
+  const netuid = parseNonNegativeIntParam(
+    url.searchParams.get("netuid"),
+    "netuid",
+  );
+  if (netuid.error) return analyticsQueryError(netuid.error);
+  const data = await loadAccountEventSummary(d1Runner(env), ss58, {
+    windowLabel,
+    limit: parsedLimit.limit,
+    netuid: netuid.value,
+  });
+  return accountEnvelopeResponse(
+    request,
+    {
+      data,
+      meta: await accountMeta(
+        env,
+        `/metagraph/accounts/${ss58}/event-summary.json`,
         data.observed_at,
       ),
     },


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/accounts/{ss58}/event-summary` — the account-scoped companion to the existing subnet event summary ([#2837](https://github.com/JSONbored/metagraphed/pull/2837)). Over a `7d`/`30d`/`90d` window it returns kind/category aggregates, subnet footprint, TAO/alpha sums, first/last evidence bounds, and a capped newest-first evidence slice from the first-party `account_events` tier.

Optional `?netuid=` narrows the window to one subnet (same filter semantics as `/accounts/{ss58}/events`). Cold/absent D1 → schema-stable zeros (never 404).

## What changed

| Area | Change |
| --- | --- |
| Loader | `loadAccountEventSummary` / `buildAccountEventSummary` in `src/account-events.mjs` (indexed UNION-of-seeks, shared row summarizer with subnet route) |
| Handler | `handleAccountEventSummary` in `workers/request-handlers/entities.mjs` |
| Routing | `ACCOUNT_EVENT_SUMMARY_PATH_PATTERN` + dispatch before `/events` |
| Contract | `AccountEventSummaryArtifact` schema, artifact + route in `src/contracts.mjs`; regenerated OpenAPI + types |
| Tests | `tests/account-event-summary.test.mjs` + unit coverage in `tests/account-events.test.mjs` |

## Design

- Reuses `SubnetEventCategorySummary` / `SubnetEventKindSummary` row shapes — only the subject key differs (`ss58` + `subnet_count` vs `netuid`).
- Aggregates run over an indexed hotkey/coldkey union with `observed_at >= cutoff`, matching the account-events read path (#2059).
- Served live (no edge cache), like `/accounts/{ss58}/events`.

## Test evidence

```bash
npm test -- tests/account-event-summary.test.mjs tests/account-events.test.mjs
npm run validate:contract-drift
```

## Test plan

- [x] Windowed summary returns kind/category aggregates + recent evidence slice
- [x] Bad `?window=` → 400
- [x] Cold D1 → 200 with zeroed payload
- [x] `validate:contract-drift` green
- [ ] Full `npm run validate` + CI green
