### PR TITLE
fix(counterparties): reject blank amount_tao cells that coerce to 0

### DIFF
--- a/src/counterparties.mjs
+++ b/src/counterparties.mjs
@@ -59,7 +59,9 @@ function raoBigToTao(rao) {
 }
 
 function nullableNumber(value) {
-  if (value == null || value === "") return null;
+  if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = typeof value === "number" ? value : Number(value);
   return Number.isFinite(n) ? round(n) : null;
 }

--- a/tests/counterparties.test.mjs
+++ b/tests/counterparties.test.mjs
@@ -346,6 +346,64 @@ describe("buildCounterpartyRelationship", () => {
     }
   });
 
+  test("blank amount_tao cells stay null on relationship transfers (not 0 TAO)", () => {
+    // Mirrors the blank-cell guard in account-events.mjs (#3031): Number("") is 0.
+    for (const blank of ["", "   "]) {
+      const data = buildCounterpartyRelationship(
+        [
+          {
+            block_number: 5,
+            event_index: 0,
+            hotkey: ME,
+            coldkey: "A",
+            netuid: 1,
+            amount_tao: blank,
+            observed_at: Date.UTC(2026, 5, 1),
+          },
+          {
+            block_number: 6,
+            event_index: 0,
+            hotkey: ME,
+            coldkey: "A",
+            netuid: 1,
+            amount_tao: 2,
+            observed_at: Date.UTC(2026, 5, 2),
+          },
+        ],
+        ME,
+        "A",
+        {},
+      );
+      assert.equal(
+        data.transfer_count,
+        1,
+        `transfer_count for amount ${JSON.stringify(blank)}`,
+      );
+      assert.equal(data.total_sent_tao, 2);
+      assert.equal(data.transfers.length, 1);
+      assert.equal(data.transfers[0].amount_tao, 2);
+    }
+    // A literal zero amount is still valid — only blank strings are rejected.
+    const zero = buildCounterpartyRelationship(
+      [
+        {
+          block_number: 7,
+          event_index: 0,
+          hotkey: ME,
+          coldkey: "A",
+          netuid: 1,
+          amount_tao: 0,
+          observed_at: Date.UTC(2026, 5, 3),
+        },
+      ],
+      ME,
+      "A",
+      {},
+    );
+    assert.equal(zero.transfer_count, 1);
+    assert.equal(zero.transfers[0].amount_tao, 0);
+  });
+
   test("skips sparse pair rows while preserving valid string and null evidence cells", () => {
     const data = buildCounterpartyRelationship(
       [

--- a/tests/counterparties.test.mjs
+++ b/tests/counterparties.test.mjs
@@ -383,6 +383,36 @@ describe("buildCounterpartyRelationship", () => {
       assert.equal(data.transfers.length, 1);
       assert.equal(data.transfers[0].amount_tao, 2);
     }
+    // Explicit null must skip the row (nullableNumber null guard), not coerce to 0.
+    const missing = buildCounterpartyRelationship(
+      [
+        {
+          block_number: 8,
+          event_index: 0,
+          hotkey: ME,
+          coldkey: "A",
+          netuid: 1,
+          amount_tao: null,
+          observed_at: Date.UTC(2026, 5, 4),
+        },
+        {
+          block_number: 9,
+          event_index: 0,
+          hotkey: ME,
+          coldkey: "A",
+          netuid: 1,
+          amount_tao: 3,
+          observed_at: Date.UTC(2026, 5, 5),
+        },
+      ],
+      ME,
+      "A",
+      {},
+    );
+    assert.equal(missing.transfer_count, 1);
+    assert.equal(missing.total_sent_tao, 3);
+    assert.equal(missing.transfers.length, 1);
+    assert.equal(missing.transfers[0].amount_tao, 3);
     // A literal zero amount is still valid — only blank strings are rejected.
     const zero = buildCounterpartyRelationship(
       [


### PR DESCRIPTION
## Summary

Reject blank D1 `amount_tao` cells in counterparty relationship evidence so empty strings and whitespace-only values return `null` instead of coercing to `0` TAO.

## What Changed

- Add a trim guard to `nullableNumber()` in `src/counterparties.mjs`, matching the pattern merged in `nullableInteger()` (#3008).
- Add regression coverage in `tests/counterparties.test.mjs` for blank vs literal-zero amount cells.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/counterparties.test.mjs`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Sibling fix to the merged blank-cell guard series (#3008).
