### PR TITLE
fix(rpc-usage): clamp a sub-perfect error/cache-hit rate below a flat 1.0

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -470,8 +470,14 @@ export const INCIDENT_GAP_MS = 30 * 60 * 1000;
 // sustained) the ledger reflects real dips, not prober flapping.
 export const MIN_INCIDENT_SAMPLES = 2;
 
+// Round a ratio to 4 dp. A sub-perfect ratio (strictly < 1) that would round up
+// to a flat 1.0 is clamped to 0.9999 so a near-total error/failover/cache-hit
+// rate is never overstated as an exact 100% (mirrors chain-analytics round4);
+// null passes through.
 function round4(value) {
-  return value == null ? null : Number(Number(value).toFixed(4));
+  if (value == null) return null;
+  const rounded = Number(Number(value).toFixed(4));
+  return rounded >= 1 && value < 1 ? 0.9999 : rounded;
 }
 function roundInt(value) {
   return value == null ? null : Math.round(Number(value));

--- a/tests/rpc-usage.test.mjs
+++ b/tests/rpc-usage.test.mjs
@@ -120,6 +120,34 @@ describe("formatRpcUsage", () => {
     assert.equal(out.endpoints[0].error_rate, null);
     assert.equal(out.networks[0].error_rate, null);
   });
+
+  test("clamps a sub-perfect rate below a flat 1.0 (never overstates 100%)", () => {
+    const out = formatRpcUsage({
+      // 199995/200000 = 0.999975 and 199998/200000 = 0.99999 both round to
+      // 1.0000; clamped so a near-total rate is never reported as a perfect 1.
+      totals: {
+        total: 200000,
+        ok_count: 5,
+        failover_count: 199990,
+        cache_hits: 199998,
+      },
+      endpointRows: [{ endpoint_id: "e", requests: 200000, ok_count: 5 }],
+      networkRows: [{ network: "finney", requests: 200000, ok_count: 5 }],
+    });
+    assert.equal(out.summary.error_rate, 0.9999); // not 1
+    assert.equal(out.summary.cache_hit_rate, 0.9999); // not 1
+    assert.equal(out.endpoints[0].error_rate, 0.9999); // not 1
+    assert.equal(out.networks[0].error_rate, 0.9999); // not 1
+  });
+
+  test("keeps a genuine 100% rate at exactly 1", () => {
+    const out = formatRpcUsage({
+      // Every request errored: a true 1.0 must stay 1 (the clamp only guards
+      // sub-perfect ratios that round up).
+      totals: { total: 10, ok_count: 0 },
+    });
+    assert.equal(out.summary.error_rate, 1);
+  });
 });
 
 // --- /api/v1/rpc/usage route ------------------------------------------------


### PR DESCRIPTION
## Summary
- `formatRpcUsage` rounds `error_rate`, `failover_rate`, and `cache_hit_rate` (summary plus per-endpoint / per-network `error_rate`) to 4 dp via `round4`
- A ratio strictly below 1 (e.g. `199995/200000 = 0.999975`) rounded **up** to an exact `1.0`, overstating a near-total rate as a perfect 100% even when some requests succeeded
- Clamp a sub-perfect ratio to `0.9999` so it never reads as a flat `1`, mirroring the same anti-overstatement guard already applied to `chain-analytics` `round4`
- A genuine `1.0` (all requests errored) and `null` still pass through unchanged

## Test plan
- [x] `npm run test -- tests/rpc-usage.test.mjs` (adds sub-perfect clamp + genuine-100% cases)
- [x] `npm run test -- tests/health-serving.test.mjs`
- [x] `npm run lint && npm run format:check`