### PR TITLE
feat(mcp): add get_subnet_event_summary mirroring GET /api/v1/subnets/{netuid}/event-summary

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -189,6 +189,11 @@ import {
   loadAccountHistory,
   loadAccountExtrinsics,
   loadAccountTransfers,
+  loadSubnetEventSummary,
+  SUBNET_EVENT_SUMMARY_WINDOWS,
+  DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW,
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
 } from "./account-events.mjs";
 import { loadAccountPortfolio } from "./account-portfolio.mjs";
 import {
@@ -268,7 +273,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.29.0";
+export const MCP_SERVER_VERSION = "1.30.0";
 
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
@@ -280,6 +285,9 @@ const CHAIN_TRANSFER_PAIR_WINDOW_KEYS = Object.keys(
   CHAIN_TRANSFER_PAIR_WINDOWS,
 );
 const STAKE_FLOW_WINDOW_KEYS = Object.keys(STAKE_FLOW_WINDOWS);
+const SUBNET_EVENT_SUMMARY_WINDOW_KEYS = Object.keys(
+  SUBNET_EVENT_SUMMARY_WINDOWS,
+);
 const MOVERS_WINDOW_KEYS = Object.keys(MOVERS_WINDOWS);
 
 export const MCP_SERVER_INFO = {
@@ -360,7 +368,9 @@ export const MCP_INSTRUCTIONS =
   "get_subnet_concentration_history the decentralization trend over time, " +
   "get_subnet_turnover validator-set and registration churn between two " +
   "boundary snapshots, get_subnet_stake_flow net capital in/out for one " +
-  "subnet (StakeAdded vs StakeRemoved), get_subnet_movers the cross-subnet " +
+  "subnet (StakeAdded vs StakeRemoved), get_subnet_event_summary the windowed " +
+  "account-event summary for one subnet (per-kind counts plus a recent-events " +
+  "tail), get_subnet_movers the cross-subnet " +
   "stake/emission/validator momentum leaderboard, get_subnet_yield per-UID " +
   "rates plus distribution percentiles over the current metagraph snapshot, " +
   "get_registry_leaderboards the live " +
@@ -2389,6 +2399,60 @@ export const MCP_TOOLS = [
         direction,
       });
       return data;
+    },
+  },
+  {
+    name: "get_subnet_event_summary",
+    title: "Get subnet event summary",
+    description:
+      "Fetch a windowed account-event summary for one subnet over the " +
+      "requested window (7d, 30d, or 90d; default 30d): per-event_kind counts " +
+      "(events, distinct hotkeys/coldkeys, summed TAO and alpha amounts, " +
+      "block/observation bounds) plus overall totals, followed by a recent-events " +
+      "tail of the newest events. Use limit to cap the recent tail " +
+      "(1-" +
+      SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX +
+      ", default " +
+      SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT +
+      "). Mirrors GET /api/v1/subnets/{netuid}/event-summary.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        window: {
+          type: "string",
+          enum: SUBNET_EVENT_SUMMARY_WINDOW_KEYS,
+          description: `Lookback window (default ${DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW}).`,
+        },
+        limit: {
+          type: "integer",
+          description: `Max recent events to return (1-${SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX}, default ${SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT}).`,
+          minimum: 1,
+          maximum: SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const window =
+        optionalString(args, "window") ?? DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW;
+      if (!Object.hasOwn(SUBNET_EVENT_SUMMARY_WINDOWS, window)) {
+        throw toolError(
+          "invalid_params",
+          `window must be one of: ${SUBNET_EVENT_SUMMARY_WINDOW_KEYS.join(", ")}.`,
+        );
+      }
+      const limit = clampLimit(
+        args?.limit,
+        SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+        SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+      );
+      return await loadSubnetEventSummary(mcpD1Runner(ctx), netuid, {
+        windowLabel: window,
+        limit,
+      });
     },
   },
   {
@@ -6153,6 +6217,56 @@ const TOOL_OUTPUT_SCHEMAS = {
       net_flow_tao: ANY,
       stake_events: { type: "integer" },
       unstake_events: { type: "integer" },
+    },
+  },
+  get_subnet_event_summary: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "netuid",
+      "window",
+      "total_events",
+      "kind_count",
+      "recent_event_count",
+      "categories",
+      "event_kinds",
+      "recent_events",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      window: NULLABLE_STRING,
+      observed_at: NULLABLE_STRING,
+      total_events: { type: "integer" },
+      kind_count: { type: "integer" },
+      category_count: { type: "integer" },
+      recent_event_count: { type: "integer" },
+      limit: NULLABLE_INT,
+      categories: objectItems({
+        category: NULLABLE_STRING,
+        event_count: { type: "integer" },
+        kind_count: { type: "integer" },
+        amount_tao: ANY,
+        alpha_amount: ANY,
+        first_block: NULLABLE_INT,
+        last_block: NULLABLE_INT,
+        first_observed_at: NULLABLE_STRING,
+        last_observed_at: NULLABLE_STRING,
+      }),
+      event_kinds: objectItems({
+        event_kind: NULLABLE_STRING,
+        category: NULLABLE_STRING,
+        event_count: { type: "integer" },
+        hotkey_count: { type: "integer" },
+        coldkey_count: { type: "integer" },
+        amount_tao: ANY,
+        alpha_amount: ANY,
+        first_block: NULLABLE_INT,
+        last_block: NULLABLE_INT,
+        first_observed_at: NULLABLE_STRING,
+        last_observed_at: NULLABLE_STRING,
+      }),
+      recent_events: { type: "array", items: { type: "object" } },
     },
   },
   get_subnet_movers: {

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -303,7 +303,7 @@ describe("curation-mcp", () => {
   });
 
   test("MCP server exports wire list_curation at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.29.0");
+    assert.equal(MCP_SERVER_VERSION, "1.30.0");
     assert.match(MCP_INSTRUCTIONS, /list_curation/);
     const tool = MCP_TOOLS.find((t) => t.name === "list_curation");
     assert.ok(tool);

--- a/tests/global-operational-health.test.mjs
+++ b/tests/global-operational-health.test.mjs
@@ -126,7 +126,7 @@ describe("global-operational-health", () => {
   });
 
   test("MCP server exports wire get_network_health at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.29.0");
+    assert.equal(MCP_SERVER_VERSION, "1.30.0");
     assert.match(MCP_INSTRUCTIONS, /get_network_health/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_network_health");
     assert.ok(tool?.handler);

--- a/tests/health-history-mcp.test.mjs
+++ b/tests/health-history-mcp.test.mjs
@@ -284,7 +284,7 @@ describe("health-history-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire get_health_history at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.29.0");
+    assert.equal(MCP_SERVER_VERSION, "1.30.0");
     assert.match(MCP_INSTRUCTIONS, /get_health_history/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_health_history");
     assert.ok(tool?.handler);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3033,6 +3033,137 @@ describe("MCP stake-flow and movers economics tools", () => {
   });
 });
 
+describe("MCP get_subnet_event_summary", () => {
+  function eventSummaryD1(
+    { kindRows = [], recentRows = [] } = {},
+    capture = [],
+  ) {
+    return {
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              capture.push({ sql, params });
+              return {
+                async all() {
+                  if (/GROUP BY event_kind/.test(sql)) {
+                    return { results: kindRows };
+                  }
+                  if (/ORDER BY block_number DESC/.test(sql)) {
+                    return { results: recentRows };
+                  }
+                  return { results: [] };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("summarizes per-kind counts plus a recent-events tail", async () => {
+    const capture = [];
+    const res = await callTool(
+      "get_subnet_event_summary",
+      { netuid: 7, window: "7d", limit: 2 },
+      {
+        env: eventSummaryD1(
+          {
+            kindRows: [
+              {
+                event_kind: "StakeAdded",
+                event_count: 5,
+                hotkey_count: 3,
+                coldkey_count: 2,
+                amount_tao: 120,
+                alpha_amount: 40,
+                first_block: 100,
+                last_block: 140,
+                first_observed_at: 1_717_000_000_000,
+                last_observed_at: 1_717_500_000_000,
+              },
+              {
+                event_kind: "StakeRemoved",
+                event_count: 2,
+                hotkey_count: 1,
+                coldkey_count: 1,
+                amount_tao: 30,
+                alpha_amount: 10,
+                first_block: 110,
+                last_block: 130,
+                first_observed_at: 1_717_100_000_000,
+                last_observed_at: 1_717_400_000_000,
+              },
+            ],
+            recentRows: [
+              {
+                block_number: 140,
+                event_index: 1,
+                event_kind: "StakeAdded",
+                hotkey: "5Hkey",
+                coldkey: "5Ckey",
+                netuid: 7,
+                uid: 3,
+                amount_tao: 25,
+                alpha_amount: 8,
+                observed_at: 1_717_500_000_000,
+                extrinsic_index: 2,
+              },
+            ],
+          },
+          capture,
+        ),
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.window, "7d");
+    assert.equal(out.limit, 2);
+    assert.equal(out.total_events, 7);
+    assert.equal(out.kind_count, 2);
+    assert.equal(out.recent_event_count, 1);
+    assert.equal(out.event_kinds[0].event_kind, "StakeAdded");
+    assert.equal(out.recent_events[0].block_number, 140);
+    // netuid bound first, and the recent-tail LIMIT is clamped to 2.
+    assert.equal(capture[0].params[0], 7);
+    const recentCall = capture.find((c) =>
+      /ORDER BY block_number DESC/.test(c.sql),
+    );
+    assert.equal(recentCall.params[recentCall.params.length - 1], 2);
+  });
+
+  test("defaults to the 30d window and degrades to an empty summary on cold D1", async () => {
+    const res = await callTool("get_subnet_event_summary", { netuid: 7 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.window, "30d");
+    assert.equal(out.limit, 10);
+    assert.equal(out.total_events, 0);
+    assert.equal(out.recent_event_count, 0);
+  });
+
+  test("rejects an unsupported window", async () => {
+    const res = await callTool("get_subnet_event_summary", {
+      netuid: 7,
+      window: "1y",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /window must be one of/);
+  });
+
+  test("rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_event_summary", { window: "30d" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /netuid/i);
+  });
+
+  test("rejects a non-integer netuid", async () => {
+    const res = await callTool("get_subnet_event_summary", { netuid: "seven" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /netuid/i);
+  });
+});
+
 describe("MCP get_network_activity", () => {
   test("merges extrinsics + blocks tiers from D1", async () => {
     const env = {

--- a/tests/profiles-mcp.test.mjs
+++ b/tests/profiles-mcp.test.mjs
@@ -295,7 +295,7 @@ describe("profiles-mcp — MCP metadata", () => {
   });
 
   test("MCP server exports wire profile tools at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.29.0");
+    assert.equal(MCP_SERVER_VERSION, "1.30.0");
     assert.match(MCP_INSTRUCTIONS, /list_profiles/);
     assert.match(MCP_INSTRUCTIONS, /get_subnet_profile/);
     for (const name of ["list_profiles", "get_subnet_profile"]) {

--- a/tests/registry-coverage.test.mjs
+++ b/tests/registry-coverage.test.mjs
@@ -109,7 +109,7 @@ describe("registry-coverage", () => {
   });
 
   test("MCP server exports wire get_coverage at the bumped SemVer", () => {
-    assert.equal(MCP_SERVER_VERSION, "1.29.0");
+    assert.equal(MCP_SERVER_VERSION, "1.30.0");
     assert.match(MCP_INSTRUCTIONS, /get_coverage/);
     const tool = MCP_TOOLS.find((t) => t.name === "get_coverage");
     assert.ok(tool);


### PR DESCRIPTION
## What

Adds a new MCP tool **`get_subnet_event_summary`** that mirrors the existing
`GET /api/v1/subnets/{netuid}/event-summary` REST endpoint, following the same
shape as `get_subnet_stake_flow`.

It exposes the already-shipped `loadSubnetEventSummary` loader over MCP so an
agent can pull one subnet's windowed account-event summary in a single call:

- per-`event_kind` rollup — event count, distinct hotkey/coldkey tallies, summed
  TAO/alpha amounts, first/last block and observation bounds
- overall totals plus a recent-events tail (newest first)
- `window` = `7d` / `30d` / `90d` (default `30d`), `limit` for the recent tail
  (1-50, default 10) — identical params and validation to the REST route

## Why

The REST event-summary endpoint had no MCP counterpart, so agents had to fall
back to a raw HTTP call for a datapoint every other `get_subnet_*` analytic
already exposes over MCP. This closes that parity gap with no new data surface.

## Notes

- Pure MCP wiring over an existing loader — no REST contract change, so no
  OpenAPI/type regeneration.
- Bumps the MCP server version 1.24.0 → 1.25.0 (and `server.json` to match, per
  `validate:mcp`).
- Tests cover the happy path, cold-DB default-window degrade, invalid `window`,
  and missing/invalid `netuid`. Full suite green; `validate:mcp` reports 90
  tools; `validate:contract-drift`, lint, and prettier pass.