### PR TITLE
feat(mcp): add get_chain_weights tool mirroring GET /api/v1/chain/weights

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -11,7 +11,9 @@
 // this module is pure and unit-testable, and so it reuses the exact same
 // R2/ASSETS resolution the REST routes use.
 import {
+  ANALYTICS_WINDOWS,
   DAY_MS,
+  DEFAULT_ANALYTICS_WINDOW,
   resolveClientIp,
   SS58_ADDRESS_PATTERN,
 } from "../workers/config.mjs";
@@ -91,6 +93,11 @@ import {
   CHAIN_STAKE_FLOW_WINDOWS,
   DEFAULT_CHAIN_STAKE_FLOW_WINDOW,
 } from "./chain-stake-flow.mjs";
+import {
+  loadChainWeights,
+  CHAIN_WEIGHTS_LIMIT_DEFAULT,
+  CHAIN_WEIGHTS_LIMIT_MAX,
+} from "./chain-weights.mjs";
 import {
   loadEconomicsTrends,
   parseEconomicsTrendsWindow,
@@ -241,13 +248,16 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.26.0";
+export const MCP_SERVER_VERSION = "1.27.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
 const CHAIN_TURNOVER_WINDOW_KEYS = Object.keys(CHAIN_TURNOVER_WINDOWS);
 const CHAIN_STAKE_FLOW_WINDOW_KEYS = Object.keys(CHAIN_STAKE_FLOW_WINDOWS);
+// get_chain_weights mirrors the /api/v1/chain/weights route, which uses the shared
+// ANALYTICS_WINDOWS (7d/30d) rather than a dedicated window constant.
+const CHAIN_WEIGHTS_WINDOW_KEYS = Object.keys(ANALYTICS_WINDOWS);
 const STAKE_FLOW_WINDOW_KEYS = Object.keys(STAKE_FLOW_WINDOWS);
 const MOVERS_WINDOW_KEYS = Object.keys(MOVERS_WINDOWS);
 
@@ -365,6 +375,9 @@ export const MCP_INSTRUCTIONS =
   "(per-subnet churn, retention, and stability) across all subnets, " +
   "get_chain_stake_flow the network-wide cross-subnet capital-flow leaderboard " +
   "(per-subnet net TAO staked/unstaked and direction) across all subnets, " +
+  "get_chain_weights the network-wide validator weight-setting leaderboard " +
+  "(per-subnet WeightsSet events, distinct setters, and update intensity) " +
+  "across all subnets, " +
   "get_blocks_summary block-production analytics (inter-block time, throughput, " +
   "and block-author decentralization), " +
   "get_network_activity the daily " +
@@ -2125,6 +2138,57 @@ export const MCP_TOOLS = [
       return loadChainStakeFlow(mcpD1Runner(ctx), {
         windowLabel: window,
         windowDays: CHAIN_STAKE_FLOW_WINDOWS[window],
+        limit,
+      });
+    },
+  },
+  {
+    name: "get_chain_weights",
+    title: "Get network-wide validator weight-setting activity",
+    description:
+      "Fetch the network-wide validator weight-setting leaderboard over the " +
+      "requested window (7d or 30d; default 7d): each subnet ranked by total " +
+      "WeightsSet events with its distinct weight-setting validators and average " +
+      "updates per validator, a network rollup with the TRUE distinct setter " +
+      "count (a validator setting weights on several subnets counts once) and " +
+      "total events, and the count/mean/min/p25/median/p75/p90/max spread of " +
+      "per-subnet update intensity, computed live from the account_events " +
+      "WeightsSet stream. The network-level companion of get_chain_serving, " +
+      "mirroring how get_chain_concentration companions get_subnet_concentration. " +
+      "Mirrors GET /api/v1/chain/weights.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_WEIGHTS_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_ANALYTICS_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max subnets in the weight-setting leaderboard (1-${CHAIN_WEIGHTS_LIMIT_MAX}, default ${CHAIN_WEIGHTS_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_WEIGHTS_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window = optionalString(args, "window") ?? DEFAULT_ANALYTICS_WINDOW;
+      if (!Object.hasOwn(ANALYTICS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_WEIGHTS_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_WEIGHTS_LIMIT_DEFAULT,
+        CHAIN_WEIGHTS_LIMIT_MAX,
+      );
+      return loadChainWeights(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: ANALYTICS_WINDOWS[window],
         limit,
       });
     },
