### PR TITLE
feat(registry): add SN64 Chutes user growth history data-artifact

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -408,6 +408,22 @@
         "https://chutes.ai/llms.txt"
       ],
       "url": "https://llm.chutes.ai/v1/chat/completions"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-64-chutes-user-growth",
+      "kind": "data-artifact",
+      "name": "Chutes user growth history",
+      "notes": "Public no-auth JSON time series of Chutes platform user growth (daily and cumulative user counts), served by the official Chutes API and defined in its OpenAPI spec.",
+      "provider": "chutes",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": ["https://api.chutes.ai/openapi.json"],
+      "url": "https://api.chutes.ai/users/growth"
     }
   ],
   "website_url": "https://chutes.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/chutes.json` (SN64 Chutes). Append-only; no other files changed.

## Summary

The Chutes API exposes a public, no-auth JSON endpoint reporting platform user-growth history — a daily and cumulative user-count time series (`GET /users/growth`). It's live and current (latest point is today). This adds it as a `data-artifact`, consistent with the subnet's other registered operational data-artifacts (`/chutes/utilization`, `/chutes/gpu_count_history`, `/chutes/boosted`), all sourced from the same official Chutes OpenAPI contract.

## Surface

- Netuid: 64
- Kind: data-artifact
- Public URL: https://api.chutes.ai/users/growth
- Source URL (proves the claim): https://api.chutes.ai/openapi.json
- Provider slug: chutes

The endpoint is defined in the official Chutes OpenAPI spec (`api.chutes.ai/openapi.json`) with no security requirement — the same source used by the subnet's existing data-artifact surfaces.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this specific endpoint, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public endpoint plus the official OpenAPI source fully establish and verify the claim, so it stands on its own merit.

## Checklist

- [x] Changes exactly one `registry/subnets/chutes.json` file (append-only).
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public, no-auth, read-only-safe; the `source_url` (official OpenAPI) independently proves the subnet publishes it.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface (distinct endpoint from existing /chutes/* data-artifacts).
- [x] No linked issue — rationale provided above.

## Validation

- [x] `npm run validate:surface -- registry/subnets/chutes.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate` (full suite, green)
