### PR TITLE
fix(neurons): reject blank integer cells that coerce to 0

### DIFF
--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -77,6 +77,8 @@ function nonNegativeInt(value) {
   // nullable INTEGER) would masquerade as the real chain height / netuid / uid 0
   // instead of "absent". A numeric string like "10" from D1 must still pass.
   if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
 }

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -222,6 +222,36 @@ describe("metagraph-neurons builders", () => {
     assert.equal(n.emission_tao, null);
   });
 
+  test("formatNeuron rejects blank integer cells that coerce to 0 (not uid/block 0)", () => {
+    // Mirrors the blank-cell guard in chain-analytics.mjs (#3019): Number("") is 0.
+    for (const blank of ["", "   "]) {
+      const n = formatNeuron({
+        uid: blank,
+        registered_at_block: blank,
+      });
+      assert.equal(n.uid, null, `uid for ${JSON.stringify(blank)}`);
+      assert.equal(
+        n.registered_at_block,
+        null,
+        `registered_at_block for ${JSON.stringify(blank)}`,
+      );
+    }
+  });
+
+  test("buildSubnetMetagraph nulls blank snapshot block_number cells (not block 0)", () => {
+    for (const blank of ["", "   "]) {
+      const data = buildSubnetMetagraph(
+        [{ ...ROW, block_number: blank, uid: 1 }],
+        7,
+      );
+      assert.equal(
+        data.block_number,
+        null,
+        `block_number for ${JSON.stringify(blank)}`,
+      );
+    }
+  });
+
   test("buildSubnetMetagraph stamps count + ISO captured_at", () => {
     const data = buildSubnetMetagraph([ROW, MINER], 7);
     assert.equal(data.netuid, 7);


### PR DESCRIPTION
## Summary

Reject blank D1 integer cells in metagraph neuron formatting so empty strings and whitespace-only values return `null` instead of coercing to `0` on `uid`, `registered_at_block`, and snapshot `block_number`.

## What Changed

- Add a trim guard to `nonNegativeInt()` in `src/metagraph-neurons.mjs`, matching the pattern merged in chain-analytics.mjs (#3019).
- Add regression coverage in `tests/metagraph-neurons.test.mjs` for blank cells in `formatNeuron` and `buildSubnetMetagraph`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/metagraph-neurons.test.mjs` (54 passed)
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Sibling fix to the merged blank-cell guard series.
