### PR TITLE
feat(mcp): add get_chain_stake_flow mirroring GET /api/v1/chain/stake-flow

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -404,6 +404,16 @@ assert.ok(
     chainTurnover.network != null,
   "get_chain_turnover must return comparable + subnet_count + network + subnets[]",
 );
+const chainStakeFlow = await callOk("get_chain_stake_flow", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  Number.isInteger(chainStakeFlow.subnet_count) &&
+    Array.isArray(chainStakeFlow.subnets) &&
+    chainStakeFlow.network != null,
+  "get_chain_stake_flow must return subnet_count + network + subnets[]",
+);
 const meta = await callOk("get_subnet_metagraph", { netuid: 7 });
 assert.ok(
   Array.isArray(meta.neurons),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/chain-stake-flow.mjs
+++ b/src/chain-stake-flow.mjs
@@ -17,6 +17,12 @@ export const STAKE_REMOVED_KIND = "StakeRemoved";
 export const CHAIN_STAKE_FLOW_LIMIT_DEFAULT = 20;
 export const CHAIN_STAKE_FLOW_LIMIT_MAX = 100;
 
+// Supported lookback windows (label -> days), matching the REST route's
+// analytics window set (7d/30d, default 7d). Kept next to the loader so the MCP
+// tool's input schema and runtime validation cannot drift from the endpoint.
+export const CHAIN_STAKE_FLOW_WINDOWS = { "7d": 7, "30d": 30 };
+export const DEFAULT_CHAIN_STAKE_FLOW_WINDOW = "7d";
+
 // 1 TAO = 1e9 rao. Summing many REAL amount_tao values accumulates IEEE-754 noise below the
 // rao floor; round every TAO output to rao precision (the same rounding the sibling scorecards
 // apply). A non-finite sum can only arise from a malformed direct call — coerce it to 0.

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -85,6 +85,13 @@ import {
   DEFAULT_CHAIN_TURNOVER_WINDOW,
 } from "./chain-turnover.mjs";
 import {
+  loadChainStakeFlow,
+  CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
+  CHAIN_STAKE_FLOW_LIMIT_MAX,
+  CHAIN_STAKE_FLOW_WINDOWS,
+  DEFAULT_CHAIN_STAKE_FLOW_WINDOW,
+} from "./chain-stake-flow.mjs";
+import {
   loadEconomicsTrends,
   parseEconomicsTrendsWindow,
 } from "./economics-trends.mjs";
@@ -234,12 +241,13 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.25.0";
+export const MCP_SERVER_VERSION = "1.26.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
 const CHAIN_TURNOVER_WINDOW_KEYS = Object.keys(CHAIN_TURNOVER_WINDOWS);
+const CHAIN_STAKE_FLOW_WINDOW_KEYS = Object.keys(CHAIN_STAKE_FLOW_WINDOWS);
 const STAKE_FLOW_WINDOW_KEYS = Object.keys(STAKE_FLOW_WINDOWS);
 const MOVERS_WINDOW_KEYS = Object.keys(MOVERS_WINDOWS);
 
@@ -355,6 +363,8 @@ export const MCP_INSTRUCTIONS =
   "distribution across all subnets, " +
   "get_chain_turnover the network-wide validator-turnover leaderboard " +
   "(per-subnet churn, retention, and stability) across all subnets, " +
+  "get_chain_stake_flow the network-wide cross-subnet capital-flow leaderboard " +
+  "(per-subnet net TAO staked/unstaked and direction) across all subnets, " +
   "get_blocks_summary block-production analytics (inter-block time, throughput, " +
   "and block-author decentralization), " +
   "get_network_activity the daily " +
@@ -2064,6 +2074,57 @@ export const MCP_TOOLS = [
       );
       return loadChainTurnover(mcpD1Runner(ctx), {
         windowLabel: window,
+        limit,
+      });
+    },
+  },
+  {
+    name: "get_chain_stake_flow",
+    title: "Get network-wide net stake flow",
+    description:
+      "Fetch the network-wide cross-subnet capital-flow leaderboard over the " +
+      "requested window (7d or 30d; default 7d): each subnet ranked by net TAO " +
+      "flow (StakeAdded minus StakeRemoved) with staked/unstaked/gross totals, " +
+      "stake/unstake event counts, and an inflow/outflow/balanced direction " +
+      "label, plus a network rollup (gaining/losing/flat subnet counts) and the " +
+      "count/mean/min/p25/median/p75/p90/max spread of per-subnet net flow, " +
+      "summed live from the account_events stream. The network-level companion " +
+      "of get_subnet_stake_flow, mirroring how get_chain_concentration " +
+      "companions get_subnet_concentration. Mirrors GET /api/v1/chain/stake-flow.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_STAKE_FLOW_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_CHAIN_STAKE_FLOW_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max subnets in the stake-flow leaderboard (1-${CHAIN_STAKE_FLOW_LIMIT_MAX}, default ${CHAIN_STAKE_FLOW_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_STAKE_FLOW_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window =
+        optionalString(args, "window") ?? DEFAULT_CHAIN_STAKE_FLOW_WINDOW;
+      if (!Object.hasOwn(CHAIN_STAKE_FLOW_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_STAKE_FLOW_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
+        CHAIN_STAKE_FLOW_LIMIT_MAX,
+      );
+      return loadChainStakeFlow(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: CHAIN_STAKE_FLOW_WINDOWS[window],
         limit,
       });
     },
