### PR TITLE
fix(chain-transfers): preserve exact decimal sender shares

### DIFF
--- a/src/chain-transfers.mjs
+++ b/src/chain-transfers.mjs
@@ -77,7 +77,9 @@ export function buildChainTransfers({
   const totalVolume = roundTao(totals?.total_volume_tao);
   const topSenders = shapeParties(senders);
   const topReceivers = shapeParties(receivers);
-  const topSenderVolume = topSenders.reduce((sum, s) => sum + s.volume_tao, 0);
+  const topSenderVolume = roundTao(
+    topSenders.reduce((sum, s) => sum + s.volume_tao, 0),
+  );
   const topSenderShare =
     totalVolume > 0 ? roundShare(topSenderVolume / totalVolume) : null;
   return {

--- a/tests/chain-transfers.test.mjs
+++ b/tests/chain-transfers.test.mjs
@@ -86,6 +86,14 @@ describe("buildChainTransfers", () => {
     assert.equal(d.top_sender_share, 1);
   });
 
+  test("keeps exact decimal full-volume top_sender_share at 1 despite float underflow", () => {
+    const d = buildChainTransfers({
+      totals: { total_volume_tao: 0.8, unique_senders: 2 },
+      senders: [party("5Sa", 0.1), party("5Sb", 0.7)], // JS sum is 0.7999999999999999
+    });
+    assert.equal(d.top_sender_share, 1);
+  });
+
   test("top_sender_share is null when there is no volume", () => {
     const d = buildChainTransfers({
       totals: { total_volume_tao: 0 },


### PR DESCRIPTION
### Motivation

- Prevent IEEE-754 underflow in summed top-sender volumes from making a semantic full-volume share (e.g. `0.1 + 0.7 == 0.8`) be misreported as `0.9999` by the existing 4-decimal clamp.
- Keep the anti-overstatement guard that clamps true sub-1 ratios while preserving cases that are semantically exact 1.

### Description

- In `src/chain-transfers.mjs` round the summed top-sender TAO volume with `roundTao(...)` before dividing by `totalVolume`, so the ratio calculation compares values at the same RAO precision.
- Add a regression test in `tests/chain-transfers.test.mjs` that asserts a decimal full-volume case (`0.1 + 0.7`) yields `top_sender_share === 1` to prevent future regressions while keeping the near-monopoly clamp behavior.

### Testing

- Ran `git diff --check` and `npm run lint` with no failures.
- Ran the focused suite `npm test -- --run tests/chain-transfers.test.mjs --testNamePattern top_sender_share` and the full file `npm test -- --run tests/chain-transfers.test.mjs`, and all tests passed.
- The new regression test verifies the fix and existing tests confirm the clamp behavior remains intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48c9f74234832c80f5157ab1b74cbd)