### PR TITLE
feat(mcp): add get_chain_serving mirroring GET /api/v1/chain/serving

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -92,6 +92,11 @@ import {
   DEFAULT_CHAIN_STAKE_FLOW_WINDOW,
 } from "./chain-stake-flow.mjs";
 import {
+  loadChainServing,
+  CHAIN_SERVING_LIMIT_DEFAULT,
+  CHAIN_SERVING_LIMIT_MAX,
+} from "./chain-serving.mjs";
+import {
   loadEconomicsTrends,
   parseEconomicsTrendsWindow,
 } from "./economics-trends.mjs";
@@ -365,6 +370,9 @@ export const MCP_INSTRUCTIONS =
   "(per-subnet churn, retention, and stability) across all subnets, " +
   "get_chain_stake_flow the network-wide cross-subnet capital-flow leaderboard " +
   "(per-subnet net TAO staked/unstaked and direction) across all subnets, " +
+  "get_chain_serving the network-wide axon-serving leaderboard (per-subnet " +
+  "AxonServed announcements, distinct servers, and announce intensity) across " +
+  "all subnets, " +
   "get_blocks_summary block-production analytics (inter-block time, throughput, " +
   "and block-author decentralization), " +
   "get_network_activity the daily " +
@@ -2125,6 +2133,54 @@ export const MCP_TOOLS = [
       return loadChainStakeFlow(mcpD1Runner(ctx), {
         windowLabel: window,
         windowDays: CHAIN_STAKE_FLOW_WINDOWS[window],
+        limit,
+      });
+    },
+  },
+  {
+    name: "get_chain_serving",
+    title: "Get network-wide axon-serving activity",
+    description:
+      "Fetch the network-wide axon-serving leaderboard across ALL subnets over " +
+      "the requested window (7d or 30d; default 7d): each subnet ranked by total " +
+      "AxonServed announcements, with its distinct announcing servers (hotkeys) " +
+      "and average announcements per server (intensity), a network rollup with " +
+      "the true distinct server count (not a per-subnet sum) and total " +
+      "announcements, and the count/mean/min/p25/median/p75/p90/max spread of " +
+      "per-subnet serving intensity, summed live from the account_events " +
+      "AxonServed stream. The account_events kind-filtered companion of " +
+      "get_chain_stake_flow. Mirrors GET /api/v1/chain/serving.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: ["7d", "30d"],
+          description: "Lookback window (default 7d).",
+        },
+        limit: {
+          type: "integer",
+          description: `Max subnets in the serving leaderboard (1-${CHAIN_SERVING_LIMIT_MAX}, default ${CHAIN_SERVING_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_SERVING_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const parsed = parseAnalyticsWindow(args?.window ?? "7d");
+      if (parsed === null) {
+        throw toolError("invalid_params", "window must be one of: 7d, 30d.");
+      }
+      const { label, days } = parsed;
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_SERVING_LIMIT_DEFAULT,
+        CHAIN_SERVING_LIMIT_MAX,
+      );
+      return loadChainServing(mcpD1Runner(ctx), {
+        windowLabel: label,
+        windowDays: days,
         limit,
       });
     },
@@ -5827,6 +5883,80 @@ const TOOL_OUTPUT_SCHEMAS = {
             stake_events: { type: "integer" },
             unstake_events: { type: "integer" },
             direction: { type: "string" },
+          },
+        },
+      },
+    },
+  },
+  get_chain_serving: {
+    type: "object",
+    additionalProperties: true,
+    required: ["subnet_count", "network", "subnets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      subnet_count: { type: "integer" },
+      // Network rollup: the TRUE distinct announcing-server count across all
+      // subnets (not a per-subnet sum), total AxonServed announcements, and
+      // average announcements per server (null on a cold store with no servers).
+      network: {
+        type: "object",
+        additionalProperties: false,
+        required: [
+          "distinct_servers",
+          "announcements",
+          "announcements_per_server",
+        ],
+        properties: {
+          distinct_servers: { type: "integer" },
+          announcements: { type: "integer" },
+          announcements_per_server: { type: ["number", "null"] },
+        },
+      },
+      // Spread of per-subnet serving intensity (announcements per server) over
+      // EVERY subnet that announced; null when none did.
+      intensity_distribution: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: [
+          "count",
+          "mean",
+          "min",
+          "p25",
+          "median",
+          "p75",
+          "p90",
+          "max",
+        ],
+        properties: {
+          count: { type: "integer" },
+          mean: { type: "number" },
+          min: { type: "number" },
+          p25: { type: "number" },
+          median: { type: "number" },
+          p75: { type: "number" },
+          p90: { type: "number" },
+          max: { type: "number" },
+        },
+      },
+      // Per-subnet axon-serving leaderboard, most announcements first.
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "netuid",
+            "distinct_servers",
+            "announcements",
+            "announcements_per_server",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            distinct_servers: { type: "integer" },
+            announcements: { type: "integer" },
+            announcements_per_server: { type: "number" },
           },
         },
       },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6408,6 +6408,122 @@ describe("MCP economics + metagraph data tools", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  // loadChainServing issues TWO account_events reads: a network COUNT(DISTINCT
+  // hotkey)/MAX aggregate (no GROUP BY) and a per-subnet GROUP BY netuid
+  // leaderboard. Serve the network aggregate to the first, per-subnet rows to the
+  // second.
+  function chainServingEnv(networkRow, subnetRows) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: {
+          prepare(sql) {
+            return {
+              bind() {
+                return {
+                  all() {
+                    if (/GROUP BY netuid/.test(sql)) {
+                      return Promise.resolve({ results: subnetRows });
+                    }
+                    if (sql.includes("FROM account_events")) {
+                      return Promise.resolve({
+                        results: networkRow ? [networkRow] : [],
+                      });
+                    }
+                    return Promise.resolve({ results: [] });
+                  },
+                };
+              },
+            };
+          },
+        },
+      },
+    };
+  }
+
+  test("get_chain_serving returns a schema-stable empty block on cold D1", async () => {
+    const res = await callTool("get_chain_serving", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d"); // REST default window parity
+    assert.equal(out.subnet_count, 0);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.intensity_distribution, null);
+    assert.equal(out.network.announcements, 0);
+    assert.equal(out.network.announcements_per_server, null);
+    assert.equal(out.observed_at, null);
+  });
+
+  test("get_chain_serving ranks subnets by announcements with a network rollup", async () => {
+    const res = await callTool(
+      "get_chain_serving",
+      { window: "30d", limit: 10 },
+      chainServingEnv(
+        // Network aggregate: 6 TRUE distinct servers across subnets, newest stamp present.
+        { distinct_servers: 6, newest_observed: 1_750_000_000_000 },
+        [
+          // netuid 1: 10 announcements / 5 servers -> intensity 2 (most active -> first).
+          { netuid: 1, announcements: 10, distinct_servers: 5 },
+          // netuid 2: 4 announcements / 2 servers -> intensity 2.
+          { netuid: 2, announcements: 4, distinct_servers: 2 },
+        ],
+      ),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets[0].netuid, 1);
+    assert.equal(out.subnets[0].announcements, 10);
+    assert.equal(out.subnets[0].distinct_servers, 5);
+    assert.equal(out.subnets[0].announcements_per_server, 2);
+    assert.equal(out.subnets[1].netuid, 2);
+    // Network rollup: total announcements 14, distinct servers 6 (not the 5+2 sum).
+    assert.equal(out.network.announcements, 14);
+    assert.equal(out.network.distinct_servers, 6);
+    assert.equal(out.intensity_distribution.count, 2);
+    assert.equal(out.observed_at, new Date(1_750_000_000_000).toISOString());
+  });
+
+  test("get_chain_serving rejects an unsupported window", async () => {
+    const res = await callTool("get_chain_serving", { window: "90d" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_serving caps the leaderboard by limit", async () => {
+    const res = await callTool(
+      "get_chain_serving",
+      { limit: 1 },
+      chainServingEnv(
+        { distinct_servers: 4, newest_observed: 1_750_000_000_000 },
+        [
+          { netuid: 1, announcements: 10, distinct_servers: 3 },
+          { netuid: 2, announcements: 5, distinct_servers: 1 },
+        ],
+      ),
+    );
+    const out = res.body.result.structuredContent;
+    // Both subnets count in the rollup/distribution, but the page is capped.
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.intensity_distribution.count, 2);
+  });
+
+  test("get_chain_serving payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_serving",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_serving",
+      {},
+      chainServingEnv(
+        { distinct_servers: 3, newest_observed: 1_750_000_000_000 },
+        [{ netuid: 1, announcements: 10, distinct_servers: 3 }],
+      ),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("get_subnet_concentration_history defaults to 30d and returns points", async () => {
     const res = await callTool(
       "get_subnet_concentration_history",


### PR DESCRIPTION
## Summary

The network-wide **axon-serving** leaderboard is served over REST at `GET /api/v1/chain/serving` but had **no MCP tool**, unlike its account_events siblings (`get_chain_stake_flow`, `get_chain_turnover`, `get_chain_transfers`, …). This adds `get_chain_serving` so an agent can pull the per-subnet `AxonServed` activity (which subnets have the most servers announcing, and how intensively) without dropping to REST.

## What Changed

- **`src/mcp-server.mjs`** — register `get_chain_serving`, mirroring the just-shipped `get_chain_stake_flow` / `get_chain_turnover` tools:
  - Inputs: `window` (`7d`/`30d`, default `7d`) and `limit` (1–100, default 20) — resolved with `parseAnalyticsWindow` + `clampLimit` exactly as the REST handler does, so behavior is byte-parity with `GET /api/v1/chain/serving`.
  - Delegates to the existing shared `loadChainServing` loader (no new data logic).
  - Adds the tool to the catalog description registry and a declared `outputSchema` (network rollup with the true distinct-server count, the per-subnet leaderboard, and the intensity distribution).
- **`tests/mcp-server.test.mjs`** — five tests: cold-store empty block, ranked leaderboard + network rollup (true distinct-server count, not a per-subnet sum), unsupported-window rejection, the `limit` cap, and `outputSchema` validation via Ajv.

MCP tool additions are worker-computed, so there is **no server-card / `public/**` regeneration** (only `src` + `tests` change).

## Registry Safety

- [x] No secrets, PATs, wallet data, private URLs, or validator-local state.
- [x] No generated artifacts touched (MCP tool card is worker-computed).
- [x] Public API/OpenAPI unchanged — this is a read-only MCP mirror of an existing REST endpoint.

## Validation

Run locally (Windows; Node 22):

- [x] `vitest run tests/mcp-server.test.mjs` — 454 passing, incl. the 5 new `get_chain_serving` tests
- [x] `vitest --coverage` — the new handler is at **100%** statement coverage (verified via v8)
- [x] `npm run validate:mcp` — passes (lifecycle + all `tools/call`), 92 tools
- [x] `eslint` + `prettier --check` on the changed files (clean, LF)
- [x] `npm run scan:public-safety` · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
