### PR TITLE
fix(api): ignore invalid block summary timestamps

### DIFF
--- a/src/blocks-summary.mjs
+++ b/src/blocks-summary.mjs
@@ -24,6 +24,7 @@ export const BLOCKS_SUMMARY_SCAN_CAP = 5000;
 
 const THROUGHPUT_UNAVAILABLE = null;
 const BLOCK_TIME_PERCENTILES = [50, 90];
+const MAX_DATE_MS = 8_640_000_000_000_000;
 
 // Round a duration/mean to whole milliseconds — inter-block time has no meaningful
 // sub-ms precision, and integer ms keeps the JSON clean.
@@ -40,13 +41,14 @@ function round2(value) {
 // real number or an all-digits string, so a blank/null/false cell is rejected
 // rather than coerced to 0 (Number("") === Number(null) === Number(false) === 0).
 function toInt(value) {
-  if (typeof value === "number") {
-    return Number.isInteger(value) && value >= 0 ? value : null;
-  }
-  if (typeof value === "string" && /^\d+$/.test(value)) {
-    return Number(value);
-  }
-  return null;
+  const n =
+    typeof value === "string" && /^\d+$/.test(value) ? Number(value) : value;
+  return typeof n === "number" && Number.isSafeInteger(n) && n >= 0 ? n : null;
+}
+
+function toTimestampMs(value) {
+  const ms = toInt(value);
+  return ms != null && ms <= MAX_DATE_MS ? ms : null;
 }
 
 // A nullable count cell (extrinsic_count / event_count) coerced to a finite,
@@ -96,7 +98,7 @@ export function buildBlocksSummary(rows) {
     if (blockNumber == null) continue;
     blocks.push({
       block_number: blockNumber,
-      observed_at: toInt(row?.observed_at),
+      observed_at: toTimestampMs(row?.observed_at),
       author: typeof row?.author === "string" && row.author ? row.author : null,
       extrinsic_count: toCount(row?.extrinsic_count),
       event_count: toCount(row?.event_count),

--- a/tests/blocks-summary.test.mjs
+++ b/tests/blocks-summary.test.mjs
@@ -154,6 +154,32 @@ describe("buildBlocksSummary", () => {
     assert.equal(out.throughput.total_extrinsics, 2); // "2" coerced
   });
 
+  test("ignores unsafe and out-of-range integer cells", () => {
+    const out = buildBlocksSummary([
+      { block_number: "9007199254740992", observed_at: 1 },
+      {
+        block_number: 1,
+        observed_at: "9000000000000000",
+        spec_version: "9007199254740992",
+      },
+      { block_number: 2, observed_at: "1750000012000", spec_version: "200" },
+    ]);
+
+    assert.equal(out.block_count, 2);
+    assert.equal(out.first_block, 1);
+    assert.equal(
+      out.first_observed_at,
+      new Date(1_750_000_012_000).toISOString(),
+    );
+    assert.equal(
+      out.last_observed_at,
+      new Date(1_750_000_012_000).toISOString(),
+    );
+    assert.equal(out.block_time, null);
+    assert.equal(out.latest_spec_version, 200);
+    assert.equal(out.distinct_spec_versions, 1);
+  });
+
   test("junk count cells contribute 0, never poison the totals", () => {
     const out = buildBlocksSummary([
       { block_number: 1, extrinsic_count: "junk", event_count: null },


### PR DESCRIPTION
### Motivation
- The blocks-summary shaping could call `new Date(...).toISOString()` on unsafe or out-of-range integer cells from the D1 `blocks` tier, which throws `RangeError` and makes the summary endpoint/tool fail instead of returning a schema-stable card.

### Description
- Tighten integer coercion by making `toInt` accept only non-negative `Number.isSafeInteger` values. 
- Add `MAX_DATE_MS` and `toTimestampMs` to treat timestamp cells outside JavaScript `Date`'s valid epoch-ms range as absent. 
- Use `toTimestampMs` for the `observed_at` field when shaping blocks so invalid timestamps are dropped rather than formatted. 
- Add a regression test in `tests/blocks-summary.test.mjs` that verifies unsafe integer cells and out-of-range `observed_at` values are ignored and do not crash `buildBlocksSummary`.

### Testing
- Ran `npm test -- tests/blocks-summary.test.mjs` and the test file passed. 
- Ran `npm run lint` and `npm run format:check` and both checks passed. 
- Ran `npm run build` and the build completed successfully. 
- Ran `npm run validate`; it initially failed because generated provider artifacts were absent until a local `npm run build` was performed, and the final `npm run validate` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a488d2685e4832c844ce2f6fcf2e484)