### PR TITLE
fix(movers): skip blank snapshot aggregates in cross-subnet rollups

### DIFF
--- a/src/movers.mjs
+++ b/src/movers.mjs
@@ -33,6 +33,15 @@ function toNumber(value) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+// A finite aggregate cell, or null when absent/blank/non-numeric. Blank D1 cells coerce
+// via Number("") → 0; trim rejects "" / whitespace-only (mirrors counterparties #3059).
+function nullableNumber(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
 // A non-negative integer netuid, or null for a malformed/absent cell. Guard null
 // explicitly so a null netuid is skipped rather than coerced to subnet 0
 // (Number(null) === 0). Mirrors normalizedNetuid in account-stake-flow.mjs.
@@ -58,12 +67,19 @@ function indexByNetuid(rows) {
   for (const row of Array.isArray(rows) ? rows : []) {
     const netuid = normalizedNetuid(row?.netuid);
     if (netuid == null) continue;
-    map.set(netuid, {
-      neurons: toNumber(row?.neuron_count),
-      validators: toNumber(row?.validator_count),
-      stake: toNumber(row?.total_stake_tao),
-      emission: toNumber(row?.total_emission_tao),
-    });
+    const neurons = nullableNumber(row?.neuron_count);
+    const validators = nullableNumber(row?.validator_count);
+    const stake = nullableNumber(row?.total_stake_tao);
+    const emission = nullableNumber(row?.total_emission_tao);
+    if (
+      neurons == null ||
+      validators == null ||
+      stake == null ||
+      emission == null
+    ) {
+      continue;
+    }
+    map.set(netuid, { neurons, validators, stake, emission });
   }
   return map;
 }

--- a/tests/movers.test.mjs
+++ b/tests/movers.test.mjs
@@ -9,7 +9,11 @@ import {
 } from "../src/movers.mjs";
 
 // Aggregate row helper: one neuron_daily GROUP BY netuid,snapshot_date row.
-function agg(netuid, snapshot_date, { neurons, validators, stake, emission }) {
+function agg(
+  netuid,
+  snapshot_date,
+  { neurons = 0, validators = 0, stake = 0, emission = 0 } = {},
+) {
   return {
     netuid,
     snapshot_date,
@@ -174,10 +178,9 @@ describe("computeMovers", () => {
     assert.equal(m[0].netuid, 1);
   });
 
-  test("skips rows with a malformed netuid and coerces non-finite cells to zero", () => {
+  test("skips rows with a malformed netuid", () => {
     const m = computeMovers(
       [
-        agg(1, "s", { neurons: 1, validators: 0, stake: "oops", emission: 0 }),
         {
           netuid: "bad",
           snapshot_date: "s",
@@ -190,10 +193,99 @@ describe("computeMovers", () => {
       [agg(1, "e", { neurons: 1, validators: 0, stake: 50, emission: 0 })],
       { sort: "stake" },
     );
-    assert.equal(m.length, 1); // the "bad" netuid row is dropped
+    assert.equal(m.length, 1);
     assert.equal(m[0].netuid, 1);
-    assert.equal(m[0].stake_start_tao, 0); // "oops" coerced to 0
-    assert.equal(m[0].stake_delta_tao, 50);
+  });
+
+  test("skips blank/null/non-numeric aggregate cells instead of coercing to zero", () => {
+    for (const blank of ["", "   ", null, "oops"]) {
+      const m = computeMovers(
+        [
+          agg(1, "s", {
+            neurons: 100,
+            validators: 5,
+            stake: blank,
+            emission: 10,
+          }),
+          agg(2, "s", { neurons: 10, validators: 2, stake: 50, emission: 5 }),
+        ],
+        [
+          agg(1, "e", { neurons: 50, validators: 3, stake: 200, emission: 12 }),
+          agg(2, "e", { neurons: 10, validators: 2, stake: 60, emission: 5 }),
+        ],
+        { sort: "stake" },
+      );
+      const s1 = m.find((x) => x.netuid === 1);
+      // Start snapshot skipped -> treated as absent (zeros), not phantom 0 stake / 100 neurons.
+      assert.equal(
+        s1.stake_start_tao,
+        0,
+        `stake_start for total_stake_tao ${JSON.stringify(blank)}`,
+      );
+      assert.equal(
+        s1.neurons_start,
+        0,
+        `neurons_start for total_stake_tao ${JSON.stringify(blank)}`,
+      );
+      assert.equal(s1.stake_end_tao, 200);
+      assert.equal(s1.neurons_end, 50);
+      const { network } = buildMovers(
+        [
+          agg(1, "s", {
+            neurons: 100,
+            validators: 5,
+            stake: blank,
+            emission: 10,
+          }),
+          agg(2, "s", { neurons: 10, validators: 2, stake: 50, emission: 5 }),
+        ],
+        [
+          agg(1, "e", {
+            neurons: 50,
+            validators: 3,
+            stake: 200,
+            emission: 12,
+          }),
+          agg(2, "e", { neurons: 10, validators: 2, stake: 60, emission: 5 }),
+        ],
+        { window: "30d", startDate: "s", endDate: "e", sort: "stake" },
+      );
+      assert.equal(
+        network.total_stake_start_tao,
+        50,
+        `network stake start for total_stake_tao ${JSON.stringify(blank)}`,
+      );
+      assert.equal(
+        network.total_validators_start,
+        2,
+        `network validators start for total_stake_tao ${JSON.stringify(blank)}`,
+      );
+    }
+    const zero = computeMovers(
+      [agg(1, "s", { neurons: 1, validators: 0, stake: 0, emission: 0 })],
+      [agg(1, "e", { neurons: 1, validators: 0, stake: 50, emission: 0 })],
+      { sort: "stake" },
+    );
+    assert.equal(zero[0].stake_start_tao, 0);
+    assert.equal(zero[0].stake_delta_tao, 50);
+  });
+
+  test("skips rows with blank emission aggregates", () => {
+    const m = computeMovers(
+      [
+        agg(1, "s", {
+          neurons: 10,
+          validators: 2,
+          stake: 100,
+          emission: "   ",
+        }),
+      ],
+      [agg(1, "e", { neurons: 10, validators: 2, stake: 100, emission: 5 })],
+      { sort: "emission" },
+    );
+    assert.equal(m[0].emission_start_tao, 0);
+    assert.equal(m[0].emission_end_tao, 5);
+    assert.equal(m[0].emission_delta_tao, 5);
   });
 
   test("skips rows with a null or blank netuid instead of coercing to subnet 0", () => {


### PR DESCRIPTION
## Summary

Skip blank/null/non-numeric `neuron_daily` aggregate cells in the cross-subnet movers rollup instead of coercing them to zero while still indexing the subnet. Malformed snapshot rows were inflating network totals and distorting stake/emission/neuron deltas on the `/subnets/movers` leaderboard — the same phantom-metric class as counterparties #3059 and stake-flow #3068, but on the network-wide momentum scorecard.

## What Changed

- Add `nullableNumber()` to `src/movers.mjs` and route `indexByNetuid()` through it for all four aggregate columns (`neuron_count`, `validator_count`, `total_stake_tao`, `total_emission_tao`).
- Skip the entire snapshot row when any aggregate cell is absent/blank/non-numeric instead of materializing `{ stake: 0, neurons: N, … }` phantom boundary values.
- Replace the old “coerce non-finite cells to zero” regression with coverage for null/blank/non-numeric vs literal-zero cells, including network-summary totals and blank emission paths.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/movers.test.mjs`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. High-impact parity fix for the blank-cell guard series (#3059, #3068).
