### PR TITLE
fix(api): vary blocks JSON on Accept

### DIFF
--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -3688,6 +3688,20 @@ describe("handleBlocks", () => {
     assert.match(res.headers.get("content-type"), /^text\/csv/);
   });
 
+  test("JSON response varies on Accept for the CSV-negotiated blocks URL", async () => {
+    const { env } = dbWith({ blocksFeed: [blockRow()] });
+    const res = await handleBlocks(
+      new Request("https://api.metagraph.sh/api/v1/blocks", {
+        headers: { accept: "application/json" },
+      }),
+      env,
+      url("/api/v1/blocks"),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^application\/json/);
+    assert.equal(res.headers.get("vary"), "Accept, Accept-Encoding");
+  });
+
   test("empty CSV export still emits the header row", async () => {
     const { env } = dbWith({ blocksFeed: [] });
     const res = await handleBlocks(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -1895,6 +1895,7 @@ export async function handleBlocks(request, env, url) {
       ),
     },
     "short",
+    { vary: "Accept, Accept-Encoding" },
   );
 }
 


### PR DESCRIPTION
### Motivation
- The blocks feed added Accept-based CSV negotiation, creating two representations for the same URL (`/api/v1/blocks`), but the JSON envelope response did not include `Vary: Accept`, allowing shared caches to serve a cached JSON variant to CSV-preferring clients.

### Description
- Make the JSON envelope for the recent-blocks feed vary on `Accept` by passing `{ vary: "Accept, Accept-Encoding" }` to `envelopeResponse` in `workers/request-handlers/entities.mjs` for the `/api/v1/blocks` path.
- Add a regression test in `tests/request-handlers-entities.test.mjs` that requests the JSON variant and asserts the response `Vary` header is `Accept, Accept-Encoding`.
- Files changed: `workers/request-handlers/entities.mjs` and `tests/request-handlers-entities.test.mjs`.

### Testing
- Ran the targeted test file with `npm test -- --run tests/request-handlers-entities.test.mjs` and all tests in that file passed (`282 passed`).
- Verified formatting with `npm run format:check` and linting with `npm run lint` and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a488d266c3c832c9c20311550f79b9b)