### PR TITLE
feat(registry): add SN36 Eirel workflow specs data-artifact

### DIFF
--- a/registry/subnets/sn-36.json
+++ b/registry/subnets/sn-36.json
@@ -123,6 +123,22 @@
         "submitted_by": "codevector96"
       },
       "notes": "Public metagraph status for netuid 36 on finney (validator/miner counts, timestamp); GET /v1/metagraph/status in the OpenAPI spec."
+    },
+    {
+      "id": "sn-36-eirel-workflow-specs",
+      "name": "Eirel workflow specs",
+      "kind": "data-artifact",
+      "url": "https://api.eirel.ai/v1/workflow-specs",
+      "provider": "eirel",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://api.eirel.ai/openapi.json"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "notes": "Public no-auth JSON catalog of Eirel's evaluation workflow specifications (workflow_spec_id, class, description, node graph); GET /v1/workflow-specs in the OpenAPI spec. Distinct endpoint from the registered /api/v1/dashboard/* and /v1/metagraph/status routes."
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/sn-36.json` (SN36 Eirel). Append-only; no top-level metadata or existing surfaces touched.

## Summary

SN36 (Eirel) had no `data-artifact` surface. The official Eirel API exposes a public, no-auth JSON catalog of the subnet's evaluation workflow specifications (`GET /v1/workflow-specs`) — the workflow definitions (id, class, description, node graph) that miners are evaluated against. This adds it as a `data-artifact`, sourced from the subnet's official OpenAPI contract.

This is a **distinct endpoint** from the already-registered Eirel routes (`/api/v1/dashboard/overview`, `/api/v1/dashboard/runs`, `/v1/metagraph/status`) — a separate workflow-spec catalog, not a re-titling of an existing surface.

## Surface

- Netuid: 36
- Kind: data-artifact
- Public URL: https://api.eirel.ai/v1/workflow-specs
- Source URL (proves the claim): https://api.eirel.ai/openapi.json
- Provider slug: eirel

The endpoint is defined in the official Eirel OpenAPI spec as `Workflow Specs` with no security requirement (verified: `paths./v1/workflow-specs.get.security` is absent).

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this endpoint, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public endpoint plus the official OpenAPI source fully establish and verify the claim.

## Checklist

- [x] Changes exactly one `registry/subnets/sn-36.json` file (append-only; no top-level metadata or existing surfaces touched).
- [x] The `url` is public, no-auth, read-only-safe; the `source_url` (official OpenAPI) independently proves the subnet publishes it.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface — distinct URL from all registered Eirel routes.
- [x] No linked issue — rationale provided above.

## Validation

- [x] `npm run validate:surface -- registry/subnets/sn-36.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate` (full suite, green)
