### PR TITLE
fix(economics-trends): drop the partial oldest day when the read is row-capped

### DIFF
--- a/src/economics-trends.mjs
+++ b/src/economics-trends.mjs
@@ -39,6 +39,11 @@ export async function loadEconomicsTrends(
   sql += " ORDER BY snapshot_date DESC LIMIT ?";
   params.push(ECONOMICS_TRENDS_ROW_CAP);
   const rows = await d1(sql, params);
-  const data = buildEconomicsTrends(rows, { window: windowLabel });
+  // Hitting the LIMIT means the oldest snapshot_date is truncated mid-day; flag it
+  // so buildEconomicsTrends drops that partial day (mirrors loadSubnetConcentrationHistory).
+  const data = buildEconomicsTrends(rows, {
+    window: windowLabel,
+    capped: rows.length >= ECONOMICS_TRENDS_ROW_CAP,
+  });
   return { data, rows };
 }

--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -352,7 +352,7 @@ export function buildNeuronHistory(rows, netuid, uid, { window } = {}) {
 // stake-weighted mean + median alpha price can be computed here. Rows arrive newest
 // first; the output preserves that order. Null-safe throughout — a metric is null
 // for a day only when NO subnet reported it.
-export function buildEconomicsTrends(rows, { window } = {}) {
+export function buildEconomicsTrends(rows, { window, capped } = {}) {
   const byDay = new Map(); // snapshot_date -> accumulator (insertion order = newest first)
   for (const r of rows || []) {
     const day = r.snapshot_date;
@@ -406,7 +406,13 @@ export function buildEconomicsTrends(rows, { window } = {}) {
       }
     }
   }
-  const days = [...byDay.entries()].map(([snapshot_date, acc]) => ({
+  // A row-capped read (the loader's LIMIT was hit) cuts the oldest snapshot_date
+  // mid-day, so that day only holds the subnets that happened to fall inside the
+  // cap — a spuriously small "network total". Drop that partial oldest day (the
+  // last entry, since byDay is newest-first), matching buildConcentrationHistory.
+  let entries = [...byDay.entries()];
+  if (capped && entries.length > 1) entries = entries.slice(0, -1);
+  const days = entries.map(([snapshot_date, acc]) => ({
     snapshot_date,
     subnet_count: acc.subnet_count,
     total_stake_tao: acc.stake_seen ? roundTao(acc.stake_sum) : null,

--- a/tests/economics-trends-loader.test.mjs
+++ b/tests/economics-trends-loader.test.mjs
@@ -73,4 +73,33 @@ describe("loadEconomicsTrends", () => {
     assert.equal(data.day_count, 0);
     assert.deepEqual(data.days, []);
   });
+
+  test("flags capped and drops the truncated oldest day when the row cap is hit", async () => {
+    // Saturate the read to exactly the row cap: the newest day fills the LIMIT and
+    // the oldest snapshot_date survives with a single (partial) subnet — its
+    // network total would be spuriously tiny, so the capped path must drop it.
+    const d1 = async () => {
+      const rows = new Array(ECONOMICS_TRENDS_ROW_CAP);
+      for (let i = 0; i < ECONOMICS_TRENDS_ROW_CAP - 1; i += 1) {
+        rows[i] = {
+          snapshot_date: "2026-06-20",
+          total_stake_tao: 10,
+          validator_count: 1,
+        };
+      }
+      rows[ECONOMICS_TRENDS_ROW_CAP - 1] = {
+        snapshot_date: "2025-01-01",
+        total_stake_tao: 5,
+        validator_count: 1,
+      };
+      return rows;
+    };
+    const { data, rows } = await loadEconomicsTrends(d1, {
+      windowLabel: "all",
+      windowDays: null,
+    });
+    assert.equal(rows.length, ECONOMICS_TRENDS_ROW_CAP);
+    assert.equal(data.day_count, 1); // the truncated oldest 2025-01-01 day is dropped
+    assert.equal(data.days[0].snapshot_date, "2026-06-20");
+  });
 });

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -395,6 +395,43 @@ describe("history builders", () => {
     assert.equal(recent.mean_emission_share, 0.03);
   });
 
+  test("buildEconomicsTrends drops the partial oldest day when the read was capped", () => {
+    // A row-capped read truncates the oldest snapshot_date mid-day (only some of
+    // that day's subnets survive the LIMIT), so its network total is spuriously
+    // small. capped:true must drop it, matching buildConcentrationHistory.
+    const rows = [
+      { snapshot_date: "2026-06-02", total_stake_tao: 300, validator_count: 8 },
+      // 2026-06-01 really had the full network but only one subnet fell inside the cap.
+      { snapshot_date: "2026-06-01", total_stake_tao: 5, validator_count: 1 },
+    ];
+    const capped = buildEconomicsTrends(rows, { window: "all", capped: true });
+    assert.equal(capped.day_count, 1);
+    assert.deepEqual(
+      capped.days.map((d) => d.snapshot_date),
+      ["2026-06-02"], // the partial oldest 2026-06-01 is dropped
+    );
+    // Without the cap flag the same rows keep every day (the default path).
+    const full = buildEconomicsTrends(rows, { window: "all" });
+    assert.equal(full.day_count, 2);
+  });
+
+  test("buildEconomicsTrends keeps a lone day even when capped (never empties the series)", () => {
+    // Only one day present: there is no complete day behind it to fall back to, so
+    // the guard keeps it rather than returning an empty series.
+    const out = buildEconomicsTrends(
+      [
+        {
+          snapshot_date: "2026-06-02",
+          total_stake_tao: 100,
+          validator_count: 4,
+        },
+      ],
+      { capped: true },
+    );
+    assert.equal(out.day_count, 1);
+    assert.equal(out.days[0].snapshot_date, "2026-06-02");
+  });
+
   test("buildEconomicsTrends skips zero-stake rows from the weighted price, keeps them in the median", () => {
     const out = buildEconomicsTrends([
       {


### PR DESCRIPTION
## Summary

`loadEconomicsTrends` reads `subnet_snapshots` newest-first under `LIMIT 60000` (`ECONOMICS_TRENDS_ROW_CAP`). That table is **never pruned** and is backfilled with years of history (`scripts/backfill-economics-history.py`), so once the store spans more than `~60000 / 130 ≈ 461` days, `GET /api/v1/economics/trends?window=all` returns exactly the 60000 newest rows — and the **oldest `snapshot_date` in that result is cut mid-day**: only the subnets that happened to fall inside the cap survive.

`buildEconomicsTrends` then emits a day point for that truncated date with a **spuriously small network total** — `subnet_count`, `total_stake_tao`, `validator_count`, and the weighted/median `alpha_price` / `mean_emission_share` all computed over a partial subnet set for a day that really had the full network.

## Fix

Flag the capped read and drop that partial oldest day — exactly what the direct sibling `buildConcentrationHistory` / `loadSubnetConcentrationHistory` already do for the identical shape (per-subnet rows per day, `ORDER BY snapshot_date DESC LIMIT CAP`, one aggregated point per day):

- `src/economics-trends.mjs` — pass `capped: rows.length >= ECONOMICS_TRENDS_ROW_CAP` into `buildEconomicsTrends` (mirrors `loadSubnetConcentrationHistory`'s `capped: rows.length >= CONCENTRATION_HISTORY_ROW_CAP`).
- `src/neuron-history.mjs` — `buildEconomicsTrends` drops the oldest entry (last, since the accumulator is newest-first) when `capped && entries.length > 1`, mirroring `buildConcentrationHistory`'s `if (capped && dates.length > 1) dates = dates.slice(0, -1)`. A lone day is kept (never empties the series).

Complete days are unaffected; only the truncated boundary day is removed. No schema/contract/artifact change (live-computed route).

## Tests

- `tests/neuron-history.test.mjs` — the capped read drops the partial oldest day; a lone capped day is kept; the uncapped path keeps every day.
- `tests/economics-trends-loader.test.mjs` — saturating the read to exactly `ECONOMICS_TRENDS_ROW_CAP` rows drops the truncated oldest day end-to-end.

## Registry Safety

- [x] No secrets, PATs, wallet data, private URLs, or validator-local state.
- [x] No generated artifacts touched (live-computed route).
- [x] Public API shape unchanged — only a spurious partial-day point is removed.

## Validation

Run locally (Windows; Node 22):

- [x] `vitest run tests/neuron-history.test.mjs tests/economics-trends-loader.test.mjs --coverage` — 62 passing; **100% line coverage** of both changed modules (every changed line covered)
- [x] `eslint` + `prettier --check` on the changed files (clean, LF)
- [x] `npm run scan:public-safety` · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
