### PR TITLE
feat(mcp): add list_gaps

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -277,6 +277,8 @@ assert.ok(
   Array.isArray(curationPage.curation),
   "list_curation must return curation[]",
 );
+const gapsPage = await callOk("list_gaps", { limit: 3 });
+assert.ok(Array.isArray(gapsPage.gaps), "list_gaps must return gaps[]");
 await callOk("registry_summary", {});
 await callOk("get_coverage", {});
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/gaps-mcp.mjs
+++ b/src/gaps-mcp.mjs
@@ -1,0 +1,210 @@
+// Interface gaps list loader for MCP parity on GET /api/v1/gaps.
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/gaps.json artifact.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.mjs";
+
+export const GAPS_ARTIFACT = "/metagraph/gaps.json";
+
+const GAPS_SORT_FIELDS = API_QUERY_COLLECTIONS.gaps.sort_fields;
+const COVERAGE_LEVELS = QUERY_ENUMS.coverageLevel;
+const CURATION_LEVELS = QUERY_ENUMS.curationLevel;
+
+export function gapsMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw gapsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw gapsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function clampLimit(value, fallback, max) {
+  if (typeof value !== "number") return fallback;
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(max, Math.floor(value));
+}
+
+export function gapsQueryUrl(args) {
+  const url = new URL("https://mcp.internal/gaps");
+  if (args?.netuid !== undefined) {
+    if (!Number.isInteger(args.netuid) || args.netuid < 0) {
+      throw gapsMcpError(
+        "invalid_params",
+        "netuid must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("netuid", String(args.netuid));
+  }
+  const coverageLevel = optionalEnum(args, "coverage_level", COVERAGE_LEVELS);
+  if (coverageLevel) {
+    url.searchParams.set("coverage_level", coverageLevel);
+  }
+  const curationLevel = optionalEnum(args, "curation_level", CURATION_LEVELS);
+  if (curationLevel) {
+    url.searchParams.set("curation_level", curationLevel);
+  }
+  const sort = optionalEnum(args, "sort", GAPS_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  if (args?.limit !== undefined) {
+    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw gapsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadGapsList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = gapsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, GAPS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw gapsMcpError("not_found", "Interface gaps snapshot unavailable.");
+    }
+    throw gapsMcpError(code, `Could not load ${GAPS_ARTIFACT} (${code}).`);
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw gapsMcpError("not_found", "Interface gaps snapshot unavailable.");
+  }
+  const transformed = applyQueryFilters(blob, queryUrl, "gaps", []);
+  if (transformed.error) {
+    throw gapsMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.gaps) ? data.gaps : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    gaps: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_GAPS_INSTRUCTIONS =
+  "list_gaps per-subnet interface gap reports (missing facets, gap_count; " +
+  "mirrors GET /api/v1/gaps), ";
+
+export const LIST_GAPS_MCP_TOOL = {
+  name: "list_gaps",
+  title: "List subnet interface gaps",
+  description:
+    "Fetch per-subnet interface gap reports from the registry: missing or " +
+    "unsupported public interface facets, gap_count, coverage_level, and " +
+    "curation_level for every active subnet. Filter by netuid, coverage_level, " +
+    "or curation_level, sort with sort + order, and page with limit (1-100) / " +
+    "cursor. Use get_subnet_gaps for one subnet's contributor enrichment queue. " +
+    "Mirrors GET /api/v1/gaps.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      netuid: {
+        type: "integer",
+        description: "Filter to one subnet netuid.",
+        minimum: 0,
+      },
+      coverage_level: {
+        type: "string",
+        enum: COVERAGE_LEVELS,
+        description:
+          "Filter by coverage depth: native-only, manifested, or probed.",
+      },
+      curation_level: {
+        type: "string",
+        enum: CURATION_LEVELS,
+        description: "Filter by curation level.",
+      },
+      sort: {
+        type: "string",
+        enum: GAPS_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description: "Comma-separated projection of gap row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_GAPS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["gaps"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: NULLABLE_STRING,
+    gaps: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -32,6 +32,12 @@ import {
   loadCurationList,
 } from "./curation-mcp.mjs";
 import {
+  LIST_GAPS_INSTRUCTIONS,
+  LIST_GAPS_MCP_TOOL,
+  LIST_GAPS_OUTPUT_SCHEMA,
+  loadGapsList,
+} from "./gaps-mcp.mjs";
+import {
   GET_NETWORK_HEALTH_INSTRUCTIONS,
   GET_NETWORK_HEALTH_MCP_TOOL,
   GET_NETWORK_HEALTH_OUTPUT_SCHEMA,
@@ -254,7 +260,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.28.0";
+export const MCP_SERVER_VERSION = "1.29.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -313,6 +319,7 @@ export const MCP_INSTRUCTIONS =
   "get_best_rpc_endpoint for a live-healthy Bittensor base-layer RPC endpoint. " +
   GET_COVERAGE_INSTRUCTIONS +
   LIST_CURATION_INSTRUCTIONS +
+  LIST_GAPS_INSTRUCTIONS +
   "Use list_enrichment_targets to plan coverage-depth work across schemas, " +
   "fixtures, examples, provenance, and candidate-review gaps, and " +
   "get_subnet_gaps for one subnet's interface gap priorities and contributor " +
@@ -4429,6 +4436,12 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...LIST_GAPS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadGapsList(ctx, args);
+    },
+  },
+  {
     name: "get_lineage",
     title: "Get cross-network subnet lineage",
     description:
@@ -6885,6 +6898,7 @@ const TOOL_OUTPUT_SCHEMAS = {
     },
   },
   list_curation: LIST_CURATION_OUTPUT_SCHEMA,
+  list_gaps: LIST_GAPS_OUTPUT_SCHEMA,
   get_lineage: {
     type: "object",
     additionalProperties: true,

--- a/tests/agent-resources-mcp.test.mjs
+++ b/tests/agent-resources-mcp.test.mjs
@@ -145,7 +145,7 @@ describe("agent-resources-mcp", () => {
   });
 
   test("MCP server exports wire get_agent_resources at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.28.0");
+    assert.equal(MCP_SERVER_VERSION, "1.29.0");
     assert.match(MCP_INSTRUCTIONS, /get_agent_resources/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_agent_resources");
     assert.ok(tool);

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.28.0");
+    assert.equal(MCP_SERVER_VERSION, "1.29.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  GAPS_ARTIFACT,
+  LIST_GAPS_INSTRUCTIONS,
+  LIST_GAPS_MCP_TOOL,
+  LIST_GAPS_OUTPUT_SCHEMA,
+  gapsMcpError,
+  gapsQueryUrl,
+  loadGapsList,
+} from "../src/gaps-mcp.mjs";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_VERSION,
+  MCP_TOOLS,
+} from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: "test",
+  gaps: [
+    {
+      netuid: 7,
+      name: "Allways",
+      coverage_level: "probed",
+      curation_level: "maintainer-reviewed",
+      gap_count: 2,
+    },
+    {
+      netuid: 31,
+      name: "Candles",
+      coverage_level: "manifested",
+      curation_level: "adapter-backed",
+      gap_count: 5,
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === GAPS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("gaps-mcp", () => {
+  test("gapsMcpError is shaped for MCP toolError handling", () => {
+    const err = gapsMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("gapsQueryUrl validates netuid, filters, and cursor", () => {
+    const url = gapsQueryUrl({
+      netuid: 7,
+      coverage_level: "probed",
+      curation_level: "adapter-backed",
+      sort: "gap_count",
+      order: "desc",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("netuid"), "7");
+    assert.equal(url.searchParams.get("coverage_level"), "probed");
+    assert.equal(url.searchParams.get("curation_level"), "adapter-backed");
+    assert.equal(url.searchParams.get("sort"), "gap_count");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("gapsQueryUrl rejects invalid coverage_level", () => {
+    assert.throws(
+      () => gapsQueryUrl({ coverage_level: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("gapsQueryUrl rejects invalid curation_level", () => {
+    assert.throws(
+      () => gapsQueryUrl({ curation_level: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("gapsQueryUrl rejects invalid netuid", () => {
+    assert.throws(
+      () => gapsQueryUrl({ netuid: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("gapsQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => gapsQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("gapsQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => gapsQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("gapsQueryUrl rejects non-string fields", () => {
+    assert.throws(
+      () => gapsQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("gapsQueryUrl trims and forwards a fields projection", () => {
+    const url = gapsQueryUrl({ fields: " netuid,gap_count " });
+    assert.equal(url.searchParams.get("fields"), "netuid,gap_count");
+  });
+
+  test("gapsQueryUrl clamps a non-numeric limit to the default", () => {
+    const url = gapsQueryUrl({ limit: "lots" });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("gapsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
+    const url = gapsQueryUrl({ limit: 0 });
+    assert.equal(url.searchParams.get("limit"), "50");
+  });
+
+  test("gapsQueryUrl clamps limit above the MCP maximum", () => {
+    const url = gapsQueryUrl({ limit: 500 });
+    assert.equal(url.searchParams.get("limit"), "100");
+  });
+
+  test("gapsQueryUrl rejects a fractional netuid", () => {
+    assert.throws(
+      () => gapsQueryUrl({ netuid: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadGapsList returns filtered rows with pagination meta", async () => {
+    const out = await loadGapsList({ env: {}, readArtifact }, { netuid: 7 });
+    assert.equal(out.returned, 1);
+    assert.equal(out.gaps[0].netuid, 7);
+    assert.equal(out.gaps[0].gap_count, 2);
+  });
+
+  test("loadGapsList sorts and pages the collection", async () => {
+    const out = await loadGapsList(
+      { env: {}, readArtifact },
+      { sort: "gap_count", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 2);
+    assert.equal(out.gaps[0].netuid, 31);
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadGapsList uses an injected readArtifact dep", async () => {
+    const out = await loadGapsList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { gaps: [{ netuid: 0 }] },
+        }),
+      },
+    );
+    assert.equal(out.gaps[0].netuid, 0);
+  });
+
+  test("loadGapsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadGapsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadGapsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadGapsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" && /gaps\.json/.test(err.message),
+    );
+  });
+
+  test("loadGapsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () => loadGapsList({ env: {}, readArtifact }, { fields: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadGapsList projects row fields when requested", async () => {
+    const out = await loadGapsList(
+      { env: {}, readArtifact },
+      { fields: "netuid,gap_count", limit: 1 },
+    );
+    assert.deepEqual(out.gaps[0], { netuid: 7, gap_count: 2 });
+  });
+
+  test("loadGapsList omits nullable artifact metadata when absent", async () => {
+    const out = await loadGapsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { gaps: [{ netuid: 0 }] },
+        }),
+      },
+      {},
+    );
+    assert.equal(out.generated_at, null);
+    assert.equal(out.notes, null);
+  });
+
+  test("loadGapsList treats a non-array gaps key as empty", async () => {
+    const out = await loadGapsList(
+      {
+        env: {},
+        readArtifact: async () => ({
+          ok: true,
+          data: { gaps: null },
+        }),
+      },
+      {},
+    );
+    assert.deepEqual(out.gaps, []);
+    assert.equal(out.total, 0);
+  });
+
+  test("loadGapsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { gaps: [{ netuid: 9 }, { netuid: 10 }] },
+      meta: {},
+    });
+    try {
+      const out = await loadGapsList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("loadGapsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadGapsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadGapsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadGapsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_GAPS_MCP_TOOL.name, "list_gaps");
+    assert.match(LIST_GAPS_INSTRUCTIONS, /list_gaps/);
+    assert.ok(new Ajv2020({ strict: false }).compile(LIST_GAPS_OUTPUT_SCHEMA));
+  });
+
+  test("MCP server exports wire list_gaps at the bumped SemVer", () => {
+    assert.equal(MCP_SERVER_VERSION, "1.29.0");
+    assert.match(MCP_INSTRUCTIONS, /list_gaps/);
+    const tool = MCP_TOOLS.find((t) => t.name === "list_gaps");
+    assert.ok(tool);
+    assert.equal(tool.title, "List subnet interface gaps");
+  });
+});

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.28.0");
+    assert.equal(MCP_SERVER_VERSION, "1.29.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.28.0");
+    assert.equal(MCP_SERVER_VERSION, "1.29.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -643,6 +643,23 @@ describe("list_curation — branch coverage", () => {
   });
 });
 
+// ── list_gaps — gaps artifact list ────────────────────────────────────────
+describe("list_gaps — branch coverage", () => {
+  test("surfaces non-not_found artifact failures", async () => {
+    const deps = {
+      readArtifact: async () => ({
+        ok: false,
+        code: "artifact_timeout",
+      }),
+      readHealthKv: async () => null,
+    };
+    const res = await callTool("list_gaps", {}, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /artifact_timeout/);
+    assert.match(res.body.result.content[0].text, /gaps\.json/);
+  });
+});
+
 // ── get_agent_resources — AI-resources artifact ───────────────────────────
 describe("get_agent_resources — branch coverage", () => {
   test("surfaces non-not_found artifact failures", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1382,6 +1382,53 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  test("list_gaps returns filtered gap rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/gaps.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        gaps: [
+          {
+            netuid: 7,
+            coverage_level: "probed",
+            curation_level: "maintainer-reviewed",
+            gap_count: 2,
+          },
+          { netuid: 31, coverage_level: "manifested", gap_count: 5 },
+        ],
+      },
+    });
+    const res = await callTool("list_gaps", { netuid: 7 }, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.gaps[0].netuid, 7);
+    assert.equal(out.gaps[0].gap_count, 2);
+  });
+
+  test("list_gaps reports not_found when the artifact is absent", async () => {
+    const res = await callTool("list_gaps", {}, { deps: makeDeps() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Interface gaps snapshot unavailable/,
+    );
+  });
+
+  test("list_gaps payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_gaps",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/gaps.json": {
+        generated_at: "2026-07-01T00:00:00.000Z",
+        notes: "ok",
+        gaps: [{ netuid: 7, gap_count: 1 }],
+      },
+    });
+    const res = await callTool("list_gaps", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("registry_summary returns the summary artifact", async () => {
     const res = await callTool("registry_summary", {}, { deps });
     assert.equal(res.body.result.structuredContent.completeness, 0.42);

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.28.0");
+    assert.equal(MCP_SERVER_VERSION, "1.29.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.28.0");
+    assert.equal(MCP_SERVER_VERSION, "1.29.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary
- Add `list_gaps` MCP tool mirroring `GET /api/v1/gaps` (baked `/metagraph/gaps.json` artifact: per-subnet missing interface facets, gap_count, coverage/curation levels).
- Extract loader to `src/gaps-mcp.mjs` with REST-parity list-query filters (netuid, coverage_level, curation_level, sort, order, fields, limit, cursor) and full unit + integration tests (100% line/branch coverage on the new module).
- Bump MCP server SemVer **1.28.0 → 1.29.0** (`server.json`, `validate-mcp.mjs`).

## Test plan
- [x] `npm run lint` + `npm run format:check`
- [x] `npx vitest run tests/gaps-mcp.test.mjs` (100% coverage on new module)
- [x] `npx vitest run tests/mcp-server.test.mjs tests/mcp-server-branch-coverage.test.mjs` (list_gaps paths)
- [x] `npm run build` + `node scripts/validate-mcp.mjs` (94 tools)
- [x] SemVer asserts updated across MCP test suites


Made with [Cursor](https://cursor.com)