### PR TITLE
feat(api): add GET /api/v1/subnets/{netuid}/weights per-subnet weight-setting activity

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1891,6 +1891,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/subnets/{netuid}/weights": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch validator weight-setting activity for one subnet over a 7d or 30d window: the distinct weight-setting validators, the WeightsSet event count, and the average updates per validator, computed live from the account_events WeightsSet stream. The per-subnet drill-in of GET /api/v1/chain/weights (which ranks only the top-N subnets and cannot be queried by netuid). Schema-stable zeroed card when the subnet has no WeightsSet events in the window. */
+        get: operations["subnetWeights"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/subnets/{netuid}/yield": {
         parameters: {
             query?: never;
@@ -5908,6 +5925,18 @@ export interface components {
             [key: string]: unknown;
         };
         SubnetVerificationArtifact: components["schemas"]["VerificationArtifact"];
+        /** @description Per-subnet validator weight-setting activity over a 7d/30d window: the distinct weight-setting validators, WeightsSet event count, and updates per validator for ONE subnet. The per-subnet drill-in of /api/v1/chain/weights (which ranks only the top-N subnets and cannot be queried by netuid), served live from the account_events WeightsSet stream at /api/v1/subnets/{netuid}/weights (no static file); zeroed when the subnet has no WeightsSet events in the window. */
+        SubnetWeightsArtifact: {
+            distinct_setters: number;
+            netuid: number;
+            /** Format: date-time */
+            observed_at: string | null;
+            schema_version: number;
+            sets_per_setter: number | null;
+            weight_sets: number;
+            /** @enum {string|null} */
+            window: "7d" | "30d" | null;
+        };
         /** @description Per-UID emission yield (emission/stake return rate) for one subnet over the current metagraph snapshot, ranked high to low, with a distribution summary (subnet aggregate yield, mean, p25/median/p75/p90), a validator/miner split, and a per-UID above/below-median label, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/yield (no static file). */
         SubnetYieldArtifact: {
             block_number: number | null;
@@ -21830,6 +21859,115 @@ export interface operations {
                      *     0,hk_sample,ck_sample,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091
                      */
                     "text/csv": string;
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    subnetWeights: {
+        parameters: {
+            query?: {
+                window?: "7d" | "30d";
+            };
+            header?: never;
+            path: {
+                netuid: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "distinct_setters": 1,
+                     *         "netuid": 7,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "sets_per_setter": 0.5,
+                     *         "weight_sets": 1,
+                     *         "window": "7d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-29.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["SubnetWeightsArtifact"];
+                    };
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -394,6 +394,13 @@
     },
     {
       "contract_version": "2026-07-03.2",
+      "id": "subnet-weights",
+      "path": "/metagraph/subnets/{netuid}/weights.json",
+      "schema_ref": "#/components/schemas/SubnetWeightsArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "contract_version": "2026-07-03.2",
       "id": "subnet-stake-flow",
       "path": "/metagraph/subnets/{netuid}/stake-flow.json",
       "schema_ref": "#/components/schemas/SubnetStakeFlowArtifact",
@@ -4731,6 +4738,29 @@
           "schema": {
             "enum": [
               "true"
+            ],
+            "type": "string"
+          }
+        }
+      ]
+    },
+    {
+      "artifact_path": "/metagraph/subnets/{netuid}/weights.json",
+      "cache": "short",
+      "description": "Fetch validator weight-setting activity for one subnet over a 7d or 30d window: the distinct weight-setting validators, the WeightsSet event count, and the average updates per validator, computed live from the account_events WeightsSet stream. The per-subnet drill-in of GET /api/v1/chain/weights (which ranks only the top-N subnets and cannot be queried by netuid). Schema-stable zeroed card when the subnet has no WeightsSet events in the window.",
+      "id": "subnet-weights",
+      "method": "GET",
+      "path": "/api/v1/subnets/{netuid}/weights",
+      "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
+      "query_parameters": [
+        {
+          "name": "window",
+          "schema": {
+            "enum": [
+              "7d",
+              "30d"
             ],
             "type": "string"
           }

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -507,6 +507,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
+      "description": "Validator weight-setting activity for one subnet over a 7d or 30d window — the distinct weight-setting validators, WeightsSet event count, and average updates per validator — served live from the account_events WeightsSet stream at /api/v1/subnets/{netuid}/weights (no static file). The per-subnet drill-in of /api/v1/chain/weights.",
+      "id": "subnet-weights",
+      "path": "/metagraph/subnets/{netuid}/weights.json",
+      "schema_ref": "#/components/schemas/SubnetWeightsArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-07-03.2",
       "description": "Net stake flow for one subnet over a recent window (7d/30d/90d): total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and event counts, with optional ?direction=all|in|out to filter inflow or outflow only, summed live from the account_events stream at /api/v1/subnets/{netuid}/stake-flow (no static file).",
       "id": "subnet-stake-flow",
       "path": "/metagraph/subnets/{netuid}/stake-flow.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -16351,6 +16351,62 @@
       "SubnetVerificationArtifact": {
         "$ref": "#/components/schemas/VerificationArtifact"
       },
+      "SubnetWeightsArtifact": {
+        "additionalProperties": false,
+        "description": "Per-subnet validator weight-setting activity over a 7d/30d window: the distinct weight-setting validators, WeightsSet event count, and updates per validator for ONE subnet. The per-subnet drill-in of /api/v1/chain/weights (which ranks only the top-N subnets and cannot be queried by netuid), served live from the account_events WeightsSet stream at /api/v1/subnets/{netuid}/weights (no static file); zeroed when the subnet has no WeightsSet events in the window.",
+        "properties": {
+          "distinct_setters": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "sets_per_setter": {
+            "minimum": 0,
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "weight_sets": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "window": {
+            "enum": [
+              "7d",
+              "30d",
+              null
+            ],
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "netuid",
+          "window",
+          "observed_at",
+          "distinct_setters",
+          "weight_sets",
+          "sets_per_setter"
+        ],
+        "type": "object"
+      },
       "SubnetYieldArtifact": {
         "additionalProperties": false,
         "description": "Per-UID emission yield (emission/stake return rate) for one subnet over the current metagraph snapshot, ranked high to low, with a distribution summary (subnet aggregate yield, mean, p25/median/p75/p90), a validator/miner split, and a per-UID above/below-median label, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/yield (no static file).",
@@ -40711,6 +40767,152 @@
           }
         },
         "summary": "Fetch the validators (validator_permit) of one subnet ranked by stake, computed live from the neurons D1 tier.",
+        "tags": [
+          "subnets",
+          "analytics"
+        ]
+      }
+    },
+    "/api/v1/subnets/{netuid}/weights": {
+      "get": {
+        "operationId": "subnetWeights",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "netuid",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "window",
+            "required": false,
+            "schema": {
+              "enum": [
+                "7d",
+                "30d"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "distinct_setters": 1,
+                    "netuid": 7,
+                    "observed_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1,
+                    "sets_per_setter": 0.5,
+                    "weight_sets": 1,
+                    "window": "7d"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-29.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober",
+                    "stale_contract": {
+                      "built_under": "example",
+                      "live": "example"
+                    }
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/SubnetWeightsArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch validator weight-setting activity for one subnet over a 7d or 30d window: the distinct weight-setting validators, the WeightsSet event count, and the average updates per validator, computed live from the account_events WeightsSet stream. The per-subnet drill-in of GET /api/v1/chain/weights (which ranks only the top-N subnets and cannot be queried by netuid). Schema-stable zeroed card when the subnet has no WeightsSet events in the window.",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1891,6 +1891,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/subnets/{netuid}/weights": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch validator weight-setting activity for one subnet over a 7d or 30d window: the distinct weight-setting validators, the WeightsSet event count, and the average updates per validator, computed live from the account_events WeightsSet stream. The per-subnet drill-in of GET /api/v1/chain/weights (which ranks only the top-N subnets and cannot be queried by netuid). Schema-stable zeroed card when the subnet has no WeightsSet events in the window. */
+        get: operations["subnetWeights"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/subnets/{netuid}/yield": {
         parameters: {
             query?: never;
@@ -5908,6 +5925,18 @@ export interface components {
             [key: string]: unknown;
         };
         SubnetVerificationArtifact: components["schemas"]["VerificationArtifact"];
+        /** @description Per-subnet validator weight-setting activity over a 7d/30d window: the distinct weight-setting validators, WeightsSet event count, and updates per validator for ONE subnet. The per-subnet drill-in of /api/v1/chain/weights (which ranks only the top-N subnets and cannot be queried by netuid), served live from the account_events WeightsSet stream at /api/v1/subnets/{netuid}/weights (no static file); zeroed when the subnet has no WeightsSet events in the window. */
+        SubnetWeightsArtifact: {
+            distinct_setters: number;
+            netuid: number;
+            /** Format: date-time */
+            observed_at: string | null;
+            schema_version: number;
+            sets_per_setter: number | null;
+            weight_sets: number;
+            /** @enum {string|null} */
+            window: "7d" | "30d" | null;
+        };
         /** @description Per-UID emission yield (emission/stake return rate) for one subnet over the current metagraph snapshot, ranked high to low, with a distribution summary (subnet aggregate yield, mean, p25/median/p75/p90), a validator/miner split, and a per-UID above/below-median label, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/yield (no static file). */
         SubnetYieldArtifact: {
             block_number: number | null;
@@ -21830,6 +21859,115 @@ export interface operations {
                      *     0,hk_sample,ck_sample,true,true,1,0.5,0.99,0.4,0.1,0.2,22.1,1000.5,6702485,false,1.2.3.4:8091
                      */
                     "text/csv": string;
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    subnetWeights: {
+        parameters: {
+            query?: {
+                window?: "7d" | "30d";
+            };
+            header?: never;
+            path: {
+                netuid: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "distinct_setters": 1,
+                     *         "netuid": 7,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "sets_per_setter": 0.5,
+                     *         "weight_sets": 1,
+                     *         "window": "7d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-29.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober",
+                     *         "stale_contract": {
+                     *           "built_under": "example",
+                     *           "live": "example"
+                     *         }
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["SubnetWeightsArtifact"];
+                    };
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -16329,6 +16329,62 @@
       "SubnetVerificationArtifact": {
         "$ref": "#/components/schemas/VerificationArtifact"
       },
+      "SubnetWeightsArtifact": {
+        "additionalProperties": false,
+        "description": "Per-subnet validator weight-setting activity over a 7d/30d window: the distinct weight-setting validators, WeightsSet event count, and updates per validator for ONE subnet. The per-subnet drill-in of /api/v1/chain/weights (which ranks only the top-N subnets and cannot be queried by netuid), served live from the account_events WeightsSet stream at /api/v1/subnets/{netuid}/weights (no static file); zeroed when the subnet has no WeightsSet events in the window.",
+        "properties": {
+          "distinct_setters": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "sets_per_setter": {
+            "minimum": 0,
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "weight_sets": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "window": {
+            "enum": [
+              "7d",
+              "30d",
+              null
+            ],
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "netuid",
+          "window",
+          "observed_at",
+          "distinct_setters",
+          "weight_sets",
+          "sets_per_setter"
+        ],
+        "type": "object"
+      },
       "SubnetYieldArtifact": {
         "additionalProperties": false,
         "description": "Per-UID emission yield (emission/stake return rate) for one subnet over the current metagraph snapshot, ranked high to low, with a distribution summary (subnet aggregate yield, mean, p25/median/p75/p90), a validator/miner split, and a per-UID above/below-median label, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/yield (no static file).",

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1443,6 +1443,38 @@
           }
         }
       },
+      "SubnetWeightsArtifact": {
+        "type": "object",
+        "description": "Per-subnet validator weight-setting activity over a 7d/30d window: the distinct weight-setting validators, WeightsSet event count, and updates per validator for ONE subnet. The per-subnet drill-in of /api/v1/chain/weights (which ranks only the top-N subnets and cannot be queried by netuid), served live from the account_events WeightsSet stream at /api/v1/subnets/{netuid}/weights (no static file); zeroed when the subnet has no WeightsSet events in the window.",
+        "required": [
+          "schema_version",
+          "netuid",
+          "window",
+          "observed_at",
+          "distinct_setters",
+          "weight_sets",
+          "sets_per_setter"
+        ],
+        "properties": {
+          "schema_version": { "type": "integer" },
+          "netuid": { "type": "integer", "minimum": 0 },
+          "window": {
+            "type": ["string", "null"],
+            "enum": ["7d", "30d", null]
+          },
+          "observed_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "distinct_setters": { "type": "integer", "minimum": 0 },
+          "weight_sets": { "type": "integer", "minimum": 0 },
+          "sets_per_setter": {
+            "type": ["number", "null"],
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
       "SubnetYieldArtifact": {
         "type": "object",
         "description": "Per-UID emission yield (emission/stake return rate) for one subnet over the current metagraph snapshot, ranked high to low, with a distribution summary (subnet aggregate yield, mean, p25/median/p75/p90), a validator/miner split, and a per-UID above/below-median label, served live from the neurons D1 tier at /api/v1/subnets/{netuid}/yield (no static file).",

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -242,6 +242,20 @@ const checks = [
     },
   ],
   [
+    "/api/v1/subnets/7/weights?window=30d",
+    (body) => {
+      assert.equal(body.data.netuid, 7);
+      assert.equal(body.data.window, "30d");
+      assert.equal(typeof body.data.distinct_setters, "number");
+      assert.equal(typeof body.data.weight_sets, "number");
+      assert.equal(
+        body.data.sets_per_setter === null ||
+          typeof body.data.sets_per_setter === "number",
+        true,
+      );
+    },
+  ],
+  [
     "/api/v1/subnets/movers?window=30d&sort=stake&limit=10",
     (body) => {
       assert.equal(body.data.window, "30d");

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -32,6 +32,7 @@ const COMPUTED_ARTIFACTS = new Set([
   "subnet-performance",
   "subnet-turnover",
   "subnet-stake-flow",
+  "subnet-weights",
   "subnet-movers",
   "subnet-yield",
   "global-validators",

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -46,6 +46,8 @@ export const R2_ONLY_PATTERNS = [
   /^subnets\/(?:\d+|\{netuid\})\/turnover\.json$/,
   // Net stake flow: computed live from account_events.
   /^subnets\/(?:\d+|\{netuid\})\/stake-flow\.json$/,
+  // Validator weight-setting activity: computed live from the account_events WeightsSet stream.
+  /^subnets\/(?:\d+|\{netuid\})\/weights\.json$/,
   // Per-UID emission yield distribution: computed live from the neurons snapshot.
   /^subnets\/(?:\d+|\{netuid\})\/yield\.json$/,
   // Cross-subnet movers leaderboard: computed live from neuron_daily.

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -954,6 +954,12 @@ export const PUBLIC_ARTIFACTS = [
     "SubnetTurnoverArtifact",
   ),
   artifact(
+    "subnet-weights",
+    "/metagraph/subnets/{netuid}/weights.json",
+    "Validator weight-setting activity for one subnet over a 7d or 30d window — the distinct weight-setting validators, WeightsSet event count, and average updates per validator — served live from the account_events WeightsSet stream at /api/v1/subnets/{netuid}/weights (no static file). The per-subnet drill-in of /api/v1/chain/weights.",
+    "SubnetWeightsArtifact",
+  ),
+  artifact(
     "subnet-stake-flow",
     "/metagraph/subnets/{netuid}/stake-flow.json",
     "Net stake flow for one subnet over a recent window (7d/30d/90d): total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and event counts, with optional ?direction=all|in|out to filter inflow or outflow only, summed live from the account_events stream at /api/v1/subnets/{netuid}/stake-flow (no static file).",
@@ -1905,6 +1911,17 @@ export const API_ROUTES = [
       },
       { name: "changes", schema: { type: "string", enum: ["true"] } },
     ],
+    [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
+  ),
+  route(
+    "subnet-weights",
+    "GET",
+    "/api/v1/subnets/{netuid}/weights",
+    "/metagraph/subnets/{netuid}/weights.json",
+    "Fetch validator weight-setting activity for one subnet over a 7d or 30d window: the distinct weight-setting validators, the WeightsSet event count, and the average updates per validator, computed live from the account_events WeightsSet stream. The per-subnet drill-in of GET /api/v1/chain/weights (which ranks only the top-N subnets and cannot be queried by netuid). Schema-stable zeroed card when the subnet has no WeightsSet events in the window.",
+    "short",
+    ["subnets", "analytics"],
+    [{ name: "window", schema: { type: "string", enum: ["7d", "30d"] } }],
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/src/subnet-weights.mjs
+++ b/src/subnet-weights.mjs
@@ -1,0 +1,87 @@
+// Per-subnet validator weight-setting activity from the account_events WeightsSet stream:
+// for ONE subnet over a 7d/30d window, the distinct weight-setting validators, WeightsSet
+// event count, and average updates per validator. The direct per-subnet lookup companion to
+// the network-wide leaderboard at /api/v1/chain/weights — that route ranks only the top-N
+// subnets and cannot be queried by an arbitrary netuid, so this fills the same per-subnet /
+// chain duality the turnover, concentration, stake-flow, and yield routes already have. Pure
+// shaping (buildSubnetWeights) + a thin D1 loader (loadSubnetWeights); the Worker adds the
+// envelope. Null-safe: a cold store or a subnet with no WeightsSet events yields the zeroed card.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// The account_events kind emitted when a validator sets weights on a subnet.
+export const WEIGHTS_EVENT_KIND = "WeightsSet";
+
+// Supported windows (label -> days) + default, matching the sibling /chain/weights route.
+export const SUBNET_WEIGHTS_WINDOWS = { "7d": 7, "30d": 30 };
+export const DEFAULT_SUBNET_WEIGHTS_WINDOW = "7d";
+
+// Round an updates-per-validator ratio to a stable 2dp precision. Always finite and
+// non-negative here (events / distinct setters, with the divisor guarded below).
+function round(value, dp = 2) {
+  const factor = 10 ** dp;
+  return Math.round(value * factor) / factor;
+}
+
+// A non-negative whole count from a D1 COUNT() cell (number, numeric string, or null),
+// defaulting to 0 for anything non-finite or negative.
+function toCount(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+}
+
+// Newest epoch-ms observed_at, or null when not finite/absent — rendered as ISO for the
+// envelope's generated_at, the same way account-events does. Guards the JS Date range so a
+// finite but out-of-range epoch cannot throw a RangeError on the response.
+function toIso(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const date = new Date(n);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
+// Average WeightsSet events per distinct validator — the subnet's update intensity. A subnet
+// with no setters has no defined intensity (null) rather than a divide-by-zero.
+function setsPerSetter(sets, setters) {
+  if (setters <= 0) return null;
+  return round(sets / setters);
+}
+
+// Shape one subnet's weight-setting scorecard from the single-row account_events aggregate.
+// `row` carries weight_sets (COUNT(*)), distinct_setters (COUNT(DISTINCT hotkey)), and
+// newest_observed (MAX(observed_at)). Null-safe: a null/absent row yields the zeroed card.
+export function buildSubnetWeights(row, netuid, { window } = {}) {
+  const distinctSetters = toCount(row?.distinct_setters);
+  const weightSets = toCount(row?.weight_sets);
+  return {
+    schema_version: 1,
+    netuid,
+    window: window ?? null,
+    observed_at: toIso(row?.newest_observed),
+    distinct_setters: distinctSetters,
+    weight_sets: weightSets,
+    sets_per_setter: setsPerSetter(weightSets, distinctSetters),
+  };
+}
+
+// One subnet's weight-setting activity, computed live: read the account_events WeightsSet
+// stream for this netuid over the window (observed_at >= now - windowDays, epoch ms) as a
+// single aggregate (event count + true distinct setters + newest observed_at, served by
+// idx_account_events(netuid, event_kind, block_number) from migration 0024), and shape with
+// buildSubnetWeights. The handler resolves windowLabel/windowDays from the window param.
+// Cold/absent store -> the schema-stable zeroed card.
+export async function loadSubnetWeights(
+  d1,
+  netuid,
+  { windowLabel, windowDays } = {},
+) {
+  const cutoff = Date.now() - windowDays * DAY_MS;
+  const rows = await d1(
+    "SELECT COUNT(*) AS weight_sets, COUNT(DISTINCT hotkey) AS distinct_setters, " +
+      "MAX(observed_at) AS newest_observed " +
+      "FROM account_events WHERE netuid = ? AND event_kind = ? AND observed_at >= ?",
+    [netuid, WEIGHTS_EVENT_KIND, cutoff],
+  );
+  return buildSubnetWeights(rows?.[0] ?? null, netuid, { window: windowLabel });
+}

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -27,6 +27,7 @@ import {
   handleSubnetConcentrationHistory,
   handleSubnetTurnover,
   handleSubnetStakeFlow,
+  handleSubnetWeights,
   handleSubnetMovers,
   handleAccount,
   handleAccountEvents,
@@ -48,6 +49,7 @@ import {
   canonicalSubnetHistoryCachePath,
   canonicalSubnetTurnoverCachePath,
   canonicalSubnetStakeFlowCachePath,
+  canonicalSubnetWeightsCachePath,
   canonicalSubnetMoversCachePath,
   canonicalSubnetMetagraphCachePath,
   canonicalSubnetValidatorsCachePath,
@@ -1645,6 +1647,80 @@ describe("handleSubnetTurnover", () => {
         csvAccept,
       );
       assert.equal(json, "/api/v1/subnets/1/validators");
+    });
+  });
+});
+
+describe("handleSubnetWeights", () => {
+  test("rejects an unsupported query param with 400", async () => {
+    const res = await handleSubnetWeights(
+      req(`/api/v1/subnets/${NETUID}/weights`),
+      emptyEnv(),
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/weights?bogus=1`),
+    );
+    await errorJson(res);
+  });
+
+  test("rejects an unsupported window with 400", async () => {
+    const res = await handleSubnetWeights(
+      req(`/api/v1/subnets/${NETUID}/weights`),
+      emptyEnv(),
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/weights?window=1y`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "window");
+  });
+
+  test("returns a schema-stable zeroed card on cold D1", async () => {
+    const body = await assertColdSchema(
+      handleSubnetWeights,
+      req(`/api/v1/subnets/${NETUID}/weights`),
+      emptyEnv(),
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/weights?window=30d`),
+    );
+    assert.equal(body.data.netuid, NETUID);
+    assert.equal(body.data.window, "30d");
+    assert.equal(body.data.distinct_setters, 0);
+    assert.equal(body.data.weight_sets, 0);
+    assert.equal(body.data.sets_per_setter, null);
+    await assertValidComponent("SubnetWeightsArtifact", body.data);
+    assert.equal(
+      body.meta.artifact_path,
+      `/metagraph/subnets/${NETUID}/weights.json`,
+    );
+    // account_events provenance (not the metagraph snapshot); null on a cold store.
+    assert.equal(body.meta.generated_at, null);
+  });
+
+  describe("canonicalSubnetWeightsCachePath", () => {
+    test("canonicalizes omitted and explicit default window to one cache key", () => {
+      const omitted = canonicalSubnetWeightsCachePath(
+        new URL("https://api.metagraph.sh/api/v1/subnets/7/weights"),
+      );
+      const explicit = canonicalSubnetWeightsCachePath(
+        new URL("https://api.metagraph.sh/api/v1/subnets/7/weights?window=7d"),
+      );
+      assert.equal(omitted, explicit);
+      assert.equal(omitted, "/api/v1/subnets/7/weights?window=7d");
+    });
+
+    test("passes an invalid window through unchanged (the handler rejects it)", () => {
+      const path = canonicalSubnetWeightsCachePath(
+        new URL(
+          "https://api.metagraph.sh/api/v1/subnets/7/weights?window=bogus",
+        ),
+      );
+      assert.equal(path, "/api/v1/subnets/7/weights?window=bogus");
+    });
+
+    test("passes an unsupported query param through unchanged (validation error)", () => {
+      const path = canonicalSubnetWeightsCachePath(
+        new URL("https://api.metagraph.sh/api/v1/subnets/7/weights?bogus=1"),
+      );
+      assert.equal(path, "/api/v1/subnets/7/weights?bogus=1");
     });
   });
 });

--- a/tests/subnet-weights.test.mjs
+++ b/tests/subnet-weights.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  buildSubnetWeights,
+  loadSubnetWeights,
+  WEIGHTS_EVENT_KIND,
+  SUBNET_WEIGHTS_WINDOWS,
+  DEFAULT_SUBNET_WEIGHTS_WINDOW,
+} from "../src/subnet-weights.mjs";
+
+describe("buildSubnetWeights", () => {
+  test("cold / null row yields a zeroed, schema-stable card", () => {
+    for (const row of [null, undefined, {}]) {
+      const d = buildSubnetWeights(row, 7, { window: "7d" });
+      assert.equal(d.schema_version, 1);
+      assert.equal(d.netuid, 7);
+      assert.equal(d.window, "7d");
+      assert.equal(d.observed_at, null);
+      assert.equal(d.distinct_setters, 0);
+      assert.equal(d.weight_sets, 0);
+      assert.equal(d.sets_per_setter, null); // no setters -> undefined intensity
+    }
+  });
+
+  test("omitted window defaults to null", () => {
+    assert.equal(buildSubnetWeights({}, 7).window, null);
+  });
+
+  test("computes distinct setters, event count, and updates-per-validator", () => {
+    const d = buildSubnetWeights(
+      { distinct_setters: 4, weight_sets: 40, newest_observed: 1750000000000 },
+      7,
+      { window: "30d" },
+    );
+    assert.equal(d.distinct_setters, 4);
+    assert.equal(d.weight_sets, 40);
+    assert.equal(d.sets_per_setter, 10); // 40 / 4
+    assert.equal(d.observed_at, new Date(1750000000000).toISOString());
+  });
+
+  test("rounds sets_per_setter to 2dp", () => {
+    const d = buildSubnetWeights({ distinct_setters: 3, weight_sets: 40 }, 7);
+    assert.equal(d.sets_per_setter, 13.33); // 40 / 3 = 13.333...
+  });
+
+  test("coerces a numeric-string observed_at and drops non-finite / out-of-range / <=0", () => {
+    assert.equal(
+      buildSubnetWeights({ newest_observed: "1750000000000" }, 7).observed_at,
+      new Date(1750000000000).toISOString(),
+    );
+    for (const bad of [null, "", 0, -1, 9e15, "not-a-date"]) {
+      assert.equal(
+        buildSubnetWeights({ newest_observed: bad }, 7).observed_at,
+        null,
+        `observed_at=${JSON.stringify(bad)}`,
+      );
+    }
+  });
+
+  test("coerces numeric-string counts and floors negatives / non-finite to 0", () => {
+    const d = buildSubnetWeights(
+      { distinct_setters: "5", weight_sets: "50" },
+      7,
+    );
+    assert.equal(d.distinct_setters, 5);
+    assert.equal(d.weight_sets, 50);
+    assert.equal(d.sets_per_setter, 10);
+    const z = buildSubnetWeights({ distinct_setters: -3, weight_sets: "x" }, 7);
+    assert.equal(z.distinct_setters, 0);
+    assert.equal(z.weight_sets, 0);
+    assert.equal(z.sets_per_setter, null);
+  });
+});
+
+describe("loadSubnetWeights", () => {
+  test("queries account_events for the netuid + WeightsSet over the window and shapes it", async () => {
+    let captured;
+    const d1 = async (sql, params) => {
+      captured = { sql, params };
+      return [
+        {
+          distinct_setters: 2,
+          weight_sets: 20,
+          newest_observed: 1750000000000,
+        },
+      ];
+    };
+    const d = await loadSubnetWeights(d1, 7, {
+      windowLabel: "7d",
+      windowDays: 7,
+    });
+    assert.match(captured.sql, /FROM account_events/);
+    assert.match(captured.sql, /netuid = \?/);
+    assert.equal(captured.params[0], 7);
+    assert.equal(captured.params[1], WEIGHTS_EVENT_KIND);
+    assert.equal(typeof captured.params[2], "number"); // cutoff epoch ms
+    assert.equal(d.netuid, 7);
+    assert.equal(d.window, "7d");
+    assert.equal(d.weight_sets, 20);
+    assert.equal(d.sets_per_setter, 10);
+  });
+
+  test("a cold store (no rows) yields the zeroed card", async () => {
+    const d = await loadSubnetWeights(async () => [], 9, {
+      windowLabel: "30d",
+      windowDays: 30,
+    });
+    assert.equal(d.netuid, 9);
+    assert.equal(d.weight_sets, 0);
+    assert.equal(d.sets_per_setter, null);
+  });
+
+  test("exposes the window map + default matching /chain/weights", () => {
+    assert.deepEqual(SUBNET_WEIGHTS_WINDOWS, { "7d": 7, "30d": 30 });
+    assert.equal(DEFAULT_SUBNET_WEIGHTS_WINDOW, "7d");
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -94,6 +94,8 @@ import {
   canonicalSubnetTurnoverCachePath,
   handleSubnetStakeFlow,
   canonicalSubnetStakeFlowCachePath,
+  handleSubnetWeights,
+  canonicalSubnetWeightsCachePath,
   handleSubnetYield,
   handleSubnetPerformance,
   handleSubnetMovers,
@@ -290,6 +292,7 @@ import {
   SUBNET_CONCENTRATION_HISTORY_PATH_PATTERN,
   SUBNET_TURNOVER_PATH_PATTERN,
   SUBNET_STAKE_FLOW_PATH_PATTERN,
+  SUBNET_WEIGHTS_PATH_PATTERN,
   SUBNET_YIELD_PATH_PATTERN,
   SUBNET_PERFORMANCE_PATH_PATTERN,
   TRENDS_PATH_PATTERN,
@@ -1447,6 +1450,27 @@ export async function handleRequest(request, env = {}, ctx = {}) {
             resolved.url,
           ),
         canonicalSubnetStakeFlowCachePath(resolved.url),
+      );
+    }
+    const weightsMatch = SUBNET_WEIGHTS_PATH_PATTERN.exec(
+      resolved.url.pathname,
+    );
+    if (weightsMatch) {
+      // Validator weight-setting activity summed live from account_events over the window —
+      // deterministic per request, edge-cache like the sibling stake-flow route.
+      return withEdgeCache(
+        request,
+        ctx,
+        env,
+        "subnet-weights",
+        () =>
+          handleSubnetWeights(
+            request,
+            env,
+            Number(weightsMatch[1]),
+            resolved.url,
+          ),
+        canonicalSubnetWeightsCachePath(resolved.url),
       );
     }
     // Per-UID emission yield distribution over the current neurons snapshot — computed

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -53,6 +53,9 @@ export const SUBNET_TURNOVER_PATH_PATTERN =
 // account_events tier, no static file.
 export const SUBNET_STAKE_FLOW_PATH_PATTERN =
   /^\/api\/v1\/subnets\/(\d+)\/stake-flow$/;
+// Validator weight-setting activity over the window, live from account_events, no static file.
+export const SUBNET_WEIGHTS_PATH_PATTERN =
+  /^\/api\/v1\/subnets\/(\d+)\/weights$/;
 // Per-UID emission yield distribution over the current neurons snapshot, no static file.
 export const SUBNET_YIELD_PATH_PATTERN = /^\/api\/v1\/subnets\/(\d+)\/yield$/;
 // Reward-distribution + score-spread metrics over the current neurons snapshot

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -122,6 +122,11 @@ import {
 } from "../../src/counterparties.mjs";
 import { loadSubnetTurnover } from "../../src/turnover.mjs";
 import {
+  loadSubnetWeights,
+  SUBNET_WEIGHTS_WINDOWS,
+  DEFAULT_SUBNET_WEIGHTS_WINDOW,
+} from "../../src/subnet-weights.mjs";
+import {
   loadSubnetStakeFlow,
   STAKE_FLOW_WINDOWS,
   DEFAULT_STAKE_FLOW_WINDOW,
@@ -1063,6 +1068,54 @@ export async function handleSubnetTurnover(request, env, netuid, url) {
         env,
         `/metagraph/subnets/${netuid}/turnover.json`,
         data.end_date,
+      ),
+    },
+    "short",
+  );
+}
+
+// Canonical edge-cache key for the subnet-weights route: only ?window= (7d/30d) changes the
+// response, canonicalized to its default when omitted so equivalent requests share a slot.
+export function canonicalSubnetWeightsCachePath(url) {
+  const validationError = validateQueryParams(url, ["window"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const windowParam =
+    url.searchParams.get("window") || DEFAULT_SUBNET_WEIGHTS_WINDOW;
+  if (!Object.hasOwn(SUBNET_WEIGHTS_WINDOWS, windowParam)) {
+    return `${url.pathname}${url.search}`;
+  }
+  return `${url.pathname}?window=${encodeURIComponent(windowParam)}`;
+}
+
+// GET /api/v1/subnets/{netuid}/weights?window=7d|30d: validator weight-setting activity for
+// one subnet over the window — distinct weight-setting validators, WeightsSet event count, and
+// updates per validator — read live from the account_events WeightsSet stream. The per-subnet
+// drill-in of /api/v1/chain/weights. Cold/absent store → 200 with a zeroed card (never 404).
+export async function handleSubnetWeights(request, env, netuid, url) {
+  const validationError = validateQueryParams(url, ["window"]);
+  if (validationError) return analyticsQueryError(validationError);
+  const windowParam =
+    url.searchParams.get("window") || DEFAULT_SUBNET_WEIGHTS_WINDOW;
+  if (!Object.hasOwn(SUBNET_WEIGHTS_WINDOWS, windowParam)) {
+    return analyticsQueryError({
+      parameter: "window",
+      message: unsupportedWindowMessage(windowParam, SUBNET_WEIGHTS_WINDOWS),
+    });
+  }
+  const data = await loadSubnetWeights(d1Runner(env), netuid, {
+    windowLabel: windowParam,
+    windowDays: SUBNET_WEIGHTS_WINDOWS[windowParam],
+  });
+  // account_events-derived, so the meta reports the event-stream source (accountMeta) with
+  // generated_at the newest observed WeightsSet event, mirroring the sibling stake-flow route.
+  return envelopeResponse(
+    request,
+    {
+      data,
+      meta: await accountMeta(
+        env,
+        `/metagraph/subnets/${netuid}/weights.json`,
+        data.observed_at,
       ),
     },
     "short",


### PR DESCRIPTION
## Summary

- `GET /api/v1/chain/weights` (#2941) is a **top-N network leaderboard** and cannot be queried by netuid, so there was no way to read an arbitrary subnet's weight-setting stats directly. This adds the **per-subnet drill-in** `GET /api/v1/subnets/{netuid}/weights`, completing the same per-subnet/chain duality the `turnover`, `concentration`, `stake-flow`, and `yield` routes already have.

## What Changed

- New `src/subnet-weights.mjs` (`buildSubnetWeights` + `loadSubnetWeights`): over a 7d/30d window, returns the subnet's `distinct_setters`, `weight_sets`, and `sets_per_setter` (updates per validator), computed live from the `account_events` WeightsSet stream (`idx_account_events(netuid, event_kind, block_number)`). Schema-stable zeroed card when the subnet has no WeightsSet events in the window.
- `SubnetWeightsArtifact` schema in `schemas/components/05-subnets.schema.json`; regenerated `openapi.json` / `contracts.json` / `api-index.json` / types via `npm run build`.
- Worker route (`entities.mjs` handler + `api.mjs` dispatch + `config.mjs` path pattern), R2-only registration (`artifact-storage.mjs`), and the `validate-api` / `validate-schemas` route registrations.
- Full test coverage: builder (counts/ratio/observed_at coercion/edge cases), loader (query shape + cold store), handler (400 on bad param/window + cold-schema card), and the canonical cache-key.

## Registry Safety

- [x] No secrets/PATs/wallet data/private URLs. Additive, backward-compatible new route; no existing response changed.
- [x] Generated artifacts produced by `npm run build`, not hand-edited; `r2-manifest.json` / `schemas/index.json` (and the two other deploy-owned drift artifacts) are **not** in the diff.

## Validation

- [x] `validate:contract-drift` — passes; a fresh rebuild on the committed state regenerates **only** the deploy-owned drift files.
- [x] `validate:schemas` / `validate:api` (116 routes) / `validate:openapi` (116 routes) — all pass.
- [x] `vitest` — new `subnet-weights` suite + handler/cache-key tests; routing + contract-invariant suites green (378+ tests). Every new branch covered for Codecov.
- [x] `eslint` + `prettier --check` on the changed source — clean; `git diff --check` — clean.

17 files, +999 (a new builder + schema + route wiring + tests + regenerated contract artifacts).
