### PR TITLE
fix(counterparties): skip blank amount rows in leaderboard rollup

### DIFF
--- a/src/counterparties.mjs
+++ b/src/counterparties.mjs
@@ -24,12 +24,6 @@ export const COUNTERPARTY_RELATIONSHIP_READ_COLUMNS =
 export const COUNTERPARTIES_SCAN_CAP = 5000;
 export const COUNTERPARTY_RELATIONSHIP_SCAN_CAP = 5000;
 
-// Coerce one raw cell to a finite number (or 0) for summation.
-function numeric(value) {
-  const n = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(n) ? n : 0;
-}
-
 // Round a TAO sum to rao precision so accumulated float error never leaks a long
 // tail into the JSON.
 function round(value, dp = 9) {
@@ -102,17 +96,13 @@ export function buildCounterparties(rows, ss58, { limit = 20 } = {}) {
   for (const row of list) {
     const from = row?.hotkey;
     const to = row?.coldkey;
-    const amount = numeric(row?.amount_tao);
     const isSender = from === ss58;
     const isReceiver = to === ss58;
     // The counterparty is the side that ISN'T this account. Skip self-transfers
     // (both sides the account) and rows missing the other side's address.
     let party = null;
-    let sent = 0;
-    let received = 0;
     if (isSender && !isReceiver && typeof to === "string" && to.length > 0) {
       party = to;
-      sent = amount;
     } else if (
       isReceiver &&
       !isSender &&
@@ -120,11 +110,14 @@ export function buildCounterparties(rows, ss58, { limit = 20 } = {}) {
       from.length > 0
     ) {
       party = from;
-      received = amount;
     }
     if (party == null) continue;
-    const sentRao = toRaoBig(sent);
-    const receivedRao = toRaoBig(received);
+    // Align with buildCounterpartyRelationship: blank/null amount_tao cells must
+    // be skipped, not coerced to 0 and counted as a phantom zero-TAO transfer.
+    const amount = nullableNumber(row?.amount_tao);
+    if (amount == null) continue;
+    const sentRao = isSender && !isReceiver ? toRaoBig(amount) : 0n;
+    const receivedRao = isReceiver && !isSender ? toRaoBig(amount) : 0n;
     totalSentRao += sentRao;
     totalReceivedRao += receivedRao;
     const entry = byParty.get(party) ?? {

--- a/tests/counterparties.test.mjs
+++ b/tests/counterparties.test.mjs
@@ -99,18 +99,54 @@ describe("buildCounterparties", () => {
     assert.equal(data.total_sent_tao, 20); // the self-transfer contributes nothing
   });
 
-  test("skips rows not involving the account and coerces a non-finite amount to 0", () => {
+  test("skips rows not involving the account and rows with a null/blank amount", () => {
     const data = buildCounterparties(
       [
-        { hotkey: "ME", coldkey: "A", amount_tao: null, block_number: 1 }, // amount → 0
-        { hotkey: "X", coldkey: "Y", amount_tao: 5, block_number: 2 }, // ME absent
+        { hotkey: "ME", coldkey: "A", amount_tao: null, block_number: 1 },
+        { hotkey: "ME", coldkey: "B", amount_tao: "", block_number: 2 },
+        { hotkey: "ME", coldkey: "C", amount_tao: "   ", block_number: 3 },
+        { hotkey: "X", coldkey: "Y", amount_tao: 5, block_number: 4 }, // ME absent
       ],
       ME,
       {},
     );
-    assert.equal(data.counterparty_count, 1); // only A
-    assert.equal(data.counterparties[0].address, "A");
-    assert.equal(data.counterparties[0].sent_tao, 0);
+    assert.equal(data.counterparty_count, 0);
+    assert.equal(data.total_sent_tao, 0);
+    assert.equal(data.total_received_tao, 0);
+    assert.deepEqual(data.counterparties, []);
+  });
+
+  test("blank amount rows do not inflate transfer_count in the leaderboard rollup", () => {
+    // buildCounterpartyRelationship already skips blank amounts (#3044); the
+    // top-counterparties rollup must not count them as phantom 0-TAO transfers.
+    for (const blank of ["", "   "]) {
+      const data = buildCounterparties(
+        [
+          { hotkey: "ME", coldkey: "A", amount_tao: blank, block_number: 5 },
+          { hotkey: "ME", coldkey: "A", amount_tao: 10, block_number: 6 },
+        ],
+        ME,
+        {},
+      );
+      assert.equal(
+        data.counterparty_count,
+        1,
+        `counterparty_count for ${JSON.stringify(blank)}`,
+      );
+      assert.equal(
+        data.counterparties[0].transfer_count,
+        1,
+        `transfer_count for ${JSON.stringify(blank)}`,
+      );
+      assert.equal(data.counterparties[0].sent_tao, 10);
+    }
+    const zero = buildCounterparties(
+      [{ hotkey: "ME", coldkey: "A", amount_tao: 0, block_number: 7 }],
+      ME,
+      {},
+    );
+    assert.equal(zero.counterparties[0].transfer_count, 1);
+    assert.equal(zero.counterparties[0].sent_tao, 0);
   });
 
   test("limit caps the returned list but counterparty_count covers all", () => {


### PR DESCRIPTION
## Summary

Skip blank/null `amount_tao` rows in the top-counterparties rollup so malformed D1 cells are not counted as phantom zero-TAO transfers. Aligns `buildCounterparties()` with `buildCounterpartyRelationship()`, which already skips those rows via `nullableNumber()` (#3044).

## What Changed

- Route leaderboard aggregation through `nullableNumber()` and `continue` when the amount is absent/blank, instead of coercing via `numeric()` → 0.
- Remove the now-unused `numeric()` helper.
- Add regression coverage in `tests/counterparties.test.mjs` for null/blank vs literal-zero amount rows in the rollup.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/counterparties.test.mjs`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Parity fix for the merged blank-cell guard series (#3044).
