### PR TITLE
fix(subnet-yield): reject blank uid and block_number cells that coerce to 0

### DIFF
--- a/src/subnet-yield.mjs
+++ b/src/subnet-yield.mjs
@@ -39,6 +39,8 @@ function raoBigToTao(rao) {
 // so guard null explicitly rather than coercing it to uid 0).
 function normalizedUid(value) {
   if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const uid = Number(value);
   return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
 }
@@ -108,8 +110,15 @@ export function buildSubnetYield(rows, netuid) {
       // block is absent (the contract models it as ["integer","null"]). A
       // numeric string like "8454388" from D1 must still pass.
       const rawBlock = row?.block_number;
-      const block = rawBlock == null ? NaN : Number(rawBlock);
-      blockNumber = Number.isFinite(block) ? block : null;
+      if (
+        rawBlock == null ||
+        (typeof rawBlock === "string" && rawBlock.trim() === "")
+      ) {
+        blockNumber = null;
+      } else {
+        const block = Number(rawBlock);
+        blockNumber = Number.isFinite(block) ? block : null;
+      }
     }
     const stake = toNumber(row?.stake_tao);
     const emission = toNumber(row?.emission_tao);

--- a/tests/subnet-yield.test.mjs
+++ b/tests/subnet-yield.test.mjs
@@ -184,6 +184,30 @@ describe("buildSubnetYield", () => {
     assert.equal(d.block_number, null);
   });
 
+  test("blank uid and block_number cells stay null (not uid/block 0)", () => {
+    // Mirrors the blank-cell guard in metagraph-neurons.mjs (#3020).
+    for (const blank of ["", "   "]) {
+      const skipped = buildSubnetYield(
+        [{ ...neuron(1, { stake: 1, emission: 1 }), uid: blank }],
+        7,
+      );
+      assert.equal(
+        skipped.neuron_count,
+        0,
+        `neuron_count for uid ${JSON.stringify(blank)}`,
+      );
+      const block = buildSubnetYield(
+        [neuron(1, { stake: 1, emission: 1, block: blank })],
+        7,
+      );
+      assert.equal(
+        block.block_number,
+        null,
+        `block_number for ${JSON.stringify(blank)}`,
+      );
+    }
+  });
+
   test("coerces string-typed captured_at cells to ISO timestamps", () => {
     const d = buildSubnetYield(
       [


### PR DESCRIPTION
## Summary

Reject blank D1 integer cells in subnet yield formatting so empty strings and whitespace-only values return `null` / skip malformed rows instead of coercing to uid `0` or block `0`.

## What Changed

- Add a trim guard to `normalizedUid()` in `src/subnet-yield.mjs`.
- Reject blank `block_number` cells when stamping the snapshot envelope.
- Add regression coverage in `tests/subnet-yield.test.mjs`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/subnet-yield.test.mjs` (19 passed)
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Sibling fix to the merged blank-cell guard series.
