### PR TITLE
feat(mcp): add get_chain_transfer_pairs mirroring GET /api/v1/chain/transfer-pairs

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -424,6 +424,17 @@ assert.ok(
     chainWeights.network != null,
   "get_chain_weights must return subnet_count + network + subnets[]",
 );
+const chainTransferPairs = await callOk("get_chain_transfer_pairs", {
+  window: "7d",
+  limit: 5,
+  sort: "volume",
+});
+assert.ok(
+  Number.isInteger(chainTransferPairs.pair_count) &&
+    Array.isArray(chainTransferPairs.pairs) &&
+    typeof chainTransferPairs.total_volume_tao === "number",
+  "get_chain_transfer_pairs must return pair_count + pairs[] + total_volume_tao",
+);
 const meta = await callOk("get_subnet_metagraph", { netuid: 7 });
 assert.ok(
   Array.isArray(meta.neurons),

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -99,6 +99,14 @@ import {
   DEFAULT_CHAIN_WEIGHTS_WINDOW,
 } from "./chain-weights.mjs";
 import {
+  loadChainTransferPairs,
+  CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT,
+  CHAIN_TRANSFER_PAIR_LIMIT_MAX,
+  CHAIN_TRANSFER_PAIR_WINDOWS,
+  DEFAULT_CHAIN_TRANSFER_PAIR_WINDOW,
+  CHAIN_TRANSFER_PAIR_SORTS,
+} from "./chain-transfer-pairs.mjs";
+import {
   loadEconomicsTrends,
   parseEconomicsTrendsWindow,
 } from "./economics-trends.mjs";
@@ -248,7 +256,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.27.0";
+export const MCP_SERVER_VERSION = "1.28.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -256,6 +264,9 @@ const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
 const CHAIN_TURNOVER_WINDOW_KEYS = Object.keys(CHAIN_TURNOVER_WINDOWS);
 const CHAIN_STAKE_FLOW_WINDOW_KEYS = Object.keys(CHAIN_STAKE_FLOW_WINDOWS);
 const CHAIN_WEIGHTS_WINDOW_KEYS = Object.keys(CHAIN_WEIGHTS_WINDOWS);
+const CHAIN_TRANSFER_PAIR_WINDOW_KEYS = Object.keys(
+  CHAIN_TRANSFER_PAIR_WINDOWS,
+);
 const STAKE_FLOW_WINDOW_KEYS = Object.keys(STAKE_FLOW_WINDOWS);
 const MOVERS_WINDOW_KEYS = Object.keys(MOVERS_WINDOWS);
 
@@ -362,7 +373,10 @@ export const MCP_INSTRUCTIONS =
   "activity analytics, get_chain_calls returns the extrinsic call-mix " +
   "(count + share per pallet/module) over a 7d/30d window, get_chain_fees the " +
   "fee/tip market series plus top payers, get_chain_transfers network-wide " +
-  "native-TAO transfer volume plus top senders/receivers, get_chain_concentration " +
+  "native-TAO transfer volume plus top senders/receivers, " +
+  "get_chain_transfer_pairs the top sender->receiver transfer corridors " +
+  "(directed pairs ranked by volume or count) with a network volume rollup, " +
+  "get_chain_concentration " +
   "the network-wide stake/emission decentralization scorecard across all subnets, " +
   "get_chain_performance the network-wide reward-distribution and trust/consensus " +
   "score spread across all subnets, get_chain_identity_history the network-wide " +
@@ -4196,6 +4210,68 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_chain_transfer_pairs",
+    title: "Get top native-TAO transfer corridors",
+    description:
+      "Fetch the network-wide native-TAO transfer-corridor leaderboard over the " +
+      "requested window (7d or 30d; default 7d): the top directed sender->receiver " +
+      "pairs ranked by volume (default) or transfer count, each with its TAO " +
+      "volume, transfer count, and last block/time, plus a network rollup (total " +
+      "volume, transfer count, unique corridor count, and the top corridor's share " +
+      "of total volume). Self-transfers and malformed rows are excluded so every " +
+      "pair is a real account-to-account corridor. The pair-level companion to " +
+      "get_chain_transfers (top individual senders/receivers) and " +
+      "get_account_counterparties (one account's relationships). Mirrors GET " +
+      "/api/v1/chain/transfer-pairs.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_TRANSFER_PAIR_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_CHAIN_TRANSFER_PAIR_WINDOW}).`,
+        },
+        sort: {
+          type: "string",
+          enum: CHAIN_TRANSFER_PAIR_SORTS,
+          description:
+            "Rank corridors by total TAO volume (default) or transfer count.",
+        },
+        limit: {
+          type: "integer",
+          description: `Max corridors to return (1-${CHAIN_TRANSFER_PAIR_LIMIT_MAX}, default ${CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_TRANSFER_PAIR_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window =
+        optionalString(args, "window") ?? DEFAULT_CHAIN_TRANSFER_PAIR_WINDOW;
+      if (!Object.hasOwn(CHAIN_TRANSFER_PAIR_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_TRANSFER_PAIR_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const sort =
+        optionalEnum(args, "sort", CHAIN_TRANSFER_PAIR_SORTS) ?? "volume";
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT,
+        CHAIN_TRANSFER_PAIR_LIMIT_MAX,
+      );
+      return loadChainTransferPairs(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: CHAIN_TRANSFER_PAIR_WINDOWS[window],
+        observedAt: await mcpObservedAt(ctx),
+        limit,
+        sort,
+      });
+    },
+  },
+  {
     name: "get_network_activity",
     title: "Get daily network-activity aggregates",
     description:
@@ -6752,6 +6828,62 @@ const TOOL_OUTPUT_SCHEMAS = {
       top_receivers: {
         type: "array",
         items: CHAIN_TRANSFER_PARTY_ITEM,
+      },
+    },
+  },
+  get_chain_transfer_pairs: {
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "schema_version",
+      "window",
+      "sort",
+      "observed_at",
+      "total_volume_tao",
+      "transfer_count",
+      "unique_pairs",
+      "pair_count",
+      "top_pair_share",
+      "pairs",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      window: {
+        type: ["string", "null"],
+        enum: [...CHAIN_TRANSFER_PAIR_WINDOW_KEYS, null],
+      },
+      sort: { type: "string", enum: CHAIN_TRANSFER_PAIR_SORTS },
+      observed_at: NULLABLE_STRING,
+      total_volume_tao: { type: "number" },
+      transfer_count: { type: "integer", minimum: 0 },
+      unique_pairs: { type: "integer", minimum: 0 },
+      pair_count: { type: "integer", minimum: 0 },
+      // Top corridor's share of total volume (0..1), clamped below a flat 1 for a
+      // near-monopoly; null when there is no volume in the window.
+      top_pair_share: { type: ["number", "null"] },
+      // Directed sender->receiver corridors, ranked by the requested sort.
+      pairs: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "from",
+            "to",
+            "volume_tao",
+            "transfer_count",
+            "last_block",
+            "last_observed_at",
+          ],
+          properties: {
+            from: { type: "string" },
+            to: { type: "string" },
+            volume_tao: { type: "number" },
+            transfer_count: { type: "integer", minimum: 0 },
+            last_block: { type: ["integer", "null"] },
+            last_observed_at: NULLABLE_STRING,
+          },
+        },
       },
     },
   },

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.27.0");
+    assert.equal(MCP_SERVER_VERSION, "1.28.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.27.0");
+    assert.equal(MCP_SERVER_VERSION, "1.28.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.27.0");
+    assert.equal(MCP_SERVER_VERSION, "1.28.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5532,6 +5532,8 @@ describe("MCP economics + metagraph data tools", () => {
     accountEvents = [],
     weightsNetworkRows = [],
     weightsSubnetRows = [],
+    transferPairTotals = [],
+    transferPairRows = [],
   } = {}) {
     return {
       prepare(sql) {
@@ -5542,13 +5544,22 @@ describe("MCP economics + metagraph data tools", () => {
                 if (sql.includes("FROM account_events")) {
                   // get_chain_weights reads a network aggregate (carries
                   // newest_observed) then a per-subnet GROUP BY (carries
-                  // weight_sets); everything else uses the flat account_events
-                  // fixture (e.g. get_chain_stake_flow's single grouped read).
+                  // weight_sets); get_chain_transfer_pairs reads a totals CTE
+                  // (carries top_pair_volume_tao) then the per-corridor rows
+                  // (aliased AS from_address); everything else uses the flat
+                  // account_events fixture (e.g. get_chain_stake_flow's single
+                  // grouped read).
                   if (sql.includes("newest_observed")) {
                     return Promise.resolve({ results: weightsNetworkRows });
                   }
                   if (sql.includes("weight_sets")) {
                     return Promise.resolve({ results: weightsSubnetRows });
+                  }
+                  if (sql.includes("top_pair_volume_tao")) {
+                    return Promise.resolve({ results: transferPairTotals });
+                  }
+                  if (sql.includes("AS from_address")) {
+                    return Promise.resolve({ results: transferPairRows });
                   }
                   return Promise.resolve({ results: accountEvents });
                 }
@@ -6519,6 +6530,136 @@ describe("MCP economics + metagraph data tools", () => {
       chainWeightsEnv(weightsNetwork(30, 8), [
         weightsRow(1, 20, 5),
         weightsRow(2, 10, 4),
+      ]),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
+  // The full-window totals row loadChainTransferPairs reads first (its pair_totals
+  // CTE rollup carrying top_pair_volume_tao).
+  function transferPairTotals(
+    total_volume_tao,
+    transfer_count,
+    unique_pairs,
+    top,
+  ) {
+    return {
+      total_volume_tao,
+      transfer_count,
+      unique_pairs,
+      top_pair_volume_tao: top,
+    };
+  }
+
+  // A per-corridor row (hotkey AS from_address, coldkey AS to_address).
+  function transferPairRow(
+    from_address,
+    to_address,
+    volume_tao,
+    transfer_count,
+  ) {
+    return {
+      from_address,
+      to_address,
+      volume_tao,
+      transfer_count,
+      last_block: 5_000_000,
+      last_observed_at: 1_750_000_000_000,
+    };
+  }
+
+  function chainTransferPairsEnv(totals, pairs) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: metagraphD1({
+          transferPairTotals: totals ? [totals] : [],
+          transferPairRows: pairs,
+        }),
+      },
+    };
+  }
+
+  test("get_chain_transfer_pairs returns schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_chain_transfer_pairs", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d"); // REST default window parity
+    assert.equal(out.sort, "volume"); // REST default sort parity
+    assert.equal(out.pair_count, 0);
+    assert.deepEqual(out.pairs, []);
+    assert.equal(out.total_volume_tao, 0);
+    assert.equal(out.top_pair_share, null);
+    assert.equal(out.observed_at, null);
+  });
+
+  test("get_chain_transfer_pairs ranks corridors with a network rollup", async () => {
+    const res = await callTool(
+      "get_chain_transfer_pairs",
+      { window: "30d", limit: 10 },
+      chainTransferPairsEnv(transferPairTotals(250, 30, 3, 150), [
+        transferPairRow("A", "B", 150, 10),
+        transferPairRow("C", "D", 100, 20),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.pair_count, 2);
+    assert.equal(out.pairs[0].from, "A");
+    assert.equal(out.pairs[0].to, "B");
+    assert.equal(out.pairs[0].volume_tao, 150);
+    assert.equal(out.total_volume_tao, 250);
+    assert.equal(out.unique_pairs, 3);
+    assert.equal(out.transfer_count, 30);
+    assert.equal(out.top_pair_share, 0.6); // 150 / 250
+  });
+
+  test("get_chain_transfer_pairs drops self-transfers and honors the sort argument", async () => {
+    const res = await callTool(
+      "get_chain_transfer_pairs",
+      { sort: "count" },
+      chainTransferPairsEnv(transferPairTotals(250, 30, 2, 150), [
+        // Self-transfer (from === to) must be filtered out.
+        transferPairRow("Z", "Z", 999, 99),
+        transferPairRow("C", "D", 100, 20),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.sort, "count");
+    assert.equal(out.pair_count, 1);
+    assert.equal(out.pairs[0].from, "C");
+  });
+
+  test("get_chain_transfer_pairs rejects an unsupported window", async () => {
+    const res = await callTool(
+      "get_chain_transfer_pairs",
+      { window: "90d" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_transfer_pairs rejects an unsupported sort", async () => {
+    const res = await callTool(
+      "get_chain_transfer_pairs",
+      { sort: "recency" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /sort/);
+  });
+
+  test("get_chain_transfer_pairs payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_transfer_pairs",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_transfer_pairs",
+      {},
+      chainTransferPairsEnv(transferPairTotals(250, 30, 3, 150), [
+        transferPairRow("A", "B", 150, 10),
+        transferPairRow("C", "D", 100, 20),
       ]),
     );
     const validate = new Ajv2020().compile(schema);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.27.0");
+    assert.equal(MCP_SERVER_VERSION, "1.28.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.27.0");
+    assert.equal(MCP_SERVER_VERSION, "1.28.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Adds a new MCP tool `get_chain_transfer_pairs` that exposes the network-wide **native-TAO transfer-corridor leaderboard** — the pair-level companion to `get_chain_transfers` (top individual senders/receivers) and `get_account_counterparties` (one account's relationships).

Returns the top directed **sender→receiver corridors** over a `7d`/`30d` window (default `7d`), ranked by **volume** (default) or **transfer count**, each with:
- its TAO volume, transfer count, and last block/time,

plus a **network rollup**: total volume, transfer count, unique corridor count, and the top corridor's share of total volume (clamped below a flat `1.0` for a near-monopoly). Self-transfers and malformed rows are excluded so every pair is a real account-to-account corridor.

The tool delegates to the existing `loadChainTransferPairs` loader that already backs `GET /api/v1/chain/transfer-pairs`, so the MCP surface stays in lockstep with the REST endpoint (same window/limit bounds 1–100 default 25, same `volume`/`count` sort, same cold-store zeros).

## Changes
- `src/mcp-server.mjs`: register `get_chain_transfer_pairs` (import, window keys, instructions, handler with window/sort/limit validation, deeply-typed output schema); bump `MCP_SERVER_VERSION` to `1.28.0` (additive — new tool).
- `server.json`: version → `1.28.0`.
- `scripts/validate-mcp.mjs`: cold-path assertion for the new tool.
- Tests: cold-store zeros, corridor ranking + network rollup, self-transfer filtering + `sort` pass-through, unsupported-window/-sort rejection, and output-schema validation; version-assertion updates.

No changes to `src/chain-transfer-pairs.mjs` — the loader and its window/limit/sort constants already exist (they back the REST route), so this PR only wires the MCP surface.

## Test plan
- [x] `npm run validate:mcp` (93 tools, lifecycle + all tools/call)
- [x] `npx vitest run` for `mcp-server` + version-assertion + `chain-transfer-pairs` suites (554 passed)
- [x] `eslint` + `prettier` clean
- [x] No conflict with the one open PR (#3043, a registry data-artifact)