### PR TITLE
fix(chain-transfers): skip blank volume rows in transfer leaderboards

### DIFF
--- a/src/chain-transfers.mjs
+++ b/src/chain-transfers.mjs
@@ -10,6 +10,12 @@
 const DAY_MS = 24 * 60 * 60 * 1000;
 const TRANSFER_KIND = "Transfer";
 
+// Rows with NULL/negative amount_tao must not enter transfer rollups — COUNT(*) would
+// still count them while SUM(amount_tao) collapses to zero (mirrors chain-transfer-pairs
+// PAIR_FILTER and counterparties #3059).
+const TRANSFER_AMOUNT_FILTER =
+  "event_kind = ? AND observed_at >= ? AND amount_tao IS NOT NULL AND amount_tao >= 0";
+
 // Supported windows (label -> days), the same set + default the sibling /chain/* analytics
 // use (config.mjs ANALYTICS_WINDOWS / DEFAULT_ANALYTICS_WINDOW).
 export const CHAIN_TRANSFER_WINDOWS = { "7d": 7, "30d": 30 };
@@ -29,6 +35,14 @@ function roundTao(value) {
 function toNumber(value) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+// A finite TAO aggregate cell, or null when absent/blank/non-numeric.
+function nullableTao(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
 }
 
 // A whole non-negative count (D1 COUNT is integer; truncate defensively for direct callers).
@@ -53,13 +67,18 @@ function roundShare(value, dp = 4) {
 // Shape one side's leaderboard rows (address + summed volume + transfer count) into a
 // ranked list. Drops rows with a missing address so a NULL sender/receiver cannot leak in.
 function shapeParties(rows) {
-  return (Array.isArray(rows) ? rows : [])
-    .filter((row) => typeof row?.address === "string" && row.address.length > 0)
-    .map((row) => ({
+  const parties = [];
+  for (const row of Array.isArray(rows) ? rows : []) {
+    if (typeof row?.address !== "string" || row.address.length === 0) continue;
+    const volume = nullableTao(row?.volume_tao);
+    if (volume == null) continue;
+    parties.push({
       address: row.address,
-      volume_tao: roundTao(row?.volume_tao),
+      volume_tao: roundTao(volume),
       transfer_count: toCount(row?.transfer_count),
-    }));
+    });
+  }
+  return parties;
 }
 
 // Shape the network transfer scorecard. `totals` is the single-row aggregate (count,
@@ -120,20 +139,20 @@ export async function loadChainTransfers(
       "COALESCE(SUM(amount_tao), 0) AS total_volume_tao, " +
       "COUNT(DISTINCT hotkey) AS unique_senders, " +
       "COUNT(DISTINCT coldkey) AS unique_receivers " +
-      "FROM account_events WHERE event_kind = ? AND observed_at >= ?",
+      `FROM account_events WHERE ${TRANSFER_AMOUNT_FILTER}`,
     [TRANSFER_KIND, cutoff],
   );
   const senders = await d1(
     "SELECT hotkey AS address, SUM(amount_tao) AS volume_tao, " +
       "COUNT(*) AS transfer_count FROM account_events " +
-      "WHERE event_kind = ? AND observed_at >= ? AND hotkey IS NOT NULL " +
+      `WHERE ${TRANSFER_AMOUNT_FILTER} AND hotkey IS NOT NULL ` +
       "GROUP BY hotkey ORDER BY volume_tao DESC, hotkey ASC LIMIT ?",
     [TRANSFER_KIND, cutoff, limit],
   );
   const receivers = await d1(
     "SELECT coldkey AS address, SUM(amount_tao) AS volume_tao, " +
       "COUNT(*) AS transfer_count FROM account_events " +
-      "WHERE event_kind = ? AND observed_at >= ? AND coldkey IS NOT NULL " +
+      `WHERE ${TRANSFER_AMOUNT_FILTER} AND coldkey IS NOT NULL ` +
       "GROUP BY coldkey ORDER BY volume_tao DESC, coldkey ASC LIMIT ?",
     [TRANSFER_KIND, cutoff, limit],
   );

--- a/tests/chain-transfers.test.mjs
+++ b/tests/chain-transfers.test.mjs
@@ -122,6 +122,45 @@ describe("buildChainTransfers", () => {
     });
     assert.equal(d.total_volume_tao, 0.3);
   });
