### PR TITLE
feat(mcp): add get_chain_serving tool mirroring GET /api/v1/chain/serving

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -11,7 +11,9 @@
 // this module is pure and unit-testable, and so it reuses the exact same
 // R2/ASSETS resolution the REST routes use.
 import {
+  ANALYTICS_WINDOWS,
   DAY_MS,
+  DEFAULT_ANALYTICS_WINDOW,
   resolveClientIp,
   SS58_ADDRESS_PATTERN,
 } from "../workers/config.mjs";
@@ -98,6 +100,11 @@ import {
   CHAIN_WEIGHTS_WINDOWS,
   DEFAULT_CHAIN_WEIGHTS_WINDOW,
 } from "./chain-weights.mjs";
+import {
+  loadChainServing,
+  CHAIN_SERVING_LIMIT_DEFAULT,
+  CHAIN_SERVING_LIMIT_MAX,
+} from "./chain-serving.mjs";
 import {
   loadEconomicsTrends,
   parseEconomicsTrendsWindow,
@@ -248,7 +255,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.27.0";
+export const MCP_SERVER_VERSION = "1.28.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -256,6 +263,9 @@ const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
 const CHAIN_TURNOVER_WINDOW_KEYS = Object.keys(CHAIN_TURNOVER_WINDOWS);
 const CHAIN_STAKE_FLOW_WINDOW_KEYS = Object.keys(CHAIN_STAKE_FLOW_WINDOWS);
 const CHAIN_WEIGHTS_WINDOW_KEYS = Object.keys(CHAIN_WEIGHTS_WINDOWS);
+// get_chain_serving mirrors the /api/v1/chain/serving route, which uses the shared
+// ANALYTICS_WINDOWS (7d/30d) rather than a dedicated window constant.
+const CHAIN_SERVING_WINDOW_KEYS = Object.keys(ANALYTICS_WINDOWS);
 const STAKE_FLOW_WINDOW_KEYS = Object.keys(STAKE_FLOW_WINDOWS);
 const MOVERS_WINDOW_KEYS = Object.keys(MOVERS_WINDOWS);
 
@@ -375,6 +385,9 @@ export const MCP_INSTRUCTIONS =
   "(per-subnet net TAO staked/unstaked and direction) across all subnets, " +
   "get_chain_weights the network-wide validator weight-setting leaderboard " +
   "(per-subnet WeightsSet activity, distinct setters, and update intensity) " +
+  "across all subnets, " +
+  "get_chain_serving the network-wide axon-serving leaderboard " +
+  "(per-subnet AxonServed activity, distinct servers, and announcement intensity) " +
   "across all subnets, " +
   "get_blocks_summary block-production analytics (inter-block time, throughput, " +
   "and block-author decentralization), " +
@@ -2186,6 +2199,56 @@ export const MCP_TOOLS = [
       return loadChainWeights(mcpD1Runner(ctx), {
         windowLabel: window,
         windowDays: CHAIN_WEIGHTS_WINDOWS[window],
+        limit,
+      });
+    },
+  },
+  {
+    name: "get_chain_serving",
+    title: "Get network-wide axon-serving activity",
+    description:
+      "Fetch the network-wide axon-serving announcement leaderboard over the " +
+      "requested window (7d or 30d; default 7d): each subnet ranked by AxonServed " +
+      "events with its distinct-server count and announcements-per-server " +
+      "intensity, plus a network rollup with the TRUE distinct server count (a " +
+      "hotkey announcing on several subnets counts once) and total announcements, " +
+      "and the count/mean/min/p25/median/p75/p90/max spread of per-subnet " +
+      "re-announcement intensity, summed live from the account_events stream. The " +
+      "serving-availability companion to get_chain_weights (consensus " +
+      "maintenance). Mirrors GET /api/v1/chain/serving.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        window: {
+          type: "string",
+          enum: CHAIN_SERVING_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_ANALYTICS_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max subnets in the axon-serving leaderboard (1-${CHAIN_SERVING_LIMIT_MAX}, default ${CHAIN_SERVING_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: CHAIN_SERVING_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const window = optionalString(args, "window") ?? DEFAULT_ANALYTICS_WINDOW;
+      if (!Object.hasOwn(ANALYTICS_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${CHAIN_SERVING_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        CHAIN_SERVING_LIMIT_DEFAULT,
+        CHAIN_SERVING_LIMIT_MAX,
+      );
+      return loadChainServing(mcpD1Runner(ctx), {
+        windowLabel: window,
+        windowDays: ANALYTICS_WINDOWS[window],
         limit,
       });
     },
@@ -5960,6 +6023,82 @@ const TOOL_OUTPUT_SCHEMAS = {
             distinct_setters: { type: "integer" },
             weight_sets: { type: "integer" },
             sets_per_setter: { type: "number" },
+          },
+        },
+      },
+    },
+  },
+  get_chain_serving: {
+    type: "object",
+    additionalProperties: true,
+    required: ["subnet_count", "network", "subnets"],
+    properties: {
+      schema_version: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      subnet_count: { type: "integer" },
+      // Network rollup with the TRUE distinct server count (a hotkey announcing on
+      // several subnets counts once). announcements_per_server is null when the
+      // network-wide distinct-server count is unavailable/zero (no divide-by-zero).
+      network: {
+        type: "object",
+        additionalProperties: false,
+        required: [
+          "distinct_servers",
+          "announcements",
+          "announcements_per_server",
+        ],
+        properties: {
+          distinct_servers: { type: "integer" },
+          announcements: { type: "integer" },
+          announcements_per_server: { type: ["number", "null"] },
+        },
+      },
+      // Spread of per-subnet re-announcement intensity (AxonServed events per
+      // server) over EVERY serving subnet; null when no subnet announced in the window.
+      intensity_distribution: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: [
+          "count",
+          "mean",
+          "min",
+          "p25",
+          "median",
+          "p75",
+          "p90",
+          "max",
+        ],
+        properties: {
+          count: { type: "integer" },
+          mean: { type: "number" },
+          min: { type: "number" },
+          p25: { type: "number" },
+          median: { type: "number" },
+          p75: { type: "number" },
+          p90: { type: "number" },
+          max: { type: "number" },
+        },
+      },
+      // Per-subnet axon-serving leaderboard, most AxonServed events first. Each
+      // listed subnet has at least one distinct server, so announcements_per_server
+      // is always a finite number here (never divide-by-zero).
+      subnets: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: [
+            "netuid",
+            "distinct_servers",
+            "announcements",
+            "announcements_per_server",
+          ],
+          properties: {
+            netuid: { type: "integer" },
+            distinct_servers: { type: "integer" },
+            announcements: { type: "integer" },
+            announcements_per_server: { type: "number" },
           },
         },
       },

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.27.0");
+    assert.equal(MCP_SERVER_VERSION, "1.28.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.27.0");
+    assert.equal(MCP_SERVER_VERSION, "1.28.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.27.0");
+    assert.equal(MCP_SERVER_VERSION, "1.28.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6525,6 +6525,115 @@ describe("MCP economics + metagraph data tools", () => {
     assert.ok(validate(res.body.result.structuredContent));
   });
 
