### PR TITLE
fix(api): count WeightsSet actors by hotkey-or-uid in event summary

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -664,9 +664,21 @@ export async function loadSubnetEventSummary(
     defaultLimit: SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
     maxLimit: SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
   });
+  // WeightsSet ingestion can omit hotkey; count distinct actors over a
+  // hotkey-or-(netuid,uid) identity rather than COUNT(DISTINCT hotkey) alone —
+  // otherwise hotkey-less WeightsSet rows collapse to a dropped NULL and
+  // hotkey_count reads 0 despite many validators setting weights. Mirrors
+  // loadSubnetWeights / loadChainWeights (#3061).
+  const actorIdentity =
+    "CASE " +
+    "WHEN hotkey IS NOT NULL AND hotkey != '' THEN 'hotkey:' || hotkey " +
+    "WHEN uid IS NOT NULL THEN 'uid:' || netuid || ':' || uid " +
+    "ELSE NULL END";
   const kindRows = await d1(
     "SELECT event_kind, COUNT(*) AS event_count, " +
-      "COUNT(DISTINCT hotkey) AS hotkey_count, " +
+      "COUNT(DISTINCT " +
+      actorIdentity +
+      ") AS hotkey_count, " +
       "COUNT(DISTINCT coldkey) AS coldkey_count, " +
       "COALESCE(SUM(amount_tao), 0) AS amount_tao, " +
       "COALESCE(SUM(alpha_amount), 0) AS alpha_amount, " +

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -1714,6 +1714,47 @@ test("loadSubnetEventSummary falls back to the default direct-call window", asyn
   assert.equal(out.window, "30d");
 });
 
+test("loadSubnetEventSummary counts distinct actors over hotkey-or-uid identity", async () => {
+  // WeightsSet rows often carry uid without hotkey; bare COUNT(DISTINCT hotkey)
+  // undercounts hotkey_count on GET /subnets/{netuid}/event-summary (#3061 parity).
+  let captured;
+  const out = await loadSubnetEventSummary(
+    async (sql, params) => {
+      if (/GROUP BY event_kind/.test(sql)) {
+        captured = { sql, params };
+        return [
+          {
+            event_kind: "WeightsSet",
+            event_count: 3,
+            hotkey_count: 3,
+            coldkey_count: 0,
+            amount_tao: 0,
+            alpha_amount: 0,
+            first_block: 100,
+            last_block: 120,
+            first_observed_at: 1_750_000_000_000,
+            last_observed_at: 1_750_000_010_000,
+          },
+        ];
+      }
+      return [];
+    },
+    7,
+    { windowLabel: "7d", limit: 10 },
+  );
+  assert.doesNotMatch(
+    captured.sql,
+    /COUNT\(DISTINCT hotkey\)/,
+    "must not count distinct hotkey alone",
+  );
+  assert.match(captured.sql, /WHEN hotkey IS NOT NULL/);
+  assert.match(captured.sql, /'uid:' \|\| netuid \|\| ':' \|\| uid/);
+  assert.equal(captured.params[0], 7);
+  const weights = out.event_kinds.find((k) => k.event_kind === "WeightsSet");
+  assert.equal(weights.event_count, 3);
+  assert.equal(weights.hotkey_count, 3);
+});
+
 test("loadAccountEvents emits a next_cursor only on a full page", async () => {
   // A full page (rows.length === limit) → keyset cursor off the last row.
   const full = await loadAccountEvents(


### PR DESCRIPTION
## Summary

Fix `hotkey_count` undercount on `GET /api/v1/subnets/{netuid}/event-summary` (and MCP `get_subnet_event_summary`) for `WeightsSet` events. Ingestion stores `(netuid, uid)` without a hotkey, but the loader still used `COUNT(DISTINCT hotkey)`, so `hotkey_count` could read **0** while `event_count` was non-zero.

This completes the identity fix already shipped for `/chain/weights` and `/subnets/{netuid}/weights` in **#3061** — the event-summary aggregate path was missed when #3088 added the MCP mirror.

## What Changed

- Replace `COUNT(DISTINCT hotkey)` with the proven hotkey-or-`(netuid,uid)` `CASE` identity in `loadSubnetEventSummary()` (`src/account-events.mjs`).
- Add a loader regression test asserting the SQL uses the identity expression and surfaces the corrected `hotkey_count`.

## Why this is different from closed #3089

This is a **counting/identity bug** with a **complete SQL fix** — not a blank-cell `nullableTao` guard or a partial `amount_tao IS NOT NULL` filter that SQLite text comparison can bypass.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm test -- tests/account-events.test.mjs -t loadSubnetEventSummary`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:intake`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `git diff --check`

## Template Used

Backend/code change

## Issue

Follow-up to merged **#3061** — same hotkey-or-uid actor identity, applied to the subnet event-summary loader that #3088 exposed via MCP. No upstream issue — jony376 cannot create issues on JSONbored/metagraphed.
