### PR TITLE
fix(chain-analytics): reject blank last_tx_block cells that coerce to 0

### DIFF
--- a/src/chain-analytics.mjs
+++ b/src/chain-analytics.mjs
@@ -37,6 +37,9 @@ function toNullableTao(value) {
 // Coerce a block-height cell to a non-negative integer, or null when the value is
 // missing, non-finite, or negative — block numbers are never negative on-chain.
 function toBlockNumber(value) {
+  if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : null;
 }

--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -519,6 +519,31 @@ test("buildChainSigners nulls non-finite and negative last_tx_block", () => {
   assert.equal(out.signers[2].last_tx_block, 12345);
 });
 
+test("buildChainSigners nulls blank and missing last_tx_block cells (not block 0)", () => {
+  // Mirrors the blank-cell guard in counterparties.mjs (#3008): Number("") is 0.
+  for (const bad of [null, undefined, "", "   "]) {
+    const out = buildChainSigners({
+      window: "7d",
+      rows: [{ signer: "5A", tx_count: 1, last_tx_block: bad }],
+    });
+    assert.equal(
+      out.signers[0].last_tx_block,
+      null,
+      `last_tx_block for ${JSON.stringify(bad)}`,
+    );
+  }
+  const missing = buildChainSigners({
+    window: "7d",
+    rows: [{ signer: "5B", tx_count: 1 }],
+  });
+  assert.equal(missing.signers[0].last_tx_block, null);
+  const numericString = buildChainSigners({
+    window: "7d",
+    rows: [{ signer: "5C", tx_count: 1, last_tx_block: "12345" }],
+  });
+  assert.equal(numericString.signers[0].last_tx_block, 12345);
+});
+
 test("GET /api/v1/chain/signers ranks by tx_count via the signer GROUP BY", async () => {
   const captured = [];
   const env = {


### PR DESCRIPTION
## Summary

Reject blank and missing D1 `last_tx_block` cells in chain signer formatting so empty strings and whitespace-only values return `null` instead of coercing to block `0`.

## What Changed

- Add null/trim guards to `toBlockNumber()` in `src/chain-analytics.mjs`, matching the pattern merged in counterparties.mjs (#3008).
- Add regression coverage in `tests/chain-analytics.test.mjs` for blank, missing, and valid string `last_tx_block` cells in `buildChainSigners`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/chain-analytics.test.mjs` (42 passed)
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Replaces closed #3000 (codecov patch); sibling fix to the merged blank-cell guard series.
