### PR TITLE
feat(registry): add SN62 Ridges evaluation-set problems data-artifact

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,22 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-eval-set-problems",
+      "kind": "data-artifact",
+      "name": "Ridges latest evaluation-set problems",
+      "notes": "Public no-auth JSON catalog of the problems in Ridges' latest evaluation sets (set_id, problem_name, benchmark_family e.g. swe-bench) that agents are scored against; GET /evaluation-sets/all-latest-set-problems in the official Ridges OpenAPI spec. Distinct endpoint from the registered /retrieval/top-agents route.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": ["https://agent-upload.ridges.ai/openapi.json"],
+      "url": "https://agent-upload.ridges.ai/evaluation-sets/all-latest-set-problems"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/ridges.json` (SN62 Ridges). Append-only; no top-level metadata or existing surfaces touched.

## Summary

SN62 (Ridges) had no `data-artifact` surface. Ridges is an autonomous SWE-coding-agent subnet, and its API exposes a public, no-auth JSON catalog of the problems in its latest evaluation sets (`GET /evaluation-sets/all-latest-set-problems`) — the SWE-bench-family problems that agents are scored against. This adds it as a `data-artifact`, sourced from the subnet's official OpenAPI contract.

This is a **distinct endpoint** from the already-registered `/retrieval/top-agents` route — a separate evaluation-problem catalog, not a re-titling of an existing surface.

## Surface

- Netuid: 62
- Kind: data-artifact
- Public URL: https://agent-upload.ridges.ai/evaluation-sets/all-latest-set-problems
- Source URL (proves the claim): https://agent-upload.ridges.ai/openapi.json
- Provider slug: ridges

The endpoint is defined in the official Ridges OpenAPI spec as `Evaluation Sets All Latest Set Problems` with no security requirement (verified: `paths./evaluation-sets/all-latest-set-problems.get.security` is absent). The `agent-upload.ridges.ai` host is the first-party API base already established by the existing OpenAPI surface.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this endpoint, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public endpoint plus the official OpenAPI source fully establish and verify the claim.

## Checklist

- [x] Changes exactly one `registry/subnets/ridges.json` file (append-only; no top-level metadata or existing surfaces touched).
- [x] The `url` is public, no-auth, read-only-safe; the `source_url` (official OpenAPI) independently proves the subnet publishes it.
- [x] Public-safe: no secrets, wallet/PAT data, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface — distinct URL from all registered Ridges routes.
- [x] No linked issue — rationale provided above.

## Validation

- [x] `npm run validate:surface -- registry/subnets/ridges.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate` (full suite, green)
