### PR TITLE
fix(agent-catalog): resolve previously_known_as against native_name, not curated name

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1698,6 +1698,11 @@ for (const subnet of mergedSubnets) {
       netuid: subnet.netuid,
       slug: subnet.slug,
       name: subnet.name,
+      // On-chain identity name, distinct from the curated `name` above — the
+      // serve-time previously_known_as overlay needs this to resolve the
+      // subnet's CURRENT on-chain name (matching the per-subnet route's
+      // convention) so it isn't mistaken for one of its own past aliases.
+      native_name: subnet.native_name,
       categories: Array.isArray(profile?.categories) ? profile.categories : [],
       subnet_type: profile?.subnet_type || null,
       completeness_score: profile?.completeness_score ?? null,

--- a/src/subnet-identity-history.mjs
+++ b/src/subnet-identity-history.mjs
@@ -319,7 +319,7 @@ export async function loadPreviouslyKnownAsForNetuids(d1, entries) {
   const currentByNetuid = new Map(
     items
       .filter((entry) => Number.isInteger(entry?.netuid))
-      .map((entry) => [entry.netuid, entry.name ?? entry.native_name ?? null]),
+      .map((entry) => [entry.netuid, entry.native_name ?? entry.name ?? null]),
   );
   const grouped = new Map();
   for (const row of rows || []) {

--- a/tests/subnet-identity-history.test.mjs
+++ b/tests/subnet-identity-history.test.mjs
@@ -973,12 +973,14 @@ describe("loadPreviouslyKnownAsForNetuids", () => {
     assert.equal(map.size, 0);
   });
 
-  test("prefers name over native_name for the current label", async () => {
+  test("prefers native_name over name for the current label, matching the per-subnet route", async () => {
     const map = await loadPreviouslyKnownAsForNetuids(
-      async () => [{ netuid: 7, subnet_name: "Old Allways", observed_at: 1 }],
+      async () => [{ netuid: 7, subnet_name: "Legacy", observed_at: 1 }],
       [{ netuid: 7, name: "Allways", native_name: "Legacy" }],
     );
-    assert.deepEqual(map.get(7), ["Old Allways"]);
+    // "Legacy" is the current on-chain native_name, so it's excluded rather
+    // than leaking into the subnet's own previously_known_as list.
+    assert.equal(map.get(7), undefined);
   });
 
   test("treats null D1 rows as empty", async () => {


### PR DESCRIPTION
## Summary
- `loadPreviouslyKnownAsForNetuids` resolved a subnet's current identity as `entry.name` (the curated/display name) before `entry.native_name` - but agent-catalog build entries never carried `native_name` at all, so this always fell through to the curated name.
- When a subnet's curated `name` differs from its on-chain identity text (common for any actively-curated subnet), no identity-history row textually matches the curated name, so the subnet's own current on-chain name is never excluded from its `previously_known_as` array - it leaks into its own alias list on `GET /api/v1/agent-catalog`.
- The sibling per-subnet route (`GET /api/v1/subnets/{netuid}`) already resolves current identity as `native_name ?? name` (`workers/api.mjs:2728`); the agent-catalog list route used the opposite precedence and lacked the data to use it correctly either way.
- Fix: add `native_name` to the agent-catalog build index (`scripts/build-artifacts.mjs`) - this is R2-only/non-committed output (`agent-catalog.json` matches an R2-only storage pattern), so no derived artifact needs committing - and swap the resolution precedence in `subnet-identity-history.mjs` to match the per-subnet route's convention. The response schema already declares `additionalProperties: true` for catalog subnet entries, so the new field is not a breaking contract change.

## Test plan
- [x] Updated the existing (previously non-exercising) precedence test to actually assert the fix: a row matching `native_name` (not `name`) is now correctly excluded from `previously_known_as`
- [x] `npm run lint` (scoped to changed files)
- [x] `npm run validate`
- [x] `npm run build` then `npx vitest run tests/artifacts.test.mjs` - no regressions (pre-existing Windows-local `wrangler`/r2-upload spawn failures unrelated to this change)
- [x] `npx vitest run tests/subnet-identity-history.test.mjs --coverage --coverage.include='src/subnet-identity-history.mjs'` - 57 passed, the one changed line fully covered
