### PR TITLE
fix(api): exclude rows missing the field from a string list filter

### DIFF
--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -1177,3 +1177,64 @@ describe("list-query paginationLinkHeader canonicalization", () => {
     );
   });
 });
+
+// A string-equality filter must exclude a row that is MISSING the filtered field
+// — the same absent-field-excluded convention rangeFilterRows already applies —
+// instead of letting String(undefined)/String(null) coerce into a matchable token.
+describe("list-query string filter excludes rows missing the field", () => {
+  const collection = "__test_string_filter_missing_field";
+
+  function withCollection(fn) {
+    const previous = API_QUERY_COLLECTIONS[collection];
+    API_QUERY_COLLECTIONS[collection] = {
+      data_key: "rows",
+      filters: { provider: { type: "string" } },
+      csv_filters: {},
+      array_filters: {},
+      range_filters: [],
+      search_keys: [],
+      sort_fields: [],
+    };
+    try {
+      return fn();
+    } finally {
+      if (previous === undefined) {
+        delete API_QUERY_COLLECTIONS[collection];
+      } else {
+        API_QUERY_COLLECTIONS[collection] = previous;
+      }
+    }
+  }
+
+  const data = {
+    rows: [
+      { id: 1, provider: "alpha" },
+      { id: 2 }, // provider absent
+    ],
+  };
+  const ids = (result) => result.data.rows.map((row) => row.id);
+
+  test("?provider=undefined does not match a row whose provider is absent", () => {
+    withCollection(() => {
+      // Before the null guard, String(undefined) === "undefined" made the
+      // provider-less row match; a missing field must never satisfy a value filter.
+      const result = applyQueryFilters(
+        data,
+        query("/api/v1/x?provider=undefined"),
+        collection,
+      );
+      assert.deepEqual(ids(result), []);
+    });
+  });
+
+  test("a real filter value still matches only the rows that carry it", () => {
+    withCollection(() => {
+      const result = applyQueryFilters(
+        data,
+        query("/api/v1/x?provider=alpha"),
+        collection,
+      );
+      assert.deepEqual(ids(result), [1]);
+    });
+  });
+});

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -201,6 +201,11 @@ function filterRows(rows, params, keys, csvFilters = {}, arrayFilters = {}) {
         );
       }
       const value = row[key];
+      // A row missing the filtered field can't satisfy a value filter — exclude
+      // it rather than letting String(undefined)/String(null) coerce into a
+      // matchable "undefined"/"null" token (mirrors the absent-field exclusion in
+      // rangeFilterRows, where a non-numeric/absent field fails every bound).
+      if (value == null) return false;
       if (Array.isArray(value)) {
         return value.map((v) => String(v).toLowerCase()).includes(expectedCi);
       }


### PR DESCRIPTION
## Summary

`filterRows` in `workers/list-query.mjs` compares `String(row[key]).toLowerCase()` to the requested filter value **without guarding an absent field**. When a row omits the filtered field, `row[key]` is `undefined` and `String(undefined) === "undefined"` (and `String(null) === "null"`), so:

```
GET /api/v1/endpoints?provider=undefined     (or ?field=null)
```

matches **every row that has no `provider`** — a *missing* field satisfying a value filter purely through a JS coercion accident, not any real field value. Plain-string (`textSchema`) filters have no enum/pattern, so `validateListQuery` accepts `undefined`/`null` as ordinary values and returns a normal 200.

## Fix

Exclude a row whose filtered field is `null`/`undefined` before the string compare — the same absent-field-excluded convention the sibling `rangeFilterRows` in this file already documents and applies (*"A row whose F is absent … can't satisfy a bound, so it is excluded once any bound on F is set"*, with an explicit `if (typeof value !== "number") return false`). A present field still matches exactly as before.

```js
const value = row[key];
if (value == null) return false; // missing field can't satisfy a value filter
if (Array.isArray(value)) { ... }
return String(value).toLowerCase() === expectedCi;
```

Single-line behavioural fix; no schema/contract/artifact change.

## Tests

`tests/list-query.test.mjs` — a collection with one row that carries the field and one that omits it: `?provider=undefined` returns nothing (the provider-less row is no longer coerced into a match), while a real value (`?provider=alpha`) still matches only the row that carries it. Exercises both the new `return false` branch and the retained match/no-match paths.

## Registry Safety

- [x] No secrets, PATs, wallet data, private URLs, or validator-local state.
- [x] No generated artifacts touched.
- [x] Public API shape unchanged — a spurious match is removed; correct matches are unaffected.

## Validation

Run locally (Windows; Node 22):

- [x] `vitest run tests/list-query.test.mjs --coverage` — passing; the added line is confirmed covered (v8) — **100% patch coverage** of the change
- [x] `eslint` + `prettier --check` on the changed files (clean, LF)
- [x] `npm run scan:public-safety` · `git diff --check`

No linked issue (issue creation on this repo returns 404 for the available account; a linked issue is optional per `CONTRIBUTING.md`).
