### PR TITLE
fix(account-events): reject blank TAO cells that coerce to 0

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -159,6 +159,8 @@ function toBlockNumber(value) {
 // aggregate is null on a cold store, not 0.
 function toTaoOrNull(value) {
   if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isFinite(n) ? Math.round(n * 1e9) / 1e9 : null;
 }

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -341,6 +341,35 @@ test("formatAccountEvent coerces null amount_tao and alpha_amount to null (not 0
   assert.equal(out.alpha_amount, null);
 });
 
+test("formatAccountEvent rejects blank amount_tao/alpha_amount cells that coerce to 0", () => {
+  // Mirrors the blank-cell guard in extrinsics.mjs (#3030): Number("") is 0.
+  for (const blank of ["", "   "]) {
+    const out = formatAccountEvent({
+      block_number: 1,
+      amount_tao: blank,
+      alpha_amount: blank,
+    });
+    assert.equal(
+      out.amount_tao,
+      null,
+      `amount_tao for ${JSON.stringify(blank)}`,
+    );
+    assert.equal(
+      out.alpha_amount,
+      null,
+      `alpha_amount for ${JSON.stringify(blank)}`,
+    );
+  }
+  // A literal zero amount is still valid — only blank strings are rejected.
+  const zero = formatAccountEvent({
+    block_number: 1,
+    amount_tao: 0,
+    alpha_amount: "0",
+  });
+  assert.equal(zero.amount_tao, 0);
+  assert.equal(zero.alpha_amount, 0);
+});
+
 test("formatAccountEvent rounds amount_tao and alpha_amount to rao precision", () => {
   // The rao is the smallest TAO unit (1e-9). A SUM() over many REAL rows
   // accumulates IEEE-754 noise below the rao floor; toTaoOrNull rounds to


### PR DESCRIPTION
## Summary

Reject blank D1 `amount_tao` / `alpha_amount` cells in account-event formatting so empty strings and whitespace-only values return `null` instead of coercing to `0` TAO.

## What Changed

- Add a trim guard to `toTaoOrNull()` in `src/account-events.mjs`, matching the pattern merged in extrinsics.mjs (#3030).
- Add regression coverage in `tests/account-events.test.mjs` for blank vs literal-zero amount cells.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/account-events.test.mjs`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Sibling fix to the merged blank-cell guard series (#3030).
