### PR TITLE
feat(api): add ?format=csv to GET /api/v1/chain/turnover leaderboard

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -623,7 +623,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch network-wide validator-set turnover across all subnets between the window's start and end neuron_daily snapshots: a per-subnet leaderboard (validators entered, exited, Jaccard retention, and a 0-100 stability score) ranked by gross churn, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet stability scores. Sort is fixed to most-volatile-first; limit caps the leaderboard (default 20, max 100). Computed live from the neuron_daily D1 rollup; schema-stable zeros when cold. */
+        /** Fetch network-wide validator-set turnover across all subnets between the window's start and end neuron_daily snapshots: a per-subnet leaderboard (validators entered, exited, Jaccard retention, and a 0-100 stability score) ranked by gross churn, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet stability scores. Sort is fixed to most-volatile-first; limit caps the leaderboard (default 20, max 100). Computed live from the neuron_daily D1 rollup; schema-stable zeros when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + stability distribution stay JSON-only). */
         get: operations["chainTurnover"];
         put?: never;
         post?: never;
@@ -10862,6 +10862,8 @@ export interface operations {
             query?: {
                 window?: "7d" | "30d" | "90d";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10869,7 +10871,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -10946,6 +10948,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainTurnoverArtifact"];
                     };
+                    /**
+                     * @example netuid,validators_start,validators_end,validators_entered,validators_exited,validator_retention,stability_score
+                     *     1,64,60,8,12,0.8125,81
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -6386,7 +6386,7 @@
     {
       "artifact_path": "/metagraph/chain/turnover.json",
       "cache": "short",
-      "description": "Fetch network-wide validator-set turnover across all subnets between the window's start and end neuron_daily snapshots: a per-subnet leaderboard (validators entered, exited, Jaccard retention, and a 0-100 stability score) ranked by gross churn, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet stability scores. Sort is fixed to most-volatile-first; limit caps the leaderboard (default 20, max 100). Computed live from the neuron_daily D1 rollup; schema-stable zeros when cold.",
+      "description": "Fetch network-wide validator-set turnover across all subnets between the window's start and end neuron_daily snapshots: a per-subnet leaderboard (validators entered, exited, Jaccard retention, and a 0-100 stability score) ranked by gross churn, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet stability scores. Sort is fixed to most-volatile-first; limit caps the leaderboard (default 20, max 100). Computed live from the neuron_daily D1 rollup; schema-stable zeros when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + stability distribution stay JSON-only).",
       "id": "chain-turnover",
       "method": "GET",
       "path": "/api/v1/chain/turnover",
@@ -6411,6 +6411,17 @@
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -912,7 +912,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Network-wide validator-set turnover (churn) across all subnets between a window's start and end neuron_daily snapshots: each subnet's validators entered, exited, Jaccard retention, and a 0-100 stability score ranked into a leaderboard, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary of the per-subnet stability scores (count, mean, min, p25, median, p75, p90, max), computed live from the neuron_daily D1 rollup at /api/v1/chain/turnover (no static file).",
+      "description": "Network-wide validator-set turnover (churn) across all subnets between a window's start and end neuron_daily snapshots: each subnet's validators entered, exited, Jaccard retention, and a 0-100 stability score ranked into a leaderboard, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary of the per-subnet stability scores (count, mean, min, p25, median, p75, p90, max), computed live from the neuron_daily D1 rollup at /api/v1/chain/turnover; pass ?format=csv to download the per-subnet leaderboard as CSV (no static file).",
       "id": "chain-turnover",
       "path": "/metagraph/chain/turnover.json",
       "schema_ref": "#/components/schemas/ChainTurnoverArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -23851,6 +23851,19 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -23935,9 +23948,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,validators_start,validators_end,validators_entered,validators_exited,validator_retention,stability_score\r\n1,64,60,8,12,0.8125,81",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -23994,7 +24013,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch network-wide validator-set turnover across all subnets between the window's start and end neuron_daily snapshots: a per-subnet leaderboard (validators entered, exited, Jaccard retention, and a 0-100 stability score) ranked by gross churn, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet stability scores. Sort is fixed to most-volatile-first; limit caps the leaderboard (default 20, max 100). Computed live from the neuron_daily D1 rollup; schema-stable zeros when cold.",
+        "summary": "Fetch network-wide validator-set turnover across all subnets between the window's start and end neuron_daily snapshots: a per-subnet leaderboard (validators entered, exited, Jaccard retention, and a 0-100 stability score) ranked by gross churn, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet stability scores. Sort is fixed to most-volatile-first; limit caps the leaderboard (default 20, max 100). Computed live from the neuron_daily D1 rollup; schema-stable zeros when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + stability distribution stay JSON-only).",
         "tags": [
           "chain",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -623,7 +623,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch network-wide validator-set turnover across all subnets between the window's start and end neuron_daily snapshots: a per-subnet leaderboard (validators entered, exited, Jaccard retention, and a 0-100 stability score) ranked by gross churn, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet stability scores. Sort is fixed to most-volatile-first; limit caps the leaderboard (default 20, max 100). Computed live from the neuron_daily D1 rollup; schema-stable zeros when cold. */
+        /** Fetch network-wide validator-set turnover across all subnets between the window's start and end neuron_daily snapshots: a per-subnet leaderboard (validators entered, exited, Jaccard retention, and a 0-100 stability score) ranked by gross churn, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet stability scores. Sort is fixed to most-volatile-first; limit caps the leaderboard (default 20, max 100). Computed live from the neuron_daily D1 rollup; schema-stable zeros when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + stability distribution stay JSON-only). */
         get: operations["chainTurnover"];
         put?: never;
         post?: never;
@@ -10862,6 +10862,8 @@ export interface operations {
             query?: {
                 window?: "7d" | "30d" | "90d";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -10869,7 +10871,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -10946,6 +10948,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainTurnoverArtifact"];
                     };
+                    /**
+                     * @example netuid,validators_start,validators_end,validators_entered,validators_exited,validator_retention,stability_score
+                     *     1,64,60,8,12,0.8125,81
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1226,7 +1226,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "chain-turnover",
     "/metagraph/chain/turnover.json",
-    "Network-wide validator-set turnover (churn) across all subnets between a window's start and end neuron_daily snapshots: each subnet's validators entered, exited, Jaccard retention, and a 0-100 stability score ranked into a leaderboard, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary of the per-subnet stability scores (count, mean, min, p25, median, p75, p90, max), computed live from the neuron_daily D1 rollup at /api/v1/chain/turnover (no static file).",
+    "Network-wide validator-set turnover (churn) across all subnets between a window's start and end neuron_daily snapshots: each subnet's validators entered, exited, Jaccard retention, and a 0-100 stability score ranked into a leaderboard, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary of the per-subnet stability scores (count, mean, min, p25, median, p75, p90, max), computed live from the neuron_daily D1 rollup at /api/v1/chain/turnover; pass ?format=csv to download the per-subnet leaderboard as CSV (no static file).",
     "ChainTurnoverArtifact",
   ),
   artifact(
@@ -2696,10 +2696,10 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/chain/turnover",
     "/metagraph/chain/turnover.json",
-    "Fetch network-wide validator-set turnover across all subnets between the window's start and end neuron_daily snapshots: a per-subnet leaderboard (validators entered, exited, Jaccard retention, and a 0-100 stability score) ranked by gross churn, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet stability scores. Sort is fixed to most-volatile-first; limit caps the leaderboard (default 20, max 100). Computed live from the neuron_daily D1 rollup; schema-stable zeros when cold.",
+    "Fetch network-wide validator-set turnover across all subnets between the window's start and end neuron_daily snapshots: a per-subnet leaderboard (validators entered, exited, Jaccard retention, and a 0-100 stability score) ranked by gross churn, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet stability scores. Sort is fixed to most-volatile-first; limit caps the leaderboard (default 20, max 100). Computed live from the neuron_daily D1 rollup; schema-stable zeros when cold. Pass ?format=csv to download the per-subnet leaderboard as CSV (the network rollup + stability distribution stay JSON-only).",
     "short",
     ["chain", "analytics"],
-    [
+    csvRouteQuery([
       {
         name: "window",
         schema: { type: "string", enum: ["7d", "30d", "90d"] },
@@ -2708,7 +2708,7 @@ export const API_ROUTES = [
         name: "limit",
         schema: { type: "integer", minimum: 1, maximum: 100 },
       },
-    ],
+    ]),
     [],
   ),
   route(

--- a/src/csv-route-examples.mjs
+++ b/src/csv-route-examples.mjs
@@ -36,4 +36,9 @@ export const ROUTE_CSV_EXAMPLES = {
     "from,to,volume_tao,transfer_count,last_block,last_observed_at",
     "5Sender_sample,5Receiver_sample,1250.5,42,8454388,2026-07-03T00:00:00.000Z",
   ].join("\r\n"),
+  // The /chain/turnover per-subnet validator-churn leaderboard rows.
+  "chain-turnover": [
+    "netuid,validators_start,validators_end,validators_entered,validators_exited,validator_retention,stability_score",
+    "1,64,60,8,12,0.8125,81",
+  ].join("\r\n"),
 };

--- a/tests/chain-turnover.test.mjs
+++ b/tests/chain-turnover.test.mjs
@@ -441,6 +441,75 @@ describe("GET /api/v1/chain/turnover", () => {
     );
     assert.equal(res.status, 400);
   });
+
+  const TURNOVER_CSV_HEADER =
+    "netuid,validators_start,validators_end,validators_entered,validators_exited,validator_retention,stability_score";
+  const warm = { bounds: [{ start_date: START, end_date: END }], rows: ROWS };
+  const cold = { bounds: [{ start_date: null, end_date: null }], rows: [] };
+
+  test("exports the per-subnet churn leaderboard as CSV with ?format=csv", async () => {
+    const res = await handleRequest(
+      request("?window=30d&format=csv"),
+      neuronDailyEnv(warm),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    assert.match(
+      res.headers.get("content-disposition"),
+      /attachment; filename="chain-turnover\.csv"/,
+    );
+    const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines[0], TURNOVER_CSV_HEADER);
+    // Most-volatile first: netuid 1 (churn 2) leads, then the stable netuid 2.
+    assert.equal(lines.length, 3); // header + 2 subnet rows
+    assert.equal(lines[1], "1,2,2,1,1,0.3333,33");
+  });
+
+  test("honors Accept: text/csv the same as ?format=csv", async () => {
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/chain/turnover", {
+        headers: { accept: "text/csv" },
+      }),
+      neuronDailyEnv(warm),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+  });
+
+  test("emits a header-only CSV on a cold store", async () => {
+    const res = await handleRequest(
+      request("?format=csv"),
+      neuronDailyEnv(cold),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    assert.equal((await res.text()).trim(), TURNOVER_CSV_HEADER);
+  });
+
+  test("serves a CSV HEAD probe with the CSV headers and no body", async () => {
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/chain/turnover?format=csv", {
+        method: "HEAD",
+      }),
+      neuronDailyEnv(warm),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/csv/);
+    assert.equal(await res.text(), ""); // HEAD carries no body
+  });
+
+  test("rejects an unsupported format value with 400", async () => {
+    const res = await handleRequest(
+      request("?format=xml"),
+      neuronDailyEnv(cold),
+      {},
+    );
+    assert.equal(res.status, 400);
+  });
 });
 
 describe("readNeuronDailyCacheStamp", () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1851,7 +1851,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         env,
         "chain-turnover",
         () => handleChainTurnover(request, env, resolved.url),
-        canonicalChainTurnoverCachePath(resolved.url),
+        canonicalChainTurnoverCachePath(resolved.url, request),
         // neuron_daily-derived: stamp on the neuron_daily rollup (not the live neurons tier), so a
         // new daily snapshot invalidates the cached scorecard on the same cadence as its source.
         (edgeEnv) => readNeuronDailyCacheStamp(edgeEnv),

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -198,6 +198,18 @@ const GLOBAL_VALIDATOR_CSV_COLUMNS = [
   "latest_block_number",
   "subnets",
 ];
+// CSV column order for the /api/v1/chain/turnover per-subnet churn leaderboard
+// rows (the `subnets` array). The network rollup + stability distribution stay
+// JSON-only, mirroring the chain-analytics leaderboard CSV exports.
+const CHAIN_TURNOVER_CSV_COLUMNS = [
+  "netuid",
+  "validators_start",
+  "validators_end",
+  "validators_entered",
+  "validators_exited",
+  "validator_retention",
+  "stability_score",
+];
 const SUBNET_YIELD_CSV_COLUMNS = [
   "uid",
   "hotkey",
@@ -900,8 +912,12 @@ export function canonicalSubnetMoversCachePath(url, request = null) {
 // Canonical edge-cache key for the network turnover route: window + limit collapsed to
 // their resolved defaults so ?window=30d and the bare path share one cached entry. Falls
 // back to the raw path+search when validation fails (the handler will 400 it anyway).
-export function canonicalChainTurnoverCachePath(url) {
-  const validationError = validateQueryParams(url, ["window", "limit"]);
+export function canonicalChainTurnoverCachePath(url, request = null) {
+  const validationError = validateEntityQuery(url, [
+    "window",
+    "limit",
+    "format",
+  ]);
   if (validationError) return `${url.pathname}${url.search}`;
   const windowParam =
     url.searchParams.get("window") || DEFAULT_CHAIN_TURNOVER_WINDOW;
@@ -914,14 +930,23 @@ export function canonicalChainTurnoverCachePath(url) {
     max: CHAIN_TURNOVER_LIMIT_MAX,
   });
   if (limit.error) return `${url.pathname}${url.search}`;
-  return `${url.pathname}?window=${windowParam}&limit=${limit.value}`;
+  // CSV and JSON responses must not share one edge-cache entry.
+  return csvCacheVariant(
+    url,
+    request,
+    `${url.pathname}?window=${windowParam}&limit=${limit.value}`,
+  );
 }
 
 // GET /api/v1/chain/turnover?window=7d|30d|90d&limit=20: network-wide validator-set churn
 // across all subnets between the window's boundary neuron_daily snapshots — a per-subnet
 // turnover leaderboard plus a network rollup over the union validator set.
 export async function handleChainTurnover(request, env, url) {
-  const validationError = validateQueryParams(url, ["window", "limit"]);
+  const validationError = validateEntityQuery(url, [
+    "window",
+    "limit",
+    "format",
+  ]);
   if (validationError) return analyticsQueryError(validationError);
   const windowParam =
     url.searchParams.get("window") || DEFAULT_CHAIN_TURNOVER_WINDOW;
@@ -941,6 +966,17 @@ export async function handleChainTurnover(request, env, url) {
     windowLabel: windowParam,
     limit: limit.value,
   });
+  // CSV exports the row-shaped per-subnet churn leaderboard; the network rollup +
+  // stability distribution stay JSON-only (mirrors the chain-analytics exports).
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.subnets,
+      "chain-turnover",
+      "short",
+      request,
+      CHAIN_TURNOVER_CSV_COLUMNS,
+    );
+  }
   // neuron_daily-derived, so the meta reports the metagraph-snapshot source; generated_at
   // is the end snapshot date (string), matching the movers/turnover routes.
   return envelopeResponse(


### PR DESCRIPTION
## Summary

Add `?format=csv` (and `Accept: text/csv`) to `GET /api/v1/chain/turnover` — the network-wide validator-set churn leaderboard — so the per-subnet rows can be downloaded as CSV, mirroring the other chain-analytics leaderboard CSV exports (`chain/weights`, `chain/serving`, `chain/stake-flow`, `chain/transfer-pairs`).

## What Changed

- `workers/request-handlers/entities.mjs` (`handleChainTurnover`): validate via `validateEntityQuery` with `format` allowed, and when CSV is negotiated return `csvResponse(data.subnets, "chain-turnover", …)` with a stable `CHAIN_TURNOVER_CSV_COLUMNS` order (`netuid, validators_start, validators_end, validators_entered, validators_exited, validator_retention, stability_score`). The network rollup + stability distribution stay JSON-only (same split as the sibling leaderboards).
- `canonicalChainTurnoverCachePath` now takes `request` and routes its key through `csvCacheVariant`, so a `?format=csv` (or `Accept: text/csv`) request never shares an edge-cache entry with the JSON response — the same cache-variant guard the other CSV entity routes use. `workers/api.mjs` passes `request` at the call site.
- `src/contracts.mjs`: wrapped the `chain-turnover` route query params in `csvRouteQuery(...)` and noted `?format=csv` in the route + artifact descriptions.
- `src/csv-route-examples.mjs`: a `chain-turnover` CSV example.
- Regenerated + committed the derived contract artifacts (`npm run build`). `public/metagraph/r2-manifest.json` and `public/metagraph/schemas/index.json` are intentionally NOT included (deploy/publish-pipeline-owned).
- Tests: `?format=csv` serializes the ranked leaderboard; `Accept: text/csv` negotiates the same; a cold store emits a header-only CSV; a CSV `HEAD` probe returns the CSV headers with no body; `?format=xml` is rejected with 400. Every new branch is covered.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts (`npm run build`), not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (new `format` param + `text/csv` response on the chain-turnover route).

## Validation

- [x] `npm run build` (regenerated + committed OpenAPI/types/contracts)
- [x] `npm run validate:contract-drift` · `validate:openapi` · `validate:types` · `validate:docs`
- [x] `npx vitest run` (full suite) incl. `tests/chain-turnover.test.mjs`
- [x] `npm run lint` · `npm run format:check` · `git diff --check`
