### PR TITLE
fix(account): clamp sub-perfect stake-flow concentration below a flat 1

### DIFF
--- a/src/account-stake-flow.mjs
+++ b/src/account-stake-flow.mjs
@@ -35,6 +35,16 @@ function roundTao(value) {
   return Math.round(value * RAO_PER_TAO) / RAO_PER_TAO;
 }
 
+// Round the HHI concentration ratio to 4 decimals WITHOUT letting a sub-perfect
+// value round up to an exact 1 — the same anti-overstatement invariant the shared
+// concentration/turnover/reliability ratios enforce (roundRatio in concentration.mjs,
+// #2327). A wallet spread across two or more subnets (HHI < 1) must never render as
+// 1, which this card's own contract defines as "all flow in one subnet".
+function roundConcentration(value) {
+  const rounded = Math.round(value * 10000) / 10000;
+  return rounded >= 1 && value < 1 ? 0.9999 : rounded;
+}
+
 // Coerce a D1 SUM()/COUNT() cell (number, numeric string, or null) to a finite number.
 function toNumber(value) {
   const parsed = Number(value);
@@ -154,7 +164,7 @@ export function buildAccountStakeFlow(rows, address, { window } = {}) {
   // subnet, -> 1/n as it spreads evenly; null when there is no flow to concentrate.
   const concentration =
     totalGross > 0
-      ? Math.round((grossSquares / (totalGross * totalGross)) * 10000) / 10000
+      ? roundConcentration(grossSquares / (totalGross * totalGross))
       : null;
 
   return {

--- a/tests/account-stake-flow.test.mjs
+++ b/tests/account-stake-flow.test.mjs
@@ -115,6 +115,17 @@ describe("buildAccountStakeFlow", () => {
     );
   });
 
+  test("a near-monopoly across >1 subnet never rounds up to a perfect 1", () => {
+    // HHI = (100000^2 + 1^2) / 100001^2 = 0.99998... which a bare 4dp round would
+    // lift to exactly 1 — falsely reading as single-subnet concentration. The
+    // anti-overstatement clamp holds it at the largest sub-1 value (#2327).
+    const d = buildAccountStakeFlow([added(0, 100000), added(1, 1)], ADDR);
+    assert.equal(d.subnet_count, 2);
+    assert.equal(d.concentration, 0.9999);
+    // A genuine single-subnet wallet still reports a true, unclamped 1.
+    assert.equal(buildAccountStakeFlow([added(9, 5)], ADDR).concentration, 1);
+  });
+
   test("reports the dominant subnet by gross and ranks subnets by gross desc", () => {
     const d = buildAccountStakeFlow(
       [added(5, 10), added(9, 300), added(2, 50)],


### PR DESCRIPTION
## Summary

`buildAccountStakeFlow` (`GET /api/v1/accounts/{ss58}/stake-flow`) rounds its HHI gross-flow `concentration` with a bare `Math.round(x * 10000) / 10000`, **without** the sub-perfect clamp that every other concentration/retention ratio in the repo applies. So a wallet whose flow is spread across two or more subnets (HHI < 1) can round up to exactly `1.0` — which this card's own comment defines as *"all flow in one subnet"*.

## Repro

```js
buildAccountStakeFlow(
  [
    { netuid: 0, event_kind: "StakeAdded", total_tao: 100000, event_count: 1 },
    { netuid: 1, event_kind: "StakeAdded", total_tao: 1,      event_count: 1 },
  ],
  "addr",
)
```

HHI = (100000² + 1²) / 100001² = **0.99998…**, which a bare 4-dp round lifts to `1`.

- **Before:** `{ subnet_count: 2, concentration: 1 }` — reports total single-subnet concentration while the wallet demonstrably has flow in two subnets.
- **After:** `{ subnet_count: 2, concentration: 0.9999 }` — the largest sub-1 value. A genuine single-subnet wallet still reports a true, unclamped `1`.

## What Changed

- **`src/account-stake-flow.mjs`** — add a local `roundConcentration` helper that mirrors the established anti-overstatement invariant (`roundRatio` in `concentration.mjs`, the `round` clamp in `turnover.mjs` / `chain-turnover.mjs`, `displayUptimeRatio` in `reliability.mjs` — landed as #2327 *"clamp sub-perfect concentration ratios below a perfect 1.0"*): a sub-1 value never renders as `1`. This file had reimplemented the HHI rounding inline instead of reusing the shared clamp.
- **`tests/account-stake-flow.test.mjs`** — regression test for the near-monopoly-rounds-to-1 edge (the existing test only covered a genuine single-subnet `1` and an even two-subnet `0.5` split, so this case was untested).

Pure runtime shaping; no schema/contract/artifact change (the route is computed live, no static file), so no `public/**` regeneration.

## Registry Safety

- [x] No secrets, PATs, wallet data, private URLs, or validator-local state.
- [x] No generated artifacts touched (live-computed route).
- [x] Public API shape unchanged — only an out-of-bounds value is corrected.

## Validation

Run locally (Windows; Node 22):

- [x] `vitest run tests/account-stake-flow.test.mjs` — 25 passing, incl. the new regression test
- [x] `eslint` + `prettier --check` on the changed files (clean, LF)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).