### PR TITLE
feat(api): add ?format=csv to GET /api/v1/chain/transfer-pairs corridors

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -589,7 +589,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by ?sort=volume or ?sort=count (?limit, <=100). Computed live from the account_events Transfer feed; schema-stable zeros + an empty pairs list when cold. */
+        /** Fetch network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by ?sort=volume or ?sort=count (?limit, <=100). Computed live from the account_events Transfer feed; schema-stable zeros + an empty pairs list when cold. Pass ?format=csv to download the ranked pairs as CSV (the totals + top_pair_share stay JSON-only). */
         get: operations["chainTransferPairs"];
         put?: never;
         post?: never;
@@ -10602,6 +10602,8 @@ export interface operations {
                 window?: "7d" | "30d";
                 limit?: number;
                 sort?: "volume" | "count";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10609,7 +10611,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -10670,6 +10672,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainTransferPairsArtifact"];
                     };
+                    /**
+                     * @example from,to,volume_tao,transfer_count,last_block,last_observed_at
+                     *     5Sender_sample,5Receiver_sample,1250.5,42,8454388,2026-07-03T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -6102,7 +6102,7 @@
     {
       "artifact_path": "/metagraph/chain/transfer-pairs.json",
       "cache": "short",
-      "description": "Fetch network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by ?sort=volume or ?sort=count (?limit, <=100). Computed live from the account_events Transfer feed; schema-stable zeros + an empty pairs list when cold.",
+      "description": "Fetch network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by ?sort=volume or ?sort=count (?limit, <=100). Computed live from the account_events Transfer feed; schema-stable zeros + an empty pairs list when cold. Pass ?format=csv to download the ranked pairs as CSV (the totals + top_pair_share stay JSON-only).",
       "id": "chain-transfer-pairs",
       "method": "GET",
       "path": "/api/v1/chain/transfer-pairs",
@@ -6134,6 +6134,17 @@
             "enum": [
               "volume",
               "count"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
             ],
             "type": "string"
           }

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -831,7 +831,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by volume or count, computed live from the account_events Transfer feed at /api/v1/chain/transfer-pairs (no static file).",
+      "description": "Network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by volume or count, computed live from the account_events Transfer feed at /api/v1/chain/transfer-pairs; pass ?format=csv to download the ranked pairs as CSV (no static file).",
       "id": "chain-transfer-pairs",
       "path": "/metagraph/chain/transfer-pairs.json",
       "schema_ref": "#/components/schemas/ChainTransferPairsArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -23500,6 +23500,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -23568,9 +23581,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "from,to,volume_tao,transfer_count,last_block,last_observed_at\r\n5Sender_sample,5Receiver_sample,1250.5,42,8454388,2026-07-03T00:00:00.000Z",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -23627,7 +23646,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by ?sort=volume or ?sort=count (?limit, <=100). Computed live from the account_events Transfer feed; schema-stable zeros + an empty pairs list when cold.",
+        "summary": "Fetch network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by ?sort=volume or ?sort=count (?limit, <=100). Computed live from the account_events Transfer feed; schema-stable zeros + an empty pairs list when cold. Pass ?format=csv to download the ranked pairs as CSV (the totals + top_pair_share stay JSON-only).",
         "tags": [
           "chain",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -589,7 +589,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by ?sort=volume or ?sort=count (?limit, <=100). Computed live from the account_events Transfer feed; schema-stable zeros + an empty pairs list when cold. */
+        /** Fetch network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by ?sort=volume or ?sort=count (?limit, <=100). Computed live from the account_events Transfer feed; schema-stable zeros + an empty pairs list when cold. Pass ?format=csv to download the ranked pairs as CSV (the totals + top_pair_share stay JSON-only). */
         get: operations["chainTransferPairs"];
         put?: never;
         post?: never;
@@ -10602,6 +10602,8 @@ export interface operations {
                 window?: "7d" | "30d";
                 limit?: number;
                 sort?: "volume" | "count";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10609,7 +10611,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -10670,6 +10672,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainTransferPairsArtifact"];
                     };
