### PR TITLE
fix(account-stake-flow): reject blank netuid cells that coerce to 0

### DIFF
--- a/src/account-stake-flow.mjs
+++ b/src/account-stake-flow.mjs
@@ -55,6 +55,8 @@ function toNumber(value) {
 // explicitly so a null netuid is skipped rather than coerced to subnet 0 (Number(null) === 0).
 function normalizedNetuid(value) {
   if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const netuid = Number(value);
   return Number.isSafeInteger(netuid) && netuid >= 0 ? netuid : null;
 }

--- a/tests/account-stake-flow.test.mjs
+++ b/tests/account-stake-flow.test.mjs
@@ -192,6 +192,20 @@ describe("buildAccountStakeFlow", () => {
     assert.equal(d.total_staked_tao, 25);
   });
 
+  test("skips blank netuid cells instead of coercing to subnet 0", () => {
+    // Mirrors the blank-cell guard in turnover.mjs (#3026): Number("") is 0.
+    for (const blank of ["", "   "]) {
+      const d = buildAccountStakeFlow([added(blank, 100), added(1, 25)], ADDR);
+      assert.equal(
+        d.subnet_count,
+        1,
+        `subnet_count for netuid ${JSON.stringify(blank)}`,
+      );
+      assert.equal(d.total_staked_tao, 25);
+      assert.equal(d.subnets[0].netuid, 1);
+    }
+  });
+
   test("rounds tao output to rao precision", () => {
     const d = buildAccountStakeFlow([added(1, 0.1), removed(1, 0.2)], ADDR);
     assert.equal(d.net_flow_tao, -0.1);


### PR DESCRIPTION
## Summary

Reject blank D1 `netuid` cells in account stake-flow formatting so empty strings and whitespace-only values are skipped instead of coercing to subnet `0`.

## What Changed

- Add a trim guard to `normalizedNetuid()` in `src/account-stake-flow.mjs`, matching the pattern merged in turnover.mjs (#3026).
- Add regression coverage in `tests/account-stake-flow.test.mjs`.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/account-stake-flow.test.mjs` (27 passed)
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Sibling fix to the merged blank-cell guard series.
