### PR TITLE
fix(webhooks): preserve transient DNS retries

### DIFF
--- a/scripts/dispatch-webhooks.mjs
+++ b/scripts/dispatch-webhooks.mjs
@@ -242,13 +242,19 @@ async function resolvePublicAddressRecords(hostname) {
       ? v6.value.map((address) => ({ address, family: 6 }))
       : []),
   ];
-  if (
-    records.length === 0 ||
-    records.some((record) => !isPublicWebhookAddress(record.address))
-  ) {
+  if (records.some((record) => !isPublicWebhookAddress(record.address))) {
     const error = new Error("unsafe webhook DNS result");
     error.code = "UNSAFE_WEBHOOK_DNS_RESULT";
     throw error;
+  }
+  if (records.length === 0) {
+    const rejected = [v4, v6]
+      .filter((result) => result.status === "rejected")
+      .map((result) => result.reason);
+    if (rejected.length > 0) {
+      throw new AggregateError(rejected, "webhook DNS resolution failed");
+    }
+    throw new Error("no public webhook DNS result");
   }
   return records;
 }


### PR DESCRIPTION
### Motivation
- A change in DNS classification made empty A/AAAA lookup results indistinguishable from confirmed private-address answers, causing transient resolver failures to be treated as terminal `unsafe` and dropping parked redeliveries.
- The goal is to keep confirmed private-address outcomes terminal while allowing transient resolver failures to surface as retryable `resolve-error` so at-least-once delivery is preserved.

### Description
- Update `resolvePublicAddressRecords` in `scripts/dispatch-webhooks.mjs` to first throw `UNSAFE_WEBHOOK_DNS_RESULT` only when a resolved address is non-public. 
- When no records are produced, detect whether the A/AAAA lookups were rejected and re-throw those failures as an `AggregateError` to signal a resolver failure instead of classifying the outcome as `UNSAFE_WEBHOOK_DNS_RESULT`.
- Preserve the previous behavior for confirmed private/non-public addresses so downstream code still treats those as terminal `unsafe`.

### Testing
- Ran the focused unit tests with `npx vitest run tests/webhooks-core.test.mjs tests/webhooks-redelivery.test.mjs --testNamePattern "unsafe DNS result|transient resolver failure|resolver throws"` and the targeted tests passed. 
- Verified linting with `npm run lint -- scripts/dispatch-webhooks.mjs` succeeded and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48a8595998832cb1ae86a8587eefeb)