+  // get_chain_serving twins get_chain_weights: loadChainServing reads a network
+  // aggregate first (non-null newest_observed unlocks the per-subnet GROUP BY read).
+  function servingNetwork(announcements, distinct_servers) {
+    return {
+      announcements,
+      distinct_servers,
+      newest_observed: 1_750_000_000_000,
+    };
+  }
+  function servingRow(netuid, announcements, distinct_servers) {
+    return { netuid, announcements, distinct_servers };
+  }
+  function chainServingEnv(network, subnets) {
+    return {
+      env: {
+        METAGRAPH_HEALTH_DB: {
+          prepare(sql) {
+            return {
+              bind: () => ({
+                all: () =>
+                  Promise.resolve({
+                    results: /GROUP BY netuid/.test(sql)
+                      ? subnets
+                      : network
+                        ? [network]
+                        : [],
+                  }),
+              }),
+            };
+          },
+        },
+      },
+    };
+  }
+
+  test("get_chain_serving returns schema-stable zeros on cold D1", async () => {
+    const res = await callTool("get_chain_serving", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.window, "7d"); // REST default window parity
+    assert.equal(out.subnet_count, 0);
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.intensity_distribution, null);
+    assert.equal(out.network.announcements, 0);
+    assert.equal(out.network.announcements_per_server, null);
+    assert.equal(out.observed_at, null);
+  });
+
+  test("get_chain_serving ranks subnets by announcements with a network rollup", async () => {
+    const res = await callTool(
+      "get_chain_serving",
+      { window: "30d", limit: 10 },
+      chainServingEnv(servingNetwork(30, 8), [
+        // netuid 2: fewer announcements -> ranks last despite higher intensity.
+        servingRow(2, 10, 4),
+        // netuid 1: most AxonServed events -> ranks first.
+        servingRow(1, 20, 5),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets[0].netuid, 1);
+    assert.equal(out.subnets[0].announcements, 20);
+    assert.equal(out.subnets[0].announcements_per_server, 4); // 20 / 5
+    assert.equal(out.subnets[1].netuid, 2);
+    assert.equal(out.subnets[1].announcements_per_server, 2.5); // 10 / 4
+    // Network rollup: 30 announcements over 8 distinct servers -> 3.75.
+    assert.equal(out.network.announcements, 30);
+    assert.equal(out.network.distinct_servers, 8);
+    assert.equal(out.network.announcements_per_server, 3.75);
+    assert.equal(out.intensity_distribution.count, 2);
+    assert.equal(out.observed_at, new Date(1_750_000_000_000).toISOString());
+  });
+
+  test("get_chain_serving rejects an unsupported window", async () => {
+    const res = await callTool("get_chain_serving", { window: "90d" }, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window/);
+  });
+
+  test("get_chain_serving caps the leaderboard by limit", async () => {
+    const res = await callTool(
+      "get_chain_serving",
+      { limit: 1 },
+      chainServingEnv(servingNetwork(30, 8), [
+        servingRow(1, 20, 5),
+        servingRow(2, 10, 4),
+      ]),
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.subnet_count, 2);
+    assert.equal(out.subnets.length, 1);
+    assert.equal(out.intensity_distribution.count, 2);
+  });
+
+  test("get_chain_serving payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_chain_serving",
+    )?.outputSchema;
+    const res = await callTool(
+      "get_chain_serving",
+      {},
+      chainServingEnv(servingNetwork(30, 8), [servingRow(1, 20, 5)]),
+    );
+    const validate = new Ajv2020().compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("get_subnet_concentration_history defaults to 30d and returns points", async () => {
     const res = await callTool(
       "get_subnet_concentration_history",

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.27.0");
+    assert.equal(MCP_SERVER_VERSION, "1.28.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.27.0");
+    assert.equal(MCP_SERVER_VERSION, "1.28.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Add a `get_chain_serving` MCP tool mirroring `GET /api/v1/chain/serving` — the network-wide axon-serving announcement leaderboard — so MCP agents can read it with the same window/limit inputs as the REST route. Twins the existing `get_chain_weights` tool (both are network-wide account_events leaderboards).

## What Changed

- `src/mcp-server.mjs`:
  - New `get_chain_serving` tool: `window` (7d/30d, default 7d — the shared `ANALYTICS_WINDOWS` the route uses) and `limit` (1–100, default 20) inputs, validated the same way as the sibling tools, delegating to the same `loadChainServing` loader the REST handler uses (single source of truth, no logic fork).
  - A typed `TOOL_OUTPUT_SCHEMAS.get_chain_serving` output schema (`subnet_count`, `network` rollup, nullable `intensity_distribution`, and the per-subnet `subnets` leaderboard) so clients can validate the `structuredContent`.
  - Registered it in the server instructions catalog and bumped `MCP_SERVER_VERSION` 1.27.0 → 1.28.0 (the version-pin smoke tests updated to match).
- No server-card / OpenAPI regeneration: the MCP server card is worker-computed and the tool list is not a committed artifact.
- Tests (`tests/mcp-server.test.mjs`): ranks the per-subnet leaderboard on the default 7d window, honors an explicit 30d window + limit cap, returns a schema-stable empty block on a cold D1, rejects an unsupported window, and validates the real payload against its declared `outputSchema`. The registry tests cover it automatically.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None needed — MCP server card is worker-computed.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No REST/OpenAPI change — MCP tool only.)

## Validation

- [x] `npx vitest run tests/mcp-server.test.mjs` + the 5 version-pin suites
- [x] `npm run lint` · `npm run format:check` · `npm run validate:contract-drift` · `npm run validate:api`
- [x] `npx vitest run` (full suite, 5002 passed)
- [x] `git diff --check`
