### PR TITLE
feat(api): add ?success filter to the account extrinsics route

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -96,7 +96,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
+        /** Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?success=true|false narrows to successful or failed extrinsics (mirrors the GET /api/v1/extrinsics feed; an undeterminable success is excluded by either value); ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
         get: operations["accountExtrinsics"];
         put?: never;
         post?: never;
@@ -6832,6 +6832,7 @@ export interface operations {
     accountExtrinsics: {
         parameters: {
             query?: {
+                success?: boolean;
                 block_start?: number;
                 block_end?: number;
                 limit?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5251,7 +5251,7 @@
     {
       "artifact_path": "/metagraph/accounts/{ss58}/extrinsics.json",
       "cache": "short",
-      "description": "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
+      "description": "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?success=true|false narrows to successful or failed extrinsics (mirrors the GET /api/v1/extrinsics feed; an undeterminable success is excluded by either value); ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
       "id": "account-extrinsics",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/extrinsics",
@@ -5259,6 +5259,12 @@
       "query_collection": null,
       "query_filter_names": [],
       "query_parameters": [
+        {
+          "name": "success",
+          "schema": {
+            "type": "boolean"
+          }
+        },
         {
           "name": "block_start",
           "schema": {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -18217,6 +18217,14 @@
           },
           {
             "in": "query",
+            "name": "success",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
             "name": "block_start",
             "required": false,
             "schema": {
@@ -18398,7 +18406,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
+        "summary": "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?success=true|false narrows to successful or failed extrinsics (mirrors the GET /api/v1/extrinsics feed; an undeterminable success is excluded by either value); ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
         "tags": [
           "accounts",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -96,7 +96,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
+        /** Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?success=true|false narrows to successful or failed extrinsics (mirrors the GET /api/v1/extrinsics feed; an undeterminable success is excluded by either value); ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
         get: operations["accountExtrinsics"];
         put?: never;
         post?: never;
@@ -6832,6 +6832,7 @@ export interface operations {
     accountExtrinsics: {
         parameters: {
             query?: {
+                success?: boolean;
                 block_start?: number;
                 block_end?: number;
                 limit?: number;

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -1115,7 +1115,7 @@ export async function loadAccountHistory(
 export async function loadAccountExtrinsics(
   d1,
   ss58,
-  { limit, offset, cursor, blockStart, blockEnd } = {},
+  { limit, offset, cursor, blockStart, blockEnd, success } = {},
 ) {
   const lim = clampLimit(limit, FEED_PAGINATION);
   const off = clampOffset(offset);
@@ -1137,6 +1137,16 @@ export async function loadAccountExtrinsics(
   if (blockEnd != null) {
     sql += " AND block_number <= ?";
     params.push(blockEnd);
+  }
+  // Optional success filter (true|false only; omit for no filter), mirroring the
+  // global GET /api/v1/extrinsics feed. The boolean maps to the D1 success INTEGER
+  // (1/0); a NULL/undeterminable success is excluded by either explicit value.
+  if (success === true) {
+    sql += " AND success = ?";
+    params.push(1);
+  } else if (success === false) {
+    sql += " AND success = ?";
+    params.push(0);
   }
   const cur = decodeCursor(cursor, 2);
   const useCursor = Boolean(cur);

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2164,10 +2164,11 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/extrinsics",
     "/metagraph/accounts/{ss58}/extrinsics.json",
-    "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
+    "Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics D1 tier. Optional ?success=true|false narrows to successful or failed extrinsics (mirrors the GET /api/v1/extrinsics feed; an undeterminable success is excluded by either value); ?block_start/?block_end (block-height range); ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
     "short",
     ["accounts", "analytics"],
     csvRouteQuery([
+      { name: "success", schema: { type: "boolean" } },
       { name: "block_start", schema: { type: "integer", minimum: 0 } },
       { name: "block_end", schema: { type: "integer", minimum: 0 } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -935,6 +935,32 @@ test("loadAccountExtrinsics applies the block_start/block_end range as bound par
   assert.deepEqual(captured.params, ["5Hk", 100, 900, 100, 0]);
 });
 
+test("loadAccountExtrinsics applies ?success=true|false as a bound filter", async () => {
+  const run = async (opts) => {
+    let captured;
+    await loadAccountExtrinsics(
+      async (sql, params) => {
+        captured = { sql, params };
+        return [];
+      },
+      "5Hk",
+      opts,
+    );
+    return captured;
+  };
+  // success=true binds the D1 INTEGER 1 after the signer, before limit/offset.
+  const yes = await run({ success: true });
+  assert.ok(/AND success = \?/.test(yes.sql));
+  assert.deepEqual(yes.params, ["5Hk", 1, 100, 0]);
+  // success=false binds 0.
+  const no = await run({ success: false });
+  assert.deepEqual(no.params, ["5Hk", 0, 100, 0]);
+  // Omitting success adds no WHERE condition (no regression on the unfiltered feed).
+  const none = await run({});
+  assert.ok(!/AND success = \?/.test(none.sql));
+  assert.deepEqual(none.params, ["5Hk", 100, 0]);
+});
+
 test("loadAccountExtrinsics short-circuits an inverted block range before D1", async () => {
   let called = false;
   const out = await loadAccountExtrinsics(

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2531,6 +2531,31 @@ describe("handleAccountExtrinsics", () => {
     assert.deepEqual(captures.params[idx], [SS58, 100, 900, 100, 0]);
   });
 
+  test("rejects an invalid success filter with 400", async () => {
+    const res = await handleAccountExtrinsics(
+      req(`/api/v1/accounts/${SS58}/extrinsics`),
+      emptyEnv(),
+      SS58,
+      url(`/api/v1/accounts/${SS58}/extrinsics?success=maybe`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "success");
+  });
+
+  test("success=true is applied as a bound extrinsics filter", async () => {
+    const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
+    await handleAccountExtrinsics(
+      req(`/api/v1/accounts/${SS58}/extrinsics`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/extrinsics?success=true`),
+    );
+    const idx = captures.sql.findIndex((s) => /FROM extrinsics/.test(s));
+    assert.ok(idx !== -1);
+    assert.ok(/AND success = \?/.test(captures.sql[idx]));
+    assert.deepEqual(captures.params[idx], [SS58, 1, 100, 0]);
+  });
+
   test("cursor combines with block range filters and emits next_cursor", async () => {
     const { env, captures } = dbWith({
       extrinsics: [extrinsicRow({ block_number: 150, extrinsic_index: 4 })],

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1464,6 +1464,7 @@ export async function handleAccountHistory(request, env, ss58, url) {
 // schema-stable zero (never 404).
 export async function handleAccountExtrinsics(request, env, ss58, url) {
   const validationError = validateEntityQuery(url, [
+    "success",
     "block_start",
     "block_end",
     "limit",
@@ -1482,12 +1483,23 @@ export async function handleAccountExtrinsics(request, env, ss58, url) {
     "block_end",
   );
   if (blockEnd.error) return analyticsQueryError(blockEnd.error);
+  // ?success=true|false narrows to successful/failed signed extrinsics; reject any
+  // other value (mirrors the GET /api/v1/extrinsics feed, #2673).
+  const successRaw = url.searchParams.get("success");
+  if (successRaw !== null && successRaw !== "true" && successRaw !== "false") {
+    return analyticsQueryError({
+      parameter: "success",
+      message: "success must be one of: true, false.",
+    });
+  }
   const data = await loadAccountExtrinsics(d1Runner(env), ss58, {
     limit: url.searchParams.get("limit"),
     offset: url.searchParams.get("offset"),
     cursor: url.searchParams.get("cursor"),
     blockStart: blockStart.value,
     blockEnd: blockEnd.value,
+    success:
+      successRaw === "true" ? true : successRaw === "false" ? false : undefined,
   });
   if (csvRequested(url, request)) {
     const csvRows = data.extrinsics.map((extrinsic) => ({


### PR DESCRIPTION
## Summary

- `GET /api/v1/accounts/{ss58}/extrinsics` could not be narrowed to successful or failed extrinsics, even though the global `GET /api/v1/extrinsics` feed has supported `?success=true|false` since #2575. This adds the same filter to the per-account route for REST parity.

## What Changed

- `loadAccountExtrinsics` accepts an optional `success` boolean and binds it into the signer query as `AND success = ?` (the D1 INTEGER 1/0); a NULL/undeterminable success is excluded by either explicit value. Omitting it is unchanged (no regression).
- `handleAccountExtrinsics` parses `?success`, rejecting any non-`true`/`false` value with a 400 (mirrors the global feed, #2673).
- Added the `success` boolean query param to the route contract; regenerated the OpenAPI / api-index / contracts / typed-client artifacts (`npm run build`).

## Registry Safety

- [x] No secrets, PATs, wallet data, private/localhost URLs, or validator-local state.
- [x] Generated artifacts were produced by `npm run build`, not hand-edited; `public/metagraph/r2-manifest.json` and `schemas/index.json` are **not** in the diff (reverted against base).
- [x] Additive, backward-compatible: a new optional query param; existing responses unchanged.

## Validation

- [x] `npm run validate:contract-drift` — passes (a fresh rebuild regenerates only the deploy-owned drift files).
- [x] `npm run validate:schemas` / `validate:api` (114 routes) / `validate:openapi` (114 routes) — all pass.
- [x] `vitest` — loader (true/false/omitted) + handler (valid pass-through + invalid-value 400) covered; all affected suites green.
- [x] `eslint` + `prettier --check` on changed source — clean; `git diff --check` — clean.
