### PR TITLE
fix(api): count uid-backed weight setters

### DIFF
--- a/src/chain-weights.mjs
+++ b/src/chain-weights.mjs
@@ -92,10 +92,10 @@ const EMPTY_NETWORK = {
 };
 
 // Shape the network-wide weight-setting scorecard from the per-subnet account_events aggregate.
-// `subnetRows` carries one row per netuid (COUNT(*) weight_sets, COUNT(DISTINCT hotkey)
-// distinct_setters). `networkDistinct` carries the true network-wide distinct setter count (a
-// validator setting weights on several subnets counts once, so this is NOT the sum of the
-// per-subnet distinct_setters) plus the newest observed_at. `limit` caps the leaderboard;
+// `subnetRows` carries one row per netuid (COUNT(*) weight_sets, distinct setter count).
+// WeightsSet ingestion can omit hotkey, so the SQL loader falls back to netuid/uid identities
+// rather than dropping real activity. `networkDistinct` carries the best available network-wide
+// distinct setter count plus the newest observed_at. `limit` caps the leaderboard;
 // subnet_count and the distribution span every subnet with observed weight-setting activity
 // (subnets with no WeightsSet events in the window are absent). Null-safe: no rows yields the
 // empty block.
@@ -175,8 +175,9 @@ export function buildChainWeights(
 
 // Network-wide weight-setting activity, computed live: read the account_events WeightsSet stream
 // over the window (observed_at >= now - windowDays, epoch ms), first as a single network aggregate
-// (true distinct setters + newest observed_at, covered by idx_account_events(event_kind, observed_at)
-// from migration 0032) and then grouped by netuid for the per-subnet leaderboard (served by
+// (best available distinct setters + newest observed_at, covered by
+// idx_account_events(event_kind, observed_at) from migration 0032) and then grouped by netuid for
+// the per-subnet leaderboard (served by
 // idx_account_events(netuid, event_kind, block_number) from migration 0024), and shape with
 // buildChainWeights. The
 // newest-observed probe doubles as the cold-store guard: a null MAX(observed_at) skips the
@@ -187,9 +188,15 @@ export async function loadChainWeights(
   { windowLabel, windowDays, limit } = {},
 ) {
   const cutoff = Date.now() - windowDays * DAY_MS;
+  const setterIdentity =
+    "CASE " +
+    "WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey " +
+    "WHEN uid IS NOT NULL AND netuid IS NOT NULL THEN 'uid:' || netuid || ':' || uid " +
+    "ELSE NULL END";
   const networkRows = await d1(
-    "SELECT COUNT(*) AS weight_sets, COUNT(DISTINCT hotkey) AS distinct_setters, " +
-      "MAX(observed_at) AS newest_observed " +
+    "SELECT COUNT(*) AS weight_sets, COUNT(DISTINCT " +
+      setterIdentity +
+      ") AS distinct_setters, MAX(observed_at) AS newest_observed " +
       "FROM account_events WHERE event_kind = ? AND observed_at >= ?",
     [WEIGHTS_EVENT_KIND, cutoff],
   );
@@ -197,7 +204,9 @@ export async function loadChainWeights(
   let subnetRows = [];
   if (networkDistinct?.newest_observed != null) {
     subnetRows = await d1(
-      "SELECT netuid, COUNT(*) AS weight_sets, COUNT(DISTINCT hotkey) AS distinct_setters " +
+      "SELECT netuid, COUNT(*) AS weight_sets, COUNT(DISTINCT " +
+        setterIdentity +
+        ") AS distinct_setters " +
         "FROM account_events WHERE event_kind = ? AND observed_at >= ? GROUP BY netuid",
       [WEIGHTS_EVENT_KIND, cutoff],
     );

--- a/tests/chain-weights.test.mjs
+++ b/tests/chain-weights.test.mjs
@@ -211,7 +211,9 @@ describe("loadChainWeights", () => {
       windowDays: 7,
       limit: 20,
     });
-    assert.match(calls[0].sql, /COUNT\(DISTINCT hotkey\)/);
+    assert.match(calls[0].sql, /COUNT\(DISTINCT CASE/);
+    assert.match(calls[0].sql, /WHEN hotkey IS NOT NULL/);
+    assert.match(calls[0].sql, /WHEN uid IS NOT NULL AND netuid IS NOT NULL/);
     assert.doesNotMatch(calls[0].sql, /GROUP BY/);
     assert.match(
       calls[1].sql,
@@ -222,6 +224,84 @@ describe("loadChainWeights", () => {
     assert.equal(calls[1].params[1], calls[0].params[1]); // same window cutoff
     assert.equal(data.subnet_count, 3);
     assert.equal(data.subnets[0].netuid, 1);
+  });
+
+  test("counts uid identities when WeightsSet rows have no hotkey", async () => {
+    const now = Date.now();
+    const rows = [
+      {
+        event_kind: WEIGHTS_EVENT_KIND,
+        observed_at: now,
+        netuid: 1,
+        uid: 7,
+        hotkey: null,
+      },
+      {
+        event_kind: WEIGHTS_EVENT_KIND,
+        observed_at: now + 1,
+        netuid: 1,
+        uid: 7,
+        hotkey: null,
+      },
+      {
+        event_kind: WEIGHTS_EVENT_KIND,
+        observed_at: now + 2,
+        netuid: 2,
+        uid: 7,
+        hotkey: null,
+      },
+    ];
+    const d1 = async (sql, params) => {
+      assert.equal(params[0], WEIGHTS_EVENT_KIND);
+      const filtered = rows.filter(
+        (row) => row.event_kind === params[0] && row.observed_at >= params[1],
+      );
+      const identity = (row) =>
+        row.hotkey ? `hotkey:${row.hotkey}` : `uid:${row.netuid}:${row.uid}`;
+      if (!/GROUP BY netuid/.test(sql)) {
+        return [
+          {
+            weight_sets: filtered.length,
+            distinct_setters: new Set(filtered.map(identity)).size,
+            newest_observed: Math.max(
+              ...filtered.map((row) => row.observed_at),
+            ),
+          },
+        ];
+      }
+      const byNetuid = new Map();
+      for (const row of filtered) {
+        const bucket = byNetuid.get(row.netuid) ?? [];
+        bucket.push(row);
+        byNetuid.set(row.netuid, bucket);
+      }
+      return [...byNetuid.entries()].map(([netuid, bucket]) => ({
+        netuid,
+        weight_sets: bucket.length,
+        distinct_setters: new Set(bucket.map(identity)).size,
+      }));
+    };
+
+    const data = await loadChainWeights(d1, {
+      windowLabel: "7d",
+      windowDays: 7,
+      limit: 20,
+    });
+
+    assert.equal(data.subnet_count, 2);
+    assert.equal(data.network.weight_sets, 3);
+    assert.equal(data.network.distinct_setters, 2);
+    assert.deepEqual(
+      data.subnets.map((subnet) => [
+        subnet.netuid,
+        subnet.distinct_setters,
+        subnet.weight_sets,
+      ]),
+      [
+        [1, 1, 2],
+        [2, 1, 1],
+      ],
+    );
   });
 
   test("a cold store skips the per-subnet read and returns the empty block", async () => {


### PR DESCRIPTION
### Motivation
- The `chain/weights` loader used `COUNT(DISTINCT hotkey)` to compute distinct setter counts, but `WeightsSet` ingestion can omit `hotkey`, causing SQLite to treat those rows as NULL and return zero distinct setters, which dropped real subnet activity from the leaderboard.

### Description
- Use a SQL `CASE` expression (`setterIdentity`) that prefers `hotkey` when present and falls back to a `netuid:uid` identity string when `hotkey` is NULL, and apply `COUNT(DISTINCT ...)` over that expression in the network and per-subnet queries in `src/chain-weights.mjs`.
- Update function comments to document the fallback behavior so the loader does not discard uid-backed `WeightsSet` rows.
- Add a regression test in `tests/chain-weights.test.mjs` that simulates `WeightsSet` rows with `hotkey: null` and verifies both per-subnet and network rollups remain present and correctly counted.

### Testing
- Ran unit tests with `npm test -- --run tests/chain-weights.test.mjs` and all tests passed (23/23).
- Ran linters and format checks with `npm run lint` and `npm run format:check`, which passed.
- Performed a local build and validation with `npm run build`, `npm run validate:api`, and `npm run validate:types`, all of which completed successfully.
- Ran the public-safety scan with `npm run scan:public-safety`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48aa27b818832c818e4180f4146bc8)