### PR TITLE
feat(api): add ?format=csv to GET /api/v1/chain/weights leaderboard

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -640,7 +640,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): a per-subnet leaderboard (distinct weight-setting validators, WeightsSet event count, and average updates per validator) ranked by total events, a network rollup with the true distinct setter count (a validator setting weights on several subnets counts once) and total events, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet update intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events WeightsSet stream; schema-stable empty block when cold. */
+        /** Fetch network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): a per-subnet leaderboard (distinct weight-setting validators, WeightsSet event count, and average updates per validator) ranked by total events, a network rollup with the true distinct setter count (a validator setting weights on several subnets counts once) and total events, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet update intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events WeightsSet stream; schema-stable empty block when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + intensity distribution stay JSON-only). */
         get: operations["chainWeights"];
         put?: never;
         post?: never;
@@ -10984,6 +10984,8 @@ export interface operations {
             query?: {
                 window?: "7d" | "30d";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10991,7 +10993,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -11066,6 +11068,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainWeightsArtifact"];
                     };
+                    /**
+                     * @example netuid,distinct_setters,weight_sets,sets_per_setter
+                     *     1,4,40,10
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -6185,7 +6185,7 @@
     {
       "artifact_path": "/metagraph/chain/weights.json",
       "cache": "short",
-      "description": "Fetch network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): a per-subnet leaderboard (distinct weight-setting validators, WeightsSet event count, and average updates per validator) ranked by total events, a network rollup with the true distinct setter count (a validator setting weights on several subnets counts once) and total events, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet update intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events WeightsSet stream; schema-stable empty block when cold.",
+      "description": "Fetch network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): a per-subnet leaderboard (distinct weight-setting validators, WeightsSet event count, and average updates per validator) ranked by total events, a network rollup with the true distinct setter count (a validator setting weights on several subnets counts once) and total events, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet update intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events WeightsSet stream; schema-stable empty block when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + intensity distribution stay JSON-only).",
       "id": "chain-weights",
       "method": "GET",
       "path": "/api/v1/chain/weights",
@@ -6209,6 +6209,17 @@
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -849,7 +849,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): each subnet's distinct weight-setting validators, WeightsSet event count, and average updates per validator ranked into a leaderboard, a network rollup with the true distinct setter count (not a per-subnet sum) and total events, and a distribution summary of the per-subnet update intensity (count, mean, min, p25, median, p75, p90, max), computed live from the account_events WeightsSet stream at /api/v1/chain/weights (no static file).",
+      "description": "Network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): each subnet's distinct weight-setting validators, WeightsSet event count, and average updates per validator ranked into a leaderboard, a network rollup with the true distinct setter count (not a per-subnet sum) and total events, and a distribution summary of the per-subnet update intensity (count, mean, min, p25, median, p75, p90, max), computed live from the account_events WeightsSet stream at /api/v1/chain/weights; pass ?format=csv to download the per-subnet leaderboard as CSV (no static file).",
       "id": "chain-weights",
       "path": "/metagraph/chain/weights.json",
       "schema_ref": "#/components/schemas/ChainWeightsArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -23988,6 +23988,19 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -24070,9 +24083,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,distinct_setters,weight_sets,sets_per_setter\r\n1,4,40,10",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -24129,7 +24148,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): a per-subnet leaderboard (distinct weight-setting validators, WeightsSet event count, and average updates per validator) ranked by total events, a network rollup with the true distinct setter count (a validator setting weights on several subnets counts once) and total events, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet update intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events WeightsSet stream; schema-stable empty block when cold.",
+        "summary": "Fetch network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): a per-subnet leaderboard (distinct weight-setting validators, WeightsSet event count, and average updates per validator) ranked by total events, a network rollup with the true distinct setter count (a validator setting weights on several subnets counts once) and total events, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet update intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events WeightsSet stream; schema-stable empty block when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + intensity distribution stay JSON-only).",
         "tags": [
           "chain",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -640,7 +640,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): a per-subnet leaderboard (distinct weight-setting validators, WeightsSet event count, and average updates per validator) ranked by total events, a network rollup with the true distinct setter count (a validator setting weights on several subnets counts once) and total events, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet update intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events WeightsSet stream; schema-stable empty block when cold. */
+        /** Fetch network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): a per-subnet leaderboard (distinct weight-setting validators, WeightsSet event count, and average updates per validator) ranked by total events, a network rollup with the true distinct setter count (a validator setting weights on several subnets counts once) and total events, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet update intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events WeightsSet stream; schema-stable empty block when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + intensity distribution stay JSON-only). */
         get: operations["chainWeights"];
         put?: never;
         post?: never;
@@ -10984,6 +10984,8 @@ export interface operations {
             query?: {
                 window?: "7d" | "30d";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10991,7 +10993,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -11066,6 +11068,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainWeightsArtifact"];
                     };
+                    /**
+                     * @example netuid,distinct_setters,weight_sets,sets_per_setter
+                     *     1,4,40,10
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1184,7 +1184,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "chain-weights",
     "/metagraph/chain/weights.json",
-    "Network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): each subnet's distinct weight-setting validators, WeightsSet event count, and average updates per validator ranked into a leaderboard, a network rollup with the true distinct setter count (not a per-subnet sum) and total events, and a distribution summary of the per-subnet update intensity (count, mean, min, p25, median, p75, p90, max), computed live from the account_events WeightsSet stream at /api/v1/chain/weights (no static file).",
+    "Network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): each subnet's distinct weight-setting validators, WeightsSet event count, and average updates per validator ranked into a leaderboard, a network rollup with the true distinct setter count (not a per-subnet sum) and total events, and a distribution summary of the per-subnet update intensity (count, mean, min, p25, median, p75, p90, max), computed live from the account_events WeightsSet stream at /api/v1/chain/weights; pass ?format=csv to download the per-subnet leaderboard as CSV (no static file).",
     "ChainWeightsArtifact",
   ),
   artifact(
@@ -2597,13 +2597,13 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/chain/weights",
     "/metagraph/chain/weights.json",
-    "Fetch network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): a per-subnet leaderboard (distinct weight-setting validators, WeightsSet event count, and average updates per validator) ranked by total events, a network rollup with the true distinct setter count (a validator setting weights on several subnets counts once) and total events, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet update intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events WeightsSet stream; schema-stable empty block when cold.",
+    "Fetch network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): a per-subnet leaderboard (distinct weight-setting validators, WeightsSet event count, and average updates per validator) ranked by total events, a network rollup with the true distinct setter count (a validator setting weights on several subnets counts once) and total events, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet update intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events WeightsSet stream; schema-stable empty block when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + intensity distribution stay JSON-only).",
     "short",
     ["chain", "analytics"],
-    [
+    csvRouteQuery([
       { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
-    ],
+    ]),
     [],
   ),
   route(

--- a/src/csv-route-examples.mjs
+++ b/src/csv-route-examples.mjs
@@ -21,4 +21,9 @@ export const ROUTE_CSV_EXAMPLES = {
     "block_number,event_index,pallet,method,phase,extrinsic_index,observed_at",
     "8454388,3,Balances,Transfer,ApplyExtrinsic,2,1751500800000",
   ].join("\r\n"),
+  // The /chain/weights per-subnet weight-setting leaderboard rows.
+  "chain-weights": [
+    "netuid,distinct_setters,weight_sets,sets_per_setter",
+    "1,4,40,10",
+  ].join("\r\n"),
 };

--- a/tests/chain-weights.test.mjs
+++ b/tests/chain-weights.test.mjs
@@ -391,6 +391,65 @@ describe("GET /api/v1/chain/weights", () => {
     const res = await handleRequest(req("?limit=0"), weightsEnv(cold), {});
     assert.equal(res.status, 400);
   });
+
+  const WEIGHTS_CSV_HEADER =
+    "netuid,distinct_setters,weight_sets,sets_per_setter";
+
+  test("exports the per-subnet leaderboard as CSV with ?format=csv", async () => {
+    const res = await handleRequest(
+      req("?window=7d&format=csv"),
+      weightsEnv(warm),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    assert.match(
+      res.headers.get("content-disposition"),
+      /attachment; filename="chain-weights\.csv"/,
+    );
+    const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines[0], WEIGHTS_CSV_HEADER);
+    // Ranked by total weight_sets desc: netuid 1 (40), 2 (30), 5 (25).
+    assert.equal(lines.length, 4); // header + 3 subnet rows
+    assert.equal(lines[1], "1,4,40,10");
+  });
+
+  test("honors Accept: text/csv the same as ?format=csv", async () => {
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/chain/weights", {
+        headers: { accept: "text/csv" },
+      }),
+      weightsEnv(warm),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+  });
+
+  test("emits a header-only CSV on a cold store", async () => {
+    const res = await handleRequest(req("?format=csv"), weightsEnv(cold), {});
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    assert.equal((await res.text()).trim(), WEIGHTS_CSV_HEADER);
+  });
+
+  test("serves a CSV HEAD probe with the CSV headers and no body", async () => {
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/chain/weights?format=csv", {
+        method: "HEAD",
+      }),
+      weightsEnv(warm),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    assert.equal(await res.text(), ""); // HEAD carries no body
+  });
+
+  test("rejects an unsupported format value with 400", async () => {
+    const res = await handleRequest(req("?format=xml"), weightsEnv(cold), {});
+    assert.equal(res.status, 400);
+  });
 });
 
 describe("chain/weights edge cache", () => {

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -766,6 +766,16 @@ const CHAIN_STAKE_FLOW_CSV_COLUMNS = [
   "direction",
 ];
 
+// CSV column order for the /api/v1/chain/weights per-subnet leaderboard rows
+// (the row-shaped `subnets` array). The network rollup + intensity_distribution
+// stay JSON-only, mirroring chain-stake-flow.
+const CHAIN_WEIGHTS_CSV_COLUMNS = [
+  "netuid",
+  "distinct_setters",
+  "weight_sets",
+  "sets_per_setter",
+];
+
 // Daily network-activity aggregates over the first-party chain D1 tiers (#1987):
 // per-UTC-day extrinsic/event/block counts, success rate, and unique signers —
 // the foundation time-series for the block-explorer "network at a glance" view
@@ -1157,13 +1167,16 @@ export async function handleChainStakeFlow(request, env, url, ctx = {}) {
 // the edge cache and repeatedly force the network-wide aggregations, cache keyed on the analytics
 // cron freshness. The leaderboard is fixed to most-active-first (total WeightsSet events).
 export async function handleChainWeights(request, env, url, ctx = {}) {
-  const { label, days, error } = analyticsWindow(url, ["limit"]);
+  const { label, days, error } = analyticsWindow(url, ["limit", "format"]);
   if (error) return analyticsQueryError(error);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { limit, error: limitError } = parseLimitParam(url, {
     defaultLimit: CHAIN_WEIGHTS_LIMIT_DEFAULT,
     maxLimit: CHAIN_WEIGHTS_LIMIT_MAX,
   });
   if (limitError) return analyticsQueryError(limitError);
+  const csv = csvRequested(url, request);
 
   const cacheRequest =
     request.method === "HEAD"
@@ -1180,6 +1193,17 @@ export async function handleChainWeights(request, env, url, ctx = {}) {
         windowDays: days,
         limit,
       });
+      // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
+      // intensity_distribution stay JSON-only (mirrors chain-stake-flow).
+      if (csv) {
+        return csvResponse(
+          data.subnets,
+          "chain-weights",
+          "short",
+          cacheRequest,
+          CHAIN_WEIGHTS_CSV_COLUMNS,
+        );
+      }
       return envelopeResponse(
         cacheRequest,
         {
@@ -1193,7 +1217,7 @@ export async function handleChainWeights(request, env, url, ctx = {}) {
         "short",
       );
     },
-    canonicalAnalyticsCacheRoute(url, ["limit"]),
+    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })


### PR DESCRIPTION
## Summary

Add `?format=csv` (and `Accept: text/csv`) to `GET /api/v1/chain/weights` — the network-wide validator weight-setting leaderboard — so the per-subnet rows can be downloaded as CSV, mirroring the existing `chain/stake-flow` CSV export (#2988).

## What Changed

- `workers/request-handlers/analytics.mjs` (`handleChainWeights`): allow `format` in the window param set, validate it via the shared `validateFormatParam`, and when CSV is negotiated return `csvResponse(data.subnets, "chain-weights", …)` with a stable `CHAIN_WEIGHTS_CSV_COLUMNS` order (`netuid, distinct_setters, weight_sets, sets_per_setter`). The network rollup + `intensity_distribution` stay JSON-only (same split as chain-stake-flow / chain-fees). The edge-cache key is suffixed with `&format=csv` so CSV and JSON responses never collide in the cache. HEAD probes keep flowing through the GET cache key.
- `src/contracts.mjs`: wrapped the `chain-weights` route query params in `csvRouteQuery(...)` (adds the `format` param + `text/csv` response to the OpenAPI) and noted `?format=csv` in the route + artifact descriptions.
- `src/csv-route-examples.mjs`: a `chain-weights` CSV example (the shared no-conflict module for route CSV examples).
- Regenerated + committed the derived contract artifacts (`npm run build`): `openapi.json`, `contracts.json`, `api-index.json`, `types.d.ts`, `generated/metagraphed-api.d.ts`. Per repo policy, `public/metagraph/r2-manifest.json` and `public/metagraph/schemas/index.json` are intentionally NOT included (deploy/publish-pipeline-owned).
- Tests: `?format=csv` serializes the ranked leaderboard (header + rows); `Accept: text/csv` negotiates the same; a cold store emits a header-only CSV; a CSV `HEAD` probe returns the CSV headers with no body; and `?format=xml` is rejected with 400. Every new branch is covered.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts (`npm run build`), not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed (r2-manifest.json / schemas/index.json excluded).
- [x] Public API/OpenAPI/schema changes are intentional and documented (new `format` param + `text/csv` response on the chain-weights route).

## Validation

- [x] `npm run build` (regenerated + committed OpenAPI/types/contracts)
- [x] `npm run validate:contract-drift` · `validate:openapi` · `validate:types` · `validate:docs`
- [x] `npx vitest run tests/chain-weights.test.mjs tests/contracts.test.mjs tests/csv.test.mjs tests/api-coverage.test.mjs`
- [x] `npm run lint` · `npm run format:check` · `git diff --check`
