### PR TITLE
fix(events): strip actual NULs before JSON encoding to avoid corrupting \u0000 escapes

### DIFF
--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -508,18 +508,59 @@ def _extrinsic_signer(value):
         return None
 
 
+def _strip_json_nuls(v, seen=None):
+    """Return ``v`` with actual NUL characters removed from JSON strings."""
+    if isinstance(v, str):
+        return v.replace("\x00", "")
+    if seen is None:
+        seen = set()
+    if isinstance(v, list):
+        obj_id = id(v)
+        if obj_id in seen:
+            return v
+        seen.add(obj_id)
+        try:
+            return [_strip_json_nuls(item, seen) for item in v]
+        finally:
+            seen.remove(obj_id)
+    if isinstance(v, tuple):
+        obj_id = id(v)
+        if obj_id in seen:
+            return v
+        seen.add(obj_id)
+        try:
+            return tuple(_strip_json_nuls(item, seen) for item in v)
+        finally:
+            seen.remove(obj_id)
+    if isinstance(v, dict):
+        obj_id = id(v)
+        if obj_id in seen:
+            return v
+        seen.add(obj_id)
+        try:
+            return {
+                _strip_json_nuls(key, seen): _strip_json_nuls(value, seen)
+                for key, value in v.items()
+            }
+        finally:
+            seen.remove(obj_id)
+    return v
+
+
 def _safe_json(v):
     """Best-effort JSON serialization of a decoded call_args value.
     Returns None if the value cannot be serialized (e.g. contains non-JSON
     substrate objects). NEVER raises.
 
-    Strips the ``\\u0000`` (NUL) escape: Postgres ``jsonb`` cannot store it, and
-    EVM/Ethereum event ``data`` (and some call args) are raw bytes that serialize
-    to a string full of NULs — one such value fails the WHOLE multi-row insert,
-    silently dropping every event/extrinsic in the batch (verbatim display tier)."""
+    Strips actual NUL characters before serialization: Postgres ``jsonb`` cannot
+    store them, and EVM/Ethereum event ``data`` (and some call args) are raw
+    bytes that can contain NULs — one such value fails the WHOLE multi-row
+    insert, silently dropping every event/extrinsic in the batch (verbatim
+    display tier). Literal ``\\u0000`` text is preserved as data.
+    """
     try:
-        return json.dumps(v, separators=(",", ":")).replace("\\u0000", "")
-    except (TypeError, ValueError):
+        return json.dumps(_strip_json_nuls(v), separators=(",", ":"))
+    except (TypeError, ValueError, RecursionError):
         return None
 
 

--- a/tests/fetch-events-safe-json.test.mjs
+++ b/tests/fetch-events-safe-json.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "vitest";
+
+function runPython(script) {
+  const result = spawnSync("python", ["-c", script], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result.stdout.trim();
+}
+
+test("fetch-events _safe_json strips actual NULs without corrupting literal escapes", () => {
+  const stdout = runPython(String.raw`
+import importlib.util
+import json
+
+spec = importlib.util.spec_from_file_location("fetch_events", "scripts/fetch-events.py")
+fetch_events = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(fetch_events)
+
+actual_nul = fetch_events._safe_json({"data": "x\x00y", "\x00key": "value"})
+literal_escape = fetch_events._safe_json({"data": "x\\u0000y"})
+extrinsic = fetch_events._extrinsic_call({
+    "call": {
+        "call_module": "SubtensorModule",
+        "call_function": "set_weights",
+        "call_args": [{"name": "data", "value": "x\\u0000y"}],
+    }
+})
+
+print(json.dumps({
+    "actual_nul": json.loads(actual_nul),
+    "literal_escape": json.loads(literal_escape),
+    "extrinsic_args": json.loads(extrinsic[2]),
+}, separators=(",", ":")))
+`);
+  assert.deepEqual(JSON.parse(stdout), {
+    actual_nul: { data: "xy", key: "value" },
+    literal_escape: { data: "x\\u0000y" },
+    extrinsic_args: [{ name: "data", value: "x\\u0000y" }],
+  });
+});


### PR DESCRIPTION
### Motivation
- A prior change removed `"\\u0000"` from serialized JSON text which corrupts literal backslash-u sequences and can produce invalid JSON for Postgres `jsonb` sinks. 
- The goal is to remove actual NUL bytes that Postgres rejects while preserving literal `\u0000` text so ingestion remains available and correct.

### Description
- Add helper `def _strip_json_nuls(v, seen=None)` that walks lists/tuples/dicts/strings and removes actual NUL characters from Python `str` values. 
- Update `def _safe_json(v)` to call `_strip_json_nuls(v)` and then `json.dumps(...)`, so sanitization happens on Python values before serialization and literal `\u0000` escapes remain intact. 
- Broaden `_safe_json` error handling to catch `RecursionError` in addition to `TypeError`/`ValueError` to avoid raising on pathological inputs. 
- Add a regression test `tests/fetch-events-safe-json.test.mjs` that verifies actual NUL removal, preservation of literal `\u0000` text, and that `_extrinsic_call` returns parseable JSON for literal-escape inputs.

### Testing
- Ran `npm test -- tests/fetch-events-safe-json.test.mjs` and the new test passed. 
- Ran lint and formatting checks with `npm run lint` and `npm run format:check` and they passed. 
- Verified Python syntax with `python -m py_compile scripts/fetch-events.py` and it passed. 
- Performed `git diff --check` to ensure no trailing whitespace or check errors and it reported clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48c83f4e28832cb410c2727064bc04)