@@ -5673,6 +5734,99 @@ const TOOL_OUTPUT_SCHEMAS = {
             validators_exited: { type: "integer" },
             validator_retention: { type: "number" },
             stability_score: { type: "integer" },
+          },
+        },
+      },
+    },
+  },
+  get_chain_stake_flow: {
+    type: "object",
+    additionalProperties: true,
+    required: ["subnet_count", "network", "subnets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      subnet_count: { type: "integer" },
+      // Network rollup over every subnet that moved stake in the window, plus
+      // gaining/losing/flat subnet counts from each subnet's direction label.
+      network: {
+        type: "object",
+        additionalProperties: false,
+        required: [
+          "total_staked_tao",
+          "total_unstaked_tao",
+          "net_flow_tao",
+          "gross_flow_tao",
+          "stake_events",
+          "unstake_events",
+          "gaining",
+          "losing",
+          "flat",
+        ],
+        properties: {
+          total_staked_tao: { type: "number" },
+          total_unstaked_tao: { type: "number" },
+          net_flow_tao: { type: "number" },
+          gross_flow_tao: { type: "number" },
+          stake_events: { type: "integer" },
+          unstake_events: { type: "integer" },
+          gaining: { type: "integer" },
+          losing: { type: "integer" },
+          flat: { type: "integer" },
+        },
+      },
+      // Spread of per-subnet net flow (TAO) over EVERY active subnet; null when
+      // no subnet moved stake in the window.
+      net_flow_distribution: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: [
+          "count",
+          "mean",
+          "min",
+          "p25",
+          "median",
+          "p75",
+          "p90",
+          "max",
+        ],
+        properties: {
+          count: { type: "integer" },
+          mean: { type: "number" },
+          min: { type: "number" },
+          p25: { type: "number" },
+          median: { type: "number" },
+          p75: { type: "number" },
+          p90: { type: "number" },
+          max: { type: "number" },
+        },
+      },
+      // Per-subnet capital-flow leaderboard, biggest net inflow first.
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "netuid",
+            "total_staked_tao",
+            "total_unstaked_tao",
+            "net_flow_tao",
+            "gross_flow_tao",
+            "stake_events",
+            "unstake_events",
+            "direction",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            total_staked_tao: { type: "number" },
+            total_unstaked_tao: { type: "number" },
+            net_flow_tao: { type: "number" },
+            gross_flow_tao: { type: "number" },
+            stake_events: { type: "integer" },
+            unstake_events: { type: "integer" },
+            direction: { type: "string" },
           },
         },
       },

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.25.0");
+    assert.equal(MCP_SERVER_VERSION, "1.26.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.25.0");
+    assert.equal(MCP_SERVER_VERSION, "1.26.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.25.0");
+    assert.equal(MCP_SERVER_VERSION, "1.26.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5529,6 +5529,7 @@ describe("MCP economics + metagraph data tools", () => {
     turnoverBounds = [],
     turnoverRows = [],
     blocks = [],
+    accountEvents = [],
   } = {}) {
     return {
       prepare(sql) {
@@ -5536,6 +5537,9 @@ describe("MCP economics + metagraph data tools", () => {
           bind(...params) {
             return {
               all() {
+                if (sql.includes("FROM account_events")) {
+                  return Promise.resolve({ results: accountEvents });
+                }
                 if (sql.includes("FROM neurons")) {
                   let r = neurons;
                   if (sql.includes("validator_permit = 1")) {
@@ -6300,6 +6304,104 @@ describe("MCP economics + metagraph data tools", () => {
       chainTurnoverEnv([
         turnoverRow("2026-06-01", 1, "V1"),
         turnoverRow("2026-06-30", 1, "V2"),
+      ]),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
+  // A grouped account_events aggregate row (one per netuid+event_kind), the
+  // shape loadChainStakeFlow's SUM/COUNT/MAX query returns.
+  function stakeFlowRow(netuid, event_kind, total_tao, event_count) {
+    return {
+      netuid,
+      event_kind,
+      total_tao,
+      event_count,
+      last_observed: 1_750_000_000_000,
+    };
+  }
+
+  function chainStakeFlowEnv(rows) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: metagraphD1({ accountEvents: rows }),
+      },
+    };
+  }
+
+  test("get_chain_stake_flow returns schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_chain_stake_flow", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d"); // REST default window parity
+    assert.equal(out.subnet_count, 0);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.net_flow_distribution, null);
+    assert.equal(out.network.net_flow_tao, 0);
+    assert.equal(out.observed_at, null);
+  });
+
+  test("get_chain_stake_flow ranks subnets by net flow with a network rollup", async () => {
+    const res = await callTool(
+      "get_chain_stake_flow",
+      { window: "30d", limit: 10 },
+      chainStakeFlowEnv([
+        // netuid 1: net +80 (inflow, biggest) -> ranks first.
+        stakeFlowRow(1, "StakeAdded", 100, 5),
+        stakeFlowRow(1, "StakeRemoved", 20, 2),
+        // netuid 2: net -30 (outflow) -> ranks last.
+        stakeFlowRow(2, "StakeAdded", 10, 1),
+        stakeFlowRow(2, "StakeRemoved", 40, 3),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets[0].netuid, 1);
+    assert.equal(out.subnets[0].net_flow_tao, 80);
+    assert.equal(out.subnets[0].direction, "inflow");
+    assert.equal(out.subnets[1].netuid, 2);
+    assert.equal(out.subnets[1].direction, "outflow");
+    // Network rollup: staked 110, unstaked 60 -> net +50; 1 gaining, 1 losing.
+    assert.equal(out.network.net_flow_tao, 50);
+    assert.equal(out.network.gaining, 1);
+    assert.equal(out.network.losing, 1);
+    assert.equal(out.net_flow_distribution.count, 2);
+  });
+
+  test("get_chain_stake_flow rejects an unsupported window", async () => {
+    const res = await callTool("get_chain_stake_flow", { window: "90d" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_stake_flow caps the leaderboard by limit", async () => {
+    const res = await callTool(
+      "get_chain_stake_flow",
+      { limit: 1 },
+      chainStakeFlowEnv([
+        stakeFlowRow(1, "StakeAdded", 100, 5),
+        stakeFlowRow(2, "StakeAdded", 50, 3),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    // Both subnets are counted in the rollup/distribution, but the page is capped.
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.net_flow_distribution.count, 2);
+  });
+
+  test("get_chain_stake_flow payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_stake_flow",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_stake_flow",
+      {},
+      chainStakeFlowEnv([
+        stakeFlowRow(1, "StakeAdded", 100, 5),
+        stakeFlowRow(1, "StakeRemoved", 20, 2),
       ]),
     );
     const validate = new Ajv2020().compile(schema);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.25.0");
+    assert.equal(MCP_SERVER_VERSION, "1.26.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.25.0");
+    assert.equal(MCP_SERVER_VERSION, "1.26.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add MCP tool `get_chain_stake_flow` mirroring `GET /api/v1/chain/stake-flow`, the network-wide cross-subnet capital-flow leaderboard
- Reuses the shared `loadChainStakeFlow` loader (no new query logic): per-subnet net TAO flow (`StakeAdded - StakeRemoved`) with staked/unstaked/gross totals, event counts, and an inflow/outflow/balanced direction label, a network rollup (gaining/losing/flat subnet counts), and the per-subnet net-flow distribution
- `window` (7d/30d, default 7d) + `limit` (1-100, default 20) inputs mirror the REST route
- **Fully typed output schema**: `network`, each `subnets[]` entry, and `net_flow_distribution` declare concrete fields so generated MCP consumers get the real stake-flow contract instead of opaque objects
- The network-level companion of `get_subnet_stake_flow`, completing the network chain-analytics MCP family alongside `get_chain_turnover`, `get_chain_concentration`, `get_chain_performance`, and `get_chain_yield`. Bumps MCP SemVer to 1.26.0

## Test plan
- [x] `npm run test -- tests/mcp-server.test.mjs -t get_chain_stake_flow` (cold path, ranking + rollup, window rejection, limit cap, outputSchema)
- [x] `npm run validate:mcp` (91 tools, lifecycle + all tools/call)
- [x] `npm run lint && npm run format:check`
