### PR TITLE
feat(api): add ?format=csv to GET /api/v1/chain/serving leaderboard

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -538,7 +538,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): a per-subnet leaderboard (AxonServed event count, distinct servers, and average announcements per server) ranked by total announcements, a network rollup with the true distinct server count (a hotkey announcing on several subnets counts once) and total announcements, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-announcement intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events AxonServed stream; schema-stable empty block when cold. */
+        /** Fetch network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): a per-subnet leaderboard (AxonServed event count, distinct servers, and average announcements per server) ranked by total announcements, a network rollup with the true distinct server count (a hotkey announcing on several subnets counts once) and total announcements, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-announcement intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events AxonServed stream; schema-stable empty block when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + intensity distribution stay JSON-only). */
         get: operations["chainServing"];
         put?: never;
         post?: never;
@@ -10191,6 +10191,8 @@ export interface operations {
             query?: {
                 window?: "7d" | "30d";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10198,7 +10200,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -10273,6 +10275,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainServingArtifact"];
                     };
+                    /**
+                     * @example netuid,distinct_servers,announcements,announcements_per_server
+                     *     1,4,40,10
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -6227,7 +6227,7 @@
     {
       "artifact_path": "/metagraph/chain/serving.json",
       "cache": "short",
-      "description": "Fetch network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): a per-subnet leaderboard (AxonServed event count, distinct servers, and average announcements per server) ranked by total announcements, a network rollup with the true distinct server count (a hotkey announcing on several subnets counts once) and total announcements, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-announcement intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events AxonServed stream; schema-stable empty block when cold.",
+      "description": "Fetch network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): a per-subnet leaderboard (AxonServed event count, distinct servers, and average announcements per server) ranked by total announcements, a network rollup with the true distinct server count (a hotkey announcing on several subnets counts once) and total announcements, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-announcement intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events AxonServed stream; schema-stable empty block when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + intensity distribution stay JSON-only).",
       "id": "chain-serving",
       "method": "GET",
       "path": "/api/v1/chain/serving",
@@ -6251,6 +6251,17 @@
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -858,7 +858,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): each subnet's AxonServed event count, distinct servers (hotkeys announcing an axon), and average announcements per server ranked into a leaderboard, a network rollup with the true distinct server count (not a per-subnet sum) and total announcements, and a distribution summary of the per-subnet re-announcement intensity (count, mean, min, p25, median, p75, p90, max), computed live from the account_events AxonServed stream at /api/v1/chain/serving (no static file).",
+      "description": "Network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): each subnet's AxonServed event count, distinct servers (hotkeys announcing an axon), and average announcements per server ranked into a leaderboard, a network rollup with the true distinct server count (not a per-subnet sum) and total announcements, and a distribution summary of the per-subnet re-announcement intensity (count, mean, min, p25, median, p75, p90, max), computed live from the account_events AxonServed stream at /api/v1/chain/serving; pass ?format=csv to download the per-subnet leaderboard as CSV (no static file).",
       "id": "chain-serving",
       "path": "/metagraph/chain/serving.json",
       "schema_ref": "#/components/schemas/ChainServingArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -22906,6 +22906,19 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -22988,9 +23001,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,distinct_servers,announcements,announcements_per_server\r\n1,4,40,10",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -23047,7 +23066,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): a per-subnet leaderboard (AxonServed event count, distinct servers, and average announcements per server) ranked by total announcements, a network rollup with the true distinct server count (a hotkey announcing on several subnets counts once) and total announcements, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-announcement intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events AxonServed stream; schema-stable empty block when cold.",
+        "summary": "Fetch network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): a per-subnet leaderboard (AxonServed event count, distinct servers, and average announcements per server) ranked by total announcements, a network rollup with the true distinct server count (a hotkey announcing on several subnets counts once) and total announcements, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-announcement intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events AxonServed stream; schema-stable empty block when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + intensity distribution stay JSON-only).",
         "tags": [
           "chain",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -538,7 +538,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): a per-subnet leaderboard (AxonServed event count, distinct servers, and average announcements per server) ranked by total announcements, a network rollup with the true distinct server count (a hotkey announcing on several subnets counts once) and total announcements, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-announcement intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events AxonServed stream; schema-stable empty block when cold. */
+        /** Fetch network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): a per-subnet leaderboard (AxonServed event count, distinct servers, and average announcements per server) ranked by total announcements, a network rollup with the true distinct server count (a hotkey announcing on several subnets counts once) and total announcements, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-announcement intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events AxonServed stream; schema-stable empty block when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + intensity distribution stay JSON-only). */
         get: operations["chainServing"];
         put?: never;
         post?: never;
@@ -10191,6 +10191,8 @@ export interface operations {
             query?: {
                 window?: "7d" | "30d";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10198,7 +10200,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -10273,6 +10275,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainServingArtifact"];
                     };
+                    /**
+                     * @example netuid,distinct_servers,announcements,announcements_per_server
+                     *     1,4,40,10
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1190,7 +1190,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "chain-serving",
     "/metagraph/chain/serving.json",
-    "Network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): each subnet's AxonServed event count, distinct servers (hotkeys announcing an axon), and average announcements per server ranked into a leaderboard, a network rollup with the true distinct server count (not a per-subnet sum) and total announcements, and a distribution summary of the per-subnet re-announcement intensity (count, mean, min, p25, median, p75, p90, max), computed live from the account_events AxonServed stream at /api/v1/chain/serving (no static file).",
+    "Network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): each subnet's AxonServed event count, distinct servers (hotkeys announcing an axon), and average announcements per server ranked into a leaderboard, a network rollup with the true distinct server count (not a per-subnet sum) and total announcements, and a distribution summary of the per-subnet re-announcement intensity (count, mean, min, p25, median, p75, p90, max), computed live from the account_events AxonServed stream at /api/v1/chain/serving; pass ?format=csv to download the per-subnet leaderboard as CSV (no static file).",
     "ChainServingArtifact",
   ),
   artifact(
@@ -2611,13 +2611,13 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/chain/serving",
     "/metagraph/chain/serving.json",
-    "Fetch network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): a per-subnet leaderboard (AxonServed event count, distinct servers, and average announcements per server) ranked by total announcements, a network rollup with the true distinct server count (a hotkey announcing on several subnets counts once) and total announcements, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-announcement intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events AxonServed stream; schema-stable empty block when cold.",
+    "Fetch network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): a per-subnet leaderboard (AxonServed event count, distinct servers, and average announcements per server) ranked by total announcements, a network rollup with the true distinct server count (a hotkey announcing on several subnets counts once) and total announcements, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-announcement intensity. `limit` caps the leaderboard (default 20, max 100). Computed live from the account_events AxonServed stream; schema-stable empty block when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + intensity distribution stay JSON-only).",
     "short",
     ["chain", "analytics"],
-    [
+    csvRouteQuery([
       { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
-    ],
+    ]),
     [],
   ),
   route(

--- a/src/csv-route-examples.mjs
+++ b/src/csv-route-examples.mjs
@@ -26,4 +26,9 @@ export const ROUTE_CSV_EXAMPLES = {
     "netuid,distinct_setters,weight_sets,sets_per_setter",
     "1,4,40,10",
   ].join("\r\n"),
+  // The /chain/serving per-subnet axon-serving leaderboard rows.
+  "chain-serving": [
+    "netuid,distinct_servers,announcements,announcements_per_server",
+    "1,4,40,10",
+  ].join("\r\n"),
 };

--- a/tests/chain-serving.test.mjs
+++ b/tests/chain-serving.test.mjs
@@ -306,6 +306,65 @@ describe("GET /api/v1/chain/serving", () => {
     const res = await handleRequest(req("?limit=0"), servingEnv(cold), {});
     assert.equal(res.status, 400);
   });
+
+  const SERVING_CSV_HEADER =
+    "netuid,distinct_servers,announcements,announcements_per_server";
+
+  test("exports the per-subnet leaderboard as CSV with ?format=csv", async () => {
+    const res = await handleRequest(
+      req("?window=7d&format=csv"),
+      servingEnv(warm),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    assert.match(
+      res.headers.get("content-disposition"),
+      /attachment; filename="chain-serving\.csv"/,
+    );
+    const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines[0], SERVING_CSV_HEADER);
+    // Ranked by total announcements desc: netuid 1 (40), 2 (30), 5 (25).
+    assert.equal(lines.length, 4); // header + 3 subnet rows
+    assert.equal(lines[1], "1,4,40,10");
+  });
+
+  test("honors Accept: text/csv the same as ?format=csv", async () => {
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/chain/serving", {
+        headers: { accept: "text/csv" },
+      }),
+      servingEnv(warm),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+  });
+
+  test("emits a header-only CSV on a cold store", async () => {
+    const res = await handleRequest(req("?format=csv"), servingEnv(cold), {});
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    assert.equal((await res.text()).trim(), SERVING_CSV_HEADER);
+  });
+
+  test("serves a CSV HEAD probe with the CSV headers and no body", async () => {
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/chain/serving?format=csv", {
+        method: "HEAD",
+      }),
+      servingEnv(warm),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    assert.equal(await res.text(), ""); // HEAD carries no body
+  });
+
+  test("rejects an unsupported format value with 400", async () => {
+    const res = await handleRequest(req("?format=xml"), servingEnv(cold), {});
+    assert.equal(res.status, 400);
+  });
 });
 
 describe("chain/serving edge cache", () => {

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -776,6 +776,16 @@ const CHAIN_WEIGHTS_CSV_COLUMNS = [
   "sets_per_setter",
 ];
 
+// CSV column order for the /api/v1/chain/serving per-subnet leaderboard rows (the
+// row-shaped `subnets` array). The network rollup + intensity_distribution stay
+// JSON-only, mirroring chain-weights / chain-stake-flow.
+const CHAIN_SERVING_CSV_COLUMNS = [
+  "netuid",
+  "distinct_servers",
+  "announcements",
+  "announcements_per_server",
+];
+
 // Daily network-activity aggregates over the first-party chain D1 tiers (#1987):
 // per-UTC-day extrinsic/event/block counts, success rate, and unique signers —
 // the foundation time-series for the block-explorer "network at a glance" view
@@ -1230,13 +1240,16 @@ export async function handleChainWeights(request, env, url, ctx = {}) {
 // the edge cache and repeatedly force the network-wide aggregations, cache keyed on the analytics
 // cron freshness. The leaderboard is fixed to most-active-first (total AxonServed events).
 export async function handleChainServing(request, env, url, ctx = {}) {
-  const { label, days, error } = analyticsWindow(url, ["limit"]);
+  const { label, days, error } = analyticsWindow(url, ["limit", "format"]);
   if (error) return analyticsQueryError(error);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { limit, error: limitError } = parseLimitParam(url, {
     defaultLimit: CHAIN_SERVING_LIMIT_DEFAULT,
     maxLimit: CHAIN_SERVING_LIMIT_MAX,
   });
   if (limitError) return analyticsQueryError(limitError);
+  const csv = csvRequested(url, request);
 
   const cacheRequest =
     request.method === "HEAD"
@@ -1253,6 +1266,17 @@ export async function handleChainServing(request, env, url, ctx = {}) {
         windowDays: days,
         limit,
       });
+      // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
+      // intensity_distribution stay JSON-only (mirrors chain-weights).
+      if (csv) {
+        return csvResponse(
+          data.subnets,
+          "chain-serving",
+          "short",
+          cacheRequest,
+          CHAIN_SERVING_CSV_COLUMNS,
+        );
+      }
       return envelopeResponse(
         cacheRequest,
         {
@@ -1266,7 +1290,7 @@ export async function handleChainServing(request, env, url, ctx = {}) {
         "short",
       );
     },
-    canonicalAnalyticsCacheRoute(url, ["limit"]),
+    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })


### PR DESCRIPTION
## Summary

Add `?format=csv` (and `Accept: text/csv`) to `GET /api/v1/chain/serving` — the network-wide axon-serving activity leaderboard — so the per-subnet rows can be downloaded as CSV, mirroring the `chain/weights` and `chain/stake-flow` CSV exports.

## What Changed

- `workers/request-handlers/analytics.mjs` (`handleChainServing`): allow `format` in the window param set, validate it via the shared `validateFormatParam`, and when CSV is negotiated return `csvResponse(data.subnets, "chain-serving", …)` with a stable `CHAIN_SERVING_CSV_COLUMNS` order (`netuid, distinct_servers, announcements, announcements_per_server`). The network rollup + `intensity_distribution` stay JSON-only (same split as chain-weights / chain-stake-flow). The edge-cache key is suffixed with `&format=csv` so CSV and JSON responses never collide. HEAD probes keep flowing through the GET cache key.
- `src/contracts.mjs`: wrapped the `chain-serving` route query params in `csvRouteQuery(...)` and noted `?format=csv` in the route + artifact descriptions.
- `src/csv-route-examples.mjs`: a `chain-serving` CSV example.
- Regenerated + committed the derived contract artifacts (`npm run build`). `public/metagraph/r2-manifest.json` and `public/metagraph/schemas/index.json` are intentionally NOT included (deploy/publish-pipeline-owned).
- Tests: `?format=csv` serializes the ranked leaderboard; `Accept: text/csv` negotiates the same; a cold store emits a header-only CSV; a CSV `HEAD` probe returns the CSV headers with no body; `?format=xml` is rejected with 400. Every new branch is covered.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts (`npm run build`), not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (new `format` param + `text/csv` response on the chain-serving route).

## Validation

- [x] `npm run build` (regenerated + committed OpenAPI/types/contracts)
- [x] `npm run validate:contract-drift` · `validate:openapi` · `validate:types` · `validate:docs`
- [x] `npx vitest run` (full suite, 4969 passed) incl. `tests/chain-serving.test.mjs`
- [x] `npm run lint` · `npm run format:check` · `git diff --check`
