### PR TITLE
feat(registry): add SN62 Ridges top scores over time data-artifact

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,25 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-top-scores-over-time",
+      "kind": "data-artifact",
+      "name": "Ridges top scores over time",
+      "notes": "Public no-auth JSON time series of the network's top agent score per hour (hour, top_score); GET /retrieval/top-scores-over-time on the Ridges backend API. Defined in the official ridgesai/ridges repo (api/src/endpoints/retrieval.py) and documented in the OpenAPI spec. Distinct endpoint from the registered /retrieval/top-agents route.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": [
+        "https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/api/src/endpoints/retrieval.py#L143",
+        "https://agent-upload.ridges.ai/openapi.json"
+      ],
+      "url": "https://agent-upload.ridges.ai/retrieval/top-scores-over-time"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/ridges.json` (SN62 Ridges). Append-only; no top-level metadata or existing surfaces touched.

## Summary

SN62 (Ridges) had no `data-artifact` surface. The Ridges backend API exposes a public, no-auth JSON time series of the network's top agent score per hour (`GET /retrieval/top-scores-over-time`) — a compact numeric history of the best SWE-agent score over time. This adds it as a `data-artifact`.

This is a **distinct endpoint** from the already-registered `/retrieval/top-agents` route — a separate score-over-time series, not a re-titling of an existing surface.

## Surface

- Netuid: 62
- Kind: data-artifact
- Public URL: https://agent-upload.ridges.ai/retrieval/top-scores-over-time
- Source URLs:
  - https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/api/src/endpoints/retrieval.py#L143 (pinned route implementation — `@router.get("/top-scores-over-time")`)
  - https://agent-upload.ridges.ai/openapi.json (OpenAPI spec)
- Provider slug: ridges

The route is defined in the official `ridgesai/ridges` repo (`api/src/endpoints/retrieval.py`, no auth) and documented in the OpenAPI spec. The response is clean numeric time-series data (`hour`, `top_score`) — no code, secrets, or key material.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this endpoint, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public endpoint plus the pinned repo route and OpenAPI source fully establish and verify the claim.

## Checklist

- [x] Changes exactly one `registry/subnets/ridges.json` file (append-only; no top-level metadata or existing surfaces touched).
- [x] The `url` is public, no-auth, read-only-safe; two `source_url`s independently prove the subnet publishes it (pinned repo route + OpenAPI).
- [x] Public-safe: response is numeric time-series only; no secrets, wallet/PAT, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface — distinct URL from all registered Ridges routes.
- [x] No linked issue — rationale provided above.

## Validation

- [x] `npm run validate:surface -- registry/subnets/ridges.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate` (full suite, green)
