### PR TITLE
fix(extrinsics): reject blank fee/tip cells that coerce to 0 TAO

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -75,6 +75,8 @@ function toChainPosition(value) {
 // (#2662) and the coercion in formatRegistration (#2487).
 function toTaoOrNull(value) {
   if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isFinite(n) ? Math.round(n * 1e9) / 1e9 : null;
 }

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -206,6 +206,31 @@ test("formatExtrinsic maps a non-numeric fee_tao/tip_tao to null (not NaN)", () 
   assert.equal(out.tip_tao, null);
 });
 
+test("formatExtrinsic rejects blank fee_tao/tip_tao cells that coerce to 0", () => {
+  // Mirrors the blank-cell guard in toChainPosition() (#2974): Number("") is 0.
+  for (const blank of ["", "   "]) {
+    const out = formatExtrinsic({
+      block_number: 10,
+      extrinsic_index: 0,
+      fee_tao: blank,
+      tip_tao: blank,
+      observed_at: 1750000000000,
+    });
+    assert.equal(out.fee_tao, null, `fee_tao for ${JSON.stringify(blank)}`);
+    assert.equal(out.tip_tao, null, `tip_tao for ${JSON.stringify(blank)}`);
+  }
+  // A literal zero fee/tip is still valid — only blank strings are rejected.
+  const zero = formatExtrinsic({
+    block_number: 10,
+    extrinsic_index: 0,
+    fee_tao: 0,
+    tip_tao: "0",
+    observed_at: 1750000000000,
+  });
+  assert.equal(zero.fee_tao, 0);
+  assert.equal(zero.tip_tao, 0);
+});
+
 test("formatExtrinsic coerces a string-typed observed_at cell to an ISO timestamp", () => {
   // D1 can return the INTEGER observed_at as a numeric string; the old
   // Number.isFinite(string) guard dropped a real timestamp to null. Mirrors #2708.


### PR DESCRIPTION
## Summary

Reject blank D1 `fee_tao` / `tip_tao` cells in extrinsic formatting so empty strings and whitespace-only values return `null` instead of coercing to `0` TAO.

## What Changed

- Add a trim guard to `toTaoOrNull()` in `src/extrinsics.mjs`, matching the pattern merged in toChainPosition() (#2974).
- Add regression coverage in `tests/extrinsics.test.mjs` for blank vs literal-zero fee/tip cells.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/extrinsics.test.mjs`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Sibling fix to the merged blank-cell guard series (#2974).
