### PR TITLE
fix(turnover): reject blank uid cells that coerce to 0

### DIFF
--- a/src/turnover.mjs
+++ b/src/turnover.mjs
@@ -54,6 +54,8 @@ function validatorHotkeys(rows) {
 
 function normalizedUid(value) {
   if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const uid = Number(value);
   return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
 }

--- a/tests/turnover.test.mjs
+++ b/tests/turnover.test.mjs
@@ -170,6 +170,40 @@ describe("buildTurnover", () => {
     assert.equal(data.stability_score, 100);
   });
 
+  test("blank uid cells are skipped (not counted as uid 0)", () => {
+    // Mirrors the blank-cell guard in subnet-yield.mjs (#3022): Number("") is 0.
+    for (const blank of ["", "   "]) {
+      const data = buildTurnover(
+        [
+          {
+            snapshot_date: "2026-06-01",
+            uid: blank,
+            hotkey: "H0",
+            validator_permit: 0,
+          },
+          {
+            snapshot_date: "2026-06-30",
+            uid: 1,
+            hotkey: "H1",
+            validator_permit: 0,
+          },
+        ],
+        7,
+        {
+          window: "30d",
+          startDate: "2026-06-01",
+          endDate: "2026-06-30",
+        },
+      );
+      assert.equal(
+        data.neurons_start,
+        0,
+        `neurons_start for uid ${JSON.stringify(blank)}`,
+      );
+      assert.equal(data.neurons_end, 1);
+    }
+  });
+
   test("a fully-rotated validator set scores zero retention", () => {
     const rows = [
       { snapshot_date: "2026-05-01", uid: 0, hotkey: "A", validator_permit: 1 },
@@ -273,6 +307,40 @@ describe("buildTurnoverChanges", () => {
     assert.deepEqual(data.validators_entered, []);
     assert.deepEqual(data.validators_exited, []);
     assert.deepEqual(data.uid_reassignments, []);
+  });
+
+  test("blank uid cells do not fabricate uid 0 in validator change lists", () => {
+    const data = buildTurnoverChanges(
+      [
+        {
+          snapshot_date: "2026-06-01",
+          uid: 1,
+          hotkey: "VOLD",
+          validator_permit: 1,
+        },
+        {
+          snapshot_date: "2026-06-30",
+          uid: 1,
+          hotkey: "VOLD",
+          validator_permit: 1,
+        },
+        {
+          snapshot_date: "2026-06-30",
+          uid: "",
+          hotkey: "VNEW",
+          validator_permit: 1,
+        },
+      ],
+      9,
+      {
+        window: "30d",
+        startDate: "2026-06-01",
+        endDate: "2026-06-30",
+      },
+    );
+    assert.equal(data.validators_entered_count, 1);
+    assert.equal(data.validators_entered[0].hotkey, "VNEW");
+    assert.equal(data.validators_entered[0].uid, null);
   });
 
   test("lists validator entries, exits, and UID reassignments", () => {


### PR DESCRIPTION
## Summary

Reject blank D1 `uid` cells in subnet turnover formatting so empty strings and whitespace-only values are skipped instead of coercing to uid `0`.

## What Changed

- Add a trim guard to `normalizedUid()` in `src/turnover.mjs`, matching the pattern merged in subnet-yield.mjs (#3022).
- Add regression coverage in `tests/turnover.test.mjs` for blank cells in `buildTurnover` and `buildTurnoverChanges`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/turnover.test.mjs` (22 passed)
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Sibling fix to the merged blank-cell guard series.
