### PR TITLE
fix(counterparties): reject blank observed_at cells that coerce to 0

### DIFF
--- a/src/counterparties.mjs
+++ b/src/counterparties.mjs
@@ -75,7 +75,9 @@ function nullableInteger(value) {
 }
 
 function nullableTimestamp(value) {
-  if (value == null || value === "") return null;
+  if (value == null) return null;
+  // Blank D1 cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(n) || n <= 0) return null;
   const date = new Date(n);

--- a/tests/counterparties.test.mjs
+++ b/tests/counterparties.test.mjs
@@ -508,7 +508,7 @@ describe("buildCounterpartyRelationship", () => {
           coldkey: "A",
           netuid: 1,
           amount_tao: 1,
-          observed_at: "",
+          observed_at: null,
         },
         {
           block_number: 2,
@@ -517,10 +517,19 @@ describe("buildCounterpartyRelationship", () => {
           coldkey: "A",
           netuid: 1,
           amount_tao: 1,
-          observed_at: "   ",
+          observed_at: "",
         },
         {
           block_number: 3,
+          event_index: 0,
+          hotkey: ME,
+          coldkey: "A",
+          netuid: 1,
+          amount_tao: 1,
+          observed_at: "   ",
+        },
+        {
+          block_number: 4,
           event_index: 0,
           hotkey: ME,
           coldkey: "A",
@@ -533,12 +542,13 @@ describe("buildCounterpartyRelationship", () => {
       "A",
       {},
     );
-    assert.equal(data.transfer_count, 3);
+    assert.equal(data.transfer_count, 4);
     assert.equal(data.first_seen_at, null);
     assert.equal(data.last_seen_at, null);
     assert.equal(data.transfers[0].observed_at, null);
     assert.equal(data.transfers[1].observed_at, null);
     assert.equal(data.transfers[2].observed_at, null);
+    assert.equal(data.transfers[3].observed_at, null);
   });
 
   test("coerces string-typed observed_at cells on relationship last_seen_at", () => {


### PR DESCRIPTION
## Summary

Reject blank D1 `observed_at` cells in counterparty relationship evidence so empty strings and whitespace-only values return `null` instead of relying on `Number("") → 0` coercion.

## What Changed

- Add a trim guard to `nullableTimestamp()` in `src/counterparties.mjs`, matching the pattern merged in `nullableNumber()` (#3044).
- Extend regression coverage in `tests/counterparties.test.mjs` for null, blank, and out-of-range timestamp cells.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/counterparties.test.mjs`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Sibling fix to the merged blank-cell guard series (#3044).