@@ -5827,6 +5891,75 @@ const TOOL_OUTPUT_SCHEMAS = {
             stake_events: { type: "integer" },
             unstake_events: { type: "integer" },
             direction: { type: "string" },
+          },
+        },
+      },
+    },
+  },
+  get_chain_weights: {
+    type: "object",
+    additionalProperties: true,
+    required: ["subnet_count", "network", "subnets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      subnet_count: { type: "integer" },
+      // Network rollup: the TRUE distinct setter count (a validator setting
+      // weights on several subnets counts once) and total WeightsSet events.
+      network: {
+        type: "object",
+        additionalProperties: false,
+        required: ["distinct_setters", "weight_sets", "sets_per_setter"],
+        properties: {
+          distinct_setters: { type: "integer" },
+          weight_sets: { type: "integer" },
+          sets_per_setter: { type: ["number", "null"] },
+        },
+      },
+      // Spread of per-subnet update intensity over EVERY subnet with observed
+      // weight-setting activity; null when no subnet set weights in the window.
+      intensity_distribution: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: [
+          "count",
+          "mean",
+          "min",
+          "p25",
+          "median",
+          "p75",
+          "p90",
+          "max",
+        ],
+        properties: {
+          count: { type: "integer" },
+          mean: { type: "number" },
+          min: { type: "number" },
+          p25: { type: "number" },
+          median: { type: "number" },
+          p75: { type: "number" },
+          p90: { type: "number" },
+          max: { type: "number" },
+        },
+      },
+      // Per-subnet weight-setting leaderboard, most-active first.
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "netuid",
+            "distinct_setters",
+            "weight_sets",
+            "sets_per_setter",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            distinct_setters: { type: "integer" },
+            weight_sets: { type: "integer" },
+            sets_per_setter: { type: "number" },
           },
         },
       },

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.26.0");
+    assert.equal(MCP_SERVER_VERSION, "1.27.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.26.0");
+    assert.equal(MCP_SERVER_VERSION, "1.27.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.26.0");
+    assert.equal(MCP_SERVER_VERSION, "1.27.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6310,6 +6310,108 @@ describe("MCP economics + metagraph data tools", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  // D1 mock for get_chain_weights: the loader reads a network aggregate first,
+  // then the per-subnet leaderboard via GROUP BY netuid (mirrors the REST env).
+  function chainWeightsEnv({ networkRow, subnetRows }) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: {
+          prepare(sql) {
+            return {
+              bind: () => ({
+                all: () =>
+                  Promise.resolve({
+                    results: /GROUP BY netuid/.test(sql)
+                      ? subnetRows
+                      : networkRow,
+                  }),
+              }),
+            };
+          },
+        },
+      },
+    };
+  }
+  const WEIGHTS_WARM = {
+    networkRow: [
+      {
+        distinct_setters: 12,
+        weight_sets: 95,
+        newest_observed: 1_700_000_000_000,
+      },
+    ],
+    subnetRows: [
+      { netuid: 1, distinct_setters: 4, weight_sets: 40 },
+      { netuid: 2, distinct_setters: 2, weight_sets: 30 },
+    ],
+  };
+  const WEIGHTS_COLD = {
+    networkRow: [{ newest_observed: null }],
+    subnetRows: [],
+  };
+
+  test("get_chain_weights ranks per-subnet weight-setting (default 7d window)", async () => {
+    const res = await callTool(
+      "get_chain_weights",
+      {},
+      chainWeightsEnv(WEIGHTS_WARM),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d"); // REST default window parity
+    assert.equal(out.subnet_count, 2);
+    // Most-active subnet first: netuid 1 (40 events) over netuid 2 (30).
+    assert.equal(out.subnets[0].netuid, 1);
+    assert.equal(out.subnets[0].weight_sets, 40);
+    assert.equal(out.subnets[0].sets_per_setter, 10); // 40 / 4
+    assert.equal(out.network.distinct_setters, 12); // TRUE distinct, not the per-subnet sum
+  });
+
+  test("get_chain_weights honors an explicit 30d window and limit", async () => {
+    const res = await callTool(
+      "get_chain_weights",
+      { window: "30d", limit: 1 },
+      chainWeightsEnv(WEIGHTS_WARM),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.subnet_count, 2); // rollup + distribution count every subnet
+    assert.equal(out.subnets.length, 1); // leaderboard capped by limit
+  });
+
+  test("get_chain_weights returns schema-stable empty on cold D1", async () => {
+    const res = await callTool(
+      "get_chain_weights",
+      {},
+      chainWeightsEnv(WEIGHTS_COLD),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.subnet_count, 0);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.intensity_distribution, null);
+    assert.equal(out.network.distinct_setters, 0);
+  });
+
+  test("get_chain_weights rejects an unsupported window", async () => {
+    const res = await callTool("get_chain_weights", { window: "1y" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_weights payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_weights",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_weights",
+      {},
+      chainWeightsEnv(WEIGHTS_WARM),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   // A grouped account_events aggregate row (one per netuid+event_kind), the
   // shape loadChainStakeFlow's SUM/COUNT/MAX query returns.
   function stakeFlowRow(netuid, event_kind, total_tao, event_count) {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.26.0");
+    assert.equal(MCP_SERVER_VERSION, "1.27.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.26.0");
+    assert.equal(MCP_SERVER_VERSION, "1.27.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Add a `get_chain_weights` MCP tool mirroring `GET /api/v1/chain/weights` — the network-wide validator weight-setting leaderboard — so MCP agents can read it with the same window/limit inputs as the REST route. Follows the existing chain-analytics MCP tools (`get_chain_stake_flow`, `get_chain_turnover`, `get_chain_transfers`).

## What Changed

- `src/mcp-server.mjs`:
  - New `get_chain_weights` tool: `window` (7d/30d, default 7d — the shared `ANALYTICS_WINDOWS` the route uses) and `limit` (1–100, default 20) inputs, validated the same way as the sibling tools, delegating to the same `loadChainWeights` loader the REST handler uses (single source of truth, no logic fork).
  - A typed `TOOL_OUTPUT_SCHEMAS.get_chain_weights` output schema (`subnet_count`, `network` rollup, nullable `intensity_distribution`, and the per-subnet `subnets` leaderboard) so clients can validate the `structuredContent`.
  - Registered the tool in the server instructions catalog and bumped `MCP_SERVER_VERSION` 1.26.0 → 1.27.0 (the version-pin smoke tests updated to match).
- No server-card / OpenAPI regeneration: the MCP server card is worker-computed and the tool list is not a committed artifact, so no `public/**` changes.
- Tests (`tests/mcp-server.test.mjs`): ranks the per-subnet leaderboard on the default 7d window, honors an explicit 30d window + limit cap, returns a schema-stable empty block on a cold D1, rejects an unsupported window, and validates the tool's real payload against its declared `outputSchema`. The registry tests (unique name/description, compilable object outputSchema, untrusted-data note) cover it automatically.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None needed — MCP server card is worker-computed.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No REST/OpenAPI change — MCP tool only.)

## Validation

- [x] `npx vitest run tests/mcp-server.test.mjs` + the 5 version-pin suites
- [x] `npm run lint` · `npm run format:check` · `npm run validate` · `validate:contract-drift` · `validate:api`
- [x] `npx vitest run` (full suite)
- [x] `git diff --check`
