### PR TITLE
fix(economics-trends): reject blank D1 cells that coerce to 0

### DIFF
--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -430,8 +430,12 @@ export function buildEconomicsTrends(rows, { window } = {}) {
   };
 }
 
+// Blank D1 cells coerce via Number("") -> 0; trim rejects "" / whitespace-only
+// so a blank cell is excluded from the day's aggregate rather than read as a
+// genuine 0. Mirrors toNonNegativeInt above.
 function toFiniteOrNull(v) {
   if (v == null) return null;
+  if (typeof v === "string" && v.trim() === "") return null;
   const n = Number(v);
   return Number.isFinite(n) ? n : null;
 }

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -423,6 +423,37 @@ describe("history builders", () => {
     assert.equal(day.window, undefined);
   });
 
+  test("buildEconomicsTrends excludes blank-string cells from the day's aggregate", () => {
+    const out = buildEconomicsTrends([
+      {
+        snapshot_date: "2026-06-05",
+        total_stake_tao: "",
+        alpha_price_tao: "",
+        validator_count: "",
+        miner_count: "",
+        emission_share: "",
+      },
+      {
+        snapshot_date: "2026-06-05",
+        total_stake_tao: 200,
+        alpha_price_tao: 0.1,
+        validator_count: 3,
+        miner_count: 5,
+        emission_share: 0.2,
+      },
+    ]);
+    const [day] = out.days;
+    // Blank row contributes nothing: aggregates match the single real row, not
+    // a 0-inflated/deflated blend.
+    assert.equal(day.subnet_count, 2);
+    assert.equal(day.total_stake_tao, 200);
+    assert.equal(day.alpha_price_tao_weighted, 0.1);
+    assert.equal(day.alpha_price_tao_median, 0.1);
+    assert.equal(day.validator_count, 3);
+    assert.equal(day.miner_count, 5);
+    assert.equal(day.mean_emission_share, 0.2);
+  });
+
   test("buildEconomicsTrends is empty + null-safe on no rows", () => {
     const out = buildEconomicsTrends([]);
     assert.equal(out.day_count, 0);


### PR DESCRIPTION
## Summary
- `toFiniteOrNull` in `src/neuron-history.mjs` accepted a blank/whitespace-only string cell as `0` (`Number("") === 0`), so a `subnet_snapshots` row with a blank `total_stake_tao`, `alpha_price_tao`, `validator_count`, `miner_count`, or `emission_share` was folded into `buildEconomicsTrends`'s per-day aggregate as a genuine zero observation instead of being excluded.
- Reachable end-to-end and directly visible in the response body: `GET /api/v1/economics/trends` -> `handleEconomicsTrends` -> `loadEconomicsTrends` (a raw `SELECT` with no `GROUP BY`, so a blank cell passes through verbatim) -> `buildEconomicsTrends` -> `toFiniteOrNull`. No earlier query-param validation touches D1 row content, so nothing upstream blocks this. A blank `alpha_price_tao` skews `alpha_price_tao_median`/`alpha_price_tao_weighted` toward zero; a blank `total_stake_tao`/`validator_count`/`miner_count`/`emission_share` deflates the corresponding day-level sum.
- Mirrors `toNonNegativeInt`'s existing blank-string guard in the same file, and the same class of fix already merged elsewhere in this codebase for the same D1-blank-cell issue.

## Test plan
- [x] New unit test: `buildEconomicsTrends` with one row carrying blank-string cells for all five fields alongside one real row - asserts the day's aggregate matches the real row only, not a 0-blended value
- [x] `npm run lint` (scoped to changed files)
- [x] `npm run validate`
- [x] `npx vitest run tests/neuron-history.test.mjs --coverage --coverage.include='src/neuron-history.mjs'` - 55 passed; the single new line is fully covered (patch diff is one line)
