### PR TITLE
feat(registry): add SN36 Eirel evaluation environment windows data-artifact

### DIFF
--- a/registry/subnets/sn-36.json
+++ b/registry/subnets/sn-36.json
@@ -139,6 +139,22 @@
         "submitted_by": "davion-knight"
       },
       "notes": "Public no-auth JSON catalog of Eirel's evaluation workflow specifications (workflow_spec_id, class, description, node graph); GET /v1/workflow-specs in the OpenAPI spec. Distinct endpoint from the registered /api/v1/dashboard/* and /v1/metagraph/status routes."
+    },
+    {
+      "id": "sn-36-eirel-env-windows",
+      "name": "Eirel evaluation environment windows",
+      "kind": "data-artifact",
+      "url": "https://api.eirel.ai/v1/env-windows",
+      "provider": "eirel",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://api.eirel.ai/openapi.json"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "notes": "Public no-auth JSON of Eirel's active evaluation environment windows per capability (capability, family_id, enabled, min_completeness, weight, evaluation_split, window version); GET /v1/env-windows in the OpenAPI spec. Payload is capability configuration only — no hotkeys, keys, or user content. Distinct endpoint from the registered /api/v1/dashboard/*, /v1/metagraph/status, and /v1/workflow-specs routes."
     }
   ],
   "social": {


### PR DESCRIPTION
## Add or update a subnet surface

Appends one community `data-artifact` surface to `registry/subnets/sn-36.json` (SN36 Eirel). Append-only; no top-level metadata or existing surfaces touched.

## Summary

Adds Eirel's active evaluation environment-windows feed (`GET /v1/env-windows`) — a public, no-auth JSON of the per-capability evaluation windows (capability, family, enabled state, min-completeness, weight, evaluation split, window version). Sourced from the subnet's official OpenAPI contract.

This is a **distinct endpoint** from Eirel's already-registered routes (`/api/v1/dashboard/*`, `/v1/metagraph/status`, `/v1/workflow-specs`) — a separate capability-window configuration feed.

## Surface

- Netuid: 36
- Kind: data-artifact
- Public URL: https://api.eirel.ai/v1/env-windows
- Source URL (proves the claim): https://api.eirel.ai/openapi.json
- Provider slug: eirel

The endpoint is defined in the official Eirel OpenAPI spec as `Env Windows` with no security requirement. The response is capability configuration only — verified to contain no hotkeys/wallet addresses, keys, or user-generated content.

## No linked issue (rationale)

Intentional no-issue PR. There is no open enrichment issue tracking this endpoint, and issue creation is restricted to collaborators. The change is a single self-proving surface — the public endpoint plus the official OpenAPI source fully establish and verify the claim.

## Checklist

- [x] Changes exactly one `registry/subnets/sn-36.json` file (append-only; no top-level metadata or existing surfaces touched).
- [x] The `url` is public, no-auth, read-only-safe; the `source_url` (official OpenAPI) independently proves the subnet publishes it.
- [x] Public-safe: response is capability config only — no secrets, wallet/hotkey addresses, private URLs, or generated artifacts.
- [x] Does not duplicate an existing Metagraphed surface — distinct URL from all registered Eirel routes.
- [x] No linked issue — rationale provided above.

## Validation

- [x] `npm run validate:surface -- registry/subnets/sn-36.json`
- [x] `npm run scan:public-safety`
- [x] `npm run validate` (full suite, green)
