### PR TITLE
fix(chain-yield): read a numeric-epoch-string captured_at from D1

### DIFF
--- a/src/chain-yield.mjs
+++ b/src/chain-yield.mjs
@@ -64,6 +64,17 @@ function captureStamp(value) {
     return { ms: value, value: new Date(value).toISOString() };
   }
   if (typeof value === "string") {
+    // D1 can return an INTEGER captured_at as a numeric-epoch string; Date.parse
+    // returns NaN for a bare epoch string, so coerce the digits to epoch-ms first
+    // (mirrors concentration.mjs / chain-performance.mjs captureStamp), then fall
+    // back to ISO-8601 parsing for a real date string.
+    if (/^\d+$/.test(value)) {
+      const ms = Number(value);
+      if (Number.isFinite(ms) && ms > 0) {
+        return { ms, value: new Date(ms).toISOString() };
+      }
+      return null;
+    }
     const ms = Date.parse(value);
     if (Number.isFinite(ms)) return { ms, value };
   }

--- a/tests/chain-yield.test.mjs
+++ b/tests/chain-yield.test.mjs
@@ -126,6 +126,38 @@ describe("buildChainYield", () => {
     assert.equal(out.captured_at, "2026-06-15T00:00:00.000Z");
   });
 
+  test("coerces a numeric-epoch-string captured_at from D1 (not Date.parse NaN)", () => {
+    // D1 returns INTEGER captured_at as a numeric string; Date.parse of a bare
+    // epoch string is NaN, which would drop the stamp to null. It must be read as
+    // the real epoch-ms timestamp, matching the sibling chain readers.
+    const out = buildChainYield([
+      { stake_tao: 100, emission_tao: 5, captured_at: "1750000000000" },
+    ]);
+    assert.equal(out.captured_at, new Date(1_750_000_000_000).toISOString());
+    // A mixed batch still stamps the newest across number + numeric-string cells.
+    const mixed = buildChainYield([
+      { stake_tao: 1, emission_tao: 0, captured_at: 1_750_000_000_000 },
+      { stake_tao: 1, emission_tao: 0, captured_at: "1750000100000" },
+    ]);
+    assert.equal(mixed.captured_at, new Date(1_750_000_100_000).toISOString());
+  });
+
+  test("ignores a non-positive or overflowing numeric-string captured_at", () => {
+    // "0" is epoch 0 (no real snapshot) and a giant digit string overflows to a
+    // non-finite ms; both must drop to null rather than emit a bogus/throwing date.
+    assert.equal(
+      buildChainYield([{ stake_tao: 1, emission_tao: 0, captured_at: "0" }])
+        .captured_at,
+      null,
+    );
+    assert.equal(
+      buildChainYield([
+        { stake_tao: 1, emission_tao: 0, captured_at: "9".repeat(400) },
+      ]).captured_at,
+      null,
+    );
+  });
+
   test("coerces numeric-string stake/emission cells from D1", () => {
     const out = buildChainYield([
       {


### PR DESCRIPTION
## Summary

`captureStamp` in `src/chain-yield.mjs` handled a `number` and an ISO string, but ran a bare `Date.parse` on any other string. D1 returns an `INTEGER captured_at` column as a **numeric string** on the real read path, and `Date.parse("1750000000000")` is `NaN` — so `GET /api/v1/chain/yield` reports `captured_at: null` for a snapshot that `/chain/concentration` and `/chain/performance` stamp correctly from the *same* `neurons.captured_at` column.

## Repro

```js
buildChainYield([
  { netuid: 1, validator_permit: 1, stake_tao: 100, emission_tao: 5, captured_at: "1750000000000" },
])
```

- **Before:** `captured_at: null` — `Date.parse("1750000000000")` is `NaN`, so the stamp is dropped.
- **After:** `captured_at: "2025-06-15T15:06:40.000Z"` — the digits are coerced to epoch-ms first.

## Why this is the correct behavior

Every sibling reader of the same column already guards this exact case, and the hazard is documented in-tree:

- `src/concentration.mjs` and `src/chain-performance.mjs` `captureStamp` both coerce an all-digits string (via `epochMsStamp(Number(value))`, guarding non-finite / non-positive ms) before falling back to `Date.parse`.
- `src/subnet-performance.mjs` comment: *"D1 can return an INTEGER captured_at as a numeric-epoch string; Date.parse returns NaN for a bare epoch string, so coerce it like concentration.mjs."*
- `chain-yield.mjs` itself already coerces numeric-string `stake_tao` / `emission_tao` / `netuid` cells from D1 — only its `captured_at` path was missed.

## What Changed

- **`src/chain-yield.mjs`** — `captureStamp` coerces an all-digits string to epoch-ms, guarding non-finite / non-positive values exactly like the sibling `epochMsStamp`, before the ISO-8601 `Date.parse` fallback.
- **`tests/chain-yield.test.mjs`** — regression tests for a numeric-string `captured_at`, the newest-stamp path across mixed number + numeric-string cells, and the `"0"` / overflow guard paths. Full statement + branch coverage of the changed lines (verified locally at 100%).

Pure runtime shaping; no schema/contract/artifact change (live-computed route), so no `public/**` regeneration.

## Registry Safety

- [x] No secrets, PATs, wallet data, private URLs, or validator-local state.
- [x] No generated artifacts touched (live-computed route).
- [x] Public API shape unchanged — a dropped timestamp is corrected to the real value.

## Validation

Run locally (Windows; Node 22):

- [x] `vitest run tests/chain-yield.test.mjs --coverage` — 18 passing; **100%** statements/branches/lines on `src/chain-yield.mjs`
- [x] `eslint` + `prettier --check` on the changed files (clean, LF)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
