### PR TITLE
fix(counterparties): reject blank integer cells that coerce to 0

### DIFF
--- a/src/counterparties.mjs
+++ b/src/counterparties.mjs
@@ -66,6 +66,8 @@ function nullableNumber(value) {
 
 function nullableInteger(value) {
   if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : null;
 }

--- a/tests/counterparties.test.mjs
+++ b/tests/counterparties.test.mjs
@@ -304,6 +304,48 @@ describe("buildCounterpartyRelationship", () => {
     assert.deepEqual(data.transfers, []);
   });
 
+  test("blank integer evidence cells stay null on relationship transfers (not 0)", () => {
+    for (const blank of ["", "   "]) {
+      const data = buildCounterpartyRelationship(
+        [
+          {
+            block_number: blank,
+            event_index: blank,
+            hotkey: ME,
+            coldkey: "A",
+            netuid: blank,
+            amount_tao: 1,
+            observed_at: Date.UTC(2026, 5, 1),
+          },
+        ],
+        ME,
+        "A",
+        {},
+      );
+      assert.equal(
+        data.transfer_count,
+        1,
+        `transfer_count for ${JSON.stringify(blank)}`,
+      );
+      assert.equal(
+        data.transfers[0].block_number,
+        null,
+        `block_number for ${JSON.stringify(blank)}`,
+      );
+      assert.equal(
+        data.transfers[0].event_index,
+        null,
+        `event_index for ${JSON.stringify(blank)}`,
+      );
+      assert.equal(
+        data.transfers[0].netuid,
+        null,
+        `netuid for ${JSON.stringify(blank)}`,
+      );
+      assert.equal(data.last_block, null);
+    }
+  });
+
   test("skips sparse pair rows while preserving valid string and null evidence cells", () => {
     const data = buildCounterpartyRelationship(
       [
@@ -584,6 +626,22 @@ describe("buildCounterparties — regressions", () => {
       {},
     );
     assert.equal(data.counterparties[0].last_block, null);
+  });
+
+  test("blank block_number cells leave last_block null (not block 0)", () => {
+    // Mirrors the blank-cell guard in blocks.mjs (#2947): Number("") is 0.
+    for (const blank of ["", "   "]) {
+      const data = buildCounterparties(
+        [{ hotkey: "ME", coldkey: "A", amount_tao: 5, block_number: blank }],
+        ME,
+        {},
+      );
+      assert.equal(
+        data.counterparties[0].last_block,
+        null,
+        `last_block for ${JSON.stringify(blank)}`,
+      );
+    }
   });
 
   test("tie-break is deterministic when volumes tie AND last_block is null", () => {


### PR DESCRIPTION
## Summary

Reject blank D1 integer cells in counterparty formatting so empty strings and whitespace-only values return `null` instead of coercing to `0` on `last_block`, transfer evidence, and related fields.

## What Changed

- Add a trim guard to `nullableInteger()` in `src/counterparties.mjs`, matching the pattern merged in blocks.mjs (#2947).
- Add regression coverage in `tests/counterparties.test.mjs` for blank cells in both `buildCounterparties` and `buildCounterpartyRelationship`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/counterparties.test.mjs` (33 passed)
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Sibling fix to the merged blank-cell guard series (#2947 / #2974 / #2992).
