### PR TITLE
fix(account): clamp a near-pure stake flow_ratio below an exact +/-1

### DIFF
--- a/src/account-stake-flow.mjs
+++ b/src/account-stake-flow.mjs
@@ -88,7 +88,16 @@ function classifyDirection(netTao, grossTao) {
 // net / gross, rounded to 4dp; null when gross is 0 (ratio undefined with no flow).
 function flowRatio(netTao, grossTao) {
   if (grossTao <= 0) return null;
-  return Math.round((netTao / grossTao) * 10000) / 10000;
+  const raw = netTao / grossTao;
+  const rounded = Math.round(raw * 10000) / 10000;
+  // net/gross lies in [-1, 1]; an exact +1/-1 means purely one-directional flow
+  // (no counter-flow at all). When counter-flow exists (|net| < gross) a
+  // sub-perfect ratio must not round to +/-1 and misread as a pure direction --
+  // the same anti-overstatement clamp roundConcentration applies to this card's
+  // HHI (#2997), extended to both signs.
+  if (rounded >= 1 && raw < 1) return 0.9999;
+  if (rounded <= -1 && raw > -1) return -0.9999;
+  return rounded;
 }
 
 // Shape an account's per-(netuid, kind) StakeAdded/StakeRemoved aggregate into a

--- a/tests/account-stake-flow.test.mjs
+++ b/tests/account-stake-flow.test.mjs
@@ -105,6 +105,20 @@ describe("buildAccountStakeFlow", () => {
     );
   });
 
+  test("a near-pure flow_ratio does not round up to an exact +/-1 while counter-flow exists", () => {
+    // Accumulation with a sliver of counter-flow: net 99999 / gross 100001 =
+    // 0.99998, which a bare 4dp round lifts to exactly 1 (reads as pure
+    // one-directional flow with zero outflow). Clamp holds it below 1.
+    const acc = buildAccountStakeFlow([added(1, 100000), removed(1, 1)], ADDR);
+    assert.equal(acc.flow_ratio, 0.9999);
+    // The mirror case on the exit side must not round to a flat -1 either.
+    const exit = buildAccountStakeFlow([added(1, 1), removed(1, 100000)], ADDR);
+    assert.equal(exit.flow_ratio, -0.9999);
+    // A genuinely one-directional wallet still reports a true, unclamped +/-1.
+    assert.equal(buildAccountStakeFlow([added(9, 5)], ADDR).flow_ratio, 1);
+    assert.equal(buildAccountStakeFlow([removed(9, 5)], ADDR).flow_ratio, -1);
+  });
+
   test("concentration is the HHI of gross flow across subnets", () => {
     // all flow in one subnet -> 1
     assert.equal(buildAccountStakeFlow([added(1, 100)], ADDR).concentration, 1);


### PR DESCRIPTION
## What

`flowRatio` in the account stake-flow card rounds `net / gross` to 4 dp with a bare `Math.round`:

```js
return Math.round((netTao / grossTao) * 10000) / 10000;
```

`net / gross` lies in `[-1, 1]`, and an exact `+1` / `-1` means **purely one-directional** flow (no counter-flow at all). But a wallet with a sliver of counter-flow (`|net| < gross`) can round up to an exact `±1`, misreading as pure accumulation/exit.

## Concrete case

A wallet that staked `100000` and unstaked `1`: `net = 99999`, `gross = 100001`, ratio `0.99998`.

- **Before:** `flow_ratio: 1` (reads as pure accumulation with zero outflow)
- **After:** `flow_ratio: 0.9999`

The mirror case (`added 1`, `removed 100000` → `-0.99998`) rounds to a flat `-1` before the fix and `-0.9999` after.

## Fix

Clamp a sub-perfect ratio away from an exact `±1` — the same anti-overstatement invariant the shared concentration/turnover/reliability ratios enforce, and specifically the one **#2997** just added to this very card's HHI `concentration` field via `roundConcentration`. This extends the guard to `flow_ratio`, on both signs. A genuinely one-directional wallet still reports a true, unclamped `±1`.

The clamp is inline in `flowRatio` (both bounds) — `roundConcentration` only guards the upper bound, so no shared helper fits both signs.

## Tests

- New: a near-pure accumulation (`0.99998`) clamps to `0.9999`, and the mirror exit case to `-0.9999`; a genuinely one-directional wallet keeps a true `+1` / `-1`. Fails on the old bare round, passes with the fix.
- Existing `flow_ratio` / direction tests still pass (26/26).

Source + tests only — no schema/contract/generated-artifact changes (`flow_ratio` stays `number | null`). `eslint` clean, `prettier` clean, 100% patch coverage of the changed lines.
