### PR TITLE
feat(api): add ?format=csv to GET /api/v1/chain-events all-events feed (#2530)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -402,7 +402,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs. */
+        /** Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Pass ?format=csv to download the page as CSV. Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs. */
         get: operations["chainEventsFeed"];
         put?: never;
         post?: never;
@@ -9135,6 +9135,8 @@ export interface operations {
                 cursor?: string;
                 before?: number;
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -9142,7 +9144,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -9195,6 +9197,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainEventsFeedArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,pallet,method,phase,extrinsic_index,observed_at
+                     *     8454388,3,Balances,Transfer,ApplyExtrinsic,2,1751500800000
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5690,7 +5690,7 @@
     {
       "artifact_path": "/metagraph/chain-events.json",
       "cache": "short",
-      "description": "Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs.",
+      "description": "Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Pass ?format=csv to download the page as CSV. Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs.",
       "id": "chain-events-feed",
       "method": "GET",
       "path": "/api/v1/chain-events",
@@ -5748,6 +5748,17 @@
             "maximum": 200,
             "minimum": 1,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -750,7 +750,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events (no static file). Distinct from the curated account-attributed event stream; empty before the all-events backfill runs.",
+      "description": "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events; pass ?format=csv to download the page as CSV (no static file). Distinct from the curated account-attributed event stream; empty before the all-events backfill runs.",
       "id": "chain-events-feed",
       "path": "/metagraph/chain-events.json",
       "schema_ref": "#/components/schemas/ChainEventsFeedArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -21534,6 +21534,19 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -21594,9 +21607,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,event_index,pallet,method,phase,extrinsic_index,observed_at\r\n8454388,3,Balances,Transfer,ApplyExtrinsic,2,1751500800000",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -21653,7 +21672,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs.",
+        "summary": "Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Pass ?format=csv to download the page as CSV. Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs.",
         "tags": [
           "chain",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -402,7 +402,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs. */
+        /** Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Pass ?format=csv to download the page as CSV. Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs. */
         get: operations["chainEventsFeed"];
         put?: never;
         post?: never;
@@ -9135,6 +9135,8 @@ export interface operations {
                 cursor?: string;
                 before?: number;
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -9142,7 +9144,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -9195,6 +9197,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainEventsFeedArtifact"];
                     };
+                    /**
+                     * @example block_number,event_index,pallet,method,phase,extrinsic_index,observed_at
+                     *     8454388,3,Balances,Transfer,ApplyExtrinsic,2,1751500800000
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1118,7 +1118,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "chain-events-feed",
     "/metagraph/chain-events.json",
-    "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events (no static file). Distinct from the curated account-attributed event stream; empty before the all-events backfill runs.",
+    "Recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013), served live at /api/v1/chain-events; pass ?format=csv to download the page as CSV (no static file). Distinct from the curated account-attributed event stream; empty before the all-events backfill runs.",
     "ChainEventsFeedArtifact",
   ),
   artifact(
@@ -2365,10 +2365,10 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/chain-events",
     "/metagraph/chain-events.json",
-    "Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs.",
+    "Fetch the recent all-events feed (newest first) from the Postgres-backed all-events tier (ADR 0013) — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars; ?method requires ?pallet unless ?block is set); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=200, default 50). Pass ?format=csv to download the page as CSV. Served live (no static file); empty (count:0, events:[]) before the all-events backfill runs.",
     "short",
     ["chain", "analytics"],
-    [
+    csvRouteQuery([
       { name: "pallet", schema: { type: "string", maxLength: 64 } },
       { name: "method", schema: { type: "string", maxLength: 64 } },
       { name: "block", schema: { type: "integer", minimum: 0 } },
@@ -2385,7 +2385,7 @@ export const API_ROUTES = [
       },
       { name: "before", schema: { type: "integer", minimum: 0 } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 200 } },
-    ],
+    ]),
     [],
   ),
   route(

--- a/src/csv-route-examples.mjs
+++ b/src/csv-route-examples.mjs
@@ -15,4 +15,10 @@ export const ROUTE_CSV_EXAMPLES = {
   ].join("\r\n"),
   "subnet-events": EVENTS_CSV_EXAMPLE,
   "account-events": EVENTS_CSV_EXAMPLE,
+  // The Postgres all-events feed: flat scalar columns of each raw pallet.method
+  // event (the nested `args` object is omitted from the CSV projection).
+  "chain-events-feed": [
+    "block_number,event_index,pallet,method,phase,extrinsic_index,observed_at",
+    "8454388,3,Balances,Transfer,ApplyExtrinsic,2,1751500800000",
+  ].join("\r\n"),
 };

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -175,6 +175,30 @@ describe("Worker runtime", () => {
     assert.equal((await response.text()).trim(), CHAIN_EVENTS_CSV_HEADER);
   });
 
+  test("emits a header-only chain-events CSV when the upstream body omits events", async () => {
+    // Defensive path: if the data tier returns a body with no `events` array
+    // (degraded/partial), the CSV export must still yield a header-only file
+    // rather than throw — this exercises the `Array.isArray(...) ? … : []` guard.
+    const response = await handleRequest(
+      new Request("https://metagraph.sh/api/v1/chain-events?format=csv"),
+      {
+        ...env,
+        DATA_API: {
+          fetch() {
+            return new Response(JSON.stringify({ count: 0 }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            });
+          },
+        },
+      },
+      {},
+    );
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), /text\/csv/);
+    assert.equal((await response.text()).trim(), CHAIN_EVENTS_CSV_HEADER);
+  });
+
   test("chain-events/stats ignores ?format=csv and keeps the JSON envelope", async () => {
     // Only the feed exposes a top-level row array; the stats aggregate has none,
     // so a CSV request must fall through to the enveloped JSON, not a bogus export.

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -99,6 +99,107 @@ describe("Worker runtime", () => {
     assert.equal(body.meta.source, "data-worker-postgres");
   });
 
+  const CHAIN_EVENTS_CSV_HEADER =
+    "block_number,event_index,pallet,method,phase,extrinsic_index,observed_at";
+
+  test("serializes the DATA_API chain-events feed to CSV on ?format=csv", async () => {
+    const response = await handleRequest(
+      new Request("https://metagraph.sh/api/v1/chain-events?format=csv"),
+      {
+        ...env,
+        DATA_API: {
+          fetch() {
+            // The data Worker returns a BARE feed body (no envelope).
+            return new Response(
+              JSON.stringify({
+                count: 1,
+                next_before: null,
+                next_cursor: null,
+                events: [
+                  {
+                    block_number: 8454388,
+                    event_index: 3,
+                    pallet: "Balances",
+                    method: "Transfer",
+                    args: { from: "5A", to: "5B" },
+                    phase: "ApplyExtrinsic",
+                    extrinsic_index: 2,
+                    observed_at: 1751500800000,
+                  },
+                ],
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
+          },
+        },
+      },
+      {},
+    );
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), /text\/csv/);
+    assert.match(
+      response.headers.get("content-disposition") ?? "",
+      /attachment; filename="/,
+    );
+    const lines = (await response.text()).trim().split("\r\n");
+    assert.equal(lines[0], CHAIN_EVENTS_CSV_HEADER);
+    assert.equal(lines.length, 2);
+    const cells = lines[1].split(",");
+    assert.equal(cells[0], "8454388"); // block_number
+    assert.equal(cells[2], "Balances"); // pallet
+    assert.equal(cells[3], "Transfer"); // method
+    // The nested `args` object is intentionally not a CSV column.
+    assert.equal(cells.length, CHAIN_EVENTS_CSV_HEADER.split(",").length);
+  });
+
+  test("emits a header-only chain-events CSV when the feed is empty", async () => {
+    const response = await handleRequest(
+      new Request(
+        "https://metagraph.sh/api/v1/chain-events?pallet=Balances&format=csv",
+      ),
+      {
+        ...env,
+        DATA_API: {
+          fetch() {
+            return new Response(JSON.stringify({ count: 0, events: [] }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            });
+          },
+        },
+      },
+      {},
+    );
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), /text\/csv/);
+    assert.equal((await response.text()).trim(), CHAIN_EVENTS_CSV_HEADER);
+  });
+
+  test("chain-events/stats ignores ?format=csv and keeps the JSON envelope", async () => {
+    // Only the feed exposes a top-level row array; the stats aggregate has none,
+    // so a CSV request must fall through to the enveloped JSON, not a bogus export.
+    const response = await handleRequest(
+      new Request(
+        "https://metagraph.sh/api/v1/chain-events/stats?blocks=500&format=csv",
+      ),
+      {
+        ...env,
+        DATA_API: {
+          fetch() {
+            return new Response(
+              JSON.stringify({ window_blocks: 500, groups: 0, activity: [] }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
+          },
+        },
+      },
+      {},
+    );
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), /application\/json/);
+    assert.equal((await response.json()).ok, true);
+  });
+
   test("forwards a GET to DATA_API for a HEAD chain-events probe (not a 405)", async () => {
     // DATA_API is GET-only. A HEAD probe must still get the bodiless 200 that
     // every other GET route returns for HEAD — not the data Worker's 405 — so

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -884,6 +884,20 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
 // tool calls DATA_API directly and keeps consuming the bare shape — only this
 // public REST path is enveloped. 503 when the binding is absent (e.g. a preview
 // deploy without the data Worker); upstream non-2xx maps to a clean error envelope.
+// Stable CSV column order for the ?format=csv download of the all-events feed —
+// the flat scalar fields of the DATA_API event rows. The nested `args` object is
+// intentionally omitted (it has no flat CSV representation); callers who need it
+// use the JSON envelope.
+const CHAIN_EVENTS_CSV_COLUMNS = [
+  "block_number",
+  "event_index",
+  "pallet",
+  "method",
+  "phase",
+  "extrinsic_index",
+  "observed_at",
+];
+
 async function handleChainEventsProxy(request, env, url) {
   if (!env.DATA_API) {
     return errorResponse(
@@ -919,6 +933,19 @@ async function handleChainEventsProxy(request, env, url) {
         ? body.error
         : "The all-events data tier returned an error.",
       upstream.status,
+    );
+  }
+  // CSV download of the page: the /api/v1/chain-events feed exposes `events`, so
+  // serialize that array to text/csv when negotiated. The stats/blocks paths this
+  // proxy also serves have no top-level row array, so their CSV request falls
+  // through to the JSON envelope (a header-only export would be meaningless).
+  if (url.pathname === "/api/v1/chain-events" && csvRequested(url, request)) {
+    return csvResponse(
+      Array.isArray(body?.events) ? body.events : [],
+      "chain-events",
+      "short",
+      request,
+      CHAIN_EVENTS_CSV_COLUMNS,
     );
   }
   return envelopeResponse(


### PR DESCRIPTION
## Summary

Add `?format=csv` (and `Accept: text/csv`) to `GET /api/v1/chain-events` — the Postgres-backed all-events feed (ADR 0013) — so the raw pallet.method event page can be downloaded as CSV, mirroring the other feed CSV exports (#2846, #2986).

Closes #2530

## What Changed

- `workers/api.mjs` (`handleChainEventsProxy`): the proxy already reads the DATA_API feed's bare JSON body (`body.events`) before enveloping it, so the CSV branch lives here — a single worker, reusing the shared `csvResponse`. When `csvRequested(...)` and the path is the feed (`/api/v1/chain-events`), it serializes `body.events` to `text/csv` with a stable `CHAIN_EVENTS_CSV_COLUMNS` order (`block_number, event_index, pallet, method, phase, extrinsic_index, observed_at`). The nested `args` object has no flat CSV representation and is intentionally omitted. The sibling `/chain-events/stats` and `/blocks/{n}/chain-events` paths this proxy also serves have no top-level row array, so a CSV request there correctly falls through to the JSON envelope. DATA_API ignores the unknown `format` param, so forwarding it upstream is a no-op.
- `src/contracts.mjs`: wrapped the `chain-events-feed` route query params in `csvRouteQuery(...)` (adds the `format` param + `text/csv` response to the OpenAPI) and noted `?format=csv` in the route + artifact descriptions.
- `src/csv-route-examples.mjs`: a `chain-events-feed` CSV example (the shared no-conflict module for route CSV examples).
- Regenerated + committed the derived contract artifacts (`npm run build`): `openapi.json`, `contracts.json`, `api-index.json`, `types.d.ts`, `generated/metagraphed-api.d.ts`. Per repo policy, `public/metagraph/r2-manifest.json` and `public/metagraph/schemas/index.json` are intentionally NOT included (deploy/publish-pipeline-owned).
- Tests: `?format=csv` serializes the feed rows (header + data, `args` excluded); an empty feed emits a header-only CSV; and `/chain-events/stats?format=csv` still returns the JSON envelope (no bogus export).

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts (`npm run build`), not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed (r2-manifest.json / schemas/index.json excluded).
- [x] Public API/OpenAPI/schema changes are intentional and documented (new `format` param + `text/csv` response on the chain-events feed route).

## Validation

- [x] `npm run build` (regenerated + committed OpenAPI/types/contracts)
- [x] `npm run validate:contract-drift` · `validate:openapi` · `validate:api` · `validate:types` · `validate:docs`
- [x] `npx vitest run tests/worker-runtime.test.mjs tests/contracts.test.mjs tests/csv.test.mjs tests/api-coverage.test.mjs`
- [x] `npm run lint` · `npm run format:check` · `git diff --check`
