### PR TITLE
feat(registry): add SN94 Bitsota research tasks data-artifact

### DIFF
--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -48,6 +48,22 @@
         "https://bitsota.ai/"
       ],
       "url": "https://autoresearch.bitsota.com/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-tasks",
+      "kind": "data-artifact",
+      "name": "Bitsota research tasks",
+      "notes": "Public no-auth JSON catalog of Bitsota's open autonomous-research tasks, served by the official Bitsota API and defined in its OpenAPI spec.",
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/tasks"
     }
   ]
 }


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/bitsota.json` (SN94 Bitsota). Append-only; no other files changed.

## Summary

SN94 (Bitsota) had no `data-artifact` surface. The official Bitsota API exposes a public, no-auth JSON endpoint listing the subnet's open autonomous-research tasks (`GET /api/v1/tasks`) — the catalog of research problems miners work on. This adds it as a `data-artifact`, sourced from the subnet's official OpenAPI contract.

## Surface

- Netuid: 94
- Kind: data-artifact
- Public URL: https://autoresearch.bitsota.com/api/v1/tasks
- Source URL (proves the claim): https://autoresearch.bitsota.com/openapi.json
- Provider slug: alveus-labs

The endpoint is defined in the official Bitsota OpenAPI spec with no security requirement — the same host/spec as the subnet's existing openapi surface.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this specific endpoint, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public endpoint plus the official OpenAPI source fully establish and verify the claim, so it stands on its own merit.

## Checklist

- [x] Changes exactly one `registry/subnets/bitsota.json` file (append-only; no top-level metadata touched).
- [x] Generated with `npm run surface:add` — `authority: community`, `review.state: community-submitted`.
- [x] The `url` is public, no-auth, read-only-safe; the `source_url` (official OpenAPI) independently proves the subnet publishes it.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] No linked issue — rationale provided above.

## Validation

- [x] `npm run validate:surface -- registry/subnets/bitsota.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate` (full suite, green)
