### PR TITLE
fix(streamer): defer substrate import for tests

### DIFF
--- a/scripts/stream-events.py
+++ b/scripts/stream-events.py
@@ -42,7 +42,6 @@ import urllib.error
 import urllib.request
 from urllib.parse import urlparse
 
-from substrateinterface import SubstrateInterface
 
 RPC = os.environ.get("EVENTS_RPC_URL", "wss://entrypoint-finney.opentensor.ai:443")
 INGEST_URL = os.environ.get("EVENTS_INGEST_URL")
@@ -309,6 +308,18 @@ def push_blocks(url, block_row, extrinsic_rows):
     return ok
 
 
+def _connect_substrate(url):
+    """Import substrate-interface only when the streamer actually connects.
+
+    Unit tests for ingest-push behavior import this module without the optional
+    production runtime dependency installed; production execution still fails
+    normally here if substrate-interface is unavailable.
+    """
+    from substrateinterface import SubstrateInterface
+
+    return SubstrateInterface(url=url)
+
+
 def run():
     if not INGEST_URL or not SECRET:
         log.error("EVENTS_INGEST_URL and METAGRAPH_EVENTS_INGEST_SECRET are required")
@@ -323,7 +334,7 @@ def run():
     backoff = 5
     while not _stop:
         try:
-            s = SubstrateInterface(url=RPC)
+            s = _connect_substrate(RPC)
             log.info("connected %s — subscribing to finalized heads", RPC)
             backoff = 5  # reset after a clean connect
 
@@ -360,6 +371,17 @@ def run():
                 return None
 
             s.subscribe_block_headers(handler, finalized_only=True)
+        except ModuleNotFoundError as e:
+            # A missing substrate-interface install is a permanent configuration
+            # error, not a transient stream blip — surface it and exit rather than
+            # let the broad except below retry it forever with no chance of
+            # success (same stance as the TLS-failure exit in push()).
+            log.error(
+                "required dependency unavailable (%s) — exiting rather than "
+                "retrying a permanent configuration error.",
+                repr(e)[:160],
+            )
+            sys.exit(1)
         except Exception as e:  # noqa: BLE001 — connection lost; reconnect
             if _stop:
                 break


### PR DESCRIPTION
### Motivation
- Fix a hermeticity regression where `scripts/test_stream_events.py` crashed at import-time with `ModuleNotFoundError: No module named 'substrateinterface'` because `scripts/stream-events.py` imported `substrateinterface` at module load, breaking standalone/CI-friendly tests.
- Preserve production semantics so a missing `substrateinterface` still fails at runtime when the streamer actually attempts to connect.

### Description
- Remove the top-level `from substrateinterface import SubstrateInterface` and add a new `_connect_substrate(url)` helper that performs the import lazily.
- Replace direct calls to `SubstrateInterface(url=RPC)` in `run()` with `s = _connect_substrate(RPC)` so tests can import the module without the optional runtime dependency.

### Testing
- Ran `python3 scripts/test_stream_events.py`, which executed the three unit tests and reported `OK`.
- Ran `python3 -m unittest scripts.test_stream_events`, which also passed all tests.
- Ran `git diff --check` and there were no style or whitespace issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48d0fdbc14832cb3de2fdbe6a869fa)