### PR TITLE
feat(mcp): add get_chain_turnover mirroring GET /api/v1/chain/turnover

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -393,6 +393,17 @@ assert.ok(
   Number.isInteger(chainConc.subnet_count),
   "get_chain_concentration must return an integer subnet_count",
 );
+const chainTurnover = await callOk("get_chain_turnover", {
+  window: "30d",
+  limit: 5,
+});
+assert.ok(
+  typeof chainTurnover.comparable === "boolean" &&
+    Number.isInteger(chainTurnover.subnet_count) &&
+    Array.isArray(chainTurnover.subnets) &&
+    chainTurnover.network != null,
+  "get_chain_turnover must return comparable + subnet_count + network + subnets[]",
+);
 const meta = await callOk("get_subnet_metagraph", { netuid: 7 });
 assert.ok(
   Array.isArray(meta.neurons),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -78,6 +78,13 @@ import {
   DEFAULT_CHAIN_TRANSFER_WINDOW,
 } from "./chain-transfers.mjs";
 import {
+  loadChainTurnover,
+  CHAIN_TURNOVER_LIMIT_DEFAULT,
+  CHAIN_TURNOVER_LIMIT_MAX,
+  CHAIN_TURNOVER_WINDOWS,
+  DEFAULT_CHAIN_TURNOVER_WINDOW,
+} from "./chain-turnover.mjs";
+import {
   loadEconomicsTrends,
   parseEconomicsTrendsWindow,
 } from "./economics-trends.mjs";
@@ -227,11 +234,12 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.24.0";
+export const MCP_SERVER_VERSION = "1.25.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
+const CHAIN_TURNOVER_WINDOW_KEYS = Object.keys(CHAIN_TURNOVER_WINDOWS);
 const STAKE_FLOW_WINDOW_KEYS = Object.keys(STAKE_FLOW_WINDOWS);
 const MOVERS_WINDOW_KEYS = Object.keys(MOVERS_WINDOWS);
 
@@ -345,6 +353,8 @@ export const MCP_INSTRUCTIONS =
   "recent subnet-identity-change feed across all subnets, " +
   "get_chain_yield the network-wide emission-yield (return rate) and its " +
   "distribution across all subnets, " +
+  "get_chain_turnover the network-wide validator-turnover leaderboard " +
+  "(per-subnet churn, retention, and stability) across all subnets, " +
   "get_blocks_summary block-production analytics (inter-block time, throughput, " +
   "and block-author decentralization), " +
   "get_network_activity the daily " +
@@ -2006,6 +2016,56 @@ export const MCP_TOOLS = [
     },
     async handler(_args, ctx) {
       return loadChainYield(mcpD1Runner(ctx));
+    },
+  },
+  {
+    name: "get_chain_turnover",
+    title: "Get network-wide validator turnover",
+    description:
+      "Fetch the network-wide validator-set turnover leaderboard across ALL " +
+      "subnets between the window's boundary neuron_daily snapshots (7d, 30d, " +
+      "or 90d; default 30d): each subnet ranked by gross validator churn " +
+      "(validators entered + exited) with Jaccard retention and a 0–100 " +
+      "stability score, a network rollup over the union validator set, and the " +
+      "count/mean/min/p25/median/p75/p90/max spread of per-subnet stability. " +
+      "The network-level companion of get_subnet_turnover, mirroring how " +
+      "get_chain_concentration companions get_subnet_concentration. Mirrors " +
+      "GET /api/v1/chain/turnover.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_TURNOVER_WINDOW_KEYS,
+          description: `Comparison window (default ${DEFAULT_CHAIN_TURNOVER_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max subnets in the turnover leaderboard (1-${CHAIN_TURNOVER_LIMIT_MAX}, default ${CHAIN_TURNOVER_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_TURNOVER_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window =
+        optionalString(args, "window") ?? DEFAULT_CHAIN_TURNOVER_WINDOW;
+      if (!Object.hasOwn(CHAIN_TURNOVER_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_TURNOVER_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_TURNOVER_LIMIT_DEFAULT,
+        CHAIN_TURNOVER_LIMIT_MAX,
+      );
+      return loadChainTurnover(mcpD1Runner(ctx), {
+        windowLabel: window,
+        limit,
+      });
     },
   },
   {
@@ -5529,6 +5589,93 @@ const TOOL_OUTPUT_SCHEMAS = {
       validator_yield: { type: ["number", "null"] },
       miner_yield: { type: ["number", "null"] },
       distribution: { type: ["object", "null"] },
+    },
+  },
+  get_chain_turnover: {
+    type: "object",
+    additionalProperties: true,
+    required: ["comparable", "subnet_count", "network", "subnets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      start_date: NULLABLE_STRING,
+      end_date: NULLABLE_STRING,
+      comparable: { type: "boolean" },
+      subnet_count: { type: "integer" },
+      // Network rollup over the union validator set. retention/stability are
+      // null only on the cold/single-snapshot empty block.
+      network: {
+        type: "object",
+        additionalProperties: false,
+        required: [
+          "validators_start",
+          "validators_end",
+          "validators_entered",
+          "validators_exited",
+          "validator_retention",
+          "stability_score",
+        ],
+        properties: {
+          validators_start: { type: "integer" },
+          validators_end: { type: "integer" },
+          validators_entered: { type: "integer" },
+          validators_exited: { type: "integer" },
+          validator_retention: { type: ["number", "null"] },
+          stability_score: { type: ["integer", "null"] },
+        },
+      },
+      // Spread of per-subnet stability over EVERY comparable subnet; null when
+      // nothing is comparable.
+      stability_distribution: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: [
+          "count",
+          "mean",
+          "min",
+          "p25",
+          "median",
+          "p75",
+          "p90",
+          "max",
+        ],
+        properties: {
+          count: { type: "integer" },
+          mean: { type: "number" },
+          min: { type: "integer" },
+          p25: { type: "integer" },
+          median: { type: "integer" },
+          p75: { type: "integer" },
+          p90: { type: "integer" },
+          max: { type: "integer" },
+        },
+      },
+      // Per-subnet turnover leaderboard, most volatile first.
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "netuid",
+            "validators_start",
+            "validators_end",
+            "validators_entered",
+            "validators_exited",
+            "validator_retention",
+            "stability_score",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            validators_start: { type: "integer" },
+            validators_end: { type: "integer" },
+            validators_entered: { type: "integer" },
+            validators_exited: { type: "integer" },
+            validator_retention: { type: "number" },
+            stability_score: { type: "integer" },
+          },
+        },
+      },
     },
   },
   get_blocks_summary: {

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.24.0");
+    assert.equal(MCP_SERVER_VERSION, "1.25.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.24.0");
+    assert.equal(MCP_SERVER_VERSION, "1.25.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.24.0");
+    assert.equal(MCP_SERVER_VERSION, "1.25.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6183,6 +6183,129 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.throughput.total_extrinsics, 4);
   });
 
+  // A validator-permit neuron_daily row for one boundary snapshot; keeps the
+  // turnover fixtures compact so the churn arithmetic under test stays legible.
+  function turnoverRow(snapshot_date, netuid, hotkey) {
+    return { snapshot_date, netuid, hotkey, validator_permit: 1 };
+  }
+
+  // A metagraphD1 env wired for the chain-turnover boundary reads: the MIN/MAX
+  // bounds row plus the two-snapshot validator rows the loader reads.
+  function chainTurnoverEnv(
+    rows,
+    { start = "2026-06-01", end = "2026-06-30" } = {},
+  ) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: metagraphD1({
+          turnoverBounds: [{ start_date: start, end_date: end }],
+          turnoverRows: rows,
+        }),
+      },
+    };
+  }
+
+  test("get_chain_turnover returns schema-stable empty on cold D1", async () => {
+    const res = await callTool("get_chain_turnover", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.comparable, false);
+    assert.equal(out.subnet_count, 0);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.stability_distribution, null);
+    assert.equal(out.network.validators_start, 0);
+  });
+
+  test("get_chain_turnover defaults to the 30d window and default limit", async () => {
+    // 25 comparable subnets (each swaps its lone validator) so the default
+    // leaderboard limit (20) is observable as a cap, matching REST defaults.
+    const rows = [];
+    for (let netuid = 1; netuid <= 25; netuid += 1) {
+      rows.push(turnoverRow("2026-06-01", netuid, `A${netuid}`));
+      rows.push(turnoverRow("2026-06-30", netuid, `B${netuid}`));
+    }
+    const res = await callTool(
+      "get_chain_turnover",
+      {},
+      chainTurnoverEnv(rows),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d"); // REST default window parity
+    assert.equal(out.subnet_count, 25);
+    assert.equal(out.subnets.length, 20); // default limit
+  });
+
+  test("get_chain_turnover ranks per-subnet churn across the network", async () => {
+    const res = await callTool(
+      "get_chain_turnover",
+      { window: "30d", limit: 10 },
+      chainTurnoverEnv([
+        // netuid 1: one validator swapped (V2 -> V3) — churn of 2.
+        turnoverRow("2026-06-01", 1, "V1"),
+        turnoverRow("2026-06-01", 1, "V2"),
+        turnoverRow("2026-06-30", 1, "V1"),
+        turnoverRow("2026-06-30", 1, "V3"),
+        // netuid 2: stable set (V4 both boundaries) — churn of 0.
+        turnoverRow("2026-06-01", 2, "V4"),
+        turnoverRow("2026-06-30", 2, "V4"),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.comparable, true);
+    assert.equal(out.window, "30d");
+    assert.equal(out.start_date, "2026-06-01");
+    assert.equal(out.end_date, "2026-06-30");
+    assert.equal(out.subnet_count, 2);
+    // Most volatile subnet first: netuid 1 (churn 2) ranks above netuid 2 (churn 0).
+    assert.equal(out.subnets[0].netuid, 1);
+    assert.equal(out.subnets[0].validators_entered, 1);
+    assert.equal(out.subnets[0].validators_exited, 1);
+    // Network union set (V1,V2,V4) -> (V1,V3,V4): one entered, one exited.
+    assert.equal(out.network.validators_entered, 1);
+    assert.equal(out.network.validators_exited, 1);
+    assert.equal(out.stability_distribution.count, 2);
+  });
+
+  test("get_chain_turnover rejects an unsupported window", async () => {
+    const res = await callTool("get_chain_turnover", { window: "1y" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_turnover caps the leaderboard by limit", async () => {
+    const res = await callTool(
+      "get_chain_turnover",
+      { limit: 1 },
+      chainTurnoverEnv([
+        turnoverRow("2026-06-01", 1, "V1"),
+        turnoverRow("2026-06-30", 1, "V2"),
+        turnoverRow("2026-06-01", 2, "V3"),
+        turnoverRow("2026-06-30", 2, "V4"),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    // Both subnets are counted in the rollup/distribution, but the leaderboard is capped.
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.stability_distribution.count, 2);
+  });
+
+  test("get_chain_turnover payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_turnover",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_turnover",
+      {},
+      chainTurnoverEnv([
+        turnoverRow("2026-06-01", 1, "V1"),
+        turnoverRow("2026-06-30", 1, "V2"),
+      ]),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("get_subnet_concentration_history defaults to 30d and returns points", async () => {
     const res = await callTool(
       "get_subnet_concentration_history",

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.24.0");
+    assert.equal(MCP_SERVER_VERSION, "1.25.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.24.0");
+    assert.equal(MCP_SERVER_VERSION, "1.25.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add MCP tool `get_chain_turnover` mirroring `GET /api/v1/chain/turnover`, the network-wide validator-turnover leaderboard across all subnets
- Reuses the shared `loadChainTurnover` loader (no new query logic): per-subnet churn/retention/stability ranking, a network rollup over the union validator set, and the per-subnet stability distribution
- `window` (7d/30d/90d, default 30d) + `limit` (1-100, default 20) inputs mirror the REST route
- **Fully typed output schema**: `network`, each `subnets[]` entry, and `stability_distribution` now declare concrete fields (validator counts, entered/exited counts, retention, stability metrics) so generated MCP consumers get the real turnover contract instead of opaque objects
- Completes network-level chain-analytics MCP parity alongside `get_chain_yield`, `get_chain_concentration`, and `get_chain_performance`. Bumps MCP SemVer to 1.25.0

> Resubmit of #2930 (closed) — addresses the review: deepened the output-schema contract for `network`/`subnets`, added a default-window/limit assertion, and factored the turnover fixtures into a compact helper.

## Test plan
- [x] `npm run test -- tests/mcp-server.test.mjs -t get_chain_turnover` (cold path, ranking, default window/limit, limit cap, outputSchema)
- [x] `npm run validate:mcp` (90 tools, lifecycle + all tools/call)
- [x] `npm run lint && npm run format:check`