### PR TITLE
fix(subnet-identity-history): reject blank/negative block_number cells

### DIFF
--- a/src/subnet-identity-history.mjs
+++ b/src/subnet-identity-history.mjs
@@ -61,6 +61,16 @@ export async function identityHash(snapshot) {
   return sha256Hex(stableStringify(snapshot));
 }
 
+// Non-negative integer block height, or null for absent/blank/negative cells.
+// Mirrors toBlockNumber in account-events.mjs: Number("") / Number("   ") both
+// coerce to 0, so a blank D1 cell must be rejected before the Number() coercion.
+function toBlockNumber(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isSafeInteger(n) && n >= 0 ? n : null;
+}
+
 function toIso(ms) {
   if (ms == null) return null;
   const n = Number(ms);
@@ -79,12 +89,7 @@ function normalizeName(value) {
 export function formatIdentityHistoryEntry(row) {
   if (!row || typeof row !== "object") return null;
   const entry = sanitizeIdentityHistoryFields({
-    block_number:
-      row.block_number == null
-        ? null
-        : Number.isSafeInteger(Number(row.block_number))
-          ? Number(row.block_number)
-          : null,
+    block_number: toBlockNumber(row.block_number),
     observed_at: toIso(row.observed_at),
     subnet_name: row.subnet_name ?? null,
     symbol: row.symbol ?? null,

--- a/tests/subnet-identity-history.test.mjs
+++ b/tests/subnet-identity-history.test.mjs
@@ -240,6 +240,17 @@ describe("formatIdentityHistoryEntry", () => {
     assert.equal(out.observed_at, null);
   });
 
+  test("nulls blank/whitespace and negative block_number cells", () => {
+    for (const block_number of ["", "   ", -1, "-5"]) {
+      const out = formatIdentityHistoryEntry({
+        block_number,
+        observed_at: 1_700_000_000_000,
+        identity_hash: "abc",
+      });
+      assert.equal(out.block_number, null);
+    }
+  });
+
   test("coerces string-typed observed_at cells to ISO timestamps", () => {
     const out = formatIdentityHistoryEntry({
       block_number: 1,


### PR DESCRIPTION
## Summary
- `formatIdentityHistoryEntry` coerced `block_number` via `Number.isSafeInteger(Number(value))` without first rejecting blank/whitespace strings or negative values, so `Number("")` / `Number("   ")` (both `0`) fabricated a genesis-height `block_number` for a row whose block was actually absent, and a negative cell (e.g. `-1`) passed straight through instead of being rejected.
- This is shared by both `GET /api/v1/subnets/{netuid}/identity-history` and the network feed `GET /api/v1/chain/identity-history` (via `chain-identity-history.mjs`'s reuse of the same formatter).
- Mirrors `toBlockNumber` in `account-events.mjs`, which already guards both the blank-string and non-negative cases.

## Test plan
- [x] New unit test: `formatIdentityHistoryEntry` nulls blank/whitespace and negative `block_number` cells (`""`, `"   "`, `-1`, `"-5"`)
- [x] `npm run lint`
- [x] `npm run validate`
- [x] `npx vitest run tests/subnet-identity-history.test.mjs tests/chain-identity-history.test.mjs` (78 passed)
