### PR TITLE
fix(api): ignore invalid chain yield timestamps

### DIFF
--- a/src/chain-yield.mjs
+++ b/src/chain-yield.mjs
@@ -61,7 +61,10 @@ function subnetNetuid(value) {
 
 function captureStamp(value) {
   if (typeof value === "number" && Number.isFinite(value)) {
-    return { ms: value, value: new Date(value).toISOString() };
+    const date = new Date(value);
+    if (Number.isFinite(date.getTime())) {
+      return { ms: value, value: date.toISOString() };
+    }
   }
   if (typeof value === "string") {
     const ms = Date.parse(value);

--- a/tests/chain-yield.test.mjs
+++ b/tests/chain-yield.test.mjs
@@ -126,6 +126,22 @@ describe("buildChainYield", () => {
     assert.equal(out.captured_at, "2026-06-15T00:00:00.000Z");
   });
 
+  test("ignores out-of-range numeric captured_at values", () => {
+    const out = buildChainYield([
+      {
+        stake_tao: 1,
+        emission_tao: 0,
+        captured_at: 100_000_000_000_000_000_000,
+      },
+      {
+        stake_tao: 1,
+        emission_tao: 0,
+        captured_at: 1_750_000_000_000,
+      },
+    ]);
+    assert.equal(out.captured_at, new Date(1_750_000_000_000).toISOString());
+  });
+
   test("coerces numeric-string stake/emission cells from D1", () => {
     const out = buildChainYield([
       {


### PR DESCRIPTION
### Motivation
- Prevent the `RangeError` crash when a finite but out-of-range numeric `captured_at` from the D1 neurons tier is converted to an ISO string during `/api/v1/chain/yield` response construction.

### Description
- Guard `captureStamp()` in `src/chain-yield.mjs` by constructing `new Date(value)` and checking `Number.isFinite(date.getTime())` before calling `toISOString()`, returning `null` for invalid dates.
- Add a regression test in `tests/chain-yield.test.mjs` that verifies out-of-range numeric `captured_at` values are ignored while a valid timestamp is still selected.

### Testing
- Ran `npm test -- tests/chain-yield.test.mjs` and the test file passed (17 tests).
- Ran `npm run format:check -- src/chain-yield.mjs tests/chain-yield.test.mjs` and `git diff --check`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a488d1c5c3c832c8b079e994950b18d)