### PR TITLE
feat(mcp): add get_chain_weights mirroring GET /api/v1/chain/weights

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -414,6 +414,16 @@ assert.ok(
     chainStakeFlow.network != null,
   "get_chain_stake_flow must return subnet_count + network + subnets[]",
 );
+const chainWeights = await callOk("get_chain_weights", {
+  window: "7d",
+  limit: 5,
+});
+assert.ok(
+  Number.isInteger(chainWeights.subnet_count) &&
+    Array.isArray(chainWeights.subnets) &&
+    chainWeights.network != null,
+  "get_chain_weights must return subnet_count + network + subnets[]",
+);
 const meta = await callOk("get_subnet_metagraph", { netuid: 7 });
 assert.ok(
   Array.isArray(meta.neurons),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/chain-weights.mjs
+++ b/src/chain-weights.mjs
@@ -11,6 +11,12 @@ export const WEIGHTS_EVENT_KIND = "WeightsSet";
 export const CHAIN_WEIGHTS_LIMIT_DEFAULT = 20;
 export const CHAIN_WEIGHTS_LIMIT_MAX = 100;
 
+// Supported lookback windows (label -> days), matching the REST route's analytics
+// window set (7d/30d, default 7d). Kept next to the loader so the MCP tool's input
+// schema and runtime validation cannot drift from the endpoint.
+export const CHAIN_WEIGHTS_WINDOWS = { "7d": 7, "30d": 30 };
+export const DEFAULT_CHAIN_WEIGHTS_WINDOW = "7d";
+
 // Round an updates-per-validator ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct setters, with the divisor guarded below).
 function round(value, dp = 2) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -92,6 +92,13 @@ import {
   DEFAULT_CHAIN_STAKE_FLOW_WINDOW,
 } from "./chain-stake-flow.mjs";
 import {
+  loadChainWeights,
+  CHAIN_WEIGHTS_LIMIT_DEFAULT,
+  CHAIN_WEIGHTS_LIMIT_MAX,
+  CHAIN_WEIGHTS_WINDOWS,
+  DEFAULT_CHAIN_WEIGHTS_WINDOW,
+} from "./chain-weights.mjs";
+import {
   loadEconomicsTrends,
   parseEconomicsTrendsWindow,
 } from "./economics-trends.mjs";
@@ -241,13 +248,14 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.26.0";
+export const MCP_SERVER_VERSION = "1.27.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
 const CHAIN_TURNOVER_WINDOW_KEYS = Object.keys(CHAIN_TURNOVER_WINDOWS);
 const CHAIN_STAKE_FLOW_WINDOW_KEYS = Object.keys(CHAIN_STAKE_FLOW_WINDOWS);
+const CHAIN_WEIGHTS_WINDOW_KEYS = Object.keys(CHAIN_WEIGHTS_WINDOWS);
 const STAKE_FLOW_WINDOW_KEYS = Object.keys(STAKE_FLOW_WINDOWS);
 const MOVERS_WINDOW_KEYS = Object.keys(MOVERS_WINDOWS);
 
@@ -365,6 +373,9 @@ export const MCP_INSTRUCTIONS =
   "(per-subnet churn, retention, and stability) across all subnets, " +
   "get_chain_stake_flow the network-wide cross-subnet capital-flow leaderboard " +
   "(per-subnet net TAO staked/unstaked and direction) across all subnets, " +
+  "get_chain_weights the network-wide validator weight-setting leaderboard " +
+  "(per-subnet WeightsSet activity, distinct setters, and update intensity) " +
+  "across all subnets, " +
   "get_blocks_summary block-production analytics (inter-block time, throughput, " +
   "and block-author decentralization), " +
   "get_network_activity the daily " +
@@ -2125,6 +2136,56 @@ export const MCP_TOOLS = [
       return loadChainStakeFlow(mcpD1Runner(ctx), {
         windowLabel: window,
         windowDays: CHAIN_STAKE_FLOW_WINDOWS[window],
+        limit,
+      });
+    },
+  },
+  {
+    name: "get_chain_weights",
+    title: "Get network-wide validator weight-setting activity",
+    description:
+      "Fetch the network-wide validator weight-setting leaderboard over the " +
+      "requested window (7d or 30d; default 7d): each subnet ranked by WeightsSet " +
+      "events with its distinct-setter count and sets-per-setter update " +
+      "intensity, plus a network rollup (distinct setters, total weight sets, " +
+      "sets per setter) and the count/mean/min/p25/median/p75/p90/max spread of " +
+      "per-subnet intensity, summed live from the account_events stream. The " +
+      "consensus-maintenance companion to get_chain_stake_flow (capital) and " +
+      "get_chain_turnover (validator churn). Mirrors GET /api/v1/chain/weights.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_WEIGHTS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_CHAIN_WEIGHTS_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max subnets in the weight-setting leaderboard (1-${CHAIN_WEIGHTS_LIMIT_MAX}, default ${CHAIN_WEIGHTS_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_WEIGHTS_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window =
+        optionalString(args, "window") ?? DEFAULT_CHAIN_WEIGHTS_WINDOW;
+      if (!Object.hasOwn(CHAIN_WEIGHTS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_WEIGHTS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_WEIGHTS_LIMIT_DEFAULT,
+        CHAIN_WEIGHTS_LIMIT_MAX,
+      );
+      return loadChainWeights(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: CHAIN_WEIGHTS_WINDOWS[window],
         limit,
       });
     },
