### PR TITLE
fix(api): count subnet weight-setters over a hotkey-or-uid identity

### DIFF
--- a/src/subnet-weights.mjs
+++ b/src/subnet-weights.mjs
@@ -49,8 +49,8 @@ function setsPerSetter(sets, setters) {
 }
 
 // Shape one subnet's weight-setting scorecard from the single-row account_events aggregate.
-// `row` carries weight_sets (COUNT(*)), distinct_setters (COUNT(DISTINCT hotkey)), and
-// newest_observed (MAX(observed_at)). Null-safe: a null/absent row yields the zeroed card.
+// `row` carries weight_sets (COUNT(*)), distinct_setters (COUNT(DISTINCT setter identity)),
+// and newest_observed (MAX(observed_at)). Null-safe: a null/absent row yields the zeroed card.
 export function buildSubnetWeights(row, netuid, { window } = {}) {
   const distinctSetters = toCount(row?.distinct_setters);
   const weightSets = toCount(row?.weight_sets);
@@ -77,9 +77,20 @@ export async function loadSubnetWeights(
   { windowLabel, windowDays } = {},
 ) {
   const cutoff = Date.now() - windowDays * DAY_MS;
+  // WeightsSet ingestion can omit hotkey, so count distinct setters over a
+  // hotkey-or-(netuid,uid) identity rather than COUNT(DISTINCT hotkey) alone --
+  // otherwise every hotkey-less WeightsSet collapses to a single NULL that
+  // COUNT(DISTINCT) drops, undercounting distinct_setters (and inflating
+  // sets_per_setter). Mirrors the network /chain/weights loader (#3011).
+  const setterIdentity =
+    "CASE " +
+    "WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey " +
+    "WHEN uid IS NOT NULL THEN 'uid:' || netuid || ':' || uid " +
+    "ELSE NULL END";
   const rows = await d1(
-    "SELECT COUNT(*) AS weight_sets, COUNT(DISTINCT hotkey) AS distinct_setters, " +
-      "MAX(observed_at) AS newest_observed " +
+    "SELECT COUNT(*) AS weight_sets, COUNT(DISTINCT " +
+      setterIdentity +
+      ") AS distinct_setters, MAX(observed_at) AS newest_observed " +
       "FROM account_events WHERE netuid = ? AND event_kind = ? AND observed_at >= ?",
     [netuid, WEIGHTS_EVENT_KIND, cutoff],
   );

--- a/tests/subnet-weights.test.mjs
+++ b/tests/subnet-weights.test.mjs
@@ -100,6 +100,25 @@ describe("loadSubnetWeights", () => {
     assert.equal(d.sets_per_setter, 10);
   });
 
+  test("counts distinct setters over a hotkey-or-uid identity, not hotkey alone", async () => {
+    // WeightsSet events can carry a NULL hotkey; a bare COUNT(DISTINCT hotkey)
+    // collapses every hotkey-less event to one dropped NULL and undercounts the
+    // setters. The loader must fall back to (netuid, uid), mirroring #3011.
+    let captured;
+    const d1 = async (sql, params) => {
+      captured = { sql, params };
+      return [{ distinct_setters: 3, weight_sets: 30, newest_observed: null }];
+    };
+    await loadSubnetWeights(d1, 7, { windowLabel: "7d", windowDays: 7 });
+    assert.doesNotMatch(
+      captured.sql,
+      /COUNT\(DISTINCT hotkey\)/,
+      "must not count distinct hotkey alone",
+    );
+    assert.match(captured.sql, /WHEN hotkey IS NOT NULL/);
+    assert.match(captured.sql, /'uid:' \|\| netuid \|\| ':' \|\| uid/);
+  });
+
   test("a cold store (no rows) yields the zeroed card", async () => {
     const d = await loadSubnetWeights(async () => [], 9, {
       windowLabel: "30d",


### PR DESCRIPTION
## What

`loadSubnetWeights` (the new `GET /api/v1/subnets/{netuid}/weights` route, #3056) counts distinct weight-setting validators with:

```sql
COUNT(DISTINCT hotkey) AS distinct_setters
```

WeightsSet ingestion can omit `hotkey` (this is exactly why the network-wide `/chain/weights` loader was fixed in **#3011**), and SQL `COUNT(DISTINCT …)` ignores NULLs. So every hotkey-less `WeightsSet` event collapses to a single dropped NULL: `distinct_setters` is **undercounted**, and because `sets_per_setter = weight_sets / distinct_setters`, the reported update intensity is correspondingly **inflated** for any subnet whose validators set weights without a recorded hotkey.

## Concrete case

A subnet with, say, 30 `WeightsSet` events from 3 validators that all lack a hotkey but carry distinct `uid`s:

- **Before:** `distinct_setters: 0`, `sets_per_setter: null` (all 3 collapse to one dropped NULL)
- **After:** `distinct_setters: 3`, `sets_per_setter: 10`

## Fix

Count distinct setters over the same `hotkey`-or-`(netuid, uid)` identity the network `/chain/weights` loader already uses (#3011):

```sql
COUNT(DISTINCT CASE
  WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey
  WHEN uid IS NOT NULL THEN 'uid:' || netuid || ':' || uid
  ELSE NULL END) AS distinct_setters
```

so uid-backed setters are counted instead of dropped. The response shape is unchanged (no schema/contract regen).

## Tests

- New: asserts the loader's SQL counts distinct over the hotkey-or-uid identity and no longer uses `COUNT(DISTINCT hotkey)` alone — fails on the old query, passes with the fix.
- Existing loader/builder tests still pass (10/10).

Source + test only — no schema/contract/generated-artifact changes. `eslint` clean, `prettier` clean, 100% patch coverage.
