### PR TITLE
fix(metagraph-neurons): reject blank score cells that coerce to 0

### DIFF
--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -68,6 +68,9 @@ function numberOrZero(value) {
 }
 
 function nullableNumber(value) {
+  if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
 }

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -185,6 +185,34 @@ describe("metagraph-neurons builders", () => {
     assert.equal(n.dividends, null);
   });
 
+  test("formatNeuron rejects blank score cells that coerce to 0 (not rank/trust 0)", () => {
+    // Mirrors the blank-cell guard in account-events.mjs (#3031): Number("") is 0.
+    for (const blank of ["", "   "]) {
+      const n = formatNeuron({
+        rank: blank,
+        trust: blank,
+        validator_trust: blank,
+        consensus: blank,
+        incentive: blank,
+        dividends: blank,
+      });
+      assert.equal(n.rank, null, `rank for ${JSON.stringify(blank)}`);
+      assert.equal(n.trust, null, `trust for ${JSON.stringify(blank)}`);
+      assert.equal(
+        n.validator_trust,
+        null,
+        `validator_trust for ${JSON.stringify(blank)}`,
+      );
+      assert.equal(n.consensus, null, `consensus for ${JSON.stringify(blank)}`);
+      assert.equal(n.incentive, null, `incentive for ${JSON.stringify(blank)}`);
+      assert.equal(n.dividends, null, `dividends for ${JSON.stringify(blank)}`);
+    }
+    // A literal zero score is still valid — only blank strings are rejected.
+    const zero = formatNeuron({ rank: 0, trust: "0" });
+    assert.equal(zero.rank, 0);
+    assert.equal(zero.trust, 0);
+  });
+
   test("formatNeuron rounds stake_tao / emission_tao to rao precision (no IEEE-754 leak)", () => {
     // Regression for the Gittensory Orb follow-up blocker on #2503: stake_tao /
     // emission_tao must be rounded to 1e-9 (rao) precision so a noisy REAL


### PR DESCRIPTION
## Summary

Reject blank D1 score cells (`rank`, `trust`, `validator_trust`, `consensus`, `incentive`, `dividends`) in neuron formatting so empty strings and whitespace-only values return `null` instead of coercing to `0`.

## What Changed

- Add null + trim guards to `nullableNumber()` in `src/metagraph-neurons.mjs`, matching the pattern merged in `nonNegativeInt()` (#3020).
- Add regression coverage in `tests/metagraph-neurons.test.mjs` for blank vs literal-zero score cells.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/metagraph-neurons.test.mjs`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Sibling fix to the merged blank-cell guard series (#3020).
