### PR TITLE
fix(account-portfolio): reject blank score cells that coerce to 0

### DIFF
--- a/src/account-portfolio.mjs
+++ b/src/account-portfolio.mjs
@@ -28,7 +28,9 @@ function toNumber(value) {
 
 // A nullable 0..1 score cell -> rounded number, or null when absent/non-finite.
 function nullableScore(value) {
-  if (value == null || value === "") return null;
+  if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isFinite(n) ? round9(n) : null;
 }

--- a/tests/account-portfolio.test.mjs
+++ b/tests/account-portfolio.test.mjs
@@ -106,6 +106,69 @@ describe("buildAccountPortfolio", () => {
     assert.equal(out.total_stake_tao, 100);
   });
 
+  test("blank score cells stay null (not rank/trust 0)", () => {
+    // Mirrors the blank-cell guard in metagraph-neurons.mjs (#3033): Number("") is 0.
+    for (const blank of ["", "   "]) {
+      const out = buildAccountPortfolio(
+        [
+          {
+            netuid: 1,
+            uid: 1,
+            stake_tao: 10,
+            rank: blank,
+            trust: blank,
+            incentive: blank,
+            dividends: blank,
+          },
+        ],
+        SS58,
+      );
+      assert.equal(out.position_count, 1);
+      assert.equal(
+        out.positions[0].rank,
+        null,
+        `rank for ${JSON.stringify(blank)}`,
+      );
+      assert.equal(
+        out.positions[0].trust,
+        null,
+        `trust for ${JSON.stringify(blank)}`,
+      );
+      assert.equal(
+        out.positions[0].incentive,
+        null,
+        `incentive for ${JSON.stringify(blank)}`,
+      );
+      assert.equal(
+        out.positions[0].dividends,
+        null,
+        `dividends for ${JSON.stringify(blank)}`,
+      );
+    }
+    const missing = buildAccountPortfolio(
+      [
+        {
+          netuid: 2,
+          uid: 1,
+          stake_tao: 10,
+          rank: null,
+          trust: null,
+          incentive: null,
+          dividends: null,
+        },
+      ],
+      SS58,
+    );
+    assert.equal(missing.positions[0].rank, null);
+    assert.equal(missing.positions[0].trust, null);
+    const zero = buildAccountPortfolio(
+      [{ netuid: 3, uid: 1, stake_tao: 10, rank: 0, trust: "0" }],
+      SS58,
+    );
+    assert.equal(zero.positions[0].rank, 0);
+    assert.equal(zero.positions[0].trust, 0);
+  });
+
   test("accepts a string epoch-ms captured_at, ignoring absent ones", () => {
     const out = buildAccountPortfolio(
       [


### PR DESCRIPTION
## Summary

Reject blank D1 score cells (`rank`, `trust`, `incentive`, `dividends`) in account portfolio formatting so empty strings and whitespace-only values return `null` instead of coercing to `0`.

## What Changed

- Add null + trim guards to `nullableScore()` in `src/account-portfolio.mjs`, matching the pattern merged in metagraph-neurons.mjs (#3033).
- Add regression coverage in `tests/account-portfolio.test.mjs` for blank, null, and literal-zero score cells.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/account-portfolio.test.mjs`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Sibling fix to the merged blank-cell guard series (#3033).
