### PR TITLE
fix(chain-transfers): clamp top_sender_share so a sub-1 dominance never reads as a flat 1

### DIFF
--- a/src/chain-transfers.mjs
+++ b/src/chain-transfers.mjs
@@ -36,6 +36,20 @@ function toCount(value) {
   return Math.max(0, Math.trunc(toNumber(value)));
 }
 
+// Round a 0..1 concentration ratio to a stable precision WITHOUT letting a
+// sub-perfect value round up to an exact 1 — the same anti-overstatement guard
+// the sibling ratios apply (roundRatio in src/concentration.mjs, round in
+// src/chain-turnover.mjs, roundShare in src/chain-transfer-pairs.mjs #2971).
+// top_sender_share divides the summed top-N senders by the full-window total, so
+// a near-monopoly (e.g. 249990/250000 = 0.99996, with other senders still present
+// in unique_senders) must not surface as a flat 1 ("100% of outflow"). A genuine
+// single-sender window where the top senders ARE the whole volume keeps a true 1.
+function roundShare(value, dp = 4) {
+  const factor = 10 ** dp;
+  const rounded = Math.round(value * factor) / factor;
+  return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
+}
+
 // Shape one side's leaderboard rows (address + summed volume + transfer count) into a
 // ranked list. Drops rows with a missing address so a NULL sender/receiver cannot leak in.
 function shapeParties(rows) {
@@ -65,9 +79,7 @@ export function buildChainTransfers({
   const topReceivers = shapeParties(receivers);
   const topSenderVolume = topSenders.reduce((sum, s) => sum + s.volume_tao, 0);
   const topSenderShare =
-    totalVolume > 0
-      ? Math.round((topSenderVolume / totalVolume) * 10000) / 10000
-      : null;
+    totalVolume > 0 ? roundShare(topSenderVolume / totalVolume) : null;
   return {
     schema_version: 1,
     window: window ?? null,

--- a/tests/chain-transfers.test.mjs
+++ b/tests/chain-transfers.test.mjs
@@ -65,6 +65,27 @@ describe("buildChainTransfers", () => {
     assert.equal(d.top_sender_share, 0.8);
   });
 
+  test("clamps a near-monopoly top_sender_share below a flat 1 when other senders exist", () => {
+    // The top senders moved 249990 of 250000 TAO (99.996%); the remaining 10 TAO
+    // came from senders outside the top-N leaderboard (unique_senders is 3). At 4dp
+    // 249990/250000 rounds to 1.0000 without the clamp — which would report the top
+    // senders as 100% of outflow while other accounts still sent TAO.
+    const d = buildChainTransfers({
+      totals: { total_volume_tao: 250000, unique_senders: 3 },
+      senders: [party("5Sa", 249990)],
+    });
+    assert.ok(d.top_sender_share < 1, "near-total share must stay below 1");
+    assert.equal(d.top_sender_share, 0.9999);
+  });
+
+  test("keeps an exact 1 top_sender_share when the top senders are the whole volume", () => {
+    const d = buildChainTransfers({
+      totals: { total_volume_tao: 100, unique_senders: 2 },
+      senders: [party("5Sa", 60), party("5Sb", 40)], // 100 / 100
+    });
+    assert.equal(d.top_sender_share, 1);
+  });
+
   test("top_sender_share is null when there is no volume", () => {
     const d = buildChainTransfers({
       totals: { total_volume_tao: 0 },


### PR DESCRIPTION
## Summary

- `buildChainTransfers` computed `top_sender_share` as `Math.round((topSenderVolume / totalVolume) * 10000) / 10000`. When the top-N senders hold just under the whole window volume (e.g. `249990/250000 = 0.99996`) while other accounts still sent TAO, the 4dp rounding lands on `1.0000` — reporting the top senders as 100% of outflow when they are not.

## What Changed

- Route the ratio through a `roundShare` helper that keeps the 4dp precision but clamps a sub-1 value that rounds up back to `0.9999`, leaving only a genuine top==total window at an exact `1`. This mirrors the same anti-overstatement guard already applied to `chain-transfer-pairs`' `top_pair_share` (#2971), `movers`' dominance shares (#2985), and the `concentration`/`chain-turnover` ratios.
- Added a regression test for the near-monopoly clamp and for the genuine single-owner exact-`1` case.

## Validation

- [x] `vitest run tests/chain-transfers.test.mjs` — 14/14 pass, incl. the two new cases.
- [x] Ran the other suites referencing `top_sender_share` (chain-analytics, mcp-server, openapi-sample) — all green, no assertion churn.
- [x] `eslint` + `prettier --check` on the changed files — clean; `git diff --check` — clean.

Pure `src/` shaping + test only (2 files, +36/−3); no schema, contract, or generated-artifact changes.