@@ -5827,6 +5888,78 @@ const TOOL_OUTPUT_SCHEMAS = {
             stake_events: { type: "integer" },
             unstake_events: { type: "integer" },
             direction: { type: "string" },
+          },
+        },
+      },
+    },
+  },
+  get_chain_weights: {
+    type: "object",
+    additionalProperties: true,
+    required: ["subnet_count", "network", "subnets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      subnet_count: { type: "integer" },
+      // Network rollup over every subnet that set weights in the window.
+      // sets_per_setter is null when the network-wide distinct-setter count is
+      // unavailable/zero (no divide-by-zero).
+      network: {
+        type: "object",
+        additionalProperties: false,
+        required: ["distinct_setters", "weight_sets", "sets_per_setter"],
+        properties: {
+          distinct_setters: { type: "integer" },
+          weight_sets: { type: "integer" },
+          sets_per_setter: { type: ["number", "null"] },
+        },
+      },
+      // Spread of per-subnet update intensity (WeightsSet events per setter) over
+      // EVERY subnet that set weights; null when no subnet set weights in the window.
+      intensity_distribution: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: [
+          "count",
+          "mean",
+          "min",
+          "p25",
+          "median",
+          "p75",
+          "p90",
+          "max",
+        ],
+        properties: {
+          count: { type: "integer" },
+          mean: { type: "number" },
+          min: { type: "number" },
+          p25: { type: "number" },
+          median: { type: "number" },
+          p75: { type: "number" },
+          p90: { type: "number" },
+          max: { type: "number" },
+        },
+      },
+      // Per-subnet weight-setting leaderboard, most WeightsSet events first. Each
+      // listed subnet has at least one distinct setter, so sets_per_setter is
+      // always a finite number here (never divide-by-zero).
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "netuid",
+            "distinct_setters",
+            "weight_sets",
+            "sets_per_setter",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            distinct_setters: { type: "integer" },
+            weight_sets: { type: "integer" },
+            sets_per_setter: { type: "number" },
           },
         },
       },

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.26.0");
+    assert.equal(MCP_SERVER_VERSION, "1.27.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.26.0");
+    assert.equal(MCP_SERVER_VERSION, "1.27.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.26.0");
+    assert.equal(MCP_SERVER_VERSION, "1.27.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5530,6 +5530,8 @@ describe("MCP economics + metagraph data tools", () => {
     turnoverRows = [],
     blocks = [],
     accountEvents = [],
+    weightsNetworkRows = [],
+    weightsSubnetRows = [],
   } = {}) {
     return {
       prepare(sql) {
@@ -5538,6 +5540,16 @@ describe("MCP economics + metagraph data tools", () => {
             return {
               all() {
                 if (sql.includes("FROM account_events")) {
+                  // get_chain_weights reads a network aggregate (carries
+                  // newest_observed) then a per-subnet GROUP BY (carries
+                  // weight_sets); everything else uses the flat account_events
+                  // fixture (e.g. get_chain_stake_flow's single grouped read).
+                  if (sql.includes("newest_observed")) {
+                    return Promise.resolve({ results: weightsNetworkRows });
+                  }
+                  if (sql.includes("weight_sets")) {
+                    return Promise.resolve({ results: weightsSubnetRows });
+                  }
                   return Promise.resolve({ results: accountEvents });
                 }
                 if (sql.includes("FROM neurons")) {
@@ -6402,6 +6414,111 @@ describe("MCP economics + metagraph data tools", () => {
       chainStakeFlowEnv([
         stakeFlowRow(1, "StakeAdded", 100, 5),
         stakeFlowRow(1, "StakeRemoved", 20, 2),
+      ]),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
+  // The network-wide aggregate row loadChainWeights reads first (its COUNT/
+  // COUNT(DISTINCT)/MAX(observed_at) probe); a non-null newest_observed unlocks
+  // the per-subnet read.
+  function weightsNetwork(weight_sets, distinct_setters) {
+    return {
+      weight_sets,
+      distinct_setters,
+      newest_observed: 1_750_000_000_000,
+    };
+  }
+
+  // A per-subnet GROUP BY netuid row (COUNT weight_sets + distinct setters).
+  function weightsRow(netuid, weight_sets, distinct_setters) {
+    return { netuid, weight_sets, distinct_setters };
+  }
+
+  function chainWeightsEnv(network, subnets) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: metagraphD1({
+          weightsNetworkRows: network ? [network] : [],
+          weightsSubnetRows: subnets,
+        }),
+      },
+    };
+  }
+
+  test("get_chain_weights returns schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_chain_weights", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d"); // REST default window parity
+    assert.equal(out.subnet_count, 0);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.intensity_distribution, null);
+    assert.equal(out.network.weight_sets, 0);
+    assert.equal(out.network.sets_per_setter, null);
+    assert.equal(out.observed_at, null);
+  });
+
+  test("get_chain_weights ranks subnets by weight sets with a network rollup", async () => {
+    const res = await callTool(
+      "get_chain_weights",
+      { window: "30d", limit: 10 },
+      chainWeightsEnv(weightsNetwork(30, 8), [
+        // netuid 2: fewer sets -> ranks last despite higher intensity.
+        weightsRow(2, 10, 4),
+        // netuid 1: most WeightsSet events -> ranks first.
+        weightsRow(1, 20, 5),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets[0].netuid, 1);
+    assert.equal(out.subnets[0].weight_sets, 20);
+    assert.equal(out.subnets[0].sets_per_setter, 4); // 20 / 5
+    assert.equal(out.subnets[1].netuid, 2);
+    assert.equal(out.subnets[1].sets_per_setter, 2.5); // 10 / 4
+    // Network rollup: total sets 30 over 8 distinct setters -> 3.75.
+    assert.equal(out.network.weight_sets, 30);
+    assert.equal(out.network.distinct_setters, 8);
+    assert.equal(out.network.sets_per_setter, 3.75);
+    assert.equal(out.intensity_distribution.count, 2);
+    assert.equal(out.observed_at, new Date(1_750_000_000_000).toISOString());
+  });
+
+  test("get_chain_weights rejects an unsupported window", async () => {
+    const res = await callTool("get_chain_weights", { window: "90d" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_weights caps the leaderboard by limit", async () => {
+    const res = await callTool(
+      "get_chain_weights",
+      { limit: 1 },
+      chainWeightsEnv(weightsNetwork(30, 8), [
+        weightsRow(1, 20, 5),
+        weightsRow(2, 10, 4),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    // Both subnets feed the rollup/distribution, but the page is capped.
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.intensity_distribution.count, 2);
+  });
+
+  test("get_chain_weights payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_weights",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_weights",
+      {},
+      chainWeightsEnv(weightsNetwork(30, 8), [
+        weightsRow(1, 20, 5),
+        weightsRow(2, 10, 4),
       ]),
     );
     const validate = new Ajv2020().compile(schema);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.26.0");
+    assert.equal(MCP_SERVER_VERSION, "1.27.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.26.0");
+    assert.equal(MCP_SERVER_VERSION, "1.27.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Adds a new MCP tool `get_chain_weights` that exposes the network-wide **validator weight-setting leaderboard** — the consensus-maintenance companion to `get_chain_stake_flow` (capital) and `get_chain_turnover` (validator churn).

Each subnet is ranked by `WeightsSet` events with its distinct-setter count and `sets_per_setter` update intensity, plus:
- a **network rollup** (distinct setters, total weight sets, sets per setter), and
- the `count/mean/min/p25/median/p75/p90/max` **spread of per-subnet intensity**,

summed live from the `account_events` stream over a `7d`/`30d` window (default `7d`).

The tool delegates to the existing `loadChainWeights` loader that already backs `GET /api/v1/chain/weights`, so the MCP surface stays in lockstep with the REST endpoint (same window set, same `limit` bounds 1–100, default 20, same cold-store zeros).

## Changes
- `src/chain-weights.mjs`: export `CHAIN_WEIGHTS_WINDOWS` / `DEFAULT_CHAIN_WEIGHTS_WINDOW` (co-located with the loader so the tool schema can't drift from the route).
- `src/mcp-server.mjs`: register `get_chain_weights` (import, window keys, instructions, handler with window/limit validation, deeply-typed output schema); bump `MCP_SERVER_VERSION` to `1.27.0` (additive — new tool).
- `server.json`: version → `1.27.0`.
- `scripts/validate-mcp.mjs`: cold-path assertion for the new tool.
- Tests: cold-store zeros, ranking + network rollup, unsupported-window rejection, limit cap, and output-schema validation; version-assertion updates.

## Test plan
- [x] `npm run validate:mcp` (92 tools, lifecycle + all tools/call)
- [x] `npx vitest run` for `mcp-server` + all version-assertion suites (532 passed)
- [x] `eslint` + `prettier` clean
- [x] No conflict with open PRs (touches only the additive weights tool + shared version lines)

Made with [Cursor](https://cursor.com)