### PR TITLE
fix(api): ignore invalid stake-flow timestamps

### DIFF
--- a/src/chain-stake-flow.mjs
+++ b/src/chain-stake-flow.mjs
@@ -50,7 +50,8 @@ function normalizedNetuid(value) {
 function coerceEpochMs(value) {
   if (value == null) return null;
   const n = Number(value);
-  return Number.isFinite(n) && n > 0 ? n : null;
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Number.isFinite(new Date(n).getTime()) ? n : null;
 }
 
 function toIso(value) {

--- a/tests/chain-stake-flow.test.mjs
+++ b/tests/chain-stake-flow.test.mjs
@@ -208,6 +208,15 @@ describe("buildChainStakeFlow", () => {
     assert.equal(data.observed_at, null);
   });
 
+  test("ignores out-of-range timestamps that cannot be rendered as ISO", () => {
+    const data = buildChainStakeFlow(
+      [ev(2, "StakeAdded", 5, 1, 1e100), ev(3, "StakeAdded", 7, 1, OBS)],
+      {},
+    );
+    assert.equal(data.subnet_count, 2);
+    assert.equal(data.observed_at, new Date(OBS).toISOString());
+  });
+
   test("breaks a net-flow tie by netuid ascending", () => {
     // netuid 5 and netuid 3 both net +10 -> tie, broken by the lower netuid first.
     const data = buildChainStakeFlow(
@@ -313,6 +322,18 @@ describe("GET /api/v1/chain/stake-flow", () => {
     );
     assert.equal(res.status, 200);
     assert.equal(await res.text(), ""); // HEAD carries no body
+  });
+
+  test("ignores malformed out-of-range timestamps instead of returning 500", async () => {
+    const res = await handleRequest(
+      req(),
+      stakeFlowEnv([ev(4, "StakeAdded", 10, 1, 1e100)]),
+      {},
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet_count, 1);
+    assert.equal(body.data.observed_at, null);
   });
 
   test("serves a schema-stable empty card on a cold store", async () => {


### PR DESCRIPTION
### Motivation
- Prevent the new `/api/v1/chain/stake-flow` route from crashing when a malformed out-of-range `observed_at` value from D1 is returned, because `new Date(n).toISOString()` throws for epochs outside JS Date's supported range. 

### Description
- Tighten timestamp coercion in `src/chain-stake-flow.mjs` by validating that a coerced epoch-ms yields a finite `Date` (`new Date(n).getTime()`) and returning `null` for out-of-range values. 
- Preserve existing behavior: valid positive finite epoch-ms remain unchanged and are still serialized via `toISOString()`. 
- Add regression tests in `tests/chain-stake-flow.test.mjs` that verify the builder ignores out-of-range timestamps, and that the Worker route returns HTTP 200 with `observed_at: null` instead of 500 when D1 yields an out-of-range value. 

### Testing
- Ran `npm run lint` and `npm run format:check`, both succeeded after applying formatting fixes. 
- Ran `npm run build` and `npm run validate:api`, both succeeded with the local build artifacts. 
- Ran full validation `npm run validate`, which completed successfully. 
- Ran unit tests `npm test -- --run tests/chain-stake-flow.test.mjs`, with all tests passing (26/26).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a488e10514c832c94cfbb36b1520e3e)