+
+  test("skips blank/null/non-numeric volume rows instead of phantom zero-TAO parties", () => {
+    // Mirrors buildCounterparties #3059: blank volume must not inflate transfer_count.
+    for (const blank of ["", "   ", null, "nope"]) {
+      const d = buildChainTransfers({
+        totals: { total_volume_tao: 100, transfer_count: 2 },
+        senders: [
+          { address: "5Sa", volume_tao: blank, transfer_count: 9 },
+          party("5Sb", 100, 2),
+        ],
+        receivers: [
+          { address: "5Rx", volume_tao: blank, transfer_count: 4 },
+          party("5Ry", 50, 1),
+        ],
+      });
+      assert.equal(
+        d.top_senders.length,
+        1,
+        `sender count for volume ${JSON.stringify(blank)}`,
+      );
+      assert.equal(d.top_senders[0].address, "5Sb");
+      assert.equal(d.top_senders[0].volume_tao, 100);
+      assert.equal(d.top_senders[0].transfer_count, 2);
+      assert.equal(
+        d.top_receivers.length,
+        1,
+        `receiver count for volume ${JSON.stringify(blank)}`,
+      );
+      assert.equal(d.top_receivers[0].address, "5Ry");
+      assert.equal(d.top_receivers[0].volume_tao, 50);
+    }
+    const zero = buildChainTransfers({
+      senders: [party("5Sa", 0, 3)],
+      receivers: [party("5Rx", 0, 2)],
+    });
+    assert.equal(zero.top_senders[0].volume_tao, 0);
+    assert.equal(zero.top_senders[0].transfer_count, 3);
+    assert.equal(zero.top_receivers[0].transfer_count, 2);
+  });
 });
 
 describe("loadChainTransfers", () => {
@@ -150,10 +189,13 @@ describe("loadChainTransfers", () => {
     });
     assert.equal(calls.length, 3);
     assert.match(calls[0].sql, /FROM account_events WHERE event_kind = \?/);
+    assert.match(calls[0].sql, /amount_tao IS NOT NULL AND amount_tao >= 0/);
     assert.equal(calls[0].params[0], "Transfer");
     assert.match(calls[1].sql, /GROUP BY hotkey/);
+    assert.match(calls[1].sql, /amount_tao IS NOT NULL AND amount_tao >= 0/);
     assert.equal(calls[1].params[2], 10); // limit
     assert.match(calls[2].sql, /GROUP BY coldkey/);
+    assert.match(calls[2].sql, /amount_tao IS NOT NULL AND amount_tao >= 0/);
     assert.equal(d.total_volume_tao, 90);
     assert.equal(d.top_senders[0].address, "5Sa");
     assert.equal(d.top_receivers[0].address, "5Rx");


### PR DESCRIPTION
## Summary

Skip blank/null/non-numeric `volume_tao` rows in the network transfer leaderboard instead of materializing phantom zero-TAO senders/receivers with real `transfer_count` values. Aligns `/chain/transfers` with the already-hardened `chain-transfer-pairs` route and the merged counterparties rollup fix (#3059).

## What Changed

- Add `nullableTao()` to `src/chain-transfers.mjs` and skip leaderboard rows when `volume_tao` is absent/blank/non-numeric.
- Add `TRANSFER_AMOUNT_FILTER` (`amount_tao IS NOT NULL AND amount_tao >= 0`) to all three `loadChainTransfers()` queries so network totals and top-N leaderboards exclude malformed transfer amounts at the SQL layer.
- Add regression coverage for null/blank/non-numeric vs literal-zero volume on both sender and receiver sides, plus SQL filter assertions.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/chain-transfers.test.mjs`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

No upstream issue — jony376 cannot create issues on JSONbored/metagraphed. Direct #3059 parity on the network `/chain/transfers` leaderboard; closes the gap left after `chain-transfer-pairs` hardened its SQL filter.
