### PR TITLE
fix(stake-flow): skip blank total_tao rows in stake-flow rollups

### DIFF
--- a/src/account-stake-flow.mjs
+++ b/src/account-stake-flow.mjs
@@ -51,6 +51,16 @@ function toNumber(value) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+// A finite TAO aggregate cell, or null when absent/blank/non-numeric. Blank D1 cells
+// coerce via Number("") → 0; skip those rows rather than counting phantom zero-TAO
+// stake events (mirrors buildCounterparties #3059).
+function nullableTao(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
 // A non-negative integer netuid, or null for a malformed/absent cell. Guard null
 // explicitly so a null netuid is skipped rather than coerced to subnet 0 (Number(null) === 0).
 function normalizedNetuid(value) {
@@ -114,13 +124,14 @@ export function buildAccountStakeFlow(rows, address, { window } = {}) {
     if (netuid == null) continue;
     const kind = row?.event_kind;
     if (kind !== STAKE_ADDED_KIND && kind !== STAKE_REMOVED_KIND) continue;
+    const tao = nullableTao(row?.total_tao);
+    if (tao == null) continue;
     const bucket = perSubnet.get(netuid) ?? {
       staked: 0,
       unstaked: 0,
       stakeEvents: 0,
       unstakeEvents: 0,
     };
-    const tao = toNumber(row?.total_tao);
     // Counts are integer (the schema requires it); truncate defensively so a non-D1
     // caller passing a float cannot emit a fractional event count.
     const count = Math.max(0, Math.trunc(toNumber(row?.event_count)));

--- a/src/chain-stake-flow.mjs
+++ b/src/chain-stake-flow.mjs
@@ -40,6 +40,14 @@ function toNumber(value) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+// A finite TAO aggregate cell, or null when absent/blank/non-numeric.
+function nullableTao(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
 // A non-negative integer netuid, or null for a malformed/absent cell. Guard null AND a
 // blank/whitespace-only string explicitly so neither is silently coerced to subnet 0
 // (Number(null), Number(""), and Number("  ") all === 0); a malformed direct row must be
@@ -126,6 +134,8 @@ export function buildChainStakeFlow(
     // the pure builder aligned with the "active stake-flow subnets" contract.
     const kind = row?.event_kind;
     if (kind !== STAKE_ADDED_KIND && kind !== STAKE_REMOVED_KIND) continue;
+    const tao = nullableTao(row?.total_tao);
+    if (tao == null) continue;
     const bucket = perNetuid.get(netuid) ?? {
       staked: 0,
       unstaked: 0,
@@ -133,10 +143,10 @@ export function buildChainStakeFlow(
       unstakeEvents: 0,
     };
     if (kind === STAKE_ADDED_KIND) {
-      bucket.staked += toNumber(row?.total_tao);
+      bucket.staked += tao;
       bucket.stakeEvents += toNumber(row?.event_count);
     } else {
-      bucket.unstaked += toNumber(row?.total_tao);
+      bucket.unstaked += tao;
       bucket.unstakeEvents += toNumber(row?.event_count);
     }
     perNetuid.set(netuid, bucket);

--- a/src/stake-flow.mjs
+++ b/src/stake-flow.mjs
@@ -45,6 +45,14 @@ function toNumber(value) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+// A finite TAO aggregate cell, or null when absent/blank/non-numeric.
+function nullableTao(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
 // Convert an epoch-ms timestamp to an ISO string, or null when not finite. The
 // REST meta.generated_at is string|null per the envelope contract, so the newest
 // event's epoch-ms observed_at is rendered the same way account-events does (toIso).
@@ -75,11 +83,13 @@ export function buildStakeFlow(rows, netuid, { window } = {}) {
   // not just the single-row-per-kind shape GROUP BY event_kind guarantees.
   for (const row of list) {
     const kind = row?.event_kind;
+    const tao = nullableTao(row?.total_tao);
+    if (tao == null) continue;
     if (kind === STAKE_ADDED_KIND) {
-      stakedTao += toNumber(row?.total_tao);
+      stakedTao += tao;
       stakeEvents += toNumber(row?.event_count);
     } else if (kind === STAKE_REMOVED_KIND) {
-      unstakedTao += toNumber(row?.total_tao);
+      unstakedTao += tao;
       unstakeEvents += toNumber(row?.event_count);
     }
   }

--- a/tests/account-stake-flow.test.mjs
+++ b/tests/account-stake-flow.test.mjs
@@ -211,14 +211,57 @@ describe("buildAccountStakeFlow", () => {
     assert.equal(d.net_flow_tao, -0.1);
   });
 
-  test("coerces a non-numeric tao / count cell to 0", () => {
+  test("skips blank total_tao rows instead of counting phantom stake events", () => {
+    // Mirrors buildCounterparties #3059: blank total_tao must not inflate event_count.
+    for (const blank of ["", "   "]) {
+      const d = buildAccountStakeFlow(
+        [
+          {
+            netuid: 1,
+            event_kind: STAKE_ADDED_KIND,
+            total_tao: blank,
+            event_count: 5,
+          },
+          added(1, 25, 2),
+        ],
+        ADDR,
+      );
+      assert.equal(
+        d.stake_events,
+        2,
+        `stake_events for total_tao ${JSON.stringify(blank)}`,
+      );
+      assert.equal(d.total_staked_tao, 25);
+      assert.equal(d.subnet_count, 1);
+    }
+    const zero = buildAccountStakeFlow([added(1, 0, 3)], ADDR);
+    assert.equal(zero.total_staked_tao, 0);
+    assert.equal(zero.stake_events, 3);
+  });
+
+  test("skips null/blank/non-numeric total_tao rows instead of coercing to zero flow", () => {
     const d = buildAccountStakeFlow(
-      [{ netuid: 1, event_kind: STAKE_ADDED_KIND, total_tao: "n/a" }],
+      [
+        {
+          netuid: 1,
+          event_kind: STAKE_ADDED_KIND,
+          total_tao: null,
+          event_count: 2,
+        },
+        {
+          netuid: 1,
+          event_kind: STAKE_REMOVED_KIND,
+          total_tao: "nope",
+          event_count: 3,
+        },
+      ],
       ADDR,
     );
     assert.equal(d.total_staked_tao, 0);
-    assert.equal(d.stake_events, 0); // undefined event_count -> 0
-    assert.equal(d.subnet_count, 1);
+    assert.equal(d.total_unstaked_tao, 0);
+    assert.equal(d.stake_events, 0);
+    assert.equal(d.unstake_events, 0);
+    assert.equal(d.subnet_count, 0);
   });
 });
 

--- a/tests/account-stake-flow.test.mjs
+++ b/tests/account-stake-flow.test.mjs
@@ -222,7 +222,14 @@ describe("buildAccountStakeFlow", () => {
             total_tao: blank,
             event_count: 5,
           },
+          {
+            netuid: 1,
+            event_kind: STAKE_REMOVED_KIND,
+            total_tao: blank,
+            event_count: 3,
+          },
           added(1, 25, 2),
+          removed(1, 10, 1),
         ],
         ADDR,
       );
@@ -231,7 +238,9 @@ describe("buildAccountStakeFlow", () => {
         2,
         `stake_events for total_tao ${JSON.stringify(blank)}`,
       );
+      assert.equal(d.unstake_events, 1);
       assert.equal(d.total_staked_tao, 25);
+      assert.equal(d.total_unstaked_tao, 10);
       assert.equal(d.subnet_count, 1);
     }
     const zero = buildAccountStakeFlow([added(1, 0, 3)], ADDR);

--- a/tests/chain-stake-flow.test.mjs
+++ b/tests/chain-stake-flow.test.mjs
@@ -185,9 +185,30 @@ describe("buildChainStakeFlow", () => {
     );
   });
 
-  test("coerces non-numeric cells, zero-flow subnets, and invalid timestamps", () => {
-    // total_tao/event_count non-numeric -> 0; a subnet whose only flow is 0 has gross 0 and
-    // reads balanced; an invalid last_observed leaves observed_at null.
+  test("skips blank total_tao rows instead of counting phantom stake events", () => {
+    for (const blank of ["", "   "]) {
+      const data = buildChainStakeFlow(
+        [
+          {
+            netuid: 1,
+            event_kind: "StakeAdded",
+            total_tao: blank,
+            event_count: 9,
+          },
+          ev(1, "StakeAdded", 100, 2),
+        ],
+        {},
+      );
+      assert.equal(
+        data.network.stake_events,
+        2,
+        `stake events for total_tao ${JSON.stringify(blank)}`,
+      );
+      assert.equal(data.subnets[0].total_staked_tao, 100);
+    }
+  });
+
+  test("skips null/blank/non-numeric total_tao rows instead of materializing zero-flow subnets", () => {
     const data = buildChainStakeFlow(
       [
         {
@@ -200,11 +221,8 @@ describe("buildChainStakeFlow", () => {
       ],
       {},
     );
-    assert.equal(data.subnet_count, 1);
-    assert.equal(data.subnets[0].total_staked_tao, 0);
-    assert.equal(data.subnets[0].gross_flow_tao, 0);
-    assert.equal(data.subnets[0].direction, "balanced");
-    assert.equal(data.subnets[0].stake_events, 0);
+    assert.equal(data.subnet_count, 0);
+    assert.deepEqual(data.subnets, []);
     assert.equal(data.observed_at, null);
   });
 

--- a/tests/chain-stake-flow.test.mjs
+++ b/tests/chain-stake-flow.test.mjs
@@ -195,7 +195,14 @@ describe("buildChainStakeFlow", () => {
             total_tao: blank,
             event_count: 9,
           },
+          {
+            netuid: 1,
+            event_kind: "StakeRemoved",
+            total_tao: blank,
+            event_count: 4,
+          },
           ev(1, "StakeAdded", 100, 2),
+          ev(1, "StakeRemoved", 40, 1),
         ],
         {},
       );
@@ -204,7 +211,9 @@ describe("buildChainStakeFlow", () => {
         2,
         `stake events for total_tao ${JSON.stringify(blank)}`,
       );
+      assert.equal(data.network.unstake_events, 1);
       assert.equal(data.subnets[0].total_staked_tao, 100);
+      assert.equal(data.subnets[0].total_unstaked_tao, 40);
     }
   });
 
@@ -214,8 +223,15 @@ describe("buildChainStakeFlow", () => {
         {
           netuid: 9,
           event_kind: "StakeAdded",
+          total_tao: null,
+          event_count: 2,
+          last_observed: OBS,
+        },
+        {
+          netuid: 8,
+          event_kind: "StakeRemoved",
           total_tao: "abc",
-          event_count: "x",
+          event_count: 3,
           last_observed: 0,
         },
       ],

--- a/tests/stake-flow.test.mjs
+++ b/tests/stake-flow.test.mjs
@@ -92,15 +92,40 @@ describe("buildStakeFlow", () => {
     assert.equal(data.net_flow_tao, 0.3);
   });
 
-  test("null / non-finite total_tao defaults to zero", () => {
+  test("skips blank total_tao rows instead of counting phantom stake events", () => {
+    for (const blank of ["", "   "]) {
+      const data = buildStakeFlow(
+        [
+          {
+            event_kind: STAKE_ADDED_KIND,
+            total_tao: blank,
+            event_count: 4,
+          },
+          { event_kind: STAKE_ADDED_KIND, total_tao: 10, event_count: 1 },
+        ],
+        1,
+        {},
+      );
+      assert.equal(
+        data.stake_events,
+        1,
+        `stake_events for total_tao ${JSON.stringify(blank)}`,
+      );
+      assert.equal(data.total_staked_tao, 10);
+    }
+  });
+
+  test("skips null/blank/non-numeric total_tao rows instead of coercing to zero flow", () => {
     const rows = [
-      { event_kind: STAKE_ADDED_KIND, total_tao: null, event_count: 0 },
-      { event_kind: STAKE_REMOVED_KIND, total_tao: "nope", event_count: 0 },
+      { event_kind: STAKE_ADDED_KIND, total_tao: null, event_count: 2 },
+      { event_kind: STAKE_REMOVED_KIND, total_tao: "nope", event_count: 3 },
     ];
     const data = buildStakeFlow(rows, 1, {});
     assert.equal(data.total_staked_tao, 0);
     assert.equal(data.total_unstaked_tao, 0);
     assert.equal(data.net_flow_tao, 0);
+    assert.equal(data.stake_events, 0);
+    assert.equal(data.unstake_events, 0);
   });
 });
 

--- a/tests/stake-flow.test.mjs
+++ b/tests/stake-flow.test.mjs
@@ -101,7 +101,13 @@ describe("buildStakeFlow", () => {
             total_tao: blank,
             event_count: 4,
           },
+          {
+            event_kind: STAKE_REMOVED_KIND,
+            total_tao: blank,
+            event_count: 2,
+          },
           { event_kind: STAKE_ADDED_KIND, total_tao: 10, event_count: 1 },
+          { event_kind: STAKE_REMOVED_KIND, total_tao: 5, event_count: 1 },
         ],
         1,
         {},
@@ -111,7 +117,9 @@ describe("buildStakeFlow", () => {
         1,
         `stake_events for total_tao ${JSON.stringify(blank)}`,
       );
+      assert.equal(data.unstake_events, 1);
       assert.equal(data.total_staked_tao, 10);
+      assert.equal(data.total_unstaked_tao, 5);
     }
   });
 


### PR DESCRIPTION
## Summary

Skip blank/null/non-numeric `total_tao` rows across all three stake-flow builders so malformed D1 aggregate cells do not inflate `stake_events` / `unstake_events` as phantom zero-TAO flow. Mirrors the counterparties leaderboard parity fix (#3059).

## What Changed

- Add `nullableTao()` and skip guards in:
  - `src/account-stake-flow.mjs` (`buildAccountStakeFlow`)
  - `src/chain-stake-flow.mjs` (`buildChainStakeFlow`)
  - `src/stake-flow.mjs` (`buildStakeFlow`)
- Update regression coverage in the matching test files for blank vs literal-zero `total_tao` rows.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/account-stake-flow.test.mjs tests/chain-stake-flow.test.mjs tests/stake-flow.test.mjs`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Stake-flow family parity fix following #3059.
