### PR TITLE
fix(account-portfolio): guard 0/negative captured_at epoch sentinel

### DIFF
--- a/src/account-portfolio.mjs
+++ b/src/account-portfolio.mjs
@@ -45,15 +45,21 @@ function toInt(value) {
   return null;
 }
 
+// Guard 0/negative epoch ms (a blank/sentinel D1 cell) so captured_at never stamps
+// the 1970 epoch; mirrors epochMsStamp in concentration.mjs / subnet-performance.mjs.
 function captureStamp(value) {
+  let ms;
   if (typeof value === "number" && Number.isFinite(value)) {
-    return { ms: value, value: new Date(value).toISOString() };
+    ms = value;
+  } else if (typeof value === "string" && /^\d+$/.test(value)) {
+    ms = Number(value);
+  } else {
+    return null;
   }
-  if (typeof value === "string" && /^\d+$/.test(value)) {
-    const ms = Number(value);
-    return { ms, value: new Date(ms).toISOString() };
-  }
-  return null;
+  if (ms <= 0) return null;
+  const date = new Date(ms);
+  if (!Number.isFinite(date.getTime())) return null;
+  return { ms, value: date.toISOString() };
 }
 
 // Emission-per-stake return rate; null when stake is 0 (undefined return).

--- a/tests/account-portfolio.test.mjs
+++ b/tests/account-portfolio.test.mjs
@@ -117,6 +117,17 @@ describe("buildAccountPortfolio", () => {
     assert.equal(out.captured_at, new Date(1_750_000_000_000).toISOString());
   });
 
+  test("rejects a 0/negative captured_at sentinel rather than stamping the 1970 epoch", () => {
+    const out = buildAccountPortfolio(
+      [
+        { netuid: 1, stake_tao: 1, captured_at: 0 },
+        { netuid: 2, stake_tao: 1, captured_at: -1 },
+      ],
+      SS58,
+    );
+    assert.equal(out.captured_at, null);
+  });
+
   test("cold/empty → schema-stable empty card", () => {
     const out = buildAccountPortfolio([], SS58);
     assert.equal(out.position_count, 0);


### PR DESCRIPTION
## Summary
- `captureStamp` in `src/account-portfolio.mjs` accepted any finite number or numeric string for `captured_at`, including `0` and negative values from a blank/sentinel D1 cell, so a portfolio's `captured_at` could be emitted as the 1970 epoch instead of `null`.
- Sibling modules from the same batch (`concentration.mjs`'s `epochMsStamp`, `subnet-performance.mjs`, `chain-serving.mjs`'s `coerceEpochMs`) already reject `ms <= 0` as a blank/sentinel cell; `account-portfolio.mjs` was the one outlier missing that guard.

## Test plan
- [x] New unit test: `buildAccountPortfolio` with `captured_at: 0` and `captured_at: -1` rows returns `captured_at: null`
- [x] `npm run lint`
- [x] `npm run validate`
- [x] `npx vitest run tests/account-portfolio.test.mjs` (11 passed)