+                    /**
+                     * @example from,to,volume_tao,transfer_count,last_block,last_observed_at
+                     *     5Sender_sample,5Receiver_sample,1250.5,42,8454388,2026-07-03T00:00:00.000Z
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1172,7 +1172,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "chain-transfer-pairs",
     "/metagraph/chain/transfer-pairs.json",
-    "Network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by volume or count, computed live from the account_events Transfer feed at /api/v1/chain/transfer-pairs (no static file).",
+    "Network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by volume or count, computed live from the account_events Transfer feed at /api/v1/chain/transfer-pairs; pass ?format=csv to download the ranked pairs as CSV (no static file).",
     "ChainTransferPairsArtifact",
   ),
   artifact(
@@ -2553,17 +2553,17 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/chain/transfer-pairs",
     "/metagraph/chain/transfer-pairs.json",
-    "Fetch network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by ?sort=volume or ?sort=count (?limit, <=100). Computed live from the account_events Transfer feed; schema-stable zeros + an empty pairs list when cold.",
+    "Fetch network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by ?sort=volume or ?sort=count (?limit, <=100). Computed live from the account_events Transfer feed; schema-stable zeros + an empty pairs list when cold. Pass ?format=csv to download the ranked pairs as CSV (the totals + top_pair_share stay JSON-only).",
     "short",
     ["chain", "analytics"],
-    [
+    csvRouteQuery([
       { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
       {
         name: "sort",
         schema: { type: "string", enum: ["volume", "count"] },
       },
-    ],
+    ]),
     [],
   ),
   route(

--- a/src/csv-route-examples.mjs
+++ b/src/csv-route-examples.mjs
@@ -31,4 +31,9 @@ export const ROUTE_CSV_EXAMPLES = {
     "netuid,distinct_servers,announcements,announcements_per_server",
     "1,4,40,10",
   ].join("\r\n"),
+  // The /chain/transfer-pairs top sender -> receiver corridors.
+  "chain-transfer-pairs": [
+    "from,to,volume_tao,transfer_count,last_block,last_observed_at",
+    "5Sender_sample,5Receiver_sample,1250.5,42,8454388,2026-07-03T00:00:00.000Z",
+  ].join("\r\n"),
 };

--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -922,6 +922,124 @@ test("GET /api/v1/chain/transfer-pairs ranks directed transfer corridors", async
   assert.equal(pairs.params.at(-1), 5);
 });
 
+function transferPairsEnv({ pairs = [], totals } = {}) {
+  return {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              all: () =>
+                Promise.resolve({
+                  results: /WITH pair_totals/.test(sql)
+                    ? [
+                        totals ?? {
+                          transfer_count: 0,
+                          total_volume_tao: 0,
+                          unique_pairs: 0,
+                          top_pair_volume_tao: 0,
+                        },
+                      ]
+                    : /ORDER BY/.test(sql)
+                      ? pairs
+                      : [],
+                }),
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+const PAIRS_CSV_HEADER =
+  "from,to,volume_tao,transfer_count,last_block,last_observed_at";
+const PAIR_ROW = {
+  from: "5Sa",
+  to: "5Rx",
+  volume_tao: 80,
+  transfer_count: 5,
+  last_block: "8454388",
+  last_observed_at: Date.parse("2026-07-03T00:00:00.000Z"),
+};
+const PAIR_TOTALS = {
+  transfer_count: 10,
+  total_volume_tao: 100,
+  unique_pairs: 4,
+  top_pair_volume_tao: 80,
+};
+
+test("GET /api/v1/chain/transfer-pairs exports the ranked pairs as CSV with ?format=csv", async () => {
+  const res = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/chain/transfer-pairs?window=7d&format=csv",
+    ),
+    transferPairsEnv({ pairs: [PAIR_ROW], totals: PAIR_TOTALS }),
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  assert.match(
+    res.headers.get("content-disposition"),
+    /attachment; filename="chain-transfer-pairs\.csv"/,
+  );
+  const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines[0], PAIRS_CSV_HEADER);
+  assert.equal(lines.length, 2); // header + 1 pair row
+  assert.equal(lines[1], "5Sa,5Rx,80,5,8454388,2026-07-03T00:00:00.000Z");
+});
+
+test("GET /api/v1/chain/transfer-pairs honors Accept: text/csv the same as ?format=csv", async () => {
+  const res = await handleRequest(
+    new Request("https://api.metagraph.sh/api/v1/chain/transfer-pairs", {
+      headers: { accept: "text/csv" },
+    }),
+    transferPairsEnv({ pairs: [PAIR_ROW], totals: PAIR_TOTALS }),
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+});
+
+test("GET /api/v1/chain/transfer-pairs emits a header-only CSV on a cold store", async () => {
+  const res = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/chain/transfer-pairs?format=csv",
+    ),
+    transferPairsEnv({}),
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  assert.equal((await res.text()).trim(), PAIRS_CSV_HEADER);
+});
+
+test("HEAD /api/v1/chain/transfer-pairs?format=csv returns the CSV headers with no body", async () => {
+  const res = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/chain/transfer-pairs?format=csv",
+      { method: "HEAD" },
+    ),
+    transferPairsEnv({ pairs: [PAIR_ROW], totals: PAIR_TOTALS }),
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  assert.equal(await res.text(), "");
+});
+
+test("GET /api/v1/chain/transfer-pairs rejects an unsupported format value with 400", async () => {
+  const res = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/chain/transfer-pairs?format=xml",
+    ),
+    transferPairsEnv({}),
+    {},
+  );
+  assert.equal(res.status, 400);
+});
+
 test("HEAD /api/v1/chain/transfer-pairs returns headers without a body", async () => {
   const env = {
     ...createLocalArtifactEnv(),

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -786,6 +786,18 @@ const CHAIN_SERVING_CSV_COLUMNS = [
   "announcements_per_server",
 ];
 
+// CSV column order for the /api/v1/chain/transfer-pairs top corridors (the
+// row-shaped `pairs` array). The totals + top_pair_share rollup stay JSON-only,
+// mirroring chain-stake-flow / chain-weights.
+const CHAIN_TRANSFER_PAIRS_CSV_COLUMNS = [
+  "from",
+  "to",
+  "volume_tao",
+  "transfer_count",
+  "last_block",
+  "last_observed_at",
+];
+
 // Daily network-activity aggregates over the first-party chain D1 tiers (#1987):
 // per-UTC-day extrinsic/event/block counts, success rate, and unique signers —
 // the foundation time-series for the block-explorer "network at a glance" view
@@ -1058,16 +1070,23 @@ export async function handleChainTransfers(request, env, url, ctx = {}) {
 // /chain/transfers. Excludes malformed/self-transfer rows so every row represents
 // a real directed account corridor.
 export async function handleChainTransferPairs(request, env, url, ctx = {}) {
-  const { label, days, error } = analyticsWindow(url, ["limit", "sort"]);
+  const { label, days, error } = analyticsWindow(url, [
+    "limit",
+    "sort",
+    "format",
+  ]);
   if (error) return analyticsQueryError(error);
   const sortError = validateEnumParam(url, "sort", CHAIN_TRANSFER_PAIR_SORTS);
   if (sortError) return analyticsQueryError(sortError);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { limit, error: limitError } = parseLimitParam(url, {
     defaultLimit: 25,
     maxLimit: 100,
   });
   if (limitError) return analyticsQueryError(limitError);
   const sort = url.searchParams.get("sort") || "volume";
+  const csv = csvRequested(url, request);
 
   const cacheRequest =
     request.method === "HEAD"
@@ -1087,6 +1106,17 @@ export async function handleChainTransferPairs(request, env, url, ctx = {}) {
         limit,
         sort,
       });
+      // CSV exports the row-shaped top corridors; the totals + top_pair_share
+      // rollup stay JSON-only (mirrors chain-stake-flow / chain-weights).
+      if (csv) {
+        return csvResponse(
+          data.pairs,
+          "chain-transfer-pairs",
+          "short",
+          cacheRequest,
+          CHAIN_TRANSFER_PAIRS_CSV_COLUMNS,
+        );
+      }
       return envelopeResponse(
         cacheRequest,
         {
@@ -1100,7 +1130,7 @@ export async function handleChainTransferPairs(request, env, url, ctx = {}) {
         "short",
       );
     },
-    canonicalAnalyticsCacheRoute(url, ["limit", "sort"]),
+    `${canonicalAnalyticsCacheRoute(url, ["limit", "sort"])}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })


### PR DESCRIPTION
## Summary

Add `?format=csv` (and `Accept: text/csv`) to `GET /api/v1/chain/transfer-pairs` — the network-wide directed transfer-corridor analytics — so the ranked sender→receiver pairs can be downloaded as CSV, mirroring the other chain-analytics CSV exports (`chain/stake-flow`, `chain/weights`, `chain/serving`).

## What Changed

- `workers/request-handlers/analytics.mjs` (`handleChainTransferPairs`): allow `format` in the param set, validate it via the shared `validateFormatParam`, and when CSV is negotiated return `csvResponse(data.pairs, "chain-transfer-pairs", …)` with a stable `CHAIN_TRANSFER_PAIRS_CSV_COLUMNS` order (`from, to, volume_tao, transfer_count, last_block, last_observed_at`). The totals + `top_pair_share` rollup stay JSON-only (same split as the sibling leaderboards). The edge-cache key is suffixed with `&format=csv` so CSV and JSON responses never collide. `?sort=volume|count` still ranks the exported rows; HEAD probes keep flowing through the GET cache key.
- `src/contracts.mjs`: wrapped the `chain-transfer-pairs` route query params in `csvRouteQuery(...)` and noted `?format=csv` in the route + artifact descriptions.
- `src/csv-route-examples.mjs`: a `chain-transfer-pairs` CSV example.
- Regenerated + committed the derived contract artifacts (`npm run build`). `public/metagraph/r2-manifest.json` and `public/metagraph/schemas/index.json` are intentionally NOT included (deploy/publish-pipeline-owned).
- Tests: `?format=csv` serializes the ranked corridors; `Accept: text/csv` negotiates the same; a cold store emits a header-only CSV; a CSV `HEAD` probe returns the CSV headers with no body; `?format=xml` is rejected with 400. Every new branch is covered.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts (`npm run build`), not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (new `format` param + `text/csv` response on the chain-transfer-pairs route).

## Validation

- [x] `npm run build` (regenerated + committed OpenAPI/types/contracts)
- [x] `npm run validate:contract-drift` · `validate:openapi` · `validate:types` · `validate:docs`
- [x] `npx vitest run` (full suite) incl. `tests/chain-analytics.test.mjs`
- [x] `npm run lint` · `npm run format:check` · `git diff --check`
