### PR TITLE
feat(registry): add SN34 BitMind GAS-Station datasets data-artifact

### DIFF
--- a/registry/subnets/bitmind.json
+++ b/registry/subnets/bitmind.json
@@ -196,6 +196,24 @@
       },
       "source_urls": ["https://bitmind.ai/"],
       "url": "https://api.bitmind.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-34-gasstation-datasets",
+      "kind": "data-artifact",
+      "name": "GAS-Station datasets (Hugging Face)",
+      "notes": "BitMind's public GAS-Station Hugging Face org hosting the subnet's weekly-refreshed real/generated image and video datasets (gs-images / gs-videos), linked as \"GAS-Station\" in the official bitmind-subnet README.",
+      "provider": "bitmind",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://github.com/BitMind-AI/bitmind-subnet/blob/bdbdb75c0828125ed1891aa1f0bb5e133aa42ab9/README.md#L13"
+      ],
+      "url": "https://huggingface.co/gasstation"
     }
   ],
   "website_url": "https://bitmind.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/bitmind.json` (SN34 BitMind). Append-only; no other files changed.

## Summary

BitMind's only registered `data-artifact` was a health endpoint. This adds the subnet's actual public dataset hub: the **GAS-Station** Hugging Face organization (`huggingface.co/gasstation`), which hosts the weekly-refreshed real/generated image and video datasets (`gs-images-*`, `gs-videos-*`) the subnet trains and evaluates on. These are actively maintained (latest versions updated within the last day, thousands of downloads). The official `BitMind-AI/bitmind-subnet` README links "GAS-Station" directly, establishing first-party ownership.

## Surface

- Netuid: 34
- Kind: data-artifact
- Public URL: https://huggingface.co/gasstation
- Source URL (proves the claim): https://github.com/BitMind-AI/bitmind-subnet/blob/bdbdb75c0828125ed1891aa1f0bb5e133aa42ab9/README.md#L13
- Provider slug: bitmind

Commit-pinned line anchor points to the exact README line linking GAS-Station.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this specific gap, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public dataset-org URL plus the first-party README source fully establish and verify the claim, so it stands on its own merit.

## Checklist

- [x] Changes exactly one `registry/subnets/bitmind.json` file (append-only).
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public and read-only-safe; the `source_url` independently proves the subnet publishes it.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface (existing SN34 data-artifact is a health endpoint, not this dataset org).
- [x] No linked issue — rationale provided above.

## Validation

- [x] `npm run validate:surface -- registry/subnets/bitmind.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate` (full suite, green)
