### PR TITLE
fix(chain-serving): clamp limit floor to 0 instead of 1

### DIFF
--- a/src/chain-serving.mjs
+++ b/src/chain-serving.mjs
@@ -105,7 +105,7 @@ export function buildChainServing(
   const list = Array.isArray(subnetRows) ? subnetRows : [];
   const flooredLimit = Math.floor(Number(limit));
   const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(1, Math.min(flooredLimit, CHAIN_SERVING_LIMIT_MAX))
+    ? Math.max(0, Math.min(flooredLimit, CHAIN_SERVING_LIMIT_MAX))
     : CHAIN_SERVING_LIMIT_DEFAULT;
   const observedAt = toIso(networkDistinct?.newest_observed);
 

--- a/tests/chain-serving.test.mjs
+++ b/tests/chain-serving.test.mjs
@@ -103,6 +103,16 @@ describe("buildChainServing", () => {
     assert.equal(data.intensity_distribution.count, 3);
   });
 
+  test("limit of 0 yields an empty leaderboard, not a single row", () => {
+    const data = buildChainServing(SUBNETS, {
+      window: "7d",
+      limit: 0,
+      networkDistinct: NETWORK,
+    });
+    assert.equal(data.subnets.length, 0);
+    assert.equal(data.subnet_count, 3);
+  });
+
   test("limit above the max clamps; a non-numeric limit uses the default", () => {
     const big = buildChainServing(SUBNETS, {
       window: "7d",


### PR DESCRIPTION
## Summary
- `buildChainServing` normalized a `limit` of `0` up to `1` (`Math.max(1, ...)`), so requesting an empty leaderboard silently returned one row instead of `[]`, contradicting the function's own docblock ("`limit` caps the leaderboard").
- Sibling leaderboard builders from the same batch (`chain-turnover.mjs`, `chain-stake-flow.mjs`, `movers.mjs`, `metagraph-neurons.mjs`'s `buildGlobalValidators`) already clamp their floor to `0`; `chain-serving.mjs` was the one outlier.

## Test plan
- [x] New unit test: `buildChainServing` with `limit: 0` returns `subnets: []` (`subnet_count` unaffected)
- [x] `npm run lint` (scoped to changed files)
- [x] `npm run validate`
- [x] `npx vitest run tests/chain-serving.test.mjs --coverage --coverage.include='src/chain-serving.mjs'` — 27 passed, 100% statements/branches/functions/lines
